### PR TITLE
fix(config): infer auth profile providers from profile ids

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -204,4 +204,25 @@ describe("config schema regressions", () => {
       expect(res.config.auth?.profiles?.["qwen-portal:default"]?.provider).toBe("qwen-portal");
     }
   });
+
+  it("preserves explicit auth profile providers over the profile id prefix", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {},
+      },
+      auth: {
+        profiles: {
+          "google:custom": {
+            provider: "anthropic",
+            mode: "api_key",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.auth?.profiles?.["google:custom"]?.provider).toBe("anthropic");
+    }
+  });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,24 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("backfills auth profile provider from profile id when omitted", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {},
+      },
+      auth: {
+        profiles: {
+          "qwen-portal:default": {
+            mode: "oauth",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.auth?.profiles?.["qwen-portal:default"]?.provider).toBe("qwen-portal");
+    }
+  });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
+import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { normalizeProviderId } from "../agents/model-selection.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
 import {
   normalizePluginsConfig,
@@ -21,7 +23,6 @@ import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-di
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
 import { applyAgentDefaults, applyModelDefaults, applySessionDefaults } from "./defaults.js";
 import { findLegacyConfigIssues } from "./legacy.js";
-import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth"]);
@@ -222,6 +223,62 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
   ];
 }
 
+function inferProviderFromAuthProfileId(profileId: string): string | undefined {
+  const firstSeparator = profileId.indexOf(":");
+  if (firstSeparator <= 0) {
+    return undefined;
+  }
+  const provider = profileId.slice(0, firstSeparator).trim();
+  if (!provider) {
+    return undefined;
+  }
+  return normalizeProviderId(provider);
+}
+
+function backfillAuthProfileProviders(raw: unknown): unknown {
+  if (!isRecord(raw) || !isRecord(raw.auth) || !isRecord(raw.auth.profiles)) {
+    return raw;
+  }
+
+  let changed = false;
+  const nextProfiles: Record<string, unknown> = {};
+
+  for (const [profileId, profileValue] of Object.entries(raw.auth.profiles)) {
+    if (!isRecord(profileValue)) {
+      nextProfiles[profileId] = profileValue;
+      continue;
+    }
+
+    const currentProvider =
+      typeof profileValue.provider === "string" ? profileValue.provider.trim() : "";
+    if (currentProvider) {
+      nextProfiles[profileId] = profileValue;
+      continue;
+    }
+
+    const inferredProvider = inferProviderFromAuthProfileId(profileId);
+    if (!inferredProvider) {
+      nextProfiles[profileId] = profileValue;
+      continue;
+    }
+
+    changed = true;
+    nextProfiles[profileId] = { ...profileValue, provider: inferredProvider };
+  }
+
+  if (!changed) {
+    return raw;
+  }
+
+  return {
+    ...raw,
+    auth: {
+      ...raw.auth,
+      profiles: nextProfiles,
+    },
+  };
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -229,7 +286,8 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
 export function validateConfigObjectRaw(
   raw: unknown,
 ): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
-  const legacyIssues = findLegacyConfigIssues(raw);
+  const normalizedRaw = backfillAuthProfileProviders(raw);
+  const legacyIssues = findLegacyConfigIssues(normalizedRaw);
   if (legacyIssues.length > 0) {
     return {
       ok: false,
@@ -239,7 +297,7 @@ export function validateConfigObjectRaw(
       })),
     };
   }
-  const validated = OpenClawSchema.safeParse(raw);
+  const validated = OpenClawSchema.safeParse(normalizedRaw);
   if (!validated.success) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
- fix config validation for auth profiles that rely on their profile id to imply the provider
- backfill missing `auth.profiles[*].provider` values from the `<provider>:<name>` profile key before schema validation
- add a regression test for configs that keep an OAuth profile after its provider entry was removed

## Problem
`auth.profiles` entries are identified by `<provider>:<name>`, and existing configs rely on that key to imply the provider. If the profile omits an explicit `provider` field, config validation currently fails before CLI commands can run. This shows up when a user removes a provider entry but still has an auth profile for it.

## Root Cause
`validateConfigObjectRaw()` passes raw auth profiles straight into `OpenClawSchema`, where `auth.profiles[*].provider` is still required. We already know the provider from the profile id, but we were not normalizing that value before schema validation.

## Fix
Backfill missing auth profile `provider` values from the profile id before running legacy checks and schema validation. This keeps existing profile-key semantics intact without changing configs that already set `provider`.

## Verification
- `pnpm exec vitest run src/config/config.schema-regressions.test.ts`
- `pnpm exec oxfmt --check src/config/validation.ts src/config/config.schema-regressions.test.ts`
- `pnpm exec tsx -e "import { withTempHomeConfig, withEnvOverride } from './src/config/test-helpers.ts'; import { clearConfigCache, loadConfig } from './src/config/config.ts'; (async () => { await withTempHomeConfig({ models: { providers: {} }, auth: { profiles: { 'qwen-portal:default': { mode: 'oauth' } } } }, async ({home}) => { await withEnvOverride({ HOME: home }, async () => { clearConfigCache(); const cfg = loadConfig(); console.log(JSON.stringify(cfg.auth?.profiles?.['qwen-portal:default'] ?? null)); }); }); })();"`

Fixes #38913