### PR TITLE
fix(telegram): suppress bare NO_REPLY sends

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -171,6 +171,17 @@ describe("buildInlineKeyboard", () => {
 });
 
 describe("sendMessageTelegram", () => {
+  it("suppresses NO_REPLY text before any Telegram API call", async () => {
+    botApi.sendMessage.mockClear();
+
+    const result = await sendMessageTelegram("123", "  NO_REPLY  ", {
+      token: "tok",
+    });
+
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ messageId: "suppressed", chatId: "123" });
+  });
+
   it("applies timeoutSeconds config precedence", async () => {
     const cases = [
       {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -182,6 +182,60 @@ describe("sendMessageTelegram", () => {
     expect(result).toEqual({ messageId: "suppressed", chatId: "123" });
   });
 
+  it("does not suppress NO_REPLY when sending media", async () => {
+    const chatId = "123";
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 73,
+      chat: { id: chatId },
+    });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+
+    const result = await sendMessageTelegram(chatId, " NO_REPLY ", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expect(sendPhoto).toHaveBeenCalledWith(chatId, expect.anything(), {
+      caption: "NO_REPLY",
+      parse_mode: "HTML",
+    });
+    expect(result).toEqual({ messageId: "73", chatId });
+  });
+
+  it("does not suppress NO_REPLY when inline buttons are present", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 74,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    const result = await sendMessageTelegram(chatId, " NO_REPLY ", {
+      token: "tok",
+      api,
+      buttons: [[{ text: "Open", callback_data: "cmd:open" }]],
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "NO_REPLY", {
+      parse_mode: "HTML",
+      reply_markup: {
+        inline_keyboard: [[{ text: "Open", callback_data: "cmd:open" }]],
+      },
+    });
+    expect(result).toEqual({ messageId: "74", chatId });
+  });
+
   it("applies timeoutSeconds config precedence", async () => {
     const cases = [
       {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,6 +5,10 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
+import type { RetryConfig } from "../infra/retry.js";
+import type { MediaKind } from "../media/constants.js";
+import type { TelegramInlineButtons } from "./button-types.js";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -12,10 +16,8 @@ import { recordChannelActivity } from "../infra/channel-activity.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import { createTelegramRetryRunner } from "../infra/retry-policy.js";
-import type { RetryConfig } from "../infra/retry.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import type { MediaKind } from "../media/constants.js";
 import { buildOutboundMediaLoadOptions } from "../media/load-options.js";
 import { isGifMedia, kindFromMime } from "../media/mime.js";
 import { normalizePollInput, type PollInput } from "../polls.js";
@@ -23,7 +25,6 @@ import { loadWebMedia } from "../web/media.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
-import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
@@ -463,8 +464,17 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
-  const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
+  const mediaUrl = opts.mediaUrl?.trim();
+  const replyMarkup = buildInlineKeyboard(opts.buttons);
+  const trimmedText = text?.trim() ?? "";
+
+  if (isSilentReplyText(trimmedText) && !mediaUrl && !replyMarkup) {
+    logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", chatId: target.chatId };
+  }
+
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
   const chatId = await resolveAndPersistChatId({
     cfg,
     api,
@@ -472,11 +482,9 @@ export async function sendMessageTelegram(
     persistTarget: to,
     verbose: opts.verbose,
   });
-  const mediaUrl = opts.mediaUrl?.trim();
   const mediaMaxBytes =
     opts.maxBytes ??
     (typeof account.config.mediaMaxMb === "number" ? account.config.mediaMaxMb : 100) * 1024 * 1024;
-  const replyMarkup = buildInlineKeyboard(opts.buttons);
 
   const threadParams = buildTelegramThreadReplyParams({
     targetMessageThreadId: target.messageThreadId,


### PR DESCRIPTION
## Summary
- suppress exact `NO_REPLY` telegram sends before any API call when there is no media or inline keyboard
- return a synthetic suppressed result using the parsed telegram target
- add regression coverage for the bare-token guard

## Verification
- pnpm exec vitest run src/telegram/send.test.ts
- pnpm exec oxfmt --check src/telegram/send.ts src/telegram/send.test.ts

Closes #38603