### PR TITLE
docs(gateway): add Windows no-Docker hardening fallback guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1201,6 +1201,7 @@
                     "pages": [
                       "gateway/security/index",
                       "gateway/sandboxing",
+                      "gateway/windows-no-docker-hardening",
                       "gateway/sandbox-vs-tool-policy-vs-elevated"
                     ]
                   },

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -256,4 +256,5 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
 
 - [Sandbox Configuration](/gateway/configuration#agentsdefaults-sandbox)
 - [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools)
+- [Windows hardening without Docker/WSL](/gateway/windows-no-docker-hardening)
 - [Security](/gateway/security)

--- a/docs/gateway/windows-no-docker-hardening.md
+++ b/docs/gateway/windows-no-docker-hardening.md
@@ -172,19 +172,21 @@ openclaw status
 Remove explicit ACL entries for the constrained user:
 
 ```powershell
+$Workspace = "D:\OpenClawWorkspace"
 $Principal = "$env:COMPUTERNAME\openclaw_bot"
 
-icacls "D:\OpenClawWorkspace" /remove "$Principal" /T /C
-icacls "D:\OpenClawWorkspace" /remove:d "$Principal" /T /C
+icacls $Workspace /remove "$Principal" /T /C
+icacls $Workspace /remove:d "$Principal" /T /C
 ```
 
 Remove deny entries from sibling directories if you added them:
 
 ```powershell
+$Workspace = "D:\OpenClawWorkspace"
 $Principal = "$env:COMPUTERNAME\openclaw_bot"
-$Parent = "D:\"
+$Parent = Split-Path -Parent $Workspace
 Get-ChildItem -LiteralPath $Parent -Directory |
-  Where-Object { $_.FullName -ne "D:\OpenClawWorkspace" } |
+  Where-Object { $_.FullName -ne $Workspace } |
   ForEach-Object {
     icacls $_.FullName /remove:d "$Principal" /T /C
   }

--- a/docs/gateway/windows-no-docker-hardening.md
+++ b/docs/gateway/windows-no-docker-hardening.md
@@ -129,8 +129,8 @@ $Workspace = "D:\OpenClawWorkspace"
 $State = "D:\OpenClawWorkspace\.openclaw-state"
 
 runas /user:$env:COMPUTERNAME\openclaw_bot "powershell -NoProfile -NoExit -Command `"`
-$env:OPENCLAW_STATE_DIR='$State'; `
-$env:OPENCLAW_CONFIG_PATH='$State\openclaw.json'; `
+`$env:OPENCLAW_STATE_DIR='$State'; `
+`$env:OPENCLAW_CONFIG_PATH='$State\openclaw.json'; `
 Set-Location -LiteralPath '$Workspace'; `
 openclaw gateway`""
 ```
@@ -181,6 +181,7 @@ icacls "D:\OpenClawWorkspace" /remove:d "$Principal" /T /C
 Remove deny entries from sibling directories if you added them:
 
 ```powershell
+$Principal = "$env:COMPUTERNAME\openclaw_bot"
 $Parent = "D:\"
 Get-ChildItem -LiteralPath $Parent -Directory |
   Where-Object { $_.FullName -ne "D:\OpenClawWorkspace" } |

--- a/docs/gateway/windows-no-docker-hardening.md
+++ b/docs/gateway/windows-no-docker-hardening.md
@@ -1,0 +1,210 @@
+---
+summary: "Fallback hardening for native Windows when Docker/WSL sandboxing is unavailable"
+title: "Windows hardening without Docker/WSL"
+read_when:
+  - Running OpenClaw on native Windows
+  - Unable to use Docker or WSL2 sandboxing
+status: active
+---
+
+# Windows hardening without Docker/WSL
+
+If you can use [Sandboxing](/gateway/sandboxing), use that first.
+
+This guide is a **host hardening fallback** for native Windows when Docker/WSL
+is unavailable or unreliable on the target machine. It does **not** provide a
+container boundary. It is still better than running OpenClaw on the host with
+no isolation plan at all.
+
+## What this gives you
+
+- a dedicated low-privilege Windows user for automation
+- a dedicated workspace and state directory
+- NTFS ACL allowlists on those directories
+- a repeatable smoke test, forbidden-path test, and rollback flow
+
+## What this does not give you
+
+- container isolation
+- protection against an admin user on the same machine
+- protection if you keep running the gateway under your normal user
+- protection from tools or workflows that intentionally bypass the boundary
+
+If you enable host escapes such as elevated execution, this boundary becomes
+much weaker.
+
+## Threat model
+
+This fallback is aimed at reducing **accidental or over-broad host access** on
+native Windows:
+
+- the model should be able to work inside one chosen workspace
+- the model should not have routine access to unrelated directories
+- the gateway should not run as a local administrator
+
+This is primarily a blast-radius reduction measure, not a strong sandbox.
+
+## Before you start
+
+- Prefer [Windows (WSL2)](/platforms/windows) when possible.
+- Prefer [Sandboxing](/gateway/sandboxing) when Docker is available.
+- Use a dedicated workspace root such as `D:\OpenClawWorkspace`.
+- Keep state/config under a dedicated path such as
+  `D:\OpenClawWorkspace\.openclaw-state`.
+- Do not run the gateway as a local administrator.
+
+## 1. Create dedicated workspace and state paths
+
+In PowerShell:
+
+```powershell
+$Workspace = "D:\OpenClawWorkspace"
+$State = "D:\OpenClawWorkspace\.openclaw-state"
+
+New-Item -ItemType Directory -Force -Path $Workspace | Out-Null
+New-Item -ItemType Directory -Force -Path $State | Out-Null
+```
+
+## 2. Create a dedicated local user
+
+Create a non-admin user for running OpenClaw:
+
+```powershell
+$BotUser = "openclaw_bot"
+$Password = Read-Host "Password for $BotUser" -AsSecureString
+
+New-LocalUser -Name $BotUser `
+  -Password $Password `
+  -PasswordNeverExpires `
+  -UserMayNotChangePassword `
+  -AccountNeverExpires `
+  -Description "Constrained user for OpenClaw automation"
+```
+
+Require a password and make sure the user is not in `Administrators`:
+
+```powershell
+net user openclaw_bot /passwordreq:yes
+Remove-LocalGroupMember -Group "Administrators" -Member "openclaw_bot" -ErrorAction SilentlyContinue
+```
+
+## 3. Grant access only where OpenClaw needs it
+
+Grant modify access to the workspace and state paths:
+
+```powershell
+$Principal = "$env:COMPUTERNAME\openclaw_bot"
+
+icacls $Workspace /grant "${Principal}:(OI)(CI)M" /T /C
+icacls $State /grant "${Principal}:(OI)(CI)M" /T /C
+```
+
+If OpenClaw was installed in a per-user location, ensure the dedicated user can
+also read/execute the OpenClaw and Node install directories. If possible,
+prefer a machine-wide install so read/execute access is already available.
+
+## 4. Optional: deny sibling directories under the same parent
+
+If you keep the workspace under a parent folder with unrelated sibling
+directories, you can explicitly deny access to those siblings:
+
+```powershell
+$Parent = Split-Path -Parent $Workspace
+Get-ChildItem -LiteralPath $Parent -Directory |
+  Where-Object { $_.FullName -ne $Workspace } |
+  ForEach-Object {
+    icacls $_.FullName /deny "${Principal}:(OI)(CI)F" /T /C
+  }
+```
+
+This is optional, but it makes the boundary more explicit.
+
+## 5. Keep OpenClaw state/config in the dedicated state path
+
+When running the gateway as the dedicated user, point OpenClaw at the isolated
+state/config location:
+
+```powershell
+$Workspace = "D:\OpenClawWorkspace"
+$State = "D:\OpenClawWorkspace\.openclaw-state"
+
+runas /user:$env:COMPUTERNAME\openclaw_bot "powershell -NoProfile -NoExit -Command `"`
+$env:OPENCLAW_STATE_DIR='$State'; `
+$env:OPENCLAW_CONFIG_PATH='$State\openclaw.json'; `
+Set-Location -LiteralPath '$Workspace'; `
+openclaw gateway`""
+```
+
+If you already configured models/channels under another profile, copy or
+recreate the needed config for the dedicated user / state path before switching
+the gateway over.
+
+## 6. Verify the boundary
+
+### Smoke test
+
+The constrained user should be able to read the workspace:
+
+```powershell
+runas /user:$env:COMPUTERNAME\openclaw_bot "powershell -NoProfile -Command `"Get-ChildItem -LiteralPath 'D:\OpenClawWorkspace' | Select-Object -First 3`""
+```
+
+### Forbidden-path test
+
+The constrained user should not have broad access to unrelated directories you
+intentionally blocked:
+
+```powershell
+runas /user:$env:COMPUTERNAME\openclaw_bot "powershell -NoProfile -Command `"Get-ChildItem -LiteralPath '$env:USERPROFILE'`""
+```
+
+### Runtime sanity check
+
+Run normal health checks after starting the gateway:
+
+```powershell
+openclaw doctor
+openclaw status
+```
+
+## Rollback
+
+Remove explicit ACL entries for the constrained user:
+
+```powershell
+$Principal = "$env:COMPUTERNAME\openclaw_bot"
+
+icacls "D:\OpenClawWorkspace" /remove "$Principal" /T /C
+icacls "D:\OpenClawWorkspace" /remove:d "$Principal" /T /C
+```
+
+Remove deny entries from sibling directories if you added them:
+
+```powershell
+$Parent = "D:\"
+Get-ChildItem -LiteralPath $Parent -Directory |
+  Where-Object { $_.FullName -ne "D:\OpenClawWorkspace" } |
+  ForEach-Object {
+    icacls $_.FullName /remove:d "$Principal" /T /C
+  }
+```
+
+Delete the local user if no longer needed:
+
+```powershell
+Remove-LocalUser -Name "openclaw_bot"
+```
+
+## Limitations
+
+- This is weaker than Docker sandboxing.
+- It depends on consistently running OpenClaw under the constrained user.
+- If the gateway is still started by your normal user, most of the boundary is lost.
+- Elevated or host-escape workflows can bypass this model.
+- Some skills and tools are still more naturally supported inside Linux/WSL2.
+
+## Related docs
+
+- [Sandboxing](/gateway/sandboxing)
+- [Windows (WSL2)](/platforms/windows)
+- [Security](/gateway/security)

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -16,6 +16,10 @@ to install: `wsl --install`.
 
 Native Windows companion apps are planned.
 
+If you must run OpenClaw on native Windows without WSL2 or Docker, see
+[Windows hardening without Docker/WSL](/gateway/windows-no-docker-hardening).
+This is a host hardening fallback, not a sandbox equivalent.
+
 ## Install (WSL2)
 
 - [Getting Started](/start/getting-started) (use inside WSL)


### PR DESCRIPTION
## Summary

- Problem: native Windows users who cannot use WSL2 or Docker often end up running OpenClaw directly on the host with no meaningful boundary at all.
- Why it matters: this creates a docs gap for a real user segment and pushes them toward less safe host setups instead of a clearly documented fallback.
- What changed: adds a docs-only Windows hardening fallback based on a dedicated low-privilege user, dedicated workspace/state paths, NTFS ACL allowlists, and verify/rollback steps.
- What did NOT change: no runtime behavior, no config defaults, no sandbox claims, no installer/UI/channel-specific workflow.

## Change Type

- [x] Docs
- [x] Security hardening

## Scope

- [x] Gateway / orchestration
- [x] UI / DX

## Why this is worth taking

This PR is valuable even though it is docs-only:

1. It closes a practical gap between the current recommendation and what some Windows users can actually run.
2. It aligns with the repo's stated focus on UX, docs, and runtime hardening.
3. It gives maintainers a safer fallback to point users to instead of informal Discord-only advice.
4. It is low-risk because it is explicit about limitations and does not change product behavior.

## Linked Issue/PR

- Closes: None
- Related: None

## User-visible / Behavior Changes

- New docs page for native Windows hardening without Docker/WSL.
- New cross-links from existing Windows / sandboxing docs.
- No product behavior change.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: this PR is docs-only. The page explicitly states that the approach is weaker than Docker sandboxing and must not be presented as an equivalent security boundary.

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: native PowerShell, no Docker/WSL for the tested flow
- Model/provider: OpenClaw with existing model configuration
- Integration/channel (if any): none required for this doc validation
- Relevant config (redacted): dedicated workspace + dedicated state path

### Steps

1. Create a dedicated local user.
2. Grant NTFS ACL access only to the workspace/state paths.
3. Start OpenClaw under the constrained user with isolated `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH`.
4. Run smoke-test and forbidden-path test.
5. Run rollback commands and confirm cleanup path.

### Expected

- Constrained user can operate inside the intended workspace/state paths.
- Constrained user does not retain broad routine access to unrelated paths that were explicitly denied.
- Rollback steps are clear and reversible.

### Actual

- Validated on the reference Windows implementation using dedicated user + ACL allowlist + rollback flow.

## Evidence

- [x] Trace/log snippets
- [x] Screenshot/recording

Reference implementation and validation material:

- https://github.com/fantasyengineercdream/claw_windowsguide

## Human Verification

- Verified scenarios:
  - dedicated user creation
  - workspace/state ACL grant
  - hardening verification script
  - rollback flow
- Edge cases checked:
  - existing user path
  - missing directory handling
  - explicit limitations if the gateway still runs under the normal user
- What I did **not** verify:
  - every possible Windows edition / enterprise policy environment
  - container-equivalent isolation, which this PR does not claim

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- How to disable/revert this change quickly: revert the docs page and link additions.
- Files/config to restore: `docs/gateway/sandboxing.md`, `docs/platforms/windows.md`, and the new doc page.
- Known bad symptoms reviewers should watch for:
  - wording that overstates this as sandbox-equivalent
  - wording that appears to replace WSL2/Docker as the primary recommendation

## Risks and Mitigations

- Risk: users may overestimate the security boundary.
- Mitigation: the guide repeatedly states that this is a weaker host hardening fallback, not a container boundary.

- Risk: reviewers may read this as a proposal to bless native Windows as the default path.
- Mitigation: the PR keeps WSL2 and Docker as the primary recommendation and adds this only as a documented fallback.

## AI-assisted transparency

- AI-assisted: `Yes`
- Testing level: `Human-verified on a working Windows reference setup`
- I understand the change and can explain the threat model, limitations, and rollback flow.