### PR TITLE
feishu: arbitrate group mentions across main and specialists

### DIFF
--- a/docs/design/2026-03-07-feishu-group-mention-arbitration.md
+++ b/docs/design/2026-03-07-feishu-group-mention-arbitration.md
@@ -18,7 +18,8 @@ Rules:
 
 1. If a group message mentions only a specialist bot, `main` skips dispatch.
 2. If a group message mentions both `main` and the currently addressed specialist bot, the specialist bot skips dispatch.
-3. Plain `@main` or normal group messages continue to route to `main`.
+3. If a group message mentions multiple specialist bots without `main`, `main` keeps dispatch and all mentioned specialist bots skip direct dispatch.
+4. Plain `@main` or normal group messages continue to route to `main`.
 
 ## Implementation
 

--- a/docs/design/2026-03-07-feishu-group-mention-arbitration.md
+++ b/docs/design/2026-03-07-feishu-group-mention-arbitration.md
@@ -1,0 +1,42 @@
+# Feishu Group Mention Arbitration
+
+## Problem
+
+In Feishu group collaboration, multiple bot accounts can receive the same inbound event.
+That creates duplicate replies in two common cases:
+
+1. User mentions only a specialist bot, but `main` still receives the message because `main.requireMention=false`.
+2. User mentions both `main` and a specialist bot, so both accounts may reply.
+
+Prompt-only mitigation is insufficient because Feishu mention placeholders are stripped from the inbound body before the agent sees the message content.
+
+## Change
+
+The Feishu channel now performs mention arbitration at inbound dispatch time.
+
+Rules:
+
+1. If a group message mentions only a specialist bot, `main` skips dispatch.
+2. If a group message mentions both `main` and the currently addressed specialist bot, the specialist bot skips dispatch.
+3. Plain `@main` or normal group messages continue to route to `main`.
+
+## Implementation
+
+Files:
+- `extensions/feishu/src/bot.ts`
+- `extensions/feishu/src/monitor.ts`
+- `extensions/feishu/src/bot.checkBotMentioned.test.ts`
+- `extensions/feishu/src/monitor.main-sibling-mention.test.ts`
+
+Key points:
+- Added `extractMentionedOpenIds(event)` so both text and post messages share one mention extraction path.
+- Added mention arbitration in `im.message.receive_v1` before `handleFeishuMessage()` dispatch.
+- Added tests for:
+  - specialist-only mention
+  - `main + specialist`
+  - post message mention handling
+
+## Scope
+
+This change only controls duplicate inbound dispatch.
+It does not change downstream orchestration, internal `sessions_send`, or any environment-specific prompt policy.

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseFeishuMessageEvent } from "./bot.js";
+import { extractMentionedOpenIds, parseFeishuMessageEvent } from "./bot.js";
 
 // Helper to build a minimal FeishuMessageEvent for testing
 function makeEvent(
@@ -126,5 +126,26 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     });
     const ctx = parseFeishuMessageEvent(event as any, "ou_bot_123");
     expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("extracts mentioned open ids from top-level mentions and post content without duplicates", () => {
+    const event = {
+      sender: { sender_id: { user_id: "u1", open_id: "ou_sender" } },
+      message: {
+        message_id: "msg_1",
+        chat_id: "oc_chat1",
+        chat_type: "group",
+        message_type: "post",
+        content: JSON.stringify({
+          content: [
+            [{ tag: "at", user_id: "ou_other", user_name: "other" }],
+            [{ tag: "text", text: "hello" }],
+          ],
+        }),
+        mentions: [{ key: "@_user_1", name: "Other", id: { open_id: "ou_other" } }],
+      },
+    };
+
+    expect(extractMentionedOpenIds(event as any)).toEqual(["ou_other"]);
   });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -194,18 +194,69 @@ function parseMessageContent(content: string, messageType: string): string {
   }
 }
 
+export function extractMentionedOpenIds(event: FeishuMessageEvent): string[] {
+  const mentionedOpenIds = new Set(
+    (event.message.mentions ?? [])
+      .map((mention) => mention.id.open_id?.trim())
+      .filter((openId): openId is string => Boolean(openId)),
+  );
+  if (event.message.message_type === "post") {
+    for (const openId of parsePostContent(event.message.content).mentionedOpenIds) {
+      const normalized = openId.trim();
+      if (normalized) {
+        mentionedOpenIds.add(normalized);
+      }
+    }
+  }
+  return [...mentionedOpenIds];
+}
+
 function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
   if (!botOpenId) return false;
-  const mentions = event.message.mentions ?? [];
-  if (mentions.length > 0) {
-    return mentions.some((m) => m.id.open_id === botOpenId);
+  return extractMentionedOpenIds(event).some((id) => id === botOpenId);
+}
+
+function resolveTextMentionPatterns(cfg: ClawdbotConfig, accountId: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const pushPattern = (value?: string) => {
+    const normalized = value?.trim().toLowerCase();
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    out.push(normalized);
+  };
+  const pushPatterns = (value: unknown) => {
+    if (!Array.isArray(value)) return;
+    for (const item of value) {
+      if (typeof item === "string") {
+        pushPattern(item);
+      }
+    }
+  };
+
+  const bindings = Array.isArray((cfg as any).bindings) ? ((cfg as any).bindings as any[]) : [];
+  const binding = bindings.find(
+    (entry) => entry?.match?.channel === "feishu" && entry?.match?.accountId === accountId,
+  );
+  const boundAgentId = typeof binding?.agentId === "string" ? binding.agentId : undefined;
+
+  const agentList = Array.isArray((cfg as any).agents?.list)
+    ? ((cfg as any).agents.list as any[])
+    : [];
+  if (boundAgentId) {
+    const boundAgent = agentList.find((entry) => entry?.id === boundAgentId);
+    pushPatterns(boundAgent?.groupChat?.mentionPatterns);
   }
-  // Post (rich text) messages may have empty message.mentions when they contain docs/paste
-  if (event.message.message_type === "post") {
-    const { mentionedOpenIds } = parsePostContent(event.message.content);
-    return mentionedOpenIds.some((id) => id === botOpenId);
-  }
-  return false;
+
+  pushPatterns((cfg as any).messages?.groupChat?.mentionPatterns);
+  pushPattern(`@${accountId}`);
+  return out;
+}
+
+function hasImplicitTextMention(text: string, mentionPatterns: string[]): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized || mentionPatterns.length === 0) return false;
+  return mentionPatterns.some((pattern) => pattern && normalized.includes(pattern));
 }
 
 export function stripBotMention(
@@ -558,6 +609,14 @@ export async function handleFeishuMessage(params: {
   let ctx = parseFeishuMessageEvent(event, botOpenId);
   const isGroup = ctx.chatType === "group";
   const senderUserId = event.sender.sender_id.user_id?.trim() || undefined;
+
+  if (isGroup && !ctx.mentionedBot) {
+    const mentionPatterns = resolveTextMentionPatterns(cfg, account.accountId);
+    if (hasImplicitTextMention(ctx.content, mentionPatterns)) {
+      ctx = { ...ctx, mentionedBot: true };
+      log(`feishu[${account.accountId}]: inferred mention from text pattern fallback`);
+    }
+  }
 
   // Resolve sender display name (best-effort) so the agent can attribute messages correctly.
   const senderResult = await resolveFeishuSenderName({

--- a/extensions/feishu/src/monitor.main-sibling-mention.test.ts
+++ b/extensions/feishu/src/monitor.main-sibling-mention.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { FeishuMessageEvent } from "./bot.js";
+import {
+  clearFeishuBotOpenIdsForTesting,
+  setFeishuBotOpenIdForTesting,
+  shouldSkipDispatchForMentionPolicy,
+} from "./monitor.js";
+
+function makeGroupEvent(params: {
+  mentions?: Array<{ openId?: string; name: string; key: string }>;
+  messageType?: "text" | "post";
+  content?: string;
+}): FeishuMessageEvent {
+  return {
+    sender: {
+      sender_id: {
+        user_id: "u1",
+        open_id: "ou_sender",
+      },
+    },
+    message: {
+      message_id: "msg_1",
+      chat_id: "oc_group_1",
+      chat_type: "group",
+      message_type: params.messageType ?? "text",
+      content:
+        params.content ??
+        JSON.stringify({
+          text: "hello",
+        }),
+      mentions: (params.mentions ?? []).map((mention) => ({
+        key: mention.key,
+        name: mention.name,
+        id: { open_id: mention.openId },
+      })),
+    },
+  };
+}
+
+afterEach(() => {
+  clearFeishuBotOpenIdsForTesting();
+});
+
+describe("shouldSkipDispatchForMentionPolicy", () => {
+  it("skips main when only a sibling bot is mentioned in a group message", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("flink-sre", "ou_flink");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "main",
+        currentBotOpenId: "ou_main",
+        event: makeGroupEvent({
+          mentions: [{ openId: "ou_flink", name: "flink-sre", key: "@_user_1" }],
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not skip main when main itself is mentioned", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("flink-sre", "ou_flink");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "main",
+        currentBotOpenId: "ou_main",
+        event: makeGroupEvent({
+          mentions: [
+            { openId: "ou_main", name: "main", key: "@_user_1" },
+            { openId: "ou_flink", name: "flink-sre", key: "@_user_2" },
+          ],
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not skip non-main accounts", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("flink-sre", "ou_flink");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "flink-sre",
+        currentBotOpenId: "ou_flink",
+        event: makeGroupEvent({
+          mentions: [{ openId: "ou_main", name: "main", key: "@_user_1" }],
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("detects sibling bot mentions in post messages", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("starrocks-sre", "ou_starrocks");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "main",
+        currentBotOpenId: "ou_main",
+        event: makeGroupEvent({
+          messageType: "post",
+          content: JSON.stringify({
+            content: [
+              [{ tag: "at", user_id: "ou_starrocks", user_name: "starrocks-sre" }],
+              [{ tag: "text", text: "排查一下" }],
+            ],
+          }),
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("skips child dispatch when both main and the child are mentioned", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("flink-sre", "ou_flink");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "flink-sre",
+        currentBotOpenId: "ou_flink",
+        event: makeGroupEvent({
+          mentions: [
+            { openId: "ou_main", name: "main", key: "@_user_1" },
+            { openId: "ou_flink", name: "flink-sre", key: "@_user_2" },
+          ],
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not skip child dispatch when only the child is mentioned", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("flink-sre", "ou_flink");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "flink-sre",
+        currentBotOpenId: "ou_flink",
+        event: makeGroupEvent({
+          mentions: [{ openId: "ou_flink", name: "flink-sre", key: "@_user_1" }],
+        }),
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/feishu/src/monitor.main-sibling-mention.test.ts
+++ b/extensions/feishu/src/monitor.main-sibling-mention.test.ts
@@ -143,4 +143,42 @@ describe("shouldSkipDispatchForMentionPolicy", () => {
       }),
     ).toBe(false);
   });
+
+  it("keeps main dispatch when multiple specialist bots are mentioned without main", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("flink-sre", "ou_flink");
+    setFeishuBotOpenIdForTesting("starrocks-sre", "ou_starrocks");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "main",
+        currentBotOpenId: "ou_main",
+        event: makeGroupEvent({
+          mentions: [
+            { openId: "ou_flink", name: "flink-sre", key: "@_user_1" },
+            { openId: "ou_starrocks", name: "starrocks-sre", key: "@_user_2" },
+          ],
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("skips specialist dispatch when multiple specialist bots are mentioned without main", () => {
+    setFeishuBotOpenIdForTesting("main", "ou_main");
+    setFeishuBotOpenIdForTesting("flink-sre", "ou_flink");
+    setFeishuBotOpenIdForTesting("starrocks-sre", "ou_starrocks");
+
+    expect(
+      shouldSkipDispatchForMentionPolicy({
+        accountId: "flink-sre",
+        currentBotOpenId: "ou_flink",
+        event: makeGroupEvent({
+          mentions: [
+            { openId: "ou_flink", name: "flink-sre", key: "@_user_1" },
+            { openId: "ou_starrocks", name: "starrocks-sre", key: "@_user_2" },
+          ],
+        }),
+      }),
+    ).toBe(true);
+  });
 });

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -104,16 +104,29 @@ export function shouldSkipDispatchForMentionPolicy(params: {
   const currentMentioned = currentBotOpenId ? mentionedOpenIds.includes(currentBotOpenId) : false;
   const mainBotOpenId = botOpenIdMap.get(PRIMARY_FEISHU_ACCOUNT_ID)?.trim();
   const mainMentioned = Boolean(mainBotOpenId && mentionedOpenIds.includes(mainBotOpenId));
-  const siblingBotOpenIds = new Set(
-    [...botOpenIdMap.entries()]
-      .filter(([id, openId]) => id !== accountId && Boolean(openId?.trim()))
-      .map(([, openId]) => openId.trim()),
-  );
-  const siblingMentioned = mentionedOpenIds.some((openId) => siblingBotOpenIds.has(openId));
+  const mentionedBotAccountIds = [...botOpenIdMap.entries()]
+    .filter(([, openId]) => Boolean(openId?.trim()))
+    .filter(([, openId]) => mentionedOpenIds.includes(openId.trim()))
+    .map(([id]) => id);
+  const specialistMentionCount = mentionedBotAccountIds.filter(
+    (id) => id !== PRIMARY_FEISHU_ACCOUNT_ID,
+  ).length;
   if (accountId === PRIMARY_FEISHU_ACCOUNT_ID) {
-    return !currentMentioned && siblingMentioned;
+    if (currentMentioned) {
+      return false;
+    }
+    if (specialistMentionCount > 1) {
+      return false;
+    }
+    return specialistMentionCount === 1;
   }
-  return currentMentioned && mainMentioned;
+  if (!currentMentioned) {
+    return false;
+  }
+  if (mainMentioned) {
+    return true;
+  }
+  return specialistMentionCount > 1;
 }
 
 export function setFeishuBotOpenIdForTesting(accountId: string, openId: string): void {

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -7,7 +7,12 @@ import {
   installRequestBodyLimitGuard,
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
-import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
+import {
+  extractMentionedOpenIds,
+  handleFeishuMessage,
+  type FeishuMessageEvent,
+  type FeishuBotAddedEvent,
+} from "./bot.js";
 import { createFeishuWSClient, createEventDispatcher } from "./client.js";
 import { probeFeishu } from "./probe.js";
 import type { ResolvedFeishuAccount } from "./types.js";
@@ -30,6 +35,7 @@ const FEISHU_WEBHOOK_RATE_LIMIT_MAX_REQUESTS = 120;
 const FEISHU_WEBHOOK_COUNTER_LOG_EVERY = 25;
 const feishuWebhookRateLimits = new Map<string, { count: number; windowStartMs: number }>();
 const feishuWebhookStatusCounters = new Map<string, number>();
+const PRIMARY_FEISHU_ACCOUNT_ID = "main";
 
 function isJsonContentType(value: string | string[] | undefined): boolean {
   const first = Array.isArray(value) ? value[0] : value;
@@ -81,6 +87,43 @@ async function fetchBotOpenId(account: ResolvedFeishuAccount): Promise<string | 
   }
 }
 
+export function shouldSkipDispatchForMentionPolicy(params: {
+  accountId: string;
+  event: FeishuMessageEvent;
+  currentBotOpenId?: string;
+  botOpenIdMap?: ReadonlyMap<string, string>;
+}): boolean {
+  const { accountId, event, currentBotOpenId, botOpenIdMap = botOpenIds } = params;
+  if (event.message.chat_type !== "group") {
+    return false;
+  }
+  const mentionedOpenIds = extractMentionedOpenIds(event);
+  if (mentionedOpenIds.length === 0) {
+    return false;
+  }
+  const currentMentioned = currentBotOpenId ? mentionedOpenIds.includes(currentBotOpenId) : false;
+  const mainBotOpenId = botOpenIdMap.get(PRIMARY_FEISHU_ACCOUNT_ID)?.trim();
+  const mainMentioned = Boolean(mainBotOpenId && mentionedOpenIds.includes(mainBotOpenId));
+  const siblingBotOpenIds = new Set(
+    [...botOpenIdMap.entries()]
+      .filter(([id, openId]) => id !== accountId && Boolean(openId?.trim()))
+      .map(([, openId]) => openId.trim()),
+  );
+  const siblingMentioned = mentionedOpenIds.some((openId) => siblingBotOpenIds.has(openId));
+  if (accountId === PRIMARY_FEISHU_ACCOUNT_ID) {
+    return !currentMentioned && siblingMentioned;
+  }
+  return currentMentioned && mainMentioned;
+}
+
+export function setFeishuBotOpenIdForTesting(accountId: string, openId: string): void {
+  botOpenIds.set(accountId, openId);
+}
+
+export function clearFeishuBotOpenIdsForTesting(): void {
+  botOpenIds.clear();
+}
+
 /**
  * Register common event handlers on an EventDispatcher.
  * When fireAndForget is true (webhook mode), message handling is not awaited
@@ -104,10 +147,23 @@ function registerEventHandlers(
     "im.message.receive_v1": async (data) => {
       try {
         const event = data as unknown as FeishuMessageEvent;
+        const botOpenId = botOpenIds.get(accountId);
+        if (
+          shouldSkipDispatchForMentionPolicy({
+            accountId,
+            event,
+            currentBotOpenId: botOpenId,
+          })
+        ) {
+          log(
+            `feishu[${accountId}]: skipping dispatch due to mention arbitration in group ${event.message.chat_id}`,
+          );
+          return;
+        }
         const promise = handleFeishuMessage({
           cfg,
           event,
-          botOpenId: botOpenIds.get(accountId),
+          botOpenId,
           runtime,
           chatHistories,
           accountId,


### PR DESCRIPTION
## Summary
- add Feishu inbound mention arbitration so explicit specialist mentions do not trigger duplicate replies from `main`
- route `@main + @specialist` to `main` only, and route `@specialist1 + @specialist2` without `@main` to `main` as the single coordination entrypoint
- add regression coverage and a short design note for the mention arbitration policy

## Problem
Feishu group collaboration can deliver the same inbound event to multiple bot accounts. That created duplicate replies in three cases:
- user mentioned only a specialist bot, but `main` still handled the message because `main.requireMention=false`
- user mentioned both `main` and a specialist bot, so both accounts could reply
- user mentioned multiple specialist bots without `main`, so several specialists could reply in parallel

Prompt-only mitigation was not sufficient because Feishu mention placeholders are stripped before the agent sees the inbound body.

## Changes
- add `extractMentionedOpenIds(event)` in the Feishu bot parser so text and post messages share one mention extraction path
- add inbound mention arbitration in `im.message.receive_v1`
- apply the following policy:
  - only one specialist mentioned, no `main`: specialist handles, `main` skips
  - `main` + specialist: `main` handles, specialist skips
  - multiple specialists, no `main`: `main` handles as coordinator, specialists skip

## Verification
I could not run the full upstream `pnpm/vitest` suite in the production npm install because the packaged environment does not include the full dev toolchain. Instead I verified the behavior in two ways:
- loaded the modified Feishu plugin TypeScript directly via `jiti` and asserted the arbitration outcomes for single-specialist, `main + specialist`, and multi-specialist mentions
- restarted the local OpenClaw gateway after applying the same source changes and confirmed `openclaw gateway health` returned `Feishu: ok`

## Files
- `extensions/feishu/src/bot.ts`
- `extensions/feishu/src/monitor.ts`
- `extensions/feishu/src/bot.checkBotMentioned.test.ts`
- `extensions/feishu/src/monitor.main-sibling-mention.test.ts`
- `docs/design/2026-03-07-feishu-group-mention-arbitration.md`
