### PR TITLE
fix(gateway): improve headless Linux systemd recovery hints

### DIFF
--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -197,8 +197,13 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   const systemdUnavailable =
     process.platform === "linux" && isSystemdUnavailableDetail(service.runtime?.detail);
   if (systemdUnavailable) {
+    const env = service.command?.environment ?? process.env;
     defaultRuntime.error(errorText("systemd user services unavailable."));
-    for (const hint of renderSystemdUnavailableHints({ wsl: isWSLEnv() })) {
+    for (const hint of renderSystemdUnavailableHints({
+      wsl: isWSLEnv(),
+      detail: service.runtime?.detail,
+      env,
+    })) {
       defaultRuntime.error(errorText(hint));
     }
     spacer();

--- a/src/commands/doctor-format.test.ts
+++ b/src/commands/doctor-format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildGatewayRuntimeHints } from "./doctor-format.js";
+
+describe("buildGatewayRuntimeHints", () => {
+  it("surfaces headless systemd recovery hints on linux", () => {
+    const hints = buildGatewayRuntimeHints(
+      {
+        detail:
+          "systemctl --user unavailable: Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+      },
+      {
+        platform: "linux",
+        env: { USER: "ubuntu" },
+      },
+    );
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        "Run: sudo loginctl enable-linger ubuntu",
+        "Export: XDG_RUNTIME_DIR=/run/user/$(id -u)",
+        "Verify: systemctl --user status",
+      ]),
+    );
+  });
+});

--- a/src/commands/doctor-format.ts
+++ b/src/commands/doctor-format.ts
@@ -43,7 +43,13 @@ export function buildGatewayRuntimeHints(
     }
   })();
   if (platform === "linux" && isSystemdUnavailableDetail(runtime.detail)) {
-    hints.push(...renderSystemdUnavailableHints({ wsl: isWSLEnv() }));
+    hints.push(
+      ...renderSystemdUnavailableHints({
+        wsl: isWSLEnv(),
+        detail: runtime.detail,
+        env,
+      }),
+    );
     if (fileLog) {
       hints.push(`File logs: ${fileLog}`);
     }

--- a/src/daemon/systemd-hints.test.ts
+++ b/src/daemon/systemd-hints.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isSystemdUnavailableDetail, renderSystemdUnavailableHints } from "./systemd-hints.js";
+
+describe("isSystemdUnavailableDetail", () => {
+  it("matches headless user-bus failures", () => {
+    expect(
+      isSystemdUnavailableDetail(
+        "systemctl --user unavailable: Failed to connect to bus: No medium found",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("renderSystemdUnavailableHints", () => {
+  it("renders headless recovery steps when the user bus runtime is missing", () => {
+    const hints = renderSystemdUnavailableHints({
+      detail:
+        "systemctl --user unavailable: Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+      env: { USER: "ec2-user", OPENCLAW_PROFILE: "isolated" },
+    });
+
+    expect(hints).toEqual(
+      expect.arrayContaining([
+        "systemd user services are unavailable in this shell because the user D-Bus/session runtime is missing.",
+        "Run: sudo loginctl enable-linger ec2-user",
+        "Export: XDG_RUNTIME_DIR=/run/user/$(id -u)",
+        "Verify: systemctl --user status",
+      ]),
+    );
+    expect(hints.some((hint) => hint.includes("gateway install"))).toBe(true);
+  });
+
+  it("falls back to the generic container hint when no headless detail is present", () => {
+    const hints = renderSystemdUnavailableHints();
+
+    expect(hints[0]).toBe(
+      "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+    );
+    expect(hints[1]).toContain("openclaw gateway");
+  });
+
+  it("prefers WSL instructions when running under WSL", () => {
+    const hints = renderSystemdUnavailableHints({
+      wsl: true,
+      detail: "Failed to connect to bus: No medium found",
+    });
+
+    expect(hints).toEqual([
+      "WSL2 needs systemd enabled: edit /etc/wsl.conf with [boot]\\nsystemd=true",
+      "Then run: wsl --shutdown (from PowerShell) and reopen your distro.",
+      "Verify: systemctl --user status",
+    ]);
+  });
+});

--- a/src/daemon/systemd-hints.ts
+++ b/src/daemon/systemd-hints.ts
@@ -14,7 +14,32 @@ export function isSystemdUnavailableDetail(detail?: string): boolean {
   );
 }
 
-export function renderSystemdUnavailableHints(options: { wsl?: boolean } = {}): string[] {
+function isMissingUserBusRuntimeDetail(detail?: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("no medium found") ||
+    normalized.includes("failed to connect to user scope bus via local transport") ||
+    normalized.includes("$dbus_session_bus_address") ||
+    normalized.includes("$xdg_runtime_dir not defined") ||
+    normalized.includes("xdg_runtime_dir not defined")
+  );
+}
+
+function resolveSystemdUserHint(env?: NodeJS.ProcessEnv): string {
+  const user = env?.USER?.trim() || env?.LOGNAME?.trim();
+  return user || "$(whoami)";
+}
+
+export function renderSystemdUnavailableHints(
+  options: {
+    wsl?: boolean;
+    detail?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): string[] {
   if (options.wsl) {
     return [
       "WSL2 needs systemd enabled: edit /etc/wsl.conf with [boot]\\nsystemd=true",
@@ -22,8 +47,17 @@ export function renderSystemdUnavailableHints(options: { wsl?: boolean } = {}): 
       "Verify: systemctl --user status",
     ];
   }
+  if (isMissingUserBusRuntimeDetail(options.detail)) {
+    return [
+      "systemd user services are unavailable in this shell because the user D-Bus/session runtime is missing.",
+      `Run: sudo loginctl enable-linger ${resolveSystemdUserHint(options.env)}`,
+      "Export: XDG_RUNTIME_DIR=/run/user/$(id -u)",
+      "Verify: systemctl --user status",
+      `Then retry: ${formatCliCommand("openclaw gateway install", options.env ?? process.env)}`,
+    ];
+  }
   return [
     "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
-    `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
+    `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway", options.env ?? process.env)}\`.`,
   ];
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Linux `gateway status` / doctor can still fall back to generic `systemd user services unavailable` advice when a headless shell lacks user-bus runtime env and `systemctl --user` fails with `No medium found`-style errors.
- Why it matters: there is already a known recovery path for these EC2/headless cases, but the CLI does not surface it where operators actually look for next steps.
- What changed: detect common missing user-bus/runtime details (`No medium found`, missing `DBUS_SESSION_BUS_ADDRESS`, missing `XDG_RUNTIME_DIR`) and show actionable `loginctl enable-linger` + `XDG_RUNTIME_DIR` recovery hints in both gateway status and doctor output.
- What did NOT change (scope boundary): no change to systemd command execution, Linux scope selection, install behavior, or `--system` support.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #11805
- Related #34884

## User-visible / Behavior Changes

On Linux/headless shells that still fail `systemctl --user` due missing user-bus runtime env, `openclaw gateway status` and doctor hints now show actionable recovery steps instead of only generic systemd-unavailable text.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS for local verification; Linux/headless output path simulated from real reported error strings
- Runtime/container: Node.js via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): gateway status / doctor
- Relevant config (redacted): default local config

### Steps

1. Feed Linux runtime detail containing `systemctl --user unavailable: Failed to connect to bus: No medium found` or missing `DBUS_SESSION_BUS_ADDRESS` / `XDG_RUNTIME_DIR` markers into the gateway hint path.
2. Run the status / doctor formatting path.
3. Verify the output includes actionable headless recovery steps instead of only the generic systemd-unavailable fallback.

### Expected

- Headless Linux failures point operators to `loginctl enable-linger`, `XDG_RUNTIME_DIR=/run/user/$(id -u)`, and a retry/install path.

### Actual

- Example output after this change:

```text
systemd user services are unavailable in this shell because the user D-Bus/session runtime is missing.
Run: sudo loginctl enable-linger ubuntu
Export: XDG_RUNTIME_DIR=/run/user/$(id -u)
Verify: systemctl --user status
Then retry: openclaw gateway install
```

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm build`; `pnpm check`; `pnpm test`; direct `node --import tsx` checks for `renderSystemdUnavailableHints(...)` and `buildGatewayRuntimeHints(...)` with headless Linux error details.
- Edge cases checked: `No medium found`; missing `DBUS_SESSION_BUS_ADDRESS`; missing `XDG_RUNTIME_DIR`; generic fallback; WSL hint precedence.
- What you did **not** verify: live end-to-end run on a real Linux/EC2 host in this pass.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f18fdc8ad`.
- Files/config to restore: `src/daemon/systemd-hints.ts`, `src/commands/doctor-format.ts`, `src/cli/daemon-cli/status.print.ts`, and the two added tests.
- Known bad symptoms reviewers should watch for: non-headless Linux systemd errors incorrectly taking the headless recovery path, or WSL-specific guidance being replaced by generic Linux hints.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some unrelated Linux `systemctl --user` failures might match the new headless-detail detector too broadly.
  - Mitigation: matching is limited to specific known strings from reported headless/user-bus runtime failures, and generic fallback behavior remains for other cases.
