### PR TITLE
fix(message): ignore empty legacy target fields

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -6,13 +6,17 @@ export const CHANNEL_TARGET_DESCRIPTION =
 export const CHANNEL_TARGETS_DESCRIPTION =
   "Recipient/channel targets (same format as --target); accepts ids or names when the directory is available.";
 
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 export function applyTargetToParams(params: {
   action: string;
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo = typeof params.args.to === "string";
-  const hasLegacyChannelId = typeof params.args.channelId === "string";
+  const hasLegacyTo = hasNonEmptyString(params.args.to);
+  const hasLegacyChannelId = hasNonEmptyString(params.args.channelId);
   const mode =
     MESSAGE_ACTION_TARGET_MODE[params.action as keyof typeof MESSAGE_ACTION_TARGET_MODE] ?? "none";
 

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -17,6 +17,21 @@ describe("normalizeMessageActionInput", () => {
     expect("channelId" in normalized).toBe(false);
   });
 
+  it("ignores empty-string legacy target fields when explicit target is present", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        target: "1214056829",
+        channelId: "",
+        to: "   ",
+      },
+    });
+
+    expect(normalized.target).toBe("1214056829");
+    expect(normalized.to).toBe("1214056829");
+    expect("channelId" in normalized).toBe(false);
+  });
+
   it("maps legacy target fields into canonical target", () => {
     const normalized = normalizeMessageActionInput({
       action: "send",

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -19,11 +19,13 @@ export function normalizeMessageActionInput(params: {
 
   const explicitTarget =
     typeof normalizedArgs.target === "string" ? normalizedArgs.target.trim() : "";
+  const hasLegacyTargetFields =
+    typeof normalizedArgs.to === "string" || typeof normalizedArgs.channelId === "string";
   const hasLegacyTarget =
     (typeof normalizedArgs.to === "string" && normalizedArgs.to.trim().length > 0) ||
     (typeof normalizedArgs.channelId === "string" && normalizedArgs.channelId.trim().length > 0);
 
-  if (explicitTarget && hasLegacyTarget) {
+  if (explicitTarget && hasLegacyTargetFields) {
     delete normalizedArgs.to;
     delete normalizedArgs.channelId;
   }


### PR DESCRIPTION
## Summary
- ignore empty-string `to` / `channelId` values when deciding whether a message action mixes `target` with legacy destination fields
- keep explicit `target` sends canonical by dropping empty legacy fields during normalization
- add a regression test for wrappers that populate empty-string defaults

## Problem
The `message` tool currently treats any string-valued `to` or `channelId` as legacy-param usage, even when the value is just an empty-string default. That breaks valid calls that correctly use `target` but arrive with `channelId: ""` or `to: ""`.

## Root Cause
`applyTargetToParams()` checks `typeof params.args.to === "string"` and `typeof params.args.channelId === "string"`, so empty strings trigger the same legacy guard as real legacy destinations.

## Fix
Only treat non-empty trimmed strings as legacy destination fields, and clear empty legacy target fields when an explicit `target` is present so the normalized action stays canonical.

## Verification
- `pnpm exec vitest run src/infra/outbound/message-action-normalization.test.ts`
- `pnpm exec oxfmt --check src/infra/outbound/channel-target.ts src/infra/outbound/message-action-normalization.ts src/infra/outbound/message-action-normalization.test.ts`

Fixes #38830
