### PR TITLE
fix(agents): treat Anthropic 402 as rate_limit instead of billing

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -287,6 +287,26 @@ describe("failover-error", () => {
     expect(err?.provider).toBe("anthropic");
   });
 
+  it("treats Anthropic 402 as rate_limit instead of billing (#30484)", () => {
+    expect(
+      resolveFailoverReasonFromError({ status: 402 }, { provider: "anthropic" }),
+    ).toBe("rate_limit");
+    // Non-Anthropic 402 should still be billing
+    expect(resolveFailoverReasonFromError({ status: 402 })).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({ status: 402 }, { provider: "openai" }),
+    ).toBe("billing");
+  });
+
+  it("coerces Anthropic 402 to rate_limit failover error", () => {
+    const err = coerceToFailoverError(
+      { status: 402, message: "Payment Required" },
+      { provider: "anthropic", model: "claude-opus-4-6" },
+    );
+    expect(err?.reason).toBe("rate_limit");
+    expect(err?.provider).toBe("anthropic");
+  });
+
   it("403 permission_error returns auth_permanent", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -148,12 +148,21 @@ export function isTimeoutError(err: unknown): boolean {
   return hasTimeoutHint(cause) || hasTimeoutHint(reason);
 }
 
-export function resolveFailoverReasonFromError(err: unknown): FailoverReason | null {
+export function resolveFailoverReasonFromError(
+  err: unknown,
+  context?: { provider?: string },
+): FailoverReason | null {
   if (isFailoverError(err)) {
     return err.reason;
   }
 
   const status = getStatusCode(err);
+
+  // Anthropic Claude Max plan uses HTTP 402 for rate limits, not billing.
+  if (status === 402 && context?.provider?.toLowerCase().trim() === "anthropic") {
+    return "rate_limit";
+  }
+
   const message = getErrorMessage(err);
   const statusReason = classifyFailoverReasonFromHttpStatus(status, message);
   if (statusReason) {
@@ -185,7 +194,10 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   return classifyFailoverReason(message);
 }
 
-export function describeFailoverError(err: unknown): {
+export function describeFailoverError(
+  err: unknown,
+  context?: { provider?: string },
+): {
   message: string;
   reason?: FailoverReason;
   status?: number;
@@ -202,7 +214,7 @@ export function describeFailoverError(err: unknown): {
   const message = getErrorMessage(err) || String(err);
   return {
     message,
-    reason: resolveFailoverReasonFromError(err) ?? undefined,
+    reason: resolveFailoverReasonFromError(err, context) ?? undefined,
     status: getStatusCode(err),
     code: getErrorCode(err),
   };
@@ -219,7 +231,7 @@ export function coerceToFailoverError(
   if (isFailoverError(err)) {
     return err;
   }
-  const reason = resolveFailoverReasonFromError(err);
+  const reason = resolveFailoverReasonFromError(err, context);
   if (!reason) {
     return null;
   }


### PR DESCRIPTION
## Summary

- **Problem:** Anthropic's Claude Max plan returns HTTP 402 for rate/usage limits, not insufficient credits. OpenClaw classifies this as a billing error, showing a scary warning and skipping retry/backoff.
- **Why it matters:** Claude Max users see false billing error warnings and miss automatic retry behavior they should get.
- **What changed:** Added provider context to `resolveFailoverReasonFromError` and `coerceToFailoverError` so Anthropic 402 responses trigger `rate_limit` classification instead of `billing`.
- **What did NOT change:** 402 handling for all other providers remains `billing`. Existing message-based heuristics in `classifyFailoverReasonFromHttpStatus` are unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue

- Fixes #30484

## User-visible / Behavior Changes

- Anthropic Claude Max 402 responses now trigger retry/backoff instead of billing error warnings
- No change for non-Anthropic providers

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Approach

The existing `classifyFailoverReasonFromHttpStatus` already has message-based heuristics for 402 ("try again", "retry", "temporary"), but Anthropic's 402 responses don't always contain those keywords. This fix adds explicit provider-based detection as an early check in `resolveFailoverReasonFromError`, before the generic message-based classification.

```typescript
// Anthropic Claude Max plan uses HTTP 402 for rate limits, not billing.
if (status === 402 && context?.provider?.toLowerCase().trim() === "anthropic") {
  return "rate_limit";
}
```

## Tests

- `resolveFailoverReasonFromError` with Anthropic provider context returns `rate_limit` for 402
- Non-Anthropic 402 still returns `billing`
- `coerceToFailoverError` with Anthropic provider context produces `rate_limit` failover error

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

Low risk — provider check is narrowly scoped to Anthropic only. All other providers retain existing 402→billing behavior.

---

*Split from #30789 per feedback in #38940 — one bug per PR for easier review.*