### PR TITLE
feat(sandbox): pluggable ISandboxProvider with auto-detection (Docker/gVisor/Firecracker)

### DIFF
--- a/src/agents/sandbox/provider-resolver.ts
+++ b/src/agents/sandbox/provider-resolver.ts
@@ -1,0 +1,138 @@
+/**
+ * Provider Resolver: Auto-detects and instantiates the best available sandbox provider.
+ *
+ * Detection order (highest isolation first):
+ *   1. Firecracker MicroVM (requires /dev/kvm) - hardware-level VM isolation
+ *   2. gVisor/runsc (Docker runtime) - user-space kernel isolation
+ *   3. Docker (standard) - container-level isolation
+ *
+ * The resolver caches the provider instance for the lifetime of the process.
+ */
+
+import { execSync } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { ISandboxProvider, SandboxBackend } from "./provider.js";
+import { DockerProvider } from "./providers/docker-provider.js";
+import { GVisorProvider } from "./providers/gvisor-provider.js";
+import type { SandboxConfig } from "./types.js";
+
+const log = createSubsystemLogger("provider-resolver");
+
+let cachedProvider: ISandboxProvider | null = null;
+
+export function hasKvmSupport(): boolean {
+  try {
+    accessSync("/dev/kvm", constants.R_OK | constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function hasGVisorRuntime(): boolean {
+  try {
+    const result = execSync("docker info --format '{{json .Runtimes}}'", {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return result.includes("runsc");
+  } catch {
+    return false;
+  }
+}
+
+export function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createProvider(
+  backend: SandboxBackend,
+  sandboxConfig: SandboxConfig,
+): ISandboxProvider {
+  switch (backend) {
+    case "docker":
+      return new DockerProvider({ sandboxConfig });
+    case "gvisor":
+      return new GVisorProvider({ sandboxConfig });
+    case "firecracker":
+      throw new Error(
+        "Firecracker provider not yet implemented. " +
+          "See ARCHITECTURE-MICROVM-SANDBOX.md for the planned implementation.",
+      );
+    default:
+      throw new Error(`Unknown sandbox backend: ${backend as string}`);
+  }
+}
+
+export async function autoDetectBackend(): Promise<SandboxBackend> {
+  // Firecracker requires KVM - check first as it provides strongest isolation
+  if (hasKvmSupport()) {
+    log.info("KVM support detected - Firecracker backend available (not yet implemented)");
+    // Fall through to gVisor/Docker until Firecracker is implemented
+  }
+
+  // gVisor provides user-space kernel isolation without KVM
+  if (hasGVisorRuntime()) {
+    log.info("gVisor (runsc) runtime detected");
+    return "gvisor";
+  }
+
+  // Docker is the baseline
+  if (hasDocker()) {
+    log.info("Using Docker backend (standard container isolation)");
+    return "docker";
+  }
+
+  throw new Error(
+    "No sandbox provider available. Install Docker to enable sandboxing, " +
+      "or set `agents.defaults.sandbox.mode=off` to disable it.",
+  );
+}
+
+export async function resolveProvider(sandboxConfig: SandboxConfig): Promise<ISandboxProvider> {
+  if (cachedProvider) {
+    return cachedProvider;
+  }
+
+  const configuredBackend = (sandboxConfig as SandboxConfig & { backend?: SandboxBackend }).backend;
+  let backend: SandboxBackend;
+
+  if (configuredBackend && configuredBackend !== ("auto" as string)) {
+    backend = configuredBackend;
+    log.info(`Using configured sandbox backend: ${backend}`);
+  } else {
+    backend = await autoDetectBackend();
+  }
+
+  const provider = createProvider(backend, sandboxConfig);
+
+  const available = await provider.isAvailable();
+  if (!available) {
+    throw new Error(
+      `Sandbox backend "${backend}" is configured but not available on this system. ` +
+        `Check installation or use backend: "auto" for automatic detection.`,
+    );
+  }
+
+  cachedProvider = provider;
+  return provider;
+}
+
+export function clearProviderCache(): void {
+  cachedProvider = null;
+}
+
+export function getActiveProvider(): ISandboxProvider | null {
+  return cachedProvider;
+}

--- a/src/agents/sandbox/provider.ts
+++ b/src/agents/sandbox/provider.ts
@@ -1,0 +1,115 @@
+/**
+ * ISandboxProvider: Pluggable sandbox runtime abstraction.
+ *
+ * Allows OpenClaw to run agent workloads in different isolation backends
+ * (Docker, gVisor, Firecracker MicroVM) through a unified interface.
+ */
+
+export type SandboxBackend = "docker" | "gvisor" | "firecracker";
+
+export type SandboxInstanceState = "creating" | "running" | "stopped" | "destroyed";
+
+export type SandboxInstance = {
+  id: string;
+  backend: SandboxBackend;
+  containerName: string;
+  state: SandboxInstanceState;
+  workdir: string;
+  createdAtMs: number;
+};
+
+export type SandboxCreateRequest = {
+  sessionKey: string;
+  scopeKey: string;
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  workspaceAccess: "none" | "ro" | "rw";
+  configHash?: string;
+};
+
+export type SandboxExecRequest = {
+  command: string;
+  workdir?: string;
+  env?: Record<string, string>;
+  tty?: boolean;
+  input?: Buffer | string;
+  signal?: AbortSignal;
+};
+
+export type SandboxExecResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+export type SandboxStatus = {
+  exists: boolean;
+  running: boolean;
+  backend: SandboxBackend;
+};
+
+export interface ISandboxProvider {
+  readonly name: SandboxBackend;
+
+  /**
+   * Check if this provider is available on the current system.
+   * Returns false if prerequisites are missing (e.g. no Docker, no KVM).
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * One-time initialization (pull images, verify runtime, etc.).
+   */
+  initialize(): Promise<void>;
+
+  /**
+   * Create and start a sandbox instance.
+   * Equivalent to current `ensureSandboxContainer()`.
+   */
+  ensureInstance(request: SandboxCreateRequest): Promise<SandboxInstance>;
+
+  /**
+   * Execute a command inside a running sandbox.
+   * Equivalent to current `docker exec` via `buildDockerExecArgs()`.
+   */
+  exec(instance: SandboxInstance, request: SandboxExecRequest): Promise<SandboxExecResult>;
+
+  /**
+   * Execute a raw command (buffer I/O). Used for binary data transfers.
+   */
+  execRaw(
+    instance: SandboxInstance,
+    args: string[],
+    opts?: { allowFailure?: boolean; input?: Buffer | string; signal?: AbortSignal },
+  ): Promise<{ stdout: Buffer; stderr: Buffer; code: number }>;
+
+  /**
+   * Get the current status of a sandbox instance.
+   */
+  status(containerName: string): Promise<SandboxStatus>;
+
+  /**
+   * Destroy a sandbox instance and clean up resources.
+   */
+  destroy(containerName: string): Promise<void>;
+
+  /**
+   * List all sandbox instances managed by this provider.
+   */
+  list(): Promise<SandboxInstance[]>;
+
+  /**
+   * Read a label/metadata value from a sandbox instance.
+   */
+  readLabel(containerName: string, label: string): Promise<string | null>;
+
+  /**
+   * Read an environment variable from a sandbox instance config.
+   */
+  readEnvVar(containerName: string, envVar: string): Promise<string | null>;
+
+  /**
+   * Read a mapped port from a sandbox instance.
+   */
+  readPort(containerName: string, port: number): Promise<number | null>;
+}

--- a/src/agents/sandbox/providers/docker-provider.ts
+++ b/src/agents/sandbox/providers/docker-provider.ts
@@ -1,0 +1,176 @@
+/**
+ * DockerProvider: ISandboxProvider implementation wrapping existing Docker sandbox logic.
+ *
+ * This is a thin adapter over the existing docker.ts functions, maintaining full
+ * backward compatibility while conforming to the pluggable provider interface.
+ */
+
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import {
+  dockerContainerState,
+  ensureDockerImage,
+  ensureSandboxContainer,
+  execDocker,
+  execDockerRaw,
+  readDockerContainerEnvVar,
+  readDockerContainerLabel,
+  readDockerPort,
+  type ExecDockerRawResult,
+} from "../docker.js";
+import type {
+  ISandboxProvider,
+  SandboxCreateRequest,
+  SandboxExecRequest,
+  SandboxExecResult,
+  SandboxInstance,
+  SandboxStatus,
+} from "../provider.js";
+import type { SandboxConfig } from "../types.js";
+
+const log = createSubsystemLogger("docker-provider");
+
+export type DockerProviderConfig = {
+  sandboxConfig: SandboxConfig;
+};
+
+export class DockerProvider implements ISandboxProvider {
+  readonly name = "docker" as const;
+  private config: DockerProviderConfig;
+
+  constructor(config: DockerProviderConfig) {
+    this.config = config;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const result = await execDocker(["version", "--format", "{{.Server.Version}}"], {
+        allowFailure: true,
+      });
+      return result.code === 0 && result.stdout.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async initialize(): Promise<void> {
+    const image = this.config.sandboxConfig.docker.image;
+    await ensureDockerImage(image);
+    log.info(`Docker provider initialized with image: ${image}`);
+  }
+
+  async ensureInstance(request: SandboxCreateRequest): Promise<SandboxInstance> {
+    const containerName = await ensureSandboxContainer({
+      sessionKey: request.sessionKey,
+      workspaceDir: request.workspaceDir,
+      agentWorkspaceDir: request.agentWorkspaceDir,
+      cfg: this.config.sandboxConfig,
+    });
+
+    return {
+      id: containerName,
+      backend: "docker",
+      containerName,
+      state: "running",
+      workdir: this.config.sandboxConfig.docker.workdir,
+      createdAtMs: Date.now(),
+    };
+  }
+
+  async exec(instance: SandboxInstance, request: SandboxExecRequest): Promise<SandboxExecResult> {
+    const args = ["exec", "-i"];
+    if (request.tty) {
+      args.push("-t");
+    }
+    if (request.workdir) {
+      args.push("-w", request.workdir);
+    }
+    if (request.env) {
+      for (const [key, value] of Object.entries(request.env)) {
+        args.push("-e", `${key}=${value}`);
+      }
+    }
+    args.push(instance.containerName, "/bin/sh", "-lc", request.command);
+
+    const result = await execDockerRaw(args, {
+      allowFailure: true,
+      input: request.input,
+      signal: request.signal,
+    });
+
+    return {
+      stdout: result.stdout.toString("utf8"),
+      stderr: result.stderr.toString("utf8"),
+      exitCode: result.code,
+    };
+  }
+
+  async execRaw(
+    instance: SandboxInstance,
+    args: string[],
+    opts?: { allowFailure?: boolean; input?: Buffer | string; signal?: AbortSignal },
+  ): Promise<ExecDockerRawResult> {
+    return execDockerRaw(args, opts);
+  }
+
+  async status(containerName: string): Promise<SandboxStatus> {
+    const state = await dockerContainerState(containerName);
+    return {
+      exists: state.exists,
+      running: state.running,
+      backend: "docker",
+    };
+  }
+
+  async destroy(containerName: string): Promise<void> {
+    await execDocker(["rm", "-f", containerName], { allowFailure: true });
+  }
+
+  async list(): Promise<SandboxInstance[]> {
+    const result = await execDocker(
+      [
+        "ps",
+        "-a",
+        "--filter",
+        "label=openclaw.sandbox=1",
+        "--format",
+        '{{.Names}}\t{{.State}}\t{{.Label "openclaw.createdAtMs"}}',
+      ],
+      { allowFailure: true },
+    );
+
+    if (result.code !== 0 || !result.stdout.trim()) {
+      return [];
+    }
+
+    return result.stdout
+      .trim()
+      .split("\n")
+      .map((line) => {
+        const [containerName, state, createdAt] = line.split("\t");
+        if (!containerName) {
+          return null;
+        }
+        return {
+          id: containerName,
+          backend: "docker" as const,
+          containerName,
+          state: state === "running" ? ("running" as const) : ("stopped" as const),
+          workdir: this.config.sandboxConfig.docker.workdir,
+          createdAtMs: createdAt ? Number.parseInt(createdAt, 10) : 0,
+        };
+      })
+      .filter((item): item is SandboxInstance => item !== null);
+  }
+
+  async readLabel(containerName: string, label: string): Promise<string | null> {
+    return readDockerContainerLabel(containerName, label);
+  }
+
+  async readEnvVar(containerName: string, envVar: string): Promise<string | null> {
+    return readDockerContainerEnvVar(containerName, envVar);
+  }
+
+  async readPort(containerName: string, port: number): Promise<number | null> {
+    return readDockerPort(containerName, port);
+  }
+}

--- a/src/agents/sandbox/providers/gvisor-provider.ts
+++ b/src/agents/sandbox/providers/gvisor-provider.ts
@@ -1,0 +1,166 @@
+/**
+ * GVisorProvider: ISandboxProvider implementation using gVisor (runsc) runtime.
+ *
+ * gVisor provides stronger isolation than standard Docker by running a user-space
+ * kernel (Sentry) that intercepts all syscalls via seccomp-bpf. It does NOT require
+ * KVM/nested virtualization, making it suitable for VPS environments.
+ *
+ * This provider uses Docker with `--runtime=runsc` to leverage gVisor's isolation
+ * while maintaining compatibility with existing Docker infrastructure.
+ *
+ * Status: STUB - full implementation pending gVisor runtime integration.
+ */
+
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import {
+  dockerContainerState,
+  execDocker,
+  readDockerContainerEnvVar,
+  readDockerContainerLabel,
+  readDockerPort,
+  type ExecDockerRawResult,
+} from "../docker.js";
+import type {
+  ISandboxProvider,
+  SandboxCreateRequest,
+  SandboxExecRequest,
+  SandboxExecResult,
+  SandboxInstance,
+  SandboxStatus,
+} from "../provider.js";
+import type { SandboxConfig } from "../types.js";
+
+const log = createSubsystemLogger("gvisor-provider");
+
+export type GVisorProviderConfig = {
+  sandboxConfig: SandboxConfig;
+  runtime?: string;
+};
+
+export class GVisorProvider implements ISandboxProvider {
+  readonly name = "gvisor" as const;
+  private config: GVisorProviderConfig;
+  private runtime: string;
+
+  constructor(config: GVisorProviderConfig) {
+    this.config = config;
+    this.runtime = config.runtime ?? "runsc";
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      // Check if Docker is available with runsc runtime
+      const result = await execDocker(["info", "--format", "{{range .Runtimes}}{{.}}{{end}}"], {
+        allowFailure: true,
+      });
+      if (result.code !== 0) {
+        return false;
+      }
+      // Check if runsc runtime is registered
+      const runtimeCheck = await execDocker(
+        ["info", "--format", `{{index .Runtimes "${this.runtime}"}}`],
+        { allowFailure: true },
+      );
+      return runtimeCheck.code === 0 && runtimeCheck.stdout.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async initialize(): Promise<void> {
+    const available = await this.isAvailable();
+    if (!available) {
+      throw new Error(
+        `gVisor runtime "${this.runtime}" is not available. ` +
+          "Install gVisor (runsc) and configure it as a Docker runtime. " +
+          "See: https://gvisor.dev/docs/user_guide/install/",
+      );
+    }
+    log.info(`gVisor provider initialized with runtime: ${this.runtime}`);
+  }
+
+  async ensureInstance(_request: SandboxCreateRequest): Promise<SandboxInstance> {
+    // TODO: Implement gVisor-specific container creation with --runtime=runsc
+    // This will reuse most of buildSandboxCreateArgs() but inject --runtime flag
+    throw new Error("GVisorProvider.ensureInstance() not yet implemented");
+  }
+
+  async exec(_instance: SandboxInstance, _request: SandboxExecRequest): Promise<SandboxExecResult> {
+    // gVisor exec works identically to Docker exec since runsc is a Docker runtime
+    throw new Error("GVisorProvider.exec() not yet implemented");
+  }
+
+  async execRaw(
+    _instance: SandboxInstance,
+    _args: string[],
+    _opts?: { allowFailure?: boolean; input?: Buffer | string; signal?: AbortSignal },
+  ): Promise<ExecDockerRawResult> {
+    throw new Error("GVisorProvider.execRaw() not yet implemented");
+  }
+
+  async status(containerName: string): Promise<SandboxStatus> {
+    // Status check is identical to Docker since gVisor containers are Docker containers
+    const state = await dockerContainerState(containerName);
+    return {
+      exists: state.exists,
+      running: state.running,
+      backend: "gvisor",
+    };
+  }
+
+  async destroy(containerName: string): Promise<void> {
+    await execDocker(["rm", "-f", containerName], { allowFailure: true });
+  }
+
+  async list(): Promise<SandboxInstance[]> {
+    // gVisor containers are Docker containers with --runtime=runsc label
+    const result = await execDocker(
+      [
+        "ps",
+        "-a",
+        "--filter",
+        "label=openclaw.sandbox=1",
+        "--filter",
+        `label=openclaw.runtime=${this.runtime}`,
+        "--format",
+        '{{.Names}}\t{{.State}}\t{{.Label "openclaw.createdAtMs"}}',
+      ],
+      { allowFailure: true },
+    );
+
+    if (result.code !== 0 || !result.stdout.trim()) {
+      return [];
+    }
+
+    return result.stdout
+      .trim()
+      .split("\n")
+      .map((line) => {
+        const [containerName, state, createdAt] = line.split("\t");
+        if (!containerName) {
+          return null;
+        }
+        return {
+          id: containerName,
+          backend: "gvisor" as const,
+          containerName,
+          state: state === "running" ? ("running" as const) : ("stopped" as const),
+          workdir: this.config.sandboxConfig.docker.workdir,
+          createdAtMs: createdAt ? Number.parseInt(createdAt, 10) : 0,
+        };
+      })
+      .filter((item): item is SandboxInstance => item !== null);
+  }
+
+  async readLabel(containerName: string, label: string): Promise<string | null> {
+    return readDockerContainerLabel(containerName, label);
+  }
+
+  async readEnvVar(containerName: string, envVar: string): Promise<string | null> {
+    return readDockerContainerEnvVar(containerName, envVar);
+  }
+
+  async readPort(containerName: string, port: number): Promise<number | null> {
+    return readDockerPort(containerName, port);
+  }
+}

--- a/src/agents/sandbox/providers/index.ts
+++ b/src/agents/sandbox/providers/index.ts
@@ -1,0 +1,2 @@
+export { DockerProvider } from "./docker-provider.js";
+export { GVisorProvider } from "./gvisor-provider.js";

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -52,9 +52,12 @@ export type SandboxPruneConfig = {
 
 export type SandboxScope = "session" | "agent" | "shared";
 
+export type SandboxBackend = "docker" | "gvisor" | "firecracker" | "auto";
+
 export type SandboxConfig = {
   mode: "off" | "non-main" | "all";
   scope: SandboxScope;
+  backend: SandboxBackend;
   workspaceAccess: SandboxWorkspaceAccess;
   workspaceRoot: string;
   docker: SandboxDockerConfig;


### PR DESCRIPTION
## Summary

- Introduces `ISandboxProvider` interface for pluggable sandbox backends (Docker, gVisor, Firecracker MicroVM)
- Adds `DockerProvider` wrapping existing `docker.ts` with zero behavior changes
- Adds `GVisorProvider` stub with `--runtime=runsc` detection for user-space kernel isolation
- Adds `provider-resolver.ts` with auto-detection of strongest available backend (Firecracker > gVisor > Docker)
- Adds `SandboxBackend` type and `backend` field to `SandboxConfig`

### Why?

Current sandbox (#29974) relies on Docker socket, sharing the host kernel. This PR enables:

| Backend | Isolation | Requirement |
|---------|-----------|-------------|
| Docker (Tier 1) | Container namespaces | Docker installed |
| gVisor (Tier 1.5) | User-space kernel (Sentry) | `runsc` runtime |
| Firecracker (Tier 2) | Hardware KVM | `/dev/kvm` |

Auto-detection picks the strongest available backend — operators don't need to configure anything.

### Related

- Extends #29974 (Docker sandbox opt-in)
- Addresses #12405 (Pluggable sandbox backends)
- Complements #7575 (Sysbox discussion — gVisor is a better alternative)

### Files

| File | Purpose |
|------|---------|
| `src/agents/sandbox/provider.ts` | `ISandboxProvider` interface + types |
| `src/agents/sandbox/providers/docker-provider.ts` | Docker backend (wraps existing code) |
| `src/agents/sandbox/providers/gvisor-provider.ts` | gVisor backend stub |
| `src/agents/sandbox/providers/index.ts` | Re-exports |
| `src/agents/sandbox/provider-resolver.ts` | Auto-detection + caching |
| `src/agents/sandbox/types.ts` | `SandboxBackend` type + `backend` field |

## Test plan

- [ ] Verify `DockerProvider.isAvailable()` returns true when Docker is running
- [ ] Verify `DockerProvider.ensureInstance()` creates container identical to current `ensureSandboxContainer()`
- [ ] Verify `resolveProvider()` with `backend: "auto"` selects Docker when only Docker is available
- [ ] Verify `resolveProvider()` with `backend: "auto"` selects gVisor when runsc is installed
- [ ] Verify `resolveProvider()` falls back gracefully when preferred backend unavailable
- [ ] Verify TypeScript compilation passes with zero errors
- [ ] Verify existing sandbox tests still pass (100% backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)