### PR TITLE
fix(memory): Unicode support for MMR and FTS tokenizers

### DIFF
--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -10,6 +10,15 @@ describe("memory hybrid helpers", () => {
     expect(buildFtsQuery("   ")).toBeNull();
   });
 
+  it("buildFtsQuery handles combining marks and NFC normalization", () => {
+    // Thai with combining tone marks (would split without \p{M})
+    expect(buildFtsQuery("ฐานข้อมูล ข้อผิดพลาด")).toBe('"ฐานข้อมูล" AND "ข้อผิดพลาด"');
+    // NFD input (e + combining acute) normalizes to NFC (é)
+    expect(buildFtsQuery("cafe\u0301")).toBe('"caf\u00E9"');
+    // Finnish with diacritics
+    expect(buildFtsQuery("päätös äänestys")).toBe('"päätös" AND "äänestys"');
+  });
+
   it("bm25RankToScore is monotonic and clamped", () => {
     expect(bm25RankToScore(0)).toBeCloseTo(1);
     expect(bm25RankToScore(1)).toBeCloseTo(0.5);

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -33,7 +33,8 @@ export type HybridKeywordResult = {
 export function buildFtsQuery(raw: string): string | null {
   const tokens =
     raw
-      .match(/[\p{L}\p{N}_]+/gu)
+      .normalize("NFC")
+      .match(/[\p{L}\p{M}\p{N}_]+/gu)
       ?.map((t) => t.trim())
       .filter(Boolean) ?? [];
   if (tokens.length === 0) {

--- a/src/memory/mmr.test.ts
+++ b/src/memory/mmr.test.ts
@@ -30,6 +30,67 @@ describe("tokenize", () => {
         input: "hello hello world world",
         expected: ["hello", "world"],
       },
+      {
+        name: "unicode latin (Finnish)",
+        input: "päätös äänestys",
+        expected: ["päätös", "äänestys"],
+      },
+      {
+        name: "mixed ASCII and unicode",
+        input: "API päätös 123",
+        expected: ["api", "päätös", "123"],
+      },
+      {
+        name: "accented latin",
+        input: "café résumé naïve",
+        expected: ["café", "résumé", "naïve"],
+      },
+      {
+        name: "Chinese",
+        input: "机器学习 神经网络",
+        expected: ["机器学习", "神经网络"],
+      },
+      {
+        name: "Japanese (mixed scripts)",
+        input: "データベース 接続エラー",
+        expected: ["データベース", "接続エラー"],
+      },
+      {
+        name: "Korean",
+        input: "데이터베이스 연결 오류",
+        expected: ["데이터베이스", "연결", "오류"],
+      },
+      {
+        name: "Cyrillic (Russian)",
+        input: "база данных ошибка",
+        expected: ["база", "данных", "ошибка"],
+      },
+      {
+        name: "Arabic",
+        input: "قاعدة بيانات خطأ",
+        expected: ["قاعدة", "بيانات", "خطأ"],
+      },
+      {
+        name: "Hebrew",
+        input: "מסד נתונים שגיאה",
+        expected: ["מסד", "נתונים", "שגיאה"],
+      },
+      {
+        name: "Thai",
+        input: "ฐานข้อมูล ข้อผิดพลาด",
+        expected: ["ฐานข้อมูล", "ข้อผิดพลาด"],
+      },
+      {
+        name: "Hindi (Devanagari)",
+        input: "डेटाबेस त्रुटि कनेक्शन",
+        expected: ["डेटाबेस", "त्रुटि", "कनेक्शन"],
+      },
+      {
+        name: "NFC vs NFD normalization",
+        // "café" in NFD (e + combining acute) should match NFC (é)
+        input: "cafe\u0301",
+        expected: ["caf\u00E9"],
+      },
     ] as const;
 
     for (const testCase of cases) {
@@ -90,6 +151,18 @@ describe("textSimilarity", () => {
       { name: "same words reordered", left: "hello world", right: "world hello", expected: 1 },
       { name: "different text", left: "hello world", right: "foo bar", expected: 0 },
       { name: "case insensitive", left: "Hello World", right: "hello world", expected: 1 },
+      {
+        name: "unicode tokens produce meaningful similarity",
+        left: "päätös äänestys kokous",
+        right: "päätös äänestys budjetti",
+        expected: 0.5,
+      },
+      {
+        name: "different unicode texts are not similar",
+        left: "päätös äänestys kokous",
+        right: "tietokanta yhteys virhe",
+        expected: 0,
+      },
     ] as const;
 
     for (const testCase of cases) {

--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -27,10 +27,14 @@ export const DEFAULT_MMR_CONFIG: MMRConfig = {
 
 /**
  * Tokenize text for Jaccard similarity computation.
- * Extracts alphanumeric tokens and normalizes to lowercase.
+ * Extracts alphanumeric tokens (Unicode-aware) and normalizes to lowercase.
+ *
+ * \p{L} = letters, \p{M} = combining marks (Thai tone marks, Devanagari
+ * virama, Arabic diacritics — without this, scripts that compose characters
+ * from base + mark sequences get split mid-character), \p{N} = numbers.
  */
 export function tokenize(text: string): Set<string> {
-  const tokens = text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+  const tokens = text.toLowerCase().normalize("NFC").match(/[\p{L}\p{M}\p{N}_]+/gu) ?? [];
   return new Set(tokens);
 }
 

--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -34,7 +34,11 @@ export const DEFAULT_MMR_CONFIG: MMRConfig = {
  * from base + mark sequences get split mid-character), \p{N} = numbers.
  */
 export function tokenize(text: string): Set<string> {
-  const tokens = text.toLowerCase().normalize("NFC").match(/[\p{L}\p{M}\p{N}_]+/gu) ?? [];
+  const tokens =
+    text
+      .normalize("NFC")
+      .toLowerCase()
+      .match(/[\p{L}\p{M}\p{N}_]+/gu) ?? [];
   return new Set(tokens);
 }
 


### PR DESCRIPTION
## Summary

- Problem: MMR tokenizer (`src/memory/mmr.ts`) used `/[a-z0-9_]+/g`, dropping all non-ASCII characters. Non-English memory snippets got empty token sets, making Jaccard similarity return 1.0 (identical) for all of them. This caused MMR diversity re-ranking to actively penalize non-English results as "duplicates". FTS tokenizer (`src/memory/hybrid.ts`) was missing `\p{M}` (combining marks), splitting Thai/Hindi/Arabic words at tone marks and virama.
- Why it matters: Memory search and diversity ranking were broken for all non-English users. FTS queries with combining mark scripts produced fragmented tokens that wouldn't match stored content.
- What changed: Both tokenizers now use `[\p{L}\p{M}\p{N}_]+` with the `u` flag and NFC normalization. `\p{L}` = letters, `\p{M}` = combining marks (Thai tone marks, Devanagari virama, Arabic diacritics), `\p{N}` = numbers. NFC normalization prevents NFD/NFC mismatches (e.g. macOS filesystem returns NFD paths).
- What did NOT change (scope boundary): No changes to query-expansion tokenizer, memory storage format, or MMR algorithm logic. Only the regex patterns and normalization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: query-expansion tokenizer in `src/memory/query-expansion.ts` already uses Unicode-aware patterns; this aligns the remaining two tokenizers.

## User-visible / Behavior Changes

- Memory search results may change order for non-English users (improvement: queries now actually match non-ASCII content)
- MMR diversity re-ranking now works correctly for non-English memory snippets (previously treated all as identical)
- English-language behavior is unchanged

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node 24
- Relevant config: default memory configuration

### Steps

1. Store memories containing non-ASCII text (e.g. Finnish "päätös", "aikavyöhyke")
2. Query memory using those non-ASCII terms
3. Observe search results

### Expected

- Non-ASCII queries match stored memories correctly
- MMR re-ranking produces diverse results across languages

### Actual (before fix)

- MMR tokenizer returned empty sets for non-English → all treated as duplicates
- FTS tokenizer split Thai/Hindi words at combining marks → no matches

## Evidence

- [x] Failing test/log before + passing after
- 30 unit tests covering: English, Finnish, French, Chinese, Japanese, Korean, Russian, Arabic, Hebrew, Thai, Hindi, NFC normalization
- All tests pass

## Human Verification (required)

- Verified scenarios: I have tested that a) memory continues to work and b) enables memory queries with non-latin characters. I did not check other languages than my native Finnish in which I do have a memory in OpenClaw.
- Edge cases checked: I did not figure out any edge cases that would require checking.
- What I did **not** verify: CJK languages, Arabic, Hebrew, Thai, Hindi in live environment (covered by unit tests only).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert both commits; tokenizer changes are isolated to two functions
- Files/config to restore: `src/memory/mmr.ts`, `src/memory/hybrid.ts`
- Known bad symptoms reviewers should watch for: memory search returning no results, or unexpected results for English queries

## Risks and Mitigations

- Risk: FTS query tokenization change affects all users (not opt-in like MMR)
  - Mitigation: The change is additive — `\p{M}` only affects scripts that use combining marks; `\p{L}\p{N}` behavior unchanged. NFC normalization is idempotent for already-NFC text.