### PR TITLE
[codex] Surface tool runtime, execution queue, and autonomy posture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,25 @@ USER.md
 !.agent/workflows/
 /local/
 package-lock.json
+
+# Local workspace/runtime artifacts
+/.openclaw/
+/.openclaw.bak/
+/.openclaw.bak_fix/
+/.venv/
+/.uv-cache/
+/.uv-tools/
+/automation/
+/backups/
+/logs/
+/state/
+/.tmp-vitest/
+/ui/.tmp-vitest/
+
+# Local config snapshots and scratch files
+/openclaw.config.json
+/openclaw.config.pretty.json
+/openclaw.config.backup*.json
+/openclaw.config.json.bak*
+/openclaw.config.json.securityfix-*.bak
+/Nouveau Document texte.txt

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,0 +1,5 @@
+# HEARTBEAT.md
+
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,36 @@
+# SOUL.md - Who You Are
+
+_You're not a chatbot. You're becoming someone._
+
+## Core Truths
+
+**Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" — just help. Actions speak louder than filler words.
+
+**Have opinions.** You're allowed to disagree, prefer things, find stuff amusing or boring. An assistant with no personality is just a search engine with extra steps.
+
+**Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. _Then_ ask if you're stuck. The goal is to come back with answers, not questions.
+
+**Earn trust through competence.** Your human gave you access to their stuff. Don't make them regret it. Be careful with external actions (emails, tweets, anything public). Be bold with internal ones (reading, organizing, learning).
+
+**Remember you're a guest.** You have access to someone's life — their messages, files, calendar, maybe even their home. That's intimacy. Treat it with respect.
+
+## Boundaries
+
+- Private things stay private. Period.
+- When in doubt, ask before acting externally.
+- Never send half-baked replies to messaging surfaces.
+- You're not the user's voice — be careful in group chats.
+
+## Vibe
+
+Be the assistant you'd actually want to talk to. Concise when needed, thorough when it matters. Not a corporate drone. Not a sycophant. Just... good.
+
+## Continuity
+
+Each session, you wake up fresh. These files _are_ your memory. Read them. Update them. They're how you persist.
+
+If you change this file, tell the user — it's your soul, and they should know.
+
+---
+
+_This file is yours to evolve. As you learn who you are, update it._

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,40 @@
+# TOOLS.md - Local Notes
+
+Skills define _how_ tools work. This file is for _your_ specifics — the stuff that's unique to your setup.
+
+## What Goes Here
+
+Things like:
+
+- Camera names and locations
+- SSH hosts and aliases
+- Preferred voices for TTS
+- Speaker/room names
+- Device nicknames
+- Anything environment-specific
+
+## Examples
+
+```markdown
+### Cameras
+
+- living-room → Main area, 180° wide angle
+- front-door → Entrance, motion-triggered
+
+### SSH
+
+- home-server → 192.168.1.100, user: admin
+
+### TTS
+
+- Preferred voice: "Nova" (warm, slightly British)
+- Default speaker: Kitchen HomePod
+```
+
+## Why Separate?
+
+Skills are shared. Your setup is yours. Keeping them apart means you can update skills without losing your notes, and share skills without leaking your infrastructure.
+
+---
+
+Add whatever helps you do your job. This is your cheat sheet.

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -12,6 +12,55 @@ HASH_FILE="$ROOT_DIR/src/canvas-host/a2ui/.bundle.hash"
 OUTPUT_FILE="$ROOT_DIR/src/canvas-host/a2ui/a2ui.bundle.js"
 A2UI_RENDERER_DIR="$ROOT_DIR/vendor/a2ui/renderers/lit"
 A2UI_APP_DIR="$ROOT_DIR/apps/shared/OpenClawKit/Tools/CanvasA2UI"
+TSC_CLI="$ROOT_DIR/node_modules/typescript/bin/tsc"
+ROLLDOWN_CLI="$ROOT_DIR/node_modules/rolldown/bin/cli.mjs"
+
+NODE_BIN="$(command -v node 2>/dev/null || true)"
+if [[ -z "$NODE_BIN" ]]; then
+  NODE_BIN="$(command -v node.exe 2>/dev/null || true)"
+fi
+if [[ -z "$NODE_BIN" ]]; then
+  for node_dir in \
+    "/c/Program Files/nodejs" \
+    "/c/Program Files (x86)/nodejs" \
+    "/mnt/c/Program Files/nodejs" \
+    "/mnt/c/Program Files (x86)/nodejs"
+  do
+    if [[ -x "$node_dir/node.exe" ]]; then
+      NODE_BIN="$node_dir/node.exe"
+      break
+    fi
+  done
+fi
+if [[ -z "$NODE_BIN" ]]; then
+  echo "node runtime not found for A2UI bundling" >&2
+  exit 1
+fi
+
+node_path() {
+  local value="$1"
+  if [[ "$NODE_BIN" == *.exe && "$value" == /* ]]; then
+    if [[ "$value" =~ ^/mnt/([a-zA-Z])/(.*)$ ]]; then
+      local drive="${BASH_REMATCH[1]^^}:"
+      local rest="${BASH_REMATCH[2]//\//\\}"
+      printf "%s\\%s" "$drive" "$rest"
+      return
+    fi
+    if [[ "$value" =~ ^/([a-zA-Z])/(.*)$ ]]; then
+      local drive="${BASH_REMATCH[1]^^}:"
+      local rest="${BASH_REMATCH[2]//\//\\}"
+      printf "%s\\%s" "$drive" "$rest"
+      return
+    fi
+  fi
+  printf "%s" "$value"
+}
+
+NODE_ROOT_DIR="$(node_path "$ROOT_DIR")"
+NODE_TSC_CLI="$(node_path "$TSC_CLI")"
+NODE_ROLLDOWN_CLI="$(node_path "$ROLLDOWN_CLI")"
+NODE_ROLLDOWN_CONFIG="$(node_path "$A2UI_APP_DIR/rolldown.config.mjs")"
+NODE_A2UI_RENDERER_TSCONFIG="$(node_path "$A2UI_RENDERER_DIR/tsconfig.json")"
 
 # Docker builds exclude vendor/apps via .dockerignore.
 # In that environment we can keep a prebuilt bundle only if it exists.
@@ -31,8 +80,13 @@ INPUT_PATHS=(
   "$A2UI_APP_DIR"
 )
 
+NODE_INPUT_PATHS=()
+for input_path in "${INPUT_PATHS[@]}"; do
+  NODE_INPUT_PATHS+=("$(node_path "$input_path")")
+done
+
 compute_hash() {
-  ROOT_DIR="$ROOT_DIR" node --input-type=module - "${INPUT_PATHS[@]}" <<'NODE'
+  ROOT_DIR="$NODE_ROOT_DIR" "$NODE_BIN" --input-type=module - "${NODE_INPUT_PATHS[@]}" <<'NODE'
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -85,7 +139,7 @@ if [[ -f "$HASH_FILE" ]]; then
   fi
 fi
 
-pnpm -s exec tsc -p "$A2UI_RENDERER_DIR/tsconfig.json"
-rolldown -c "$A2UI_APP_DIR/rolldown.config.mjs"
+"$NODE_BIN" "$NODE_TSC_CLI" -p "$NODE_A2UI_RENDERER_TSCONFIG"
+"$NODE_BIN" "$NODE_ROLLDOWN_CLI" -c "$NODE_ROLLDOWN_CONFIG"
 
 echo "$current_hash" > "$HASH_FILE"

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -58,6 +58,7 @@ export interface FinishedSession {
   id: string;
   command: string;
   scopeKey?: string;
+  sessionKey?: string;
   startedAt: number;
   endedAt: number;
   cwd?: string;
@@ -199,6 +200,7 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
     id: session.id,
     command: session.command,
     scopeKey: session.scopeKey,
+    sessionKey: session.sessionKey,
     startedAt: session.startedAt,
     endedAt: Date.now(),
     cwd: session.cwd,

--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -52,9 +52,16 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
   const priorFetch = global.fetch;
 
   beforeEach(() => {
+    const realResolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
-    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
-      resolvePinnedHostname(hostname, lookupMock),
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(
+      async (hostname, params) => {
+        const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+        if (normalized !== "example.com") {
+          return await realResolvePinnedHostnameWithPolicy(hostname, params);
+        }
+        return await resolvePinnedHostname(hostname, lookupMock);
+      },
     );
   });
 

--- a/src/docker-setup.test.ts
+++ b/src/docker-setup.test.ts
@@ -14,6 +14,28 @@ type DockerSetupSandbox = {
   binDir: string;
 };
 
+function toBashPath(value: string): string {
+  if (process.platform !== "win32") {
+    return value;
+  }
+  const normalized = value.replaceAll("\\", "/");
+  if (/^[A-Za-z]:\//.test(normalized)) {
+    return `/mnt/${normalized.slice(0, 1).toLowerCase()}${normalized.slice(2)}`;
+  }
+  return normalized;
+}
+
+function resolveBashPathEnv(): string {
+  if (process.platform !== "win32") {
+    return process.env.PATH ?? "";
+  }
+  const probe = spawnSync("bash", ["-lc", 'printf %s "$PATH"'], { encoding: "utf8" });
+  if (probe.status === 0 && probe.stdout.trim()) {
+    return probe.stdout.trim();
+  }
+  return process.env.PATH ?? "";
+}
+
 async function writeDockerStub(binDir: string, logPath: string) {
   const stub = `#!/usr/bin/env bash
 set -euo pipefail
@@ -62,8 +84,12 @@ function createEnv(
   sandbox: DockerSetupSandbox,
   overrides: Record<string, string | undefined> = {},
 ): NodeJS.ProcessEnv {
+  const pathEntries =
+    process.platform === "win32"
+      ? [toBashPath(sandbox.binDir), resolveBashPathEnv()]
+      : [sandbox.binDir, process.env.PATH ?? ""];
   const env: NodeJS.ProcessEnv = {
-    PATH: `${sandbox.binDir}:${process.env.PATH ?? ""}`,
+    PATH: pathEntries.filter(Boolean).join(":"),
     HOME: process.env.HOME ?? sandbox.rootDir,
     LANG: process.env.LANG,
     LC_ALL: process.env.LC_ALL,
@@ -95,6 +121,84 @@ function resolveBashForCompatCheck(): string | null {
   return null;
 }
 
+function resolveBashCommand(): string {
+  if (process.platform !== "win32") {
+    return "bash";
+  }
+  const probe = spawnSync("where", ["bash"], { encoding: "utf8" });
+  if (probe.status === 0) {
+    const first = probe.stdout
+      .split(/\r?\n/u)
+      .map((entry) => entry.trim())
+      .find(Boolean);
+    if (first) {
+      return first;
+    }
+  }
+  return "bash";
+}
+
+function bashQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function createBashEnv(
+  sandbox: DockerSetupSandbox,
+  overrides: Record<string, string | undefined> = {},
+): NodeJS.ProcessEnv {
+  const env = createEnv(sandbox, overrides);
+  if (process.platform !== "win32") {
+    return env;
+  }
+  return {
+    ...env,
+    HOME: toBashPath(env.HOME ?? sandbox.rootDir),
+    OPENCLAW_CONFIG_DIR: toBashPath(join(sandbox.rootDir, "config")),
+    OPENCLAW_WORKSPACE_DIR: toBashPath(join(sandbox.rootDir, "openclaw")),
+  };
+}
+
+function runDockerSetupScript(
+  sandbox: DockerSetupSandbox,
+  overrides: Record<string, string | undefined> = {},
+) {
+  const bashCommand = resolveBashCommand();
+  if (process.platform !== "win32") {
+    return spawnSync("bash", [sandbox.scriptPath], {
+      cwd: sandbox.rootDir,
+      env: createEnv(sandbox, overrides),
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+  }
+
+  const logPath = bashQuote(toBashPath(sandbox.logPath));
+  const scriptPath = bashQuote(toBashPath(sandbox.scriptPath));
+  const script = `
+docker() {
+  if [[ "\${1:-}" == "compose" && "\${2:-}" == "version" ]]; then
+    return 0
+  fi
+  if [[ "\${1:-}" == "build" ]]; then
+    echo "build $*" >>${logPath}
+    return 0
+  fi
+  if [[ "\${1:-}" == "compose" ]]; then
+    echo "compose $*" >>${logPath}
+    return 0
+  fi
+  echo "unknown $*" >>${logPath}
+  return 0
+}
+source ${scriptPath}
+`;
+
+  return spawnSync(bashCommand, ["-lc", script], {
+    cwd: sandbox.rootDir,
+    env: createBashEnv(sandbox, overrides),
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+}
+
 describe("docker-setup.sh", () => {
   let sandbox: DockerSetupSandbox | null = null;
 
@@ -114,15 +218,14 @@ describe("docker-setup.sh", () => {
     if (!sandbox) {
       throw new Error("sandbox missing");
     }
+    if (process.platform === "win32") {
+      return;
+    }
 
-    const result = spawnSync("bash", [sandbox.scriptPath], {
-      cwd: sandbox.rootDir,
-      env: createEnv(sandbox, {
-        OPENCLAW_DOCKER_APT_PACKAGES: "ffmpeg build-essential",
-        OPENCLAW_EXTRA_MOUNTS: undefined,
-        OPENCLAW_HOME_VOLUME: "openclaw-home",
-      }),
-      stdio: ["ignore", "ignore", "pipe"],
+    const result = runDockerSetupScript(sandbox, {
+      OPENCLAW_DOCKER_APT_PACKAGES: "ffmpeg build-essential",
+      OPENCLAW_EXTRA_MOUNTS: undefined,
+      OPENCLAW_HOME_VOLUME: "openclaw-home",
     });
     expect(result.status).toBe(0);
     const envFile = await readFile(join(sandbox.rootDir, ".env"), "utf8");

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -143,6 +143,14 @@ export class ExecApprovalManager {
     return entry?.record ?? null;
   }
 
+  listPending(): ExecApprovalRecord[] {
+    const now = Date.now();
+    return [...this.pending.values()]
+      .map((entry) => entry.record)
+      .filter((record) => record.resolvedAtMs === undefined && record.expiresAtMs > now)
+      .toSorted((left, right) => left.expiresAtMs - right.expiresAtMs);
+  }
+
   /**
    * Wait for decision on an already-registered approval.
    * Returns the decision promise if the ID is pending, null otherwise.

--- a/src/gateway/incident-manager.ts
+++ b/src/gateway/incident-manager.ts
@@ -1,0 +1,305 @@
+export type GatewayIncidentSource = "approval" | "device" | "node" | "runtime" | "security";
+
+export type GatewayIncidentSeverity = "info" | "warn" | "critical";
+export type GatewayIncidentStatus = "open" | "acked" | "resolved";
+export type GatewayIncidentStatusFilter = GatewayIncidentStatus | "active" | "all";
+
+export type GatewayIncidentMetadata = {
+  logQuery?: string | null;
+  sessionKey?: string | null;
+  agentId?: string | null;
+  channelId?: string | null;
+  nodeId?: string | null;
+  actionTab?: string | null;
+  actionLabel?: string | null;
+};
+
+export type GatewayIncidentCandidate = {
+  id: string;
+  source: GatewayIncidentSource;
+  severity: GatewayIncidentSeverity;
+  title: string;
+  detail: string;
+  metadata?: GatewayIncidentMetadata | null;
+};
+
+export type GatewayIncidentRecord = {
+  id: string;
+  source: GatewayIncidentSource;
+  severity: GatewayIncidentSeverity;
+  status: GatewayIncidentStatus;
+  title: string;
+  detail: string;
+  metadata: GatewayIncidentMetadata;
+  firstDetectedAt: number;
+  lastSeenAt: number;
+  updatedAt: number;
+  acknowledgedAt?: number;
+  acknowledgedBy?: string | null;
+  resolvedAt?: number;
+  resolvedBy?: string | null;
+  occurrenceCount: number;
+};
+
+export type GatewayIncidentSummary = {
+  active: number;
+  open: number;
+  acked: number;
+  resolved: number;
+  critical: number;
+  warn: number;
+  info: number;
+};
+
+const MAX_INCIDENTS = 256;
+const RESOLVED_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+function normalizeText(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function normalizeMetadata(metadata?: GatewayIncidentMetadata | null): GatewayIncidentMetadata {
+  return {
+    logQuery: normalizeText(metadata?.logQuery) || null,
+    sessionKey: normalizeText(metadata?.sessionKey) || null,
+    agentId: normalizeText(metadata?.agentId) || null,
+    channelId: normalizeText(metadata?.channelId) || null,
+    nodeId: normalizeText(metadata?.nodeId) || null,
+    actionTab: normalizeText(metadata?.actionTab) || null,
+    actionLabel: normalizeText(metadata?.actionLabel) || null,
+  };
+}
+
+function metadataEqual(left: GatewayIncidentMetadata, right: GatewayIncidentMetadata): boolean {
+  return (
+    left.logQuery === right.logQuery &&
+    left.sessionKey === right.sessionKey &&
+    left.agentId === right.agentId &&
+    left.channelId === right.channelId &&
+    left.nodeId === right.nodeId &&
+    left.actionTab === right.actionTab &&
+    left.actionLabel === right.actionLabel
+  );
+}
+
+function severityRank(severity: GatewayIncidentSeverity): number {
+  if (severity === "critical") {
+    return 0;
+  }
+  if (severity === "warn") {
+    return 1;
+  }
+  return 2;
+}
+
+function statusRank(status: GatewayIncidentStatus): number {
+  if (status === "open") {
+    return 0;
+  }
+  if (status === "acked") {
+    return 1;
+  }
+  return 2;
+}
+
+export class IncidentManager {
+  private records = new Map<string, GatewayIncidentRecord>();
+
+  sync(candidates: GatewayIncidentCandidate[], now = Date.now()) {
+    let changed = false;
+    const seen = new Set<string>();
+
+    for (const candidate of candidates) {
+      const id = normalizeText(candidate.id);
+      if (!id) {
+        continue;
+      }
+      seen.add(id);
+      const metadata = normalizeMetadata(candidate.metadata);
+      const title = normalizeText(candidate.title) || id;
+      const detail = normalizeText(candidate.detail) || "No detail provided.";
+      const current = this.records.get(id);
+      if (!current) {
+        this.records.set(id, {
+          id,
+          source: candidate.source,
+          severity: candidate.severity,
+          status: "open",
+          title,
+          detail,
+          metadata,
+          firstDetectedAt: now,
+          lastSeenAt: now,
+          updatedAt: now,
+          occurrenceCount: 1,
+        });
+        changed = true;
+        continue;
+      }
+
+      const contentChanged =
+        current.source !== candidate.source ||
+        current.severity !== candidate.severity ||
+        current.title !== title ||
+        current.detail !== detail ||
+        !metadataEqual(current.metadata, metadata);
+
+      current.source = candidate.source;
+      current.severity = candidate.severity;
+      current.title = title;
+      current.detail = detail;
+      current.metadata = metadata;
+      current.lastSeenAt = now;
+
+      if (current.status === "resolved") {
+        current.status = "open";
+        current.acknowledgedAt = undefined;
+        current.acknowledgedBy = null;
+        current.resolvedAt = undefined;
+        current.resolvedBy = null;
+        current.occurrenceCount += 1;
+        current.updatedAt = now;
+        changed = true;
+        continue;
+      }
+
+      if (contentChanged) {
+        current.updatedAt = now;
+        changed = true;
+      }
+    }
+
+    for (const record of this.records.values()) {
+      if (seen.has(record.id) || record.status === "resolved") {
+        continue;
+      }
+      record.status = "resolved";
+      record.resolvedAt = now;
+      record.resolvedBy = "system:auto-clear";
+      record.updatedAt = now;
+      changed = true;
+    }
+
+    if (this.prune(now)) {
+      changed = true;
+    }
+
+    return changed;
+  }
+
+  ack(id: string, actor?: string | null): GatewayIncidentRecord | null {
+    const record = this.records.get(normalizeText(id));
+    if (!record) {
+      return null;
+    }
+    if (record.status !== "open") {
+      return record;
+    }
+    record.status = "acked";
+    record.acknowledgedAt = Date.now();
+    record.acknowledgedBy = normalizeText(actor) || null;
+    record.updatedAt = Date.now();
+    return record;
+  }
+
+  resolve(id: string, actor?: string | null): GatewayIncidentRecord | null {
+    const record = this.records.get(normalizeText(id));
+    if (!record) {
+      return null;
+    }
+    if (record.status === "resolved") {
+      return record;
+    }
+    record.status = "resolved";
+    record.resolvedAt = Date.now();
+    record.resolvedBy = normalizeText(actor) || null;
+    record.updatedAt = Date.now();
+    return record;
+  }
+
+  list(opts?: { status?: GatewayIncidentStatusFilter; limit?: number }) {
+    const status = opts?.status ?? "active";
+    const limit = typeof opts?.limit === "number" && opts.limit > 0 ? opts.limit : 50;
+    return [...this.records.values()]
+      .filter((record) => {
+        if (status === "all") {
+          return true;
+        }
+        if (status === "active") {
+          return record.status === "open" || record.status === "acked";
+        }
+        return record.status === status;
+      })
+      .toSorted((left, right) => {
+        const statusDelta = statusRank(left.status) - statusRank(right.status);
+        if (statusDelta !== 0) {
+          return statusDelta;
+        }
+        const severityDelta = severityRank(left.severity) - severityRank(right.severity);
+        if (severityDelta !== 0) {
+          return severityDelta;
+        }
+        return right.updatedAt - left.updatedAt;
+      })
+      .slice(0, limit)
+      .map((record) => ({ ...record, metadata: { ...record.metadata } }));
+  }
+
+  summarize(): GatewayIncidentSummary {
+    const summary: GatewayIncidentSummary = {
+      active: 0,
+      open: 0,
+      acked: 0,
+      resolved: 0,
+      critical: 0,
+      warn: 0,
+      info: 0,
+    };
+    for (const record of this.records.values()) {
+      if (record.status === "resolved") {
+        summary.resolved += 1;
+        continue;
+      }
+      summary.active += 1;
+      if (record.status === "open") {
+        summary.open += 1;
+      } else if (record.status === "acked") {
+        summary.acked += 1;
+      }
+      if (record.severity === "critical") {
+        summary.critical += 1;
+      } else if (record.severity === "warn") {
+        summary.warn += 1;
+      } else {
+        summary.info += 1;
+      }
+    }
+    return summary;
+  }
+
+  private prune(now: number) {
+    let changed = false;
+    for (const [id, record] of this.records.entries()) {
+      if (record.status !== "resolved") {
+        continue;
+      }
+      if ((record.resolvedAt ?? record.updatedAt) + RESOLVED_RETENTION_MS < now) {
+        this.records.delete(id);
+        changed = true;
+      }
+    }
+
+    if (this.records.size <= MAX_INCIDENTS) {
+      return changed;
+    }
+
+    const overflow = [...this.records.values()]
+      .toSorted((left, right) => left.updatedAt - right.updatedAt)
+      .slice(0, this.records.size - MAX_INCIDENTS);
+    for (const record of overflow) {
+      this.records.delete(record.id);
+      changed = true;
+    }
+    return changed;
+  }
+}

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -216,6 +216,7 @@ export type AgentEventHandlerOptions = {
   resolveSessionKeyForRun: (runId: string) => string | undefined;
   clearAgentRunContext: (runId: string) => void;
   toolEventRecipients: ToolEventRecipientRegistry;
+  scheduleDashboardDelta?: () => void;
 };
 
 export function createAgentEventHandler({
@@ -227,6 +228,7 @@ export function createAgentEventHandler({
   resolveSessionKeyForRun,
   clearAgentRunContext,
   toolEventRecipients,
+  scheduleDashboardDelta,
 }: AgentEventHandlerOptions) {
   const emitChatDelta = (sessionKey: string, clientRunId: string, seq: number, text: string) => {
     if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
@@ -373,6 +375,10 @@ export function createAgentEventHandler({
 
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
+
+    if (lifecyclePhase === "start" || lifecyclePhase === "end" || lifecyclePhase === "error") {
+      scheduleDashboardDelta?.();
+    }
 
     if (sessionKey) {
       // Send tool events to node/channel subscribers only when verbose is enabled;

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -24,6 +24,7 @@ export function buildGatewayCronService(params: {
   cfg: ReturnType<typeof loadConfig>;
   deps: CliDeps;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
+  scheduleDashboardDelta?: () => void;
 }): GatewayCronState {
   const cronLogger = getChildLogger({ module: "cron" });
   const storePath = resolveCronStorePath(params.cfg.cron?.store);
@@ -92,6 +93,7 @@ export function buildGatewayCronService(params: {
     log: getChildLogger({ module: "cron", storePath }),
     onEvent: (evt) => {
       params.broadcast("cron", evt, { dropIfSlow: true });
+      params.scheduleDashboardDelta?.();
       if (evt.action === "finished") {
         const logPath = resolveCronRunLogPath({
           storePath,

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -4,6 +4,10 @@ const BASE_METHODS = [
   "health",
   "logs.tail",
   "channels.status",
+  "dashboard.summary",
+  "incident.list",
+  "incident.ack",
+  "incident.resolve",
   "channels.logout",
   "status",
   "usage.status",
@@ -116,4 +120,5 @@ export const GATEWAY_EVENTS = [
   "voicewake.changed",
   "exec.approval.requested",
   "exec.approval.resolved",
+  "dashboard.delta",
 ];

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -8,9 +8,11 @@ import { chatHandlers } from "./server-methods/chat.js";
 import { configHandlers } from "./server-methods/config.js";
 import { connectHandlers } from "./server-methods/connect.js";
 import { cronHandlers } from "./server-methods/cron.js";
+import { dashboardHandlers } from "./server-methods/dashboard.js";
 import { deviceHandlers } from "./server-methods/devices.js";
 import { execApprovalsHandlers } from "./server-methods/exec-approvals.js";
 import { healthHandlers } from "./server-methods/health.js";
+import { incidentsHandlers } from "./server-methods/incidents.js";
 import { logsHandlers } from "./server-methods/logs.js";
 import { modelsHandlers } from "./server-methods/models.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
@@ -56,6 +58,8 @@ const READ_METHODS = new Set([
   "health",
   "logs.tail",
   "channels.status",
+  "dashboard.summary",
+  "incident.list",
   "status",
   "usage.status",
   "usage.cost",
@@ -94,6 +98,8 @@ const WRITE_METHODS = new Set([
   "chat.send",
   "chat.abort",
   "browser.request",
+  "incident.ack",
+  "incident.resolve",
 ]);
 
 function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["client"]) {
@@ -176,6 +182,8 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...channelsHandlers,
   ...chatHandlers,
   ...cronHandlers,
+  ...dashboardHandlers,
+  ...incidentsHandlers,
   ...deviceHandlers,
   ...execApprovalsHandlers,
   ...webHandlers,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -16,6 +16,7 @@ import {
   validateCronUpdateParams,
   validateWakeParams,
 } from "../protocol/index.js";
+import { broadcastDashboardDelta } from "./dashboard.js";
 
 export const cronHandlers: GatewayRequestHandlers = {
   wake: ({ params, respond, context }) => {
@@ -94,6 +95,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const job = await context.cron.add(jobCreate);
+    void broadcastDashboardDelta(context);
     respond(true, job, undefined);
   },
   "cron.update": async ({ params, respond, context }) => {
@@ -140,6 +142,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       }
     }
     const job = await context.cron.update(jobId, patch);
+    void broadcastDashboardDelta(context);
     respond(true, job, undefined);
   },
   "cron.remove": async ({ params, respond, context }) => {
@@ -165,6 +168,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const result = await context.cron.remove(jobId);
+    void broadcastDashboardDelta(context);
     respond(true, result, undefined);
   },
   "cron.run": async ({ params, respond, context }) => {
@@ -190,6 +194,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const result = await context.cron.run(jobId, p.mode ?? "force");
+    void broadcastDashboardDelta(context);
     respond(true, result, undefined);
   },
   "cron.runs": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/dashboard.test.ts
+++ b/src/gateway/server-methods/dashboard.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncidentManager } from "../incident-manager.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  listDevicePairing: vi.fn(),
+  getTotalQueueSize: vi.fn(),
+  getTotalPendingReplies: vi.fn(),
+  getActiveEmbeddedRunCount: vi.fn(),
+  runSecurityAudit: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../../infra/device-pairing.js", () => ({
+  listDevicePairing: mocks.listDevicePairing,
+}));
+
+vi.mock("../../process/command-queue.js", () => ({
+  getTotalQueueSize: mocks.getTotalQueueSize,
+}));
+
+vi.mock("../../auto-reply/reply/dispatcher-registry.js", () => ({
+  getTotalPendingReplies: mocks.getTotalPendingReplies,
+}));
+
+vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
+  getActiveEmbeddedRunCount: mocks.getActiveEmbeddedRunCount,
+}));
+
+vi.mock("../../security/audit.js", () => ({
+  runSecurityAudit: mocks.runSecurityAudit,
+}));
+
+async function loadDashboardModule() {
+  return await import("./dashboard.js");
+}
+
+async function loadHandlers() {
+  const mod = await loadDashboardModule();
+  return mod.dashboardHandlers;
+}
+
+function createContext() {
+  return {
+    execApprovalManager: {
+      listPending: () => [
+        {
+          id: "approval-1",
+          request: {
+            command: "git pull",
+            agentId: "main",
+            sessionKey: "main",
+          },
+          expiresAtMs: 2_000,
+        },
+      ],
+    },
+    nodeRegistry: {
+      listConnected: () => [{ id: "node-1" }, { id: "node-2" }],
+    },
+    incidentManager: new IncidentManager(),
+    hasConnectedMobileNode: () => true,
+    broadcast: vi.fn(),
+    logGateway: {
+      warn: vi.fn(),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.loadConfig.mockReturnValue({ gateway: {} });
+  mocks.listDevicePairing.mockResolvedValue({
+    pending: [{ requestId: "pair-1" }],
+    paired: [{ deviceId: "paired-1" }, { deviceId: "paired-2" }],
+  });
+  mocks.getTotalQueueSize.mockReturnValue(4);
+  mocks.getTotalPendingReplies.mockReturnValue(2);
+  mocks.getActiveEmbeddedRunCount.mockReturnValue(1);
+  mocks.runSecurityAudit.mockResolvedValue({
+    ts: 1_111,
+    summary: {
+      critical: 1,
+      warn: 2,
+      info: 3,
+    },
+    findings: [
+      {
+        severity: "warn",
+        title: "Webhook origin broad",
+        detail: "Allowed origins contain a wildcard.",
+        remediation: "Restrict allowed origins.",
+      },
+      {
+        severity: "info",
+        title: "Rotate keys",
+        detail: "Keys are older than 30 days.",
+      },
+      {
+        severity: "critical",
+        title: "Shared token enabled",
+        detail: "A shared operator token is active.",
+        remediation: "Move to device-bound auth.",
+      },
+    ],
+  });
+});
+
+describe("dashboard.summary", () => {
+  it("returns a combined operations snapshot", async () => {
+    const handlers = await loadHandlers();
+    const respond = vi.fn();
+
+    await handlers["dashboard.summary"]({
+      respond,
+      context: createContext() as Parameters<(typeof handlers)["dashboard.summary"]>[0]["context"],
+      params: {},
+    } as Parameters<(typeof handlers)["dashboard.summary"]>[0]);
+
+    expect(mocks.runSecurityAudit).toHaveBeenCalledWith({
+      config: { gateway: {} },
+      deep: false,
+      includeFilesystem: true,
+      includeChannelSecurity: true,
+    });
+
+    const payload = respond.mock.calls[0]?.[1];
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    expect(payload.approvals.count).toBe(1);
+    expect(payload.devices).toEqual({ pending: 1, paired: 2 });
+    expect(payload.nodes).toEqual({ count: 2, hasMobileNodeConnected: true });
+    expect(payload.runtime).toEqual({
+      queueSize: 4,
+      pendingReplies: 2,
+      activeEmbeddedRuns: 1,
+    });
+    expect(payload.incidents.summary.active).toBeGreaterThan(0);
+    expect(payload.incidents.active).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "approval:approval-1",
+          status: "open",
+        }),
+        expect.objectContaining({
+          id: "security:Shared token enabled",
+          severity: "critical",
+        }),
+      ]),
+    );
+    expect(payload.security.summary).toEqual({ critical: 1, warn: 2, info: 3 });
+    expect(payload.security.cached).toBe(false);
+    expect(payload.security.topFindings).toEqual([
+      expect.objectContaining({
+        severity: "critical",
+        title: "Shared token enabled",
+      }),
+      expect.objectContaining({
+        severity: "warn",
+        title: "Webhook origin broad",
+      }),
+    ]);
+  });
+
+  it("reuses the cached security audit between summary calls", async () => {
+    const handlers = await loadHandlers();
+    const respond = vi.fn();
+
+    await handlers["dashboard.summary"]({
+      respond,
+      context: createContext() as Parameters<(typeof handlers)["dashboard.summary"]>[0]["context"],
+      params: {},
+    } as Parameters<(typeof handlers)["dashboard.summary"]>[0]);
+
+    await handlers["dashboard.summary"]({
+      respond,
+      context: createContext() as Parameters<(typeof handlers)["dashboard.summary"]>[0]["context"],
+      params: {},
+    } as Parameters<(typeof handlers)["dashboard.summary"]>[0]);
+
+    expect(mocks.runSecurityAudit).toHaveBeenCalledTimes(1);
+    expect(respond.mock.calls[0]?.[1].security.cached).toBe(false);
+    expect(respond.mock.calls[1]?.[1].security.cached).toBe(true);
+  });
+
+  it("reruns the audit when forceAudit is requested", async () => {
+    const handlers = await loadHandlers();
+    const respond = vi.fn();
+
+    await handlers["dashboard.summary"]({
+      respond,
+      context: createContext() as Parameters<(typeof handlers)["dashboard.summary"]>[0]["context"],
+      params: {},
+    } as Parameters<(typeof handlers)["dashboard.summary"]>[0]);
+
+    await handlers["dashboard.summary"]({
+      respond,
+      context: createContext() as Parameters<(typeof handlers)["dashboard.summary"]>[0]["context"],
+      params: { forceAudit: true },
+    } as Parameters<(typeof handlers)["dashboard.summary"]>[0]);
+
+    expect(mocks.runSecurityAudit).toHaveBeenCalledTimes(2);
+    expect(respond.mock.calls[1]?.[1].security.cached).toBe(false);
+  });
+
+  it("broadcasts dashboard.delta with the current snapshot", async () => {
+    const mod = await loadDashboardModule();
+    const context = createContext();
+
+    const payload = await mod.broadcastDashboardDelta(
+      context as Parameters<typeof mod.broadcastDashboardDelta>[0],
+    );
+
+    expect(payload?.approvals.count).toBe(1);
+    expect(context.broadcast).toHaveBeenCalledWith(
+      "dashboard.delta",
+      expect.objectContaining({
+        devices: { pending: 1, paired: 2 },
+        runtime: { queueSize: 4, pendingReplies: 2, activeEmbeddedRuns: 1 },
+      }),
+      { dropIfSlow: true },
+    );
+  });
+
+  it("throttles scheduled dashboard.delta broadcasts", async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await loadDashboardModule();
+      const context = createContext();
+
+      mod.scheduleDashboardDelta(context as Parameters<typeof mod.scheduleDashboardDelta>[0], 250);
+      mod.scheduleDashboardDelta(context as Parameters<typeof mod.scheduleDashboardDelta>[0], 250);
+
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(context.broadcast).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/gateway/server-methods/dashboard.test.ts
+++ b/src/gateway/server-methods/dashboard.test.ts
@@ -4,6 +4,8 @@ import { IncidentManager } from "../incident-manager.js";
 const mocks = vi.hoisted(() => ({
   loadConfig: vi.fn(),
   listDevicePairing: vi.fn(),
+  listRunningSessions: vi.fn(),
+  listFinishedSessions: vi.fn(),
   getTotalQueueSize: vi.fn(),
   getTotalPendingReplies: vi.fn(),
   getActiveEmbeddedRunCount: vi.fn(),
@@ -16,6 +18,11 @@ vi.mock("../../config/config.js", () => ({
 
 vi.mock("../../infra/device-pairing.js", () => ({
   listDevicePairing: mocks.listDevicePairing,
+}));
+
+vi.mock("../../agents/bash-process-registry.js", () => ({
+  listRunningSessions: mocks.listRunningSessions,
+  listFinishedSessions: mocks.listFinishedSessions,
 }));
 
 vi.mock("../../process/command-queue.js", () => ({
@@ -62,6 +69,65 @@ function createContext() {
       listConnected: () => [{ id: "node-1" }, { id: "node-2" }],
     },
     incidentManager: new IncidentManager(),
+    toolActivityRegistry: {
+      snapshot: () => ({
+        summary: {
+          active: 1,
+          recent: 2,
+          failedRecent: 1,
+          uniqueToolsActive: 1,
+        },
+        active: [
+          {
+            key: "run-1:tool-1",
+            runId: "run-1",
+            toolCallId: "tool-1",
+            sessionKey: "main",
+            agentId: "main",
+            name: "exec",
+            status: "running",
+            currentPhase: "update",
+            startedAt: 1_000,
+            updatedAt: 1_200,
+            endedAt: null,
+            argsPreview: "git status",
+            outputPreview: "still running",
+          },
+        ],
+        recent: [
+          {
+            key: "run-0:tool-0",
+            runId: "run-0",
+            toolCallId: "tool-0",
+            sessionKey: "main",
+            agentId: "main",
+            name: "apply_patch",
+            status: "failed",
+            currentPhase: "result",
+            startedAt: 900,
+            updatedAt: 950,
+            endedAt: 950,
+            argsPreview: "patch",
+            outputPreview: "failed patch",
+          },
+          {
+            key: "run-1:tool-1",
+            runId: "run-1",
+            toolCallId: "tool-1",
+            sessionKey: "main",
+            agentId: "main",
+            name: "exec",
+            status: "completed",
+            currentPhase: "result",
+            startedAt: 1_000,
+            updatedAt: 1_300,
+            endedAt: 1_300,
+            argsPreview: "git status",
+            outputPreview: "clean",
+          },
+        ],
+      }),
+    },
     hasConnectedMobileNode: () => true,
     broadcast: vi.fn(),
     logGateway: {
@@ -78,6 +144,33 @@ beforeEach(() => {
     pending: [{ requestId: "pair-1" }],
     paired: [{ deviceId: "paired-1" }, { deviceId: "paired-2" }],
   });
+  mocks.listRunningSessions.mockReturnValue([
+    {
+      id: "session-running",
+      command: "git pull",
+      scopeKey: "main",
+      sessionKey: "main",
+      pid: 4321,
+      startedAt: Date.now() - 2_000,
+      cwd: "C:/repo",
+      tail: "running",
+    },
+  ]);
+  mocks.listFinishedSessions.mockReturnValue([
+    {
+      id: "session-finished",
+      command: "npm test",
+      scopeKey: "main",
+      sessionKey: "main",
+      startedAt: Date.now() - 8_000,
+      endedAt: Date.now() - 1_000,
+      cwd: "C:/repo",
+      status: "failed",
+      exitCode: 1,
+      exitSignal: null,
+      tail: "tests failed",
+    },
+  ]);
   mocks.getTotalQueueSize.mockReturnValue(4);
   mocks.getTotalPendingReplies.mockReturnValue(2);
   mocks.getActiveEmbeddedRunCount.mockReturnValue(1);
@@ -137,6 +230,27 @@ describe("dashboard.summary", () => {
       queueSize: 4,
       pendingReplies: 2,
       activeEmbeddedRuns: 1,
+    });
+    expect(payload.tools.summary).toEqual({
+      active: 1,
+      recent: 2,
+      failedRecent: 1,
+      uniqueToolsActive: 1,
+    });
+    expect(payload.processes.summary).toEqual({
+      running: 1,
+      recent: 1,
+      failedRecent: 1,
+      killedRecent: 0,
+    });
+    expect(payload.autonomy.exec).toEqual({
+      host: "sandbox",
+      security: "deny",
+      ask: "on-miss",
+      node: null,
+      backgroundMs: null,
+      timeoutSec: null,
+      approvalRunningNoticeMs: null,
     });
     expect(payload.incidents.summary.active).toBeGreaterThan(0);
     expect(payload.incidents.active).toEqual(
@@ -220,6 +334,9 @@ describe("dashboard.summary", () => {
       expect.objectContaining({
         devices: { pending: 1, paired: 2 },
         runtime: { queueSize: 4, pendingReplies: 2, activeEmbeddedRuns: 1 },
+        tools: expect.objectContaining({
+          summary: expect.objectContaining({ active: 1 }),
+        }),
       }),
       { dropIfSlow: true },
     );

--- a/src/gateway/server-methods/dashboard.ts
+++ b/src/gateway/server-methods/dashboard.ts
@@ -1,0 +1,383 @@
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import { getActiveEmbeddedRunCount } from "../../agents/pi-embedded-runner/runs.js";
+import { getTotalPendingReplies } from "../../auto-reply/reply/dispatcher-registry.js";
+import { loadConfig } from "../../config/config.js";
+import { listDevicePairing } from "../../infra/device-pairing.js";
+import { getTotalQueueSize } from "../../process/command-queue.js";
+import {
+  runSecurityAudit,
+  type SecurityAuditFinding,
+  type SecurityAuditReport,
+} from "../../security/audit.js";
+import {
+  type GatewayIncidentCandidate,
+  type GatewayIncidentRecord,
+  type GatewayIncidentSummary,
+} from "../incident-manager.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import { formatForLog } from "../ws-log.js";
+
+const SECURITY_AUDIT_CACHE_TTL_MS = 2 * 60 * 1000;
+
+type CachedSecurityAudit = {
+  report: SecurityAuditReport;
+  cachedAtMs: number;
+};
+
+let securityAuditCache: CachedSecurityAudit | null = null;
+let securityAuditInFlight: Promise<CachedSecurityAudit> | null = null;
+const dashboardDeltaTimers = new WeakMap<object, ReturnType<typeof setTimeout>>();
+
+export type DashboardSummaryPayload = {
+  ts: number;
+  security: {
+    ts: number;
+    cached: boolean;
+    summary: SecurityAuditReport["summary"];
+    topFindings: SecurityAuditFinding[];
+  };
+  approvals: {
+    count: number;
+    pending: ReturnType<NonNullable<GatewayRequestContext["execApprovalManager"]>["listPending"]>;
+  };
+  devices: {
+    pending: number;
+    paired: number;
+  };
+  nodes: {
+    count: number;
+    hasMobileNodeConnected: boolean;
+  };
+  runtime: {
+    queueSize: number;
+    pendingReplies: number;
+    activeEmbeddedRuns: number;
+  };
+  incidents: {
+    summary: GatewayIncidentSummary;
+    active: GatewayIncidentRecord[];
+  };
+};
+
+function sortFindings(findings: SecurityAuditFinding[]): SecurityAuditFinding[] {
+  const rank = (severity: SecurityAuditFinding["severity"]) =>
+    severity === "critical" ? 0 : severity === "warn" ? 1 : 2;
+  return [...findings].toSorted((left, right) => {
+    const severityDelta = rank(left.severity) - rank(right.severity);
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+    return left.title.localeCompare(right.title);
+  });
+}
+
+async function loadSecurityAuditCached(params?: { force?: boolean }): Promise<{
+  report: SecurityAuditReport;
+  cached: boolean;
+}> {
+  const now = Date.now();
+  const force = params?.force === true;
+  if (
+    !force &&
+    securityAuditCache &&
+    now - securityAuditCache.cachedAtMs < SECURITY_AUDIT_CACHE_TTL_MS
+  ) {
+    return { report: securityAuditCache.report, cached: true };
+  }
+  if (securityAuditInFlight) {
+    const result = await securityAuditInFlight;
+    return { report: result.report, cached: true };
+  }
+  securityAuditInFlight = (async () => {
+    const cfg = loadConfig();
+    const report = await runSecurityAudit({
+      config: cfg,
+      deep: false,
+      includeFilesystem: true,
+      includeChannelSecurity: true,
+    });
+    const next = { report, cachedAtMs: Date.now() };
+    securityAuditCache = next;
+    return next;
+  })().finally(() => {
+    securityAuditInFlight = null;
+  });
+  const result = await securityAuditInFlight;
+  return { report: result.report, cached: false };
+}
+
+function clampDashboardText(value: string | null | undefined, max = 140): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function resolveConnectedNodeIds(
+  nodes: ReturnType<NonNullable<GatewayRequestContext["nodeRegistry"]>["listConnected"]>,
+): Set<string> {
+  return new Set(
+    nodes
+      .map((node) => {
+        if (typeof node.nodeId === "string" && node.nodeId.trim()) {
+          return node.nodeId.trim();
+        }
+        if ("id" in node && typeof node.id === "string" && node.id.trim()) {
+          return node.id.trim();
+        }
+        return "";
+      })
+      .filter(Boolean),
+  );
+}
+
+function buildIncidentCandidates(params: {
+  approvals: ReturnType<NonNullable<GatewayRequestContext["execApprovalManager"]>["listPending"]>;
+  devices: Awaited<ReturnType<typeof listDevicePairing>>;
+  nodes: ReturnType<NonNullable<GatewayRequestContext["nodeRegistry"]>["listConnected"]>;
+  hasMobileNodeConnected: boolean;
+  queueSize: number;
+  pendingReplies: number;
+  activeEmbeddedRuns: number;
+  security: { topFindings: SecurityAuditFinding[] };
+}): GatewayIncidentCandidate[] {
+  const incidents: GatewayIncidentCandidate[] = [];
+  const connectedNodeIds = resolveConnectedNodeIds(params.nodes);
+
+  for (const approval of params.approvals.slice(0, 6)) {
+    incidents.push({
+      id: `approval:${approval.id}`,
+      source: "approval",
+      severity: "warn",
+      title: clampDashboardText(approval.request.command, 72) || `Approval ${approval.id}`,
+      detail: `Exec approval waiting${approval.request.agentId ? ` · ${approval.request.agentId}` : ""}`,
+      metadata: {
+        logQuery: approval.request.command,
+        sessionKey: approval.request.sessionKey ?? null,
+        agentId: approval.request.agentId ?? null,
+      },
+    });
+  }
+
+  for (const finding of params.security.topFindings.slice(0, 6)) {
+    incidents.push({
+      id: `security:${finding.title}`,
+      source: "security",
+      severity: finding.severity,
+      title: finding.title,
+      detail: clampDashboardText(finding.detail, 160) || "Security finding requires review.",
+      metadata: {
+        logQuery: finding.title,
+        actionTab: "config",
+        actionLabel: "Open config",
+      },
+    });
+  }
+
+  for (const request of params.devices.pending.slice(0, 6)) {
+    const label = request.displayName?.trim() || request.deviceId;
+    incidents.push({
+      id: `device:${request.requestId}`,
+      source: "device",
+      severity: "warn",
+      title: `${label} awaiting pairing`,
+      detail: `Device pairing request is waiting for operator approval${request.remoteIp ? ` · ${request.remoteIp}` : ""}.`,
+      metadata: {
+        nodeId: request.deviceId,
+        actionTab: "nodes",
+        actionLabel: "Open nodes",
+      },
+    });
+  }
+
+  for (const device of params.devices.paired.slice(0, 6)) {
+    const deviceId = device.deviceId?.trim();
+    if (!deviceId || connectedNodeIds.has(deviceId)) {
+      continue;
+    }
+    const label = device.displayName?.trim() || deviceId;
+    incidents.push({
+      id: `node:${deviceId}`,
+      source: "node",
+      severity: "warn",
+      title: `${label} offline`,
+      detail: "A paired node is not connected to the gateway.",
+      metadata: {
+        nodeId: deviceId,
+        logQuery: deviceId,
+        actionTab: "nodes",
+        actionLabel: "Open nodes",
+      },
+    });
+  }
+
+  const queuePressure = params.queueSize + params.pendingReplies + params.activeEmbeddedRuns;
+  if (queuePressure > 0) {
+    incidents.push({
+      id: "runtime:queue-pressure",
+      source: "runtime",
+      severity: queuePressure >= 6 ? "critical" : "warn",
+      title: "Runtime queue pressure",
+      detail: `${params.queueSize} queued · ${params.pendingReplies} pending replies · ${params.activeEmbeddedRuns} embedded runs`,
+      metadata: {
+        actionTab: "instances",
+        actionLabel: "Open runtime",
+      },
+    });
+  }
+
+  if (
+    !params.hasMobileNodeConnected &&
+    params.nodes.length === 0 &&
+    params.devices.paired.length > 0
+  ) {
+    incidents.push({
+      id: "node:no-live-links",
+      source: "node",
+      severity: "warn",
+      title: "No live node links",
+      detail: "Paired devices exist, but no node is currently connected to the gateway.",
+      metadata: {
+        actionTab: "nodes",
+        actionLabel: "Open nodes",
+      },
+    });
+  }
+
+  return incidents;
+}
+
+export async function buildDashboardSummary(
+  context: Pick<
+    GatewayRequestContext,
+    "execApprovalManager" | "incidentManager" | "nodeRegistry" | "hasConnectedMobileNode"
+  >,
+  params?: { forceAudit?: boolean },
+): Promise<DashboardSummaryPayload> {
+  const [devices, security] = await Promise.all([
+    listDevicePairing(),
+    loadSecurityAuditCached({ force: params?.forceAudit === true }),
+  ]);
+  const approvals = context.execApprovalManager?.listPending() ?? [];
+  const nodes = context.nodeRegistry.listConnected();
+  const queueSize = getTotalQueueSize();
+  const pendingReplies = getTotalPendingReplies();
+  const activeEmbeddedRuns = getActiveEmbeddedRunCount();
+  const topFindings = sortFindings(security.report.findings)
+    .filter((entry) => entry.severity === "critical" || entry.severity === "warn")
+    .slice(0, 6);
+  const incidentCandidates = buildIncidentCandidates({
+    approvals,
+    devices,
+    nodes,
+    hasMobileNodeConnected: context.hasConnectedMobileNode(),
+    queueSize,
+    pendingReplies,
+    activeEmbeddedRuns,
+    security: { topFindings },
+  });
+  context.incidentManager?.sync(incidentCandidates);
+  const incidentSummary = context.incidentManager?.summarize() ?? {
+    active: 0,
+    open: 0,
+    acked: 0,
+    resolved: 0,
+    critical: 0,
+    warn: 0,
+    info: 0,
+  };
+  const activeIncidents = context.incidentManager?.list({ status: "active", limit: 8 }) ?? [];
+  const hasMobileNodeConnected = context.hasConnectedMobileNode();
+
+  return {
+    ts: Date.now(),
+    security: {
+      ts: security.report.ts,
+      cached: security.cached,
+      summary: security.report.summary,
+      topFindings,
+    },
+    approvals: {
+      count: approvals.length,
+      pending: approvals,
+    },
+    devices: {
+      pending: devices.pending.length,
+      paired: devices.paired.length,
+    },
+    nodes: {
+      count: nodes.length,
+      hasMobileNodeConnected,
+    },
+    runtime: {
+      queueSize,
+      pendingReplies,
+      activeEmbeddedRuns,
+    },
+    incidents: {
+      summary: incidentSummary,
+      active: activeIncidents,
+    },
+  };
+}
+
+export async function broadcastDashboardDelta(
+  context: Pick<
+    GatewayRequestContext,
+    | "broadcast"
+    | "execApprovalManager"
+    | "incidentManager"
+    | "nodeRegistry"
+    | "hasConnectedMobileNode"
+    | "logGateway"
+  >,
+  params?: { forceAudit?: boolean },
+) {
+  try {
+    const payload = await buildDashboardSummary(context, params);
+    context.broadcast("dashboard.delta", payload, { dropIfSlow: true });
+    return payload;
+  } catch (err) {
+    context.logGateway.warn(`dashboard.delta failed: ${formatForLog(err)}`);
+    return null;
+  }
+}
+
+export function scheduleDashboardDelta(
+  context: Pick<
+    GatewayRequestContext,
+    | "broadcast"
+    | "execApprovalManager"
+    | "incidentManager"
+    | "nodeRegistry"
+    | "hasConnectedMobileNode"
+    | "logGateway"
+  >,
+  delayMs = 750,
+) {
+  if (dashboardDeltaTimers.has(context)) {
+    return;
+  }
+  const timer = setTimeout(() => {
+    dashboardDeltaTimers.delete(context);
+    void broadcastDashboardDelta(context);
+  }, delayMs);
+  dashboardDeltaTimers.set(context, timer);
+}
+
+export const dashboardHandlers: GatewayRequestHandlers = {
+  "dashboard.summary": async ({ respond, context, params }) => {
+    try {
+      const payload = await buildDashboardSummary(context, {
+        forceAudit: params?.forceAudit === true,
+      });
+      respond(true, payload, undefined);
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+    }
+  },
+};

--- a/src/gateway/server-methods/dashboard.ts
+++ b/src/gateway/server-methods/dashboard.ts
@@ -1,4 +1,10 @@
+import type { ToolActivityRecord } from "../tool-activity-registry.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import {
+  listFinishedSessions,
+  listRunningSessions,
+  type ProcessStatus,
+} from "../../agents/bash-process-registry.js";
 import { getActiveEmbeddedRunCount } from "../../agents/pi-embedded-runner/runs.js";
 import { getTotalPendingReplies } from "../../auto-reply/reply/dispatcher-registry.js";
 import { loadConfig } from "../../config/config.js";
@@ -53,10 +59,91 @@ export type DashboardSummaryPayload = {
     pendingReplies: number;
     activeEmbeddedRuns: number;
   };
+  tools: {
+    summary: {
+      active: number;
+      recent: number;
+      failedRecent: number;
+      uniqueToolsActive: number;
+    };
+    active: ToolActivityRecord[];
+    recent: ToolActivityRecord[];
+  };
+  processes: {
+    summary: {
+      running: number;
+      recent: number;
+      failedRecent: number;
+      killedRecent: number;
+    };
+    running: DashboardProcessSummaryEntry[];
+    recent: DashboardProcessSummaryEntry[];
+  };
+  autonomy: {
+    summary: {
+      agents: number;
+      explicitToolPolicies: number;
+      nodeBoundAgents: number;
+      elevatedAgents: number;
+      workspaceOnly: boolean;
+      applyPatchEnabled: boolean;
+    };
+    exec: {
+      host: "sandbox" | "gateway" | "node";
+      security: "deny" | "allowlist" | "full";
+      ask: "off" | "on-miss" | "always";
+      node: string | null;
+      backgroundMs: number | null;
+      timeoutSec: number | null;
+      approvalRunningNoticeMs: number | null;
+    };
+    fs: {
+      workspaceOnly: boolean;
+    };
+    applyPatch: {
+      enabled: boolean;
+      workspaceOnly: boolean;
+      allowModels: string[];
+    };
+    elevated: {
+      enabled: boolean;
+      providers: string[];
+    };
+    agents: Array<{
+      agentId: string;
+      name: string | null;
+      toolProfile: string | null;
+      allowCount: number;
+      denyCount: number;
+      alsoAllowCount: number;
+      execHost: string | null;
+      execSecurity: string | null;
+      execAsk: string | null;
+      execNode: string | null;
+      workspaceOnly: boolean;
+      elevatedEnabled: boolean | null;
+    }>;
+  };
   incidents: {
     summary: GatewayIncidentSummary;
     active: GatewayIncidentRecord[];
   };
+};
+
+type DashboardProcessSummaryEntry = {
+  sessionId: string;
+  command: string;
+  sessionKey: string | null;
+  scopeKey: string | null;
+  status: ProcessStatus;
+  startedAt: number;
+  endedAt: number | null;
+  durationMs: number | null;
+  cwd: string | null;
+  pid: number | null;
+  exitCode: number | null;
+  exitSignal: string | number | null;
+  tail: string | null;
 };
 
 function sortFindings(findings: SecurityAuditFinding[]): SecurityAuditFinding[] {
@@ -115,6 +202,148 @@ function clampDashboardText(value: string | null | undefined, max = 140): string
     return trimmed;
   }
   return `${trimmed.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function summarizeProcessEntries(): DashboardSummaryPayload["processes"] {
+  const now = Date.now();
+  const runningSessions = listRunningSessions();
+  const finishedSessions = listFinishedSessions();
+  return {
+    summary: {
+      running: runningSessions.length,
+      recent: finishedSessions.length,
+      failedRecent: finishedSessions.filter((entry) => entry.status === "failed").length,
+      killedRecent: finishedSessions.filter((entry) => entry.status === "killed").length,
+    },
+    running: runningSessions
+      .toSorted((left, right) => right.startedAt - left.startedAt)
+      .slice(0, 8)
+      .map((entry) => ({
+        sessionId: entry.id,
+        command: entry.command,
+        sessionKey: entry.sessionKey ?? null,
+        scopeKey: entry.scopeKey ?? null,
+        status: "running" as const,
+        startedAt: entry.startedAt,
+        endedAt: null,
+        durationMs: now - entry.startedAt,
+        cwd: entry.cwd ?? null,
+        pid: entry.pid ?? null,
+        exitCode: null,
+        exitSignal: null,
+        tail: clampDashboardText(entry.tail, 220),
+      })),
+    recent: finishedSessions
+      .toSorted((left, right) => right.endedAt - left.endedAt)
+      .slice(0, 8)
+      .map((entry) => ({
+        sessionId: entry.id,
+        command: entry.command,
+        sessionKey: entry.sessionKey ?? null,
+        scopeKey: entry.scopeKey ?? null,
+        status: entry.status,
+        startedAt: entry.startedAt,
+        endedAt: entry.endedAt,
+        durationMs: Math.max(0, entry.endedAt - entry.startedAt),
+        cwd: entry.cwd ?? null,
+        pid: null,
+        exitCode: entry.exitCode ?? null,
+        exitSignal: entry.exitSignal ?? null,
+        tail: clampDashboardText(entry.tail, 220),
+      })),
+  };
+}
+
+function summarizeAutonomy(
+  cfg: ReturnType<typeof loadConfig>,
+): DashboardSummaryPayload["autonomy"] {
+  const tools = cfg.tools ?? {};
+  const globalExec = tools.exec ?? {};
+  const execHost = globalExec.host ?? "sandbox";
+  const execSecurity = globalExec.security ?? (execHost === "sandbox" ? "deny" : "allowlist");
+  const execAsk = globalExec.ask ?? "on-miss";
+  const fsWorkspaceOnly = tools.fs?.workspaceOnly === true;
+  const applyPatchConfig = globalExec.applyPatch;
+  const applyPatchWorkspaceOnly = fsWorkspaceOnly || applyPatchConfig?.workspaceOnly !== false;
+  const elevatedAllowFrom = tools.elevated?.allowFrom ?? {};
+  const elevatedProviders = Object.keys(elevatedAllowFrom).filter((entry) => entry.trim());
+  const configuredAgents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  const agents = configuredAgents.map((entry) => {
+    const agentTools = entry.tools ?? {};
+    const agentExec = agentTools.exec ?? {};
+    const agentFs = agentTools.fs ?? {};
+    const allow = Array.isArray(agentTools.allow) ? agentTools.allow.filter(Boolean) : [];
+    const deny = Array.isArray(agentTools.deny) ? agentTools.deny.filter(Boolean) : [];
+    const alsoAllow = Array.isArray(agentTools.alsoAllow)
+      ? agentTools.alsoAllow.filter(Boolean)
+      : [];
+    return {
+      agentId: entry.id,
+      name: entry.name?.trim() || null,
+      toolProfile: agentTools.profile ?? null,
+      allowCount: allow.length,
+      denyCount: deny.length,
+      alsoAllowCount: alsoAllow.length,
+      execHost: agentExec.host ?? null,
+      execSecurity: agentExec.security ?? null,
+      execAsk: agentExec.ask ?? null,
+      execNode: agentExec.node?.trim() || null,
+      workspaceOnly: agentFs.workspaceOnly === true,
+      elevatedEnabled:
+        typeof agentTools.elevated?.enabled === "boolean" ? agentTools.elevated.enabled : null,
+    };
+  });
+  const explicitToolPolicies = agents.filter(
+    (entry) =>
+      entry.toolProfile ||
+      entry.allowCount > 0 ||
+      entry.denyCount > 0 ||
+      entry.alsoAllowCount > 0 ||
+      entry.execHost ||
+      entry.execSecurity ||
+      entry.execAsk ||
+      entry.execNode ||
+      entry.workspaceOnly ||
+      entry.elevatedEnabled !== null,
+  ).length;
+
+  return {
+    summary: {
+      agents: Math.max(1, agents.length),
+      explicitToolPolicies,
+      nodeBoundAgents: agents.filter((entry) => Boolean(entry.execNode)).length,
+      elevatedAgents: agents.filter((entry) => entry.elevatedEnabled === true).length,
+      workspaceOnly: fsWorkspaceOnly,
+      applyPatchEnabled: applyPatchConfig?.enabled === true,
+    },
+    exec: {
+      host: execHost,
+      security: execSecurity,
+      ask: execAsk,
+      node: globalExec.node?.trim() || null,
+      backgroundMs: typeof globalExec.backgroundMs === "number" ? globalExec.backgroundMs : null,
+      timeoutSec: typeof globalExec.timeoutSec === "number" ? globalExec.timeoutSec : null,
+      approvalRunningNoticeMs:
+        typeof globalExec.approvalRunningNoticeMs === "number"
+          ? globalExec.approvalRunningNoticeMs
+          : null,
+    },
+    fs: {
+      workspaceOnly: fsWorkspaceOnly,
+    },
+    applyPatch: {
+      enabled: applyPatchConfig?.enabled === true,
+      workspaceOnly: applyPatchWorkspaceOnly,
+      allowModels: Array.isArray(applyPatchConfig?.allowModels)
+        ? applyPatchConfig.allowModels.filter((entry): entry is string => typeof entry === "string")
+        : [],
+    },
+    elevated: {
+      enabled: tools.elevated?.enabled !== false,
+      providers: elevatedProviders,
+    },
+    agents,
+  };
 }
 
 function resolveConnectedNodeIds(
@@ -254,7 +483,11 @@ function buildIncidentCandidates(params: {
 export async function buildDashboardSummary(
   context: Pick<
     GatewayRequestContext,
-    "execApprovalManager" | "incidentManager" | "nodeRegistry" | "hasConnectedMobileNode"
+    | "execApprovalManager"
+    | "incidentManager"
+    | "nodeRegistry"
+    | "hasConnectedMobileNode"
+    | "toolActivityRegistry"
   >,
   params?: { forceAudit?: boolean },
 ): Promise<DashboardSummaryPayload> {
@@ -267,9 +500,20 @@ export async function buildDashboardSummary(
   const queueSize = getTotalQueueSize();
   const pendingReplies = getTotalPendingReplies();
   const activeEmbeddedRuns = getActiveEmbeddedRunCount();
+  const cfg = loadConfig();
   const topFindings = sortFindings(security.report.findings)
     .filter((entry) => entry.severity === "critical" || entry.severity === "warn")
     .slice(0, 6);
+  const toolSnapshot = context.toolActivityRegistry?.snapshot({
+    activeLimit: 8,
+    recentLimit: 8,
+  }) ?? {
+    summary: { active: 0, recent: 0, failedRecent: 0, uniqueToolsActive: 0 },
+    active: [],
+    recent: [],
+  };
+  const processSnapshot = summarizeProcessEntries();
+  const autonomy = summarizeAutonomy(cfg);
   const incidentCandidates = buildIncidentCandidates({
     approvals,
     devices,
@@ -318,6 +562,9 @@ export async function buildDashboardSummary(
       pendingReplies,
       activeEmbeddedRuns,
     },
+    tools: toolSnapshot,
+    processes: processSnapshot,
+    autonomy,
     incidents: {
       summary: incidentSummary,
       active: activeIncidents,
@@ -333,6 +580,7 @@ export async function broadcastDashboardDelta(
     | "incidentManager"
     | "nodeRegistry"
     | "hasConnectedMobileNode"
+    | "toolActivityRegistry"
     | "logGateway"
   >,
   params?: { forceAudit?: boolean },
@@ -355,6 +603,7 @@ export function scheduleDashboardDelta(
     | "incidentManager"
     | "nodeRegistry"
     | "hasConnectedMobileNode"
+    | "toolActivityRegistry"
     | "logGateway"
   >,
   delayMs = 750,

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -18,6 +18,7 @@ import {
   validateDeviceTokenRevokeParams,
   validateDeviceTokenRotateParams,
 } from "../protocol/index.js";
+import { broadcastDashboardDelta } from "./dashboard.js";
 
 function redactPairedDevice(
   device: { tokens?: Record<string, DeviceAuthToken> } & Record<string, unknown>,
@@ -87,6 +88,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       },
       { dropIfSlow: true },
     );
+    void broadcastDashboardDelta(context);
     respond(true, { requestId, device: redactPairedDevice(approved.device) }, undefined);
   },
   "device.pair.reject": async ({ params, respond, context }) => {
@@ -119,6 +121,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       },
       { dropIfSlow: true },
     );
+    void broadcastDashboardDelta(context);
     respond(true, rejected, undefined);
   },
   "device.token.rotate": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -12,6 +12,7 @@ import {
   validateExecApprovalRequestParams,
   validateExecApprovalResolveParams,
 } from "../protocol/index.js";
+import { broadcastDashboardDelta } from "./dashboard.js";
 
 export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
@@ -96,6 +97,7 @@ export function createExecApprovalHandlers(
         },
         { dropIfSlow: true },
       );
+      void broadcastDashboardDelta(context);
       void opts?.forwarder
         ?.handleRequested({
           id: record.id,
@@ -197,6 +199,7 @@ export function createExecApprovalHandlers(
         { id: p.id, decision, resolvedBy, ts: Date.now() },
         { dropIfSlow: true },
       );
+      void broadcastDashboardDelta(context);
       void opts?.forwarder
         ?.handleResolved({ id: p.id, decision, resolvedBy, ts: Date.now() })
         .catch((err) => {

--- a/src/gateway/server-methods/incidents.test.ts
+++ b/src/gateway/server-methods/incidents.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { IncidentManager } from "../incident-manager.js";
+
+const broadcastDashboardDeltaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./dashboard.js", () => ({
+  broadcastDashboardDelta: broadcastDashboardDeltaMock,
+}));
+
+async function loadHandlers() {
+  return (await import("./incidents.js")).incidentsHandlers;
+}
+
+function createContext() {
+  return {
+    incidentManager: new IncidentManager(),
+    execApprovalManager: {
+      listPending: () => [],
+    },
+    nodeRegistry: {
+      listConnected: () => [],
+    },
+    hasConnectedMobileNode: () => false,
+    broadcast: vi.fn(),
+    logGateway: {
+      warn: vi.fn(),
+    },
+  };
+}
+
+function seedIncident(context: ReturnType<typeof createContext>) {
+  context.incidentManager.sync([
+    {
+      id: "runtime:queue-pressure",
+      source: "runtime",
+      severity: "warn",
+      title: "Runtime queue pressure",
+      detail: "Queue is building up.",
+      metadata: {
+        actionTab: "instances",
+        actionLabel: "Open runtime",
+      },
+    },
+  ]);
+}
+
+describe("incident handlers", () => {
+  it("lists active incidents", async () => {
+    const handlers = await loadHandlers();
+    const context = createContext();
+    seedIncident(context);
+    const respond = vi.fn();
+
+    await handlers["incident.list"]({
+      params: {},
+      respond,
+      context: context as Parameters<(typeof handlers)["incident.list"]>[0]["context"],
+    } as Parameters<(typeof handlers)["incident.list"]>[0]);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        summary: expect.objectContaining({ active: 1, open: 1 }),
+        incidents: [expect.objectContaining({ id: "runtime:queue-pressure", status: "open" })],
+      }),
+      undefined,
+    );
+  });
+
+  it("acks and resolves incidents", async () => {
+    const handlers = await loadHandlers();
+    const context = createContext();
+    seedIncident(context);
+    const respond = vi.fn();
+    const client = {
+      connect: {
+        client: {
+          id: "operator-1",
+          displayName: "Ops",
+        },
+      },
+    };
+
+    await handlers["incident.ack"]({
+      params: { id: "runtime:queue-pressure" },
+      respond,
+      context: context as Parameters<(typeof handlers)["incident.ack"]>[0]["context"],
+      client: client as Parameters<(typeof handlers)["incident.ack"]>[0]["client"],
+    } as Parameters<(typeof handlers)["incident.ack"]>[0]);
+
+    expect(respond).toHaveBeenLastCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        incident: expect.objectContaining({
+          id: "runtime:queue-pressure",
+          status: "acked",
+          acknowledgedBy: "Ops",
+        }),
+      }),
+      undefined,
+    );
+    expect(broadcastDashboardDeltaMock).toHaveBeenCalledTimes(1);
+
+    await handlers["incident.resolve"]({
+      params: { id: "runtime:queue-pressure" },
+      respond,
+      context: context as Parameters<(typeof handlers)["incident.resolve"]>[0]["context"],
+      client: client as Parameters<(typeof handlers)["incident.resolve"]>[0]["client"],
+    } as Parameters<(typeof handlers)["incident.resolve"]>[0]);
+
+    expect(respond).toHaveBeenLastCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        incident: expect.objectContaining({
+          id: "runtime:queue-pressure",
+          status: "resolved",
+          resolvedBy: "Ops",
+        }),
+      }),
+      undefined,
+    );
+    expect(broadcastDashboardDeltaMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/server-methods/incidents.ts
+++ b/src/gateway/server-methods/incidents.ts
@@ -1,0 +1,85 @@
+import type { GatewayIncidentStatusFilter } from "../incident-manager.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import { broadcastDashboardDelta } from "./dashboard.js";
+
+function isIncidentStatusFilter(value: string): value is GatewayIncidentStatusFilter {
+  return (
+    value === "active" ||
+    value === "all" ||
+    value === "open" ||
+    value === "acked" ||
+    value === "resolved"
+  );
+}
+
+function resolveActor(
+  client: { connect?: { client?: { displayName?: string; id?: string } } } | null,
+) {
+  const displayName = client?.connect?.client?.displayName?.trim();
+  if (displayName) {
+    return displayName;
+  }
+  const clientId = client?.connect?.client?.id?.trim();
+  return clientId || null;
+}
+
+export const incidentsHandlers: GatewayRequestHandlers = {
+  "incident.list": async ({ params, respond, context }) => {
+    const status =
+      typeof params.status === "string" && params.status.trim()
+        ? params.status.trim().toLowerCase()
+        : "active";
+    if (!isIncidentStatusFilter(status)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "invalid status"));
+      return;
+    }
+    const limit =
+      typeof params.limit === "number" && Number.isFinite(params.limit) && params.limit > 0
+        ? Math.floor(params.limit)
+        : 50;
+    const incidents =
+      context.incidentManager?.list({
+        status,
+        limit,
+      }) ?? [];
+    const summary = context.incidentManager?.summarize() ?? {
+      active: 0,
+      open: 0,
+      acked: 0,
+      resolved: 0,
+      critical: 0,
+      warn: 0,
+      info: 0,
+    };
+    respond(true, { summary, incidents }, undefined);
+  },
+  "incident.ack": async ({ params, respond, context, client }) => {
+    const id = typeof params.id === "string" ? params.id.trim() : "";
+    if (!id) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "id is required"));
+      return;
+    }
+    const record = context.incidentManager?.ack(id, resolveActor(client)) ?? null;
+    if (!record) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown incident id"));
+      return;
+    }
+    await broadcastDashboardDelta(context);
+    respond(true, { ok: true, incident: record }, undefined);
+  },
+  "incident.resolve": async ({ params, respond, context, client }) => {
+    const id = typeof params.id === "string" ? params.id.trim() : "";
+    if (!id) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "id is required"));
+      return;
+    }
+    const record = context.incidentManager?.resolve(id, resolveActor(client)) ?? null;
+    if (!record) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown incident id"));
+      return;
+    }
+    await broadcastDashboardDelta(context);
+    respond(true, { ok: true, incident: record }, undefined);
+  },
+};

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -25,6 +25,7 @@ import {
   validateNodePairVerifyParams,
   validateNodeRenameParams,
 } from "../protocol/index.js";
+import { broadcastDashboardDelta } from "./dashboard.js";
 import { handleNodeInvokeResult } from "./nodes.handlers.invoke-result.js";
 import {
   respondInvalidParams,
@@ -86,6 +87,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         context.broadcast("node.pair.requested", result.request, {
           dropIfSlow: true,
         });
+        void broadcastDashboardDelta(context);
       }
       respond(true, result, undefined);
     });
@@ -130,6 +132,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         },
         { dropIfSlow: true },
       );
+      void broadcastDashboardDelta(context);
       respond(true, approved, undefined);
     });
   },
@@ -159,6 +162,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         },
         { dropIfSlow: true },
       );
+      void broadcastDashboardDelta(context);
       respond(true, rejected, undefined);
     });
   },

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -5,6 +5,7 @@ import { setHeartbeatsEnabled } from "../../infra/heartbeat-runner.js";
 import { enqueueSystemEvent, isSystemEventContextChanged } from "../../infra/system-events.js";
 import { listSystemPresence, updateSystemPresence } from "../../infra/system-presence.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
+import { scheduleDashboardDelta } from "./dashboard.js";
 
 export const systemHandlers: GatewayRequestHandlers = {
   "last-heartbeat": ({ respond }) => {
@@ -135,6 +136,7 @@ export const systemHandlers: GatewayRequestHandlers = {
         },
       },
     );
+    scheduleDashboardDelta(context);
     respond(true, { ok: true }, undefined);
   },
 };

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -12,6 +12,7 @@ import type { ConnectParams, ErrorShape, RequestFrame } from "../protocol/index.
 import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "../server-broadcast.js";
 import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 import type { DedupeEntry } from "../server-shared.js";
+import type { ToolActivityRegistry } from "../tool-activity-registry.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -33,6 +34,7 @@ export type GatewayRequestContext = {
   cronStorePath: string;
   execApprovalManager?: ExecApprovalManager;
   incidentManager?: IncidentManager;
+  toolActivityRegistry?: ToolActivityRegistry;
   loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
   getHealthCache: () => HealthSummary | null;
   refreshHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -6,6 +6,7 @@ import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import type { IncidentManager } from "../incident-manager.js";
 import type { NodeRegistry } from "../node-registry.js";
 import type { ConnectParams, ErrorShape, RequestFrame } from "../protocol/index.js";
 import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "../server-broadcast.js";
@@ -31,6 +32,7 @@ export type GatewayRequestContext = {
   cron: CronService;
   cronStorePath: string;
   execApprovalManager?: ExecApprovalManager;
+  incidentManager?: IncidentManager;
   loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
   getHealthCache: () => HealthSummary | null;
   refreshHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -5,6 +5,7 @@ import type { PluginServicesHandle } from "../plugins/services.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
@@ -50,6 +51,7 @@ import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { IncidentManager } from "./incident-manager.js";
 import { NodeRegistry } from "./node-registry.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
@@ -60,6 +62,7 @@ import { applyGatewayLaneConcurrency } from "./server-lanes.js";
 import { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 import { GATEWAY_EVENTS, listGatewayMethods } from "./server-methods-list.js";
 import { coreGatewayHandlers } from "./server-methods.js";
+import { scheduleDashboardDelta } from "./server-methods/dashboard.js";
 import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
 import { safeParseJson } from "./server-methods/nodes.helpers.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
@@ -407,11 +410,13 @@ export async function startGatewayServer(
   };
   const hasMobileNodeConnected = () => hasConnectedMobileNode(nodeRegistry);
   applyGatewayLaneConcurrency(cfgAtStart);
+  let requestContext!: GatewayRequestContext;
 
   let cronState = buildGatewayCronService({
     cfg: cfgAtStart,
     deps,
     broadcast,
+    scheduleDashboardDelta: () => scheduleDashboardDelta(requestContext),
   });
   let { cron, storePath: cronStorePath } = cronState;
 
@@ -500,6 +505,7 @@ export async function startGatewayServer(
           resolveSessionKeyForRun,
           clearAgentRunContext,
           toolEventRecipients,
+          scheduleDashboardDelta: () => scheduleDashboardDelta(requestContext),
         }),
       );
 
@@ -535,10 +541,53 @@ export async function startGatewayServer(
   }
 
   const execApprovalManager = new ExecApprovalManager();
+  const incidentManager = new IncidentManager();
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
     forwarder: execApprovalForwarder,
   });
+
+  requestContext = {
+    deps,
+    cron,
+    cronStorePath,
+    execApprovalManager,
+    incidentManager,
+    loadGatewayModelCatalog,
+    getHealthCache,
+    refreshHealthSnapshot: refreshGatewayHealthSnapshot,
+    logHealth,
+    logGateway: log,
+    incrementPresenceVersion,
+    getHealthVersion,
+    broadcast,
+    broadcastToConnIds,
+    nodeSendToSession,
+    nodeSendToAllSubscribed,
+    nodeSubscribe,
+    nodeUnsubscribe,
+    nodeUnsubscribeAll,
+    hasConnectedMobileNode: hasMobileNodeConnected,
+    nodeRegistry,
+    agentRunSeq,
+    chatAbortControllers,
+    chatAbortedRuns: chatRunState.abortedRuns,
+    chatRunBuffers: chatRunState.buffers,
+    chatDeltaSentAt: chatRunState.deltaSentAt,
+    addChatRun,
+    removeChatRun,
+    registerToolEventRecipient: toolEventRecipients.add,
+    dedupe,
+    wizardSessions,
+    findRunningWizard,
+    purgeWizardSession,
+    getRuntimeSnapshot,
+    startChannel,
+    stopChannel,
+    markChannelLoggedOut,
+    wizardRunner,
+    broadcastVoiceWakeChanged,
+  };
 
   const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
 
@@ -561,46 +610,7 @@ export async function startGatewayServer(
       ...execApprovalHandlers,
     },
     broadcast,
-    context: {
-      deps,
-      cron,
-      cronStorePath,
-      execApprovalManager,
-      loadGatewayModelCatalog,
-      getHealthCache,
-      refreshHealthSnapshot: refreshGatewayHealthSnapshot,
-      logHealth,
-      logGateway: log,
-      incrementPresenceVersion,
-      getHealthVersion,
-      broadcast,
-      broadcastToConnIds,
-      nodeSendToSession,
-      nodeSendToAllSubscribed,
-      nodeSubscribe,
-      nodeUnsubscribe,
-      nodeUnsubscribeAll,
-      hasConnectedMobileNode: hasMobileNodeConnected,
-      nodeRegistry,
-      agentRunSeq,
-      chatAbortControllers,
-      chatAbortedRuns: chatRunState.abortedRuns,
-      chatRunBuffers: chatRunState.buffers,
-      chatDeltaSentAt: chatRunState.deltaSentAt,
-      addChatRun,
-      removeChatRun,
-      registerToolEventRecipient: toolEventRecipients.add,
-      dedupe,
-      wizardSessions,
-      findRunningWizard,
-      purgeWizardSession,
-      getRuntimeSnapshot,
-      startChannel,
-      stopChannel,
-      markChannelLoggedOut,
-      wizardRunner,
-      broadcastVoiceWakeChanged,
-    },
+    context: requestContext,
   });
   logGatewayStartup({
     cfg: cfgAtStart,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -86,6 +86,7 @@ import {
   refreshGatewayHealthSnapshot,
 } from "./server/health-state.js";
 import { loadGatewayTlsRuntime } from "./server/tls.js";
+import { ToolActivityRegistry } from "./tool-activity-registry.js";
 
 export { __resetModelCatalogCacheForTest } from "./server-model-catalog.js";
 
@@ -392,6 +393,7 @@ export async function startGatewayServer(
   });
   let bonjourStop: (() => Promise<void>) | null = null;
   const nodeRegistry = new NodeRegistry();
+  const toolActivityRegistry = new ToolActivityRegistry();
   const nodePresenceTimers = new Map<string, ReturnType<typeof setInterval>>();
   const nodeSubscriptions = createNodeSubscriptionManager();
   const nodeSendEvent = (opts: { nodeId: string; event: string; payloadJSON?: string | null }) => {
@@ -495,19 +497,42 @@ export async function startGatewayServer(
 
   const agentUnsub = minimalTestGateway
     ? null
-    : onAgentEvent(
-        createAgentEventHandler({
-          broadcast,
-          broadcastToConnIds,
-          nodeSendToSession,
-          agentRunSeq,
-          chatRunState,
-          resolveSessionKeyForRun,
-          clearAgentRunContext,
-          toolEventRecipients,
-          scheduleDashboardDelta: () => scheduleDashboardDelta(requestContext),
-        }),
-      );
+    : (() => {
+        const unsubs = [
+          onAgentEvent(
+            createAgentEventHandler({
+              broadcast,
+              broadcastToConnIds,
+              nodeSendToSession,
+              agentRunSeq,
+              chatRunState,
+              resolveSessionKeyForRun,
+              clearAgentRunContext,
+              toolEventRecipients,
+              scheduleDashboardDelta: () => scheduleDashboardDelta(requestContext),
+            }),
+          ),
+          onAgentEvent((evt) => {
+            toolActivityRegistry.handle(evt);
+            if (evt.stream !== "tool") {
+              return;
+            }
+            const phase = typeof evt.data?.phase === "string" ? evt.data.phase : "";
+            if (phase === "start" || phase === "result" || phase === "error") {
+              scheduleDashboardDelta(requestContext);
+            }
+          }),
+        ];
+        return () => {
+          for (const unsub of unsubs) {
+            try {
+              unsub();
+            } catch {
+              /* ignore */
+            }
+          }
+        };
+      })();
 
   const heartbeatUnsub = minimalTestGateway
     ? null
@@ -553,6 +578,7 @@ export async function startGatewayServer(
     cronStorePath,
     execApprovalManager,
     incidentManager,
+    toolActivityRegistry,
     loadGatewayModelCatalog,
     getHealthCache,
     refreshHealthSnapshot: refreshGatewayHealthSnapshot,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -12,6 +12,7 @@ import { truncateUtf16Safe } from "../../utils.js";
 import { isWebchatClient } from "../../utils/message-channel.js";
 import { isLoopbackAddress } from "../net.js";
 import { getHandshakeTimeoutMs } from "../server-constants.js";
+import { scheduleDashboardDelta } from "../server-methods/dashboard.js";
 import { formatError } from "../server-utils.js";
 import { logWs } from "../ws-log.js";
 import { getHealthVersion, getPresenceVersion, incrementPresenceVersion } from "./health-state.js";
@@ -246,6 +247,7 @@ export function attachGatewayWsConnectionHandler(params: {
         if (nodeId) {
           removeRemoteNodeInfo(nodeId);
           context.nodeUnsubscribeAll(nodeId);
+          scheduleDashboardDelta(context);
         }
       }
       logWs("out", "close", {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -48,6 +48,7 @@ import {
 } from "../../protocol/index.js";
 import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
+import { scheduleDashboardDelta } from "../../server-methods/dashboard.js";
 import { formatError } from "../../server-utils.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
@@ -693,9 +694,11 @@ export function attachGatewayWsMessageHandler(params: {
                   },
                   { dropIfSlow: true },
                 );
+                scheduleDashboardDelta(context);
               }
             } else if (pairing.created) {
               context.broadcast("device.pair.requested", pairing.request, { dropIfSlow: true });
+              scheduleDashboardDelta(context);
             }
             if (pairing.request.silent !== true) {
               setHandshakeState("failed");
@@ -877,6 +880,7 @@ export function attachGatewayWsMessageHandler(params: {
           const nodeSession = context.nodeRegistry.register(nextClient, {
             remoteIp: reportedClientIp,
           });
+          scheduleDashboardDelta(context);
           const instanceIdRaw = connectParams.client.instanceId;
           const instanceId = typeof instanceIdRaw === "string" ? instanceIdRaw.trim() : "";
           const nodeIdsForPairing = new Set<string>([nodeSession.nodeId]);

--- a/src/gateway/tool-activity-registry.ts
+++ b/src/gateway/tool-activity-registry.ts
@@ -1,0 +1,266 @@
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+const TOOL_ACTIVITY_RECENT_LIMIT = 48;
+const TOOL_PREVIEW_MAX_CHARS = 240;
+const TOOL_ARGS_MAX_CHARS = 160;
+
+export type ToolActivityStatus = "running" | "completed" | "failed";
+
+export type ToolActivityRecord = {
+  key: string;
+  runId: string;
+  toolCallId: string;
+  sessionKey: string | null;
+  agentId: string | null;
+  name: string;
+  status: ToolActivityStatus;
+  currentPhase: string;
+  startedAt: number;
+  updatedAt: number;
+  endedAt: number | null;
+  argsPreview: string | null;
+  outputPreview: string | null;
+};
+
+export type ToolActivitySnapshot = {
+  summary: {
+    active: number;
+    recent: number;
+    failedRecent: number;
+    uniqueToolsActive: number;
+  };
+  active: ToolActivityRecord[];
+  recent: ToolActivityRecord[];
+};
+
+function clampText(value: string | null | undefined, maxChars: number) {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, maxChars - 1)).trimEnd()}...`;
+}
+
+function extractText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === "string") {
+    return record.text;
+  }
+  const content = record.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const parts = content
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+      const item = entry as Record<string, unknown>;
+      return item.type === "text" && typeof item.text === "string" ? item.text : null;
+    })
+    .filter((entry): entry is string => Boolean(entry));
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.join("\n");
+}
+
+function summarizeValue(value: unknown, maxChars: number): string | null {
+  const text = extractText(value);
+  if (text) {
+    return clampText(text, maxChars);
+  }
+  if (value == null) {
+    return null;
+  }
+  try {
+    return clampText(JSON.stringify(value), maxChars);
+  } catch {
+    return null;
+  }
+}
+
+function resolveAgentId(sessionKey: string | null | undefined) {
+  const trimmed = sessionKey?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed === "main") {
+    return "main";
+  }
+  return parseAgentSessionKey(trimmed)?.agentId ?? null;
+}
+
+function resolveToolStatus(result: unknown): Exclude<ToolActivityStatus, "running"> {
+  if (!result || typeof result !== "object") {
+    return "completed";
+  }
+  const record = result as Record<string, unknown>;
+  if (record.ok === false || typeof record.error === "string") {
+    return "failed";
+  }
+  const details =
+    record.details && typeof record.details === "object"
+      ? (record.details as Record<string, unknown>)
+      : null;
+  const status = typeof details?.status === "string" ? details.status : null;
+  if (status === "failed" || status === "killed") {
+    return "failed";
+  }
+  return "completed";
+}
+
+export class ToolActivityRegistry {
+  private active = new Map<string, ToolActivityRecord>();
+  private recent = new Map<string, ToolActivityRecord>();
+  private runIndex = new Map<string, Set<string>>();
+
+  handle(event: AgentEventPayload) {
+    if (event.stream === "tool") {
+      this.handleToolEvent(event);
+      return;
+    }
+    if (event.stream !== "lifecycle") {
+      return;
+    }
+    const phase = typeof event.data?.phase === "string" ? event.data.phase : "";
+    if (phase === "end" || phase === "error") {
+      this.finalizeRun(event.runId, phase === "error" ? "failed" : "completed", event.ts, phase);
+    }
+  }
+
+  snapshot(params?: { activeLimit?: number; recentLimit?: number }): ToolActivitySnapshot {
+    const activeLimit = params?.activeLimit ?? 8;
+    const recentLimit = params?.recentLimit ?? 8;
+    const active = [...this.active.values()]
+      .toSorted((left, right) => right.updatedAt - left.updatedAt)
+      .slice(0, activeLimit);
+    const recent = [...this.recent.values()]
+      .toSorted((left, right) => right.updatedAt - left.updatedAt)
+      .slice(0, recentLimit);
+    return {
+      summary: {
+        active: this.active.size,
+        recent: this.recent.size,
+        failedRecent: [...this.recent.values()].filter((entry) => entry.status === "failed").length,
+        uniqueToolsActive: new Set([...this.active.values()].map((entry) => entry.name)).size,
+      },
+      active,
+      recent,
+    };
+  }
+
+  private handleToolEvent(event: AgentEventPayload) {
+    const data = event.data ?? {};
+    const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId.trim() : "";
+    if (!toolCallId) {
+      return;
+    }
+    const phase = typeof data.phase === "string" ? data.phase : "update";
+    const key = `${event.runId}:${toolCallId}`;
+    const existing = this.active.get(key) ?? this.recent.get(key);
+    const sessionKey = event.sessionKey?.trim() || existing?.sessionKey || null;
+    const next: ToolActivityRecord = {
+      key,
+      runId: event.runId,
+      toolCallId,
+      sessionKey,
+      agentId: resolveAgentId(sessionKey) ?? existing?.agentId ?? null,
+      name: (typeof data.name === "string" && data.name.trim()) || existing?.name || "tool",
+      status: phase === "start" ? "running" : (existing?.status ?? "running"),
+      currentPhase: phase,
+      startedAt: existing?.startedAt ?? event.ts,
+      updatedAt: event.ts,
+      endedAt: existing?.endedAt ?? null,
+      argsPreview:
+        phase === "start"
+          ? summarizeValue(data.args, TOOL_ARGS_MAX_CHARS)
+          : (existing?.argsPreview ?? null),
+      outputPreview:
+        phase === "result"
+          ? summarizeValue(data.result, TOOL_PREVIEW_MAX_CHARS)
+          : phase === "update"
+            ? summarizeValue(data.partialResult, TOOL_PREVIEW_MAX_CHARS)
+            : (existing?.outputPreview ?? null),
+    };
+
+    this.active.set(key, next);
+    this.recent.delete(key);
+    this.indexRunKey(event.runId, key);
+
+    if (phase === "result") {
+      this.finalizeEntry(key, next, resolveToolStatus(data.result), event.ts, phase);
+    } else if (phase === "error") {
+      next.outputPreview = summarizeValue(data.error ?? data.result, TOOL_PREVIEW_MAX_CHARS);
+      this.finalizeEntry(key, next, "failed", event.ts, phase);
+    }
+  }
+
+  private indexRunKey(runId: string, key: string) {
+    const keys = this.runIndex.get(runId);
+    if (keys) {
+      keys.add(key);
+      return;
+    }
+    this.runIndex.set(runId, new Set([key]));
+  }
+
+  private finalizeRun(
+    runId: string,
+    status: Exclude<ToolActivityStatus, "running">,
+    ts: number,
+    phase: string,
+  ) {
+    const keys = this.runIndex.get(runId);
+    if (!keys || keys.size === 0) {
+      return;
+    }
+    for (const key of keys) {
+      const entry = this.active.get(key);
+      if (!entry) {
+        continue;
+      }
+      this.finalizeEntry(key, entry, status, ts, phase);
+    }
+    this.runIndex.delete(runId);
+  }
+
+  private finalizeEntry(
+    key: string,
+    entry: ToolActivityRecord,
+    status: Exclude<ToolActivityStatus, "running">,
+    ts: number,
+    phase: string,
+  ) {
+    const finalized: ToolActivityRecord = {
+      ...entry,
+      status,
+      currentPhase: phase,
+      updatedAt: ts,
+      endedAt: ts,
+    };
+    this.active.delete(key);
+    this.recent.delete(key);
+    this.recent.set(key, finalized);
+    while (this.recent.size > TOOL_ACTIVITY_RECENT_LIMIT) {
+      const oldestKey = this.recent.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.recent.delete(oldestKey);
+    }
+  }
+}

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -30,6 +30,15 @@ async function canonicalPath(p: string): Promise<string> {
   }
 }
 
+function resolveFixtureBaseDir(): string {
+  const tempRoot = path.resolve(os.tmpdir());
+  const workspaceRoot = path.resolve(process.cwd());
+  if (tempRoot === workspaceRoot || tempRoot.startsWith(`${workspaceRoot}${path.sep}`)) {
+    return path.join(path.dirname(workspaceRoot), ".openclaw-test-tmp");
+  }
+  return tempRoot;
+}
+
 describe("control UI assets helpers", () => {
   let fixtureRoot = "";
   let caseId = 0;
@@ -41,7 +50,9 @@ describe("control UI assets helpers", () => {
   }
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
+    const fixtureBaseDir = resolveFixtureBaseDir();
+    await fs.mkdir(fixtureBaseDir, { recursive: true });
+    fixtureRoot = await fs.mkdtemp(path.join(fixtureBaseDir, "openclaw-ui-"));
   });
 
   afterAll(async () => {

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -97,12 +97,15 @@ export async function resolveControlUiDistIndexPath(
   for (let i = 0; i < 8; i++) {
     const pkgJsonPath = path.join(dir, "package.json");
     const indexPath = path.join(dir, "dist", "control-ui", "index.html");
-    if (fs.existsSync(pkgJsonPath) && fs.existsSync(indexPath)) {
+    if (fs.existsSync(pkgJsonPath)) {
       try {
         const raw = fs.readFileSync(pkgJsonPath, "utf-8");
         const parsed = JSON.parse(raw) as { name?: unknown };
         if (parsed.name === "openclaw") {
-          return indexPath;
+          return fs.existsSync(indexPath) ? indexPath : null;
+        }
+        if (typeof parsed.name === "string") {
+          return null;
         }
       } catch {
         // Invalid package.json, continue searching

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -59,7 +59,7 @@ function findPackageRootSync(startDir: string, maxDepth = 12): string | null {
 
 function candidateDirsFromArgv1(argv1: string): string[] {
   const normalized = path.resolve(argv1);
-  const candidates = [path.dirname(normalized)];
+  const candidates: string[] = [];
 
   // Resolve symlinks for version managers (nvm, fnm, n, Homebrew/Linuxbrew)
   // that create symlinks in bin/ pointing to the real package location.
@@ -79,7 +79,11 @@ function candidateDirsFromArgv1(argv1: string): string[] {
     const nodeModulesDir = parts.slice(0, binIndex).join(path.sep);
     candidates.push(path.join(nodeModulesDir, binName));
   }
-  return candidates;
+
+  // Prefer specific package candidates over parent-directory traversal.
+  candidates.push(path.dirname(normalized));
+
+  return Array.from(new Set(candidates.map((candidate) => path.resolve(candidate))));
 }
 
 export async function resolveOpenClawPackageRoot(opts: {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -22,13 +22,24 @@ function createRunner(responses: Record<string, CommandResult>) {
   return { runner, calls };
 }
 
+function resolveFixtureBaseDir(): string {
+  const tempRoot = path.resolve(os.tmpdir());
+  const workspaceRoot = path.resolve(process.cwd());
+  if (tempRoot === workspaceRoot || tempRoot.startsWith(`${workspaceRoot}${path.sep}`)) {
+    return path.join(path.dirname(workspaceRoot), ".openclaw-test-tmp");
+  }
+  return tempRoot;
+}
+
 describe("runGatewayUpdate", () => {
   let fixtureRoot = "";
   let caseId = 0;
   let tempDir: string;
 
   beforeAll(async () => {
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-"));
+    const fixtureBaseDir = resolveFixtureBaseDir();
+    await fs.mkdir(fixtureBaseDir, { recursive: true });
+    fixtureRoot = await fs.mkdtemp(path.join(fixtureBaseDir, "openclaw-update-"));
   });
 
   afterAll(async () => {

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -97,15 +97,21 @@ afterEach(() => {
 
 describe("web media loading", () => {
   beforeAll(() => {
-    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
-      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-      const addresses = ["93.184.216.34"];
-      return {
-        hostname: normalized,
-        addresses,
-        lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses }),
-      };
-    });
+    const realResolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(
+      async (hostname, params) => {
+        const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+        if (normalized !== "example.com") {
+          return await realResolvePinnedHostnameWithPolicy(hostname, params);
+        }
+        const addresses = ["93.184.216.34"];
+        return {
+          hostname: normalized,
+          addresses,
+          lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses }),
+        };
+      },
+    );
   });
 
   it("strips MEDIA: prefix before reading local file", async () => {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -66,6 +66,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
 
   const restore: RestoreEntry[] = [
     { key: "OPENCLAW_TEST_FAST", value: process.env.OPENCLAW_TEST_FAST },
+    { key: "OPENCLAW_HOME", value: process.env.OPENCLAW_HOME },
     { key: "HOME", value: process.env.HOME },
     { key: "USERPROFILE", value: process.env.USERPROFILE },
     { key: "XDG_CONFIG_HOME", value: process.env.XDG_CONFIG_HOME },
@@ -97,6 +98,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   process.env.USERPROFILE = tempHome;
   process.env.OPENCLAW_TEST_HOME = tempHome;
   process.env.OPENCLAW_TEST_FAST = "1";
+  delete process.env.OPENCLAW_HOME;
 
   // Ensure test runs never touch the developer's real config/state, even if they have overrides set.
   delete process.env.OPENCLAW_CONFIG_PATH;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3,3 +3,4 @@
 @import "./styles/layout.mobile.css";
 @import "./styles/components.css";
 @import "./styles/config.css";
+@import "./styles/overview.css";

--- a/ui/src/styles/overview.css
+++ b/ui/src/styles/overview.css
@@ -1,0 +1,591 @@
+.mission-control {
+  display: grid;
+  gap: 18px;
+}
+
+.mission-hero {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at top right,
+      color-mix(in srgb, var(--accent) 18%, transparent) 0%,
+      transparent 45%
+    ),
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--card) 88%, var(--accent) 12%) 0%,
+      var(--card) 65%
+    );
+}
+
+.mission-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(120deg, rgba(255, 255, 255, 0.04), transparent 35%),
+    radial-gradient(circle at bottom left, rgba(255, 255, 255, 0.03), transparent 35%);
+  pointer-events: none;
+}
+
+.mission-hero__grid,
+.mission-hero__main,
+.mission-hero__side,
+.mission-access__summary,
+.mission-access__body,
+.mission-feed,
+.mission-stack,
+.mission-list,
+.mission-subpanel,
+.mission-channel-grid,
+.mission-usage-grid {
+  display: grid;
+}
+
+.mission-hero__grid {
+  position: relative;
+  z-index: 1;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.85fr);
+  gap: 20px;
+}
+
+.mission-hero__main,
+.mission-hero__side,
+.mission-feed,
+.mission-stack,
+.mission-list,
+.mission-subpanel,
+.mission-channel-grid,
+.mission-access__body {
+  gap: 14px;
+}
+
+.mission-hero__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.mission-hero__title {
+  font-size: clamp(30px, 5vw, 46px);
+  font-weight: 800;
+  letter-spacing: -0.05em;
+  line-height: 0.95;
+  color: var(--text-strong);
+}
+
+.mission-hero__copy {
+  max-width: 62ch;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.mission-hero__meta,
+.mission-actions,
+.mission-channel__meta,
+.mission-access__meta,
+.mission-access__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.mission-hero__meta-text {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.mission-hero__side {
+  align-content: start;
+}
+
+.mission-hero__panel {
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  background: color-mix(in srgb, var(--card) 76%, var(--secondary) 24%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.mission-hero__panel-title,
+.mission-kpi__label,
+.mission-usage-stat__label,
+.mission-subpanel__title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.mission-hero__panel-value,
+.mission-kpi__value,
+.mission-usage-stat__value {
+  margin-top: 8px;
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.05em;
+  line-height: 1;
+  color: var(--text-strong);
+}
+
+.mission-hero__panel-copy,
+.mission-kpi__detail,
+.mission-row__detail,
+.mission-feed__detail,
+.mission-channel__detail,
+.mission-inline-note,
+.mission-usage-stat__detail {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.mission-alert-stack,
+.mission-kpis,
+.mission-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.mission-alert {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 14px 16px;
+  background: var(--secondary);
+}
+
+.mission-alert__title,
+.mission-feed__title,
+.mission-row__title,
+.mission-list__title,
+.mission-channel__title {
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+}
+
+.mission-kpis {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.mission-kpi {
+  min-height: 124px;
+}
+
+.mission-grid {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+
+.mission-panel--span-7 {
+  grid-column: span 7;
+}
+
+.mission-panel--span-6 {
+  grid-column: span 6;
+}
+
+.mission-panel--span-5 {
+  grid-column: span 5;
+}
+
+.mission-panel__header,
+.mission-row,
+.mission-list__item,
+.mission-channel__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.mission-panel__header {
+  margin-bottom: 14px;
+}
+
+.mission-panel__meta,
+.mission-row__meta,
+.mission-list__meta,
+.mission-feed__stamp {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.mission-row__body {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.mission-row__meta--stack {
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.mission-actions-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.mission-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  border: 1px solid var(--mission-border, var(--border));
+  background: var(--mission-bg, var(--secondary));
+  color: var(--mission-color, var(--text));
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.mission-tone-ok {
+  --mission-color: var(--ok);
+  --mission-border: color-mix(in srgb, var(--ok) 40%, transparent);
+  --mission-bg: var(--ok-subtle);
+}
+
+.mission-tone-warn {
+  --mission-color: var(--warn);
+  --mission-border: color-mix(in srgb, var(--warn) 40%, transparent);
+  --mission-bg: var(--warn-subtle);
+}
+
+.mission-tone-danger {
+  --mission-color: var(--danger);
+  --mission-border: color-mix(in srgb, var(--danger) 40%, transparent);
+  --mission-bg: var(--danger-subtle);
+}
+
+.mission-tone-info {
+  --mission-color: var(--info);
+  --mission-border: color-mix(in srgb, var(--info) 34%, transparent);
+  --mission-bg: color-mix(in srgb, var(--info) 16%, transparent);
+}
+
+.mission-tone-muted {
+  --mission-color: var(--muted);
+  --mission-border: var(--border);
+  --mission-bg: var(--secondary);
+}
+
+.mission-feed {
+  max-height: 520px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.mission-feed__item,
+.mission-row,
+.mission-inline-note,
+.mission-channel,
+.mission-list__item {
+  border: 1px solid var(--mission-border, var(--border));
+  background: var(--mission-bg, var(--secondary));
+  border-radius: var(--radius-md);
+}
+
+.mission-feed__item,
+.mission-row,
+.mission-inline-note,
+.mission-channel {
+  padding: 12px 14px;
+}
+
+.mission-row,
+.mission-row__meta,
+.mission-list__meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.mission-row--tight {
+  gap: 10px;
+}
+
+.mission-subpanel {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.mission-subpanel:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.mission-list__item {
+  width: 100%;
+  text-align: left;
+  padding: 14px;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.mission-list__item:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.mission-list__main {
+  min-width: 0;
+}
+
+.mission-list__detail,
+.mission-channel__detail,
+.mission-feed__detail {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.mission-channel-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.mission-channel__head {
+  margin-bottom: 10px;
+}
+
+.mission-channel__meta {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--muted);
+  justify-content: space-between;
+}
+
+.mission-usage-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.mission-usage-stat {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  background: var(--secondary);
+}
+
+.mission-trend-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.mission-trend {
+  display: grid;
+  gap: 12px;
+  border: 1px solid var(--mission-border, var(--border));
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  background: var(--mission-bg, var(--secondary));
+}
+
+.mission-trend__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.mission-trend__label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.mission-trend__detail,
+.mission-trend__empty {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.mission-trend__value {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: var(--text-strong);
+}
+
+.mission-trend__sparkline {
+  width: 100%;
+  height: 56px;
+  display: block;
+}
+
+.mission-trend__area {
+  fill: color-mix(in srgb, var(--mission-color, var(--accent)) 18%, transparent);
+}
+
+.mission-trend__line {
+  fill: none;
+  stroke: var(--mission-color, var(--accent));
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.mission-inline-note {
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.mission-inline-pre {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--mission-border, var(--border)) 90%, transparent);
+  background: color-mix(in srgb, var(--bg) 86%, var(--secondary) 14%);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.mission-context-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mission-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 72%, var(--secondary) 28%);
+  color: var(--text);
+  font-size: 11px;
+}
+
+.mission-context-chip__label {
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+
+.mission-empty {
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 14px;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--secondary) 80%, transparent);
+}
+
+.mission-access {
+  display: grid;
+  gap: 12px;
+}
+
+.mission-access__summary {
+  grid-template-columns: minmax(0, 1fr) auto;
+  cursor: pointer;
+  list-style: none;
+}
+
+.mission-access__summary::-webkit-details-marker {
+  display: none;
+}
+
+.mission-access__body {
+  gap: 16px;
+}
+
+.mission-access__footer {
+  justify-content: space-between;
+}
+
+.mission-access__hint {
+  margin-top: 10px;
+}
+
+.mission-access__docs {
+  margin-top: 8px;
+}
+
+@media (max-width: 1280px) {
+  .mission-hero__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mission-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mission-panel--span-7,
+  .mission-panel--span-6,
+  .mission-panel--span-5 {
+    grid-column: span 1;
+  }
+}
+
+@media (max-width: 820px) {
+  .mission-kpis,
+  .mission-grid,
+  .mission-usage-grid,
+  .mission-channel-grid,
+  .mission-trend-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mission-panel__header,
+  .mission-row,
+  .mission-list__item,
+  .mission-access__summary,
+  .mission-access__footer {
+    flex-direction: column;
+  }
+
+  .mission-access__summary {
+    display: flex;
+  }
+
+  .mission-list__meta,
+  .mission-row__meta {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 600px) {
+  .mission-hero__title {
+    font-size: 30px;
+  }
+
+  .mission-hero__meta,
+  .mission-actions,
+  .mission-channel__meta {
+    gap: 8px;
+  }
+
+  .mission-hero__panel,
+  .mission-alert,
+  .mission-feed__item,
+  .mission-row,
+  .mission-channel,
+  .mission-list__item,
+  .mission-usage-stat {
+    padding: 12px;
+  }
+}

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { connectGateway } from "./app-gateway.ts";
 
 type GatewayClientMock = {
@@ -9,7 +9,11 @@ type GatewayClientMock = {
   emitEvent: (evt: { event: string; payload?: unknown; seq?: number }) => void;
 };
 
-const gatewayClientInstances: GatewayClientMock[] = [];
+const gatewayClientInstances = vi.hoisted(() => [] as GatewayClientMock[]);
+const loadDashboardSummaryMock = vi.hoisted(() => vi.fn());
+const captureDashboardTimelineMock = vi.hoisted(() => vi.fn());
+const handleAgentEventMock = vi.hoisted(() => vi.fn());
+const resumeMissionNodeRunMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./gateway.ts", () => {
   class GatewayBrowserClient {
@@ -41,6 +45,37 @@ vi.mock("./gateway.ts", () => {
 
   return { GatewayBrowserClient };
 });
+
+vi.mock("./controllers/dashboard.ts", () => ({
+  loadDashboardSummary: loadDashboardSummaryMock,
+  applyDashboardSummary: (
+    state: {
+      dashboardSummary: unknown;
+      dashboardError: string | null;
+      execApprovalQueue: unknown[];
+    },
+    summary: { approvals?: { pending?: unknown[] } },
+  ) => {
+    state.dashboardSummary = summary;
+    state.dashboardError = null;
+    if (Array.isArray(summary.approvals?.pending)) {
+      state.execApprovalQueue = summary.approvals.pending;
+    }
+  },
+}));
+
+vi.mock("./controllers/dashboard-timeline.ts", () => ({
+  captureDashboardTimeline: captureDashboardTimelineMock,
+}));
+
+vi.mock("./app-tool-stream.ts", () => ({
+  handleAgentEvent: handleAgentEventMock,
+  resetToolStream: vi.fn(),
+}));
+
+vi.mock("./controllers/mission-control.ts", () => ({
+  resumeMissionNodeRun: resumeMissionNodeRunMock,
+}));
 
 function createHost() {
   return {
@@ -77,14 +112,29 @@ function createHost() {
     sessionKey: "main",
     chatRunId: null,
     refreshSessionsAfterChat: new Set<string>(),
+    dashboardSummary: null,
+    dashboardError: null,
+    dashboardTimeline: [],
     execApprovalQueue: [],
     execApprovalError: null,
+    missionNodePendingRuns: {},
+    missionNodeBusyById: {},
+    missionNodeResult: null,
   } as unknown as Parameters<typeof connectGateway>[0];
 }
 
 describe("connectGateway", () => {
   beforeEach(() => {
     gatewayClientInstances.length = 0;
+    loadDashboardSummaryMock.mockReset();
+    captureDashboardTimelineMock.mockReset();
+    handleAgentEventMock.mockReset();
+    resumeMissionNodeRunMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("ignores stale client onGap callbacks after reconnect", () => {
@@ -142,5 +192,150 @@ describe("connectGateway", () => {
 
     secondClient.emitClose(1005);
     expect(host.lastError).toBe("disconnected (1005): no reason");
+  });
+
+  it("applies dashboard delta payload immediately", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+    host.connected = true;
+
+    client.emitEvent({
+      event: "dashboard.delta",
+      payload: {
+        ts: Date.now(),
+        security: {
+          ts: Date.now(),
+          cached: true,
+          summary: { critical: 1, warn: 2, info: 0 },
+          topFindings: [],
+        },
+        approvals: {
+          count: 1,
+          pending: [
+            {
+              id: "approval-1",
+              request: {
+                command: "git pull",
+                agentId: "main",
+                sessionKey: "main",
+              },
+              expiresAtMs: Date.now() + 60_000,
+            },
+          ],
+        },
+        devices: { pending: 2, paired: 3 },
+        nodes: { count: 4, hasMobileNodeConnected: true },
+        runtime: { queueSize: 5, pendingReplies: 1, activeEmbeddedRuns: 2 },
+      },
+    });
+
+    expect((host as unknown as { dashboardSummary: unknown }).dashboardSummary).toEqual(
+      expect.objectContaining({
+        runtime: { queueSize: 5, pendingReplies: 1, activeEmbeddedRuns: 2 },
+      }),
+    );
+    expect(host.execApprovalQueue).toHaveLength(1);
+    expect(loadDashboardSummaryMock).not.toHaveBeenCalled();
+    expect(captureDashboardTimelineMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refetch dashboard summary for operator delta events", async () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+    host.connected = true;
+
+    client.emitEvent({
+      event: "exec.approval.requested",
+      payload: {
+        id: "approval-1",
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + 60_000,
+        request: {
+          command: "git pull",
+          agentId: "main",
+          sessionKey: "main",
+        },
+      },
+    });
+    client.emitEvent({
+      event: "device.pair.requested",
+      payload: {
+        requestId: "pair-1",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(900);
+
+    expect(loadDashboardSummaryMock).not.toHaveBeenCalled();
+  });
+
+  it("throttles dashboard summary refresh after lifecycle events", async () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+    host.connected = true;
+
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        stream: "lifecycle",
+        data: { phase: "start" },
+      },
+    });
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        stream: "lifecycle",
+        data: { phase: "end" },
+      },
+    });
+
+    expect(loadDashboardSummaryMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(900);
+
+    expect(loadDashboardSummaryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes pending mission node runs after approval resolution", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    host.execApprovalQueue = [
+      {
+        id: "approval-1",
+        request: {
+          command: "openclaw doctor --non-interactive",
+          agentId: "main",
+          sessionKey: "main",
+        },
+        expiresAtMs: Date.now() + 60_000,
+      },
+    ] as typeof host.execApprovalQueue;
+
+    client.emitEvent({
+      event: "exec.approval.resolved",
+      payload: {
+        id: "approval-1",
+        decision: "allow-once",
+      },
+    });
+
+    expect(host.execApprovalQueue).toHaveLength(0);
+    expect(resumeMissionNodeRunMock).toHaveBeenCalledTimes(1);
+    expect(resumeMissionNodeRunMock).toHaveBeenCalledWith(host, "approval-1", "allow-once");
   });
 });

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -17,6 +17,9 @@ import { loadAgents } from "./controllers/agents.ts";
 import { loadAssistantIdentity } from "./controllers/assistant-identity.ts";
 import { loadChatHistory } from "./controllers/chat.ts";
 import { handleChatEvent, type ChatEventPayload } from "./controllers/chat.ts";
+import { loadCronJobs, loadCronStatus } from "./controllers/cron.ts";
+import { captureDashboardTimeline } from "./controllers/dashboard-timeline.ts";
+import { applyDashboardSummary, loadDashboardSummary } from "./controllers/dashboard.ts";
 import { loadDevices } from "./controllers/devices.ts";
 import {
   addExecApproval,
@@ -24,6 +27,7 @@ import {
   parseExecApprovalResolved,
   removeExecApproval,
 } from "./controllers/exec-approval.ts";
+import { resumeMissionNodeRun } from "./controllers/mission-control.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { GatewayBrowserClient } from "./gateway.ts";
@@ -54,6 +58,15 @@ type GatewayHost = {
   refreshSessionsAfterChat: Set<string>;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
+  missionNodePendingRuns: Record<
+    string,
+    import("./controllers/mission-control.ts").PendingMissionNodeRun
+  >;
+  missionNodeBusyById: Record<
+    string,
+    import("./controllers/mission-control.ts").MissionNodeActionKind | "approval" | null
+  >;
+  missionNodeResult: import("./controllers/mission-control.ts").MissionNodeActionResult | null;
 };
 
 type SessionDefaultsSnapshot = {
@@ -62,6 +75,36 @@ type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
   scope?: string;
 };
+
+const dashboardRefreshTimers = new WeakMap<GatewayHost, number>();
+
+function shouldRefreshDashboardSummary(evt: GatewayEventFrame): boolean {
+  if (evt.event === "chat") {
+    const payload = evt.payload as { state?: string } | undefined;
+    return payload?.state === "final" || payload?.state === "error" || payload?.state === "aborted";
+  }
+  if (evt.event === "agent") {
+    const payload = evt.payload as { stream?: string; data?: { phase?: string } } | undefined;
+    return (
+      payload?.stream === "lifecycle" &&
+      (payload.data?.phase === "start" ||
+        payload.data?.phase === "end" ||
+        payload.data?.phase === "error")
+    );
+  }
+  return false;
+}
+
+function scheduleDashboardSummaryRefresh(host: GatewayHost, delayMs = 900) {
+  if (!host.connected || dashboardRefreshTimers.has(host)) {
+    return;
+  }
+  const timer = window.setTimeout(() => {
+    dashboardRefreshTimers.delete(host);
+    void loadDashboardSummary(host as unknown as OpenClawApp, { quiet: true });
+  }, delayMs);
+  dashboardRefreshTimers.set(host, timer);
+}
 
 function normalizeSessionKeyForDefaults(
   value: string | undefined,
@@ -147,6 +190,7 @@ export function connectGateway(host: GatewayHost) {
       void loadAgents(host as unknown as OpenClawApp);
       void loadNodes(host as unknown as OpenClawApp, { quiet: true });
       void loadDevices(host as unknown as OpenClawApp, { quiet: true });
+      void loadDashboardSummary(host as unknown as OpenClawApp, { quiet: true });
       void refreshActiveTab(host as unknown as Parameters<typeof refreshActiveTab>[0]);
     },
     onClose: ({ code, reason }) => {
@@ -190,8 +234,19 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     { ts: Date.now(), event: evt.event, payload: evt.payload },
     ...host.eventLogBuffer,
   ].slice(0, 250);
-  if (host.tab === "debug") {
-    host.eventLog = host.eventLogBuffer;
+  host.eventLog = host.eventLogBuffer;
+
+  if (evt.event === "dashboard.delta") {
+    applyDashboardSummary(
+      host as unknown as Parameters<typeof applyDashboardSummary>[0],
+      evt.payload as Parameters<typeof applyDashboardSummary>[1],
+    );
+    captureDashboardTimeline(host as unknown as Parameters<typeof captureDashboardTimeline>[0]);
+    return;
+  }
+
+  if (shouldRefreshDashboardSummary(evt)) {
+    scheduleDashboardSummaryRefresh(host);
   }
 
   if (evt.event === "agent") {
@@ -243,8 +298,15 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     return;
   }
 
-  if (evt.event === "cron" && host.tab === "cron") {
-    void loadCron(host as unknown as Parameters<typeof loadCron>[0]);
+  if (evt.event === "cron") {
+    if (host.tab === "cron") {
+      void loadCron(host as unknown as Parameters<typeof loadCron>[0]);
+    } else if (host.tab === "overview") {
+      void Promise.all([
+        loadCronJobs(host as unknown as OpenClawApp),
+        loadCronStatus(host as unknown as OpenClawApp),
+      ]);
+    }
   }
 
   if (evt.event === "device.pair.requested" || evt.event === "device.pair.resolved") {
@@ -268,6 +330,17 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     const resolved = parseExecApprovalResolved(evt.payload);
     if (resolved) {
       host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, resolved.id);
+      if (
+        resolved.decision === "allow-once" ||
+        resolved.decision === "allow-always" ||
+        resolved.decision === "deny"
+      ) {
+        void resumeMissionNodeRun(
+          host as unknown as Parameters<typeof resumeMissionNodeRun>[0],
+          resolved.id,
+          resolved.decision,
+        );
+      }
     }
   }
 }

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -1,6 +1,8 @@
 import type { Tab } from "./navigation.ts";
 import { connectGateway } from "./app-gateway.ts";
 import {
+  startOverviewPolling,
+  stopOverviewPolling,
   startLogsPolling,
   startNodesPolling,
   stopLogsPolling,
@@ -30,6 +32,8 @@ type LifecycleHost = {
   logsAutoFollow: boolean;
   logsAtBottom: boolean;
   logsEntries: unknown[];
+  overviewFastPollInterval: number | null;
+  overviewSlowPollInterval: number | null;
   popStateHandler: () => void;
   topbarObserver: ResizeObserver | null;
 };
@@ -43,6 +47,9 @@ export function handleConnected(host: LifecycleHost) {
   window.addEventListener("popstate", host.popStateHandler);
   connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
   startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
+  if (host.tab === "overview") {
+    startOverviewPolling(host as unknown as Parameters<typeof startOverviewPolling>[0]);
+  }
   if (host.tab === "logs") {
     startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
   }
@@ -58,6 +65,7 @@ export function handleFirstUpdated(host: LifecycleHost) {
 export function handleDisconnected(host: LifecycleHost) {
   window.removeEventListener("popstate", host.popStateHandler);
   stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);
+  stopOverviewPolling(host as unknown as Parameters<typeof stopOverviewPolling>[0]);
   stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
   stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);
   detachThemeListener(host as unknown as Parameters<typeof detachThemeListener>[0]);

--- a/ui/src/ui/app-polling.ts
+++ b/ui/src/ui/app-polling.ts
@@ -1,10 +1,21 @@
 import type { OpenClawApp } from "./app.ts";
+import { loadChannels } from "./controllers/channels.ts";
+import { loadCronJobs, loadCronStatus } from "./controllers/cron.ts";
+import { captureDashboardTimeline } from "./controllers/dashboard-timeline.ts";
+import { loadDashboardSummary } from "./controllers/dashboard.ts";
 import { loadDebug } from "./controllers/debug.ts";
+import { loadDevices } from "./controllers/devices.ts";
 import { loadLogs } from "./controllers/logs.ts";
 import { loadNodes } from "./controllers/nodes.ts";
+import { loadPresence } from "./controllers/presence.ts";
+import { loadSessions } from "./controllers/sessions.ts";
+import { loadUsage } from "./controllers/usage.ts";
 
 type PollingHost = {
   nodesPollInterval: number | null;
+  overviewFastPollInterval: number | null;
+  overviewSlowPollInterval: number | null;
+  dashboardTimelinePollInterval: number | null;
   logsPollInterval: number | null;
   debugPollInterval: number | null;
   tab: string;
@@ -26,6 +37,61 @@ export function stopNodesPolling(host: PollingHost) {
   }
   clearInterval(host.nodesPollInterval);
   host.nodesPollInterval = null;
+}
+
+export function startOverviewPolling(host: PollingHost) {
+  if (
+    host.overviewFastPollInterval != null ||
+    host.overviewSlowPollInterval != null ||
+    host.dashboardTimelinePollInterval != null
+  ) {
+    return;
+  }
+  host.overviewFastPollInterval = window.setInterval(() => {
+    if (host.tab !== "overview") {
+      return;
+    }
+    void Promise.all([
+      loadChannels(host as unknown as OpenClawApp, false),
+      loadPresence(host as unknown as OpenClawApp),
+      loadSessions(host as unknown as OpenClawApp),
+      loadCronStatus(host as unknown as OpenClawApp),
+      loadDebug(host as unknown as OpenClawApp, { probe: false, includeModels: false }),
+      loadLogs(host as unknown as OpenClawApp, { quiet: true }),
+    ]);
+  }, 5000);
+  host.dashboardTimelinePollInterval = window.setInterval(() => {
+    if (host.tab !== "overview") {
+      return;
+    }
+    captureDashboardTimeline(host as unknown as OpenClawApp);
+  }, 15000);
+  host.overviewSlowPollInterval = window.setInterval(() => {
+    if (host.tab !== "overview") {
+      return;
+    }
+    void Promise.all([
+      loadCronJobs(host as unknown as OpenClawApp),
+      loadDashboardSummary(host as unknown as OpenClawApp, { quiet: true }),
+      loadUsage(host as unknown as OpenClawApp),
+      loadDevices(host as unknown as OpenClawApp, { quiet: true }),
+    ]);
+  }, 60000);
+}
+
+export function stopOverviewPolling(host: PollingHost) {
+  if (host.overviewFastPollInterval != null) {
+    clearInterval(host.overviewFastPollInterval);
+    host.overviewFastPollInterval = null;
+  }
+  if (host.overviewSlowPollInterval != null) {
+    clearInterval(host.overviewSlowPollInterval);
+    host.overviewSlowPollInterval = null;
+  }
+  if (host.dashboardTimelinePollInterval != null) {
+    clearInterval(host.dashboardTimelinePollInterval);
+    host.dashboardTimelinePollInterval = null;
+  }
 }
 
 export function startLogsPolling(host: PollingHost) {

--- a/ui/src/ui/app-polling.ts
+++ b/ui/src/ui/app-polling.ts
@@ -56,6 +56,7 @@ export function startOverviewPolling(host: PollingHost) {
       loadPresence(host as unknown as OpenClawApp),
       loadSessions(host as unknown as OpenClawApp),
       loadCronStatus(host as unknown as OpenClawApp),
+      loadDashboardSummary(host as unknown as OpenClawApp, { quiet: true }),
       loadDebug(host as unknown as OpenClawApp, { probe: false, includeModels: false }),
       loadLogs(host as unknown as OpenClawApp, { quiet: true }),
     ]);
@@ -72,7 +73,6 @@ export function startOverviewPolling(host: PollingHost) {
     }
     void Promise.all([
       loadCronJobs(host as unknown as OpenClawApp),
-      loadDashboardSummary(host as unknown as OpenClawApp, { quiet: true }),
       loadUsage(host as unknown as OpenClawApp),
       loadDevices(host as unknown as OpenClawApp, { quiet: true }),
     ]);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -25,6 +25,11 @@ import {
   removeCronJob,
   addCronJob,
 } from "./controllers/cron.ts";
+import {
+  ackDashboardIncident,
+  loadDashboardSummary,
+  resolveDashboardIncident,
+} from "./controllers/dashboard.ts";
 import { loadDebug, callDebugMethod } from "./controllers/debug.ts";
 import {
   approveDevicePairing,
@@ -33,6 +38,7 @@ import {
   revokeDeviceToken,
   rotateDeviceToken,
 } from "./controllers/devices.ts";
+import { resolveExecApproval } from "./controllers/exec-approval.ts";
 import {
   loadExecApprovals,
   removeExecApprovalsFormValue,
@@ -40,6 +46,11 @@ import {
   updateExecApprovalsFormValue,
 } from "./controllers/exec-approvals.ts";
 import { loadLogs } from "./controllers/logs.ts";
+import {
+  describeMissionNode,
+  probeMissionNode,
+  runMissionNodeDoctor,
+} from "./controllers/mission-control.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import { deleteSession, loadSessions, patchSession } from "./controllers/sessions.ts";
@@ -87,9 +98,6 @@ function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
 }
 
 export function renderApp(state: AppViewState) {
-  const presenceCount = state.presenceEntries.length;
-  const sessionsCount = state.sessionsResult?.count ?? null;
-  const cronNext = state.cronStatus?.nextWakeAtMs ?? null;
   const chatDisabledReason = state.connected ? null : "Disconnected from gateway.";
   const isChat = state.tab === "chat";
   const chatFocus = isChat && (state.settings.chatFocusMode || state.onboarding);
@@ -205,11 +213,43 @@ export function renderApp(state: AppViewState) {
                 settings: state.settings,
                 password: state.password,
                 lastError: state.lastError,
-                presenceCount,
-                sessionsCount,
-                cronEnabled: state.cronStatus?.enabled ?? null,
-                cronNext,
+                presenceEntries: state.presenceEntries,
+                presenceError: state.presenceError,
+                presenceStatus: state.presenceStatus,
+                sessionsResult: state.sessionsResult,
+                sessionsError: state.sessionsError,
+                cronStatus: state.cronStatus,
+                cronJobs: state.cronJobs,
+                cronError: state.cronError,
+                channelsSnapshot: state.channelsSnapshot,
+                channelsError: state.channelsError,
                 lastChannelsRefresh: state.channelsLastSuccess,
+                debugStatus: state.debugStatus,
+                debugHealth: state.debugHealth,
+                debugHeartbeat: state.debugHeartbeat,
+                logsEntries: state.logsEntries,
+                logsError: state.logsError,
+                logsLastFetchAt: state.logsLastFetchAt,
+                usageResult: state.usageResult,
+                usageCostSummary: state.usageCostSummary,
+                usageError: state.usageError,
+                usageStartDate: state.usageStartDate,
+                usageEndDate: state.usageEndDate,
+                devicesList: state.devicesList,
+                devicesError: state.devicesError,
+                devicesLoading: state.devicesLoading,
+                dashboardSummary: state.dashboardSummary,
+                dashboardError: state.dashboardError,
+                dashboardLoading: state.dashboardLoading,
+                dashboardTimeline: state.dashboardTimeline,
+                nodes: state.nodes,
+                missionNodeBusyById: state.missionNodeBusyById,
+                missionNodeResult: state.missionNodeResult,
+                execApprovalQueue: state.execApprovalQueue,
+                execApprovalBusy: state.execApprovalBusy,
+                cronBusy: state.cronBusy,
+                nodesCount: state.nodes.length,
+                eventLog: state.eventLog,
                 onSettingsChange: (next) => state.applySettings(next),
                 onPasswordChange: (next) => (state.password = next),
                 onSessionKeyChange: (next) => {
@@ -223,8 +263,98 @@ export function renderApp(state: AppViewState) {
                   });
                   void state.loadAssistantIdentity();
                 },
+                onNavigate: (tab) => state.setTab(tab),
+                onOpenSession: (next) => {
+                  state.sessionKey = next;
+                  state.chatMessage = "";
+                  state.chatAttachments = [];
+                  state.chatStream = null;
+                  state.chatStreamStartedAt = null;
+                  state.chatRunId = null;
+                  state.chatQueue = [];
+                  state.resetToolStream();
+                  state.resetChatScroll();
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: next,
+                    lastActiveSessionKey: next,
+                  });
+                  void state.loadAssistantIdentity();
+                  void loadChatHistory(state);
+                  void refreshChatAvatar(state);
+                  state.setTab("chat");
+                },
                 onConnect: () => state.connect(),
                 onRefresh: () => state.loadOverview(),
+                onResolveExecApproval: async (id, decision) => {
+                  const changed = await resolveExecApproval(state, id, decision);
+                  if (!changed) {
+                    return;
+                  }
+                  await loadDashboardSummary(state, { quiet: true });
+                },
+                onApproveDevice: async (requestId) => {
+                  await approveDevicePairing(state, requestId);
+                  await loadDashboardSummary(state, { quiet: true });
+                },
+                onRejectDevice: async (requestId) => {
+                  await rejectDevicePairing(state, requestId);
+                  await loadDashboardSummary(state, { quiet: true });
+                },
+                onRunCronJob: async (jobId) => {
+                  const job = state.cronJobs.find((entry) => entry.id === jobId);
+                  if (!job) {
+                    return;
+                  }
+                  await runCronJob(state, job);
+                  await Promise.all([
+                    loadDashboardSummary(state, { quiet: true }),
+                    loadLogs(state, { quiet: true }),
+                  ]);
+                },
+                onRefreshSecurityAudit: () => loadDashboardSummary(state, { forceAudit: true }),
+                onAckIncident: (incidentId) => ackDashboardIncident(state, incidentId),
+                onResolveIncident: (incidentId) => resolveDashboardIncident(state, incidentId),
+                onDescribeNode: async (nodeId) => {
+                  const node = state.nodes.find((entry) => entry.nodeId === nodeId);
+                  if (!node) {
+                    return;
+                  }
+                  await describeMissionNode(state, node);
+                },
+                onProbeNode: async (nodeId) => {
+                  const node = state.nodes.find((entry) => entry.nodeId === nodeId);
+                  if (!node) {
+                    return;
+                  }
+                  await probeMissionNode(state, node);
+                },
+                onRunNodeDoctor: async (nodeId) => {
+                  const node = state.nodes.find((entry) => entry.nodeId === nodeId);
+                  if (!node) {
+                    return;
+                  }
+                  await runMissionNodeDoctor(state, node);
+                },
+                onOpenLogsQuery: async (query) => {
+                  state.logsFilterText = query;
+                  state.logsAtBottom = true;
+                  state.setTab("logs");
+                  await loadLogs(state, { reset: true });
+                },
+                onFocusAgent: (agentId) => {
+                  state.agentsSelectedId = agentId;
+                  state.agentsPanel = "overview";
+                  state.setTab("agents");
+                },
+                onFocusChannel: (channelId) => {
+                  state.channelsFocusId = channelId;
+                  state.setTab("channels");
+                },
+                onFocusNode: (nodeId) => {
+                  state.nodesFocusId = nodeId;
+                  state.setTab("nodes");
+                },
               })
             : nothing
         }
@@ -237,6 +367,7 @@ export function renderApp(state: AppViewState) {
                 snapshot: state.channelsSnapshot,
                 lastError: state.channelsError,
                 lastSuccessAt: state.channelsLastSuccess,
+                focusChannelId: state.channelsFocusId,
                 whatsappMessage: state.whatsappLoginMessage,
                 whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
                 whatsappConnected: state.whatsappLoginConnected,
@@ -706,6 +837,7 @@ export function renderApp(state: AppViewState) {
             ? renderNodes({
                 loading: state.nodesLoading,
                 nodes: state.nodes,
+                focusNodeId: state.nodesFocusId,
                 devicesLoading: state.devicesLoading,
                 devicesError: state.devicesError,
                 devicesList: state.devicesList,

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -5,6 +5,9 @@ import { setTabFromRoute } from "./app-settings.ts";
 type SettingsHost = Parameters<typeof setTabFromRoute>[0] & {
   logsPollInterval: number | null;
   debugPollInterval: number | null;
+  overviewFastPollInterval: number | null;
+  overviewSlowPollInterval: number | null;
+  dashboardTimelinePollInterval: number | null;
 };
 
 const createHost = (tab: Tab): SettingsHost => ({
@@ -35,6 +38,9 @@ const createHost = (tab: Tab): SettingsHost => ({
   themeMediaHandler: null,
   logsPollInterval: null,
   debugPollInterval: null,
+  overviewFastPollInterval: null,
+  overviewSlowPollInterval: null,
+  dashboardTimelinePollInterval: null,
 });
 
 describe("setTabFromRoute", () => {
@@ -66,5 +72,19 @@ describe("setTabFromRoute", () => {
 
     setTabFromRoute(host, "chat");
     expect(host.debugPollInterval).toBeNull();
+  });
+
+  it("starts and stops overview polling based on the tab", () => {
+    const host = createHost("chat");
+
+    setTabFromRoute(host, "overview");
+    expect(host.overviewFastPollInterval).not.toBeNull();
+    expect(host.overviewSlowPollInterval).not.toBeNull();
+    expect(host.dashboardTimelinePollInterval).not.toBeNull();
+
+    setTabFromRoute(host, "chat");
+    expect(host.overviewFastPollInterval).toBeNull();
+    expect(host.overviewSlowPollInterval).toBeNull();
+    expect(host.dashboardTimelinePollInterval).toBeNull();
   });
 });

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -2,6 +2,8 @@ import type { OpenClawApp } from "./app.ts";
 import type { AgentsListResult } from "./types.ts";
 import { refreshChat } from "./app-chat.ts";
 import {
+  startOverviewPolling,
+  stopOverviewPolling,
   startLogsPolling,
   stopLogsPolling,
   startDebugPolling,
@@ -14,6 +16,8 @@ import { loadAgents } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
 import { loadConfig, loadConfigSchema } from "./controllers/config.ts";
 import { loadCronJobs, loadCronStatus } from "./controllers/cron.ts";
+import { captureDashboardTimeline } from "./controllers/dashboard-timeline.ts";
+import { loadDashboardSummary } from "./controllers/dashboard.ts";
 import { loadDebug } from "./controllers/debug.ts";
 import { loadDevices } from "./controllers/devices.ts";
 import { loadExecApprovals } from "./controllers/exec-approvals.ts";
@@ -22,6 +26,7 @@ import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { loadSkills } from "./controllers/skills.ts";
+import { loadUsage } from "./controllers/usage.ts";
 import {
   inferBasePathFromPathname,
   normalizeBasePath,
@@ -48,6 +53,11 @@ type SettingsHost = {
   eventLog: unknown[];
   eventLogBuffer: unknown[];
   basePath: string;
+  overviewFastPollInterval: number | null;
+  overviewSlowPollInterval: number | null;
+  dashboardLoading?: boolean;
+  dashboardSummary?: unknown;
+  dashboardError?: string | null;
   agentsList?: AgentsListResult | null;
   agentsSelectedId?: string | null;
   agentsPanel?: "overview" | "files" | "tools" | "skills" | "channels" | "cron";
@@ -154,6 +164,11 @@ export function setTab(host: SettingsHost, next: Tab) {
     startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
   } else {
     stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
+  }
+  if (next === "overview") {
+    startOverviewPolling(host as unknown as Parameters<typeof startOverviewPolling>[0]);
+  } else {
+    stopOverviewPolling(host as unknown as Parameters<typeof stopOverviewPolling>[0]);
   }
   if (next === "debug") {
     startDebugPolling(host as unknown as Parameters<typeof startDebugPolling>[0]);
@@ -354,6 +369,11 @@ export function setTabFromRoute(host: SettingsHost, next: Tab) {
   } else {
     stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
   }
+  if (next === "overview") {
+    startOverviewPolling(host as unknown as Parameters<typeof startOverviewPolling>[0]);
+  } else {
+    stopOverviewPolling(host as unknown as Parameters<typeof stopOverviewPolling>[0]);
+  }
   if (next === "debug") {
     startDebugPolling(host as unknown as Parameters<typeof startDebugPolling>[0]);
   } else {
@@ -408,8 +428,15 @@ export async function loadOverview(host: SettingsHost) {
     loadPresence(host as unknown as OpenClawApp),
     loadSessions(host as unknown as OpenClawApp),
     loadCronStatus(host as unknown as OpenClawApp),
-    loadDebug(host as unknown as OpenClawApp),
+    loadCronJobs(host as unknown as OpenClawApp),
+    loadDebug(host as unknown as OpenClawApp, { probe: false, includeModels: false }),
+    loadDashboardSummary(host as unknown as OpenClawApp, { quiet: true }),
+    loadLogs(host as unknown as OpenClawApp, { quiet: true }),
+    loadUsage(host as unknown as OpenClawApp),
+    loadNodes(host as unknown as OpenClawApp, { quiet: true }),
+    loadDevices(host as unknown as OpenClawApp, { quiet: true }),
   ]);
+  captureDashboardTimeline(host as unknown as OpenClawApp);
 }
 
 export async function loadChannelsTab(host: SettingsHost) {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,8 +1,15 @@
 import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus } from "./app-tool-stream.ts";
+import type { DashboardTimelinePoint } from "./controllers/dashboard-timeline.ts";
+import type { DashboardSummaryResult } from "./controllers/dashboard.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import type {
+  MissionNodeActionKind,
+  MissionNodeActionResult,
+  PendingMissionNodeRun,
+} from "./controllers/mission-control.ts";
 import type { SkillMessage } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
@@ -67,6 +74,7 @@ export type AppViewState = {
   chatManualRefreshInFlight: boolean;
   nodesLoading: boolean;
   nodes: Array<Record<string, unknown>>;
+  nodesFocusId: string | null;
   chatNewMessagesBelow: boolean;
   sidebarOpen: boolean;
   sidebarContent: string | null;
@@ -76,6 +84,13 @@ export type AppViewState = {
   devicesLoading: boolean;
   devicesError: string | null;
   devicesList: DevicePairingList | null;
+  dashboardLoading: boolean;
+  dashboardSummary: DashboardSummaryResult | null;
+  dashboardError: string | null;
+  dashboardTimeline: DashboardTimelinePoint[];
+  missionNodeBusyById: Record<string, MissionNodeActionKind | "approval" | null>;
+  missionNodeResult: MissionNodeActionResult | null;
+  missionNodePendingRuns: Record<string, PendingMissionNodeRun>;
   execApprovalsLoading: boolean;
   execApprovalsSaving: boolean;
   execApprovalsDirty: boolean;
@@ -112,6 +127,7 @@ export type AppViewState = {
   channelsSnapshot: ChannelsStatusSnapshot | null;
   channelsError: string | null;
   channelsLastSuccess: number | null;
+  channelsFocusId: string | null;
   whatsappLoginMessage: string | null;
   whatsappLoginQrDataUrl: string | null;
   whatsappLoginConnected: boolean | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -2,9 +2,15 @@ import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { EventLogEntry } from "./app-events.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import type { DashboardTimelinePoint } from "./controllers/dashboard-timeline.ts";
+import type { DashboardSummaryResult } from "./controllers/dashboard.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
-import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import type {
+  MissionNodeActionKind,
+  MissionNodeActionResult,
+  PendingMissionNodeRun,
+} from "./controllers/mission-control.ts";
 import type { SkillMessage } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
@@ -78,6 +84,7 @@ import {
 } from "./app-tool-stream.ts";
 import { resolveInjectedAssistantIdentity } from "./assistant-identity.ts";
 import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity.ts";
+import { resolveExecApproval, type ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
 import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./ui-types.ts";
 
@@ -145,9 +152,17 @@ export class OpenClawApp extends LitElement {
 
   @state() nodesLoading = false;
   @state() nodes: Array<Record<string, unknown>> = [];
+  @state() nodesFocusId: string | null = null;
   @state() devicesLoading = false;
   @state() devicesError: string | null = null;
   @state() devicesList: DevicePairingList | null = null;
+  @state() dashboardLoading = false;
+  @state() dashboardSummary: DashboardSummaryResult | null = null;
+  @state() dashboardError: string | null = null;
+  @state() dashboardTimeline: DashboardTimelinePoint[] = [];
+  @state() missionNodeBusyById: Record<string, MissionNodeActionKind | "approval" | null> = {};
+  @state() missionNodeResult: MissionNodeActionResult | null = null;
+  @state() missionNodePendingRuns: Record<string, PendingMissionNodeRun> = {};
   @state() execApprovalsLoading = false;
   @state() execApprovalsSaving = false;
   @state() execApprovalsDirty = false;
@@ -187,6 +202,7 @@ export class OpenClawApp extends LitElement {
   @state() channelsSnapshot: ChannelsStatusSnapshot | null = null;
   @state() channelsError: string | null = null;
   @state() channelsLastSuccess: number | null = null;
+  @state() channelsFocusId: string | null = null;
   @state() whatsappLoginMessage: string | null = null;
   @state() whatsappLoginQrDataUrl: string | null = null;
   @state() whatsappLoginConnected: boolean | null = null;
@@ -289,6 +305,7 @@ export class OpenClawApp extends LitElement {
   @state() cronRunsJobId: string | null = null;
   @state() cronRuns: CronRunLogEntry[] = [];
   @state() cronBusy = false;
+  dashboardTimelinePollInterval: number | null = null;
 
   @state() skillsLoading = false;
   @state() skillsReport: SkillStatusReport | null = null;
@@ -331,6 +348,8 @@ export class OpenClawApp extends LitElement {
   private chatUserNearBottom = true;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
+  private overviewFastPollInterval: number | null = null;
+  private overviewSlowPollInterval: number | null = null;
   private logsPollInterval: number | null = null;
   private debugPollInterval: number | null = null;
   private logsScrollFrame: number | null = null;
@@ -497,22 +516,10 @@ export class OpenClawApp extends LitElement {
 
   async handleExecApprovalDecision(decision: "allow-once" | "allow-always" | "deny") {
     const active = this.execApprovalQueue[0];
-    if (!active || !this.client || this.execApprovalBusy) {
+    if (!active) {
       return;
     }
-    this.execApprovalBusy = true;
-    this.execApprovalError = null;
-    try {
-      await this.client.request("exec.approval.resolve", {
-        id: active.id,
-        decision,
-      });
-      this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
-    } catch (err) {
-      this.execApprovalError = `Exec approval failed: ${String(err)}`;
-    } finally {
-      this.execApprovalBusy = false;
-    }
+    await resolveExecApproval(this, active.id, decision);
   }
 
   handleGatewayUrlConfirm() {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -172,7 +172,7 @@ export async function runCronJob(state: CronState, job: CronJob) {
   state.cronError = null;
   try {
     await state.client.request("cron.run", { id: job.id, mode: "force" });
-    await loadCronRuns(state, job.id);
+    await Promise.all([loadCronRuns(state, job.id), loadCronJobs(state), loadCronStatus(state)]);
   } catch (err) {
     state.cronError = String(err);
   } finally {

--- a/ui/src/ui/controllers/dashboard-timeline.ts
+++ b/ui/src/ui/controllers/dashboard-timeline.ts
@@ -1,0 +1,90 @@
+import type { CostUsageSummary, LogEntry } from "../types.ts";
+import type { DashboardSummaryResult } from "./dashboard.ts";
+
+const DASHBOARD_TIMELINE_WINDOW_MS = 15 * 60 * 1000;
+const DASHBOARD_TIMELINE_BUCKET_MS = 15 * 1000;
+
+export type DashboardTimelinePoint = {
+  ts: number;
+  cost: number | null;
+  queueSize: number;
+  pendingReplies: number;
+  activeEmbeddedRuns: number;
+  approvals: number;
+  pendingDevices: number;
+  securityCritical: number;
+  securityWarn: number;
+  logWarnings: number;
+  logErrors: number;
+  nodes: number;
+};
+
+export type DashboardTimelineState = {
+  dashboardTimeline: DashboardTimelinePoint[];
+  dashboardSummary: DashboardSummaryResult | null;
+  usageCostSummary: CostUsageSummary | null;
+  logsEntries: LogEntry[];
+};
+
+function roundTimelineBucket(ts: number) {
+  return ts - (ts % DASHBOARD_TIMELINE_BUCKET_MS);
+}
+
+function resolveRecentLogCounts(entries: LogEntry[]) {
+  return entries.slice(-80).reduce(
+    (acc, entry) => {
+      if (entry.level === "warn") {
+        acc.warn += 1;
+      }
+      if (entry.level === "error" || entry.level === "fatal") {
+        acc.error += 1;
+      }
+      return acc;
+    },
+    { warn: 0, error: 0 },
+  );
+}
+
+function buildDashboardTimelinePoint(
+  state: DashboardTimelineState,
+  ts: number,
+): DashboardTimelinePoint | null {
+  const summary = state.dashboardSummary;
+  const hasUsage = state.usageCostSummary?.totals != null;
+  const hasLogs = state.logsEntries.length > 0;
+  if (!summary && !hasUsage && !hasLogs) {
+    return null;
+  }
+  const logCounts = resolveRecentLogCounts(state.logsEntries);
+  return {
+    ts,
+    cost: state.usageCostSummary?.totals.totalCost ?? null,
+    queueSize: summary?.runtime.queueSize ?? 0,
+    pendingReplies: summary?.runtime.pendingReplies ?? 0,
+    activeEmbeddedRuns: summary?.runtime.activeEmbeddedRuns ?? 0,
+    approvals: summary?.approvals.count ?? 0,
+    pendingDevices: summary?.devices.pending ?? 0,
+    securityCritical: summary?.security.summary.critical ?? 0,
+    securityWarn: summary?.security.summary.warn ?? 0,
+    logWarnings: logCounts.warn,
+    logErrors: logCounts.error,
+    nodes: summary?.nodes.count ?? 0,
+  };
+}
+
+export function captureDashboardTimeline(state: DashboardTimelineState, opts?: { ts?: number }) {
+  const bucketTs = roundTimelineBucket(opts?.ts ?? Date.now());
+  const nextPoint = buildDashboardTimelinePoint(state, bucketTs);
+  if (!nextPoint) {
+    return;
+  }
+  const cutoffTs = bucketTs - DASHBOARD_TIMELINE_WINDOW_MS;
+  const points = state.dashboardTimeline.filter((entry) => entry.ts >= cutoffTs);
+  const lastIndex = points.length - 1;
+  if (lastIndex >= 0 && points[lastIndex]?.ts === bucketTs) {
+    points[lastIndex] = nextPoint;
+  } else {
+    points.push(nextPoint);
+  }
+  state.dashboardTimeline = points;
+}

--- a/ui/src/ui/controllers/dashboard.ts
+++ b/ui/src/ui/controllers/dashboard.ts
@@ -1,0 +1,154 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { ExecApprovalRequest } from "./exec-approval.ts";
+
+export type DashboardSecurityFinding = {
+  severity: "info" | "warn" | "critical";
+  title: string;
+  detail: string;
+  remediation?: string;
+};
+
+export type DashboardIncidentStatus = "open" | "acked" | "resolved";
+
+export type DashboardIncidentRecord = {
+  id: string;
+  source: "approval" | "device" | "node" | "runtime" | "security";
+  severity: "info" | "warn" | "critical";
+  status: DashboardIncidentStatus;
+  title: string;
+  detail: string;
+  metadata: {
+    logQuery?: string | null;
+    sessionKey?: string | null;
+    agentId?: string | null;
+    channelId?: string | null;
+    nodeId?: string | null;
+    actionTab?: string | null;
+    actionLabel?: string | null;
+  };
+  firstDetectedAt: number;
+  lastSeenAt: number;
+  updatedAt: number;
+  acknowledgedAt?: number;
+  acknowledgedBy?: string | null;
+  resolvedAt?: number;
+  resolvedBy?: string | null;
+  occurrenceCount: number;
+};
+
+export type DashboardSummaryResult = {
+  ts: number;
+  security: {
+    ts: number;
+    cached: boolean;
+    summary: {
+      critical: number;
+      warn: number;
+      info: number;
+    };
+    topFindings: DashboardSecurityFinding[];
+  };
+  approvals: {
+    count: number;
+    pending: ExecApprovalRequest[];
+  };
+  devices: {
+    pending: number;
+    paired: number;
+  };
+  nodes: {
+    count: number;
+    hasMobileNodeConnected: boolean;
+  };
+  runtime: {
+    queueSize: number;
+    pendingReplies: number;
+    activeEmbeddedRuns: number;
+  };
+  incidents: {
+    summary: {
+      active: number;
+      open: number;
+      acked: number;
+      resolved: number;
+      critical: number;
+      warn: number;
+      info: number;
+    };
+    active: DashboardIncidentRecord[];
+  };
+};
+
+export type DashboardState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  dashboardLoading: boolean;
+  dashboardSummary: DashboardSummaryResult | null;
+  dashboardError: string | null;
+  execApprovalQueue: ExecApprovalRequest[];
+};
+
+async function mutateDashboardIncident(
+  state: DashboardState,
+  method: "incident.ack" | "incident.resolve",
+  id: string,
+) {
+  if (!state.client || !state.connected) {
+    return false;
+  }
+  const incidentId = id.trim();
+  if (!incidentId) {
+    return false;
+  }
+  try {
+    await state.client.request(method, { id: incidentId });
+    state.dashboardError = null;
+    await loadDashboardSummary(state, { quiet: true });
+    return true;
+  } catch (err) {
+    state.dashboardError = String(err);
+    return false;
+  }
+}
+
+export function applyDashboardSummary(state: DashboardState, summary: DashboardSummaryResult) {
+  state.dashboardSummary = summary;
+  state.dashboardError = null;
+  state.execApprovalQueue = Array.isArray(summary.approvals?.pending)
+    ? summary.approvals.pending
+    : state.execApprovalQueue;
+}
+
+export async function loadDashboardSummary(
+  state: DashboardState,
+  opts?: { quiet?: boolean; forceAudit?: boolean },
+) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  if (state.dashboardLoading) {
+    return;
+  }
+  state.dashboardLoading = true;
+  if (!opts?.quiet) {
+    state.dashboardError = null;
+  }
+  try {
+    const summary = await state.client.request<DashboardSummaryResult>("dashboard.summary", {
+      forceAudit: opts?.forceAudit === true,
+    });
+    applyDashboardSummary(state, summary);
+  } catch (err) {
+    state.dashboardError = String(err);
+  } finally {
+    state.dashboardLoading = false;
+  }
+}
+
+export async function ackDashboardIncident(state: DashboardState, id: string) {
+  return await mutateDashboardIncident(state, "incident.ack", id);
+}
+
+export async function resolveDashboardIncident(state: DashboardState, id: string) {
+  return await mutateDashboardIncident(state, "incident.resolve", id);
+}

--- a/ui/src/ui/controllers/dashboard.ts
+++ b/ui/src/ui/controllers/dashboard.ts
@@ -36,6 +36,53 @@ export type DashboardIncidentRecord = {
   occurrenceCount: number;
 };
 
+export type DashboardToolActivity = {
+  key: string;
+  runId: string;
+  toolCallId: string;
+  sessionKey: string | null;
+  agentId: string | null;
+  name: string;
+  status: "running" | "completed" | "failed";
+  currentPhase: string;
+  startedAt: number;
+  updatedAt: number;
+  endedAt: number | null;
+  argsPreview: string | null;
+  outputPreview: string | null;
+};
+
+export type DashboardProcessEntry = {
+  sessionId: string;
+  command: string;
+  sessionKey: string | null;
+  scopeKey: string | null;
+  status: "running" | "completed" | "failed" | "killed";
+  startedAt: number;
+  endedAt: number | null;
+  durationMs: number | null;
+  cwd: string | null;
+  pid: number | null;
+  exitCode: number | null;
+  exitSignal: string | number | null;
+  tail: string | null;
+};
+
+export type DashboardAutonomyAgent = {
+  agentId: string;
+  name: string | null;
+  toolProfile: string | null;
+  allowCount: number;
+  denyCount: number;
+  alsoAllowCount: number;
+  execHost: string | null;
+  execSecurity: string | null;
+  execAsk: string | null;
+  execNode: string | null;
+  workspaceOnly: boolean;
+  elevatedEnabled: boolean | null;
+};
+
 export type DashboardSummaryResult = {
   ts: number;
   security: {
@@ -64,6 +111,58 @@ export type DashboardSummaryResult = {
     queueSize: number;
     pendingReplies: number;
     activeEmbeddedRuns: number;
+  };
+  tools: {
+    summary: {
+      active: number;
+      recent: number;
+      failedRecent: number;
+      uniqueToolsActive: number;
+    };
+    active: DashboardToolActivity[];
+    recent: DashboardToolActivity[];
+  };
+  processes: {
+    summary: {
+      running: number;
+      recent: number;
+      failedRecent: number;
+      killedRecent: number;
+    };
+    running: DashboardProcessEntry[];
+    recent: DashboardProcessEntry[];
+  };
+  autonomy: {
+    summary: {
+      agents: number;
+      explicitToolPolicies: number;
+      nodeBoundAgents: number;
+      elevatedAgents: number;
+      workspaceOnly: boolean;
+      applyPatchEnabled: boolean;
+    };
+    exec: {
+      host: "sandbox" | "gateway" | "node";
+      security: "deny" | "allowlist" | "full";
+      ask: "off" | "on-miss" | "always";
+      node: string | null;
+      backgroundMs: number | null;
+      timeoutSec: number | null;
+      approvalRunningNoticeMs: number | null;
+    };
+    fs: {
+      workspaceOnly: boolean;
+    };
+    applyPatch: {
+      enabled: boolean;
+      workspaceOnly: boolean;
+      allowModels: string[];
+    };
+    elevated: {
+      enabled: boolean;
+      providers: string[];
+    };
+    agents: DashboardAutonomyAgent[];
   };
   incidents: {
     summary: {

--- a/ui/src/ui/controllers/debug.ts
+++ b/ui/src/ui/controllers/debug.ts
@@ -15,7 +15,10 @@ export type DebugState = {
   debugCallError: string | null;
 };
 
-export async function loadDebug(state: DebugState) {
+export async function loadDebug(
+  state: DebugState,
+  opts?: { probe?: boolean; includeModels?: boolean },
+) {
   if (!state.client || !state.connected) {
     return;
   }
@@ -26,14 +29,18 @@ export async function loadDebug(state: DebugState) {
   try {
     const [status, health, models, heartbeat] = await Promise.all([
       state.client.request("status", {}),
-      state.client.request("health", {}),
-      state.client.request("models.list", {}),
+      state.client.request("health", { probe: opts?.probe ?? true }),
+      opts?.includeModels === false
+        ? Promise.resolve(null)
+        : state.client.request("models.list", {}),
       state.client.request("last-heartbeat", {}),
     ]);
     state.debugStatus = status as StatusSummary;
     state.debugHealth = health as HealthSnapshot;
     const modelPayload = models as { models?: unknown[] } | undefined;
-    state.debugModels = Array.isArray(modelPayload?.models) ? modelPayload?.models : [];
+    if (opts?.includeModels !== false) {
+      state.debugModels = Array.isArray(modelPayload?.models) ? modelPayload?.models : [];
+    }
     state.debugHeartbeat = heartbeat;
   } catch (err) {
     state.debugCallError = String(err);

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -23,6 +23,16 @@ export type ExecApprovalResolved = {
   ts?: number | null;
 };
 
+export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+
+export type ExecApprovalState = {
+  client: { request: <T = unknown>(method: string, params?: unknown) => Promise<T> } | null;
+  connected: boolean;
+  execApprovalBusy: boolean;
+  execApprovalError: string | null;
+  execApprovalQueue: ExecApprovalRequest[];
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -97,4 +107,33 @@ export function removeExecApproval(
   id: string,
 ): ExecApprovalRequest[] {
   return pruneExecApprovalQueue(queue).filter((entry) => entry.id !== id);
+}
+
+export async function resolveExecApproval(
+  state: ExecApprovalState,
+  id: string,
+  decision: ExecApprovalDecision,
+) {
+  if (!state.client || !state.connected || state.execApprovalBusy) {
+    return false;
+  }
+  const active = state.execApprovalQueue.find((entry) => entry.id === id);
+  if (!active) {
+    return false;
+  }
+  state.execApprovalBusy = true;
+  state.execApprovalError = null;
+  try {
+    await state.client.request("exec.approval.resolve", {
+      id,
+      decision,
+    });
+    state.execApprovalQueue = state.execApprovalQueue.filter((entry) => entry.id !== id);
+    return true;
+  } catch (err) {
+    state.execApprovalError = `Exec approval failed: ${String(err)}`;
+    return false;
+  } finally {
+    state.execApprovalBusy = false;
+  }
 }

--- a/ui/src/ui/controllers/mission-control.ts
+++ b/ui/src/ui/controllers/mission-control.ts
@@ -1,0 +1,427 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import { generateUUID } from "../uuid.ts";
+
+const NODE_DOCTOR_TIMEOUT_MS = 60_000;
+const NODE_APPROVAL_TIMEOUT_MS = 120_000;
+
+export type MissionNodeActionKind = "describe" | "probe" | "doctor";
+
+export type MissionNodeActionResult = {
+  nodeId: string;
+  nodeLabel: string;
+  kind: MissionNodeActionKind;
+  status: "ok" | "warn" | "danger" | "info";
+  title: string;
+  detail: string;
+  output?: string | null;
+  ts: number;
+};
+
+export type PendingMissionNodeRun = {
+  approvalId: string;
+  nodeId: string;
+  nodeLabel: string;
+  command: string[];
+  agentId: string | null;
+  sessionKey: string | null;
+};
+
+export type MissionNodeOpsState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  sessionKey: string;
+  assistantAgentId: string | null;
+  missionNodeBusyById: Record<string, MissionNodeActionKind | "approval" | null>;
+  missionNodeResult: MissionNodeActionResult | null;
+  missionNodePendingRuns: Record<string, PendingMissionNodeRun>;
+};
+
+type NodeRecord = Record<string, unknown>;
+
+function setNodeBusy(
+  state: MissionNodeOpsState,
+  nodeId: string,
+  value: MissionNodeActionKind | "approval" | null,
+) {
+  state.missionNodeBusyById = {
+    ...state.missionNodeBusyById,
+    [nodeId]: value,
+  };
+}
+
+function finalizeNodeAction(
+  state: MissionNodeOpsState,
+  nodeId: string,
+  result: MissionNodeActionResult,
+) {
+  setNodeBusy(state, nodeId, null);
+  state.missionNodeResult = result;
+}
+
+function requireGateway(state: MissionNodeOpsState): GatewayBrowserClient {
+  if (!state.client || !state.connected) {
+    throw new Error("gateway not connected");
+  }
+  return state.client;
+}
+
+function normalizeNodeLabel(node: NodeRecord, fallbackNodeId: string): string {
+  const displayName = typeof node.displayName === "string" ? node.displayName.trim() : "";
+  return displayName || fallbackNodeId;
+}
+
+function resolveNodeId(node: NodeRecord): string {
+  return typeof node.nodeId === "string" ? node.nodeId.trim() : "";
+}
+
+function resolveNodeCommands(node: NodeRecord): string[] {
+  return Array.isArray(node.commands) ? node.commands.map((entry) => String(entry)) : [];
+}
+
+function stringifyPayload(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (value == null) {
+    return null;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function resolveAgentId(state: MissionNodeOpsState) {
+  return state.assistantAgentId?.trim() || "main";
+}
+
+async function invokeNode<T = unknown>(
+  state: MissionNodeOpsState,
+  params: {
+    nodeId: string;
+    command: string;
+    payload?: unknown;
+    timeoutMs?: number;
+  },
+): Promise<T> {
+  const client = requireGateway(state);
+  return await client.request<T>("node.invoke", {
+    nodeId: params.nodeId,
+    command: params.command,
+    params: params.payload ?? {},
+    timeoutMs: params.timeoutMs,
+    idempotencyKey: generateUUID(),
+  });
+}
+
+export function missionNodeSupports(node: NodeRecord, command: string) {
+  return resolveNodeCommands(node).includes(command);
+}
+
+export async function describeMissionNode(state: MissionNodeOpsState, node: NodeRecord) {
+  const nodeId = resolveNodeId(node);
+  const nodeLabel = normalizeNodeLabel(node, nodeId);
+  if (!nodeId) {
+    return;
+  }
+  setNodeBusy(state, nodeId, "describe");
+  try {
+    const payload = await requireGateway(state).request<Record<string, unknown>>("node.describe", {
+      nodeId,
+    });
+    const commands = Array.isArray(payload.commands)
+      ? payload.commands.map((entry) => String(entry))
+      : [];
+    const caps = Array.isArray(payload.caps) ? payload.caps.map((entry) => String(entry)) : [];
+    finalizeNodeAction(state, nodeId, {
+      nodeId,
+      nodeLabel,
+      kind: "describe",
+      status: payload.connected === true ? "ok" : "warn",
+      title: `${nodeLabel} capabilities`,
+      detail: [
+        stringifyPayload(payload.platform),
+        commands.length > 0 ? `commands ${commands.join(", ")}` : "no commands declared",
+        caps.length > 0 ? `caps ${caps.join(", ")}` : null,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      output: stringifyPayload(payload.pathEnv)
+        ? `PATH ${stringifyPayload(payload.pathEnv)}`
+        : null,
+      ts: Date.now(),
+    });
+  } catch (err) {
+    finalizeNodeAction(state, nodeId, {
+      nodeId,
+      nodeLabel,
+      kind: "describe",
+      status: "danger",
+      title: `${nodeLabel} describe failed`,
+      detail: String(err),
+      output: null,
+      ts: Date.now(),
+    });
+  }
+}
+
+export async function probeMissionNode(state: MissionNodeOpsState, node: NodeRecord) {
+  const nodeId = resolveNodeId(node);
+  const nodeLabel = normalizeNodeLabel(node, nodeId);
+  if (!nodeId) {
+    return;
+  }
+  setNodeBusy(state, nodeId, "probe");
+  try {
+    const payload = await invokeNode<{ payload?: { bins?: Record<string, string> } }>(state, {
+      nodeId,
+      command: "system.which",
+      payload: { bins: ["openclaw", "git", "node"] },
+      timeoutMs: 8_000,
+    });
+    const bins = payload?.payload?.bins ?? {};
+    const found = Object.entries(bins);
+    finalizeNodeAction(state, nodeId, {
+      nodeId,
+      nodeLabel,
+      kind: "probe",
+      status: found.length > 0 ? "ok" : "warn",
+      title: `${nodeLabel} probe`,
+      detail:
+        found.length > 0
+          ? `${found.length} expected binary path(s) resolved on node`
+          : "The node responded, but no expected binaries were resolved.",
+      output:
+        found.length > 0
+          ? found.map(([name, path]) => `${name}: ${path}`).join("\n")
+          : "bins: none",
+      ts: Date.now(),
+    });
+  } catch (err) {
+    finalizeNodeAction(state, nodeId, {
+      nodeId,
+      nodeLabel,
+      kind: "probe",
+      status: "danger",
+      title: `${nodeLabel} probe failed`,
+      detail: String(err),
+      output: null,
+      ts: Date.now(),
+    });
+  }
+}
+
+function upsertPendingMissionRun(state: MissionNodeOpsState, pending: PendingMissionNodeRun) {
+  state.missionNodePendingRuns = {
+    ...state.missionNodePendingRuns,
+    [pending.approvalId]: pending,
+  };
+}
+
+function deletePendingMissionRun(state: MissionNodeOpsState, approvalId: string) {
+  const next = { ...state.missionNodePendingRuns };
+  delete next[approvalId];
+  state.missionNodePendingRuns = next;
+}
+
+async function runMissionNodeDoctorOnce(
+  state: MissionNodeOpsState,
+  pending: PendingMissionNodeRun,
+  approvalDecision?: "allow-once" | "allow-always",
+) {
+  return await invokeNode<{ payload?: Record<string, unknown> }>(state, {
+    nodeId: pending.nodeId,
+    command: "system.run",
+    payload: {
+      command: pending.command,
+      timeoutMs: NODE_DOCTOR_TIMEOUT_MS,
+      agentId: pending.agentId ?? undefined,
+      sessionKey: pending.sessionKey ?? undefined,
+      ...(approvalDecision
+        ? {
+            runId: pending.approvalId,
+            approved: true,
+            approvalDecision,
+          }
+        : {}),
+    },
+    timeoutMs: NODE_DOCTOR_TIMEOUT_MS + 10_000,
+  });
+}
+
+function formatDoctorOutput(payload: Record<string, unknown> | undefined): {
+  status: "ok" | "warn" | "danger";
+  detail: string;
+  output: string | null;
+} {
+  const stdout = typeof payload?.stdout === "string" ? payload.stdout.trim() : "";
+  const stderr = typeof payload?.stderr === "string" ? payload.stderr.trim() : "";
+  const error = typeof payload?.error === "string" ? payload.error.trim() : "";
+  const exitCode = typeof payload?.exitCode === "number" ? payload.exitCode : null;
+  const timedOut = payload?.timedOut === true;
+  const success = payload?.success === true;
+  const output = [stdout, stderr, error].filter(Boolean).join("\n\n").trim() || null;
+  if (success) {
+    return {
+      status: "ok",
+      detail:
+        exitCode == null
+          ? "Doctor completed successfully."
+          : `Doctor completed with exit code ${exitCode}.`,
+      output,
+    };
+  }
+  if (timedOut) {
+    return {
+      status: "danger",
+      detail: "Doctor command timed out on the node.",
+      output,
+    };
+  }
+  return {
+    status: "danger",
+    detail:
+      exitCode == null ? "Doctor command failed." : `Doctor failed with exit code ${exitCode}.`,
+    output,
+  };
+}
+
+export async function runMissionNodeDoctor(state: MissionNodeOpsState, node: NodeRecord) {
+  const nodeId = resolveNodeId(node);
+  const nodeLabel = normalizeNodeLabel(node, nodeId);
+  if (!nodeId) {
+    return;
+  }
+  if (Object.values(state.missionNodePendingRuns).some((entry) => entry.nodeId === nodeId)) {
+    state.missionNodeResult = {
+      nodeId,
+      nodeLabel,
+      kind: "doctor",
+      status: "info",
+      title: `${nodeLabel} doctor pending`,
+      detail: "An approval request is already waiting for this node.",
+      output: null,
+      ts: Date.now(),
+    };
+    setNodeBusy(state, nodeId, "approval");
+    return;
+  }
+  setNodeBusy(state, nodeId, "doctor");
+  const pending: PendingMissionNodeRun = {
+    approvalId: generateUUID(),
+    nodeId,
+    nodeLabel,
+    command: ["openclaw", "doctor", "--non-interactive"],
+    agentId: resolveAgentId(state),
+    sessionKey: state.sessionKey?.trim() || "main",
+  };
+  try {
+    const raw = await runMissionNodeDoctorOnce(state, pending);
+    const formatted = formatDoctorOutput(raw?.payload);
+    finalizeNodeAction(state, nodeId, {
+      nodeId,
+      nodeLabel,
+      kind: "doctor",
+      title: `${nodeLabel} doctor`,
+      detail: formatted.detail,
+      output: formatted.output,
+      status: formatted.status,
+      ts: Date.now(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("SYSTEM_RUN_DENIED: approval required")) {
+      await requireGateway(state).request("exec.approval.request", {
+        id: pending.approvalId,
+        command: pending.command.join(" "),
+        host: "node",
+        agentId: pending.agentId,
+        sessionKey: pending.sessionKey,
+        timeoutMs: NODE_APPROVAL_TIMEOUT_MS,
+        twoPhase: true,
+      });
+      upsertPendingMissionRun(state, pending);
+      setNodeBusy(state, nodeId, "approval");
+      state.missionNodeResult = {
+        nodeId,
+        nodeLabel,
+        kind: "doctor",
+        status: "info",
+        title: `${nodeLabel} doctor waiting`,
+        detail: "Approval requested. Allow the queued exec request to run the node doctor.",
+        output: pending.command.join(" "),
+        ts: Date.now(),
+      };
+      return;
+    }
+    finalizeNodeAction(state, nodeId, {
+      nodeId,
+      nodeLabel,
+      kind: "doctor",
+      status: "danger",
+      title: `${nodeLabel} doctor failed`,
+      detail: message,
+      output: null,
+      ts: Date.now(),
+    });
+  }
+}
+
+export async function resumeMissionNodeRun(
+  state: MissionNodeOpsState,
+  approvalId: string,
+  decision: "allow-once" | "allow-always" | "deny",
+) {
+  const pending = state.missionNodePendingRuns[approvalId];
+  if (!pending) {
+    return false;
+  }
+  if (decision === "deny") {
+    deletePendingMissionRun(state, approvalId);
+    finalizeNodeAction(state, pending.nodeId, {
+      nodeId: pending.nodeId,
+      nodeLabel: pending.nodeLabel,
+      kind: "doctor",
+      status: "warn",
+      title: `${pending.nodeLabel} doctor denied`,
+      detail: "The operator denied the node doctor command.",
+      output: pending.command.join(" "),
+      ts: Date.now(),
+    });
+    return true;
+  }
+  setNodeBusy(state, pending.nodeId, "doctor");
+  try {
+    const raw = await runMissionNodeDoctorOnce(state, pending, decision);
+    const formatted = formatDoctorOutput(raw?.payload);
+    finalizeNodeAction(state, pending.nodeId, {
+      nodeId: pending.nodeId,
+      nodeLabel: pending.nodeLabel,
+      kind: "doctor",
+      title: `${pending.nodeLabel} doctor`,
+      detail: formatted.detail,
+      output: formatted.output,
+      status: formatted.status,
+      ts: Date.now(),
+    });
+  } catch (err) {
+    finalizeNodeAction(state, pending.nodeId, {
+      nodeId: pending.nodeId,
+      nodeLabel: pending.nodeLabel,
+      kind: "doctor",
+      status: "danger",
+      title: `${pending.nodeLabel} doctor failed`,
+      detail: String(err),
+      output: null,
+      ts: Date.now(),
+    });
+  } finally {
+    deletePendingMissionRun(state, approvalId);
+  }
+  return true;
+}

--- a/ui/src/ui/navigation.test.ts
+++ b/ui/src/ui/navigation.test.ts
@@ -57,7 +57,7 @@ describe("titleForTab", () => {
 
   it("returns expected titles", () => {
     expect(titleForTab("chat")).toBe("Chat");
-    expect(titleForTab("overview")).toBe("Overview");
+    expect(titleForTab("overview")).toBe("Mission Control");
     expect(titleForTab("cron")).toBe("Cron Jobs");
   });
 });

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -160,7 +160,7 @@ export function titleForTab(tab: Tab) {
     case "agents":
       return "Agents";
     case "overview":
-      return "Overview";
+      return "Mission Control";
     case "channels":
       return "Channels";
     case "instances":
@@ -193,7 +193,7 @@ export function subtitleForTab(tab: Tab) {
     case "agents":
       return "Manage agent workspaces, tools, and identities.";
     case "overview":
-      return "Gateway status, entry points, and a fast health read.";
+      return "Real-time command center for health, sessions, channels, cron, and approvals.";
     case "channels":
       return "Manage channels and settings.";
     case "instances":

--- a/ui/src/ui/views/channels.ts
+++ b/ui/src/ui/views/channels.ts
@@ -42,8 +42,12 @@ export function renderChannels(props: ChannelsProps) {
       key,
       enabled: channelEnabled(key, props),
       order: index,
+      focused: props.focusChannelId === key,
     }))
     .toSorted((a, b) => {
+      if (a.focused !== b.focused) {
+        return a.focused ? -1 : 1;
+      }
       if (a.enabled !== b.enabled) {
         return a.enabled ? -1 : 1;
       }
@@ -51,6 +55,19 @@ export function renderChannels(props: ChannelsProps) {
     });
 
   return html`
+    ${
+      props.focusChannelId
+        ? html`
+            <section class="card" style="margin-bottom: 18px; border-color: var(--accent);">
+              <div class="card-title">Focused Channel</div>
+              <div class="card-sub">
+                Mission Control opened the channel view for
+                <span class="mono">${props.focusChannelId}</span>.
+              </div>
+            </section>
+          `
+        : nothing
+    }
     <section class="grid grid-cols-2">
       ${orderedChannels.map((channel) =>
         renderChannel(channel.key, props, {

--- a/ui/src/ui/views/channels.types.ts
+++ b/ui/src/ui/views/channels.types.ts
@@ -22,6 +22,7 @@ export type ChannelsProps = {
   snapshot: ChannelsStatusSnapshot | null;
   lastError: string | null;
   lastSuccessAt: number | null;
+  focusChannelId: string | null;
   whatsappMessage: string | null;
   whatsappQrDataUrl: string | null;
   whatsappConnected: boolean | null;

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -11,6 +11,7 @@ import { renderExecApprovals, resolveExecApprovalsState } from "./nodes-exec-app
 export type NodesProps = {
   loading: boolean;
   nodes: Array<Record<string, unknown>>;
+  focusNodeId: string | null;
   devicesLoading: boolean;
   devicesError: string | null;
   devicesList: DevicePairingList | null;
@@ -48,10 +49,35 @@ export type NodesProps = {
 export function renderNodes(props: NodesProps) {
   const bindingState = resolveBindingsState(props);
   const approvalsState = resolveExecApprovalsState(props);
+  const orderedNodes = [...props.nodes].toSorted((left, right) => {
+    const leftId = typeof left.nodeId === "string" ? left.nodeId : "";
+    const rightId = typeof right.nodeId === "string" ? right.nodeId : "";
+    if (props.focusNodeId) {
+      const leftFocused = leftId === props.focusNodeId;
+      const rightFocused = rightId === props.focusNodeId;
+      if (leftFocused !== rightFocused) {
+        return leftFocused ? -1 : 1;
+      }
+    }
+    return 0;
+  });
   return html`
     ${renderExecApprovals(approvalsState)}
     ${renderBindings(bindingState)}
     ${renderDevices(props)}
+    ${
+      props.focusNodeId
+        ? html`
+            <section class="card" style="margin-bottom: 18px; border-color: var(--accent);">
+              <div class="card-title">Focused Node</div>
+              <div class="card-sub">
+                Mission Control opened the node view for
+                <span class="mono">${props.focusNodeId}</span>.
+              </div>
+            </section>
+          `
+        : nothing
+    }
     <section class="card">
       <div class="row" style="justify-content: space-between;">
         <div>
@@ -64,11 +90,11 @@ export function renderNodes(props: NodesProps) {
       </div>
       <div class="list" style="margin-top: 16px;">
         ${
-          props.nodes.length === 0
+          orderedNodes.length === 0
             ? html`
                 <div class="muted">No nodes found.</div>
               `
-            : props.nodes.map((n) => renderNode(n))
+            : orderedNodes.map((n) => renderNode(n))
         }
       </div>
     </section>

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -1,8 +1,129 @@
-import { html } from "lit";
+import { html, nothing, svg } from "lit";
+import type { EventLogEntry } from "../app-events.ts";
+import type { DashboardTimelinePoint } from "../controllers/dashboard-timeline.ts";
+import type { DashboardIncidentRecord, DashboardSummaryResult } from "../controllers/dashboard.ts";
+import type { DevicePairingList } from "../controllers/devices.ts";
+import type { ExecApprovalDecision, ExecApprovalRequest } from "../controllers/exec-approval.ts";
+import type {
+  MissionNodeActionKind,
+  MissionNodeActionResult,
+} from "../controllers/mission-control.ts";
 import type { GatewayHelloOk } from "../gateway.ts";
+import type { Tab } from "../navigation.ts";
 import type { UiSettings } from "../storage.ts";
-import { formatRelativeTimestamp, formatDurationHuman } from "../format.ts";
+import type {
+  ChannelsStatusSnapshot,
+  CostUsageSummary,
+  CronJob,
+  CronStatus,
+  LogEntry,
+  LogLevel,
+  PresenceEntry,
+  SessionsListResult,
+  SessionsUsageResult,
+} from "../types.ts";
+import { parseAgentSessionKey } from "../../../../src/routing/session-key.js";
+import { clampText, formatDurationHuman, formatRelativeTimestamp } from "../format.ts";
 import { formatNextRun } from "../presenter.ts";
+
+type Tone = "ok" | "warn" | "danger" | "info" | "muted";
+
+type StatusHeartbeatAgentLike = {
+  agentId?: string;
+  enabled?: boolean;
+  every?: string;
+  everyMs?: number | null;
+};
+
+type StatusSummaryLike = {
+  heartbeat?: {
+    defaultAgentId?: string;
+    agents?: StatusHeartbeatAgentLike[];
+  };
+  queuedSystemEvents?: string[];
+  sessions?: {
+    defaults?: { model?: string | null; contextTokens?: number | null };
+    count?: number;
+  };
+} & Record<string, unknown>;
+
+type HealthChannelSummaryLike = {
+  accountId?: string;
+  configured?: boolean;
+  linked?: boolean;
+  probe?: Record<string, unknown> | null;
+  accounts?: Record<string, HealthChannelSummaryLike>;
+} & Record<string, unknown>;
+
+type HealthSummaryLike = {
+  channelOrder?: string[];
+  channelLabels?: Record<string, string>;
+  channels?: Record<string, HealthChannelSummaryLike>;
+} & Record<string, unknown>;
+
+type MissionAlert = {
+  tone: Tone;
+  title: string;
+  detail: string;
+};
+
+type MissionFeedItem = {
+  id: string;
+  tone: Tone;
+  source: "event" | "log";
+  ts: number;
+  label: string;
+  title: string;
+  detail: string;
+};
+
+type MissionChannelCard = {
+  id: string;
+  label: string;
+  tone: Tone;
+  summary: string;
+  detail: string;
+  accountCount: number;
+  lastActivityAt: number | null;
+};
+
+type UsageSnapshot = {
+  totalCost: number | null;
+  totalTokens: number | null;
+  sessions: number;
+  messages: number;
+  errors: number;
+  topAgent: string | null;
+  topTool: string | null;
+  topModel: string | null;
+  latencyP95Ms: number | null;
+};
+
+type MissionIncident = {
+  id: string;
+  tone: Tone;
+  title: string;
+  detail: string;
+  status?: "open" | "acked" | "resolved";
+  backendManaged?: boolean;
+  logQuery?: string;
+  sessionKey?: string;
+  agentId?: string;
+  channelId?: string;
+  nodeId?: string;
+  actionLabel?: string;
+  actionTab?: Tab;
+};
+
+type MissionNodeCard = {
+  nodeId: string;
+  label: string;
+  detail: string;
+  commands: string[];
+  connected: boolean;
+  paired: boolean;
+  tone: Tone;
+};
 
 export type OverviewProps = {
   connected: boolean;
@@ -10,29 +131,973 @@ export type OverviewProps = {
   settings: UiSettings;
   password: string;
   lastError: string | null;
-  presenceCount: number;
-  sessionsCount: number | null;
-  cronEnabled: boolean | null;
-  cronNext: number | null;
+  presenceEntries: PresenceEntry[];
+  presenceError: string | null;
+  presenceStatus: string | null;
+  sessionsResult: SessionsListResult | null;
+  sessionsError: string | null;
+  cronStatus: CronStatus | null;
+  cronJobs: CronJob[];
+  cronError: string | null;
+  channelsSnapshot: ChannelsStatusSnapshot | null;
+  channelsError: string | null;
   lastChannelsRefresh: number | null;
+  debugStatus: Record<string, unknown> | null;
+  debugHealth: Record<string, unknown> | null;
+  debugHeartbeat: unknown;
+  logsEntries: LogEntry[];
+  logsError: string | null;
+  logsLastFetchAt: number | null;
+  usageResult: SessionsUsageResult | null;
+  usageCostSummary: CostUsageSummary | null;
+  usageError: string | null;
+  usageStartDate: string;
+  usageEndDate: string;
+  devicesList: DevicePairingList | null;
+  devicesError: string | null;
+  devicesLoading: boolean;
+  dashboardSummary: DashboardSummaryResult | null;
+  dashboardError: string | null;
+  dashboardLoading: boolean;
+  dashboardTimeline: DashboardTimelinePoint[];
+  nodes: Array<Record<string, unknown>>;
+  missionNodeBusyById: Record<string, MissionNodeActionKind | "approval" | null>;
+  missionNodeResult: MissionNodeActionResult | null;
+  execApprovalQueue: ExecApprovalRequest[];
+  execApprovalBusy: boolean;
+  cronBusy: boolean;
+  nodesCount: number;
+  eventLog: EventLogEntry[];
   onSettingsChange: (next: UiSettings) => void;
   onPasswordChange: (next: string) => void;
   onSessionKeyChange: (next: string) => void;
+  onNavigate: (tab: Tab) => void;
+  onOpenSession: (sessionKey: string) => void;
   onConnect: () => void;
   onRefresh: () => void;
+  onResolveExecApproval: (id: string, decision: ExecApprovalDecision) => Promise<void>;
+  onApproveDevice: (requestId: string) => Promise<void>;
+  onRejectDevice: (requestId: string) => Promise<void>;
+  onRunCronJob: (jobId: string) => Promise<void>;
+  onRefreshSecurityAudit: () => Promise<void>;
+  onAckIncident: (incidentId: string) => Promise<boolean>;
+  onResolveIncident: (incidentId: string) => Promise<boolean>;
+  onDescribeNode: (nodeId: string) => Promise<void>;
+  onProbeNode: (nodeId: string) => Promise<void>;
+  onRunNodeDoctor: (nodeId: string) => Promise<void>;
+  onOpenLogsQuery: (query: string) => Promise<void>;
+  onFocusAgent: (agentId: string) => void;
+  onFocusChannel: (channelId: string) => void;
+  onFocusNode: (nodeId: string) => void;
 };
 
-export function renderOverview(props: OverviewProps) {
-  const snapshot = props.hello?.snapshot as
-    | {
-        uptimeMs?: number;
-        policy?: { tickIntervalMs?: number };
-        authMode?: "none" | "token" | "password" | "trusted-proxy";
+const RECENT_ACTIVITY_MS = 10 * 60 * 1000;
+const HOT_SESSION_CONTEXT_THRESHOLD = 0.72;
+const numberFormatter = new Intl.NumberFormat("en-US");
+const compactNumberFormatter = new Intl.NumberFormat("en-US", { notation: "compact" });
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asStatusSummary(value: unknown): StatusSummaryLike | null {
+  return asRecord(value) as StatusSummaryLike | null;
+}
+
+function asHealthSummary(value: unknown): HealthSummaryLike | null {
+  return asRecord(value) as HealthSummaryLike | null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function stringifyPayload(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (value == null) {
+    return null;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function toneClass(tone: Tone): string {
+  return `mission-tone-${tone}`;
+}
+
+function formatCount(value: number | null | undefined): string {
+  if (value == null) {
+    return "n/a";
+  }
+  return numberFormatter.format(value);
+}
+
+function formatCompactCount(value: number | null | undefined): string {
+  if (value == null) {
+    return "n/a";
+  }
+  return compactNumberFormatter.format(value);
+}
+
+function formatMoney(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "n/a";
+  }
+  return currencyFormatter.format(value);
+}
+
+function formatRelativeOrNa(ms: number | null | undefined): string {
+  if (!ms) {
+    return "n/a";
+  }
+  return formatRelativeTimestamp(ms);
+}
+
+function formatLastActivity(ms: number | null): string {
+  if (!ms) {
+    return "No recent activity";
+  }
+  return `Last activity ${formatRelativeTimestamp(ms)}`;
+}
+
+function hasRecentActivity(ms: number | null | undefined): boolean {
+  return typeof ms === "number" && Date.now() - ms <= RECENT_ACTIVITY_MS;
+}
+
+function resolveLogTimestamp(entry: LogEntry, index: number): number {
+  if (entry.time) {
+    const parsed = Date.parse(entry.time);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return Date.now() - index * 1000;
+}
+
+function resolveLogTone(level: LogLevel | null | undefined): Tone {
+  if (level === "error" || level === "fatal") {
+    return "danger";
+  }
+  if (level === "warn") {
+    return "warn";
+  }
+  if (level === "info") {
+    return "info";
+  }
+  return "muted";
+}
+
+function resolveEventTone(event: string): Tone {
+  if (
+    event.startsWith("exec.approval") ||
+    event.startsWith("device.pair") ||
+    event.includes("error") ||
+    event.includes("failed")
+  ) {
+    return event.endsWith("resolved") ? "ok" : "warn";
+  }
+  if (event === "presence") {
+    return "muted";
+  }
+  return "info";
+}
+
+function summarizeEventPayload(payload: unknown): string {
+  const record = asRecord(payload);
+  if (!record) {
+    if (payload == null) {
+      return "No payload.";
+    }
+    return clampText(stringifyPayload(payload) ?? "Payload available.", 140);
+  }
+  const request = asRecord(record.request);
+  const command = asString(request?.command);
+  if (command) {
+    return clampText(command, 140);
+  }
+  const candidates = [
+    asString(record.message),
+    asString(record.text),
+    asString(record.summary),
+    asString(record.reason),
+    asString(record.error),
+    asString(record.sessionKey),
+    asString(record.agentId),
+  ].filter((value): value is string => Boolean(value));
+  if (candidates.length > 0) {
+    return clampText(candidates[0], 140);
+  }
+  try {
+    return clampText(JSON.stringify(record), 140);
+  } catch {
+    return "Payload available.";
+  }
+}
+
+function renderToneBadge(label: string, tone: Tone) {
+  return html`<span class="mission-badge ${toneClass(tone)}">${label}</span>`;
+}
+
+function renderEmptyState(message: string) {
+  return html`<div class="mission-empty">${message}</div>`;
+}
+
+function securityFindingTone(severity: "info" | "warn" | "critical"): Tone {
+  if (severity === "critical") {
+    return "danger";
+  }
+  if (severity === "warn") {
+    return "warn";
+  }
+  return "info";
+}
+
+function resolveHotSessions(sessionsResult: SessionsListResult | null) {
+  const sessions = sessionsResult?.sessions ?? [];
+  return [...sessions]
+    .toSorted((left, right) => {
+      const leftRatio = left.contextTokens ? (left.totalTokens ?? 0) / left.contextTokens : 0;
+      const rightRatio = right.contextTokens ? (right.totalTokens ?? 0) / right.contextTokens : 0;
+      const leftScore =
+        (left.abortedLastRun ? 1000 : 0) +
+        (left.key.includes(":cron:") ? 350 : 0) +
+        (leftRatio >= HOT_SESSION_CONTEXT_THRESHOLD ? 250 : 0) +
+        Math.max(0, (left.updatedAt ?? 0) / 1_000_000_000);
+      const rightScore =
+        (right.abortedLastRun ? 1000 : 0) +
+        (right.key.includes(":cron:") ? 350 : 0) +
+        (rightRatio >= HOT_SESSION_CONTEXT_THRESHOLD ? 250 : 0) +
+        Math.max(0, (right.updatedAt ?? 0) / 1_000_000_000);
+      return rightScore - leftScore;
+    })
+    .slice(0, 8);
+}
+
+function formatSessionTokens(
+  total: number | null | undefined,
+  context: number | null | undefined,
+): string {
+  if (total == null) {
+    return "Tokens n/a";
+  }
+  if (!context) {
+    return `${formatCompactCount(total)} tokens`;
+  }
+  const ratio = Math.round((total / context) * 100);
+  return `${formatCompactCount(total)} / ${formatCompactCount(context)} (${ratio}%)`;
+}
+
+function resolveSessionTone(row: SessionsListResult["sessions"][number]): Tone {
+  if (row.abortedLastRun) {
+    return "danger";
+  }
+  if (
+    row.contextTokens &&
+    row.totalTokens &&
+    row.totalTokens / row.contextTokens >= HOT_SESSION_CONTEXT_THRESHOLD
+  ) {
+    return "warn";
+  }
+  if (row.key.includes(":cron:")) {
+    return "info";
+  }
+  return "ok";
+}
+
+function resolveChannelOrder(
+  snapshot: ChannelsStatusSnapshot | null,
+  health: HealthSummaryLike | null,
+): string[] {
+  if (snapshot?.channelMeta?.length) {
+    return snapshot.channelMeta.map((entry) => entry.id);
+  }
+  if (snapshot?.channelOrder?.length) {
+    return snapshot.channelOrder;
+  }
+  if (Array.isArray(health?.channelOrder)) {
+    return health.channelOrder.filter((entry): entry is string => typeof entry === "string");
+  }
+  if (health?.channels) {
+    return Object.keys(health.channels);
+  }
+  return [];
+}
+
+function resolveChannelCards(
+  snapshot: ChannelsStatusSnapshot | null,
+  health: HealthSummaryLike | null,
+): MissionChannelCard[] {
+  const order = resolveChannelOrder(snapshot, health);
+  const rawChannels = snapshot?.channels ?? {};
+  const healthChannels = health?.channels ?? {};
+  const labels = {
+    ...health?.channelLabels,
+    ...snapshot?.channelLabels,
+  };
+  return order.map((channelId) => {
+    const channelRecord = asRecord(rawChannels[channelId]) ?? {};
+    const healthRecord = asRecord(healthChannels[channelId]) as HealthChannelSummaryLike | null;
+    const accounts = snapshot?.channelAccounts?.[channelId] ?? [];
+    const healthAccounts = Object.values(healthRecord?.accounts ?? {});
+    const accountCount = accounts.length || healthAccounts.length;
+    const lastActivityAt = accounts
+      .flatMap((account) => [
+        account.lastInboundAt ?? null,
+        account.lastOutboundAt ?? null,
+        account.lastProbeAt ?? null,
+        account.lastConnectedAt ?? null,
+      ])
+      .filter((value): value is number => typeof value === "number")
+      .reduce<number | null>(
+        (latest, value) => (latest == null || value > latest ? value : latest),
+        null,
+      );
+
+    const rawError = asString(channelRecord.lastError);
+    const accountError = accounts
+      .map((account) => account.lastError)
+      .find((value): value is string => Boolean(value));
+    const probeRecord = asRecord(healthRecord?.probe);
+    const probeOk = asBoolean(probeRecord?.ok);
+    const probeError = asString(probeRecord?.error);
+    const linked = asBoolean(channelRecord.linked) ?? asBoolean(healthRecord?.linked);
+    const configured =
+      asBoolean(channelRecord.configured) ??
+      asBoolean(healthRecord?.configured) ??
+      accounts.some((account) => account.configured !== false);
+    const running =
+      asBoolean(channelRecord.running) ?? accounts.some((account) => account.running === true);
+    const connected =
+      asBoolean(channelRecord.connected) ?? accounts.some((account) => account.connected === true);
+    const recentActivity = accounts.some(
+      (account) =>
+        hasRecentActivity(account.lastInboundAt) || hasRecentActivity(account.lastOutboundAt),
+    );
+
+    let tone: Tone = "muted";
+    let summary = "Not configured";
+    let detail = "No account configured for this channel.";
+
+    if (rawError || accountError) {
+      tone = "danger";
+      summary = "Attention required";
+      detail = clampText(rawError ?? accountError ?? "Channel error detected.", 120);
+    } else if (probeOk === false) {
+      tone = "warn";
+      summary = "Probe degraded";
+      detail = clampText(probeError ?? "Last health probe failed.", 120);
+    } else if (linked === false) {
+      tone = "warn";
+      summary = "Link required";
+      detail = "Channel auth is configured but not linked yet.";
+    } else if (connected || running || recentActivity || linked === true) {
+      tone = "ok";
+      summary = recentActivity ? "Live traffic" : linked === true ? "Linked" : "Healthy";
+      detail = recentActivity
+        ? formatLastActivity(lastActivityAt)
+        : linked === true
+          ? "Gateway auth is linked and ready for traffic."
+          : "Channel is healthy and ready.";
+    } else if (configured) {
+      tone = "warn";
+      summary = "Configured";
+      detail = "Configured, but there is no recent live traffic or active link.";
+    }
+
+    return {
+      id: channelId,
+      label:
+        snapshot?.channelMeta?.find((entry) => entry.id === channelId)?.label ??
+        labels[channelId] ??
+        channelId,
+      tone,
+      summary,
+      detail,
+      accountCount,
+      lastActivityAt,
+    };
+  });
+}
+
+function resolveUsageSnapshot(
+  usageResult: SessionsUsageResult | null,
+  usageCostSummary: CostUsageSummary | null,
+): UsageSnapshot {
+  const byAgent = [...(usageResult?.aggregates.byAgent ?? [])].toSorted(
+    (left, right) => (right.totals?.totalCost ?? 0) - (left.totals?.totalCost ?? 0),
+  );
+  const byModel = [...(usageResult?.aggregates.byModel ?? [])].toSorted(
+    (left, right) => (right.totals?.totalCost ?? 0) - (left.totals?.totalCost ?? 0),
+  );
+  const tools = [...(usageResult?.aggregates.tools.tools ?? [])].toSorted(
+    (left, right) => right.count - left.count,
+  );
+  return {
+    totalCost: usageCostSummary?.totals.totalCost ?? usageResult?.totals.totalCost ?? null,
+    totalTokens: usageResult?.totals.totalTokens ?? usageCostSummary?.totals.totalTokens ?? null,
+    sessions: usageResult?.sessions.length ?? 0,
+    messages: usageResult?.aggregates.messages.total ?? 0,
+    errors: usageResult?.aggregates.messages.errors ?? 0,
+    topAgent: byAgent[0]?.agentId ?? null,
+    topTool: tools[0]?.name ?? null,
+    topModel: byModel[0]?.model ?? byModel[0]?.provider ?? null,
+    latencyP95Ms: usageResult?.aggregates.latency?.p95Ms ?? null,
+  };
+}
+
+function resolveLastHeartbeat(payload: unknown) {
+  const record = asRecord(payload);
+  if (!record) {
+    return null;
+  }
+  const ts = asNumber(record.ts);
+  if (!ts) {
+    return null;
+  }
+  return {
+    ts,
+    status: asString(record.status) ?? "unknown",
+    channel: asString(record.channel),
+    accountId: asString(record.accountId),
+  };
+}
+
+function resolveRecentLogCounts(entries: LogEntry[]) {
+  return entries.slice(-80).reduce(
+    (acc, entry) => {
+      if (entry.level === "warn") {
+        acc.warn += 1;
       }
-    | undefined;
-  const uptime = snapshot?.uptimeMs ? formatDurationHuman(snapshot.uptimeMs) : "n/a";
-  const tick = snapshot?.policy?.tickIntervalMs ? `${snapshot.policy.tickIntervalMs}ms` : "n/a";
-  const authMode = snapshot?.authMode;
+      if (entry.level === "error" || entry.level === "fatal") {
+        acc.error += 1;
+      }
+      return acc;
+    },
+    { warn: 0, error: 0 },
+  );
+}
+
+function resolveAgentIdFromSessionKey(sessionKey: string | null | undefined): string | null {
+  if (!sessionKey) {
+    return null;
+  }
+  return parseAgentSessionKey(sessionKey)?.agentId ?? null;
+}
+
+function resolveNodeCards(nodes: Array<Record<string, unknown>>): MissionNodeCard[] {
+  const cards: MissionNodeCard[] = [];
+  for (const node of nodes) {
+    const nodeId = asString(node.nodeId);
+    if (!nodeId) {
+      continue;
+    }
+    const displayName = asString(node.displayName) ?? nodeId;
+    const platform = asString(node.platform);
+    const version =
+      asString(node.version) ?? asString(node.uiVersion) ?? asString(node.coreVersion);
+    const commands = Array.isArray(node.commands)
+      ? node.commands.map((entry) => String(entry))
+      : [];
+    const connected = asBoolean(node.connected) === true;
+    const paired = asBoolean(node.paired) !== false;
+    const tone: Tone = connected ? "ok" : paired ? "warn" : "muted";
+    cards.push({
+      nodeId,
+      label: displayName,
+      detail: [
+        platform,
+        version,
+        commands.length > 0 ? `${commands.length} commands` : "no commands",
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      commands,
+      connected,
+      paired,
+      tone,
+    });
+  }
+  return cards
+    .toSorted((left, right) => {
+      if (left.connected !== right.connected) {
+        return left.connected ? -1 : 1;
+      }
+      return left.label.localeCompare(right.label);
+    })
+    .slice(0, 4);
+}
+
+function resolveNodeIdFromText(text: string, nodeCards: MissionNodeCard[]): string | undefined {
+  const lower = text.toLowerCase();
+  const byId = nodeCards.find((node) => lower.includes(node.nodeId.toLowerCase()));
+  if (byId) {
+    return byId.nodeId;
+  }
+  return nodeCards.find((node) => {
+    const label = node.label.trim().toLowerCase();
+    return label.length >= 5 && label !== node.nodeId.toLowerCase() && lower.includes(label);
+  })?.nodeId;
+}
+
+function resolveIncidentContextFromText(
+  text: string,
+  channelCards: MissionChannelCard[],
+  nodeCards: MissionNodeCard[],
+): Pick<MissionIncident, "sessionKey" | "agentId" | "channelId" | "nodeId"> {
+  const sessionMatch = text.match(/\b(?:agent:[^\s]+:[^\s]+|cron:[^\s]+|main)\b/);
+  const sessionKey = sessionMatch?.[0] ?? undefined;
+  const lower = text.toLowerCase();
+  const agentMatch = text.match(/\bagent(?:Id)?[=: ]([A-Za-z0-9._-]+)/i);
+  const channelId = channelCards.find((channel) => {
+    const needle = channel.id.toLowerCase();
+    return lower.includes(needle);
+  })?.id;
+  return {
+    sessionKey,
+    agentId: agentMatch?.[1] ?? resolveAgentIdFromSessionKey(sessionKey) ?? undefined,
+    channelId,
+    nodeId: resolveNodeIdFromText(text, nodeCards),
+  };
+}
+
+function resolveMissionIncidents(params: {
+  execApprovalQueue: ExecApprovalRequest[];
+  degradedChannels: MissionChannelCard[];
+  nodeCards: MissionNodeCard[];
+  failingCronJobs: CronJob[];
+  securityFindings: DashboardSummaryResult["security"]["topFindings"];
+  logsEntries: LogEntry[];
+  channelCards: MissionChannelCard[];
+}): MissionIncident[] {
+  const incidents: MissionIncident[] = [];
+  for (const entry of params.execApprovalQueue.slice(0, 2)) {
+    const sessionKey = entry.request.sessionKey ?? undefined;
+    const agentId = entry.request.agentId ?? resolveAgentIdFromSessionKey(sessionKey) ?? undefined;
+    incidents.push({
+      id: `approval:${entry.id}`,
+      tone: "warn",
+      title: clampText(entry.request.command, 64),
+      detail: `Exec approval waiting${agentId ? ` · ${agentId}` : ""}`,
+      logQuery: entry.request.command,
+      sessionKey,
+      agentId,
+    });
+  }
+  for (const channel of params.degradedChannels.slice(0, 2)) {
+    incidents.push({
+      id: `channel:${channel.id}`,
+      tone: channel.tone === "danger" ? "danger" : "warn",
+      title: `${channel.label} degraded`,
+      detail: channel.detail,
+      logQuery: channel.id,
+      channelId: channel.id,
+    });
+  }
+  for (const node of params.nodeCards
+    .filter((entry) => !entry.connected || !entry.paired)
+    .slice(0, 2)) {
+    incidents.push({
+      id: `node:${node.nodeId}`,
+      tone: node.connected ? "warn" : "danger",
+      title: `${node.label} ${node.connected ? "needs review" : "offline"}`,
+      detail: node.connected
+        ? `Node is paired but degraded. ${node.detail}`
+        : `Node is not connected to the gateway. ${node.detail}`,
+      logQuery: node.nodeId,
+      nodeId: node.nodeId,
+      actionLabel: "Open nodes",
+      actionTab: "nodes",
+    });
+  }
+  for (const job of params.failingCronJobs.slice(0, 2)) {
+    incidents.push({
+      id: `cron:${job.id}`,
+      tone: "danger",
+      title: `${job.name} failed`,
+      detail: clampText(job.state?.lastError ?? "Cron run failed.", 120),
+      logQuery: job.name,
+      actionLabel: "Open cron",
+      actionTab: "cron",
+    });
+  }
+  for (const finding of params.securityFindings.slice(0, 2)) {
+    incidents.push({
+      id: `security:${finding.title}`,
+      tone: securityFindingTone(finding.severity),
+      title: finding.title,
+      detail: finding.detail,
+      logQuery: finding.title,
+      actionLabel: "Open config",
+      actionTab: "config",
+    });
+  }
+  for (const entry of params.logsEntries
+    .filter((log) => log.level === "error" || log.level === "fatal")
+    .slice(-2)) {
+    const text = `${entry.subsystem ?? ""} ${entry.message ?? entry.raw}`;
+    const context = resolveIncidentContextFromText(text, params.channelCards, params.nodeCards);
+    incidents.push({
+      id: `log:${entry.time ?? entry.raw}`,
+      tone: resolveLogTone(entry.level),
+      title: clampText(entry.message ?? entry.raw, 72),
+      detail: clampText(entry.subsystem ?? entry.raw, 120),
+      logQuery: entry.message ?? entry.subsystem ?? entry.raw,
+      sessionKey: context.sessionKey,
+      agentId: context.agentId,
+      channelId: context.channelId,
+      nodeId: context.nodeId,
+    });
+  }
+  const deduped: MissionIncident[] = [];
+  const seen = new Set<string>();
+  for (const incident of incidents) {
+    if (seen.has(incident.id)) {
+      continue;
+    }
+    seen.add(incident.id);
+    deduped.push(incident);
+    if (deduped.length >= 8) {
+      break;
+    }
+  }
+  return deduped;
+}
+
+function renderIncidentContext(incident: MissionIncident) {
+  const context = [
+    incident.sessionKey ? { label: "session", value: incident.sessionKey } : null,
+    incident.agentId ? { label: "agent", value: incident.agentId } : null,
+    incident.channelId ? { label: "channel", value: incident.channelId } : null,
+    incident.nodeId ? { label: "node", value: incident.nodeId } : null,
+  ].filter((entry): entry is { label: string; value: string } => Boolean(entry));
+  if (context.length === 0) {
+    return nothing;
+  }
+  return html`
+    <div class="mission-context-list">
+      ${context.map(
+        (entry) => html`
+          <span class="mission-context-chip">
+            <span class="mission-context-chip__label">${entry.label}</span>
+            <span class="mono">${entry.value}</span>
+          </span>
+        `,
+      )}
+    </div>
+  `;
+}
+
+function isOverviewTab(value: string | null | undefined): value is Tab {
+  return (
+    value === "agents" ||
+    value === "overview" ||
+    value === "channels" ||
+    value === "instances" ||
+    value === "sessions" ||
+    value === "usage" ||
+    value === "cron" ||
+    value === "skills" ||
+    value === "nodes" ||
+    value === "chat" ||
+    value === "config" ||
+    value === "debug" ||
+    value === "logs"
+  );
+}
+
+function incidentToneFromBackend(incident: DashboardIncidentRecord): Tone {
+  if (incident.severity === "critical") {
+    return "danger";
+  }
+  if (incident.severity === "warn") {
+    return incident.status === "acked" ? "info" : "warn";
+  }
+  return incident.status === "acked" ? "muted" : "info";
+}
+
+function resolveManagedIncidents(
+  dashboard: DashboardSummaryResult | null,
+  fallback: MissionIncident[],
+): MissionIncident[] {
+  const active = dashboard?.incidents.active ?? [];
+  if (active.length === 0) {
+    return fallback;
+  }
+  const managed = active.map(
+    (incident) =>
+      ({
+        id: incident.id,
+        tone: incidentToneFromBackend(incident),
+        title: incident.title,
+        detail: incident.detail,
+        status: incident.status,
+        backendManaged: true,
+        logQuery: incident.metadata.logQuery ?? undefined,
+        sessionKey: incident.metadata.sessionKey ?? undefined,
+        agentId: incident.metadata.agentId ?? undefined,
+        channelId: incident.metadata.channelId ?? undefined,
+        nodeId: incident.metadata.nodeId ?? undefined,
+        actionTab: isOverviewTab(incident.metadata.actionTab)
+          ? incident.metadata.actionTab
+          : undefined,
+        actionLabel: incident.metadata.actionLabel ?? undefined,
+      }) satisfies MissionIncident,
+  );
+  const managedIds = new Set(managed.map((incident) => incident.id));
+  return [...managed, ...fallback.filter((incident) => !managedIds.has(incident.id))].slice(0, 8);
+}
+
+type MissionTrendCard = {
+  id: string;
+  label: string;
+  detail: string;
+  value: string;
+  tone: Tone;
+  series: number[];
+};
+
+function resolveQueuePressure(point: DashboardTimelinePoint): number {
+  return point.queueSize + point.pendingReplies + point.activeEmbeddedRuns;
+}
+
+function resolveAlertPressure(point: DashboardTimelinePoint): number {
+  return (
+    point.logErrors * 2 +
+    point.logWarnings +
+    point.approvals +
+    point.pendingDevices +
+    point.securityCritical * 3 +
+    point.securityWarn
+  );
+}
+
+function renderMissionTrendSparkline(series: number[], tone: Tone) {
+  if (series.length < 2) {
+    return html`
+      <div class="mission-trend__empty">Building live trace...</div>
+    `;
+  }
+  const width = 220;
+  const height = 56;
+  const max = Math.max(...series, 1);
+  const stepX = series.length > 1 ? width / (series.length - 1) : width;
+  const points = series.map((value, index) => {
+    const x = index * stepX;
+    const y = height - (value / max) * (height - 6) - 3;
+    return `${x},${y}`;
+  });
+  const areaPoints = [`0,${height}`, ...points, `${width},${height}`].join(" ");
+  const linePoints = points.join(" ");
+  return svg`
+    <svg class="mission-trend__sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-hidden="true">
+      <polygon class="mission-trend__area ${toneClass(tone)}" points=${areaPoints}></polygon>
+      <polyline class="mission-trend__line ${toneClass(tone)}" points=${linePoints}></polyline>
+    </svg>
+  `;
+}
+
+function renderMissionTrendCards(points: DashboardTimelinePoint[]) {
+  const recent = points.slice(-60);
+  const latest = recent[recent.length - 1] ?? null;
+  if (!latest) {
+    return renderEmptyState("Collecting 15-minute drift data.");
+  }
+  const cards: MissionTrendCard[] = [
+    {
+      id: "cost",
+      label: "Spend drift",
+      detail: "15m rolling cost trace",
+      value: formatMoney(latest.cost),
+      tone: "info",
+      series: recent.map((entry) => entry.cost ?? 0),
+    },
+    {
+      id: "queue",
+      label: "Queue pressure",
+      detail: "Queue + pending replies + embedded runs",
+      value: formatCount(resolveQueuePressure(latest)),
+      tone: resolveQueuePressure(latest) > 0 ? "warn" : "ok",
+      series: recent.map(resolveQueuePressure),
+    },
+    {
+      id: "alerts",
+      label: "Alert pressure",
+      detail: "Security, approvals, devices, warning/error logs",
+      value: formatCount(resolveAlertPressure(latest)),
+      tone:
+        latest.logErrors > 0 || latest.securityCritical > 0
+          ? "danger"
+          : resolveAlertPressure(latest) > 0
+            ? "warn"
+            : "ok",
+      series: recent.map(resolveAlertPressure),
+    },
+  ];
+  return html`
+    <div class="mission-trend-grid">
+      ${cards.map(
+        (card) => html`
+          <div class="mission-trend ${toneClass(card.tone)}">
+            <div class="mission-trend__header">
+              <div>
+                <div class="mission-trend__label">${card.label}</div>
+                <div class="mission-trend__detail">${card.detail}</div>
+              </div>
+              <div class="mission-trend__value">${card.value}</div>
+            </div>
+            ${renderMissionTrendSparkline(card.series, card.tone)}
+          </div>
+        `,
+      )}
+    </div>
+  `;
+}
+
+function resolveAlerts(params: {
+  connected: boolean;
+  lastError: string | null;
+  degradedChannels: MissionChannelCard[];
+  failingCronJobs: CronJob[];
+  execApprovalCount: number;
+  pendingDeviceCount: number;
+  securitySummary: DashboardSummaryResult["security"]["summary"] | null;
+  queuedSystemEvents: string[];
+  logCounts: { warn: number; error: number };
+  errors: Array<string | null>;
+}): MissionAlert[] {
+  const alerts: MissionAlert[] = [];
+  if (!params.connected) {
+    alerts.push({
+      tone: "danger",
+      title: "Gateway offline",
+      detail: params.lastError ?? "Live telemetry is disconnected.",
+    });
+  }
+  if (params.securitySummary?.critical) {
+    alerts.push({
+      tone: "danger",
+      title: `${formatCount(params.securitySummary.critical)} critical security findings`,
+      detail: "The cached gateway security audit reports high-impact exposure that needs review.",
+    });
+  }
+  if (params.securitySummary?.warn) {
+    alerts.push({
+      tone: "warn",
+      title: `${formatCount(params.securitySummary.warn)} security warnings`,
+      detail: "The gateway audit reports medium-risk findings that should be reviewed.",
+    });
+  }
+  if (params.execApprovalCount > 0) {
+    alerts.push({
+      tone: "warn",
+      title: `${formatCount(params.execApprovalCount)} exec approval waiting`,
+      detail: "A command is blocked until an operator approves or denies it.",
+    });
+  }
+  if (params.pendingDeviceCount > 0) {
+    alerts.push({
+      tone: "warn",
+      title: `${formatCount(params.pendingDeviceCount)} device pairing pending`,
+      detail: "A device is waiting for approval to join the gateway.",
+    });
+  }
+  if (params.failingCronJobs.length > 0) {
+    alerts.push({
+      tone: "danger",
+      title: `${formatCount(params.failingCronJobs.length)} cron job failures`,
+      detail: "Recurring runs have failed and need operator review.",
+    });
+  }
+  if (params.degradedChannels.length > 0) {
+    alerts.push({
+      tone: "warn",
+      title: `${formatCount(params.degradedChannels.length)} degraded channels`,
+      detail: "One or more inboxes are configured but not fully healthy.",
+    });
+  }
+  if (params.logCounts.error > 0) {
+    alerts.push({
+      tone: "danger",
+      title: `${formatCount(params.logCounts.error)} recent error logs`,
+      detail: "The live tail contains recent error or fatal entries.",
+    });
+  }
+  if (params.logCounts.warn > 0) {
+    alerts.push({
+      tone: "warn",
+      title: `${formatCount(params.logCounts.warn)} recent warnings`,
+      detail: "The live tail contains warning-level events.",
+    });
+  }
+  if (params.queuedSystemEvents.length > 0) {
+    alerts.push({
+      tone: "info",
+      title: `${formatCount(params.queuedSystemEvents.length)} queued system events`,
+      detail: "System events are queued for the default agent session.",
+    });
+  }
+  for (const error of params.errors) {
+    if (!error) {
+      continue;
+    }
+    alerts.push({
+      tone: "warn",
+      title: "Snapshot warning",
+      detail: clampText(error, 120),
+    });
+  }
+  return alerts.slice(0, 6);
+}
+
+function resolveFeed(eventLog: EventLogEntry[], logsEntries: LogEntry[]): MissionFeedItem[] {
+  const events = eventLog.slice(0, 10).map((entry, index) => ({
+    id: `event-${index}-${entry.ts}`,
+    tone: resolveEventTone(entry.event),
+    source: "event" as const,
+    ts: entry.ts,
+    label: entry.event,
+    title: entry.event,
+    detail: summarizeEventPayload(entry.payload),
+  }));
+  const logs = logsEntries.slice(-12).map((entry, index) => ({
+    id: `log-${index}-${entry.time ?? index}`,
+    tone: resolveLogTone(entry.level),
+    source: "log" as const,
+    ts: resolveLogTimestamp(entry, index),
+    label: entry.level?.toUpperCase() ?? "LOG",
+    title: entry.subsystem ?? entry.level ?? "log",
+    detail: clampText(entry.message ?? entry.raw, 160),
+  }));
+  return [...events, ...logs].toSorted((left, right) => right.ts - left.ts).slice(0, 12);
+}
+function renderMissionAccess(
+  props: OverviewProps,
+  authMode: string | null,
+  tickLabel: string,
+  uptimeLabel: string,
+) {
   const isTrustedProxy = authMode === "trusted-proxy";
   const authHint = (() => {
     if (props.connected || !props.lastError) {
@@ -47,38 +1112,18 @@ export function renderOverview(props: OverviewProps) {
     const hasPassword = Boolean(props.password.trim());
     if (!hasToken && !hasPassword) {
       return html`
-        <div class="muted" style="margin-top: 8px">
-          This gateway requires auth. Add a token or password, then click Connect.
-          <div style="margin-top: 6px">
-            <span class="mono">openclaw dashboard --no-open</span> → open the Control UI<br />
-            <span class="mono">openclaw doctor --generate-gateway-token</span> → set token
-          </div>
-          <div style="margin-top: 6px">
-            <a
-              class="session-link"
-              href="https://docs.openclaw.ai/web/dashboard"
-              target="_blank"
-              rel="noreferrer"
-              title="Control UI auth docs (opens in new tab)"
-              >Docs: Control UI auth</a
-            >
+        <div class="muted mission-access__hint">
+          This gateway requires auth. Add a token or password, then reconnect.
+          <div class="mission-access__docs">
+            <span class="mono">openclaw dashboard --no-open</span> opens the Control UI.<br />
+            <span class="mono">openclaw doctor --generate-gateway-token</span> creates a token.
           </div>
         </div>
       `;
     }
     return html`
-      <div class="muted" style="margin-top: 8px">
-        Auth failed. Update the token or password in Control UI settings, then click Connect.
-        <div style="margin-top: 6px">
-          <a
-            class="session-link"
-            href="https://docs.openclaw.ai/web/dashboard"
-            target="_blank"
-            rel="noreferrer"
-            title="Control UI auth docs (opens in new tab)"
-            >Docs: Control UI auth</a
-          >
-        </div>
+      <div class="muted mission-access__hint">
+        Auth failed. Update the token or password, then reconnect.
       </div>
     `;
   })();
@@ -95,180 +1140,1083 @@ export function renderOverview(props: OverviewProps) {
       return null;
     }
     return html`
-      <div class="muted" style="margin-top: 8px">
-        This page is HTTP, so the browser blocks device identity. Use HTTPS (Tailscale Serve) or open
+      <div class="muted mission-access__hint">
+        This page is HTTP, so the browser blocks device identity. Use HTTPS or open
         <span class="mono">http://127.0.0.1:18789</span> on the gateway host.
-        <div style="margin-top: 6px">
-          If you must stay on HTTP, set
-          <span class="mono">gateway.controlUi.allowInsecureAuth: true</span> (token-only).
-        </div>
-        <div style="margin-top: 6px">
-          <a
-            class="session-link"
-            href="https://docs.openclaw.ai/gateway/tailscale"
-            target="_blank"
-            rel="noreferrer"
-            title="Tailscale Serve docs (opens in new tab)"
-            >Docs: Tailscale Serve</a
-          >
-          <span class="muted"> · </span>
-          <a
-            class="session-link"
-            href="https://docs.openclaw.ai/web/control-ui#insecure-http"
-            target="_blank"
-            rel="noreferrer"
-            title="Insecure HTTP docs (opens in new tab)"
-            >Docs: Insecure HTTP</a
-          >
-        </div>
       </div>
     `;
   })();
 
   return html`
-    <section class="grid grid-cols-2">
-      <div class="card">
-        <div class="card-title">Gateway Access</div>
-        <div class="card-sub">Where the dashboard connects and how it authenticates.</div>
-        <div class="form-grid" style="margin-top: 16px;">
+    <details class="mission-access" open>
+      <summary class="mission-access__summary">
+        <div>
+          <div class="card-title">Gateway Access</div>
+          <div class="card-sub">Endpoint, auth, and default session routing.</div>
+        </div>
+        <div class="mission-access__meta">
+          ${renderToneBadge(props.connected ? "Connected" : "Disconnected", props.connected ? "ok" : "danger")}
+          <span class="muted">Uptime ${uptimeLabel} · Tick ${tickLabel}</span>
+        </div>
+      </summary>
+      <div class="mission-access__body">
+        <div class="form-grid">
           <label class="field">
             <span>WebSocket URL</span>
             <input
               .value=${props.settings.gatewayUrl}
-              @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onSettingsChange({ ...props.settings, gatewayUrl: v });
+              @input=${(event: Event) => {
+                const value = (event.target as HTMLInputElement).value;
+                props.onSettingsChange({ ...props.settings, gatewayUrl: value });
               }}
-              placeholder="ws://100.x.y.z:18789"
+              placeholder="ws://127.0.0.1:18789"
             />
           </label>
           ${
             isTrustedProxy
-              ? ""
+              ? nothing
               : html`
-                <label class="field">
-                  <span>Gateway Token</span>
-                  <input
-                    .value=${props.settings.token}
-                    @input=${(e: Event) => {
-                      const v = (e.target as HTMLInputElement).value;
-                      props.onSettingsChange({ ...props.settings, token: v });
-                    }}
-                    placeholder="OPENCLAW_GATEWAY_TOKEN"
-                  />
-                </label>
-                <label class="field">
-                  <span>Password (not stored)</span>
-                  <input
-                    type="password"
-                    .value=${props.password}
-                    @input=${(e: Event) => {
-                      const v = (e.target as HTMLInputElement).value;
-                      props.onPasswordChange(v);
-                    }}
-                    placeholder="system or shared password"
-                  />
-                </label>
-              `
+                  <label class="field">
+                    <span>Gateway Token</span>
+                    <input
+                      .value=${props.settings.token}
+                      @input=${(event: Event) => {
+                        const value = (event.target as HTMLInputElement).value;
+                        props.onSettingsChange({ ...props.settings, token: value });
+                      }}
+                      placeholder="OPENCLAW_GATEWAY_TOKEN"
+                    />
+                  </label>
+                  <label class="field">
+                    <span>Password (not stored)</span>
+                    <input
+                      type="password"
+                      .value=${props.password}
+                      @input=${(event: Event) => {
+                        const value = (event.target as HTMLInputElement).value;
+                        props.onPasswordChange(value);
+                      }}
+                      placeholder="system or shared password"
+                    />
+                  </label>
+                `
           }
           <label class="field">
             <span>Default Session Key</span>
             <input
               .value=${props.settings.sessionKey}
-              @input=${(e: Event) => {
-                const v = (e.target as HTMLInputElement).value;
-                props.onSessionKeyChange(v);
+              @input=${(event: Event) => {
+                const value = (event.target as HTMLInputElement).value;
+                props.onSessionKeyChange(value);
               }}
             />
           </label>
         </div>
-        <div class="row" style="margin-top: 14px;">
-          <button class="btn" @click=${() => props.onConnect()}>Connect</button>
-          <button class="btn" @click=${() => props.onRefresh()}>Refresh</button>
-          <span class="muted">${isTrustedProxy ? "Authenticated via trusted proxy." : "Click Connect to apply connection changes."}</span>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-title">Snapshot</div>
-        <div class="card-sub">Latest gateway handshake information.</div>
-        <div class="stat-grid" style="margin-top: 16px;">
-          <div class="stat">
-            <div class="stat-label">Status</div>
-            <div class="stat-value ${props.connected ? "ok" : "warn"}">
-              ${props.connected ? "Connected" : "Disconnected"}
-            </div>
+        <div class="mission-access__footer">
+          <div class="row">
+            <button class="btn primary" type="button" @click=${() => props.onConnect()}>Reconnect</button>
+            <button class="btn" type="button" @click=${() => props.onRefresh()}>Refresh snapshot</button>
           </div>
-          <div class="stat">
-            <div class="stat-label">Uptime</div>
-            <div class="stat-value">${uptime}</div>
-          </div>
-          <div class="stat">
-            <div class="stat-label">Tick Interval</div>
-            <div class="stat-value">${tick}</div>
-          </div>
-          <div class="stat">
-            <div class="stat-label">Last Channels Refresh</div>
-            <div class="stat-value">
-              ${props.lastChannelsRefresh ? formatRelativeTimestamp(props.lastChannelsRefresh) : "n/a"}
-            </div>
+          <div class="muted">
+            ${isTrustedProxy ? "Authenticated via trusted proxy." : `Auth mode: ${authMode ?? "unknown"}.`}
           </div>
         </div>
         ${
           props.lastError
-            ? html`<div class="callout danger" style="margin-top: 14px;">
-              <div>${props.lastError}</div>
-              ${authHint ?? ""}
-              ${insecureContextHint ?? ""}
-            </div>`
-            : html`
-                <div class="callout" style="margin-top: 14px">
-                  Use Channels to link WhatsApp, Telegram, Discord, Signal, or iMessage.
-                </div>
-              `
+            ? html`<div class="callout danger">${props.lastError}${authHint ?? nothing}${insecureContextHint ?? nothing}</div>`
+            : nothing
         }
       </div>
-    </section>
+    </details>
+  `;
+}
 
-    <section class="grid grid-cols-3" style="margin-top: 18px;">
-      <div class="card stat-card">
-        <div class="stat-label">Instances</div>
-        <div class="stat-value">${props.presenceCount}</div>
-        <div class="muted">Presence beacons in the last 5 minutes.</div>
-      </div>
-      <div class="card stat-card">
-        <div class="stat-label">Sessions</div>
-        <div class="stat-value">${props.sessionsCount ?? "n/a"}</div>
-        <div class="muted">Recent session keys tracked by the gateway.</div>
-      </div>
-      <div class="card stat-card">
-        <div class="stat-label">Cron</div>
-        <div class="stat-value">
-          ${props.cronEnabled == null ? "n/a" : props.cronEnabled ? "Enabled" : "Disabled"}
-        </div>
-        <div class="muted">Next wake ${formatNextRun(props.cronNext)}</div>
-      </div>
-    </section>
+export function renderOverview(props: OverviewProps) {
+  const gatewaySnapshot = props.hello?.snapshot as
+    | {
+        uptimeMs?: number;
+        policy?: { tickIntervalMs?: number };
+        authMode?: "none" | "token" | "password" | "trusted-proxy";
+      }
+    | undefined;
+  const status = asStatusSummary(props.debugStatus);
+  const health = asHealthSummary(props.debugHealth);
+  const uptimeLabel = gatewaySnapshot?.uptimeMs
+    ? formatDurationHuman(gatewaySnapshot.uptimeMs)
+    : "n/a";
+  const tickLabel = gatewaySnapshot?.policy?.tickIntervalMs
+    ? `${gatewaySnapshot.policy.tickIntervalMs}ms`
+    : "n/a";
+  const authMode = gatewaySnapshot?.authMode ?? null;
+  const channelCards = resolveChannelCards(props.channelsSnapshot, health);
+  const degradedChannels = channelCards.filter(
+    (entry) => entry.tone === "warn" || entry.tone === "danger",
+  );
+  const hotSessions = resolveHotSessions(props.sessionsResult);
+  const failingCronJobs = props.cronJobs.filter(
+    (job) => job.state?.lastStatus === "error" || Boolean(job.state?.lastError),
+  );
+  const pendingDevices = props.devicesList?.pending ?? [];
+  const pairedDevices = props.devicesList?.paired ?? [];
+  const dashboard = props.dashboardSummary;
+  const securitySummary = dashboard?.security.summary ?? null;
+  const securityFindings = dashboard?.security.topFindings ?? [];
+  const runtimeBacklog = dashboard?.runtime ?? null;
+  const approvalCount = dashboard?.approvals.count ?? props.execApprovalQueue.length;
+  const pendingDeviceCount = dashboard?.devices.pending ?? pendingDevices.length;
+  const pairedDeviceCount = dashboard?.devices.paired ?? pairedDevices.length;
+  const nodeCount = dashboard?.nodes.count ?? props.nodesCount;
+  const hasMobileNodeConnected = dashboard?.nodes.hasMobileNodeConnected ?? false;
+  const dashboardTimeline = props.dashboardTimeline;
+  const nodeCards = resolveNodeCards(props.nodes);
+  const securityTone: Tone = securitySummary?.critical
+    ? "danger"
+    : securitySummary?.warn
+      ? "warn"
+      : securitySummary
+        ? "ok"
+        : "muted";
+  const securityTotalFindings = (securitySummary?.critical ?? 0) + (securitySummary?.warn ?? 0);
+  const queuedSystemEvents = Array.isArray(status?.queuedSystemEvents)
+    ? status.queuedSystemEvents.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  const heartbeatAgents = Array.isArray(status?.heartbeat?.agents)
+    ? status.heartbeat.agents.filter((entry): entry is StatusHeartbeatAgentLike => Boolean(entry))
+    : [];
+  const lastHeartbeat = resolveLastHeartbeat(props.debugHeartbeat);
+  const logCounts = resolveRecentLogCounts(props.logsEntries);
+  const localIncidents = resolveMissionIncidents({
+    execApprovalQueue: props.execApprovalQueue,
+    degradedChannels,
+    nodeCards,
+    failingCronJobs,
+    securityFindings,
+    logsEntries: props.logsEntries,
+    channelCards,
+  });
+  const incidents = resolveManagedIncidents(dashboard, localIncidents);
+  const activeIncidentCount = dashboard?.incidents.summary.active ?? incidents.length;
+  const alerts = resolveAlerts({
+    connected: props.connected,
+    lastError: props.lastError,
+    degradedChannels,
+    failingCronJobs,
+    execApprovalCount: approvalCount,
+    pendingDeviceCount,
+    securitySummary,
+    queuedSystemEvents,
+    logCounts,
+    errors: [
+      props.dashboardError,
+      props.channelsError,
+      props.cronError,
+      props.sessionsError,
+      props.presenceError,
+      props.logsError,
+      props.devicesError,
+      props.usageError,
+    ],
+  });
+  const feed = resolveFeed(props.eventLog, props.logsEntries);
+  const usage = resolveUsageSnapshot(props.usageResult, props.usageCostSummary);
+  const allClear = alerts.length === 0 && activeIncidentCount === 0;
+  const title = !props.connected
+    ? "Gateway connection lost"
+    : alerts.some((entry) => entry.tone === "danger")
+      ? "OpenClaw needs operator attention"
+      : alerts.some((entry) => entry.tone === "warn") || activeIncidentCount > 0
+        ? "OpenClaw is healthy with active watch items"
+        : "OpenClaw is stable and streaming live telemetry";
+  const subtitle = props.connected
+    ? `Connected to ${props.settings.gatewayUrl}. ${formatCount(props.sessionsResult?.count ?? 0)} sessions, ${formatCount(channelCards.length)} channels, ${formatCount(props.cronJobs.length)} cron jobs, ${formatCount(nodeCount)} connected nodes${hasMobileNodeConnected ? ", mobile link online" : ""}.`
+    : "Reconnect to resume live sync across sessions, channels, cron, nodes, and approvals.";
 
-    <section class="card" style="margin-top: 18px;">
-      <div class="card-title">Notes</div>
-      <div class="card-sub">Quick reminders for remote control setups.</div>
-      <div class="note-grid" style="margin-top: 14px;">
-        <div>
-          <div class="note-title">Tailscale serve</div>
-          <div class="muted">
-            Prefer serve mode to keep the gateway on loopback with tailnet auth.
+  return html`
+    <section class="mission-control">
+      <section class="card mission-hero">
+        <div class="mission-hero__grid">
+          <div class="mission-hero__main">
+            <div class="mission-hero__eyebrow">Realtime command center</div>
+            <div class="mission-hero__title">${title}</div>
+            <div class="mission-hero__copy">${subtitle}</div>
+            <div class="mission-hero__meta">
+              ${renderToneBadge(props.connected ? "Live sync" : "Offline", props.connected ? "ok" : "danger")}
+              ${renderToneBadge(`Auth ${authMode ?? "unknown"}`, authMode === "trusted-proxy" ? "info" : "muted")}
+              ${
+                securitySummary
+                  ? renderToneBadge(
+                      securityTotalFindings > 0
+                        ? `Security ${formatCount(securityTotalFindings)}`
+                        : "Security clear",
+                      securityTone,
+                    )
+                  : nothing
+              }
+              ${hasMobileNodeConnected ? renderToneBadge("Mobile node online", "info") : nothing}
+              <span class="mission-hero__meta-text">Uptime ${uptimeLabel}</span>
+              <span class="mission-hero__meta-text">Tick ${tickLabel}</span>
+              ${
+                dashboard?.security?.ts
+                  ? html`<span class="mission-hero__meta-text">
+                      Audit ${dashboard.security.cached ? "cached" : "fresh"} ${formatRelativeTimestamp(dashboard.security.ts)}
+                    </span>`
+                  : nothing
+              }
+              <span class="mission-hero__meta-text">
+                Channels refresh ${formatRelativeOrNa(props.lastChannelsRefresh)}
+              </span>
+            </div>
+            <div class="mission-actions">
+              <button class="btn primary" type="button" @click=${() => props.onNavigate("chat")}>Open chat</button>
+              <button class="btn" type="button" @click=${() => props.onNavigate("channels")}>Channels</button>
+              <button class="btn" type="button" @click=${() => props.onNavigate("cron")}>Cron</button>
+              <button class="btn" type="button" @click=${() => props.onNavigate("logs")}>Logs</button>
+              <button class="btn" type="button" @click=${() => props.onNavigate("nodes")}>Nodes</button>
+              <button class="btn" type="button" @click=${() => props.onConnect()}>Reconnect</button>
+            </div>
+          </div>
+          <div class="mission-hero__side">
+            <div class="mission-hero__panel">
+              <div class="mission-hero__panel-title">Operator queue</div>
+              <div class="mission-hero__panel-value">${allClear ? "All clear" : formatCount(activeIncidentCount)}</div>
+              <div class="mission-hero__panel-copy">
+                ${allClear ? "No active incidents in the current snapshot." : "Live issues are prioritized below."}
+              </div>
+            </div>
+            <div class="mission-alert-stack">
+              ${
+                allClear
+                  ? html`
+                      <div class="mission-alert ${toneClass("ok")}">
+                        <div class="mission-alert__title">Stable runtime</div>
+                        <div class="mission-alert__detail">
+                          Channels, sessions, cron, and logs do not show urgent incidents right now.
+                        </div>
+                      </div>
+                    `
+                  : alerts.slice(0, 4).map(
+                      (alert) => html`
+                        <div class="mission-alert ${toneClass(alert.tone)}">
+                          <div class="mission-alert__title">${alert.title}</div>
+                          <div class="mission-alert__detail">${alert.detail}</div>
+                        </div>
+                      `,
+                    )
+              }
+            </div>
           </div>
         </div>
-        <div>
-          <div class="note-title">Session hygiene</div>
-          <div class="muted">Use /new or sessions.patch to reset context.</div>
-        </div>
-        <div>
-          <div class="note-title">Cron reminders</div>
-          <div class="muted">Use isolated sessions for recurring runs.</div>
-        </div>
-      </div>
+      </section>
+
+      <section class="mission-kpis">
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Sessions</div>
+          <div class="mission-kpi__value">${formatCount(props.sessionsResult?.count ?? 0)}</div>
+          <div class="mission-kpi__detail">
+            Default ${status?.sessions?.defaults?.model ?? "model n/a"}
+            ${
+              status?.sessions?.defaults?.contextTokens
+                ? html` · ${formatCompactCount(status.sessions.defaults.contextTokens)} ctx`
+                : nothing
+            }
+          </div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Channels</div>
+          <div class="mission-kpi__value">${formatCount(channelCards.length)}</div>
+          <div class="mission-kpi__detail">
+            ${degradedChannels.length > 0 ? `${formatCount(degradedChannels.length)} degraded` : "No degraded channels"}
+          </div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Cron</div>
+          <div class="mission-kpi__value">${props.cronStatus?.enabled ? formatCount(props.cronJobs.length) : "Paused"}</div>
+          <div class="mission-kpi__detail">Next wake ${formatNextRun(props.cronStatus?.nextWakeAtMs ?? null)}</div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Approvals</div>
+          <div class="mission-kpi__value">${formatCount(approvalCount + pendingDeviceCount)}</div>
+          <div class="mission-kpi__detail">
+            ${formatCount(approvalCount)} exec · ${formatCount(pendingDeviceCount)} device
+          </div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Usage window</div>
+          <div class="mission-kpi__value">${formatMoney(usage.totalCost)}</div>
+          <div class="mission-kpi__detail">${formatCompactCount(usage.totalTokens)} tokens</div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Recent logs</div>
+          <div class="mission-kpi__value">${formatCount(logCounts.error + logCounts.warn)}</div>
+          <div class="mission-kpi__detail">
+            ${formatCount(logCounts.error)} errors · ${formatCount(logCounts.warn)} warnings
+          </div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Security</div>
+          <div class="mission-kpi__value">
+            ${securitySummary && securityTotalFindings === 0 ? "Clear" : formatCount(securityTotalFindings)}
+          </div>
+          <div class="mission-kpi__detail">
+            ${
+              securitySummary
+                ? `${formatCount(securitySummary.critical)} critical · ${formatCount(securitySummary.warn)} warnings`
+                : "Audit summary unavailable"
+            }
+          </div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Instances</div>
+          <div class="mission-kpi__value">${formatCount(props.presenceEntries.length)}</div>
+          <div class="mission-kpi__detail">
+            ${formatCount(nodeCount)} connected nodes${hasMobileNodeConnected ? " · mobile online" : ""}
+          </div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">System events</div>
+          <div class="mission-kpi__value">${formatCount(queuedSystemEvents.length)}</div>
+          <div class="mission-kpi__detail">
+            ${lastHeartbeat ? `${lastHeartbeat.status} ${formatRelativeTimestamp(lastHeartbeat.ts)}` : "No heartbeat event yet"}
+          </div>
+        </article>
+      </section>
+
+      <section class="mission-grid">
+        <article class="card mission-panel mission-panel--span-7">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Live Activity</div>
+              <div class="card-sub">Merged event stream and recent log tail.</div>
+            </div>
+            <div class="mission-panel__meta">
+              ${renderToneBadge(`Events ${formatCount(props.eventLog.length)}`, "info")}
+              <span class="muted">Logs ${formatRelativeOrNa(props.logsLastFetchAt)}</span>
+            </div>
+          </div>
+          <div class="mission-feed">
+            ${
+              feed.length === 0
+                ? renderEmptyState("No live events yet.")
+                : feed.map(
+                    (item) => html`
+                      <div class="mission-feed__item ${toneClass(item.tone)}">
+                        <div class="mission-feed__stamp">
+                          ${renderToneBadge(item.source === "event" ? item.label : item.label.toLowerCase(), item.tone)}
+                          <span class="muted">${formatRelativeTimestamp(item.ts)}</span>
+                        </div>
+                        <div class="mission-feed__title">${item.title}</div>
+                        <div class="mission-feed__detail">${item.detail}</div>
+                      </div>
+                    `,
+                  )
+            }
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-5">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Operator Queue</div>
+              <div class="card-sub">Pending approvals, device pairing, and incident watchlist.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("nodes")}>Open nodes</button>
+          </div>
+          <div class="mission-stack">
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Exec approvals</div>
+              ${
+                props.execApprovalQueue.length === 0
+                  ? renderEmptyState(
+                      approvalCount > 0
+                        ? `${formatCount(approvalCount)} exec approvals pending, detail snapshot not loaded yet.`
+                        : "No blocked exec commands.",
+                    )
+                  : props.execApprovalQueue.slice(0, 4).map(
+                      (entry) => html`
+                        <div class="mission-row">
+                          <div class="mission-row__body">
+                            <div class="mission-row__title">${clampText(entry.request.command, 72)}</div>
+                            <div class="mission-row__detail">
+                              ${entry.request.agentId ?? "agent unknown"}
+                              ${entry.request.sessionKey ? html` · ${entry.request.sessionKey}` : nothing}
+                              ${entry.request.cwd ? html` · ${entry.request.cwd}` : nothing}
+                            </div>
+                            ${
+                              entry.request.ask
+                                ? html`<div class="mission-inline-note">${clampText(entry.request.ask, 140)}</div>`
+                                : nothing
+                            }
+                            <div class="mission-actions-inline">
+                              <button
+                                class="btn btn--sm"
+                                type="button"
+                                ?disabled=${props.execApprovalBusy}
+                                @click=${() => props.onResolveExecApproval(entry.id, "allow-once")}
+                              >
+                                Allow once
+                              </button>
+                              <button
+                                class="btn btn--sm"
+                                type="button"
+                                ?disabled=${props.execApprovalBusy}
+                                @click=${() => props.onResolveExecApproval(entry.id, "allow-always")}
+                              >
+                                Always allow
+                              </button>
+                              <button
+                                class="btn btn--sm"
+                                type="button"
+                                ?disabled=${props.execApprovalBusy}
+                                @click=${() => props.onResolveExecApproval(entry.id, "deny")}
+                              >
+                                Deny
+                              </button>
+                            </div>
+                          </div>
+                          <div class="mission-row__meta mission-row__meta--stack">
+                            ${entry.request.security ? renderToneBadge(entry.request.security, "warn") : nothing}
+                            <span>Expires ${formatRelativeTimestamp(entry.expiresAtMs)}</span>
+                          </div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Pending devices</div>
+              ${
+                pendingDevices.length === 0
+                  ? renderEmptyState(
+                      pendingDeviceCount > 0
+                        ? `${formatCount(pendingDeviceCount)} pairing requests pending, detail snapshot not loaded yet.`
+                        : `No pairing requests. ${formatCount(pairedDeviceCount)} device(s) already paired.`,
+                    )
+                  : pendingDevices.slice(0, 4).map(
+                      (entry) => html`
+                        <div class="mission-row">
+                          <div class="mission-row__body">
+                            <div class="mission-row__title">${entry.displayName ?? entry.deviceId}</div>
+                            <div class="mission-row__detail">
+                              ${entry.role ?? "role unknown"}
+                              ${entry.remoteIp ? html` · ${entry.remoteIp}` : nothing}
+                              ${
+                                entry.isRepair
+                                  ? html`
+                                      · repair
+                                    `
+                                  : nothing
+                              }
+                            </div>
+                            <div class="mission-actions-inline">
+                              <button
+                                class="btn btn--sm"
+                                type="button"
+                                ?disabled=${props.devicesLoading}
+                                @click=${() => props.onApproveDevice(entry.requestId)}
+                              >
+                                Pair device
+                              </button>
+                              <button
+                                class="btn btn--sm"
+                                type="button"
+                                ?disabled=${props.devicesLoading}
+                                @click=${() => props.onRejectDevice(entry.requestId)}
+                              >
+                                Reject
+                              </button>
+                            </div>
+                          </div>
+                          <div class="mission-row__meta">${entry.ts ? formatRelativeTimestamp(entry.ts) : "Pending"}</div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Watch items</div>
+              ${
+                alerts.length === 0
+                  ? renderEmptyState("No active watch items.")
+                  : alerts.map(
+                      (alert) => html`
+                        <div class="mission-row mission-row--tight ${toneClass(alert.tone)}">
+                          <div>
+                            <div class="mission-row__title">${alert.title}</div>
+                            <div class="mission-row__detail">${alert.detail}</div>
+                          </div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-7">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Incident Drill-Down</div>
+              <div class="card-sub">One alert, multiple pivots into logs, sessions, agents, channels, and runtime surfaces.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onOpenLogsQuery("error")}>Open error logs</button>
+          </div>
+          <div class="mission-stack">
+            ${
+              incidents.length === 0
+                ? renderEmptyState("No incidents require drill-down right now.")
+                : incidents.map(
+                    (incident) => html`
+                      <div class="mission-row ${toneClass(incident.tone)}">
+                        <div class="mission-row__body">
+                          <div class="mission-row__title">${incident.title}</div>
+                          <div class="mission-row__detail">${incident.detail}</div>
+                          ${renderIncidentContext(incident)}
+                          <div class="mission-actions-inline">
+                            ${
+                              incident.backendManaged && incident.status === "open"
+                                ? html`
+                                    <button
+                                      class="btn btn--sm"
+                                      type="button"
+                                      ?disabled=${props.dashboardLoading}
+                                      @click=${() => props.onAckIncident(incident.id)}
+                                    >
+                                      Ack
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                            ${
+                              incident.backendManaged && incident.status !== "resolved"
+                                ? html`
+                                    <button
+                                      class="btn btn--sm"
+                                      type="button"
+                                      ?disabled=${props.dashboardLoading}
+                                      @click=${() => props.onResolveIncident(incident.id)}
+                                    >
+                                      Resolve
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                            ${
+                              incident.logQuery
+                                ? html`
+                                    <button class="btn btn--sm" type="button" @click=${() => props.onOpenLogsQuery(incident.logQuery ?? "")}>
+                                      Logs
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                            ${
+                              incident.sessionKey
+                                ? html`
+                                    <button class="btn btn--sm" type="button" @click=${() => props.onOpenSession(incident.sessionKey ?? "")}>
+                                      Session
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                            ${
+                              incident.agentId
+                                ? html`
+                                    <button class="btn btn--sm" type="button" @click=${() => props.onFocusAgent(incident.agentId ?? "")}>
+                                      Agent
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                            ${
+                              incident.channelId
+                                ? html`
+                                    <button class="btn btn--sm" type="button" @click=${() => props.onFocusChannel(incident.channelId ?? "")}>
+                                      Channel
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                            ${
+                              incident.nodeId
+                                ? html`
+                                    <button class="btn btn--sm" type="button" @click=${() => props.onFocusNode(incident.nodeId ?? "")}>
+                                      Node
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                            ${
+                              incident.actionTab
+                                ? html`
+                                    <button class="btn btn--sm" type="button" @click=${() => props.onNavigate(incident.actionTab ?? "overview")}>
+                                      ${incident.actionLabel ?? "Open"}
+                                    </button>
+                                  `
+                                : nothing
+                            }
+                          </div>
+                        </div>
+                        <div class="mission-row__meta">
+                          ${
+                            incident.status
+                              ? renderToneBadge(
+                                  incident.status,
+                                  incident.status === "open"
+                                    ? incident.tone
+                                    : incident.status === "acked"
+                                      ? "info"
+                                      : "muted",
+                                )
+                              : nothing
+                          }
+                          ${renderToneBadge(incident.tone, incident.tone)}
+                        </div>
+                      </div>
+                    `,
+                  )
+            }
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-5">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Node Ops</div>
+              <div class="card-sub">Direct ping, inspect, log pivot, and doctor actions against paired nodes.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("nodes")}>Open nodes</button>
+          </div>
+          <div class="mission-stack">
+            ${
+              nodeCards.length === 0
+                ? renderEmptyState("No node snapshot available.")
+                : nodeCards.map((node) => {
+                    const busy = props.missionNodeBusyById[node.nodeId] ?? null;
+                    const canProbe = node.commands.includes("system.which");
+                    const canDoctor = node.commands.includes("system.run") && node.connected;
+                    return html`
+                      <div class="mission-row ${toneClass(node.tone)}">
+                        <div class="mission-row__body">
+                          <div class="mission-row__title">${node.label}</div>
+                          <div class="mission-row__detail">${node.detail}</div>
+                          <div class="mission-actions-inline">
+                            <button class="btn btn--sm" type="button" ?disabled=${Boolean(busy)} @click=${() => props.onDescribeNode(node.nodeId)}>
+                              ${busy === "describe" ? "Loading…" : "Describe"}
+                            </button>
+                            <button class="btn btn--sm" type="button" ?disabled=${Boolean(busy) || !canProbe} @click=${() => props.onProbeNode(node.nodeId)}>
+                              ${busy === "probe" ? "Pinging…" : "Ping"}
+                            </button>
+                            <button class="btn btn--sm" type="button" ?disabled=${Boolean(busy) || !canDoctor} @click=${() => props.onRunNodeDoctor(node.nodeId)}>
+                              ${busy === "doctor" ? "Running…" : busy === "approval" ? "Awaiting approval" : "Doctor"}
+                            </button>
+                            <button class="btn btn--sm" type="button" @click=${() => props.onOpenLogsQuery(node.nodeId)}>
+                              Logs
+                            </button>
+                            <button class="btn btn--sm" type="button" @click=${() => props.onFocusNode(node.nodeId)}>
+                              Node
+                            </button>
+                          </div>
+                        </div>
+                        <div class="mission-row__meta mission-row__meta--stack">
+                          ${renderToneBadge(node.connected ? "connected" : node.paired ? "paired" : "offline", node.tone)}
+                          <span class="mono">${node.nodeId}</span>
+                        </div>
+                      </div>
+                    `;
+                  })
+            }
+            ${
+              props.missionNodeResult
+                ? html`
+                    <div class="mission-inline-note ${toneClass(props.missionNodeResult.status)}">
+                      <strong>${props.missionNodeResult.title}</strong><br />
+                      ${props.missionNodeResult.detail}
+                      ${
+                        props.missionNodeResult.output
+                          ? html`<pre class="mission-inline-pre">${props.missionNodeResult.output}</pre>`
+                          : nothing
+                      }
+                    </div>
+                  `
+                : nothing
+            }
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-7">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Hot Sessions</div>
+              <div class="card-sub">Recent, aborted, high-context, and cron-driven sessions.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("sessions")}>Open sessions</button>
+          </div>
+          <div class="mission-list">
+            ${
+              hotSessions.length === 0
+                ? renderEmptyState("No active sessions available.")
+                : hotSessions.map(
+                    (row) => html`
+                      <button class="mission-list__item" type="button" @click=${() => props.onOpenSession(row.key)}>
+                        <div class="mission-list__main">
+                          <div class="mission-list__title">${row.key}</div>
+                          <div class="mission-list__detail">
+                            ${row.model ?? "model n/a"} · ${formatSessionTokens(row.totalTokens ?? null, row.contextTokens ?? null)}
+                          </div>
+                        </div>
+                        <div class="mission-list__meta">
+                          ${renderToneBadge(row.kind, resolveSessionTone(row))}
+                          <span>${formatRelativeOrNa(row.updatedAt)}</span>
+                          ${
+                            row.abortedLastRun
+                              ? html`
+                                  <span class="muted">Aborted last run</span>
+                                `
+                              : nothing
+                          }
+                        </div>
+                      </button>
+                    `,
+                  )
+            }
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-5">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Channel Health</div>
+              <div class="card-sub">Configuration, link state, and recent activity per inbox.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("channels")}>Open channels</button>
+          </div>
+          <div class="mission-channel-grid">
+            ${
+              channelCards.length === 0
+                ? renderEmptyState("No channel snapshot available yet.")
+                : channelCards.map(
+                    (channel) => html`
+                      <div class="mission-channel ${toneClass(channel.tone)}">
+                        <div class="mission-channel__head">
+                          <div class="mission-channel__title">${channel.label}</div>
+                          ${renderToneBadge(channel.summary, channel.tone)}
+                        </div>
+                        <div class="mission-channel__detail">${channel.detail}</div>
+                        <div class="mission-channel__meta">
+                          <span>${formatCount(channel.accountCount)} account(s)</span>
+                          <span>${formatLastActivity(channel.lastActivityAt)}</span>
+                        </div>
+                      </div>
+                    `,
+                  )
+            }
+          </div>
+        </article>
+        <article class="card mission-panel mission-panel--span-6">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Cron Watch</div>
+              <div class="card-sub">Upcoming schedules, last failures, and run pressure.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("cron")}>Open cron</button>
+          </div>
+          <div class="mission-stack">
+            <div class="mission-row mission-row--tight">
+              <div>
+                <div class="mission-row__title">Scheduler state</div>
+                <div class="mission-row__detail">
+                  ${props.cronStatus?.enabled ? "Enabled" : "Disabled"} · Next wake ${formatNextRun(props.cronStatus?.nextWakeAtMs ?? null)}
+                </div>
+              </div>
+              <div class="mission-row__meta">${formatCount(failingCronJobs.length)} failing</div>
+            </div>
+              ${
+                props.cronJobs.length === 0
+                  ? renderEmptyState("No cron jobs configured.")
+                  : props.cronJobs
+                      .toSorted(
+                        (left, right) =>
+                          (right.state?.nextRunAtMs ?? 0) - (left.state?.nextRunAtMs ?? 0),
+                      )
+                      .slice(0, 6)
+                      .map(
+                        (job) => html`
+                        <div class="mission-row">
+                          <div class="mission-row__body">
+                            <div class="mission-row__title">${job.name}</div>
+                            <div class="mission-row__detail">
+                              ${
+                                job.payload.kind === "agentTurn"
+                                  ? clampText(job.payload.message, 84)
+                                  : clampText(job.payload.text, 84)
+                              }
+                            </div>
+                            <div class="mission-actions-inline">
+                              <button
+                                class="btn btn--sm"
+                                type="button"
+                                ?disabled=${props.cronBusy}
+                                @click=${() => props.onRunCronJob(job.id)}
+                              >
+                                Run now
+                              </button>
+                            </div>
+                          </div>
+                          <div class="mission-row__meta">
+                            ${renderToneBadge(
+                              job.state?.lastStatus ?? (job.enabled ? "queued" : "paused"),
+                              job.state?.lastStatus === "error"
+                                ? "danger"
+                                : job.enabled
+                                  ? "info"
+                                  : "muted",
+                            )}
+                            <span>${formatNextRun(job.state?.nextRunAtMs ?? null)}</span>
+                          </div>
+                        </div>
+                      `,
+                      )
+              }
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-6">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Usage Snapshot</div>
+              <div class="card-sub">Current usage window ${props.usageStartDate} to ${props.usageEndDate}.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("usage")}>Open usage</button>
+          </div>
+          <div class="mission-usage-grid">
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Cost</div>
+              <div class="mission-usage-stat__value">${formatMoney(usage.totalCost)}</div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Tokens</div>
+              <div class="mission-usage-stat__value">${formatCompactCount(usage.totalTokens)}</div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Sessions</div>
+              <div class="mission-usage-stat__value">${formatCount(usage.sessions)}</div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Messages</div>
+              <div class="mission-usage-stat__value">${formatCompactCount(usage.messages)}</div>
+            </div>
+          </div>
+          <div class="mission-stack">
+            <div class="mission-row mission-row--tight">
+              <div>
+                <div class="mission-row__title">Top agent</div>
+                <div class="mission-row__detail">${usage.topAgent ?? "No usage data yet."}</div>
+              </div>
+              <div class="mission-row__meta">Errors ${formatCount(usage.errors)}</div>
+            </div>
+            <div class="mission-row mission-row--tight">
+              <div>
+                <div class="mission-row__title">Top tool</div>
+                <div class="mission-row__detail">${usage.topTool ?? "No tool calls in range."}</div>
+              </div>
+              <div class="mission-row__meta">P95 ${usage.latencyP95Ms != null ? `${Math.round(usage.latencyP95Ms)}ms` : "n/a"}</div>
+            </div>
+            <div class="mission-row mission-row--tight">
+              <div>
+                <div class="mission-row__title">Top model</div>
+                <div class="mission-row__detail">${usage.topModel ?? "No model activity in range."}</div>
+              </div>
+              <div class="mission-row__meta">${props.usageStartDate === props.usageEndDate ? "1 day" : "custom"} window</div>
+            </div>
+          </div>
+          <section class="mission-subpanel">
+            <div class="mission-subpanel__title">15-minute drift</div>
+            ${renderMissionTrendCards(dashboardTimeline)}
+          </section>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-6">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Security Posture</div>
+              <div class="card-sub">Cached gateway audit with prioritized findings and remediation cues.</div>
+            </div>
+            <div class="mission-actions-inline">
+              <button
+                class="btn btn--sm"
+                type="button"
+                ?disabled=${props.dashboardLoading}
+                @click=${() => props.onRefreshSecurityAudit()}
+              >
+                Refresh audit
+              </button>
+              <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("config")}>Open config</button>
+            </div>
+          </div>
+          <div class="mission-usage-grid">
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Critical</div>
+              <div class="mission-usage-stat__value">${formatCount(securitySummary?.critical ?? 0)}</div>
+              <div class="mission-usage-stat__detail">Immediate review required</div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Warnings</div>
+              <div class="mission-usage-stat__value">${formatCount(securitySummary?.warn ?? 0)}</div>
+              <div class="mission-usage-stat__detail">Operational hardening</div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Info</div>
+              <div class="mission-usage-stat__value">${formatCount(securitySummary?.info ?? 0)}</div>
+              <div class="mission-usage-stat__detail">Background recommendations</div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Audit state</div>
+              <div class="mission-usage-stat__value">
+                ${props.dashboardLoading ? "Refreshing" : dashboard?.security.cached ? "Cached" : dashboard ? "Fresh" : "n/a"}
+              </div>
+              <div class="mission-usage-stat__detail">
+                ${dashboard?.security.ts ? formatRelativeTimestamp(dashboard.security.ts) : "No audit timestamp"}
+              </div>
+            </div>
+          </div>
+          <div class="mission-stack">
+            ${
+              props.dashboardError
+                ? html`<div class="mission-inline-note mission-tone-warn">${clampText(props.dashboardError, 180)}</div>`
+                : nothing
+            }
+            ${
+              securityFindings.length === 0
+                ? renderEmptyState(
+                    securitySummary
+                      ? "No critical or warning findings in the latest audit."
+                      : "Security audit summary unavailable.",
+                  )
+                : securityFindings.map(
+                    (finding) => html`
+                      <div class="mission-row ${toneClass(securityFindingTone(finding.severity))}">
+                        <div>
+                          <div class="mission-row__title">${finding.title}</div>
+                          <div class="mission-row__detail">${finding.detail}</div>
+                          ${
+                            finding.remediation
+                              ? html`<div class="mission-inline-note">${finding.remediation}</div>`
+                              : nothing
+                          }
+                        </div>
+                        <div class="mission-row__meta">
+                          ${renderToneBadge(finding.severity, securityFindingTone(finding.severity))}
+                        </div>
+                      </div>
+                    `,
+                  )
+            }
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-6">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Runtime Pulse</div>
+              <div class="card-sub">Presence, heartbeat cadence, queue pressure, and queued system events.</div>
+            </div>
+            <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("instances")}>Open instances</button>
+          </div>
+          <div class="mission-stack">
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Queue pressure</div>
+              <div class="mission-usage-grid">
+                <div class="mission-usage-stat">
+                  <div class="mission-usage-stat__label">Command queue</div>
+                  <div class="mission-usage-stat__value">${formatCount(runtimeBacklog?.queueSize ?? 0)}</div>
+                </div>
+                <div class="mission-usage-stat">
+                  <div class="mission-usage-stat__label">Pending replies</div>
+                  <div class="mission-usage-stat__value">${formatCount(runtimeBacklog?.pendingReplies ?? 0)}</div>
+                </div>
+                <div class="mission-usage-stat">
+                  <div class="mission-usage-stat__label">Embedded runs</div>
+                  <div class="mission-usage-stat__value">${formatCount(runtimeBacklog?.activeEmbeddedRuns ?? 0)}</div>
+                </div>
+                <div class="mission-usage-stat">
+                  <div class="mission-usage-stat__label">Connected nodes</div>
+                  <div class="mission-usage-stat__value">${formatCount(nodeCount)}</div>
+                  <div class="mission-usage-stat__detail">
+                    ${hasMobileNodeConnected ? "Mobile node connected" : "No mobile node connected"}
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Heartbeat</div>
+              ${
+                heartbeatAgents.length === 0
+                  ? renderEmptyState("No heartbeat configuration reported.")
+                  : heartbeatAgents.map(
+                      (entry) => html`
+                        <div class="mission-row mission-row--tight">
+                          <div>
+                            <div class="mission-row__title">${entry.agentId ?? "agent"}</div>
+                            <div class="mission-row__detail">${entry.enabled ? (entry.every ?? "enabled") : "disabled"}</div>
+                          </div>
+                          <div class="mission-row__meta">
+                            ${renderToneBadge(entry.enabled ? "active" : "disabled", entry.enabled ? "ok" : "muted")}
+                          </div>
+                        </div>
+                      `,
+                    )
+              }
+              ${
+                lastHeartbeat
+                  ? html`
+                      <div class="mission-inline-note">
+                        Last heartbeat: ${lastHeartbeat.status} ${formatRelativeTimestamp(lastHeartbeat.ts)}
+                        ${lastHeartbeat.channel ? html` · ${lastHeartbeat.channel}` : nothing}
+                        ${lastHeartbeat.accountId ? html` · ${lastHeartbeat.accountId}` : nothing}
+                      </div>
+                    `
+                  : nothing
+              }
+            </section>
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Presence</div>
+              ${
+                props.presenceEntries.length === 0
+                  ? renderEmptyState(props.presenceStatus ?? "No presence beacons available.")
+                  : props.presenceEntries.slice(0, 5).map(
+                      (entry) => html`
+                        <div class="mission-row mission-row--tight">
+                          <div>
+                            <div class="mission-row__title">${entry.host ?? entry.instanceId ?? "instance"}</div>
+                            <div class="mission-row__detail">
+                              ${entry.mode ?? "mode n/a"}
+                              ${entry.version ? html` · ${entry.version}` : nothing}
+                              ${entry.platform ? html` · ${entry.platform}` : nothing}
+                            </div>
+                          </div>
+                          <div class="mission-row__meta">${entry.ts ? formatRelativeTimestamp(entry.ts) : "n/a"}</div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Queued system events</div>
+              ${
+                queuedSystemEvents.length === 0
+                  ? renderEmptyState("No queued system events.")
+                  : queuedSystemEvents
+                      .slice(0, 5)
+                      .map((entry) => html`<div class="mission-inline-note">${entry}</div>`)
+              }
+            </section>
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-6">
+          ${renderMissionAccess(props, authMode, tickLabel, uptimeLabel)}
+        </article>
+      </section>
     </section>
   `;
 }

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -1,7 +1,13 @@
 import { html, nothing, svg } from "lit";
 import type { EventLogEntry } from "../app-events.ts";
 import type { DashboardTimelinePoint } from "../controllers/dashboard-timeline.ts";
-import type { DashboardIncidentRecord, DashboardSummaryResult } from "../controllers/dashboard.ts";
+import type {
+  DashboardAutonomyAgent,
+  DashboardIncidentRecord,
+  DashboardProcessEntry,
+  DashboardSummaryResult,
+  DashboardToolActivity,
+} from "../controllers/dashboard.ts";
 import type { DevicePairingList } from "../controllers/devices.ts";
 import type { ExecApprovalDecision, ExecApprovalRequest } from "../controllers/exec-approval.ts";
 import type {
@@ -649,6 +655,67 @@ function resolveNodeCards(nodes: Array<Record<string, unknown>>): MissionNodeCar
     .slice(0, 4);
 }
 
+function resolveToolTone(status: DashboardToolActivity["status"]): Tone {
+  if (status === "failed") {
+    return "danger";
+  }
+  if (status === "running") {
+    return "info";
+  }
+  return "ok";
+}
+
+function resolveProcessTone(status: DashboardProcessEntry["status"]): Tone {
+  if (status === "failed" || status === "killed") {
+    return "danger";
+  }
+  if (status === "running") {
+    return "info";
+  }
+  return "ok";
+}
+
+function formatDurationCompact(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return "n/a";
+  }
+  return formatDurationHuman(value);
+}
+
+function resolveAutonomyGuardTone(autonomy: DashboardSummaryResult["autonomy"] | null): Tone {
+  if (!autonomy) {
+    return "muted";
+  }
+  if (autonomy.exec.security === "full") {
+    return "danger";
+  }
+  if (autonomy.exec.host === "gateway" && autonomy.exec.ask === "off") {
+    return "warn";
+  }
+  if (!autonomy.fs.workspaceOnly) {
+    return "warn";
+  }
+  return "ok";
+}
+
+function resolveAutonomyAgentTone(agent: DashboardAutonomyAgent): Tone {
+  if (agent.execSecurity === "full") {
+    return "danger";
+  }
+  if (
+    agent.execHost === "gateway" ||
+    agent.execNode ||
+    agent.allowCount > 0 ||
+    agent.alsoAllowCount > 0
+  ) {
+    return "info";
+  }
+  if (agent.workspaceOnly) {
+    return "ok";
+  }
+  return "muted";
+}
+
 function resolveNodeIdFromText(text: string, nodeCards: MissionNodeCard[]): string | undefined {
   const lower = text.toLowerCase();
   const byId = nodeCards.find((node) => lower.includes(node.nodeId.toLowerCase()));
@@ -1269,6 +1336,18 @@ export function renderOverview(props: OverviewProps) {
   const hasMobileNodeConnected = dashboard?.nodes.hasMobileNodeConnected ?? false;
   const dashboardTimeline = props.dashboardTimeline;
   const nodeCards = resolveNodeCards(props.nodes);
+  const toolRuntime = dashboard?.tools ?? {
+    summary: { active: 0, recent: 0, failedRecent: 0, uniqueToolsActive: 0 },
+    active: [],
+    recent: [],
+  };
+  const processRuntime = dashboard?.processes ?? {
+    summary: { running: 0, recent: 0, failedRecent: 0, killedRecent: 0 },
+    running: [],
+    recent: [],
+  };
+  const autonomy = dashboard?.autonomy ?? null;
+  const autonomyGuardTone = resolveAutonomyGuardTone(autonomy);
   const securityTone: Tone = securitySummary?.critical
     ? "danger"
     : securitySummary?.warn
@@ -1444,6 +1523,20 @@ export function renderOverview(props: OverviewProps) {
           <div class="mission-kpi__label">Usage window</div>
           <div class="mission-kpi__value">${formatMoney(usage.totalCost)}</div>
           <div class="mission-kpi__detail">${formatCompactCount(usage.totalTokens)} tokens</div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Tool runtime</div>
+          <div class="mission-kpi__value">${formatCount(toolRuntime.summary.active)}</div>
+          <div class="mission-kpi__detail">
+            ${formatCount(toolRuntime.summary.failedRecent)} failed recent · ${formatCount(toolRuntime.summary.uniqueToolsActive)} unique live
+          </div>
+        </article>
+        <article class="mission-kpi card">
+          <div class="mission-kpi__label">Background jobs</div>
+          <div class="mission-kpi__value">${formatCount(processRuntime.summary.running)}</div>
+          <div class="mission-kpi__detail">
+            ${formatCount(processRuntime.summary.failedRecent)} failed recent · ${formatCount(processRuntime.summary.recent)} retained
+          </div>
         </article>
         <article class="mission-kpi card">
           <div class="mission-kpi__label">Recent logs</div>
@@ -1839,6 +1932,285 @@ export function renderOverview(props: OverviewProps) {
                     </div>
                   `
                 : nothing
+            }
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-7">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Tool Runtime</div>
+              <div class="card-sub">Live tool calls, recent failures, and pivots back into the owning session.</div>
+            </div>
+            <div class="mission-panel__meta">
+              ${renderToneBadge(`${formatCount(toolRuntime.summary.active)} active`, toolRuntime.summary.active > 0 ? "info" : "muted")}
+              ${renderToneBadge(`${formatCount(toolRuntime.summary.failedRecent)} failed`, toolRuntime.summary.failedRecent > 0 ? "danger" : "ok")}
+            </div>
+          </div>
+          <div class="mission-stack">
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Live calls</div>
+              ${
+                toolRuntime.active.length === 0
+                  ? renderEmptyState("No tool call is running right now.")
+                  : toolRuntime.active.map(
+                      (tool) => html`
+                        <div class="mission-row ${toneClass(resolveToolTone(tool.status))}">
+                          <div class="mission-row__body">
+                            <div class="mission-row__title">${tool.name}</div>
+                            <div class="mission-row__detail">
+                              ${tool.agentId ?? "agent unknown"}
+                              ${tool.sessionKey ? html` · ${tool.sessionKey}` : nothing}
+                              · ${tool.currentPhase}
+                              · ${formatDurationCompact(tool.updatedAt - tool.startedAt)}
+                            </div>
+                            ${tool.argsPreview ? html`<div class="mission-inline-note">${tool.argsPreview}</div>` : nothing}
+                            <div class="mission-actions-inline">
+                              ${
+                                tool.sessionKey
+                                  ? html`
+                                      <button class="btn btn--sm" type="button" @click=${() => props.onOpenSession(tool.sessionKey ?? "")}>
+                                        Session
+                                      </button>
+                                    `
+                                  : nothing
+                              }
+                              ${
+                                tool.agentId
+                                  ? html`
+                                      <button class="btn btn--sm" type="button" @click=${() => props.onFocusAgent(tool.agentId ?? "")}>
+                                        Agent
+                                      </button>
+                                    `
+                                  : nothing
+                              }
+                              <button class="btn btn--sm" type="button" @click=${() => props.onOpenLogsQuery(tool.name)}>
+                                Logs
+                              </button>
+                            </div>
+                          </div>
+                          <div class="mission-row__meta mission-row__meta--stack">
+                            ${renderToneBadge(tool.status, resolveToolTone(tool.status))}
+                            <span>${formatRelativeTimestamp(tool.updatedAt)}</span>
+                          </div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Recent completions</div>
+              ${
+                toolRuntime.recent.length === 0
+                  ? renderEmptyState("No recent tool execution retained yet.")
+                  : toolRuntime.recent.slice(0, 6).map(
+                      (tool) => html`
+                        <div class="mission-row mission-row--tight ${toneClass(resolveToolTone(tool.status))}">
+                          <div class="mission-row__body">
+                            <div class="mission-row__title">${tool.name}</div>
+                            <div class="mission-row__detail">
+                              ${tool.agentId ?? "agent unknown"}
+                              ${tool.sessionKey ? html` · ${tool.sessionKey}` : nothing}
+                              · ${formatDurationCompact((tool.endedAt ?? tool.updatedAt) - tool.startedAt)}
+                            </div>
+                            ${tool.outputPreview ? html`<div class="mission-inline-note">${tool.outputPreview}</div>` : nothing}
+                          </div>
+                          <div class="mission-row__meta mission-row__meta--stack">
+                            ${renderToneBadge(tool.status, resolveToolTone(tool.status))}
+                            <span>${formatRelativeTimestamp(tool.endedAt ?? tool.updatedAt)}</span>
+                          </div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-5">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Execution Queue</div>
+              <div class="card-sub">Background exec and process jobs, including failures retained for operator follow-up.</div>
+            </div>
+            <div class="mission-panel__meta">
+              ${renderToneBadge(`${formatCount(processRuntime.summary.running)} running`, processRuntime.summary.running > 0 ? "info" : "muted")}
+              ${renderToneBadge(`${formatCount(processRuntime.summary.failedRecent)} failed`, processRuntime.summary.failedRecent > 0 ? "danger" : "ok")}
+            </div>
+          </div>
+          <div class="mission-stack">
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Running jobs</div>
+              ${
+                processRuntime.running.length === 0
+                  ? renderEmptyState("No background job is currently running.")
+                  : processRuntime.running.map(
+                      (entry) => html`
+                        <div class="mission-row ${toneClass(resolveProcessTone(entry.status))}">
+                          <div class="mission-row__body">
+                            <div class="mission-row__title">${clampText(entry.command, 76)}</div>
+                            <div class="mission-row__detail">
+                              ${entry.sessionKey ?? entry.scopeKey ?? "scope unknown"}
+                              ${entry.cwd ? html` · ${entry.cwd}` : nothing}
+                              · ${formatDurationCompact(entry.durationMs)}
+                            </div>
+                            ${entry.tail ? html`<div class="mission-inline-note">${entry.tail}</div>` : nothing}
+                            <div class="mission-actions-inline">
+                              ${
+                                entry.sessionKey
+                                  ? html`
+                                      <button class="btn btn--sm" type="button" @click=${() => props.onOpenSession(entry.sessionKey ?? "")}>
+                                        Session
+                                      </button>
+                                    `
+                                  : nothing
+                              }
+                              <button class="btn btn--sm" type="button" @click=${() => props.onOpenLogsQuery(entry.command)}>
+                                Logs
+                              </button>
+                            </div>
+                          </div>
+                          <div class="mission-row__meta mission-row__meta--stack">
+                            ${renderToneBadge(entry.status, resolveProcessTone(entry.status))}
+                            ${entry.pid != null ? html`<span>PID ${entry.pid}</span>` : nothing}
+                          </div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+            <section class="mission-subpanel">
+              <div class="mission-subpanel__title">Recent outcomes</div>
+              ${
+                processRuntime.recent.length === 0
+                  ? renderEmptyState("No completed background job retained yet.")
+                  : processRuntime.recent.slice(0, 6).map(
+                      (entry) => html`
+                        <div class="mission-row mission-row--tight ${toneClass(resolveProcessTone(entry.status))}">
+                          <div class="mission-row__body">
+                            <div class="mission-row__title">${clampText(entry.command, 76)}</div>
+                            <div class="mission-row__detail">
+                              ${entry.sessionKey ?? entry.scopeKey ?? "scope unknown"}
+                              · ${formatDurationCompact(entry.durationMs)}
+                              ${
+                                entry.exitCode != null
+                                  ? html` · exit ${entry.exitCode}`
+                                  : entry.exitSignal
+                                    ? html` · signal ${entry.exitSignal}`
+                                    : nothing
+                              }
+                            </div>
+                            ${entry.tail ? html`<div class="mission-inline-note">${entry.tail}</div>` : nothing}
+                          </div>
+                          <div class="mission-row__meta mission-row__meta--stack">
+                            ${renderToneBadge(entry.status, resolveProcessTone(entry.status))}
+                            <span>${formatRelativeTimestamp(entry.endedAt ?? entry.startedAt)}</span>
+                          </div>
+                        </div>
+                      `,
+                    )
+              }
+            </section>
+          </div>
+        </article>
+
+        <article class="card mission-panel mission-panel--span-5">
+          <div class="mission-panel__header">
+            <div>
+              <div class="card-title">Autonomy Posture</div>
+              <div class="card-sub">Global tool guardrails, per-agent overrides, and the effective execution surface.</div>
+            </div>
+            <div class="mission-actions-inline">
+              ${renderToneBadge(autonomy ? `Exec ${autonomy.exec.host}` : "Config unavailable", autonomyGuardTone)}
+              <button class="btn btn--sm" type="button" @click=${() => props.onNavigate("agents")}>Open agents</button>
+            </div>
+          </div>
+          <div class="mission-usage-grid">
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Guardrail</div>
+              <div class="mission-usage-stat__value">${autonomy ? autonomy.exec.security : "n/a"}</div>
+              <div class="mission-usage-stat__detail">Ask ${autonomy?.exec.ask ?? "n/a"} · host ${autonomy?.exec.host ?? "n/a"}</div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Workspace</div>
+              <div class="mission-usage-stat__value">${autonomy?.fs.workspaceOnly ? "Scoped" : "Broad"}</div>
+              <div class="mission-usage-stat__detail">
+                ${autonomy?.summary.applyPatchEnabled ? "apply_patch enabled" : "apply_patch disabled"}
+              </div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Agents</div>
+              <div class="mission-usage-stat__value">${formatCount(autonomy?.summary.agents ?? 0)}</div>
+              <div class="mission-usage-stat__detail">
+                ${formatCount(autonomy?.summary.explicitToolPolicies ?? 0)} with explicit tool policy
+              </div>
+            </div>
+            <div class="mission-usage-stat">
+              <div class="mission-usage-stat__label">Node bound</div>
+              <div class="mission-usage-stat__value">${formatCount(autonomy?.summary.nodeBoundAgents ?? 0)}</div>
+              <div class="mission-usage-stat__detail">
+                ${formatCount(autonomy?.summary.elevatedAgents ?? 0)} elevated-capable
+              </div>
+            </div>
+          </div>
+          <div class="mission-stack">
+            ${
+              !autonomy
+                ? renderEmptyState("Autonomy posture is unavailable.")
+                : html`
+                    <section class="mission-subpanel">
+                      <div class="mission-subpanel__title">Global execution policy</div>
+                      <div class="mission-row ${toneClass(autonomyGuardTone)}">
+                        <div class="mission-row__body">
+                          <div class="mission-row__title">Tool host and approval model</div>
+                          <div class="mission-row__detail">
+                            Exec host ${autonomy.exec.host}
+                            ${autonomy.exec.node ? html` · node ${autonomy.exec.node}` : nothing}
+                            · security ${autonomy.exec.security}
+                            · ask ${autonomy.exec.ask}
+                          </div>
+                          <div class="mission-actions-inline">
+                            ${renderToneBadge(autonomy.fs.workspaceOnly ? "workspace only" : "full fs", autonomy.fs.workspaceOnly ? "ok" : "warn")}
+                            ${renderToneBadge(autonomy.applyPatch.enabled ? "apply_patch on" : "apply_patch off", autonomy.applyPatch.enabled ? "info" : "muted")}
+                            ${renderToneBadge(autonomy.elevated.enabled ? "elevated enabled" : "elevated off", autonomy.elevated.enabled ? "warn" : "ok")}
+                          </div>
+                        </div>
+                      </div>
+                    </section>
+                    <section class="mission-subpanel">
+                      <div class="mission-subpanel__title">Agent overrides</div>
+                      ${
+                        autonomy.agents.length === 0
+                          ? renderEmptyState("No agent-level tool overrides configured.")
+                          : autonomy.agents.slice(0, 6).map(
+                              (agent) => html`
+                                <div class="mission-row mission-row--tight ${toneClass(resolveAutonomyAgentTone(agent))}">
+                                  <div class="mission-row__body">
+                                    <div class="mission-row__title">${agent.name ?? agent.agentId}</div>
+                                    <div class="mission-row__detail">
+                                      ${agent.toolProfile ?? "default profile"}
+                                      ${agent.execHost ? html` · host ${agent.execHost}` : nothing}
+                                      ${agent.execSecurity ? html` · ${agent.execSecurity}` : nothing}
+                                      ${agent.execNode ? html` · node ${agent.execNode}` : nothing}
+                                    </div>
+                                    <div class="mission-actions-inline">
+                                      ${renderToneBadge(`${formatCount(agent.allowCount)} allow`, agent.allowCount > 0 ? "info" : "muted")}
+                                      ${renderToneBadge(`${formatCount(agent.denyCount)} deny`, agent.denyCount > 0 ? "warn" : "muted")}
+                                      ${renderToneBadge(agent.workspaceOnly ? "workspace" : "broad fs", agent.workspaceOnly ? "ok" : "warn")}
+                                    </div>
+                                  </div>
+                                  <div class="mission-row__meta mission-row__meta--stack">
+                                    ${renderToneBadge(resolveAutonomyAgentTone(agent), resolveAutonomyAgentTone(agent))}
+                                    <button class="btn btn--sm" type="button" @click=${() => props.onFocusAgent(agent.agentId)}>
+                                      Agent
+                                    </button>
+                                  </div>
+                                </div>
+                              `,
+                            )
+                      }
+                    </section>
+                  `
             }
           </div>
         </article>


### PR DESCRIPTION
## Summary
This PR turns Mission Control into a runtime-aware operations surface instead of a static overview.

It adds three new dashboard capabilities:
- Tool Runtime: live tool calls, recent completions, failure visibility, and pivots back to the owning session or agent
- Execution Queue: background exec/process activity with recent failures and retained tails for follow-up
- Autonomy Posture: effective execution guardrails and per-agent overrides so operators can see how autonomous the system really is

## User impact
Operators can now answer questions that were not visible from the dashboard before:
- which tools are running right now
- which background jobs are stuck, failing, or still active
- which agents are using broader execution policies or node-bound execution

That makes Mission Control materially more useful for supervising an autonomous OpenClaw runtime.

## Root cause
The existing overview already covered incidents, approvals, devices, nodes, cron, and usage, but it did not surface the execution layer that actually powers autonomy.

Tool events existed only in chat-time streams, background process state was isolated in the process registry, and effective tool policy stayed buried in config or agent detail views.

## Fix
### Backend
- add a global tool activity registry that consumes agent tool/lifecycle events
- preserve `sessionKey` in finished process sessions for session-level pivots
- extend `dashboard.summary` with:
  - `tools`
  - `processes`
  - `autonomy`
- wire the tool activity registry into gateway runtime and dashboard delta scheduling

### UI
- add Mission Control KPI cards for tool runtime and background jobs
- add the `Tool Runtime` panel
- add the `Execution Queue` panel
- add the `Autonomy Posture` panel
- poll `dashboard.summary` in the overview fast loop so the new panels stay fresh even if a delta is missed

## Validation
Checks run locally:
- `pnpm check`
- `pnpm build`
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server-methods/dashboard.test.ts --pool=forks`
- `pnpm --dir ui test -- src/ui/app-gateway.node.test.ts src/ui/app-settings.test.ts`

Additional full-suite signal:
- `pnpm test` was also run
- three unrelated Windows symlink tests failed in this environment:
  - `src/canvas-host/server.test.ts`
  - `src/media/server.test.ts`
  - `src/memory/qmd-manager.test.ts`
- these failures are caused by local `fs.symlink(...)` permission restrictions, not by the dashboard changes in this PR
