### PR TITLE
fix(session): avoid Discord channel key poisoning from sender-shaped From

### DIFF
--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { resolveGroupSessionKey } from "./group.js";
+
+describe("resolveGroupSessionKey", () => {
+  it("uses OriginatingTo channel id when Discord channel chats provide sender-shaped From", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+      OriginatingTo: "channel:1476858065914695741",
+      To: "slash:657229412030480397",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:1476858065914695741",
+      channel: "discord",
+      id: "1476858065914695741",
+      chatType: "channel",
+    });
+  });
+
+  it("falls back to To when OriginatingTo is absent", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+      To: "discord:channel:1476858065914695741",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:1476858065914695741",
+      channel: "discord",
+      id: "1476858065914695741",
+      chatType: "channel",
+    });
+  });
+
+  it("keeps legacy behavior when no Discord channel hint is available", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:657229412030480397",
+      channel: "discord",
+      id: "657229412030480397",
+      chatType: "channel",
+    });
+  });
+});

--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -36,6 +36,43 @@ describe("resolveGroupSessionKey", () => {
     });
   });
 
+  it("prefers ThreadParentId over other Discord routing targets", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+      ThreadParentId: "discord:channel:1476858065914695741",
+      NativeChannelId: "1476858065914695742",
+      OriginatingTo: "channel:1476858065914695743",
+      To: "discord:channel:1476858065914695744",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:1476858065914695741",
+      channel: "discord",
+      id: "1476858065914695741",
+      chatType: "channel",
+    });
+  });
+
+  it("prefers NativeChannelId when ThreadParentId is absent", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+      NativeChannelId: "1476858065914695742",
+      OriginatingTo: "channel:1476858065914695743",
+      To: "discord:channel:1476858065914695744",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:1476858065914695742",
+      channel: "discord",
+      id: "1476858065914695742",
+      chatType: "channel",
+    });
+  });
+
   it("keeps legacy behavior when no Discord channel hint is available", () => {
     const ctx = {
       Provider: "discord",

--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -73,6 +73,22 @@ describe("resolveGroupSessionKey", () => {
     });
   });
 
+  it("ignores bare discord user-shaped To values when no channel prefix is present", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+      To: "discord:1476858065914695741",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:657229412030480397",
+      channel: "discord",
+      id: "657229412030480397",
+      chatType: "channel",
+    });
+  });
+
   it("keeps legacy behavior when no Discord channel hint is available", () => {
     const ctx = {
       Provider: "discord",

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -20,6 +20,35 @@ function shortenGroupId(value?: string) {
   return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
 }
 
+function resolveDiscordChannelIdFromTarget(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const withoutProvider = trimmed.replace(/^discord:/i, "").trim();
+  if (!withoutProvider) {
+    return undefined;
+  }
+  const withoutChannelPrefix = withoutProvider.replace(/^channel:/i, "").trim();
+  if (!withoutChannelPrefix) {
+    return undefined;
+  }
+  // Accept bare numeric IDs and channel-prefixed numeric IDs.
+  return /^\d+$/.test(withoutChannelPrefix) ? withoutChannelPrefix : undefined;
+}
+
+function resolveGroupIdHintFromTargets(ctx: MsgContext, provider?: string): string | undefined {
+  if (provider !== "discord") {
+    return undefined;
+  }
+  return (
+    resolveDiscordChannelIdFromTarget(ctx.ThreadParentId) ??
+    resolveDiscordChannelIdFromTarget(ctx.NativeChannelId) ??
+    resolveDiscordChannelIdFromTarget(ctx.OriginatingTo) ??
+    resolveDiscordChannelIdFromTarget(ctx.To)
+  );
+}
+
 export function buildGroupDisplayName(params: {
   provider?: string;
   subject?: string;
@@ -88,10 +117,13 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
     : from.includes(":channel:") || normalizedChatType === "channel"
       ? "channel"
       : "group";
+  const targetHintId = resolveGroupIdHintFromTargets(ctx, provider);
   const id = headIsSurface
     ? secondIsKind
       ? parts.slice(2).join(":")
-      : parts.slice(1).join(":")
+      : kind === "channel"
+        ? (targetHintId ?? parts.slice(1).join(":"))
+        : parts.slice(1).join(":")
     : from;
   const finalId = id.trim().toLowerCase();
   if (!finalId) {

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -1,7 +1,7 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
+import type { GroupKeyResolution } from "./types.js";
 import { normalizeHyphenSlug } from "../../shared/string-normalization.js";
 import { listDeliverableMessageChannels } from "../../utils/message-channel.js";
-import type { GroupKeyResolution } from "./types.js";
 
 const getGroupSurfaces = () => new Set<string>([...listDeliverableMessageChannels(), "webchat"]);
 
@@ -20,13 +20,19 @@ function shortenGroupId(value?: string) {
   return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
 }
 
-function resolveDiscordChannelIdFromTarget(raw?: string): string | undefined {
+function resolveDiscordChannelIdFromTarget(
+  raw?: string,
+  opts: { requireChannelPrefix?: boolean } = {},
+): string | undefined {
   const trimmed = raw?.trim();
   if (!trimmed) {
     return undefined;
   }
   const withoutProvider = trimmed.replace(/^discord:/i, "").trim();
   if (!withoutProvider) {
+    return undefined;
+  }
+  if (opts.requireChannelPrefix && !/^channel:/i.test(withoutProvider)) {
     return undefined;
   }
   const withoutChannelPrefix = withoutProvider.replace(/^channel:/i, "").trim();
@@ -44,8 +50,8 @@ function resolveGroupIdHintFromTargets(ctx: MsgContext, provider?: string): stri
   return (
     resolveDiscordChannelIdFromTarget(ctx.ThreadParentId) ??
     resolveDiscordChannelIdFromTarget(ctx.NativeChannelId) ??
-    resolveDiscordChannelIdFromTarget(ctx.OriginatingTo) ??
-    resolveDiscordChannelIdFromTarget(ctx.To)
+    resolveDiscordChannelIdFromTarget(ctx.OriginatingTo, { requireChannelPrefix: true }) ??
+    resolveDiscordChannelIdFromTarget(ctx.To, { requireChannelPrefix: true })
   );
 }
 


### PR DESCRIPTION
## Summary
- prefer Discord routing targets over sender-shaped `From` values when resolving channel session keys
- add coverage for routing target precedence, including `ThreadParentId` and `NativeChannelId`
- keep non-Discord and already well-formed channel keys unchanged

Closes #38487