### PR TITLE
fix(outbound): ignore empty legacy message targets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12342,21 +12342,21 @@
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "0091061a3babbe6f11d48aa0142e22341b3ea446",
         "is_verified": false,
-        "line_number": 665
+        "line_number": 700
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
         "is_verified": false,
-        "line_number": 811
+        "line_number": 846
       },
       {
         "type": "Secret Keyword",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 1490
+        "line_number": 1525
       }
     ],
     "src/agents/sandbox/browser.novnc-url.test.ts": [
@@ -14725,5 +14725,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T11:12:54Z"
+  "generated_at": "2026-03-07T15:58:21Z"
 }

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -38,7 +38,7 @@ def maybe_decode_hex_keychain_secret(value)
 
     # `security find-generic-password -w` can return hex when the stored secret
     # includes newlines/non-printable bytes (like PEM files).
-    if decoded.include?("BEGIN PRIVATE KEY") || decoded.include?("END PRIVATE KEY")
+    if decoded.include?("BEGIN PRIVATE KEY") || decoded.include?("END PRIVATE KEY") # pragma: allowlist secret
       UI.message("Decoded hex-encoded ASC key content from Keychain.")
       return decoded
     end

--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -11,8 +11,9 @@ export function applyTargetToParams(params: {
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo = typeof params.args.to === "string";
-  const hasLegacyChannelId = typeof params.args.channelId === "string";
+  const hasLegacyTo = typeof params.args.to === "string" && params.args.to.trim().length > 0;
+  const hasLegacyChannelId =
+    typeof params.args.channelId === "string" && params.args.channelId.trim().length > 0;
   const mode =
     MESSAGE_ACTION_TARGET_MODE[params.action as keyof typeof MESSAGE_ACTION_TARGET_MODE] ?? "none";
 

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -17,6 +17,23 @@ describe("normalizeMessageActionInput", () => {
     expect("channelId" in normalized).toBe(false);
   });
 
+  it("ignores empty legacy target fields when explicit target is present", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        channel: "telegram",
+        target: "1214056829",
+        to: " ",
+        channelId: "",
+        filePath: "/workspace/example.png",
+      },
+    });
+
+    expect(normalized.target).toBe("1214056829");
+    expect(normalized.to).toBe("1214056829");
+    expect(normalized.channelId).toBe("");
+  });
+
   it("maps legacy target fields into canonical target", () => {
     const normalized = normalizeMessageActionInput({
       action: "send",


### PR DESCRIPTION
## Summary

`message(action=send)` can reject valid `target`-based sends with `Use target instead of to/channelId` when a wrapper passes empty-string defaults for `to` or `channelId`. `applyTargetToParams()` was treating any string-typed legacy field as present, even when the value was empty.

This narrows the legacy-param check to non-empty strings and adds a regression test covering explicit `target` with empty `to`/`channelId` defaults.

The PR also carries a small CI unblock: the current Fastlane keychain helper triggers a `detect-secrets` false positive on `BEGIN PRIVATE KEY`, and full scans refresh three stale line numbers in `.secrets.baseline`. I added the inline allowlist comment recommended by `detect-secrets` and refreshed those baseline entries so the `secrets` job can complete.

## Testing

- `pnpm test src/infra/outbound/message-action-normalization.test.ts`
- `pnpm test src/infra/outbound/message-action-runner.test.ts`
- `pnpm build`
- `pnpm check`
- `pnpm test`
- `pre-commit run detect-secrets --files apps/ios/fastlane/Fastfile`
- `pre-commit run --all-files detect-secrets`
- `pre-commit run --all-files detect-private-key`

Fixes #38830