### PR TITLE
fix(web-search): add Content-Type header to Brave Search API requests

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1405,6 +1405,7 @@ async function runWebSearch(params: {
         method: "GET",
         headers: {
           Accept: "application/json",
+          "Content-Type": "application/json",
           "X-Subscription-Token": params.apiKey,
         },
       },


### PR DESCRIPTION
## Problem

Brave Search API returns 422 error when calling web_search tool. The issue description indicates that the API requires both headers to be sent, but the current implementation only sends the Accept header.

## Solution

Add \Content-Type: application/json\ header to Brave Search API requests to match other search providers (Perplexity, Gemini, Grok, Kimi) and ensure both headers are sent to the API.

## Changes

- Modified \unWebSearch\ function in \src/agents/tools/web-search.ts\ to include \Content-Type: application/json\ header alongside existing \Accept\ and \X-Subscription-Token\ headers

## Testing

- Linting passed
- Header format matches other search providers in the same file

Fixes #38867