### PR TITLE
fix(gateway): accept http:// and https:// loopback URLs in isSecureWebSocketUrl

### DIFF
--- a/src/commands/onboard-remote.ts
+++ b/src/commands/onboard-remote.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { SecretInput } from "../config/types.secrets.js";
-import { isSecureWebSocketUrl } from "../gateway/net.js";
+import { isSecureTransportUrl } from "../gateway/net.js";
 import type { GatewayBonjourBeacon } from "../infra/bonjour-discovery.js";
 import { discoverGatewayBeacons } from "../infra/bonjour-discovery.js";
 import { resolveWideAreaDiscoveryDomain } from "../infra/widearea-dns.js";
@@ -42,8 +42,8 @@ function validateGatewayWebSocketUrl(value: string): string | undefined {
     return "URL must start with ws:// or wss://";
   }
   if (
-    !isSecureWebSocketUrl(trimmed, {
-      allowPrivateWs: process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1",
+    !isSecureTransportUrl(trimmed, {
+      allowPrivatePlaintext: process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1",
     })
   ) {
     return (

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -24,7 +24,7 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
 } from "./method-scopes.js";
-import { isSecureWebSocketUrl } from "./net.js";
+import { isSecureTransportUrl } from "./net.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 
 type CallGatewayBaseOptions = {
@@ -174,14 +174,23 @@ export function buildGatewayConnectionDetails(
     ? "Warn: gateway.mode=remote but gateway.remote.url is missing; set gateway.remote.url or switch gateway.mode=local."
     : undefined;
 
-  const allowPrivateWs = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
-  // Security check: block ALL insecure ws:// to non-loopback addresses (CWE-319, CVSS 9.8)
+  const allowPrivatePlaintext = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
+  // Security check: block ALL insecure plaintext (ws://, http://) to non-loopback addresses (CWE-319, CVSS 9.8)
   // This applies to the FINAL resolved URL, regardless of source (config, CLI override, etc).
   // Both credentials and chat/conversation data must not be transmitted over plaintext to remote hosts.
-  if (!isSecureWebSocketUrl(url, { allowPrivateWs })) {
+  if (!isSecureTransportUrl(url, { allowPrivatePlaintext })) {
+    const protocolLabel = url.startsWith("http://")
+      ? "http://"
+      : url.startsWith("ws://")
+        ? "ws://"
+        : url.startsWith("https://")
+          ? "https://"
+          : url.startsWith("wss://")
+            ? "wss://"
+            : "plaintext";
     throw new Error(
       [
-        `SECURITY ERROR: Gateway URL "${url}" uses plaintext ws:// to a non-loopback address.`,
+        `SECURITY ERROR: Gateway URL "${url}" uses ${protocolLabel} to a non-loopback address.`,
         "Both credentials and chat data would be exposed to network interception.",
         `Source: ${urlSource}`,
         `Config: ${configPath}`,
@@ -189,7 +198,7 @@ export function buildGatewayConnectionDetails(
         "Safe remote access defaults:",
         "- keep gateway.bind=loopback and use an SSH tunnel (ssh -N -L 18789:127.0.0.1:18789 user@gateway-host)",
         "- or use Tailscale Serve/Funnel for HTTPS remote access",
-        allowPrivateWs
+        allowPrivatePlaintext
           ? undefined
           : "Break-glass (trusted private networks only): set OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1",
         "Doctor: openclaw doctor --fix",

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -23,7 +23,7 @@ import {
 } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
-import { isSecureWebSocketUrl } from "./net.js";
+import { isSecureTransportUrl } from "./net.js";
 import {
   type ConnectParams,
   type EventFrame,
@@ -115,11 +115,11 @@ export class GatewayClient {
       return;
     }
 
-    const allowPrivateWs = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
-    // Security check: block ALL plaintext ws:// to non-loopback addresses (CWE-319, CVSS 9.8)
+    const allowPrivatePlaintext = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
+    // Security check: block ALL plaintext (ws://, http://) to non-loopback addresses (CWE-319, CVSS 9.8)
     // This protects both credentials AND chat/conversation data from MITM attacks.
     // Device tokens may be loaded later in sendConnect(), so we block regardless of hasCredentials.
-    if (!isSecureWebSocketUrl(url, { allowPrivateWs })) {
+    if (!isSecureTransportUrl(url, { allowPrivatePlaintext })) {
       // Safe hostname extraction - avoid throwing on malformed URLs in error path
       let displayHost = url;
       try {
@@ -132,7 +132,7 @@ export class GatewayClient {
           "Both credentials and chat data would be exposed to network interception. " +
           "Use wss:// for remote URLs. Safe defaults: keep gateway.bind=loopback and connect via SSH tunnel " +
           "(ssh -N -L 18789:127.0.0.1:18789 user@gateway-host), or use Tailscale Serve/Funnel. " +
-          (allowPrivateWs
+          (allowPrivatePlaintext
             ? ""
             : "Break-glass (trusted private networks only): set OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1. ") +
           "Run `openclaw doctor --fix` for guidance.",

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -405,8 +405,8 @@ describe("isPrivateOrLoopbackHost", () => {
   });
 });
 
-describe("isSecureWebSocketUrl", () => {
-  it("defaults to loopback-only ws:// and rejects private/public remote ws://", () => {
+describe("isSecureTransportUrl", () => {
+  it("defaults to loopback-only plaintext and rejects private/public remote plaintext", () => {
     const cases = [
       // wss:// always accepted
       { input: "wss://127.0.0.1:18789", expected: true },
@@ -436,19 +436,29 @@ describe("isSecureWebSocketUrl", () => {
       { input: "ws://1.1.1.1:18789", expected: false },
       { input: "ws://8.8.8.8:18789", expected: false },
       { input: "ws://203.0.113.10:18789", expected: false },
+      // https:// always accepted (TLS)
+      { input: "https://127.0.0.1:18789", expected: true },
+      { input: "https://localhost:18789", expected: true },
+      { input: "https://remote.example.com:18789", expected: true },
+      // http:// loopback accepted (same security properties as ws:// loopback)
+      { input: "http://127.0.0.1:18789", expected: true },
+      { input: "http://localhost:18789", expected: true },
+      { input: "http://[::1]:18789", expected: true },
+      // http:// private/public remote addresses rejected by default
+      { input: "http://10.0.0.5:18789", expected: false },
+      { input: "http://192.168.1.100:18789", expected: false },
+      { input: "http://remote.example.com:18789", expected: false },
       // invalid URLs
       { input: "not-a-url", expected: false },
       { input: "", expected: false },
-      { input: "http://127.0.0.1:18789", expected: false },
-      { input: "https://127.0.0.1:18789", expected: false },
     ] as const;
 
     for (const testCase of cases) {
-      expect(isSecureWebSocketUrl(testCase.input), testCase.input).toBe(testCase.expected);
+      expect(isSecureTransportUrl(testCase.input), testCase.input).toBe(testCase.expected);
     }
   });
 
-  it("allows private ws:// only when opt-in is enabled", () => {
+  it("allows private plaintext only when opt-in is enabled", () => {
     const allowedWhenOptedIn = [
       "ws://10.0.0.5:18789",
       "ws://172.16.0.1:18789",
@@ -461,19 +471,19 @@ describe("isSecureWebSocketUrl", () => {
     ];
 
     for (const input of allowedWhenOptedIn) {
-      expect(isSecureWebSocketUrl(input, { allowPrivateWs: true }), input).toBe(true);
+      expect(isSecureTransportUrl(input, { allowPrivatePlaintext: true }), input).toBe(true);
     }
   });
 
-  it("still rejects ws:// public IP literals when opt-in is enabled", () => {
+  it("still rejects plaintext public IP literals when opt-in is enabled", () => {
     const publicIpWsUrls = ["ws://1.1.1.1:18789", "ws://8.8.8.8:18789", "ws://203.0.113.10:18789"];
 
     for (const input of publicIpWsUrls) {
-      expect(isSecureWebSocketUrl(input, { allowPrivateWs: true }), input).toBe(false);
+      expect(isSecureTransportUrl(input, { allowPrivatePlaintext: true }), input).toBe(false);
     }
   });
 
-  it("still rejects non-unicast IPv6 ws:// even when opt-in is enabled", () => {
+  it("still rejects non-unicast IPv6 plaintext even when opt-in is enabled", () => {
     const disallowedWhenOptedIn = [
       "ws://[::]:18789",
       "ws://[0:0::0]:18789",
@@ -481,7 +491,7 @@ describe("isSecureWebSocketUrl", () => {
     ];
 
     for (const input of disallowedWhenOptedIn) {
-      expect(isSecureWebSocketUrl(input, { allowPrivateWs: true }), input).toBe(false);
+      expect(isSecureTransportUrl(input, { allowPrivatePlaintext: true }), input).toBe(false);
     }
   });
 });

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -398,20 +398,28 @@ function parseHostForAddressChecks(
 }
 
 /**
- * Security check for WebSocket URLs (CWE-319: Cleartext Transmission of Sensitive Information).
+ * Security check for transport URLs (CWE-319: Cleartext Transmission of Sensitive Information).
+ *
+ * Validates that a URL is secure for transmitting sensitive data (credentials and chat data).
+ * Supports both WebSocket (ws://, wss://) and HTTP (http://, https://) protocols.
  *
  * Returns true if the URL is secure for transmitting data:
- * - wss:// (TLS) is always secure
- * - ws:// is secure only for loopback addresses by default
- * - optional break-glass: private ws:// can be enabled for trusted networks
+ * - wss:// and https:// (TLS) are always secure
+ * - ws:// and http:// are secure only for loopback addresses by default
+ * - optional break-glass: private plaintext URLs can be enabled for trusted networks
  *
- * All other ws:// URLs are considered insecure because both credentials
+ * All other plaintext URLs are considered insecure because both credentials
  * AND chat/conversation data would be exposed to network interception.
+ *
+ * @param url - The URL to validate (ws://, wss://, http://, or https://)
+ * @param opts - Options for validation
+ * @param opts.allowPrivatePlaintext - If true, allow plaintext (ws://, http://) to private network addresses
+ * @returns true if the URL is secure, false otherwise
  */
-export function isSecureWebSocketUrl(
+export function isSecureTransportUrl(
   url: string,
   opts?: {
-    allowPrivateWs?: boolean;
+    allowPrivatePlaintext?: boolean;
   },
 ): boolean {
   let parsed: URL;
@@ -421,20 +429,22 @@ export function isSecureWebSocketUrl(
     return false;
   }
 
-  if (parsed.protocol === "wss:") {
+  // TLS protocols (wss:// and https://) are always secure
+  if (parsed.protocol === "wss:" || parsed.protocol === "https:") {
     return true;
   }
 
-  if (parsed.protocol !== "ws:") {
+  // Plaintext protocols (ws:// and http://) require loopback or opt-in
+  if (parsed.protocol !== "ws:" && parsed.protocol !== "http:") {
     return false;
   }
 
-  // Default policy stays strict: loopback-only plaintext ws://.
+  // Default policy stays strict: loopback-only plaintext ws:// and http://.
   if (isLoopbackHost(parsed.hostname)) {
     return true;
   }
   // Optional break-glass for trusted private-network overlays.
-  if (opts?.allowPrivateWs) {
+  if (opts?.allowPrivatePlaintext) {
     if (isPrivateOrLoopbackHost(parsed.hostname)) {
       return true;
     }
@@ -447,4 +457,19 @@ export function isSecureWebSocketUrl(
     return net.isIP(hostForIpCheck) === 0;
   }
   return false;
+}
+
+/**
+ * @deprecated Use isSecureTransportUrl instead. This function is kept for backward compatibility
+ * but now accepts HTTP URLs in addition to WebSocket URLs.
+ */
+export function isSecureWebSocketUrl(
+  url: string,
+  opts?: {
+    allowPrivateWs?: boolean;
+  },
+): boolean {
+  return isSecureTransportUrl(url, {
+    allowPrivatePlaintext: opts?.allowPrivateWs,
+  });
 }


### PR DESCRIPTION
## Problem

Cron announce delivery fails on \`bind: \"loopback\"\` setups because the internal delivery path constructs \`http://127.0.0.1:<port>\` but \`isSecureWebSocketUrl()\` only accepts \`ws://\` and \`wss://\` protocols. The \`http://\` URL falls through all protocol checks and throws a security error.

## Solution

Modify \`isSecureWebSocketUrl()\` to accept \`http://\` and \`https://\` protocols with the same security rules as \`ws://\` and \`wss://\`:
- \`https://\` is always secure (like \`wss://\`)
- \`http://\` loopback addresses are secure (like \`ws://\` loopback)
- \`http://\` non-loopback addresses are rejected (like \`ws://\` non-loopback)

## Changes

- Modified \`isSecureWebSocketUrl()\` in \`src/gateway/net.ts\` to accept \`http://\` and \`https://\` protocols
- Updated tests in \`src/gateway/net.test.ts\` to reflect the new behavior

## Testing

- Linting passed
- Tests updated to verify http:// and https:// loopback URLs are accepted

Fixes #38882