### PR TITLE
fix(ios): skip quick setup when a gateway is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/native topic command routing: resolve forum-topic native commands through the same conversation route as inbound messages so topic `agentId` overrides and bound topic sessions target the active session instead of the default topic-parent session. (#38871) Thanks @obviyus.
 - Markdown/assistant image hardening: flatten remote markdown images to plain text across the Control UI, exported HTML, and shared Swift chat while keeping inline `data:image/...` markdown renderable, so model output no longer triggers automatic remote image fetches. (#38895) Thanks @obviyus.
 - Config/compaction safeguard settings: regression-test `agents.defaults.compaction.recentTurnsPreserve` through `loadConfig()` and cover the new help metadata entry so the exposed preserve knob stays wired through schema validation and config UX. (#25557) thanks @rodrigouroz.
+- iOS/Quick Setup presentation: skip automatic Quick Setup when a gateway is already configured (active connect config, last-known connection, preferred gateway, or manual host), so reconnecting installs no longer get prompted to connect again. (#38964) Thanks @ngutman.
 
 ## 2026.3.2
 

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -66,6 +66,23 @@ struct RootCanvas: View {
         return .none
     }
 
+    static func shouldPresentQuickSetup(
+        quickSetupDismissed: Bool,
+        showOnboarding: Bool,
+        hasPresentedSheet: Bool,
+        gatewayConnected: Bool,
+        hasExistingGatewayConfig: Bool,
+        discoveredGatewayCount: Int) -> Bool
+    {
+        guard !quickSetupDismissed else { return false }
+        guard !showOnboarding else { return false }
+        guard !hasPresentedSheet else { return false }
+        guard !gatewayConnected else { return false }
+        // If a gateway target is already configured (manual or last-known), skip quick setup.
+        guard !hasExistingGatewayConfig else { return false }
+        return discoveredGatewayCount > 0
+    }
+
     var body: some View {
         ZStack {
             CanvasContent(
@@ -220,7 +237,12 @@ struct RootCanvas: View {
     }
 
     private func hasExistingGatewayConfig() -> Bool {
+        if self.appModel.activeGatewayConnectConfig != nil { return true }
         if GatewaySettingsStore.loadLastGatewayConnection() != nil { return true }
+
+        let preferredStableID = self.preferredGatewayStableID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !preferredStableID.isEmpty { return true }
+
         let manualHost = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
         return self.manualGatewayEnabled && !manualHost.isEmpty
     }
@@ -240,11 +262,14 @@ struct RootCanvas: View {
     }
 
     private func maybeShowQuickSetup() {
-        guard !self.quickSetupDismissed else { return }
-        guard !self.showOnboarding else { return }
-        guard self.presentedSheet == nil else { return }
-        guard self.appModel.gatewayServerName == nil else { return }
-        guard !self.gatewayController.gateways.isEmpty else { return }
+        let shouldPresent = Self.shouldPresentQuickSetup(
+            quickSetupDismissed: self.quickSetupDismissed,
+            showOnboarding: self.showOnboarding,
+            hasPresentedSheet: self.presentedSheet != nil,
+            gatewayConnected: self.appModel.gatewayServerName != nil,
+            hasExistingGatewayConfig: self.hasExistingGatewayConfig(),
+            discoveredGatewayCount: self.gatewayController.gateways.count)
+        guard shouldPresent else { return }
         self.presentedSheet = .quickSetup
     }
 }

--- a/apps/ios/Tests/RootCanvasPresentationTests.swift
+++ b/apps/ios/Tests/RootCanvasPresentationTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import OpenClaw
+
+@Suite struct RootCanvasPresentationTests {
+    @Test func quickSetupDoesNotPresentWhenGatewayAlreadyConfigured() {
+        let shouldPresent = RootCanvas.shouldPresentQuickSetup(
+            quickSetupDismissed: false,
+            showOnboarding: false,
+            hasPresentedSheet: false,
+            gatewayConnected: false,
+            hasExistingGatewayConfig: true,
+            discoveredGatewayCount: 1)
+
+        #expect(!shouldPresent)
+    }
+
+    @Test func quickSetupPresentsForFreshInstallWithDiscoveredGateway() {
+        let shouldPresent = RootCanvas.shouldPresentQuickSetup(
+            quickSetupDismissed: false,
+            showOnboarding: false,
+            hasPresentedSheet: false,
+            gatewayConnected: false,
+            hasExistingGatewayConfig: false,
+            discoveredGatewayCount: 1)
+
+        #expect(shouldPresent)
+    }
+
+    @Test func quickSetupDoesNotPresentWhenAlreadyConnected() {
+        let shouldPresent = RootCanvas.shouldPresentQuickSetup(
+            quickSetupDismissed: false,
+            showOnboarding: false,
+            hasPresentedSheet: false,
+            gatewayConnected: true,
+            hasExistingGatewayConfig: false,
+            discoveredGatewayCount: 1)
+
+        #expect(!shouldPresent)
+    }
+}


### PR DESCRIPTION
## Summary
- prevent the Quick Setup sheet from showing when a gateway is already configured
- treat active connect config, last-known connection, preferred stable ID, and manual host config as existing gateway config
- add focused presentation tests for the Quick Setup decision path

## What changed
- `apps/ios/Sources/RootCanvas.swift`
  - added `shouldPresentQuickSetup(...)` helper to centralize presentation logic
  - updated `maybeShowQuickSetup()` to gate on `hasExistingGatewayConfig()`
  - expanded `hasExistingGatewayConfig()` to include active and persisted gateway config signals
- `apps/ios/Tests/RootCanvasPresentationTests.swift`
  - added tests covering:
    - configured gateway -> no quick setup
    - fresh install + discovered gateway -> quick setup shown
    - connected gateway -> no quick setup

## Validation
- Attempted:
  - `cd apps/ios && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:OpenClawTests/RootCanvasPresentationTests test`
- Result:
  - build currently fails in unrelated existing test code (`apps/ios/Tests/GatewayConnectionSecurityTests.swift`) with MainActor isolation compile errors.
