### PR TITLE
fix: guard clack cancel symbol in models auth CLI prompts

### DIFF
--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1,4 +1,10 @@
-import { confirm as clackConfirm, select as clackSelect, text as clackText } from "@clack/prompts";
+import {
+  cancel,
+  confirm as clackConfirm,
+  isCancel,
+  select as clackSelect,
+  text as clackText,
+} from "@clack/prompts";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -34,24 +40,38 @@ import {
 } from "../provider-auth-helpers.js";
 import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
 
-const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
-  clackConfirm({
-    ...params,
-    message: stylePromptMessage(params.message),
-  });
-const text = (params: Parameters<typeof clackText>[0]) =>
-  clackText({
-    ...params,
-    message: stylePromptMessage(params.message),
-  });
-const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
-  clackSelect({
-    ...params,
-    message: stylePromptMessage(params.message),
-    options: params.options.map((opt) =>
-      opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-    ),
-  });
+function guardCancel<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel("Cancelled.");
+    process.exit(0);
+  }
+  return value;
+}
+
+const confirm = async (params: Parameters<typeof clackConfirm>[0]) =>
+  guardCancel(
+    await clackConfirm({
+      ...params,
+      message: stylePromptMessage(params.message),
+    }),
+  );
+const text = async (params: Parameters<typeof clackText>[0]) =>
+  guardCancel(
+    await clackText({
+      ...params,
+      message: stylePromptMessage(params.message),
+    }),
+  );
+const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
+  guardCancel(
+    await clackSelect({
+      ...params,
+      message: stylePromptMessage(params.message),
+      options: params.options.map((opt) =>
+        opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
+      ),
+    }),
+  );
 
 type TokenProvider = "anthropic";
 
@@ -165,13 +185,13 @@ export async function modelsAuthPasteTokenCommand(
 }
 
 export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime: RuntimeEnv) {
-  const provider = (await select({
+  const provider = await select({
     message: "Token provider",
     options: [
       { value: "anthropic", label: "anthropic" },
       { value: "custom", label: "custom (type provider id)" },
     ],
-  })) as TokenProvider | "custom";
+  });
 
   const providerId =
     provider === "custom"


### PR DESCRIPTION
## Summary

- When user cancels a manual token prompt (Ctrl+C / Escape) in `openclaw models auth` commands, the `@clack/prompts` cancel symbol was coerced to the string `"Symbol(clack:cancel)"` and persisted as the token value in `auth-profiles.json`, causing 401 errors when the profile was later selected as a fallback.
- Added `isCancel` guard to the local `text` / `select` / `confirm` wrappers in `src/commands/models/auth.ts` so cancellation exits cleanly via `process.exit(0)` instead of persisting a bogus token.

Closes #38928

## Test plan

- [ ] Run `openclaw models auth paste-token --provider openai`, press Escape or Ctrl+C at the token prompt — verify the process exits without writing to `auth-profiles.json`
- [ ] Run `openclaw models auth add`, cancel at any prompt — verify clean exit
- [ ] Run `openclaw models auth setup-token`, cancel at confirm or token prompt — verify clean exit
- [ ] Normal token entry still works and persists correctly