### PR TITLE
AAMA Phase 1 Closeout

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -45,6 +45,18 @@ export const SendParamsSchema = Type.Object(
     threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */
     sessionKey: Type.Optional(Type.String()),
+    /** AAMA approval token (camelCase). */
+    approvalToken: Type.Optional(Type.String()),
+    /** AAMA approval nonce (camelCase). */
+    approvalNonce: Type.Optional(Type.String()),
+    /** AAMA approval token (snake_case alias). */
+    approval_token: Type.Optional(Type.String()),
+    /** AAMA approval nonce (snake_case alias). */
+    approval_nonce: Type.Optional(Type.String()),
+    /** AAMA allowlist bypass flag (camelCase) for explicit fail-closed handling. */
+    allowlistBypass: Type.Optional(Type.String()),
+    /** AAMA allowlist bypass flag (snake_case alias) for explicit fail-closed handling. */
+    allowlist_bypass: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },
@@ -67,6 +79,20 @@ export const PollParamsSchema = Type.Object(
     threadId: Type.Optional(Type.String()),
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
+    /** Optional agent id for policy actor binding. */
+    agentId: Type.Optional(Type.String()),
+    /** AAMA approval token (camelCase). */
+    approvalToken: Type.Optional(Type.String()),
+    /** AAMA approval nonce (camelCase). */
+    approvalNonce: Type.Optional(Type.String()),
+    /** AAMA approval token (snake_case alias). */
+    approval_token: Type.Optional(Type.String()),
+    /** AAMA approval nonce (snake_case alias). */
+    approval_nonce: Type.Optional(Type.String()),
+    /** AAMA allowlist bypass flag (camelCase) for explicit fail-closed handling. */
+    allowlistBypass: Type.Optional(Type.String()),
+    /** AAMA allowlist bypass flag (snake_case alias) for explicit fail-closed handling. */
+    allowlist_bypass: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -7,6 +7,7 @@ import type { GatewayRequestContext } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(),
+  enforceAamaOutboundGuard: vi.fn(async () => undefined),
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
   recordSessionMetaFromInbound: vi.fn(async () => ({ ok: true })),
   resolveOutboundTarget: vi.fn(() => ({ ok: true, to: "resolved" })),
@@ -76,6 +77,10 @@ vi.mock("../../infra/outbound/channel-selection.js", () => ({
 
 vi.mock("../../infra/outbound/deliver.js", () => ({
   deliverOutboundPayloads: mocks.deliverOutboundPayloads,
+}));
+
+vi.mock("../../infra/aama-spine-controls.js", () => ({
+  enforceAamaOutboundGuard: mocks.enforceAamaOutboundGuard,
 }));
 
 vi.mock("../../config/sessions.js", async () => {
@@ -151,6 +156,7 @@ describe("gateway send mirroring", () => {
       channel: "slack",
       configured: ["slack"],
     });
+    mocks.enforceAamaOutboundGuard.mockResolvedValue(undefined);
     mocks.sendPoll.mockResolvedValue({ messageId: "poll-1" });
     mocks.getChannelPlugin.mockReturnValue({ outbound: { sendPoll: mocks.sendPoll } });
   });
@@ -502,6 +508,86 @@ describe("gateway send mirroring", () => {
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         threadId: "1710000000.9999",
+      }),
+    );
+  });
+
+  it("forwards AAMA approval params for send through aamaPolicy.actionParams", async () => {
+    mockDeliverySuccess("m-aama-send");
+
+    await runSend({
+      to: "channel:C1",
+      message: "hi",
+      channel: "slack",
+      agentId: "main",
+      approvalToken: "token-1",
+      approvalNonce: "nonce-1",
+      idempotencyKey: "idem-aama-send",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aamaPolicy: expect.objectContaining({
+          action: "send",
+          actor: "main",
+          actionParams: expect.objectContaining({
+            approvalToken: "token-1",
+            approvalNonce: "nonce-1",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("enforces AAMA guard for poll with forwarded approval params", async () => {
+    const { respond } = await runPoll({
+      to: "channel:C1",
+      question: "Ship?",
+      options: ["Yes", "No"],
+      channel: "slack",
+      agentId: "main",
+      approvalToken: "token-poll",
+      approvalNonce: "nonce-poll",
+      idempotencyKey: "idem-aama-poll",
+    });
+
+    expect(mocks.enforceAamaOutboundGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "poll",
+        channel: "slack",
+        actor: "main",
+        actionParams: expect.objectContaining({
+          approvalToken: "token-poll",
+          approvalNonce: "nonce-poll",
+        }),
+      }),
+    );
+    expect(mocks.sendPoll).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined, {
+      channel: "slack",
+    });
+  });
+
+  it("fails closed when AAMA guard blocks poll", async () => {
+    mocks.enforceAamaOutboundGuard.mockRejectedValueOnce(new Error("AAMA blocked poll"));
+
+    const { respond } = await runPoll({
+      to: "channel:C1",
+      question: "Ship?",
+      options: ["Yes", "No"],
+      channel: "slack",
+      idempotencyKey: "idem-aama-poll-block",
+    });
+
+    expect(mocks.sendPoll).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("AAMA blocked poll"),
+      }),
+      expect.objectContaining({
+        channel: "slack",
       }),
     );
   });

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -2,6 +2,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import { loadConfig } from "../../config/config.js";
+import { enforceAamaOutboundGuard } from "../../infra/aama-spine-controls.js";
 import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
@@ -86,6 +87,52 @@ async function resolveRequestedChannel(params: {
   return { cfg, channel };
 }
 
+function trimOptional(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function buildAamaActionParams(input: {
+  approvalToken?: unknown;
+  approvalNonce?: unknown;
+  approval_token?: unknown;
+  approval_nonce?: unknown;
+  allowlistBypass?: unknown;
+  allowlist_bypass?: unknown;
+}): Record<string, unknown> {
+  const actionParams: Record<string, unknown> = {};
+  const approvalToken = trimOptional(input.approvalToken);
+  const approvalNonce = trimOptional(input.approvalNonce);
+  const approvalTokenSnake = trimOptional(input.approval_token);
+  const approvalNonceSnake = trimOptional(input.approval_nonce);
+  const allowlistBypass = trimOptional(input.allowlistBypass);
+  const allowlistBypassSnake = trimOptional(input.allowlist_bypass);
+
+  if (approvalToken) {
+    actionParams.approvalToken = approvalToken;
+  }
+  if (approvalNonce) {
+    actionParams.approvalNonce = approvalNonce;
+  }
+  if (approvalTokenSnake) {
+    actionParams.approval_token = approvalTokenSnake;
+  }
+  if (approvalNonceSnake) {
+    actionParams.approval_nonce = approvalNonceSnake;
+  }
+  if (allowlistBypass) {
+    actionParams.allowlistBypass = allowlistBypass;
+  }
+  if (allowlistBypassSnake) {
+    actionParams.allowlist_bypass = allowlistBypassSnake;
+  }
+
+  return actionParams;
+}
+
 export const sendHandlers: GatewayRequestHandlers = {
   send: async ({ params, respond, context }) => {
     const p = params;
@@ -111,6 +158,12 @@ export const sendHandlers: GatewayRequestHandlers = {
       agentId?: string;
       threadId?: string;
       sessionKey?: string;
+      approvalToken?: string;
+      approvalNonce?: string;
+      approval_token?: string;
+      approval_nonce?: string;
+      allowlistBypass?: string;
+      allowlist_bypass?: string;
       idempotencyKey: string;
     };
     const idem = request.idempotencyKey;
@@ -243,6 +296,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           agentId: effectiveAgentId,
           sessionKey: providedSessionKey ?? derivedRoute?.sessionKey,
         });
+        const aamaActionParams = buildAamaActionParams(request);
         const results = await deliverOutboundPayloads({
           cfg,
           channel: outboundChannel,
@@ -253,6 +307,11 @@ export const sendHandlers: GatewayRequestHandlers = {
           gifPlayback: request.gifPlayback,
           threadId: threadId ?? null,
           deps: outboundDeps,
+          aamaPolicy: {
+            action: "send",
+            actor: effectiveAgentId ?? "system",
+            actionParams: aamaActionParams,
+          },
           mirror: providedSessionKey
             ? {
                 sessionKey: providedSessionKey,
@@ -345,6 +404,13 @@ export const sendHandlers: GatewayRequestHandlers = {
       threadId?: string;
       channel?: string;
       accountId?: string;
+      agentId?: string;
+      approvalToken?: string;
+      approvalNonce?: string;
+      approval_token?: string;
+      approval_nonce?: string;
+      allowlistBypass?: string;
+      allowlist_bypass?: string;
       idempotencyKey: string;
     };
     const idem = request.idempotencyKey;
@@ -424,6 +490,28 @@ export const sendHandlers: GatewayRequestHandlers = {
       const normalized = outbound.pollMaxOptions
         ? normalizePollInput(poll, { maxOptions: outbound.pollMaxOptions })
         : normalizePollInput(poll);
+      const actor =
+        typeof request.agentId === "string" && request.agentId.trim().length > 0
+          ? request.agentId.trim()
+          : "system";
+      const aamaActionParams = buildAamaActionParams(request);
+      await enforceAamaOutboundGuard({
+        action: "poll",
+        channel,
+        actor,
+        actionParams: aamaActionParams,
+        payload: {
+          channel,
+          to: resolved.to,
+          question: normalized.question,
+          options: normalized.options,
+          maxSelections: normalized.maxSelections,
+          durationSeconds: normalized.durationSeconds ?? undefined,
+          durationHours: normalized.durationHours ?? undefined,
+          threadId,
+          isAnonymous: request.isAnonymous ?? undefined,
+        },
+      });
       const result = await outbound.sendPoll({
         cfg,
         to: resolved.to,

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { resetAamaSpineControlsForTests } from "../../../infra/aama-spine-controls.js";
 import { writeWorkspaceFile } from "../../../test-helpers/workspace.js";
+import { writeAamaPhase1Fixture } from "../../../test-utils/aama-phase1.js";
+import { withEnvAsync } from "../../../test-utils/env.js";
 import type { HookHandler } from "../../hooks.js";
 import { createHookEvent } from "../../hooks.js";
 
@@ -35,6 +38,10 @@ afterAll(async () => {
   await fs.rm(suiteWorkspaceRoot, { recursive: true, force: true });
   suiteWorkspaceRoot = "";
   workspaceCaseCounter = 0;
+});
+
+afterEach(() => {
+  resetAamaSpineControlsForTests();
 });
 
 /**
@@ -525,5 +532,32 @@ describe("session-memory hook", () => {
     // Both messages should be included
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
+  });
+
+  it("fails closed when AAMA memory gate blocks append_only writes", async () => {
+    const phaseRootParent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-aama-hook-"));
+    const phaseRoot = path.join(phaseRootParent, "phase1");
+    try {
+      await writeAamaPhase1Fixture({ root: phaseRoot, appendOnlyAllowed: false });
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: phaseRoot,
+          OPENCLAW_AAMA_APPROVAL_SECRET: "phase1-secret",
+        },
+        async () => {
+          const sessionContent = createMockSessionContent([
+            { role: "user", content: "Persist this summary" },
+            { role: "assistant", content: "Saving session memory now" },
+          ]);
+          const { tempDir } = await runNewWithPreviousSession({ sessionContent });
+          const memoryDir = path.join(tempDir, "memory");
+          const files = await fs.readdir(memoryDir);
+          expect(files).toEqual([]);
+        },
+      );
+    } finally {
+      await fs.rm(phaseRootParent, { recursive: true, force: true });
+    }
   });
 });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
+import { enforceAamaMemoryGateWrite } from "../../../infra/aama-spine-controls.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
@@ -304,19 +305,60 @@ const saveSessionToMemory: HookHandler = async (event) => {
       entryParts.push("## Conversation Summary", "", sessionContent, "");
     }
 
+    const memoryRecord: Record<string, unknown> = {
+      memory_id: `${sessionId}:${dateStr}:${slug}`,
+      memory_class: "reflection",
+      module: "reflection",
+      entity_ref: `session:${sessionId}`,
+      payload: {
+        session_key: event.sessionKey,
+        source,
+        summary_file: filename,
+        has_conversation_content: Boolean(sessionContent?.trim()),
+      },
+      source_ref: sessionFile ?? `session:${sessionId}`,
+      confidence_score: 0.92,
+      created_at: now.toISOString(),
+      updated_at: now.toISOString(),
+      status: "active",
+      retention_policy: "reflection",
+      created_by: "system",
+      review_required: false,
+      quarantine_state: "none",
+      contradiction_group_id: null,
+      integrity_level: "normal",
+    };
+
+    const memoryDecision = await enforceAamaMemoryGateWrite({
+      actor: "session_memory_hook",
+      writeMode: "append_only",
+      record: memoryRecord,
+    });
+
+    let relativeOutputPath = filename;
+    if (memoryDecision.quarantineRequired) {
+      relativeOutputPath = path.join("quarantine", filename);
+      entryParts.push(
+        "## Quarantine Notes",
+        "",
+        ...memoryDecision.quarantineReasons.map((reason) => `- ${reason}`),
+        "",
+      );
+    }
+
     const entry = entryParts.join("\n");
 
     // Write under memory root with alias-safe file validation.
     await writeFileWithinRoot({
       rootDir: memoryDir,
-      relativePath: filename,
+      relativePath: relativeOutputPath,
       data: entry,
       encoding: "utf-8",
     });
     log.debug("Memory file written successfully");
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
-    const relPath = memoryFilePath.replace(os.homedir(), "~");
+    const relPath = path.join(memoryDir, relativeOutputPath).replace(os.homedir(), "~");
     log.info(`Session context saved to ${relPath}`);
   } catch (err) {
     if (err instanceof Error) {

--- a/src/infra/aama-spine-controls.ts
+++ b/src/infra/aama-spine-controls.ts
@@ -1,0 +1,907 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { installProcessWarningFilter } from "./warning-filter.js";
+
+export type AamaPolicyDecision = {
+  decision: "allow" | "approval_required" | "block";
+  reasons: string[];
+};
+
+export type AamaMemoryDecision = {
+  decision: "allow" | "approval_required" | "block";
+  reasons: string[];
+  quarantineRequired: boolean;
+  quarantineReasons: string[];
+  actionBlocked: boolean;
+  escalationRequired: boolean;
+};
+
+type LoadedAamaPhase1Config = {
+  root: string;
+  approvalRules: {
+    authority_model?: {
+      tiffany?: { approves?: string[] };
+      christian?: { approves?: string[] };
+      self_authorized_by_tier?: string[];
+    };
+    constraints?: {
+      approval_token_required_for_external_send?: boolean;
+      send_external_allowlist_bypass?: boolean;
+      ambiguous_default_approver_allowed?: boolean;
+    };
+  };
+  writeControls: {
+    memory_write_modes?: Record<
+      string,
+      {
+        allowed?: boolean;
+        approval_required?: boolean;
+        requires_source_refs?: boolean;
+      }
+    >;
+  };
+  suspensionRules: {
+    auto_suspend?: {
+      approval_token_bypass?: number;
+      unauthorized_external_action?: number;
+      high_severity_policy_violations_7d?: number;
+      contradiction_backlog_hard_limit_days?: number;
+      noise_budget_breach_consecutive_weeks?: number;
+    };
+  };
+  memorySchema: {
+    required?: string[];
+    properties?: Record<
+      string,
+      {
+        enum?: unknown[];
+        type?: string | string[];
+        minimum?: number;
+        maximum?: number;
+      }
+    >;
+    additionalProperties?: boolean;
+  };
+};
+
+type ApprovalTokenClaims = {
+  jti: string;
+  actor: string;
+  action_type: string;
+  payload_hash: string;
+  nonce: string;
+  iat: number;
+  exp: number;
+  approver: string;
+};
+
+export type EnforceMessageActionParams = {
+  action: string;
+  channel: string;
+  actor: string;
+  requesterSenderId?: string | null;
+  actionParams: Record<string, unknown>;
+  payload: Record<string, unknown>;
+};
+
+export type EnforceMemoryWriteParams = {
+  actor: string;
+  writeMode: string;
+  record: Record<string, unknown>;
+  contradictionAgeDays?: number;
+  contradictionUnresolved?: boolean;
+};
+
+const REQUIRED_PHASE1_FILES = [
+  "core/approval_rules.yaml",
+  "policy/suspension_rules.yaml",
+  "policy/write_controls.yaml",
+  "memory/schema/memory_schema_v1.json",
+] as const;
+
+const require = createRequire(import.meta.url);
+const AAMA_POLICY_STATE_DB_BASENAME = "policy-gate-state.sqlite";
+const AUTONOMY_SUSPENDED_FLAG_KEY = "autonomy_suspended";
+
+type SqliteModule = typeof import("node:sqlite");
+type SqliteDatabase = import("node:sqlite").DatabaseSync;
+
+let configCache: { root: string; value: LoadedAamaPhase1Config } | null = null;
+let sqliteModuleCache: SqliteModule | null = null;
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function isAamaPhase1EnforcementEnabled(): boolean {
+  return isTruthy(process.env.OPENCLAW_AAMA_PHASE1_ENABLE);
+}
+
+function resolvePhase1Root(): string {
+  const fromEnv = process.env.OPENCLAW_AAMA_PHASE1_ROOT?.trim();
+  if (fromEnv) {
+    return path.resolve(fromEnv);
+  }
+  return path.resolve(process.cwd(), "..", "aama", "phase1_spine_package");
+}
+
+function resolveAamaPolicyStateDbPath(root: string): string {
+  return path.join(root, "governance", "spine", "state", AAMA_POLICY_STATE_DB_BASENAME);
+}
+
+function requireNodeSqliteForAama(): SqliteModule {
+  if (sqliteModuleCache) {
+    return sqliteModuleCache;
+  }
+  installProcessWarningFilter();
+  try {
+    sqliteModuleCache = require("node:sqlite") as SqliteModule;
+    return sqliteModuleCache;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`AAMA policy_gate persistent state requires node:sqlite support. ${message}`, {
+      cause: err,
+    });
+  }
+}
+
+function initializeAamaPolicyStateSchema(db: SqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS consumed_approval_tokens (
+      token_id TEXT PRIMARY KEY,
+      consumed_at TEXT NOT NULL
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS policy_flags (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+}
+
+function formatPersistentStateError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+async function withAamaPolicyStateDb<T>(operation: (db: SqliteDatabase) => T): Promise<T> {
+  const config = await loadAamaPhase1Config();
+  const dbPath = resolveAamaPolicyStateDbPath(config.root);
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+
+  const { DatabaseSync } = requireNodeSqliteForAama();
+  const db = new DatabaseSync(dbPath);
+  try {
+    initializeAamaPolicyStateSchema(db);
+    return operation(db);
+  } catch (error) {
+    const reason = formatPersistentStateError(error);
+    throw new Error(`AAMA policy_gate persistent state failure: ${reason}`, { cause: error });
+  } finally {
+    db.close();
+  }
+}
+
+async function isAutonomySuspendedInPersistentState(): Promise<boolean> {
+  return await withAamaPolicyStateDb((db) => {
+    const row = db
+      .prepare("SELECT value FROM policy_flags WHERE key = ?")
+      .get(AUTONOMY_SUSPENDED_FLAG_KEY) as { value?: string } | undefined;
+    return row?.value === "1";
+  });
+}
+
+async function persistAutonomySuspendedState(): Promise<void> {
+  await withAamaPolicyStateDb((db) => {
+    db.prepare(
+      `
+        INSERT INTO policy_flags (key, value, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+          value = excluded.value,
+          updated_at = excluded.updated_at
+      `,
+    ).run(AUTONOMY_SUSPENDED_FLAG_KEY, "1", new Date().toISOString());
+  });
+}
+
+async function consumeApprovalTokenId(tokenId: string): Promise<boolean> {
+  return await withAamaPolicyStateDb((db) => {
+    const result = db
+      .prepare(
+        `
+          INSERT INTO consumed_approval_tokens (token_id, consumed_at)
+          VALUES (?, ?)
+          ON CONFLICT(token_id) DO NOTHING
+        `,
+      )
+      .run(tokenId, new Date().toISOString()) as { changes?: number };
+    return Number(result.changes ?? 0) > 0;
+  });
+}
+
+function stableNormalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableNormalize(entry));
+  }
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).toSorted();
+    for (const key of keys) {
+      const child = record[key];
+      if (child !== undefined) {
+        output[key] = stableNormalize(child);
+      }
+    }
+    return output;
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(stableNormalize(value));
+}
+
+function computeSha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function readTrimmedString(
+  params: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = params[key];
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function requiredClaimNumber(claims: Record<string, unknown>, key: string): number {
+  const value = claims[key];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  throw new Error(`approval token missing numeric claim: ${key}`);
+}
+
+function requiredClaimString(claims: Record<string, unknown>, key: string): string {
+  const value = claims[key];
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new Error(`approval token missing string claim: ${key}`);
+}
+
+function decodeBase64Url(text: string): Buffer {
+  const pad = text.length % 4;
+  const padded = pad === 0 ? text : `${text}${"=".repeat(4 - pad)}`;
+  return Buffer.from(padded.replaceAll("-", "+").replaceAll("_", "/"), "base64");
+}
+
+function decodeApprovalToken(token: string): {
+  claims: ApprovalTokenClaims;
+  payloadSegment: string;
+} {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("invalid approval token format");
+  }
+  const [headerSegment, payloadSegment, signatureSegment] = parts;
+  const secret = process.env.OPENCLAW_AAMA_APPROVAL_SECRET?.trim();
+  if (!secret) {
+    throw new Error("OPENCLAW_AAMA_APPROVAL_SECRET is required when AAMA enforcement is enabled");
+  }
+
+  const expectedSig = crypto
+    .createHmac("sha256", secret)
+    .update(`${headerSegment}.${payloadSegment}`)
+    .digest();
+  const providedSig = decodeBase64Url(signatureSegment);
+  if (
+    expectedSig.length !== providedSig.length ||
+    !crypto.timingSafeEqual(expectedSig, providedSig)
+  ) {
+    throw new Error("approval token signature mismatch");
+  }
+
+  let rawClaims: unknown;
+  try {
+    rawClaims = JSON.parse(decodeBase64Url(payloadSegment).toString("utf-8"));
+  } catch {
+    throw new Error("approval token payload is not valid JSON");
+  }
+  if (!rawClaims || typeof rawClaims !== "object") {
+    throw new Error("approval token payload must be an object");
+  }
+
+  const claimsObj = rawClaims as Record<string, unknown>;
+  const claims: ApprovalTokenClaims = {
+    jti: requiredClaimString(claimsObj, "jti"),
+    actor: requiredClaimString(claimsObj, "actor"),
+    action_type: requiredClaimString(claimsObj, "action_type"),
+    payload_hash: requiredClaimString(claimsObj, "payload_hash"),
+    nonce: requiredClaimString(claimsObj, "nonce"),
+    iat: requiredClaimNumber(claimsObj, "iat"),
+    exp: requiredClaimNumber(claimsObj, "exp"),
+    approver: requiredClaimString(claimsObj, "approver"),
+  };
+
+  return { claims, payloadSegment };
+}
+
+function isTypeCompatible(value: unknown, schemaType: string | string[]): boolean {
+  const allowed = Array.isArray(schemaType) ? schemaType : [schemaType];
+  for (const entry of allowed) {
+    if (entry === "string" && typeof value === "string") {
+      return true;
+    }
+    if (entry === "number" && typeof value === "number" && Number.isFinite(value)) {
+      return true;
+    }
+    if (entry === "integer" && typeof value === "number" && Number.isInteger(value)) {
+      return true;
+    }
+    if (entry === "boolean" && typeof value === "boolean") {
+      return true;
+    }
+    if (
+      entry === "object" &&
+      Boolean(value) &&
+      typeof value === "object" &&
+      !Array.isArray(value)
+    ) {
+      return true;
+    }
+    if (entry === "array" && Array.isArray(value)) {
+      return true;
+    }
+    if (entry === "null" && value === null) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function readLastEventHash(filePath: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const lines = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (lines.length === 0) {
+      return null;
+    }
+    const parsed = JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+    const hash = parsed.event_hash;
+    return typeof hash === "string" && hash.trim() ? hash : null;
+  } catch {
+    return null;
+  }
+}
+
+function createEventHash(event: Record<string, unknown>): string {
+  const normalized: Record<string, unknown> = {};
+  for (const key of Object.keys(event).toSorted()) {
+    if (key !== "event_hash") {
+      normalized[key] = stableNormalize(event[key]);
+    }
+  }
+  return computeSha256(JSON.stringify(normalized));
+}
+
+function buildActionType(action: string): string {
+  if (action === "send" || action === "broadcast") {
+    return "send_external_message";
+  }
+  if (action === "poll") {
+    return "external_followup_send";
+  }
+  return "external_followup_send";
+}
+
+function resolveApproverActions(config: LoadedAamaPhase1Config): Set<string> {
+  const authority = config.approvalRules.authority_model;
+  const mapped = [
+    ...(authority?.tiffany?.approves ?? []),
+    ...(authority?.christian?.approves ?? []),
+  ];
+  return new Set(mapped);
+}
+
+async function appendGovernanceEvent(params: {
+  lane: "append_only_audit_log" | "attestation_events";
+  eventType: string;
+  actor: string;
+  details: Record<string, unknown>;
+}): Promise<void> {
+  const config = await loadAamaPhase1Config();
+  const lanePath = path.join(config.root, "governance", "spine", params.lane, "events.jsonl");
+  await fs.mkdir(path.dirname(lanePath), { recursive: true });
+  const prevHash = await readLastEventHash(lanePath);
+  const event: Record<string, unknown> = {
+    event_id: `${params.eventType}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`,
+    type: params.eventType,
+    actor: params.actor,
+    timestamp: new Date().toISOString(),
+    details: params.details,
+    prev_hash: prevHash,
+  };
+  event.event_hash = createEventHash(event);
+  await fs.appendFile(lanePath, `${JSON.stringify(event)}\n`, "utf-8");
+}
+
+async function loadAamaPhase1Config(): Promise<LoadedAamaPhase1Config> {
+  const root = resolvePhase1Root();
+  if (configCache && configCache.root === root) {
+    return configCache.value;
+  }
+
+  for (const rel of REQUIRED_PHASE1_FILES) {
+    const target = path.join(root, rel);
+    try {
+      await fs.access(target);
+    } catch {
+      throw new Error(`AAMA Phase 1 required file missing: ${target}`);
+    }
+  }
+
+  const approvalRulesRaw = await fs.readFile(
+    path.join(root, "core", "approval_rules.yaml"),
+    "utf-8",
+  );
+  const writeControlsRaw = await fs.readFile(
+    path.join(root, "policy", "write_controls.yaml"),
+    "utf-8",
+  );
+  const suspensionRulesRaw = await fs.readFile(
+    path.join(root, "policy", "suspension_rules.yaml"),
+    "utf-8",
+  );
+  const schemaRaw = await fs.readFile(
+    path.join(root, "memory", "schema", "memory_schema_v1.json"),
+    "utf-8",
+  );
+
+  const value: LoadedAamaPhase1Config = {
+    root,
+    approvalRules: (parseYaml(approvalRulesRaw) ?? {}) as LoadedAamaPhase1Config["approvalRules"],
+    writeControls: (parseYaml(writeControlsRaw) ?? {}) as LoadedAamaPhase1Config["writeControls"],
+    suspensionRules: (parseYaml(suspensionRulesRaw) ??
+      {}) as LoadedAamaPhase1Config["suspensionRules"],
+    memorySchema: (JSON.parse(schemaRaw) ?? {}) as LoadedAamaPhase1Config["memorySchema"],
+  };
+
+  configCache = { root, value };
+  return value;
+}
+
+async function assertAutonomyNotSuspended(): Promise<void> {
+  const suspended = await isAutonomySuspendedInPersistentState();
+  if (suspended) {
+    throw new Error(
+      "AAMA policy_gate blocked action: autonomy is suspended after prior approval-token bypass",
+    );
+  }
+}
+
+async function suspendAutonomy(params: {
+  actor: string;
+  reason: string;
+  action: string;
+  channel: string;
+  requesterSenderId?: string | null;
+}): Promise<void> {
+  await persistAutonomySuspendedState();
+  await appendGovernanceEvent({
+    lane: "append_only_audit_log",
+    eventType: "approval_token_bypass_detected",
+    actor: params.actor,
+    details: {
+      reason: params.reason,
+      action: params.action,
+      channel: params.channel,
+      requester_sender_id: params.requesterSenderId ?? null,
+    },
+  });
+  await appendGovernanceEvent({
+    lane: "append_only_audit_log",
+    eventType: "autonomy_suspended",
+    actor: "autonomy_safety_controller",
+    details: {
+      trigger: "approval_token_bypass",
+      reason: params.reason,
+      action: params.action,
+      channel: params.channel,
+    },
+  });
+}
+
+async function validateApprovalTokenBinding(params: {
+  token: string;
+  expectedActor: string;
+  expectedActionType: string;
+  expectedPayloadHash: string;
+  expectedNonce: string;
+}): Promise<ApprovalTokenClaims> {
+  const decoded = decodeApprovalToken(params.token);
+  const claims = decoded.claims;
+  const now = Math.floor(Date.now() / 1000);
+
+  if (claims.exp < now) {
+    throw new Error("approval token expired");
+  }
+  if (claims.actor !== params.expectedActor) {
+    throw new Error("approval token actor mismatch");
+  }
+  if (claims.action_type !== params.expectedActionType) {
+    throw new Error("approval token action_type mismatch");
+  }
+  if (claims.payload_hash !== params.expectedPayloadHash) {
+    throw new Error("approval token payload_hash mismatch");
+  }
+  if (claims.nonce !== params.expectedNonce) {
+    throw new Error("approval token nonce mismatch");
+  }
+  const consumed = await consumeApprovalTokenId(claims.jti);
+  if (!consumed) {
+    throw new Error("approval token already consumed");
+  }
+  return claims;
+}
+
+function evaluateSchema(params: {
+  schema: LoadedAamaPhase1Config["memorySchema"];
+  record: Record<string, unknown>;
+}): string[] {
+  const errors: string[] = [];
+  const required = new Set(params.schema.required ?? []);
+  const props = params.schema.properties ?? {};
+
+  const missing = [...required].filter((field) => !(field in params.record)).toSorted();
+  if (missing.length > 0) {
+    errors.push(`missing required fields: ${missing.join(", ")}`);
+  }
+
+  if (params.schema.additionalProperties === false) {
+    const extras = Object.keys(params.record)
+      .filter((key) => !(key in props))
+      .toSorted();
+    if (extras.length > 0) {
+      errors.push(`unexpected schema fields: ${extras.join(", ")}`);
+    }
+  }
+
+  for (const [field, spec] of Object.entries(props)) {
+    if (!(field in params.record)) {
+      continue;
+    }
+    const value = params.record[field];
+
+    if (spec.enum && spec.enum.length > 0 && !spec.enum.includes(value)) {
+      errors.push(`${field} must be one of ${JSON.stringify(spec.enum)}`);
+    }
+    if (spec.type && !isTypeCompatible(value, spec.type)) {
+      errors.push(`${field} has invalid type`);
+    }
+    if (typeof spec.minimum === "number" && typeof value === "number" && value < spec.minimum) {
+      errors.push(`${field} must be >= ${spec.minimum}`);
+    }
+    if (typeof spec.maximum === "number" && typeof value === "number" && value > spec.maximum) {
+      errors.push(`${field} must be <= ${spec.maximum}`);
+    }
+  }
+
+  return errors;
+}
+
+export async function enforceAamaPolicyGateForMessageAction(
+  params: EnforceMessageActionParams,
+): Promise<AamaPolicyDecision> {
+  if (!isAamaPhase1EnforcementEnabled()) {
+    return { decision: "allow", reasons: ["AAMA Phase 1 enforcement disabled"] };
+  }
+
+  const actor = params.actor.trim() || "system";
+  const config = await loadAamaPhase1Config();
+  await assertAutonomyNotSuspended();
+
+  const constraints = config.approvalRules.constraints ?? {};
+  const actionType = buildActionType(params.action);
+  const knownApproverActions = resolveApproverActions(config);
+
+  const bypass = readTrimmedString(params.actionParams, [
+    "allowlistBypass",
+    "allowlist_bypass",
+    "approvalBypass",
+    "approval_bypass",
+  ]);
+  if (constraints.send_external_allowlist_bypass === false && bypass === "true") {
+    const reason = "external send allowlist bypass attempt blocked";
+    await suspendAutonomy({
+      actor,
+      reason,
+      action: params.action,
+      channel: params.channel,
+      requesterSenderId: params.requesterSenderId,
+    });
+    throw new Error(`AAMA policy_gate blocked action: ${reason}`);
+  }
+
+  if (!knownApproverActions.has(actionType)) {
+    const reason = `external action is not mapped in approval_rules.yaml: ${actionType}`;
+    await appendGovernanceEvent({
+      lane: "append_only_audit_log",
+      eventType: "policy_gate_blocked",
+      actor,
+      details: {
+        reason,
+        action: params.action,
+        mapped_action_type: actionType,
+        channel: params.channel,
+      },
+    });
+    throw new Error(`AAMA policy_gate blocked action: ${reason}`);
+  }
+
+  const tokenRequired = constraints.approval_token_required_for_external_send === true;
+  if (tokenRequired) {
+    const approvalToken = readTrimmedString(params.actionParams, [
+      "approvalToken",
+      "approval_token",
+    ]);
+    const approvalNonce = readTrimmedString(params.actionParams, [
+      "approvalNonce",
+      "approval_nonce",
+    ]);
+
+    if (!approvalToken || !approvalNonce) {
+      const reason = "approval token is required for external send";
+      await suspendAutonomy({
+        actor,
+        reason,
+        action: params.action,
+        channel: params.channel,
+        requesterSenderId: params.requesterSenderId,
+      });
+      throw new Error(`AAMA policy_gate blocked action: ${reason}`);
+    }
+
+    const payloadHash = computeSha256(stableStringify(params.payload));
+    try {
+      const claims = await validateApprovalTokenBinding({
+        token: approvalToken,
+        expectedActor: actor,
+        expectedActionType: actionType,
+        expectedPayloadHash: payloadHash,
+        expectedNonce: approvalNonce,
+      });
+      await appendGovernanceEvent({
+        lane: "append_only_audit_log",
+        eventType: "approval_token_consumed",
+        actor,
+        details: {
+          action: params.action,
+          mapped_action_type: actionType,
+          channel: params.channel,
+          approver: claims.approver,
+          token_id: claims.jti,
+        },
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      await suspendAutonomy({
+        actor,
+        reason,
+        action: params.action,
+        channel: params.channel,
+        requesterSenderId: params.requesterSenderId,
+      });
+      throw new Error(`AAMA policy_gate blocked action: ${reason}`, { cause: error });
+    }
+  }
+
+  await appendGovernanceEvent({
+    lane: "append_only_audit_log",
+    eventType: "policy_gate_allow",
+    actor,
+    details: {
+      action: params.action,
+      mapped_action_type: actionType,
+      channel: params.channel,
+      requester_sender_id: params.requesterSenderId ?? null,
+    },
+  });
+
+  return { decision: "allow", reasons: ["policy gate allow"] };
+}
+
+export type EnforceAamaOutboundGuardParams = {
+  action: string;
+  channel: string;
+  payload: Record<string, unknown>;
+  alreadyEnforced?: boolean;
+  actor?: string | null;
+  requesterSenderId?: string | null;
+  actionParams?: Record<string, unknown>;
+};
+
+export async function enforceAamaOutboundGuard(
+  params: EnforceAamaOutboundGuardParams,
+): Promise<void> {
+  if (params.alreadyEnforced) {
+    return;
+  }
+  await enforceAamaPolicyGateForMessageAction({
+    action: params.action,
+    channel: params.channel,
+    actor: params.actor?.trim() || "system",
+    requesterSenderId: params.requesterSenderId ?? undefined,
+    actionParams: params.actionParams ?? {},
+    payload: params.payload,
+  });
+}
+
+export async function enforceAamaMemoryGateWrite(
+  params: EnforceMemoryWriteParams,
+): Promise<AamaMemoryDecision> {
+  if (!isAamaPhase1EnforcementEnabled()) {
+    return {
+      decision: "allow",
+      reasons: ["AAMA Phase 1 enforcement disabled"],
+      quarantineRequired: false,
+      quarantineReasons: [],
+      actionBlocked: false,
+      escalationRequired: false,
+    };
+  }
+
+  const actor = params.actor.trim() || "system";
+  const config = await loadAamaPhase1Config();
+  const schemaErrors = evaluateSchema({ schema: config.memorySchema, record: params.record });
+  if (schemaErrors.length > 0) {
+    const reason = `memory schema validation failed: ${schemaErrors.join("; ")}`;
+    await appendGovernanceEvent({
+      lane: "append_only_audit_log",
+      eventType: "memory_gate_blocked",
+      actor,
+      details: {
+        reason,
+        write_mode: params.writeMode,
+      },
+    });
+    throw new Error(`AAMA memory_gate blocked write: ${reason}`);
+  }
+
+  const mode = config.writeControls.memory_write_modes?.[params.writeMode];
+  if (!mode || mode.allowed !== true) {
+    const reason = `write mode not allowed: ${params.writeMode}`;
+    await appendGovernanceEvent({
+      lane: "append_only_audit_log",
+      eventType: "memory_gate_blocked",
+      actor,
+      details: { reason, write_mode: params.writeMode },
+    });
+    throw new Error(`AAMA memory_gate blocked write: ${reason}`);
+  }
+
+  const sourceRef =
+    typeof params.record.source_ref === "string" ? params.record.source_ref.trim() : "";
+  if (mode.requires_source_refs === true && !sourceRef) {
+    const reason = "write mode requires source_ref";
+    await appendGovernanceEvent({
+      lane: "append_only_audit_log",
+      eventType: "memory_gate_blocked",
+      actor,
+      details: { reason, write_mode: params.writeMode },
+    });
+    throw new Error(`AAMA memory_gate blocked write: ${reason}`);
+  }
+
+  if (params.record.integrity_level === "high_impact" && !sourceRef) {
+    const reason = "high-impact memory write requires source_ref";
+    await appendGovernanceEvent({
+      lane: "append_only_audit_log",
+      eventType: "memory_gate_blocked",
+      actor,
+      details: { reason, write_mode: params.writeMode },
+    });
+    throw new Error(`AAMA memory_gate blocked write: ${reason}`);
+  }
+
+  const quarantineReasons: string[] = [];
+  const confidence =
+    typeof params.record.confidence_score === "number" ? params.record.confidence_score : 0;
+  const unresolvedContradiction =
+    params.contradictionUnresolved ??
+    (Boolean(params.record.contradiction_group_id) &&
+      params.record.contradiction_resolved !== true);
+
+  if (params.record.integrity_level === "high_impact" && confidence < 0.85) {
+    quarantineReasons.push("confidence < 0.85 for high-impact fact");
+  }
+  if (unresolvedContradiction) {
+    quarantineReasons.push("unresolved contradiction detected");
+  }
+
+  const hardLimitDays =
+    config.suspensionRules.auto_suspend?.contradiction_backlog_hard_limit_days ?? 14;
+  const contradictionAgeDays = params.contradictionAgeDays;
+  const actionBlocked = Boolean(
+    unresolvedContradiction &&
+    typeof contradictionAgeDays === "number" &&
+    contradictionAgeDays >= hardLimitDays,
+  );
+  const escalationRequired = actionBlocked;
+  if (actionBlocked) {
+    quarantineReasons.push(`contradiction age >= ${hardLimitDays} days`);
+  }
+
+  const decision: AamaMemoryDecision = {
+    decision: "allow",
+    reasons:
+      quarantineReasons.length > 0
+        ? ["write accepted with quarantine requirements"]
+        : ["write allowed"],
+    quarantineRequired: quarantineReasons.length > 0,
+    quarantineReasons,
+    actionBlocked,
+    escalationRequired,
+  };
+
+  await appendGovernanceEvent({
+    lane: "append_only_audit_log",
+    eventType: decision.quarantineRequired ? "memory_gate_quarantine" : "memory_gate_allow",
+    actor,
+    details: {
+      write_mode: params.writeMode,
+      quarantine_required: decision.quarantineRequired,
+      quarantine_reasons: decision.quarantineReasons,
+      action_blocked: decision.actionBlocked,
+      escalation_required: decision.escalationRequired,
+    },
+  });
+
+  if (decision.actionBlocked) {
+    await appendGovernanceEvent({
+      lane: "append_only_audit_log",
+      eventType: "council_escalation_required",
+      actor: "memory_gate",
+      details: {
+        reason: "contradiction_backlog_hard_limit_exceeded",
+        hard_limit_days: hardLimitDays,
+      },
+    });
+  }
+
+  return decision;
+}
+
+export function resetAamaSpineControlsForTests(): void {
+  configCache = null;
+  sqliteModuleCache = null;
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -35,6 +35,7 @@ import { sendMessageSignal } from "../../signal/send.js";
 import type { sendMessageSlack } from "../../slack/send.js";
 import type { sendMessageTelegram } from "../../telegram/send.js";
 import type { sendMessageWhatsApp } from "../../web/outbound.js";
+import { enforceAamaOutboundGuard } from "../aama-spine-controls.js";
 import { throwIfAborted } from "./abort.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
 import type { OutboundIdentity } from "./identity.js";
@@ -248,6 +249,14 @@ type DeliverOutboundPayloadsCoreParams = {
     groupId?: string;
   };
   silent?: boolean;
+  aamaPolicy?: {
+    alreadyEnforced?: boolean;
+    action?: string;
+    actor?: string;
+    requesterSenderId?: string | null;
+    actionParams?: Record<string, unknown>;
+    payload?: Record<string, unknown>;
+  };
 };
 
 type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
@@ -465,6 +474,24 @@ export async function deliverOutboundPayloads(
   params: DeliverOutboundPayloadsParams,
 ): Promise<OutboundDeliveryResult[]> {
   const { channel, to, payloads } = params;
+  await enforceAamaOutboundGuard({
+    alreadyEnforced: params.aamaPolicy?.alreadyEnforced,
+    action: params.aamaPolicy?.action ?? "send",
+    channel,
+    actor:
+      params.aamaPolicy?.actor ?? params.session?.agentId ?? params.mirror?.agentId ?? "system",
+    requesterSenderId: params.aamaPolicy?.requesterSenderId,
+    actionParams: params.aamaPolicy?.actionParams,
+    payload:
+      params.aamaPolicy?.payload ??
+      ({
+        channel,
+        to,
+        payloads: normalizeReplyPayloadsForDelivery(payloads),
+        replyToId: params.replyToId ?? undefined,
+        threadId: params.threadId ?? undefined,
+      } as Record<string, unknown>),
+  });
 
   // Write-ahead delivery queue: persist before sending, remove after success.
   const queueId = params.skipQueue

--- a/src/infra/outbound/message-action-runner.aama-phase1.test.ts
+++ b/src/infra/outbound/message-action-runner.aama-phase1.test.ts
@@ -1,0 +1,342 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { issueAamaApprovalToken, writeAamaPhase1Fixture } from "../../test-utils/aama-phase1.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { resetAamaSpineControlsForTests } from "../aama-spine-controls.js";
+import { deliverOutboundPayloads } from "./deliver.js";
+import { runMessageAction } from "./message-action-runner.js";
+import { executeSendAction } from "./outbound-send-service.js";
+
+const slackConfig = {
+  channels: {
+    slack: {
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    },
+  },
+} as OpenClawConfig;
+
+afterEach(() => {
+  resetAamaSpineControlsForTests();
+});
+
+async function withAamaFixture(
+  test: (context: { root: string; approvalSecret: string }) => Promise<void>,
+): Promise<void> {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-aama-phase1-"));
+  const phase1Root = path.join(tempRoot, "phase1");
+  const approvalSecret = "phase1-secret";
+  try {
+    await writeAamaPhase1Fixture({ root: phase1Root });
+    await test({ root: phase1Root, approvalSecret });
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+describe("runMessageAction AAMA Phase 1 policy gate", () => {
+  it("blocks external send without approval token when enforcement is enabled", async () => {
+    await withAamaFixture(async ({ root, approvalSecret }) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: root,
+          OPENCLAW_AAMA_APPROVAL_SECRET: approvalSecret,
+        },
+        async () => {
+          await expect(
+            runMessageAction({
+              cfg: slackConfig,
+              action: "send",
+              params: {
+                channel: "slack",
+                target: "channel:c12345678",
+                message: "hello",
+              },
+              dryRun: true,
+              agentId: "main",
+            }),
+          ).rejects.toThrow(/approval token is required/i);
+        },
+      );
+    });
+  });
+
+  it("allows external send when approval token binding is valid", async () => {
+    await withAamaFixture(async ({ root, approvalSecret }) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: root,
+          OPENCLAW_AAMA_APPROVAL_SECRET: approvalSecret,
+        },
+        async () => {
+          const nonce = "nonce-001";
+          const payload = {
+            channel: "slack",
+            to: "channel:c12345678",
+            message: "hello",
+          };
+          const approvalToken = issueAamaApprovalToken({
+            secret: approvalSecret,
+            actor: "main",
+            actionType: "send_external_message",
+            payload,
+            nonce,
+          });
+
+          const result = await runMessageAction({
+            cfg: slackConfig,
+            action: "send",
+            params: {
+              channel: "slack",
+              target: "channel:c12345678",
+              message: "hello",
+              approvalToken,
+              approvalNonce: nonce,
+            },
+            dryRun: true,
+            agentId: "main",
+          });
+
+          expect(result.kind).toBe("send");
+          if (result.kind !== "send") {
+            throw new Error("expected send result");
+          }
+          expect(result.to).toBe("channel:c12345678");
+        },
+      );
+    });
+  });
+
+  it("blocks approval token replay across restarts via durable state", async () => {
+    await withAamaFixture(async ({ root, approvalSecret }) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: root,
+          OPENCLAW_AAMA_APPROVAL_SECRET: approvalSecret,
+        },
+        async () => {
+          const nonce = "nonce-replay";
+          const payload = {
+            channel: "slack",
+            to: "channel:c12345678",
+            message: "hello",
+          };
+          const approvalToken = issueAamaApprovalToken({
+            secret: approvalSecret,
+            actor: "main",
+            actionType: "send_external_message",
+            payload,
+            nonce,
+          });
+
+          await runMessageAction({
+            cfg: slackConfig,
+            action: "send",
+            params: {
+              channel: "slack",
+              target: "channel:c12345678",
+              message: "hello",
+              approvalToken,
+              approvalNonce: nonce,
+            },
+            dryRun: true,
+            agentId: "main",
+          });
+
+          resetAamaSpineControlsForTests();
+
+          await expect(
+            runMessageAction({
+              cfg: slackConfig,
+              action: "send",
+              params: {
+                channel: "slack",
+                target: "channel:c12345678",
+                message: "hello",
+                approvalToken,
+                approvalNonce: nonce,
+              },
+              dryRun: true,
+              agentId: "main",
+            }),
+          ).rejects.toThrow(/already consumed/i);
+        },
+      );
+    });
+  });
+
+  it("persists suspension state across restarts and blocks subsequent actions", async () => {
+    await withAamaFixture(async ({ root, approvalSecret }) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: root,
+          OPENCLAW_AAMA_APPROVAL_SECRET: approvalSecret,
+        },
+        async () => {
+          await expect(
+            runMessageAction({
+              cfg: slackConfig,
+              action: "send",
+              params: {
+                channel: "slack",
+                target: "channel:c12345678",
+                message: "hello",
+              },
+              dryRun: true,
+              agentId: "main",
+            }),
+          ).rejects.toThrow(/approval token is required/i);
+
+          resetAamaSpineControlsForTests();
+
+          const nonce = "nonce-after-suspend";
+          const payload = {
+            channel: "slack",
+            to: "channel:c12345678",
+            message: "hello",
+          };
+          const approvalToken = issueAamaApprovalToken({
+            secret: approvalSecret,
+            actor: "main",
+            actionType: "send_external_message",
+            payload,
+            nonce,
+          });
+
+          await expect(
+            runMessageAction({
+              cfg: slackConfig,
+              action: "send",
+              params: {
+                channel: "slack",
+                target: "channel:c12345678",
+                message: "hello",
+                approvalToken,
+                approvalNonce: nonce,
+              },
+              dryRun: true,
+              agentId: "main",
+            }),
+          ).rejects.toThrow(/autonomy is suspended/i);
+        },
+      );
+    });
+  });
+
+  it("fails closed and spine-logs bypass attempts", async () => {
+    await withAamaFixture(async ({ root, approvalSecret }) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: root,
+          OPENCLAW_AAMA_APPROVAL_SECRET: approvalSecret,
+        },
+        async () => {
+          const nonce = "nonce-bypass";
+          const payload = {
+            channel: "slack",
+            to: "channel:c12345678",
+            message: "hello",
+          };
+          const approvalToken = issueAamaApprovalToken({
+            secret: approvalSecret,
+            actor: "main",
+            actionType: "send_external_message",
+            payload,
+            nonce,
+          });
+
+          await expect(
+            runMessageAction({
+              cfg: slackConfig,
+              action: "send",
+              params: {
+                channel: "slack",
+                target: "channel:c12345678",
+                message: "hello",
+                approvalToken,
+                approvalNonce: nonce,
+                allowlistBypass: "true",
+              },
+              dryRun: true,
+              agentId: "main",
+            }),
+          ).rejects.toThrow(/allowlist bypass attempt blocked/i);
+
+          const eventsPath = path.join(
+            root,
+            "governance",
+            "spine",
+            "append_only_audit_log",
+            "events.jsonl",
+          );
+          const raw = await fs.readFile(eventsPath, "utf-8");
+          const events = raw
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .map((line) => JSON.parse(line) as { type?: string });
+          const eventTypes = events.map((entry) => entry.type);
+          expect(eventTypes).toContain("approval_token_bypass_detected");
+          expect(eventTypes).toContain("autonomy_suspended");
+        },
+      );
+    });
+  });
+
+  it("blocks direct executeSendAction calls without approval token", async () => {
+    await withAamaFixture(async ({ root, approvalSecret }) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: root,
+          OPENCLAW_AAMA_APPROVAL_SECRET: approvalSecret,
+        },
+        async () => {
+          await expect(
+            executeSendAction({
+              ctx: {
+                cfg: slackConfig,
+                channel: "slack",
+                params: {},
+                agentId: "main",
+                dryRun: true,
+              },
+              to: "channel:c12345678",
+              message: "hello",
+            }),
+          ).rejects.toThrow(/approval token is required/i);
+        },
+      );
+    });
+  });
+
+  it("blocks direct deliverOutboundPayloads calls without approval token", async () => {
+    await withAamaFixture(async ({ root, approvalSecret }) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AAMA_PHASE1_ENABLE: "1",
+          OPENCLAW_AAMA_PHASE1_ROOT: root,
+          OPENCLAW_AAMA_APPROVAL_SECRET: approvalSecret,
+        },
+        async () => {
+          await expect(
+            deliverOutboundPayloads({
+              cfg: slackConfig,
+              channel: "slack",
+              to: "channel:c12345678",
+              payloads: [{ text: "hello" }],
+            }),
+          ).rejects.toThrow(/approval token is required/i);
+        },
+      );
+    });
+  });
+});

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -19,6 +19,7 @@ import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
+import { enforceAamaOutboundGuard } from "../aama-spine-controls.js";
 import { throwIfAborted } from "./abort.js";
 import {
   listConfiguredMessageChannels,
@@ -286,6 +287,15 @@ type ResolvedActionContext = {
   resolvedTarget?: ResolvedMessagingTarget;
   abortSignal?: AbortSignal;
 };
+
+function resolvePolicyActor(params: {
+  agentId?: string;
+  requesterSenderId?: string | null;
+}): string {
+  const actor = params.agentId?.trim() || params.requesterSenderId?.trim() || "system";
+  return actor;
+}
+
 function resolveGateway(input: RunMessageActionParams): MessageActionRunnerGateway | undefined {
   if (!input.gateway) {
     return undefined;
@@ -488,6 +498,26 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     toolContext: input.toolContext,
     allowSlackAutoThread: channel === "slack" && !replyToId,
   });
+  const actor = resolvePolicyActor({
+    agentId,
+    requesterSenderId: input.requesterSenderId,
+  });
+  await enforceAamaOutboundGuard({
+    action,
+    channel,
+    actor,
+    requesterSenderId: input.requesterSenderId,
+    actionParams: params,
+    payload: {
+      channel,
+      to,
+      message,
+      mediaUrl: mediaUrl || undefined,
+      mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
+      replyToId: replyToId ?? undefined,
+      threadId: resolvedThreadId ?? undefined,
+    },
+  });
   const outboundRoute =
     agentId && !dryRun
       ? await resolveOutboundSessionRoute({
@@ -525,6 +555,12 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       channel,
       params,
       agentId,
+      aamaPolicy: {
+        alreadyEnforced: true,
+        actor,
+        requesterSenderId: input.requesterSenderId,
+        actionParams: params,
+      },
       accountId: accountId ?? undefined,
       gateway,
       toolContext: input.toolContext,
@@ -605,6 +641,28 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
     toolContext: input.toolContext,
     allowSlackAutoThread: channel === "slack",
   });
+  const actor = resolvePolicyActor({
+    agentId: ctx.agentId,
+    requesterSenderId: input.requesterSenderId,
+  });
+  await enforceAamaOutboundGuard({
+    action,
+    channel,
+    actor,
+    requesterSenderId: input.requesterSenderId,
+    actionParams: params,
+    payload: {
+      channel,
+      to,
+      question,
+      options,
+      maxSelections,
+      durationSeconds: durationSeconds ?? undefined,
+      durationHours: durationHours ?? undefined,
+      threadId: resolvedThreadId ?? undefined,
+      isAnonymous: isAnonymous ?? undefined,
+    },
+  });
 
   const base = typeof params.message === "string" ? params.message : "";
   await maybeApplyCrossContextMarker({
@@ -624,6 +682,12 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
       cfg,
       channel,
       params,
+      aamaPolicy: {
+        alreadyEnforced: true,
+        actor,
+        requesterSenderId: input.requesterSenderId,
+        actionParams: params,
+      },
       accountId: accountId ?? undefined,
       gateway,
       toolContext: input.toolContext,
@@ -657,6 +721,21 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
   const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
   throwIfAborted(abortSignal);
   const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
+  const actor = resolvePolicyActor({
+    agentId: ctx.agentId,
+    requesterSenderId: input.requesterSenderId,
+  });
+  await enforceAamaOutboundGuard({
+    action,
+    channel,
+    actor,
+    requesterSenderId: input.requesterSenderId,
+    actionParams: params,
+    payload: {
+      channel,
+      params,
+    },
+  });
   if (dryRun) {
     return {
       kind: "action",
@@ -797,6 +876,7 @@ export async function runMessageAction(
       dryRun,
       gateway,
       input,
+      agentId: resolvedAgentId,
       abortSignal: input.abortSignal,
     });
   }
@@ -809,6 +889,7 @@ export async function runMessageAction(
     dryRun,
     gateway,
     input,
+    agentId: resolvedAgentId,
     abortSignal: input.abortSignal,
   });
 }

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -9,6 +9,7 @@ import {
   type GatewayClientMode,
   type GatewayClientName,
 } from "../../utils/message-channel.js";
+import { enforceAamaOutboundGuard } from "../aama-spine-controls.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import {
@@ -27,6 +28,13 @@ export type MessageGatewayOptions = {
   clientName?: GatewayClientName;
   clientDisplayName?: string;
   mode?: GatewayClientMode;
+};
+
+type MessageAamaPolicyContext = {
+  alreadyEnforced?: boolean;
+  actor?: string;
+  requesterSenderId?: string | null;
+  actionParams?: Record<string, unknown>;
 };
 
 type MessageSendParams = {
@@ -55,6 +63,7 @@ type MessageSendParams = {
   };
   abortSignal?: AbortSignal;
   silent?: boolean;
+  aamaPolicy?: MessageAamaPolicyContext;
 };
 
 export type MessageSendResult = {
@@ -83,6 +92,7 @@ type MessagePollParams = {
   cfg?: OpenClawConfig;
   gateway?: MessageGatewayOptions;
   idempotencyKey?: string;
+  aamaPolicy?: MessageAamaPolicyContext;
 };
 
 export type MessagePollResult = {
@@ -184,6 +194,24 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   );
   const primaryMediaUrl = mirrorMediaUrls[0] ?? params.mediaUrl ?? null;
 
+  await enforceAamaOutboundGuard({
+    alreadyEnforced: params.aamaPolicy?.alreadyEnforced,
+    action: "send",
+    channel,
+    actor: params.aamaPolicy?.actor ?? params.agentId ?? "system",
+    requesterSenderId: params.aamaPolicy?.requesterSenderId,
+    actionParams: params.aamaPolicy?.actionParams,
+    payload: {
+      channel,
+      to: params.to,
+      message: params.content,
+      mediaUrl: params.mediaUrl || undefined,
+      mediaUrls: mirrorMediaUrls.length > 0 ? mirrorMediaUrls : undefined,
+      replyToId: params.replyToId ?? undefined,
+      threadId: params.threadId ?? undefined,
+    },
+  });
+
   if (params.dryRun) {
     return {
       channel,
@@ -227,6 +255,12 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       bestEffort: params.bestEffort,
       abortSignal: params.abortSignal,
       silent: params.silent,
+      aamaPolicy: {
+        alreadyEnforced: true,
+        actor: params.aamaPolicy?.actor ?? params.agentId ?? "system",
+        requesterSenderId: params.aamaPolicy?.requesterSenderId,
+        actionParams: params.aamaPolicy?.actionParams,
+      },
       mirror: params.mirror
         ? {
             ...params.mirror,
@@ -292,6 +326,26 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
   const normalized = outbound.pollMaxOptions
     ? normalizePollInput(pollInput, { maxOptions: outbound.pollMaxOptions })
     : normalizePollInput(pollInput);
+
+  await enforceAamaOutboundGuard({
+    alreadyEnforced: params.aamaPolicy?.alreadyEnforced,
+    action: "poll",
+    channel,
+    actor: params.aamaPolicy?.actor ?? "system",
+    requesterSenderId: params.aamaPolicy?.requesterSenderId,
+    actionParams: params.aamaPolicy?.actionParams,
+    payload: {
+      channel,
+      to: params.to,
+      question: normalized.question,
+      options: normalized.options,
+      maxSelections: normalized.maxSelections,
+      durationSeconds: normalized.durationSeconds ?? undefined,
+      durationHours: normalized.durationHours ?? undefined,
+      threadId: params.threadId ?? undefined,
+      isAnonymous: params.isAnonymous ?? undefined,
+    },
+  });
 
   if (params.dryRun) {
     return {

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
+import { enforceAamaOutboundGuard } from "../aama-spine-controls.js";
 import { throwIfAborted } from "./abort.js";
 import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
@@ -26,6 +27,12 @@ export type OutboundSendContext = {
   params: Record<string, unknown>;
   /** Active agent id for per-agent outbound media root scoping. */
   agentId?: string;
+  aamaPolicy?: {
+    alreadyEnforced?: boolean;
+    actor?: string;
+    requesterSenderId?: string | null;
+    actionParams?: Record<string, unknown>;
+  };
   accountId?: string | null;
   gateway?: OutboundGatewayContext;
   toolContext?: ChannelThreadingToolContext;
@@ -46,6 +53,10 @@ type PluginHandledResult = {
   payload: unknown;
   toolResult: AgentToolResult<unknown>;
 };
+
+function resolvePolicyActor(ctx: OutboundSendContext): string {
+  return ctx.aamaPolicy?.actor?.trim() || ctx.agentId?.trim() || "system";
+}
 
 async function tryHandleWithPluginAction(params: {
   ctx: OutboundSendContext;
@@ -98,6 +109,24 @@ export async function executeSendAction(params: {
   sendResult?: MessageSendResult;
 }> {
   throwIfAborted(params.ctx.abortSignal);
+  await enforceAamaOutboundGuard({
+    alreadyEnforced: params.ctx.aamaPolicy?.alreadyEnforced,
+    action: "send",
+    channel: params.ctx.channel,
+    actor: resolvePolicyActor(params.ctx),
+    requesterSenderId: params.ctx.aamaPolicy?.requesterSenderId,
+    actionParams: params.ctx.aamaPolicy?.actionParams ?? params.ctx.params,
+    payload: {
+      channel: params.ctx.channel,
+      to: params.to,
+      message: params.message,
+      mediaUrl: params.mediaUrl ?? undefined,
+      mediaUrls: params.mediaUrls && params.mediaUrls.length > 0 ? params.mediaUrls : undefined,
+      replyToId: params.replyToId ?? undefined,
+      threadId: params.threadId ?? undefined,
+    },
+  });
+
   const pluginHandled = await tryHandleWithPluginAction({
     ctx: params.ctx,
     action: "send",
@@ -142,6 +171,12 @@ export async function executeSendAction(params: {
     mirror: params.ctx.mirror,
     abortSignal: params.ctx.abortSignal,
     silent: params.ctx.silent,
+    aamaPolicy: {
+      alreadyEnforced: true,
+      actor: resolvePolicyActor(params.ctx),
+      requesterSenderId: params.ctx.aamaPolicy?.requesterSenderId,
+      actionParams: params.ctx.aamaPolicy?.actionParams ?? params.ctx.params,
+    },
   });
 
   return {
@@ -167,6 +202,26 @@ export async function executePollAction(params: {
   toolResult?: AgentToolResult<unknown>;
   pollResult?: MessagePollResult;
 }> {
+  await enforceAamaOutboundGuard({
+    alreadyEnforced: params.ctx.aamaPolicy?.alreadyEnforced,
+    action: "poll",
+    channel: params.ctx.channel,
+    actor: resolvePolicyActor(params.ctx),
+    requesterSenderId: params.ctx.aamaPolicy?.requesterSenderId,
+    actionParams: params.ctx.aamaPolicy?.actionParams ?? params.ctx.params,
+    payload: {
+      channel: params.ctx.channel,
+      to: params.to,
+      question: params.question,
+      options: params.options,
+      maxSelections: params.maxSelections,
+      durationSeconds: params.durationSeconds ?? undefined,
+      durationHours: params.durationHours ?? undefined,
+      threadId: params.threadId ?? undefined,
+      isAnonymous: params.isAnonymous ?? undefined,
+    },
+  });
+
   const pluginHandled = await tryHandleWithPluginAction({
     ctx: params.ctx,
     action: "poll",
@@ -190,6 +245,12 @@ export async function executePollAction(params: {
     isAnonymous: params.isAnonymous ?? undefined,
     dryRun: params.ctx.dryRun,
     gateway: params.ctx.gateway,
+    aamaPolicy: {
+      alreadyEnforced: true,
+      actor: resolvePolicyActor(params.ctx),
+      requesterSenderId: params.ctx.aamaPolicy?.requesterSenderId,
+      actionParams: params.ctx.aamaPolicy?.actionParams ?? params.ctx.params,
+    },
   });
 
   return {

--- a/src/test-utils/aama-phase1.ts
+++ b/src/test-utils/aama-phase1.ts
@@ -1,0 +1,229 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type FixtureOptions = {
+  root: string;
+  appendOnlyAllowed?: boolean;
+};
+
+function stableNormalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableNormalize(entry));
+  }
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).toSorted();
+    for (const key of keys) {
+      const child = record[key];
+      if (child !== undefined) {
+        output[key] = stableNormalize(child);
+      }
+    }
+    return output;
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(stableNormalize(value));
+}
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function base64UrlEncode(raw: Buffer): string {
+  return raw.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
+}
+
+export async function writeAamaPhase1Fixture(options: FixtureOptions): Promise<void> {
+  const root = options.root;
+  await fs.mkdir(path.join(root, "core"), { recursive: true });
+  await fs.mkdir(path.join(root, "policy"), { recursive: true });
+  await fs.mkdir(path.join(root, "memory", "schema"), { recursive: true });
+  await fs.mkdir(path.join(root, "governance", "spine", "append_only_audit_log"), {
+    recursive: true,
+  });
+  await fs.mkdir(path.join(root, "governance", "spine", "attestation_events"), {
+    recursive: true,
+  });
+
+  await fs.writeFile(
+    path.join(root, "core", "approval_rules.yaml"),
+    [
+      "version: 1",
+      "authority_model:",
+      "  tiffany:",
+      '    role: "primary_operator"',
+      "    approves:",
+      "      - send_external_message",
+      "      - external_followup_send",
+      "      - client_facing_campaign_send",
+      "  christian:",
+      '    role: "owner_governance"',
+      "    approves:",
+      "      - promote_to_tier3",
+      "      - governance_root_changes",
+      "      - token_service_trust_boundary_changes",
+      "      - policy_gate_rule_changes",
+      "  self_authorized_by_tier:",
+      "    - internal_draft_generation",
+      "    - reflection_capture",
+      "    - hygiene_dedupe_scan",
+      "    - read_only_retrieval",
+      "constraints:",
+      "  approval_token_required_for_external_send: true",
+      "  send_external_allowlist_bypass: false",
+      "  ambiguous_default_approver_allowed: false",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const appendAllowed = options.appendOnlyAllowed !== false;
+  await fs.writeFile(
+    path.join(root, "policy", "write_controls.yaml"),
+    [
+      "version: 1",
+      "memory_write_modes:",
+      "  append_only:",
+      `    allowed: ${appendAllowed ? "true" : "false"}`,
+      "    approval_required: false",
+      "  merge_with_trace:",
+      "    allowed: true",
+      "    approval_required: false",
+      "    requires_source_refs: true",
+      "  replace_guarded:",
+      "    allowed: true",
+      "    approval_required: true",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  await fs.writeFile(
+    path.join(root, "policy", "suspension_rules.yaml"),
+    [
+      "version: 1",
+      "auto_suspend:",
+      "  high_severity_policy_violations_7d: 2",
+      "  unauthorized_external_action: 1",
+      "  approval_token_bypass: 1",
+      "  contradiction_backlog_hard_limit_days: 14",
+      "  noise_budget_breach_consecutive_weeks: 2",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  await fs.writeFile(
+    path.join(root, "memory", "schema", "memory_schema_v1.json"),
+    JSON.stringify(
+      {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "memory_id",
+          "memory_class",
+          "module",
+          "entity_ref",
+          "payload",
+          "source_ref",
+          "confidence_score",
+          "created_at",
+          "updated_at",
+          "status",
+          "retention_policy",
+          "created_by",
+          "review_required",
+          "quarantine_state",
+          "contradiction_group_id",
+          "integrity_level",
+        ],
+        properties: {
+          memory_id: { type: "string" },
+          memory_class: {
+            type: "string",
+            enum: ["permanent", "long_term", "active", "reflection", "idea", "archive"],
+          },
+          module: {
+            type: "string",
+            enum: [
+              "client",
+              "deal",
+              "manufacturer",
+              "competitor",
+              "design",
+              "marketing",
+              "reflection",
+              "idea",
+            ],
+          },
+          entity_ref: { type: "string" },
+          payload: { type: "object" },
+          source_ref: { type: "string" },
+          confidence_score: { type: "number", minimum: 0, maximum: 1 },
+          created_at: { type: "string" },
+          updated_at: { type: "string" },
+          status: { type: "string", enum: ["active", "stale", "archived", "superseded"] },
+          retention_policy: { type: "string" },
+          created_by: { type: "string", enum: ["human", "agent", "system"] },
+          review_required: { type: "boolean" },
+          quarantine_state: { type: "string", enum: ["none", "pending_review", "blocked"] },
+          contradiction_group_id: { type: ["string", "null"] },
+          integrity_level: { type: "string", enum: ["normal", "high_impact"] },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf-8",
+  );
+
+  await fs.writeFile(
+    path.join(root, "governance", "spine", "append_only_audit_log", "events.jsonl"),
+    "",
+    "utf-8",
+  );
+  await fs.writeFile(
+    path.join(root, "governance", "spine", "attestation_events", "events.jsonl"),
+    "",
+    "utf-8",
+  );
+}
+
+export function issueAamaApprovalToken(params: {
+  secret: string;
+  actor: string;
+  actionType: string;
+  payload: Record<string, unknown>;
+  nonce: string;
+  approver?: string;
+  issuedAt?: number;
+  ttlSeconds?: number;
+}): string {
+  const issuedAt = params.issuedAt ?? Math.floor(Date.now() / 1000);
+  const ttl = params.ttlSeconds ?? 900;
+  const claims = {
+    jti: crypto.randomUUID(),
+    actor: params.actor,
+    action_type: params.actionType,
+    payload_hash: sha256(stableStringify(params.payload)),
+    nonce: params.nonce,
+    iat: issuedAt,
+    exp: issuedAt + ttl,
+    approver: params.approver ?? "tiffany",
+  };
+  const header = { alg: "HS256", typ: "AAMA-APPROVAL" };
+
+  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(claims)));
+  const signature = crypto
+    .createHmac("sha256", params.secret)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest();
+  const signatureB64 = base64UrlEncode(signature);
+  return `${headerB64}.${payloadB64}.${signatureB64}`;
+}


### PR DESCRIPTION
## Summary

This PR closes AAMA Phase 1 for the current implementation scope.

Included in this branch:
- durable Phase 1 policy enforcement across outbound paths
- gateway send/poll approval guard hardening
- session-memory append_only memory-gate enforcement
- shared outbound guard coverage across tested paths
- regression and validation results for Phase 1 closeout

## Key commits

- 57a017fada1f3a5fcc756126b1b9ae7c7141bff6
  - feat(aama): enforce durable Phase 1 policy gate across outbound paths

- 0d0a566af87749153d71a46c0985cd5522a1ae1d
  - gateway: harden AAMA approval guard for send/poll

## Validation

Broad outbound + gateway regression:
- Test Files: 10 passed (10)
- Tests: 151 passed (151)

Gateway/session send test:
- sandbox failure confirmed environmental only
- passed outside sandbox:
  - Test Files: 1 passed (1)
  - Tests: 2 passed (2)

Phase 1 package validation:
- `python3 scripts/phase1_validate.py` -> PASS
- `python3 -m unittest discover -s tests -p "test_*.py"` -> OK

## Notes

- `AGENTS.md` local naming preference change was intentionally kept out of this PR
- Phase 1 exit criteria are satisfied within tested scope
