### PR TITLE
fix(models): skip cancelled token persistence

### DIFF
--- a/src/commands/models/auth.cancel.test.ts
+++ b/src/commands/models/auth.cancel.test.ts
@@ -65,7 +65,7 @@ describe("models auth cancel handling", () => {
       if (previous) {
         Object.defineProperty(stdin, "isTTY", previous);
       } else {
-        delete stdin.isTTY;
+        delete (stdin as { isTTY?: boolean }).isTTY;
       }
     };
   });

--- a/src/commands/models/auth.cancel.test.ts
+++ b/src/commands/models/auth.cancel.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
+
+const CANCELLED = Symbol("clack:cancel");
+
+const mocks = vi.hoisted(() => ({
+  clackConfirm: vi.fn(),
+  clackText: vi.fn(),
+  clackSelect: vi.fn(),
+  clackCancel: vi.fn(),
+  upsertAuthProfile: vi.fn(),
+  updateConfig: vi.fn(),
+  logConfigUpdated: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  cancel: (message: unknown) => mocks.clackCancel(message),
+  confirm: (params: unknown) => mocks.clackConfirm(params),
+  isCancel: (value: unknown) => value === CANCELLED,
+  select: (params: unknown) => mocks.clackSelect(params),
+  text: (params: unknown) => mocks.clackText(params),
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  upsertAuthProfile: (params: unknown) => mocks.upsertAuthProfile(params),
+}));
+
+vi.mock("../../config/logging.js", () => ({
+  logConfigUpdated: (runtime: unknown) => mocks.logConfigUpdated(runtime),
+}));
+
+vi.mock("./shared.js", async (importActual) => {
+  const actual = await importActual<typeof import("./shared.js")>();
+  return {
+    ...actual,
+    updateConfig: (mutator: unknown) => mocks.updateConfig(mutator),
+  };
+});
+
+const { modelsAuthPasteTokenCommand, modelsAuthSetupTokenCommand } = await import("./auth.js");
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("models auth cancel handling", () => {
+  let restoreStdin: (() => void) | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateConfig.mockResolvedValue(undefined);
+
+    const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+    const previous = Object.getOwnPropertyDescriptor(stdin, "isTTY");
+    Object.defineProperty(stdin, "isTTY", {
+      configurable: true,
+      enumerable: true,
+      get: () => true,
+    });
+    restoreStdin = () => {
+      if (previous) {
+        Object.defineProperty(stdin, "isTTY", previous);
+      } else {
+        delete stdin.isTTY;
+      }
+    };
+  });
+
+  afterEach(() => {
+    restoreStdin?.();
+    restoreStdin = null;
+  });
+
+  it("does not persist a cancelled pasted token", async () => {
+    const runtime = createRuntime();
+    mocks.clackText.mockResolvedValueOnce(CANCELLED);
+
+    await expect(
+      modelsAuthPasteTokenCommand({ provider: "openai" }, runtime),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.clackCancel).toHaveBeenCalledOnce();
+    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("does not persist a cancelled setup token", async () => {
+    const runtime = createRuntime();
+    mocks.clackText.mockResolvedValueOnce(CANCELLED);
+
+    await expect(
+      modelsAuthSetupTokenCommand({ provider: "anthropic", yes: true }, runtime),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.clackCancel).toHaveBeenCalledOnce();
+    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1,4 +1,10 @@
-import { confirm as clackConfirm, select as clackSelect, text as clackText } from "@clack/prompts";
+import {
+  cancel as clackCancel,
+  confirm as clackConfirm,
+  isCancel,
+  select as clackSelect,
+  text as clackText,
+} from "@clack/prompts";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -14,7 +20,11 @@ import { logConfigUpdated } from "../../config/logging.js";
 import { resolvePluginProviders } from "../../plugins/providers.js";
 import type { ProviderAuthResult, ProviderPlugin } from "../../plugins/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
+import {
+  stylePromptHint,
+  stylePromptMessage,
+  stylePromptTitle,
+} from "../../terminal/prompt-style.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { validateAnthropicSetupToken } from "../auth-token.js";
 import { isRemoteEnvironment } from "../oauth-env.js";
@@ -34,24 +44,38 @@ import {
 } from "../provider-auth-helpers.js";
 import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
 
-const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
-  clackConfirm({
-    ...params,
-    message: stylePromptMessage(params.message),
-  });
-const text = (params: Parameters<typeof clackText>[0]) =>
-  clackText({
-    ...params,
-    message: stylePromptMessage(params.message),
-  });
-const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
-  clackSelect({
-    ...params,
-    message: stylePromptMessage(params.message),
-    options: params.options.map((opt) =>
-      opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-    ),
-  });
+function guardPromptCancel<T>(value: T | symbol): T | undefined {
+  if (isCancel(value)) {
+    clackCancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
+    return undefined;
+  }
+  return value;
+}
+
+const confirm = async (params: Parameters<typeof clackConfirm>[0]) =>
+  guardPromptCancel(
+    await clackConfirm({
+      ...params,
+      message: stylePromptMessage(params.message),
+    }),
+  );
+const text = async (params: Parameters<typeof clackText>[0]) =>
+  guardPromptCancel(
+    await clackText({
+      ...params,
+      message: stylePromptMessage(params.message),
+    }),
+  );
+const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
+  guardPromptCancel(
+    await clackSelect({
+      ...params,
+      message: stylePromptMessage(params.message),
+      options: params.options.map((opt) =>
+        opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
+      ),
+    }),
+  );
 
 type TokenProvider = "anthropic";
 
@@ -98,7 +122,10 @@ export async function modelsAuthSetupTokenCommand(
     message: "Paste Anthropic setup-token",
     validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
   });
-  const token = String(tokenInput ?? "").trim();
+  if (tokenInput === undefined) {
+    return;
+  }
+  const token = String(tokenInput).trim();
   const profileId = resolveDefaultTokenProfileId(provider);
 
   upsertAuthProfile({
@@ -141,7 +168,10 @@ export async function modelsAuthPasteTokenCommand(
     message: `Paste token for ${provider}`,
     validate: (value) => (value?.trim() ? undefined : "Required"),
   });
-  const token = String(tokenInput ?? "").trim();
+  if (tokenInput === undefined) {
+    return;
+  }
+  const token = String(tokenInput).trim();
 
   const expires =
     opts.expiresIn?.trim() && opts.expiresIn.trim().length > 0
@@ -165,27 +195,30 @@ export async function modelsAuthPasteTokenCommand(
 }
 
 export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime: RuntimeEnv) {
-  const provider = (await select({
+  const provider = await select<TokenProvider | "custom">({
     message: "Token provider",
     options: [
       { value: "anthropic", label: "anthropic" },
       { value: "custom", label: "custom (type provider id)" },
     ],
-  })) as TokenProvider | "custom";
+  });
+  if (!provider) {
+    return;
+  }
 
-  const providerId =
-    provider === "custom"
-      ? normalizeProviderId(
-          String(
-            await text({
-              message: "Provider id",
-              validate: (value) => (value?.trim() ? undefined : "Required"),
-            }),
-          ),
-        )
-      : provider;
+  let providerId = provider;
+  if (provider === "custom") {
+    const providerInput = await text({
+      message: "Provider id",
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    });
+    if (providerInput === undefined) {
+      return;
+    }
+    providerId = normalizeProviderId(String(providerInput));
+  }
 
-  const method = (await select({
+  const method = await select<"setup-token" | "paste">({
     message: "Token method",
     options: [
       ...(providerId === "anthropic"
@@ -199,7 +232,10 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
         : []),
       { value: "paste", label: "paste token" },
     ],
-  })) as "setup-token" | "paste";
+  });
+  if (!method) {
+    return;
+  }
 
   if (method === "setup-token") {
     await modelsAuthSetupTokenCommand({ provider: providerId }, runtime);
@@ -207,34 +243,42 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
   }
 
   const profileIdDefault = resolveDefaultTokenProfileId(providerId);
-  const profileId = String(
-    await text({
-      message: "Profile id",
-      initialValue: profileIdDefault,
-      validate: (value) => (value?.trim() ? undefined : "Required"),
-    }),
-  ).trim();
+  const profileInput = await text({
+    message: "Profile id",
+    initialValue: profileIdDefault,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  if (profileInput === undefined) {
+    return;
+  }
+  const profileId = String(profileInput).trim();
 
   const wantsExpiry = await confirm({
     message: "Does this token expire?",
     initialValue: false,
   });
-  const expiresIn = wantsExpiry
-    ? String(
-        await text({
-          message: "Expires in (duration)",
-          initialValue: "365d",
-          validate: (value) => {
-            try {
-              parseDurationMs(String(value ?? ""), { defaultUnit: "d" });
-              return undefined;
-            } catch {
-              return "Invalid duration (e.g. 365d, 12h, 30m)";
-            }
-          },
-        }),
-      ).trim()
-    : undefined;
+  if (wantsExpiry === undefined) {
+    return;
+  }
+  let expiresIn: string | undefined;
+  if (wantsExpiry) {
+    const expiresInput = await text({
+      message: "Expires in (duration)",
+      initialValue: "365d",
+      validate: (value) => {
+        try {
+          parseDurationMs(String(value ?? ""), { defaultUnit: "d" });
+          return undefined;
+        } catch {
+          return "Invalid duration (e.g. 365d, 12h, 30m)";
+        }
+      },
+    });
+    if (expiresInput === undefined) {
+      return;
+    }
+    expiresIn = String(expiresInput).trim();
+  }
 
   await modelsAuthPasteTokenCommand({ provider: providerId, profileId, expiresIn }, runtime);
 }

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -206,7 +206,7 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
     return;
   }
 
-  let providerId = provider;
+  let providerId: string = provider;
   if (provider === "custom") {
     const providerInput = await text({
       message: "Provider id",
@@ -218,20 +218,23 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
     providerId = normalizeProviderId(String(providerInput));
   }
 
+  const methodOptions: Array<{
+    value: "setup-token" | "paste";
+    label: string;
+    hint?: string;
+  }> = [];
+  if (providerId === "anthropic") {
+    methodOptions.push({
+      value: "setup-token",
+      label: "setup-token (claude)",
+      hint: "Paste a setup-token from `claude setup-token`",
+    });
+  }
+  methodOptions.push({ value: "paste", label: "paste token" });
+
   const method = await select<"setup-token" | "paste">({
     message: "Token method",
-    options: [
-      ...(providerId === "anthropic"
-        ? [
-            {
-              value: "setup-token",
-              label: "setup-token (claude)",
-              hint: "Paste a setup-token from `claude setup-token`",
-            },
-          ]
-        : []),
-      { value: "paste", label: "paste token" },
-    ],
+    options: methodOptions,
   });
   if (!method) {
     return;


### PR DESCRIPTION
## Summary

- Problem: manual token auth prompts in the `models auth` CLI path could stringify Clack's cancel symbol and persist `Symbol(clack:cancel)` into `auth-profiles.json`.
- Why it matters: a cancelled prompt could leave behind a bogus `*:manual` token profile that later gets selected and sent as an invalid bearer token.
- What changed: `src/commands/models/auth.ts` now treats Clack cancel results as cancellation, returns early before any auth profile write, and covers the affected token flows with regression tests.
- What did NOT change (scope boundary): this does not change auth profile selection/fallback behavior, onboarding model defaults, or other wizard flows that already use guarded prompt wrappers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38928
- Related #38928

## User-visible / Behavior Changes

Cancelling a manual token prompt in `openclaw models auth` no longer writes `Symbol(clack:cancel)` into `auth-profiles.json`.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:
  - This change only affects local token persistence. Cancelled prompts now return before `upsertAuthProfile`/`updateConfig`, which avoids storing a bogus secret value.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): CLI `models auth` flows
- Relevant config (redacted): none

### Steps

1. Run `openclaw models auth paste-token --provider openai` (or the setup-token flow for Anthropic).
2. Cancel the prompt with Ctrl+C / Escape.
3. Inspect `auth-profiles.json`.

### Expected

- No auth profile is written for the cancelled prompt.

### Actual

- Before this fix, the cancel symbol could be coerced to `"Symbol(clack:cancel)"` and persisted as the token value.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/commands/models/auth.cancel.test.ts`; both cancelled `paste-token` and cancelled `setup-token` flows return without writing profiles.
- Edge cases checked: cancel path still emits the Clack cancel message and skips both `upsertAuthProfile` and `updateConfig`.
- What you did **not** verify: full interactive end-to-end TTY reproduction outside the focused Vitest coverage.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR's commit.
- Files/config to restore: `src/commands/models/auth.ts`
- Known bad symptoms reviewers should watch for: token auth helpers exiting early on cancel without showing the existing cancel message.

## Risks and Mitigations

- Risk: cancel handling in `models auth` could accidentally suppress a real input value if the prompt wrapper misclassifies responses.
  - Mitigation: the guard relies on Clack's `isCancel`, and regression tests cover both affected token-entry commands.
