### PR TITLE
fix(telegram): use message transport for all DM streaming lanes

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1167,7 +1167,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     },
   );
 
-  it("uses message preview transport for DM reasoning lane when answer preview lane is active", async () => {
+  it("uses message preview transport for all DM lanes when streaming is active", async () => {
     setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -1183,10 +1183,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(2);
+    // Both answer (call[0]) and reasoning (call[1]) lanes should use message
+    // transport in DMs to prevent duplicate messages. (Fixes #33453)
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "auto",
+        previewTransport: "message",
       }),
     );
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -190,15 +190,18 @@ export const dispatchTelegramMessage = async ({
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
-    const useMessagePreviewTransportForDmReasoning =
-      laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
+    // Use message transport (sendMessage + editMessageText) for all lanes in
+    // DMs so that streamMessageId is tracked. Draft transport doesn't track a
+    // messageId, causing resolvePreviewTarget() to miss the preview on final
+    // delivery — which sends a duplicate message. (Fixes #33453)
+    const useMessagePreviewTransportForDm = threadSpec?.scope === "dm" && canStreamAnswerDraft;
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
-          previewTransport: useMessagePreviewTransportForDmReasoning ? "message" : "auto",
+          previewTransport: useMessagePreviewTransportForDm ? "message" : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,


### PR DESCRIPTION
## Summary

Fixes #33453

When `channels.telegram.streaming` is set to `"partial"`, Telegram DM conversations show duplicate messages — the streaming preview plus a separate final message.

**Root cause:** The answer lane in DMs uses draft transport (`sendMessageDraft`), which doesn't track a `streamMessageId`. When the final delivery arrives, `resolvePreviewTarget()` can't find the preview message to edit in place, so `deliverLaneText` falls through to `sendPayload()` and sends a duplicate.

The reasoning lane already had a fix for this, but the answer lane was still using draft transport.

**Fix:** Remove the `laneName === "reasoning"` guard so all lanes use message transport in DMs.

## Test plan

- [x] Updated existing test to verify both lanes use `"message"` transport in DMs
- [x] All 139 test files pass (1150 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)