### PR TITLE
fix: prefer configured provider when default provider is removed from config

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -481,6 +481,83 @@ describe("model-selection", () => {
       });
       expect(result).toEqual({ provider: "openai", model: "gpt-4" });
     });
+
+    it("should prefer configured custom provider when default provider is not in models.providers", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        models: {
+          providers: {
+            n1n: {
+              baseUrl: "https://n1n.example.com",
+              models: [
+                {
+                  id: "gpt-5.4",
+                  name: "GPT 5.4",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      });
+      expect(result).toEqual({ provider: "n1n", model: "gpt-5.4" });
+    });
+
+    it("should keep default provider when it is in models.providers", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  id: "claude-opus-4-6",
+                  name: "Claude Opus 4.6",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 200000,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      });
+      expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+    });
+
+    it("should fall back to hardcoded default when no custom providers have models", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        models: {
+          providers: {
+            "empty-provider": {
+              baseUrl: "https://example.com",
+              models: [],
+            },
+          },
+        },
+      };
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      });
+      expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+    });
   });
 
   describe("resolveThinkingDefault", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -317,6 +317,28 @@ export function resolveConfiguredModelRef(params: {
       return resolved.ref;
     }
   }
+  // Before falling back to the hardcoded default, check if the default provider
+  // is actually available. If it isn't but other providers are configured, prefer
+  // the first configured provider's first model to avoid reporting a stale default
+  // from a removed provider. (See #38880)
+  const configuredProviders = params.cfg.models?.providers;
+  if (configuredProviders && typeof configuredProviders === "object") {
+    const hasDefaultProvider = Boolean(configuredProviders[params.defaultProvider]);
+    if (!hasDefaultProvider) {
+      const availableProvider = Object.entries(configuredProviders).find(
+        ([, providerCfg]) =>
+          providerCfg &&
+          Array.isArray(providerCfg.models) &&
+          providerCfg.models.length > 0 &&
+          providerCfg.models[0]?.id,
+      );
+      if (availableProvider) {
+        const [providerName, providerCfg] = availableProvider;
+        const firstModel = providerCfg.models[0];
+        return { provider: providerName, model: firstModel.id };
+      }
+    }
+  }
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 


### PR DESCRIPTION
## Summary

When no explicit model is set in `agents.defaults.model`, `resolveConfiguredModelRef` falls back to the hardcoded default (`anthropic/claude-opus-4-6`). If the user has removed anthropic from `models.providers` and configured a different provider, `openclaw status` and `openclaw models status --json` still report the stale anthropic model as the default — even though runtime sessions correctly use the configured provider.

## Root Cause

`resolveConfiguredModelRef()` unconditionally returns `{ provider: defaultProvider, model: defaultModel }` when no explicit model is configured, without checking whether the default provider is actually available.

## Fix

Before returning the hardcoded fallback, the function now checks whether the default provider exists in `cfg.models.providers`. If it does not, but another provider with models is configured, it returns that provider's first model instead.

This ensures:
- `openclaw status` shows the correct effective default model
- `openclaw models status --json` reports accurate `defaultModel` and `resolvedDefault`
- `missingProvidersInUse` no longer falsely flags removed providers

## Tests

Added 3 new test cases to `model-selection.test.ts`:
- Prefers configured custom provider when default provider is not in `models.providers`
- Keeps default provider when it IS in `models.providers`  
- Falls back to hardcoded default when no custom providers have models

All 43 tests in `model-selection.test.ts` pass.

Fixes #38880