### PR TITLE
fix(models auth): don't persist clack cancel symbol as token

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { WizardCancelledError } from "../../wizard/prompts.js";
+import { OPENAI_CODEX_DEFAULT_MODEL } from "../openai-codex-model-default.js";
 
 const mocks = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  isCancel: vi.fn(),
+  clackConfirm: vi.fn(),
+  clackSelect: vi.fn(),
+  clackText: vi.fn(),
   resolveDefaultAgentId: vi.fn(),
   resolveAgentDir: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(),
@@ -15,6 +22,14 @@ const mocks = vi.hoisted(() => ({
   updateConfig: vi.fn(),
   logConfigUpdated: vi.fn(),
   openUrl: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  cancel: mocks.cancel,
+  isCancel: mocks.isCancel,
+  confirm: mocks.clackConfirm,
+  select: mocks.clackSelect,
+  text: mocks.clackText,
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -64,7 +79,7 @@ vi.mock("../onboard-helpers.js", () => ({
   openUrl: mocks.openUrl,
 }));
 
-const { modelsAuthLoginCommand } = await import("./auth.js");
+const { modelsAuthLoginCommand, modelsAuthPasteTokenCommand } = await import("./auth.js");
 
 function createRuntime(): RuntimeEnv {
   return {
@@ -92,7 +107,7 @@ function withInteractiveStdin() {
   };
 }
 
-describe("modelsAuthLoginCommand", () => {
+describe("models auth commands", () => {
   let restoreStdin: (() => void) | null = null;
   let currentConfig: OpenClawConfig;
   let lastUpdatedConfig: OpenClawConfig | null;
@@ -103,6 +118,10 @@ describe("modelsAuthLoginCommand", () => {
     currentConfig = {};
     lastUpdatedConfig = null;
 
+    mocks.clackConfirm.mockResolvedValue(true);
+    mocks.clackSelect.mockResolvedValue("anthropic");
+    mocks.clackText.mockResolvedValue("test-token");
+    mocks.isCancel.mockReturnValue(false);
     mocks.resolveDefaultAgentId.mockReturnValue("main");
     mocks.resolveAgentDir.mockReturnValue("/tmp/openclaw/agents/main");
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
@@ -157,7 +176,7 @@ describe("modelsAuthLoginCommand", () => {
       "Auth profile: openai-codex:user@example.com (openai-codex/oauth)",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Default model available: openai-codex/gpt-5.3-codex (use --set-default to apply)",
+      `Default model available: ${OPENAI_CODEX_DEFAULT_MODEL} (use --set-default to apply)`,
     );
   });
 
@@ -167,9 +186,9 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthLoginCommand({ provider: "openai-codex", setDefault: true }, runtime);
 
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
-      primary: "openai-codex/gpt-5.3-codex",
+      primary: OPENAI_CODEX_DEFAULT_MODEL,
     });
-    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.3-codex");
+    expect(runtime.log).toHaveBeenCalledWith(`Default model set to ${OPENAI_CODEX_DEFAULT_MODEL}`);
   });
 
   it("keeps existing plugin error behavior for non built-in providers", async () => {
@@ -178,5 +197,21 @@ describe("modelsAuthLoginCommand", () => {
     await expect(modelsAuthLoginCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
       "No provider plugins found.",
     );
+  });
+
+  it("throws WizardCancelledError and skips writes when token paste prompt is cancelled", async () => {
+    const runtime = createRuntime();
+    const cancelSymbol = Symbol.for("clack:cancel");
+    mocks.clackText.mockResolvedValueOnce(cancelSymbol);
+    mocks.isCancel.mockImplementation((value: unknown) => value === cancelSymbol);
+
+    await expect(
+      modelsAuthPasteTokenCommand({ provider: "openai", profileId: "openai:manual" }, runtime),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+    expect(mocks.cancel).toHaveBeenCalled();
   });
 });

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1,4 +1,10 @@
-import { confirm as clackConfirm, select as clackSelect, text as clackText } from "@clack/prompts";
+import {
+  cancel,
+  confirm as clackConfirm,
+  isCancel,
+  select as clackSelect,
+  text as clackText,
+} from "@clack/prompts";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -14,8 +20,13 @@ import { logConfigUpdated } from "../../config/logging.js";
 import { resolvePluginProviders } from "../../plugins/providers.js";
 import type { ProviderAuthResult, ProviderPlugin } from "../../plugins/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
+import {
+  stylePromptHint,
+  stylePromptMessage,
+  stylePromptTitle,
+} from "../../terminal/prompt-style.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
+import { WizardCancelledError } from "../../wizard/prompts.js";
 import { validateAnthropicSetupToken } from "../auth-token.js";
 import { isRemoteEnvironment } from "../oauth-env.js";
 import { createVpsAwareOAuthHandlers } from "../oauth-flow.js";
@@ -53,6 +64,14 @@ const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
     ),
   });
 
+function guardCancel<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
+    throw new WizardCancelledError();
+  }
+  return value;
+}
+
 type TokenProvider = "anthropic";
 
 function resolveTokenProvider(raw?: string): TokenProvider | "custom" | null {
@@ -85,19 +104,23 @@ export async function modelsAuthSetupTokenCommand(
   }
 
   if (!opts.yes) {
-    const proceed = await confirm({
-      message: "Have you run `claude setup-token` and copied the token?",
-      initialValue: true,
-    });
+    const proceed = guardCancel(
+      await confirm({
+        message: "Have you run `claude setup-token` and copied the token?",
+        initialValue: true,
+      }),
+    );
     if (!proceed) {
       return;
     }
   }
 
-  const tokenInput = await text({
-    message: "Paste Anthropic setup-token",
-    validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
-  });
+  const tokenInput = guardCancel(
+    await text({
+      message: "Paste Anthropic setup-token",
+      validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
+    }),
+  );
   const token = String(tokenInput ?? "").trim();
   const profileId = resolveDefaultTokenProfileId(provider);
 
@@ -137,10 +160,12 @@ export async function modelsAuthPasteTokenCommand(
   const provider = normalizeProviderId(rawProvider);
   const profileId = opts.profileId?.trim() || resolveDefaultTokenProfileId(provider);
 
-  const tokenInput = await text({
-    message: `Paste token for ${provider}`,
-    validate: (value) => (value?.trim() ? undefined : "Required"),
-  });
+  const tokenInput = guardCancel(
+    await text({
+      message: `Paste token for ${provider}`,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    }),
+  );
   const token = String(tokenInput ?? "").trim();
 
   const expires =
@@ -165,41 +190,47 @@ export async function modelsAuthPasteTokenCommand(
 }
 
 export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime: RuntimeEnv) {
-  const provider = (await select({
-    message: "Token provider",
-    options: [
-      { value: "anthropic", label: "anthropic" },
-      { value: "custom", label: "custom (type provider id)" },
-    ],
-  })) as TokenProvider | "custom";
+  const provider = guardCancel(
+    await select({
+      message: "Token provider",
+      options: [
+        { value: "anthropic", label: "anthropic" },
+        { value: "custom", label: "custom (type provider id)" },
+      ],
+    }),
+  );
 
   const providerId =
     provider === "custom"
       ? normalizeProviderId(
           String(
-            await text({
-              message: "Provider id",
-              validate: (value) => (value?.trim() ? undefined : "Required"),
-            }),
+            guardCancel(
+              await text({
+                message: "Provider id",
+                validate: (value) => (value?.trim() ? undefined : "Required"),
+              }),
+            ),
           ),
         )
       : provider;
 
-  const method = (await select({
-    message: "Token method",
-    options: [
-      ...(providerId === "anthropic"
-        ? [
-            {
-              value: "setup-token",
-              label: "setup-token (claude)",
-              hint: "Paste a setup-token from `claude setup-token`",
-            },
-          ]
-        : []),
-      { value: "paste", label: "paste token" },
-    ],
-  })) as "setup-token" | "paste";
+  const method = guardCancel(
+    await select({
+      message: "Token method",
+      options: [
+        ...(providerId === "anthropic"
+          ? [
+              {
+                value: "setup-token",
+                label: "setup-token (claude)",
+                hint: "Paste a setup-token from `claude setup-token`",
+              },
+            ]
+          : []),
+        { value: "paste", label: "paste token" },
+      ],
+    }),
+  ) as "setup-token" | "paste";
 
   if (method === "setup-token") {
     await modelsAuthSetupTokenCommand({ provider: providerId }, runtime);
@@ -208,31 +239,37 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
 
   const profileIdDefault = resolveDefaultTokenProfileId(providerId);
   const profileId = String(
-    await text({
-      message: "Profile id",
-      initialValue: profileIdDefault,
-      validate: (value) => (value?.trim() ? undefined : "Required"),
-    }),
+    guardCancel(
+      await text({
+        message: "Profile id",
+        initialValue: profileIdDefault,
+        validate: (value) => (value?.trim() ? undefined : "Required"),
+      }),
+    ),
   ).trim();
 
-  const wantsExpiry = await confirm({
-    message: "Does this token expire?",
-    initialValue: false,
-  });
+  const wantsExpiry = guardCancel(
+    await confirm({
+      message: "Does this token expire?",
+      initialValue: false,
+    }),
+  );
   const expiresIn = wantsExpiry
     ? String(
-        await text({
-          message: "Expires in (duration)",
-          initialValue: "365d",
-          validate: (value) => {
-            try {
-              parseDurationMs(String(value ?? ""), { defaultUnit: "d" });
-              return undefined;
-            } catch {
-              return "Invalid duration (e.g. 365d, 12h, 30m)";
-            }
-          },
-        }),
+        guardCancel(
+          await text({
+            message: "Expires in (duration)",
+            initialValue: "365d",
+            validate: (value) => {
+              try {
+                parseDurationMs(String(value ?? ""), { defaultUnit: "d" });
+                return undefined;
+              } catch {
+                return "Invalid duration (e.g. 365d, 12h, 30m)";
+              }
+            },
+          }),
+        ),
       ).trim()
     : undefined;
 


### PR DESCRIPTION
## Summary
Fixes #38928 by treating `@clack/prompts` cancel responses as explicit wizard cancellation in `models auth` token flows.

### What changed
- Added a local `guardCancel(...)` helper in `src/commands/models/auth.ts` that:
  - checks `isCancel(...)`
  - emits `cancel("Setup cancelled.")`
  - throws `WizardCancelledError`
- Wrapped all interactive `confirm/select/text` calls used by:
  - `modelsAuthSetupTokenCommand`
  - `modelsAuthPasteTokenCommand`
  - `modelsAuthAddCommand`
  so cancellation aborts before any profile/config writes.
- Added regression coverage in `src/commands/models/auth.test.ts`:
  - `throws WizardCancelledError and skips writes when token paste prompt is cancelled`
  - verifies `updateConfig`, `logConfigUpdated`, and runtime logs are not called on cancel.

## Why this is safe
- Scope is limited to models-auth interactive token commands.
- No behavior change for valid token input paths.
- Cancellation behavior now matches onboarding/configure wizard semantics.

## Validation
- `pnpm -s vitest run src/commands/models/auth.test.ts src/commands/auth-choice.apply.openai.test.ts src/commands/auth-choice.apply.anthropic.test.ts`
  - 3 files passed, 8 tests passed.

## Risk / Rollback
- Risk: low; localized to prompt cancellation handling in one command module.
- Rollback: revert this PR commit.
