### PR TITLE
fix(discord): use globalThis singleton for component registry Maps

### DIFF
--- a/src/discord/components-registry.ts
+++ b/src/discord/components-registry.ts
@@ -2,8 +2,29 @@ import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
 const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
 
-const componentEntries = new Map<string, DiscordComponentEntry>();
-const modalEntries = new Map<string, DiscordModalEntry>();
+const COMPONENT_KEY = "__openclaw_discord_component_entries";
+const MODAL_KEY = "__openclaw_discord_modal_entries";
+
+// Use globalThis singletons so every bundle chunk shares the same Map.
+// Without this, the build can produce multiple copies of this module in
+// different output chunks, each with its own module-scoped Map.  The send
+// path registers entries in one Map while the interaction handler looks
+// them up in another, causing buttons to appear "expired" immediately.
+function getComponentEntries(): Map<string, DiscordComponentEntry> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (!g[COMPONENT_KEY]) {
+    g[COMPONENT_KEY] = new Map<string, DiscordComponentEntry>();
+  }
+  return g[COMPONENT_KEY] as Map<string, DiscordComponentEntry>;
+}
+
+function getModalEntries(): Map<string, DiscordModalEntry> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (!g[MODAL_KEY]) {
+    g[MODAL_KEY] = new Map<string, DiscordModalEntry>();
+  }
+  return g[MODAL_KEY] as Map<string, DiscordModalEntry>;
+}
 
 function isExpired(entry: { expiresAt?: number }, now: number) {
   return typeof entry.expiresAt === "number" && entry.expiresAt <= now;
@@ -33,7 +54,7 @@ export function registerDiscordComponentEntries(params: {
       now,
       ttlMs,
     );
-    componentEntries.set(entry.id, normalized);
+    getComponentEntries().set(entry.id, normalized);
   }
   for (const modal of params.modals) {
     const normalized = normalizeEntryTimestamps(
@@ -41,7 +62,7 @@ export function registerDiscordComponentEntries(params: {
       now,
       ttlMs,
     );
-    modalEntries.set(modal.id, normalized);
+    getModalEntries().set(modal.id, normalized);
   }
 }
 
@@ -49,17 +70,18 @@ export function resolveDiscordComponentEntry(params: {
   id: string;
   consume?: boolean;
 }): DiscordComponentEntry | null {
-  const entry = componentEntries.get(params.id);
+  const entries = getComponentEntries();
+  const entry = entries.get(params.id);
   if (!entry) {
     return null;
   }
   const now = Date.now();
   if (isExpired(entry, now)) {
-    componentEntries.delete(params.id);
+    entries.delete(params.id);
     return null;
   }
   if (params.consume !== false) {
-    componentEntries.delete(params.id);
+    entries.delete(params.id);
   }
   return entry;
 }
@@ -68,22 +90,23 @@ export function resolveDiscordModalEntry(params: {
   id: string;
   consume?: boolean;
 }): DiscordModalEntry | null {
-  const entry = modalEntries.get(params.id);
+  const modals = getModalEntries();
+  const entry = modals.get(params.id);
   if (!entry) {
     return null;
   }
   const now = Date.now();
   if (isExpired(entry, now)) {
-    modalEntries.delete(params.id);
+    modals.delete(params.id);
     return null;
   }
   if (params.consume !== false) {
-    modalEntries.delete(params.id);
+    modals.delete(params.id);
   }
   return entry;
 }
 
 export function clearDiscordComponentEntries(): void {
-  componentEntries.clear();
-  modalEntries.clear();
+  getComponentEntries().clear();
+  getModalEntries().clear();
 }


### PR DESCRIPTION
## Summary

- **Problem:** Discord components (buttons) sent via the `message` tool report "This component has expired" immediately when clicked, even with `reusable: true` and within the TTL window.
- **Why it matters:** All button-based Discord interactions are broken — users cannot click any components sent by agents.
- **What changed:** Replaced module-scoped `componentEntries` and `modalEntries` Maps in `src/discord/components-registry.ts` with `globalThis` singletons so all bundle chunks share the same registry.
- **What did NOT change:** Component registration/resolution logic, TTL handling, expiration behavior.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue

- Fixes #30772

## User-visible / Behavior Changes

- Discord buttons sent via the `message` tool will now work correctly when clicked
- Components remain valid for their configured TTL (default 30 minutes)

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Root Cause

The build produces multiple copies of `components-registry.ts` in different output chunks:
- `send-D7vrI6SY.js` (used by the send path)
- `shared-Rg_TF0Yf.js` (used by the interaction handler)

Each copy has its own module-scoped `Map`, so registration (send path) writes to Map A while lookup (interaction handler) reads from Map B (always empty).

## Fix

Use `globalThis` keys so all bundle copies share the same Map instance:
```typescript
const COMPONENT_KEY = "__openclaw_discord_component_entries";
function getComponentEntries(): Map<string, DiscordComponentEntry> {
  const g = globalThis as unknown as Record<string, unknown>;
  if (!g[COMPONENT_KEY]) {
    g[COMPONENT_KEY] = new Map();
  }
  return g[COMPONENT_KEY] as Map<string, DiscordComponentEntry>;
}
```

## Production Validation (Field Report)

We hit this exact issue in production and applied this fix as a local hotfix on our deployment (v2026.2.26):

**Environment:** VPS, 3 agents (main + 2 secondary), Discord channel with components v2 buttons (approval flows, batch actions, interactive controls).

**Results after 48+ hours:**
- ✅ Buttons remain functional across gateway restarts — previously expired immediately on first click
- ✅ `reusable: true` buttons persist correctly until TTL expiry
- ✅ Component interactions route properly to the originating agent
- ✅ No regressions observed in any other functionality

**Root cause confirmation:** The module-reload orphaning of `Map` instances was exactly the issue. `globalThis` singleton approach is the correct fix.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

Low risk — the `globalThis` pattern is well-established for cross-bundle singletons in Node.js.

---

*Split from #30789 per feedback in #38940 — one bug per PR for easier review.*