### PR TITLE
fix(skills): discover workspace skills across full candidate root window

### DIFF
--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -263,6 +263,40 @@ describe("buildWorkspaceSkillSnapshot", () => {
     expect(snapshot.prompt).toContain("late-skill");
   });
 
+  it("scans up to maxCandidatesPerRoot before applying skill-load caps", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+
+    for (let i = 0; i < 200; i += 1) {
+      await fs.mkdir(path.join(workspaceDir, "skills", `junk-${String(i).padStart(3, "0")}`), {
+        recursive: true,
+      });
+    }
+
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "valid-skill"),
+      name: "valid-skill",
+      description: "Should be discovered even after many non-skill dirs",
+    });
+
+    const snapshot = withWorkspaceHome(workspaceDir, () =>
+      buildWorkspaceSkillSnapshot(workspaceDir, {
+        config: {
+          skills: {
+            limits: {
+              maxCandidatesPerRoot: 300,
+              maxSkillsLoadedPerSource: 10,
+            },
+          },
+        },
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      }),
+    );
+
+    expect(snapshot.skills.map((s) => s.name)).toContain("valid-skill");
+    expect(snapshot.prompt).toContain("valid-skill");
+  });
+
   it("enforces maxSkillFileBytes for root-level SKILL.md", async () => {
     const workspaceDir = await fixtureSuite.createCaseDir("workspace");
     const rootSkillDir = await fixtureSuite.createCaseDir("root-skill");

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -259,7 +259,7 @@ function loadSkillEntries(
     const childDirs = listChildDirectories(baseDir);
     const suspicious = childDirs.length > limits.maxCandidatesPerRoot;
 
-    const maxCandidates = Math.max(0, limits.maxSkillsLoadedPerSource);
+    const maxCandidates = Math.max(0, limits.maxCandidatesPerRoot);
     const limitedChildren = childDirs.slice().sort().slice(0, maxCandidates);
 
     if (suspicious) {


### PR DESCRIPTION
## Summary
Fixes #38886.

Workspace skill discovery was truncating candidate directories using `maxSkillsLoadedPerSource` instead of `maxCandidatesPerRoot`.
When a skills root contains many directories (including non-skill folders), this could skip valid skill folders before they were even inspected.

This patch updates discovery to:
- scan child directories up to `maxCandidatesPerRoot`
- continue capping loaded skills with `maxSkillsLoadedPerSource`

## Test plan
- `pnpm test src/agents/skills.buildworkspaceskillsnapshot.test.ts`
- `pnpm check:docs`
- `pnpm protocol:check`
- `pnpm check` (currently fails on upstream baseline TypeScript/module errors unrelated to this change; details below)

### `pnpm check` current baseline failure (unrelated)
Errors currently present on main include missing exports/modules from `@mariozechner/pi-ai`, for example:
- `src/agents/auth-profiles/oauth.ts`: `getOAuthApiKey` / `getOAuthProviders`
- `src/commands/openai-codex-oauth.ts`: `loginOpenAICodex`
- multiple `src/providers/google-shared.*` test imports from `@mariozechner/pi-ai/dist/...`

## Checklist
- [x] Single-issue focused change
- [x] Added regression coverage for candidate-root scanning behavior
- [x] No protocol/schema drift
