### PR TITLE
fix(web-search): use lowercase Brave auth header for 422 compatibility

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -14,6 +14,7 @@ const {
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,
+  resolveBraveRequestHeaders,
   extractKimiCitations,
 } = __testing;
 
@@ -68,6 +69,15 @@ describe("web_search freshness normalization", () => {
     expect(normalizeFreshness("2024-13-01to2024-01-31", "brave")).toBeUndefined();
     expect(normalizeFreshness("2024-02-30to2024-03-01", "brave")).toBeUndefined();
     expect(normalizeFreshness("2024-03-10to2024-03-01", "brave")).toBeUndefined();
+  });
+});
+
+describe("web_search brave headers", () => {
+  it("uses lowercase subscription header and accept header", () => {
+    const headers = new Headers(resolveBraveRequestHeaders("brave-key"));
+    expect(headers.get("accept")).toBe("application/json");
+    expect(headers.get("x-subscription-token")).toBe("brave-key");
+    expect(headers.get("X-Subscription-Token")).toBe("brave-key");
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1397,16 +1397,15 @@ async function runWebSearch(params: {
     url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
   }
 
+  const braveHeaders = resolveBraveRequestHeaders(params.apiKey);
+
   const mapped = await withTrustedWebSearchEndpoint(
     {
       url: url.toString(),
       timeoutSeconds: params.timeoutSeconds,
       init: {
         method: "GET",
-        headers: {
-          Accept: "application/json",
-          "X-Subscription-Token": params.apiKey,
-        },
+        headers: braveHeaders,
       },
     },
     async (res) => {
@@ -1449,6 +1448,14 @@ async function runWebSearch(params: {
   };
   writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
   return payload;
+}
+
+function resolveBraveRequestHeaders(apiKey: string): HeadersInit {
+  return {
+    Accept: "application/json",
+    // Lowercase key keeps compatibility with brittle intermediary gateways.
+    "x-subscription-token": apiKey,
+  };
 }
 
 export function createWebSearchTool(options?: {
@@ -1682,6 +1689,7 @@ export const __testing = {
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,
+  resolveBraveRequestHeaders,
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
 } as const;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Brave web search requests could fail with 422 in environments that rely on lowercase auth header handling.
- Why it matters: `web_search` becomes unavailable for Brave users behind brittle proxy/gateway paths.
- What changed: switched Brave request auth header key to lowercase `x-subscription-token` and added a regression unit test for Brave headers.
- What did NOT change (scope boundary): no provider selection, caching, or response parsing behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38867
- Related #

## User-visible / Behavior Changes

Brave-backed `web_search` calls now send the auth token with lowercase header key (`x-subscription-token`) for better compatibility with intermediaries that mishandle header casing.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local node runtime
- Model/provider: Brave web_search provider
- Integration/channel (if any): n/a
- Relevant config (redacted): `BRAVE_API_KEY` set

### Steps

1. Configure `BRAVE_API_KEY` and run a `web_search` tool call.
2. Observe outbound Brave request headers.
3. Confirm `x-subscription-token` and `accept` are present.

### Expected

- Brave request includes `x-subscription-token` auth header and succeeds through proxy/gateway paths.

### Actual

- Header construction now uses lowercase key; regression unit test covers this behavior.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: code path updated in Brave provider branch and header helper unit assertion added.
- Edge cases checked: header lookup remains case-insensitive via `Headers.get` checks.
- What you did **not** verify: full end-to-end live Brave API call in this environment; local vitest command did not complete in this session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `616c92463`.
- Files/config to restore: `src/agents/tools/web-search.ts`, `src/agents/tools/web-search.test.ts`.
- Known bad symptoms reviewers should watch for: Brave requests missing auth token header.

## Risks and Mitigations

- Risk: some runtime/proxy stack expects previous header casing behavior.
  - Mitigation: HTTP headers are case-insensitive and unit assertions validate effective header retrieval.
