### PR TITLE
fix(cron): backfill legacy job timestamps for cron.list

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12342,21 +12342,21 @@
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "0091061a3babbe6f11d48aa0142e22341b3ea446",
         "is_verified": false,
-        "line_number": 665
+        "line_number": 700
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
         "is_verified": false,
-        "line_number": 811
+        "line_number": 846
       },
       {
         "type": "Secret Keyword",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 1490
+        "line_number": 1525
       }
     ],
     "src/agents/sandbox/browser.novnc-url.test.ts": [
@@ -14725,5 +14725,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T11:12:54Z"
+  "generated_at": "2026-03-07T16:21:59Z"
 }

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -38,7 +38,7 @@ def maybe_decode_hex_keychain_secret(value)
 
     # `security find-generic-password -w` can return hex when the stored secret
     # includes newlines/non-printable bytes (like PEM files).
-    if decoded.include?("BEGIN PRIVATE KEY") || decoded.include?("END PRIVATE KEY")
+    if decoded.include?("BEGIN PRIVATE KEY") || decoded.include?("END PRIVATE KEY") # pragma: allowlist secret
       UI.message("Decoded hex-encoded ASC key content from Keychain.")
       return decoded
     end

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -79,7 +79,7 @@ describe("Cron issue regressions", () => {
     cron.stop();
   });
 
-  it("repairs isolated every jobs missing createdAtMs and sets nextWakeAtMs", async () => {
+  it("repairs isolated every jobs missing timestamps and keeps cron.list decodable", async () => {
     const store = makeStorePath();
     await writeCronStoreSnapshot(store.storePath, [
       {
@@ -109,13 +109,26 @@ describe("Cron issue regressions", () => {
     const status = await cron.status();
     const jobs = await cron.list({ includeDisabled: true });
     const isolated = jobs.find((job) => job.id === "legacy-isolated");
+    expect(typeof isolated?.createdAtMs).toBe("number");
+    expect(Number.isFinite(isolated?.createdAtMs)).toBe(true);
+    expect(typeof isolated?.updatedAtMs).toBe("number");
+    expect(Number.isFinite(isolated?.updatedAtMs)).toBe(true);
     expect(Number.isFinite(isolated?.state.nextRunAtMs)).toBe(true);
     expect(Number.isFinite(status.nextWakeAtMs)).toBe(true);
 
     const persisted = JSON.parse(await fs.readFile(store.storePath, "utf8")) as {
-      jobs: Array<{ id: string; state?: { nextRunAtMs?: number | null } }>;
+      jobs: Array<{
+        id: string;
+        createdAtMs?: number | null;
+        updatedAtMs?: number | null;
+        state?: { nextRunAtMs?: number | null };
+      }>;
     };
     const persistedIsolated = persisted.jobs.find((job) => job.id === "legacy-isolated");
+    expect(typeof persistedIsolated?.createdAtMs).toBe("number");
+    expect(Number.isFinite(persistedIsolated?.createdAtMs)).toBe(true);
+    expect(typeof persistedIsolated?.updatedAtMs).toBe("number");
+    expect(Number.isFinite(persistedIsolated?.updatedAtMs)).toBe(true);
     expect(typeof persistedIsolated?.state?.nextRunAtMs).toBe("number");
     expect(Number.isFinite(persistedIsolated?.state?.nextRunAtMs)).toBe(true);
 

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -77,6 +77,14 @@ function mergeLegacyDeliveryInto(
   return { delivery: next, mutated };
 }
 
+function normalizeTimestampMs(value: unknown): number | undefined {
+  const coerced = coerceFiniteScheduleNumber(value);
+  if (coerced === undefined) {
+    return undefined;
+  }
+  return Math.max(0, Math.floor(coerced));
+}
+
 function normalizePayloadKind(payload: Record<string, unknown>) {
   const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
   if (raw === "agentturn") {
@@ -254,9 +262,37 @@ export async function ensureLoaded(
   const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   let mutated = false;
   for (const raw of jobs) {
-    const state = raw.state;
-    if (!state || typeof state !== "object" || Array.isArray(state)) {
+    const jobState = raw.state;
+    if (!jobState || typeof jobState !== "object" || Array.isArray(jobState)) {
       raw.state = {};
+      mutated = true;
+    }
+    const stateRecord =
+      raw.state && typeof raw.state === "object" && !Array.isArray(raw.state)
+        ? (raw.state as Record<string, unknown>)
+        : null;
+
+    // Backfill required contract fields so legacy jobs remain decodable via cron.list.
+    const nowMs = Math.max(0, Math.floor(state.deps.nowMs()));
+    const createdAtMs = normalizeTimestampMs(raw.createdAtMs);
+    const updatedAtMs = normalizeTimestampMs(raw.updatedAtMs);
+    const lastRunAtMs = normalizeTimestampMs(stateRecord?.lastRunAtMs);
+    const createdFallbackAtMs = updatedAtMs ?? lastRunAtMs ?? nowMs;
+    const updatedFallbackAtMs = createdAtMs ?? lastRunAtMs ?? nowMs;
+
+    if (createdAtMs === undefined) {
+      raw.createdAtMs = createdFallbackAtMs;
+      mutated = true;
+    } else if (raw.createdAtMs !== createdAtMs) {
+      raw.createdAtMs = createdAtMs;
+      mutated = true;
+    }
+
+    if (updatedAtMs === undefined) {
+      raw.updatedAtMs = updatedFallbackAtMs;
+      mutated = true;
+    } else if (raw.updatedAtMs !== updatedAtMs) {
+      raw.updatedAtMs = updatedAtMs;
       mutated = true;
     }
 


### PR DESCRIPTION
## Summary

Fixes #38971.

Legacy cron jobs can still load and execute without `createdAtMs` / `updatedAtMs`, but `cron.list` was returning those jobs as-is. The macOS Cron tab decodes those fields as required integers, so a legacy store could surface `The data couldn’t be read because it is missing.` even though the jobs themselves still ran.

This backfills missing timestamps during cron store load and extends the existing regression to assert both the in-memory `cron.list` view and the persisted store carry numeric timestamps after repair.

## Testing

- `pnpm test src/cron/service.issue-regressions.test.ts`
- `pnpm test src/cron/service.store.migration.test.ts`
- `pnpm check`
- `pnpm build`
- Manual `node --import tsx` repro with a legacy cron store missing timestamps
