### PR TITLE
fix(imessage): strip [[reply_to:...]] directive tags before delivery

### DIFF
--- a/src/imessage/monitor/sanitize-outbound.test.ts
+++ b/src/imessage/monitor/sanitize-outbound.test.ts
@@ -61,4 +61,19 @@ describe("sanitizeOutboundText", () => {
     expect(result).not.toMatch(/assistant to=final/i);
     expect(result).toContain("Actual reply");
   });
+
+  it("strips [[reply_to_current]] directive tag", () => {
+    const text = "[[reply_to_current]] Hello from iMessage!";
+    expect(sanitizeOutboundText(text)).toBe("Hello from iMessage!");
+  });
+
+  it("strips [[reply_to:<id>]] directive tag with message id", () => {
+    const text = "[[reply_to:1234567890]] Thanks for your message.";
+    expect(sanitizeOutboundText(text)).toBe("Thanks for your message.");
+  });
+
+  it("strips inline directive tags while preserving surrounding content", () => {
+    const text = "[[reply_to_current]]Here is your answer: 42";
+    expect(sanitizeOutboundText(text)).toBe("Here is your answer: 42");
+  });
 });

--- a/src/imessage/monitor/sanitize-outbound.ts
+++ b/src/imessage/monitor/sanitize-outbound.ts
@@ -1,4 +1,5 @@
 import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-visible-text.js";
+import { stripInlineDirectiveTagsForDisplay } from "../../utils/directive-tags.js";
 
 /**
  * Patterns that indicate assistant-internal metadata leaked into text.
@@ -10,7 +11,8 @@ const ROLE_TURN_MARKER_RE = /\b(?:user|system|assistant)\s*:\s*$/gm;
 
 /**
  * Strip all assistant-internal scaffolding from outbound text before delivery.
- * Applies reasoning/thinking tag removal, memory tag removal, and
+ * Applies reasoning/thinking tag removal, memory tag removal,
+ * inline directive tag removal ([[reply_to:...]], [[audio:...]]), and
  * model-specific internal separator stripping.
  */
 export function sanitizeOutboundText(text: string): string {
@@ -19,6 +21,10 @@ export function sanitizeOutboundText(text: string): string {
   }
 
   let cleaned = stripAssistantInternalScaffolding(text);
+
+  // Strip [[reply_to:...]] and [[audio:...]] inline directive tags so they
+  // are never delivered as raw text to the user (e.g. via iMessage).
+  cleaned = stripInlineDirectiveTagsForDisplay(cleaned).text;
 
   cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
   cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");


### PR DESCRIPTION
## Summary

Fixes #38578

When an agent reply begins with a `[[reply_to_current]]` or `[[reply_to:<id>]]` inline directive tag, the tag is used by OpenClaw's routing layer to thread the reply — but the tag itself must **not** appear in the delivered message text.

The iMessage delivery path calls `sanitizeOutboundText` in `sanitize-outbound.ts`, which strips thinking/reasoning tags, memory tags, and internal separator patterns. However, it did **not** strip inline directive tags (`[[reply_to:...]]`, `[[audio:...]]`), so those tags leaked through as raw plain text visible on the recipient's iPhone.

## Fix

Add a call to `stripInlineDirectiveTagsForDisplay` (from `src/utils/directive-tags.ts`) inside `sanitizeOutboundText`, applied immediately after `stripAssistantInternalScaffolding` and before the existing regex-based cleanup passes.

## Tests

Added 3 new test cases to `sanitize-outbound.test.ts`:
- `[[reply_to_current]]` stripped from message start
- `[[reply_to:<id>]]` with numeric id stripped
- Tag stripped while preserving surrounding content

All 14 tests in `sanitize-outbound.test.ts` pass. All 48 tests in `src/imessage/monitor/` pass.