### PR TITLE
fix: guard clack cancel symbols via typeof check to prevent token corruption

### DIFF
--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1,4 +1,10 @@
-import { confirm as clackConfirm, select as clackSelect, text as clackText } from "@clack/prompts";
+import {
+  cancel,
+  confirm as clackConfirm,
+  isCancel,
+  select as clackSelect,
+  text as clackText,
+} from "@clack/prompts";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -34,24 +40,38 @@ import {
 } from "../provider-auth-helpers.js";
 import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
 
-const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
-  clackConfirm({
-    ...params,
-    message: stylePromptMessage(params.message),
-  });
-const text = (params: Parameters<typeof clackText>[0]) =>
-  clackText({
-    ...params,
-    message: stylePromptMessage(params.message),
-  });
-const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
-  clackSelect({
-    ...params,
-    message: stylePromptMessage(params.message),
-    options: params.options.map((opt) =>
-      opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
-    ),
-  });
+function guardCancel<T>(value: T | symbol): T {
+  if (typeof value === "symbol" || isCancel(value)) {
+    cancel("Cancelled.");
+    process.exit(0);
+  }
+  return value;
+}
+
+const confirm = async (params: Parameters<typeof clackConfirm>[0]) =>
+  guardCancel(
+    await clackConfirm({
+      ...params,
+      message: stylePromptMessage(params.message),
+    }),
+  );
+const text = async (params: Parameters<typeof clackText>[0]) =>
+  guardCancel(
+    await clackText({
+      ...params,
+      message: stylePromptMessage(params.message),
+    }),
+  );
+const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
+  guardCancel(
+    await clackSelect({
+      ...params,
+      message: stylePromptMessage(params.message),
+      options: params.options.map((opt) =>
+        opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
+      ),
+    }),
+  );
 
 type TokenProvider = "anthropic";
 
@@ -165,13 +185,13 @@ export async function modelsAuthPasteTokenCommand(
 }
 
 export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime: RuntimeEnv) {
-  const provider = (await select({
+  const provider = await select({
     message: "Token provider",
     options: [
       { value: "anthropic", label: "anthropic" },
       { value: "custom", label: "custom (type provider id)" },
     ],
-  })) as TokenProvider | "custom";
+  });
 
   const providerId =
     provider === "custom"

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -29,7 +29,9 @@ import { VERSION } from "../version.js";
 import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
 
 export function guardCancel<T>(value: T | symbol, runtime: RuntimeEnv): T {
-  if (isCancel(value)) {
+  // Check typeof first: catches cancel symbols from any @clack/prompts version
+  // (Symbol identity via isCancel fails when multiple versions are installed).
+  if (typeof value === "symbol" || isCancel(value)) {
     cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
     runtime.exit(0);
     throw new Error("unreachable");

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -20,7 +20,9 @@ import type { WizardProgress, WizardPrompter } from "./prompts.js";
 import { WizardCancelledError } from "./prompts.js";
 
 function guardCancel<T>(value: T | symbol): T {
-  if (isCancel(value)) {
+  // Check typeof first: catches cancel symbols from any @clack/prompts version
+  // (Symbol identity via isCancel fails when multiple versions are installed).
+  if (typeof value === "symbol" || isCancel(value)) {
     cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
     throw new WizardCancelledError();
   }


### PR DESCRIPTION
## Summary

Fixes #38928

When the user cancels a manual token prompt (Ctrl+C / Escape), the `@clack/prompts` cancel symbol can leak past `guardCancel` and get coerced to `"Symbol(clack:cancel)"` via `String()`. This bogus value is then persisted as the token in `auth-profiles.json`, causing 401 errors when the profile is later used as a fallback.

**Root cause:** The lockfile contains two versions of `@clack/prompts` (v1.0.1 and v1.1.0). `isCancel` uses strict Symbol identity (`value === S_CANCEL`), which fails across versions because each version creates its own `Symbol('clack:cancel')` instance.

**Fix:** Add `typeof value === "symbol"` checks to all three `guardCancel` implementations so any symbol triggers cancellation regardless of which `@clack/prompts` version produced it. This matches the existing `assertNoCancel` pattern already used in `secrets/configure.ts`.

### Changes

- **`src/wizard/clack-prompter.ts`** — Add `typeof value === "symbol"` check before `isCancel` in `guardCancel`
- **`src/commands/onboard-helpers.ts`** — Same fix for the exported `guardCancel`
- **`src/commands/models/auth.ts`** — Add missing `guardCancel` wrappers to the `confirm`/`text`/`select` helpers (previously had no cancel handling at all) with the robust `typeof` check

## Test plan

- [x] `pnpm tsgo` — type check passes
- [x] `pnpm check` — lint passes
- [x] `pnpm format` — format passes
- [x] Relevant tests pass: `clack-prompter.test.ts`, `onboard-interactive.test.ts`, `normalize-secret-input.test.ts`
- [ ] Manual: run `openclaw models auth add`, press Ctrl+C during token entry — should exit cleanly without writing to `auth-profiles.json`