### PR TITLE
fix(chatui): show stdout for structured tool results

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
@@ -36,6 +36,7 @@ enum ToolResultTextFormatter {
         let status = (dict["status"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let errorText = self.firstString(in: dict, keys: ["error", "reason"])
         let stdoutText = self.firstString(in: dict, keys: ["stdout"])
+        let stderrText = self.firstString(in: dict, keys: ["stderr"])
         let messageText = self.firstString(in: dict, keys: ["message", "result", "detail"])
 
         if status?.lowercased() == "error" || errorText != nil {
@@ -52,8 +53,12 @@ enum ToolResultTextFormatter {
             return summary
         }
 
-        if let stdoutText, !stdoutText.isEmpty {
+        if let stdoutText {
             return stdoutText
+        }
+
+        if let stderrText {
+            return stderrText
         }
 
         if let message = messageText {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
@@ -35,6 +35,7 @@ enum ToolResultTextFormatter {
     private static func renderDictionary(_ dict: [String: Any], toolName: String?) -> String {
         let status = (dict["status"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let errorText = self.firstString(in: dict, keys: ["error", "reason"])
+        let stdoutText = self.firstString(in: dict, keys: ["stdout"])
         let messageText = self.firstString(in: dict, keys: ["message", "result", "detail"])
 
         if status?.lowercased() == "error" || errorText != nil {
@@ -49,6 +50,10 @@ enum ToolResultTextFormatter {
 
         if toolName == "nodes", let summary = self.renderNodesSummary(dict) {
             return summary
+        }
+
+        if let stdoutText, !stdoutText.isEmpty {
+            return stdoutText
         }
 
         if let message = messageText {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
@@ -36,7 +36,6 @@ enum ToolResultTextFormatter {
         let status = (dict["status"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let errorText = self.firstString(in: dict, keys: ["error", "reason"])
         let stdoutText = self.firstString(in: dict, keys: ["stdout"])
-        let stderrText = self.firstString(in: dict, keys: ["stderr"])
         let messageText = self.firstString(in: dict, keys: ["message", "result", "detail"])
 
         if status?.lowercased() == "error" || errorText != nil {
@@ -53,12 +52,8 @@ enum ToolResultTextFormatter {
             return summary
         }
 
-        if let stdoutText {
+        if let stdoutText, !stdoutText.isEmpty {
             return stdoutText
-        }
-
-        if let stderrText {
-            return stderrText
         }
 
         if let message = messageText {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
@@ -78,4 +78,16 @@ struct ToolResultTextFormatterTests {
         let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
         #expect(result == "primary output")
     }
+
+    @Test func surfacesStderrWhenStdoutIsMissing() {
+        let json = """
+        {
+          "stderr": "permission denied",
+          "exitCode": 1
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
+        #expect(result == "permission denied")
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
@@ -78,16 +78,4 @@ struct ToolResultTextFormatterTests {
         let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
         #expect(result == "primary output")
     }
-
-    @Test func surfacesStderrWhenStdoutIsMissing() {
-        let json = """
-        {
-          "stderr": "permission denied",
-          "exitCode": 1
-        }
-        """
-
-        let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
-        #expect(result == "permission denied")
-    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
@@ -65,4 +65,17 @@ struct ToolResultTextFormatterTests {
         let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
         #expect(result == "test output\nsecond line")
     }
+
+    @Test func prefersStdoutWhenStdoutAndStderrAreBothPresent() {
+        let json = """
+        {
+          "stdout": "primary output",
+          "stderr": "warning output",
+          "exitCode": 0
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
+        #expect(result == "primary output")
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
@@ -51,4 +51,18 @@ struct ToolResultTextFormatterTests {
         let result = ToolResultTextFormatter.format(text: json, toolName: "nodes")
         #expect(result.isEmpty)
     }
+
+    @Test func surfacesStdoutFromSuccessfulExecPayload() {
+        let json = """
+        {
+          "message": "tool completed successfully",
+          "stdout": "test output\\nsecond line",
+          "stderr": "",
+          "exitCode": 0
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
+        #expect(result == "test output\nsecond line")
+    }
 }


### PR DESCRIPTION
## Summary
- render structured successful tool results from `stdout` before falling back to generic message fields
- preserve existing nodes summary and error formatting paths
- cover exec-style payloads in chat UI formatter tests

Closes #38133