### PR TITLE
fix(mattermost): accept interaction actions when label matches id

### DIFF
--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -735,6 +735,51 @@ describe("createMattermostInteractionHandler", () => {
     expect(res.body).toContain("Unknown action");
   });
 
+  it("accepts actions when the button name matches the action id", async () => {
+    const context = { action_id: "approve", __openclaw_channel_id: "chan-1" };
+    const token = generateInteractionToken(context, "acct");
+    const requestLog: Array<{ path: string; method?: string }> = [];
+    const handler = createMattermostInteractionHandler({
+      client: {
+        request: async (path: string, init?: { method?: string }) => {
+          requestLog.push({ path, method: init?.method });
+          if (init?.method === "PUT") {
+            return { id: "post-1" };
+          }
+          return {
+            channel_id: "chan-1",
+            message: "Choose",
+            props: {
+              attachments: [{ actions: [{ id: "approve", name: "approve" }] }],
+            },
+          };
+        },
+      } as unknown as MattermostClient,
+      botUserId: "bot",
+      accountId: "acct",
+    });
+
+    const req = createReq({
+      body: {
+        user_id: "user-1",
+        user_name: "alice",
+        channel_id: "chan-1",
+        post_id: "post-1",
+        context: { ...context, _token: token },
+      },
+    });
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe("{}");
+    expect(requestLog).toEqual([
+      { path: "/posts/post-1", method: undefined },
+      { path: "/posts/post-1", method: "PUT" },
+    ]);
+  });
+
   it("lets a custom interaction handler short-circuit generic completion updates", async () => {
     const context = { action_id: "mdlprov", __openclaw_channel_id: "chan-1" };
     const token = generateInteractionToken(context, "acct");

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -503,7 +503,7 @@ export function createMattermostInteractionHandler(params: {
 
     const userName = payload.user_name ?? payload.user_id;
     let originalMessage = "";
-    let clickedButtonName = actionId;
+    let clickedButtonName: string | null = null;
     try {
       const originalPost = await client.request<{
         channel_id?: string | null;
@@ -535,7 +535,7 @@ export function createMattermostInteractionHandler(params: {
           break;
         }
       }
-      if (clickedButtonName === actionId) {
+      if (clickedButtonName === null) {
         log?.(`mattermost interaction: action ${actionId} not found in post ${payload.post_id}`);
         res.statusCode = 403;
         res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Mattermost interaction handling used `clickedButtonName === actionId` as the sentinel for “action not found”.
- Why it matters: valid callbacks were rejected with 403 when a button display name legitimately matched its id.
- What changed: switched the sentinel to an explicit nullable lookup result and added a regression test for the `name === id` case.
- What did NOT change (scope boundary): no auth model changes, no callback route changes, no config changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #38057

## User-visible / Behavior Changes

- Mattermost interactive buttons no longer fail with 403 when the button label equals the action id.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm worktree
- Model/provider: n/a
- Integration/channel (if any): Mattermost plugin
- Relevant config (redacted): n/a

### Steps

1. Create a Mattermost interactive message with a button whose `name` equals its `id`.
2. Click the button.
3. Observe callback handling.

### Expected

- The callback is accepted and processed.

### Actual

- Before this patch, the callback could be rejected as `Unknown action`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused `extensions/mattermost/src/mattermost/interactions.test.ts` passed after the patch.
- Edge cases checked: valid `name === id` callback and the existing unknown-action rejection path.
- What you did **not** verify: live Mattermost end-to-end behavior against a real server.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Mattermost: fix interaction action lookup sentinel`.
- Files/config to restore: `extensions/mattermost/src/mattermost/interactions.ts` and `extensions/mattermost/src/mattermost/interactions.test.ts`.
- Known bad symptoms reviewers should watch for: valid Mattermost button clicks with matching label/id still returning `Unknown action`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None.
