### PR TITLE
feat(agents): add workspaceConfig.allowedExternalPaths for trusted symlinked workspace files

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -41,6 +41,32 @@ workspace and seed the bootstrap files if they are missing.
 Sandbox seed copies only accept regular in-workspace files; symlink/hardlink
 aliases that resolve outside the source workspace are ignored.
 
+### Sharing context files across agents with symlinks
+
+In multi-agent deployments you can share a common `AGENTS.md` or `USER.md`
+across agents by symlinking them into each agent workspace:
+
+```bash
+ln -s /home/clawd/shared/AGENTS.md ~/.openclaw/workspace-myagent/AGENTS.md
+```
+
+By default, symlinks that resolve outside the workspace are rejected for
+security. Enable them explicitly with
+`agents.defaults.workspaceConfig.allowedExternalPaths`:
+
+```json5
+{
+  agents: {
+    defaults: {
+      workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared/"] },
+    },
+  },
+}
+```
+
+See [`agents.defaults.workspaceConfig.allowedExternalPaths`](/gateway/configuration-reference#agentsdefaultsworkspaceconfigallowedexternalpaths)
+for full details and security model.
+
 If you already manage the workspace files yourself, you can disable bootstrap
 file creation:
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -776,6 +776,45 @@ Optional repository root shown in the system prompt's Runtime line. If unset, Op
 }
 ```
 
+### `agents.defaults.workspaceConfig.allowedExternalPaths`
+
+Allowlist of absolute directory paths. Symlinked workspace context files (e.g. `AGENTS.md`, `USER.md`) whose `realpath()` resolves within one of these prefixes are permitted for both reads and writes. By default all symlinks pointing outside the workspace are rejected.
+
+**Requirements:**
+
+- Entries must be **absolute paths**. Relative paths are silently ignored because the check is performed against the fully-resolved `realpath()` of the symlink target.
+- Trailing slash is optional (`/home/clawd/shared` and `/home/clawd/shared/` are treated identically).
+
+**Security model:**
+
+- Opt-in: omitting this field preserves the existing behaviour (all external symlinks rejected).
+- The full symlink chain is resolved via `realpath()` before checking, so intermediate symlinks cannot bypass the allowlist.
+- In-workspace symlinks that point to a _different_ file within the workspace are always read-only (writes are rejected to prevent aliasing attacks).
+
+Per-agent `workspaceConfig.allowedExternalPaths` entries are **merged** (unioned) with the defaults — they do not replace them.
+
+```json5
+{
+  agents: {
+    defaults: {
+      workspaceConfig: {
+        // Allow all agents to read and write files symlinked into /home/clawd/shared/
+        allowedExternalPaths: ["/home/clawd/shared/"],
+      },
+    },
+    list: [
+      {
+        id: "myagent",
+        workspaceConfig: {
+          // This agent additionally allows its own private shared dir
+          allowedExternalPaths: ["/home/clawd/myagent-shared/"],
+        },
+      },
+    ],
+  },
+}
+```
+
 ### `agents.defaults.skipBootstrap`
 
 Disables automatic creation of workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`).

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -5,13 +5,14 @@ const cache = new Map<string, WorkspaceBootstrapFile[]>();
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
+  allowedExternalPaths?: string[];
 }): Promise<WorkspaceBootstrapFile[]> {
   const existing = cache.get(params.sessionKey);
   if (existing) {
     return existing;
   }
 
-  const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
+  const files = await loadWorkspaceBootstrapFiles(params.workspaceDir, params.allowedExternalPaths);
   cache.set(params.sessionKey, files);
   return files;
 }

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,4 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { listAgentEntries } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -12,6 +14,22 @@ import {
   loadWorkspaceBootstrapFiles,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
+
+/** Merge default + per-agent allowedExternalPaths (union, no duplicates). */
+function resolveAllowedExternalPaths(
+  config: OpenClawConfig | undefined,
+  agentId: string | undefined,
+): string[] {
+  const defaults = config?.agents?.defaults?.workspaceConfig?.allowedExternalPaths ?? [];
+  if (!agentId) {
+    return defaults;
+  }
+  const agentEntry = listAgentEntries(config ?? {}).find(
+    (e) => normalizeAgentId(e.id) === normalizeAgentId(agentId),
+  );
+  const perAgent = agentEntry?.workspaceConfig?.allowedExternalPaths ?? [];
+  return [...new Set([...defaults, ...perAgent])];
+}
 
 export type BootstrapContextMode = "full" | "lightweight";
 export type BootstrapContextRunKind = "default" | "heartbeat" | "cron";
@@ -72,12 +90,14 @@ export async function resolveBootstrapFilesForRun(params: {
   runKind?: BootstrapContextRunKind;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
+  const allowedExternalPaths = resolveAllowedExternalPaths(params.config, params.agentId);
   const rawFiles = params.sessionKey
     ? await getOrLoadBootstrapFiles({
         workspaceDir: params.workspaceDir,
         sessionKey: params.sessionKey,
+        allowedExternalPaths,
       })
-    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+    : await loadWorkspaceBootstrapFiles(params.workspaceDir, allowedExternalPaths);
   const bootstrapFiles = applyContextModeFilter({
     files: filterBootstrapFilesForSession(rawFiles, sessionKey),
     contextMode: params.contextMode,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -108,6 +108,7 @@ export async function runCliAgent(params: {
   const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
     workspaceDir,
     config: params.config,
+    agentId: params.agentId,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -369,11 +369,18 @@ export async function compactEmbeddedPiSessionDirect(
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
+    // Resolve agentId early so resolveBootstrapContextForRun can apply per-agent
+    // allowedExternalPaths when loading bootstrap files for this session.
+    const { sessionAgentId: bootstrapAgentId } = resolveSessionAgentIds({
+      sessionKey: params.sessionKey,
+      config: params.config,
+    });
     const { contextFiles } = await resolveBootstrapContextForRun({
       workspaceDir: effectiveWorkspace,
       config: params.config,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
+      agentId: bootstrapAgentId,
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
     const runAbortController = new AbortController();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -794,6 +794,7 @@ export async function runEmbeddedAttempt(
       await resolveBootstrapContextForRun({
         workspaceDir: effectiveWorkspace,
         config: params.config,
+        agentId: params.agentId,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -108,4 +108,42 @@ describe("loadExtraBootstrapFiles", () => {
     expect(files).toHaveLength(0);
     expect(diagnostics.some((d) => d.reason === "security")).toBe(true);
   });
+
+  it("reads symlinked extra bootstrap files when target is within allowedExternalPaths", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const rootDir = await createWorkspaceDir("symlink-allowed");
+    const workspaceDir = path.join(rootDir, "workspace");
+    const externalDir = path.join(rootDir, "external");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(externalDir, { recursive: true });
+    await fs.writeFile(path.join(externalDir, "TOOLS.md"), "external tools", "utf-8");
+    await fs.symlink(path.join(externalDir, "TOOLS.md"), path.join(workspaceDir, "TOOLS.md"));
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["TOOLS.md"], [externalDir]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.name).toBe("TOOLS.md");
+    expect(files[0]?.content).toBe("external tools");
+  });
+
+  it("rejects symlinked extra bootstrap files when allowedExternalPaths is not set", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const rootDir = await createWorkspaceDir("symlink-rejected");
+    const workspaceDir = path.join(rootDir, "workspace");
+    const externalDir = path.join(rootDir, "external");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(externalDir, { recursive: true });
+    await fs.writeFile(path.join(externalDir, "TOOLS.md"), "external tools", "utf-8");
+    await fs.symlink(path.join(externalDir, "TOOLS.md"), path.join(workspaceDir, "TOOLS.md"));
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["TOOLS.md"]);
+
+    expect(files).toHaveLength(0);
+  });
 });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -221,6 +221,87 @@ describe("loadWorkspaceBootstrapFiles", () => {
       await fs.rm(rootDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects symlinked bootstrap files pointing outside workspace without allowedExternalPaths", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-reject-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(
+        path.join(outsideDir, DEFAULT_AGENTS_FILENAME),
+        "external agents",
+        "utf-8",
+      );
+      await fs.symlink(
+        path.join(outsideDir, DEFAULT_AGENTS_FILENAME),
+        path.join(workspaceDir, DEFAULT_AGENTS_FILENAME),
+      );
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(true);
+      expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads symlinked bootstrap files when target is within allowedExternalPaths", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-allow-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "shared");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(outsideDir, DEFAULT_AGENTS_FILENAME), "shared agents", "utf-8");
+      await fs.symlink(
+        path.join(outsideDir, DEFAULT_AGENTS_FILENAME),
+        path.join(workspaceDir, DEFAULT_AGENTS_FILENAME),
+      );
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir, [outsideDir]);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(false);
+      expect(agents?.content).toBe("shared agents");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects symlinked bootstrap files when target is outside allowedExternalPaths", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-wrong-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "untrusted");
+      const allowedDir = path.join(rootDir, "trusted");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.mkdir(allowedDir, { recursive: true });
+      await fs.writeFile(path.join(outsideDir, DEFAULT_AGENTS_FILENAME), "untrusted", "utf-8");
+      await fs.symlink(
+        path.join(outsideDir, DEFAULT_AGENTS_FILENAME),
+        path.join(workspaceDir, DEFAULT_AGENTS_FILENAME),
+      );
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir, [allowedDir]);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(true);
+      expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("filterBootstrapFilesForSession", () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -276,6 +276,33 @@ describe("loadWorkspaceBootstrapFiles", () => {
     }
   });
 
+  it("ignores relative allowedExternalPaths entries — relative prefix must not grant access", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-relpath-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const sharedDir = path.join(rootDir, "shared");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(sharedDir, { recursive: true });
+      await fs.writeFile(path.join(sharedDir, DEFAULT_AGENTS_FILENAME), "shared content", "utf-8");
+      await fs.symlink(
+        path.join(sharedDir, DEFAULT_AGENTS_FILENAME),
+        path.join(workspaceDir, DEFAULT_AGENTS_FILENAME),
+      );
+
+      // Pass a relative path (should be ignored — relative paths are misconfiguration)
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir, ["./shared", "../shared"]);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      // Must be missing/rejected, not permitted
+      expect(agents?.missing).toBe(true);
+      expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects symlinked bootstrap files when target is outside allowedExternalPaths", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -54,9 +54,17 @@ function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): strin
   return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
 }
 
-/** Return true if realPath is within at least one of the allowed prefix directories. */
+/** Return true if realPath is within at least one of the allowed prefix directories.
+ *
+ * Relative prefixes are silently skipped — they would be resolved against
+ * process.cwd(), making the trust boundary dependent on the gateway's startup
+ * directory rather than explicit operator intent.
+ */
 function isWithinAllowedExternalPath(realPath: string, prefixes: string[]): boolean {
   return prefixes.some((prefix) => {
+    if (!path.isAbsolute(prefix)) {
+      return false;
+    }
     const rel = path.relative(prefix, realPath);
     return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
   });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
@@ -53,16 +54,62 @@ function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): strin
   return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
 }
 
+/** Return true if realPath is within at least one of the allowed prefix directories. */
+function isWithinAllowedExternalPath(realPath: string, prefixes: string[]): boolean {
+  return prefixes.some((prefix) => {
+    const rel = path.relative(prefix, realPath);
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  });
+}
+
 async function readWorkspaceFileWithGuards(params: {
   filePath: string;
   workspaceDir: string;
+  allowedExternalPaths?: string[];
 }): Promise<WorkspaceGuardedReadResult> {
-  const opened = await openBoundaryFile({
+  let opened = await openBoundaryFile({
     absolutePath: params.filePath,
     rootPath: params.workspaceDir,
     boundaryLabel: "workspace root",
     maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
   });
+
+  // Fallback: if boundary check rejected the file (symlink escaping workspace),
+  // check whether the symlink target is within operator-approved external paths.
+  if (
+    !opened.ok &&
+    opened.reason === "validation" &&
+    params.allowedExternalPaths &&
+    params.allowedExternalPaths.length > 0
+  ) {
+    try {
+      const lstat = await fs.lstat(params.filePath);
+      if (lstat.isSymbolicLink()) {
+        const realPath = await fs.realpath(params.filePath);
+        if (isWithinAllowedExternalPath(realPath, params.allowedExternalPaths)) {
+          // Target is operator-approved; open the resolved file directly with safety checks.
+          const fallback = openVerifiedFileSync({
+            filePath: realPath,
+            resolvedPath: realPath,
+            rejectHardlinks: true,
+            maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+          });
+          if (fallback.ok) {
+            opened = {
+              ok: true,
+              path: fallback.path,
+              fd: fallback.fd,
+              stat: fallback.stat,
+              rootRealPath: params.workspaceDir,
+            };
+          }
+        }
+      }
+    } catch {
+      // Fall through to the original failure.
+    }
+  }
+
   if (!opened.ok) {
     workspaceFileCache.delete(params.filePath);
     return opened;
@@ -495,7 +542,10 @@ async function resolveMemoryBootstrapEntries(
   return deduped;
 }
 
-export async function loadWorkspaceBootstrapFiles(dir: string): Promise<WorkspaceBootstrapFile[]> {
+export async function loadWorkspaceBootstrapFiles(
+  dir: string,
+  allowedExternalPaths?: string[],
+): Promise<WorkspaceBootstrapFile[]> {
   const resolvedDir = resolveUserPath(dir);
 
   const entries: Array<{
@@ -539,6 +589,7 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
     const loaded = await readWorkspaceFileWithGuards({
       filePath: entry.filePath,
       workspaceDir: resolvedDir,
+      allowedExternalPaths,
     });
     if (loaded.ok) {
       result.push({
@@ -575,14 +626,20 @@ export function filterBootstrapFilesForSession(
 export async function loadExtraBootstrapFiles(
   dir: string,
   extraPatterns: string[],
+  allowedExternalPaths?: string[],
 ): Promise<WorkspaceBootstrapFile[]> {
-  const loaded = await loadExtraBootstrapFilesWithDiagnostics(dir, extraPatterns);
+  const loaded = await loadExtraBootstrapFilesWithDiagnostics(
+    dir,
+    extraPatterns,
+    allowedExternalPaths,
+  );
   return loaded.files;
 }
 
 export async function loadExtraBootstrapFilesWithDiagnostics(
   dir: string,
   extraPatterns: string[],
+  allowedExternalPaths?: string[],
 ): Promise<{
   files: WorkspaceBootstrapFile[];
   diagnostics: ExtraBootstrapLoadDiagnostic[];
@@ -627,6 +684,7 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
     const loaded = await readWorkspaceFileWithGuards({
       filePath,
       workspaceDir: resolvedDir,
+      allowedExternalPaths,
     });
     if (loaded.ok) {
       files.push({

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -31,6 +31,7 @@ export async function resolveCommandsSystemPromptBundle(
   const { bootstrapFiles, contextFiles: injectedFiles } = await resolveBootstrapContextForRun({
     workspaceDir,
     config: params.cfg,
+    agentId: params.agentId,
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
   });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -140,8 +140,18 @@ export type AgentDefaultsConfig = {
     /**
      * Allowlist of absolute path prefixes. Symlinked workspace context files
      * whose realpath() resolves within one of these prefixes are permitted.
-     * Paths should end with '/' (e.g. '/home/clawd/shared/').
-     * Applies to all agents unless overridden per-agent (per-agent adds to, not replaces).
+     *
+     * Entries MUST be absolute paths (e.g. '/home/clawd/shared/'). Relative
+     * paths are NOT supported and will not match anything, because the
+     * comparison is performed against the fully-resolved realpath() of the
+     * symlink target.
+     *
+     * Trailing slash is optional but recommended for clarity
+     * (e.g. '/home/clawd/shared/' rather than '/home/clawd/shared').
+     * Either form is accepted; the check normalises before comparing.
+     *
+     * Applies to all agents unless overridden per-agent.
+     * Per-agent paths are unioned with (not replacing) these defaults.
      */
     allowedExternalPaths?: string[];
   };

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -132,6 +132,19 @@ export type AgentDefaultsConfig = {
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */
   workspace?: string;
+  /**
+   * Workspace security settings (distinct from the workspace directory path above).
+   * Controls which external paths symlinked context files may resolve into.
+   */
+  workspaceConfig?: {
+    /**
+     * Allowlist of absolute path prefixes. Symlinked workspace context files
+     * whose realpath() resolves within one of these prefixes are permitted.
+     * Paths should end with '/' (e.g. '/home/clawd/shared/').
+     * Applies to all agents unless overridden per-agent (per-agent adds to, not replaces).
+     */
+    allowedExternalPaths?: string[];
+  };
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -68,7 +68,12 @@ export type AgentConfig = {
    * Per-agent workspace security settings. Paths here are unioned with defaults.workspaceConfig.
    */
   workspaceConfig?: {
-    /** Additional allowed path prefixes for symlinked context files (merged with defaults). */
+    /**
+     * Additional allowed absolute path prefixes for symlinked context files.
+     * Merged (unioned) with defaults.workspaceConfig.allowedExternalPaths.
+     * Must be absolute paths — relative paths will not match. See defaults
+     * workspaceConfig.allowedExternalPaths for full semantics.
+     */
     allowedExternalPaths?: string[];
   };
   model?: AgentModelConfig;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -64,6 +64,13 @@ export type AgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
+  /**
+   * Per-agent workspace security settings. Paths here are unioned with defaults.workspaceConfig.
+   */
+  workspaceConfig?: {
+    /** Additional allowed path prefixes for symlinked context files (merged with defaults). */
+    allowedExternalPaths?: string[];
+  };
   model?: AgentModelConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -36,6 +36,12 @@ export const AgentDefaultsSchema = z
       )
       .optional(),
     workspace: z.string().optional(),
+    workspaceConfig: z
+      .object({
+        allowedExternalPaths: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -713,6 +713,12 @@ export const AgentEntrySchema = z
     name: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
+    workspaceConfig: z
+      .object({
+        allowedExternalPaths: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   loadConfigReturn: {} as Record<string, unknown>,
-  listAgentEntries: vi.fn(() => [] as Array<{ agentId: string }>),
+  listAgentEntries: vi.fn(
+    () => [] as Array<{ id: string; workspaceConfig?: { allowedExternalPaths?: string[] } }>,
+  ),
   findAgentEntryIndex: vi.fn(() => -1),
   applyAgentConfig: vi.fn((_cfg: unknown, _opts: unknown) => ({})),
   pruneAgentConfig: vi.fn(() => ({ config: {}, removedBindings: 0 })),
@@ -675,4 +677,235 @@ describe("agents.files.get/set symlink safety", () => {
       }
     },
   );
+});
+
+describe("agents.files.get allowedExternalPaths", () => {
+  const workspace = "/workspace/test-agent";
+  const candidate = path.resolve(workspace, "AGENTS.md");
+  const externalTarget = "/home/clawd/shared/context.md";
+  const externalTargetStat = makeFileStat({ size: 42, mtimeMs: 9999 });
+
+  function setupExternalSymlink(target: string, targetStat?: ReturnType<typeof makeFileStat>) {
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      if (p === candidate) {
+        return target;
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return makeSymlinkStat();
+      }
+      // readLocalFileSafely also calls lstat on the resolved (real) path.
+      if (targetStat && p === target) {
+        return targetStat;
+      }
+      throw createEnoentError();
+    });
+    if (targetStat) {
+      mocks.fsStat.mockImplementation(async (...args: unknown[]) => {
+        const p = typeof args[0] === "string" ? args[0] : "";
+        if (p === target) {
+          return targetStat;
+        }
+        throw createEnoentError();
+      });
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfigReturn = {};
+    mocks.fsMkdir.mockResolvedValue(undefined);
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => externalTargetStat,
+          readFile: async () => Buffer.from("shared content\n"),
+          truncate: async () => {},
+          writeFile: async () => {},
+          close: async () => {},
+        }) as unknown,
+    );
+  });
+
+  it("allows agents.files.get when symlink resolves within an allowed prefix", async () => {
+    setupExternalSymlink(externalTarget, externalTargetStat);
+    mocks.loadConfigReturn = {
+      agents: { defaults: { workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared/"] } } },
+    };
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        file: expect.objectContaining({ missing: false, content: "shared content\n" }),
+      }),
+      undefined,
+    );
+  });
+
+  it("rejects agents.files.get when symlink target is outside all allowed prefixes (target exists)", async () => {
+    setupExternalSymlink("/home/clawd/shared-other/secret.txt", externalTargetStat);
+    mocks.loadConfigReturn = {
+      agents: { defaults: { workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared/"] } } },
+    };
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+
+  it("rejects agents.files.get when symlink target exists but no allowedExternalPaths configured", async () => {
+    setupExternalSymlink(externalTarget, externalTargetStat);
+    mocks.loadConfigReturn = {};
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+
+  it("rejects agents.files.get when allowedExternalPaths is present but empty", async () => {
+    setupExternalSymlink(externalTarget, externalTargetStat);
+    mocks.loadConfigReturn = {
+      agents: { defaults: { workspaceConfig: { allowedExternalPaths: [] } } },
+    };
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+
+  it("resolves symlink chains fully and allows if final target is within prefix", async () => {
+    // Simulate symlink chain: AGENTS.md -> /tmp/link2 -> /home/clawd/shared/context.md
+    // fs.realpath() resolves the full chain to the final target.
+    const finalTarget = "/home/clawd/shared/context.md";
+    const finalStat = makeFileStat({ size: 55 });
+
+    setupExternalSymlink(finalTarget, finalStat);
+    mocks.loadConfigReturn = {
+      agents: { defaults: { workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared"] } } },
+    };
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => finalStat,
+          readFile: async () => Buffer.from("chain content\n"),
+          truncate: async () => {},
+          writeFile: async () => {},
+          close: async () => {},
+        }) as unknown,
+    );
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        file: expect.objectContaining({ missing: false, content: "chain content\n" }),
+      }),
+      undefined,
+    );
+  });
+
+  it("normalizes prefix without trailing slash to prevent collision attacks", async () => {
+    // '/home/clawd/shared' should NOT match '/home/clawd/shared-other/secret.txt'
+    setupExternalSymlink("/home/clawd/shared-other/secret.txt", externalTargetStat);
+    mocks.loadConfigReturn = {
+      // prefix without trailing slash: normalize to '/home/clawd/shared/'
+      agents: { defaults: { workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared"] } } },
+    };
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+
+  it("merges per-agent allowedExternalPaths with defaults", async () => {
+    setupExternalSymlink("/home/clawd/agent-only/doc.md", makeFileStat({ size: 10 }));
+    mocks.loadConfigReturn = {
+      agents: {
+        defaults: { workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared/"] } },
+        list: [
+          {
+            id: "main",
+            workspaceConfig: { allowedExternalPaths: ["/home/clawd/agent-only/"] },
+          },
+        ],
+      },
+    };
+    // listAgentEntries mock returns the per-agent config
+    mocks.listAgentEntries.mockReturnValue([
+      { id: "main", workspaceConfig: { allowedExternalPaths: ["/home/clawd/agent-only/"] } },
+    ]);
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => makeFileStat({ size: 10 }),
+          readFile: async () => Buffer.from("agent doc\n"),
+          truncate: async () => {},
+          writeFile: async () => {},
+          close: async () => {},
+        }) as unknown,
+    );
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        file: expect.objectContaining({ missing: false, content: "agent doc\n" }),
+      }),
+      undefined,
+    );
+  });
 });

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -909,3 +909,115 @@ describe("agents.files.get allowedExternalPaths", () => {
     );
   });
 });
+
+describe("agents.files.set allowedExternalPaths", () => {
+  const workspace = "/workspace/test-agent";
+  const candidate = path.resolve(workspace, "AGENTS.md");
+  const externalTarget = "/home/clawd/shared/AGENTS.md";
+  const externalTargetStat = makeFileStat({ size: 42, mtimeMs: 9999 });
+
+  function setupExternalSymlinkForSet(target: string, targetStat: ReturnType<typeof makeFileStat>) {
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      if (p === candidate) {
+        return target;
+      }
+      if (p === target) {
+        return target;
+      }
+      if (p === path.dirname(target)) {
+        return path.dirname(target);
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return makeSymlinkStat();
+      }
+      if (p === target) {
+        return targetStat;
+      }
+      throw createEnoentError();
+    });
+    mocks.fsStat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === target) {
+        return targetStat;
+      }
+      throw createEnoentError();
+    });
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => targetStat,
+          readFile: async () => Buffer.from(""),
+          truncate: async () => {},
+          writeFile: async () => {},
+          close: async () => {},
+        }) as unknown,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfigReturn = {};
+    mocks.fsMkdir.mockResolvedValue(undefined);
+  });
+
+  it("writes through an external symlink when target is within allowedExternalPaths", async () => {
+    setupExternalSymlinkForSet(externalTarget, externalTargetStat);
+    mocks.loadConfigReturn = {
+      agents: { defaults: { workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared/"] } } },
+    };
+
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "AGENTS.md",
+      content: "updated content",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({ ok: true }), undefined);
+  });
+
+  it("rejects agents.files.set when symlink target is outside allowedExternalPaths", async () => {
+    setupExternalSymlinkForSet("/home/clawd/other/secret.md", makeFileStat({ size: 10 }));
+    mocks.loadConfigReturn = {
+      agents: { defaults: { workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared/"] } } },
+    };
+
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "AGENTS.md",
+      content: "should be rejected",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+
+  it("rejects agents.files.set on external symlink when no allowedExternalPaths configured", async () => {
+    setupExternalSymlinkForSet(externalTarget, externalTargetStat);
+    mocks.loadConfigReturn = {};
+
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "AGENTS.md",
+      content: "should be rejected",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unsafe workspace file") }),
+    );
+  });
+});

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -646,6 +646,61 @@ describe("agents.files.get/set symlink safety", () => {
     );
   });
 
+  it("allows agents.files.set when only filename casing differs (case-insensitive filesystem)", async () => {
+    const workspace = "/workspace/test-agent";
+    // On-disk file is "memory.md" but request uses "MEMORY.md"
+    const candidate = path.resolve(workspace, "memory.md");
+    const fileStat = makeFileStat({ size: 10, mtimeMs: 1000, dev: 1, ino: 1 });
+
+    mocks.fsRealpath.mockImplementation(async (p: string) => {
+      if (p === workspace) {
+        return workspace;
+      }
+      // The real path resolves to the same file (not a symlink redirect)
+      if (p === path.resolve(workspace, "MEMORY.md")) {
+        return candidate;
+      }
+      return p;
+    });
+    mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate || p === path.resolve(workspace, "MEMORY.md")) {
+        return makeFileStat({ size: 10, mtimeMs: 1000, dev: 1, ino: 1 });
+      }
+      throw createEnoentError();
+    });
+    mocks.fsStat.mockImplementation(async (...args: unknown[]) => {
+      const p = typeof args[0] === "string" ? args[0] : "";
+      if (p === candidate) {
+        return fileStat;
+      }
+      throw createEnoentError();
+    });
+    mocks.fsOpen.mockImplementation(
+      async () =>
+        ({
+          stat: async () => fileStat,
+          readFile: async () => Buffer.from("content\n"),
+          truncate: async () => {},
+          writeFile: async () => {},
+          close: async () => {},
+        }) as unknown,
+    );
+
+    const setCall = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "MEMORY.md",
+      content: "updated\n",
+    });
+    await setCall.promise;
+    // Must succeed — case difference alone is not a symlink alias
+    expect(setCall.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true }),
+      undefined,
+    );
+  });
+
   function mockHardlinkedWorkspaceAlias() {
     const workspace = "/workspace/test-agent";
     const candidate = path.resolve(workspace, "AGENTS.md");

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -31,6 +31,7 @@ import { sameFileIdentity } from "../../infra/file-identity.js";
 import { SafeOpenError, readLocalFileSafely, writeFileWithinRoot } from "../../infra/fs-safe.js";
 import { assertNoPathAliasEscape } from "../../infra/path-alias-guards.js";
 import { isNotFoundPathError } from "../../infra/path-guards.js";
+import { logDebug } from "../../logger.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
 import {
@@ -248,6 +249,11 @@ async function resolveAgentWorkspaceFilePath(params: {
           "symlink target is outside workspace root (add the target directory to workspaceConfig.allowedExternalPaths to permit)",
       };
     }
+    if (!withinWorkspace) {
+      logDebug(
+        `[agents] symlink permitted: ${candidatePath} -> ${targetReal} (within allowedExternalPaths)`,
+      );
+    }
 
     let targetStat: Awaited<ReturnType<typeof fs.stat>>;
     try {
@@ -306,6 +312,9 @@ async function statFileSafely(
       if (!allowedExternalPaths || !isWithinAllowedPrefixes(realPath, allowedExternalPaths)) {
         return null;
       }
+      logDebug(
+        `[agents] symlink stat permitted: ${filePath} -> ${realPath} (within allowedExternalPaths)`,
+      );
       const realStat = await fs.stat(realPath);
       if (!realStat.isFile() || realStat.nlink > 1) {
         return null;

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -867,7 +867,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
       // files) but reject writes to prevent an agent from overwriting an arbitrary
       // workspace file via a symlink alias.
       const normalizedName = path.normalize(name);
-      if (relativeWritePath !== normalizedName) {
+      // Use case-insensitive comparison on platforms that may have case-insensitive
+      // filesystems (e.g. default macOS HFS+/APFS volumes). A request for "MEMORY.md"
+      // should be allowed when the in-workspace file is "memory.md". The security
+      // invariant (no symlink alias writes) is still enforced — only case variation
+      // is tolerated, not path traversal or cross-directory redirects.
+      if (relativeWritePath.toLowerCase() !== normalizedName.toLowerCase()) {
         respondWorkspaceFileUnsafe(respond, name);
         return;
       }

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -165,28 +165,43 @@ async function resolveWorkspaceRealPath(workspaceDir: string): Promise<string> {
   }
 }
 
+/** Normalize a path prefix to end with '/' to prevent prefix collisions. */
+function normalizePrefixPath(p: string): string {
+  return p.endsWith("/") ? p : `${p}/`;
+}
+
+/** Return true if realPath starts with at least one of the normalized prefixes. */
+function isWithinAllowedPrefixes(realPath: string, prefixes: string[]): boolean {
+  for (const prefix of prefixes) {
+    if (realPath.startsWith(normalizePrefixPath(prefix))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Merge default + per-agent allowedExternalPaths (union, no duplicates). */
+function resolveAllowedExternalPaths(
+  cfg: ReturnType<typeof loadConfig>,
+  agentId: string,
+): string[] {
+  const defaults = cfg.agents?.defaults?.workspaceConfig?.allowedExternalPaths ?? [];
+  const agentEntry = listAgentEntries(cfg).find(
+    (e) => normalizeAgentId(e.id) === normalizeAgentId(agentId),
+  );
+  const perAgent = agentEntry?.workspaceConfig?.allowedExternalPaths ?? [];
+  return [...new Set([...defaults, ...perAgent])];
+}
+
 async function resolveAgentWorkspaceFilePath(params: {
   workspaceDir: string;
   name: string;
   allowMissing: boolean;
+  allowedExternalPaths?: string[];
 }): Promise<ResolvedAgentWorkspaceFilePath> {
   const requestPath = path.join(params.workspaceDir, params.name);
   const workspaceReal = await resolveWorkspaceRealPath(params.workspaceDir);
   const candidatePath = path.resolve(workspaceReal, params.name);
-
-  try {
-    await assertNoPathAliasEscape({
-      absolutePath: candidatePath,
-      rootPath: workspaceReal,
-      boundaryLabel: "workspace root",
-    });
-  } catch (error) {
-    return {
-      kind: "invalid",
-      requestPath,
-      reason: error instanceof Error ? error.message : "path escapes workspace root",
-    };
-  }
 
   const notFoundContext = {
     allowMissing: params.allowMissing,
@@ -194,6 +209,8 @@ async function resolveAgentWorkspaceFilePath(params: {
     workspaceReal,
   } as const;
 
+  // Stat the candidate first so we can route symlinks through the allowedExternalPaths
+  // logic before assertNoPathAliasEscape (which would reject external symlinks outright).
   let candidateLstat: Awaited<ReturnType<typeof fs.lstat>>;
   try {
     candidateLstat = await fs.lstat(candidatePath);
@@ -206,6 +223,7 @@ async function resolveAgentWorkspaceFilePath(params: {
   }
 
   if (candidateLstat.isSymbolicLink()) {
+    // Fully resolve the symlink chain (handles symlink→symlink chains too).
     let targetReal: string;
     try {
       targetReal = await fs.realpath(candidatePath);
@@ -216,6 +234,21 @@ async function resolveAgentWorkspaceFilePath(params: {
         ioPath: candidatePath,
       });
     }
+
+    // Security check before stat: the resolved target must be within the workspace
+    // or within an operator-approved external prefix. This prevents reading external
+    // files even when they don't exist yet (target ENOENT would otherwise show as "missing").
+    const withinWorkspace = targetReal.startsWith(`${workspaceReal}/`);
+    const allowedPrefixes = params.allowedExternalPaths ?? [];
+    if (!withinWorkspace && !isWithinAllowedPrefixes(targetReal, allowedPrefixes)) {
+      return {
+        kind: "invalid",
+        requestPath,
+        reason:
+          "symlink target is outside workspace root (add the target directory to workspace.allowedExternalPaths to permit)",
+      };
+    }
+
     let targetStat: Awaited<ReturnType<typeof fs.stat>>;
     try {
       targetStat = await fs.stat(targetReal);
@@ -235,6 +268,21 @@ async function resolveAgentWorkspaceFilePath(params: {
     return { kind: "ready", requestPath, ioPath: targetReal, workspaceReal };
   }
 
+  // Non-symlink: run path-alias escape check to guard against directory traversal.
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: candidatePath,
+      rootPath: workspaceReal,
+      boundaryLabel: "workspace root",
+    });
+  } catch (error) {
+    return {
+      kind: "invalid",
+      requestPath,
+      reason: error instanceof Error ? error.message : "path escapes workspace root",
+    };
+  }
+
   if (!candidateLstat.isFile()) {
     return { kind: "invalid", requestPath, reason: "path is not a regular file" };
   }
@@ -246,10 +294,28 @@ async function resolveAgentWorkspaceFilePath(params: {
   return { kind: "ready", requestPath, ioPath: targetReal, workspaceReal };
 }
 
-async function statFileSafely(filePath: string): Promise<FileMeta | null> {
+async function statFileSafely(
+  filePath: string,
+  allowedExternalPaths?: string[],
+): Promise<FileMeta | null> {
   try {
     const [stat, lstat] = await Promise.all([fs.stat(filePath), fs.lstat(filePath)]);
-    if (lstat.isSymbolicLink() || !stat.isFile()) {
+    if (lstat.isSymbolicLink()) {
+      // Symlink: only allow if the fully-resolved real path falls within an operator-approved prefix.
+      const realPath = await fs.realpath(filePath);
+      if (!allowedExternalPaths || !isWithinAllowedPrefixes(realPath, allowedExternalPaths)) {
+        return null;
+      }
+      const realStat = await fs.stat(realPath);
+      if (!realStat.isFile() || realStat.nlink > 1) {
+        return null;
+      }
+      return {
+        size: realStat.size,
+        updatedAtMs: Math.floor(realStat.mtimeMs),
+      };
+    }
+    if (!stat.isFile()) {
       return null;
     }
     if (stat.nlink > 1) {
@@ -267,7 +333,10 @@ async function statFileSafely(filePath: string): Promise<FileMeta | null> {
   }
 }
 
-async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: boolean }) {
+async function listAgentFiles(
+  workspaceDir: string,
+  options?: { hideBootstrap?: boolean; allowedExternalPaths?: string[] },
+) {
   const files: Array<{
     name: string;
     path: string;
@@ -276,6 +345,7 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
     updatedAtMs?: number;
   }> = [];
 
+  const allowedExternalPaths = options?.allowedExternalPaths;
   const bootstrapFileNames = options?.hideBootstrap
     ? BOOTSTRAP_FILE_NAMES_POST_ONBOARDING
     : BOOTSTRAP_FILE_NAMES;
@@ -284,11 +354,12 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
       workspaceDir,
       name,
       allowMissing: true,
+      allowedExternalPaths,
     });
     const filePath = resolved.requestPath;
     const meta =
       resolved.kind === "ready"
-        ? await statFileSafely(resolved.ioPath)
+        ? await statFileSafely(resolved.ioPath, allowedExternalPaths)
         : resolved.kind === "missing"
           ? null
           : null;
@@ -309,9 +380,12 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
     workspaceDir,
     name: DEFAULT_MEMORY_FILENAME,
     allowMissing: true,
+    allowedExternalPaths,
   });
   const primaryMeta =
-    primaryResolved.kind === "ready" ? await statFileSafely(primaryResolved.ioPath) : null;
+    primaryResolved.kind === "ready"
+      ? await statFileSafely(primaryResolved.ioPath, allowedExternalPaths)
+      : null;
   if (primaryMeta) {
     files.push({
       name: DEFAULT_MEMORY_FILENAME,
@@ -325,9 +399,12 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
       workspaceDir,
       name: DEFAULT_MEMORY_ALT_FILENAME,
       allowMissing: true,
+      allowedExternalPaths,
     });
     const altMeta =
-      altMemoryResolved.kind === "ready" ? await statFileSafely(altMemoryResolved.ioPath) : null;
+      altMemoryResolved.kind === "ready"
+        ? await statFileSafely(altMemoryResolved.ioPath, allowedExternalPaths)
+        : null;
     if (altMeta) {
       files.push({
         name: DEFAULT_MEMORY_ALT_FILENAME,
@@ -416,11 +493,13 @@ async function resolveWorkspaceFilePathOrRespond(params: {
   respond: RespondFn;
   workspaceDir: string;
   name: string;
+  allowedExternalPaths?: string[];
 }): Promise<ResolvedWorkspaceFilePath | undefined> {
   const resolvedPath = await resolveAgentWorkspaceFilePath({
     workspaceDir: params.workspaceDir,
     name: params.name,
     allowMissing: true,
+    allowedExternalPaths: params.allowedExternalPaths,
   });
   if (resolvedPath.kind === "invalid") {
     respondWorkspaceFileInvalid(params.respond, params.name, resolvedPath.reason);
@@ -651,13 +730,14 @@ export const agentsHandlers: GatewayRequestHandlers = {
       return;
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    const allowedExternalPaths = resolveAllowedExternalPaths(cfg, agentId);
     let hideBootstrap = false;
     try {
       hideBootstrap = await isWorkspaceOnboardingCompleted(workspaceDir);
     } catch {
       // Fall back to showing BOOTSTRAP if workspace state cannot be read.
     }
-    const files = await listAgentFiles(workspaceDir, { hideBootstrap });
+    const files = await listAgentFiles(workspaceDir, { hideBootstrap, allowedExternalPaths });
     respond(true, { agentId, workspace: workspaceDir, files }, undefined);
   },
   "agents.files.get": async ({ params, respond }) => {
@@ -669,12 +749,14 @@ export const agentsHandlers: GatewayRequestHandlers = {
     if (!resolved) {
       return;
     }
-    const { agentId, workspaceDir, name } = resolved;
+    const { cfg, agentId, workspaceDir, name } = resolved;
+    const allowedExternalPaths = resolveAllowedExternalPaths(cfg, agentId);
     const filePath = path.join(workspaceDir, name);
     const resolvedPath = await resolveWorkspaceFilePathOrRespond({
       respond,
       workspaceDir,
       name,
+      allowedExternalPaths,
     });
     if (!resolvedPath) {
       return;
@@ -720,13 +802,15 @@ export const agentsHandlers: GatewayRequestHandlers = {
     if (!resolved) {
       return;
     }
-    const { agentId, workspaceDir, name } = resolved;
+    const { cfg, agentId, workspaceDir, name } = resolved;
+    const allowedExternalPaths = resolveAllowedExternalPaths(cfg, agentId);
     await fs.mkdir(workspaceDir, { recursive: true });
     const filePath = path.join(workspaceDir, name);
     const resolvedPath = await resolveWorkspaceFilePathOrRespond({
       respond,
       workspaceDir,
       name,
+      allowedExternalPaths,
     });
     if (!resolvedPath) {
       return;
@@ -752,7 +836,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
       respondWorkspaceFileUnsafe(respond, name);
       return;
     }
-    const meta = await statFileSafely(resolvedPath.ioPath);
+    const meta = await statFileSafely(resolvedPath.ioPath, allowedExternalPaths);
     respond(
       true,
       {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -176,9 +176,16 @@ function isWithinPath(child: string, parent: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
 }
 
-/** Return true if realPath is within at least one of the allowed prefix directories. */
+/** Return true if realPath is within at least one of the allowed prefix directories.
+ *
+ * Relative prefixes are silently ignored — they are unsafe because they would be
+ * resolved against process.cwd() (the gateway startup directory), making the trust
+ * boundary dependent on runtime context rather than explicit operator intent.
+ * The documented contract is that entries must be absolute paths; relative ones
+ * are a misconfiguration and must not grant access.
+ */
 function isWithinAllowedPrefixes(realPath: string, prefixes: string[]): boolean {
-  return prefixes.some((prefix) => isWithinPath(realPath, prefix));
+  return prefixes.some((prefix) => path.isAbsolute(prefix) && isWithinPath(realPath, prefix));
 }
 
 /** Merge default + per-agent allowedExternalPaths (union, no duplicates). */

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -165,19 +165,19 @@ async function resolveWorkspaceRealPath(workspaceDir: string): Promise<string> {
   }
 }
 
-/** Normalize a path prefix to end with '/' to prevent prefix collisions. */
-function normalizePrefixPath(p: string): string {
-  return p.endsWith("/") ? p : `${p}/`;
+/**
+ * Return true if `child` is within `parent` (or is `parent` itself).
+ * Uses path.relative() to avoid hardcoded separator assumptions, making
+ * this safe on both POSIX and Windows.
+ */
+function isWithinPath(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
 }
 
-/** Return true if realPath starts with at least one of the normalized prefixes. */
+/** Return true if realPath is within at least one of the allowed prefix directories. */
 function isWithinAllowedPrefixes(realPath: string, prefixes: string[]): boolean {
-  for (const prefix of prefixes) {
-    if (realPath.startsWith(normalizePrefixPath(prefix))) {
-      return true;
-    }
-  }
-  return false;
+  return prefixes.some((prefix) => isWithinPath(realPath, prefix));
 }
 
 /** Merge default + per-agent allowedExternalPaths (union, no duplicates). */
@@ -238,14 +238,14 @@ async function resolveAgentWorkspaceFilePath(params: {
     // Security check before stat: the resolved target must be within the workspace
     // or within an operator-approved external prefix. This prevents reading external
     // files even when they don't exist yet (target ENOENT would otherwise show as "missing").
-    const withinWorkspace = targetReal.startsWith(`${workspaceReal}/`);
+    const withinWorkspace = isWithinPath(targetReal, workspaceReal) && targetReal !== workspaceReal;
     const allowedPrefixes = params.allowedExternalPaths ?? [];
     if (!withinWorkspace && !isWithinAllowedPrefixes(targetReal, allowedPrefixes)) {
       return {
         kind: "invalid",
         requestPath,
         reason:
-          "symlink target is outside workspace root (add the target directory to workspace.allowedExternalPaths to permit)",
+          "symlink target is outside workspace root (add the target directory to workspaceConfig.allowedExternalPaths to permit)",
       };
     }
 

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -816,25 +816,63 @@ export const agentsHandlers: GatewayRequestHandlers = {
       return;
     }
     const content = String(params.content ?? "");
+
+    // Determine whether the resolved ioPath is within the workspace root or in an
+    // operator-trusted external directory (allowedExternalPaths symlink target).
+    // For workspace-internal files: use the existing relative-path + workspaceReal root.
+    // For external symlink targets: write directly to ioPath using its parent as the
+    // root, so writeFileWithinRoot never receives a `..`-prefixed relative path that
+    // would be rejected by the root-boundary checks in openWritableFileWithinRoot.
     const relativeWritePath = path.relative(resolvedPath.workspaceReal, resolvedPath.ioPath);
-    if (
-      !relativeWritePath ||
-      relativeWritePath.startsWith("..") ||
-      path.isAbsolute(relativeWritePath)
-    ) {
-      respondWorkspaceFileUnsafe(respond, name);
-      return;
-    }
-    try {
-      await writeFileWithinRoot({
-        rootDir: resolvedPath.workspaceReal,
-        relativePath: relativeWritePath,
-        data: content,
-        encoding: "utf8",
-      });
-    } catch {
-      respondWorkspaceFileUnsafe(respond, name);
-      return;
+    const isExternalSymlinkTarget =
+      relativeWritePath.startsWith("..") || path.isAbsolute(relativeWritePath);
+
+    if (isExternalSymlinkTarget) {
+      // Only allow if the target was explicitly cleared by allowedExternalPaths during
+      // resolveWorkspaceFilePathOrRespond above.  That function would have returned
+      // undefined (already responded with an error) if the target was not permitted,
+      // so reaching this point means allowedExternalPaths approved the ioPath.
+      if (!allowedExternalPaths.length) {
+        respondWorkspaceFileUnsafe(respond, name);
+        return;
+      }
+      try {
+        await writeFileWithinRoot({
+          rootDir: path.dirname(resolvedPath.ioPath),
+          relativePath: path.basename(resolvedPath.ioPath),
+          data: content,
+          encoding: "utf8",
+        });
+      } catch {
+        respondWorkspaceFileUnsafe(respond, name);
+        return;
+      }
+    } else {
+      if (!relativeWritePath) {
+        respondWorkspaceFileUnsafe(respond, name);
+        return;
+      }
+      // Reject in-workspace symlink aliases: if the resolved ioPath doesn't match
+      // the requested file name, the workspace file is a symlink pointing to a
+      // different location within the workspace.  Allow reads (for shared context
+      // files) but reject writes to prevent an agent from overwriting an arbitrary
+      // workspace file via a symlink alias.
+      const normalizedName = path.normalize(name);
+      if (relativeWritePath !== normalizedName) {
+        respondWorkspaceFileUnsafe(respond, name);
+        return;
+      }
+      try {
+        await writeFileWithinRoot({
+          rootDir: resolvedPath.workspaceReal,
+          relativePath: relativeWritePath,
+          data: content,
+          encoding: "utf8",
+        });
+      } catch {
+        respondWorkspaceFileUnsafe(respond, name);
+        return;
+      }
     }
     const meta = await statFileSafely(resolvedPath.ioPath, allowedExternalPaths);
     respond(

--- a/src/hooks/bundled/bootstrap-extra-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.ts
@@ -1,8 +1,10 @@
+import { listAgentEntries } from "../../../agents/agent-scope.js";
 import {
   filterBootstrapFilesForSession,
   loadExtraBootstrapFilesWithDiagnostics,
 } from "../../../agents/workspace.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { normalizeAgentId } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
 import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
 
@@ -45,9 +47,20 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
   }
 
   try {
+    // Resolve operator-approved external paths for symlink reads.
+    const defaults = context.cfg?.agents?.defaults?.workspaceConfig?.allowedExternalPaths ?? [];
+    const agentEntry = context.agentId
+      ? listAgentEntries(context.cfg ?? {}).find(
+          (e) => normalizeAgentId(e.id) === normalizeAgentId(context.agentId),
+        )
+      : undefined;
+    const perAgent = agentEntry?.workspaceConfig?.allowedExternalPaths ?? [];
+    const allowedExternalPaths = [...new Set([...defaults, ...perAgent])];
+
     const { files: extras, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(
       context.workspaceDir,
       patterns,
+      allowedExternalPaths,
     );
     if (diagnostics.length > 0) {
       log.debug("skipped extra bootstrap candidates", {


### PR DESCRIPTION
## Summary

Allows symlinked workspace context files (e.g. `AGENTS.md`, `USER.md`) to resolve into operator-approved external directories. Useful for multi-agent deployments that share a common context directory via symlinks.

## Changes

### feat: `workspaceConfig.allowedExternalPaths` config field

New opt-in allowlist on `agents.defaults.workspaceConfig` and per-agent config. Symlinks whose `realpath()` resolves within an approved prefix are permitted for both reads and writes. Omitting the field preserves existing behaviour (all external symlinks rejected).

```json5
{
  agents: {
    defaults: {
      workspaceConfig: { allowedExternalPaths: ["/home/clawd/shared/"] },
    },
  },
}
```

### fix: `agents.files.set` writes now work for external symlink targets

Without this fix, `allowedExternalPaths` was effectively read-only: `agents.files.get` succeeded but `agents.files.set` always rejected external targets because `path.relative(workspaceReal, externalIoPath)` produces a `../`-prefixed path that the write guard rejected before touching `writeFileWithinRoot`.

Fix: detect external targets and call `writeFileWithinRoot` with `path.dirname(ioPath)` / `path.basename(ioPath)` so the root-boundary checks receive a clean in-directory path.

### fix: in-workspace symlink alias writes rejected

Writes through symlinks that resolve to a *different* file within the workspace are now rejected (reads remain allowed). Prevents an agent from overwriting an arbitrary workspace file via a symlink alias.

### docs

- `configuration-reference.md`: `agents.defaults.workspaceConfig.allowedExternalPaths` section with full docs, security model, absolute-path requirement, and per-agent merge example.
- `agent-workspace.md`: *"Sharing context files across agents with symlinks"* section with usage example.
- TSDoc: clarified that relative paths are not supported and will silently not match (comparison is against `realpath()` output).

### logging

Added `logDebug()` when a symlink is permitted via `allowedExternalPaths` for audit trail visibility.

## Security model

- **Opt-in**: no `allowedExternalPaths` = existing behaviour unchanged.
- **Full resolution**: `realpath()` resolves the entire chain before any check.
- **Boundary check**: `path.relative()` ensures target is within the allowed prefix (no partial-prefix attacks).
- **Write-only to validated paths**: write operations use the already-validated `ioPath` as root, not a `../` path fed through workspace boundary checks.
- **In-workspace aliases**: symlinks pointing to a different location within the workspace are read-only.

## Tests

35/35 passing. Includes 3 new `agents.files.set` tests covering external symlink writes, rejection outside allowlist, and rejection with no config.