### PR TITLE
fix: logging- unify timestamp format across console and file logs, Issue- 38756

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Docs/IRC: fix five `json55` code-fence typos in the IRC channel examples so Mintlify applies JSON5 syntax highlighting correctly. (#50842) Thanks @Hollychou924.
 - Telegram/forum topics: recover `#General` topic `1` routing when Telegram omits forum metadata, including native commands, interactive callbacks, inbound message context, and fallback error replies. (#53699) thanks @huntharo
 - Discord/config types: add missing `autoArchiveDuration` to `DiscordGuildChannelConfig` so TypeScript config definitions match the existing schema and runtime support. (#43427) Thanks @davidguttman.
+- CLI/logging: make pretty log timestamps always include an explicit timezone offset in default UTC and `--local-time` modes, so incident triage no longer mixes ambiguous clock displays. (#38904) Thanks @sahilsatralkar.
 - Feishu/startup: treat unresolved `SecretRef` app credentials as not configured during account resolution so CLI startup and read-only Feishu config surfaces stop crashing before runtime-backed secret resolution is available. (#53675) Thanks @hpt.
 - DeepSeek/pricing: replace the zero-cost DeepSeek catalog rates with the current DeepSeek V3.2 pricing so usage totals stop showing `$0.00` for DeepSeek sessions. (#54143) Thanks @arkyu2077.
 - Docker/setup: avoid the pre-start `openclaw-cli` shared-network namespace loop by routing setup-time onboard/config writes through `openclaw-gateway`, so fresh Docker installs stop failing before the gateway comes up. (#53385) Thanks @amsminn.

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -117,7 +117,7 @@ describe("logs cli", () => {
 
     it("formats UTC timestamp in pretty mode", () => {
       const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty");
-      expect(result).toBe("12:00:00");
+      expect(result).toBe("12:00:00+00:00");
     });
 
     it("formats local time in plain mode when localTime is true", () => {
@@ -132,13 +132,8 @@ describe("logs cli", () => {
     it("formats local time in pretty mode when localTime is true", () => {
       const utcTime = "2025-01-01T12:00:00.000Z";
       const result = formatLogTimestamp(utcTime, "pretty", true);
-      // Should be HH:MM:SS format
-      expect(result).toMatch(/^\d{2}:\d{2}:\d{2}$/);
-      // Should be different from UTC time (12:00:00) if not in UTC timezone
-      const tzOffset = new Date(utcTime).getTimezoneOffset();
-      if (tzOffset !== 0) {
-        expect(result).not.toBe("12:00:00");
-      }
+      // Should be HH:MM:SS±HH:MM format with timezone offset.
+      expect(result).toMatch(/^\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
     });
 
     it.each([

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -2,7 +2,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import type { Command } from "commander";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { parseLogLine } from "../logging/parse-log-line.js";
-import { formatLocalIsoWithOffset, isValidTimeZone } from "../logging/timestamps.js";
+import { formatTimestamp, isValidTimeZone } from "../logging/timestamps.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
 import { createSafeStreamWriter } from "../terminal/stream-writer.js";
@@ -74,16 +74,10 @@ export function formatLogTimestamp(
     return value;
   }
 
-  let timeString: string;
-  if (localTime) {
-    timeString = formatLocalIsoWithOffset(parsed);
-  } else {
-    timeString = parsed.toISOString();
-  }
   if (mode === "pretty") {
-    return timeString.slice(11, 19);
+    return formatTimestamp(parsed, { style: "short", timeZone: localTime ? undefined : "UTC" });
   }
-  return timeString;
+  return localTime ? formatTimestamp(parsed, { style: "long" }) : parsed.toISOString();
 }
 
 function formatLogLine(

--- a/src/infra/format-time/format-datetime.ts
+++ b/src/infra/format-time/format-datetime.ts
@@ -5,7 +5,6 @@
  * Consolidates duplicated formatUtcTimestamp / formatZonedTimestamp / resolveExplicitTimezone
  * that previously lived in envelope.ts and session-updates.ts.
  */
-
 /**
  * Validate an IANA timezone string. Returns the string if valid, undefined otherwise.
  */

--- a/src/logging/console-timestamp.test.ts
+++ b/src/logging/console-timestamp.test.ts
@@ -29,15 +29,20 @@ describe("formatConsoleTimestamp", () => {
     return `${year}-${month}-${day}T${h}:${m}:${s}.${ms}${tzSign}${tzHours}:${tzMinutes}`;
   }
 
-  it("pretty style returns local HH:MM:SS", () => {
+  it("pretty style returns local HH:MM:SS with timezone offset", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-17T18:01:02.345Z"));
 
     const result = formatConsoleTimestamp("pretty");
     const now = new Date();
-    expect(result).toBe(
-      `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())}`,
-    );
+    const h = pad2(now.getHours());
+    const m = pad2(now.getMinutes());
+    const s = pad2(now.getSeconds());
+    const tzOffset = now.getTimezoneOffset();
+    const tzSign = tzOffset <= 0 ? "+" : "-";
+    const tzHours = pad2(Math.floor(Math.abs(tzOffset) / 60));
+    const tzMinutes = pad2(Math.abs(tzOffset) % 60);
+    expect(result).toBe(`${h}:${m}:${s}${tzSign}${tzHours}:${tzMinutes}`);
   });
 
   it("compact style returns local ISO-like timestamp with timezone offset", () => {

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -8,7 +8,7 @@ import { type LogLevel, normalizeLogLevel } from "./levels.js";
 import { getLogger, type LoggerSettings } from "./logger.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
-import { formatLocalIsoWithOffset } from "./timestamps.js";
+import { formatLocalIsoWithOffset, formatTimestamp } from "./timestamps.js";
 
 export type ConsoleStyle = "pretty" | "compact" | "json";
 type ConsoleSettings = {
@@ -175,10 +175,7 @@ function isEpipeError(err: unknown): boolean {
 export function formatConsoleTimestamp(style: ConsoleStyle): string {
   const now = new Date();
   if (style === "pretty") {
-    const h = String(now.getHours()).padStart(2, "0");
-    const m = String(now.getMinutes()).padStart(2, "0");
-    const s = String(now.getSeconds()).padStart(2, "0");
-    return `${h}:${m}:${s}`;
+    return formatTimestamp(now, { style: "short" });
   }
   return formatLocalIsoWithOffset(now);
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -13,7 +13,7 @@ import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
-import { formatLocalIsoWithOffset } from "./timestamps.js";
+import { formatTimestamp } from "./timestamps.js";
 
 type ProcessWithBuiltinModule = NodeJS.Process & {
   getBuiltinModule?: (id: string) => unknown;
@@ -185,7 +185,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
 
   logger.attachTransport((logObj: LogObj) => {
     try {
-      const time = formatLocalIsoWithOffset(logObj.date ?? new Date());
+      const time = formatTimestamp(logObj.date ?? new Date(), { style: "long" });
       const line = JSON.stringify({ ...logObj, time });
       const payload = `${line}\n`;
       const payloadBytes = Buffer.byteLength(payload, "utf8");
@@ -194,7 +194,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
         if (!warnedAboutSizeCap) {
           warnedAboutSizeCap = true;
           const warningLine = JSON.stringify({
-            time: formatLocalIsoWithOffset(new Date()),
+            time: formatTimestamp(new Date(), { style: "long" }),
             level: "warn",
             subsystem: "logging",
             message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,

--- a/src/logging/timestamps.test.ts
+++ b/src/logging/timestamps.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
-import { formatLocalIsoWithOffset, isValidTimeZone } from "./timestamps.js";
+import { formatLocalIsoWithOffset, formatTimestamp, isValidTimeZone } from "./timestamps.js";
 
 describe("formatLocalIsoWithOffset", () => {
   const testDate = new Date("2025-01-01T04:00:00.000Z");
@@ -47,6 +47,35 @@ describe("formatLocalIsoWithOffset", () => {
     expect(source).not.toMatch(/\.getHours\s*\(/);
     expect(source).not.toMatch(/\.getMinutes\s*\(/);
     expect(source).not.toMatch(/\.getTimezoneOffset\s*\(/);
+  });
+});
+
+describe("formatTimestamp", () => {
+  const testDate = new Date("2024-01-15T14:30:45.123Z");
+
+  it("formats short style with explicit UTC offset", () => {
+    expect(formatTimestamp(testDate, { style: "short", timeZone: "UTC" })).toBe("14:30:45+00:00");
+  });
+
+  it("formats medium style with milliseconds and offset", () => {
+    expect(formatTimestamp(testDate, { style: "medium", timeZone: "UTC" })).toBe(
+      "14:30:45.123+00:00",
+    );
+  });
+
+  it.each(["UTC", "America/New_York", "Europe/Paris"])(
+    "matches formatLocalIsoWithOffset for long style in %s",
+    (timeZone) => {
+      expect(formatTimestamp(testDate, { style: "long", timeZone })).toBe(
+        formatLocalIsoWithOffset(testDate, timeZone),
+      );
+    },
+  );
+
+  it("falls back to a valid offset when the timezone is invalid", () => {
+    expect(formatTimestamp(testDate, { style: "short", timeZone: "not-a-tz" })).toMatch(
+      /^\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/,
+    );
   });
 });
 

--- a/src/logging/timestamps.ts
+++ b/src/logging/timestamps.ts
@@ -7,15 +7,27 @@ export function isValidTimeZone(tz: string): boolean {
   }
 }
 
-export function formatLocalIsoWithOffset(now: Date, timeZone?: string): string {
-  const explicit = timeZone ?? process.env.TZ;
-  const tz =
-    explicit && isValidTimeZone(explicit)
-      ? explicit
-      : Intl.DateTimeFormat().resolvedOptions().timeZone;
+export type TimestampStyle = "short" | "medium" | "long";
 
+export type FormatTimestampOptions = {
+  style?: TimestampStyle;
+  timeZone?: string;
+};
+
+function resolveEffectiveTimeZone(timeZone?: string): string {
+  const explicit = timeZone ?? process.env.TZ;
+  return explicit && isValidTimeZone(explicit)
+    ? explicit
+    : Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+function formatOffset(offsetRaw: string): string {
+  return offsetRaw === "GMT" ? "+00:00" : offsetRaw.slice(3);
+}
+
+function getTimestampParts(date: Date, timeZone?: string) {
   const fmt = new Intl.DateTimeFormat("en", {
-    timeZone: tz,
+    timeZone: resolveEffectiveTimeZone(timeZone),
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -27,10 +39,37 @@ export function formatLocalIsoWithOffset(now: Date, timeZone?: string): string {
     timeZoneName: "longOffset",
   });
 
-  const parts = Object.fromEntries(fmt.formatToParts(now).map((p) => [p.type, p.value]));
+  const parts = Object.fromEntries(fmt.formatToParts(date).map((part) => [part.type, part.value]));
+  return {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour: parts.hour,
+    minute: parts.minute,
+    second: parts.second,
+    fractionalSecond: parts.fractionalSecond,
+    offset: formatOffset(parts.timeZoneName ?? "GMT"),
+  };
+}
 
-  const offsetRaw = parts.timeZoneName ?? "GMT";
-  const offset = offsetRaw === "GMT" ? "+00:00" : offsetRaw.slice(3);
+export function formatTimestamp(date: Date, options?: FormatTimestampOptions): string {
+  const style = options?.style ?? "medium";
+  const parts = getTimestampParts(date, options?.timeZone);
 
-  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}${offset}`;
+  switch (style) {
+    case "short":
+      return `${parts.hour}:${parts.minute}:${parts.second}${parts.offset}`;
+    case "medium":
+      return `${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}${parts.offset}`;
+    case "long":
+      return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}${parts.offset}`;
+  }
+}
+
+/**
+ * @deprecated Use formatTimestamp from "./timestamps.js" instead.
+ * This function will be removed in a future version.
+ */
+export function formatLocalIsoWithOffset(now: Date, timeZone?: string): string {
+  return formatTimestamp(now, { style: "long", timeZone });
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Console "pretty" mode showed HH:MM:SS while compact/json/file logs showed ISO 8601 with timezone offset, causing confusion during incident triage
- Why it matters: Same moment in time appeared differently depending on output path, making log correlation difficult
- What changed: Added unified formatTimestamp() formatter that always includes timezone offset; console pretty now shows HH:MM:SS±HH:MM instead of HH:MM:SS
- What did NOT change (scope boundary): Envelope timestamps remain untouched; file log format unchanged (still uses ISO with offset); deprecated formatLocalIsoWithOffset() kept for backward compatibility

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38756
- Related #

## User-visible / Behavior Changes

- Console pretty mode timestamp now includes timezone offset (e.g., 14:30:45+00:00 instead of 14:30:45)
- All log outputs now show consistent timestamp format with timezone

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node 22+
- Tests: Vitest

### Steps

1. Run pnpm test src/logging/ src/infra/format-time/
2. Verify all 107 tests pass
3. Verify pnpm check passes

### Expected

- All tests pass

### Actual

- All 107 tests pass ✓

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after (updated test for new pretty timestamp behavior)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Manual testing of formatTimestamp() across UTC, America/New_York, Europe/Paris, Asia/Tokyo timezones
- Edge cases checked: UTC shows +00:00, different offsets format correctly
- What you did not verify: Live gateway runtime behavior

## Compatibility / Migration

- Backward compatible? (Yes - deprecated function still available)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: git revert HEAD
- Files/config to restore: All 7 modified files
- Known bad symptoms reviewers should watch for: Console output format change

## Risks and Mitigations

- Risk: Console pretty timestamp now longer (adds ±HH:MM)
  - Mitigation: Minimal visual change; improves readability during debugging

## Built with OpenCode and MiniMax M2.5

# Build prompt-

# Plan: Fix Inconsistent Log Timezones (Issue #38756)

---

## Overview

Fix inconsistent log timezones across OpenClaw outputs by creating a unified timestamp formatter that always includes timezone offset.

## Issue Summary

- **Problem**: Console "pretty" mode shows `HH:MM:SS` while "compact"/"json"/file logs show ISO 8601 with offset
- **Impact**: Confusing during incident triage - same moment appears as `08:31` vs `08:31:00.123+03:00`
- **Scope**: Logging timestamps only (NOT envelope timestamps)

## Baseline

### Existing Tests (All Passing)

```bash
pnpm test src/logging/console-timestamp.test.ts src/logging/timestamps.test.ts src/logging/logger-timestamp.test.ts src/infra/format-time/format-time.test.ts
```

- ✅ 46 tests passing

### CI Tests (from `.github/workflows/ci.yml`)

- `pnpm test` - Main unit tests
- `pnpm test:extensions` - Extension tests
- `pnpm check` - Format, lint, typecheck

---

## Step-by-Step Implementation Plan

### Phase 1: Add Unified Formatter (3 commits)

- [ ] **Step 1.1**: Add types and helper functions
  - File: `src/infra/format-time/format-datetime.ts`
  - Add: `TimestampStyle` type, `UnifiedTimestampOptions` interface
  - Add: `resolveEffectiveTimezone()`, `formatOffset()`, `getTimeInZone()` helpers
  - Commit: `infra: add timezone helper functions for unified formatter`
  - Verify: Build passes

- [ ] **Step 1.2**: Add main formatTimestamp function
  - File: `src/infra/format-time/format-datetime.ts`
  - Add: `formatTimestamp()` function with short/medium/long styles
  - Commit: `infra: add formatTimestamp() unified formatter function`
  - Verify: Build passes

- [ ] **Step 1.3**: Commit
  - Commit: `infra: add unified formatTimestamp() formatter`
  - (Combined from 1.1 + 1.2)

---

### Phase 2: Create New Tests (2 commits)

- [ ] **Step 2.1**: Create test file for formatTimestamp
  - File: `src/infra/format-time/format-timestamp.test.ts`
  - Test: all styles (short/medium/long), timezone options, offset always included
  - Commit: `test: add formatTimestamp() tests`
  - Verify: 18 tests pass

- [ ] **Step 2.2**: Run all related tests
  - Verify: 46 existing tests still pass

---

### Phase 3: Update Console Logger (2 commits)

- [ ] **Step 3.1**: Add import for formatTimestamp
  - File: `src/logging/console.ts`
  - Add: `import { formatTimestamp } from "../infra/format-time/format-datetime.js"`
  - Commit: `logging: add import for unified formatter`
  - Verify: Build passes

- [ ] **Step 3.2**: Update formatConsoleTimestamp function
  - File: `src/logging/console.ts`
  - Change: Pretty style now uses `formatTimestamp(now, { style: "short" })`
  - Add: Deprecation comment above old code path
  - Commit: `logging: use unified formatter for console timestamps`
  - Verify: New behavior works (pretty now shows HH:MM:SS±HH:MM)

---

### Phase 4: Update File Logger (2 commits)

- [ ] **Step 4.1**: Add import for formatTimestamp
  - File: `src/logging/logger.ts`
  - Add: `import { formatTimestamp } from "../infra/format-time/format-datetime.js"`
  - Commit: `logging: add import for unified formatter in logger`
  - Verify: Build passes

- [ ] **Step 4.2**: Update file log timestamp
  - File: `src/logging/logger.ts`
  - Change: Use `formatTimestamp(date, { style: "long" })` for file logs
  - Add: Deprecation comment above old code path
  - Commit: `logging: use unified formatter for file logs`
  - Verify: File log test passes

---

### Phase 5: Update CLI Logs Command (2 commits)

- [ ] **Step 5.1**: Add import for formatTimestamp
  - File: `src/cli/logs-cli.ts`
  - Add: `import { formatTimestamp } from "../infra/format-time/format-datetime.js"`
  - Commit: `CLI: add import for unified formatter`
  - Verify: Build passes

- [ ] **Step 5.2**: Update formatLogTimestamp function
  - File: `src/cli/logs-cli.ts`
  - Change: Use `formatTimestamp(parsed, { style: "long" })` when localTime=true
  - Add: Deprecation comment above old code path
  - Commit: `CLI: use unified formatter for logs command`
  - Verify: Build passes

---

### Phase 6: Add Deprecation Comments (1 commit)

- [ ] **Step 6.1**: Add deprecation to formatLocalIsoWithOffset
  - File: `src/logging/timestamps.ts`
  - Add: Deprecation comment above `formatLocalIsoWithOffset()`
  - Commit: `logging: deprecate formatLocalIsoWithOffset()`

---

### Phase 7: Final Verification (3 commits)

- [ ] **Step 7.1**: Run all logging tests
  - Verify: All 46+ tests pass

- [ ] **Step 7.2**: Run format and lint
  - Verify: `pnpm check` passes

- [ ] **Step 7.3**: Run full test suite
  - Verify: `pnpm test` passes
  - Commit: `chore: complete log timezone unification`

---

## Expected Results After Fix

| Output Path       | Before          | After                     |
| ----------------- | --------------- | ------------------------- |
| Console - Pretty  | `HH:MM:SS`      | `HH:MM:SS±HH:MM`          |
| Console - Compact | ISO with offset | Same (already had offset) |
| Console - JSON    | ISO with offset | Same (already had offset) |
| File Logs         | ISO with offset | Same (already had offset) |

---

## Files Modified

### Implementation Files

- `src/infra/format-time/format-datetime.ts` - Add unified formatter
- `src/logging/console.ts` - Use unified formatter
- `src/logging/logger.ts` - Use unified formatter
- `src/cli/logs-cli.ts` - Use unified formatter
- `src/logging/timestamps.ts` - Add deprecation comment

### New Test Files

- `src/infra/format-time/format-timestamp.test.ts` - Test unified formatter

### Existing Tests (Unchanged - kept for backward compatibility verification)

- `src/logging/console-timestamp.test.ts` - Tests deprecated path
- `src/logging/timestamps.test.ts` - Tests deprecated path
- `src/logging/logger-timestamp.test.ts` - Tests deprecated path

---

## Commands Reference

### Run Tests

```bash
# Specific logging tests
pnpm test src/logging/console-timestamp.test.ts src/logging/timestamps.test.ts src/logging/logger-timestamp.test.ts src/infra/format-time/format-time.test.ts

# All logging tests
pnpm test src/logging/ src/infra/format-time/

# Full test suite
pnpm test
```

### Build & Check

```bash
# Build
pnpm build

# Format check
pnpm format

# Lint
pnpm lint

# Full check
pnpm check
```

### Commit

```bash
# Using scripts/committer for conventional commits
./scripts/committer "<message>" <files...>
```

---

## Notes

1. **Backward Compatibility**: Existing formatters kept with deprecation comments - NOT removed
2. **Test Strategy**: New tests added for unified formatter; existing tests left unchanged
3. **Scope**: Only logging timestamps modified; envelope timestamps are out of scope
4. **CI Pipeline**: All tests from `.github/workflows/ci.yml` must pass before pushing
5. **Small Commits**: Each logical change is a separate commit for better traceability

---

## Issue Reference

- GitHub Issue: https://github.com/openclaw/openclaw/issues/38756

