### PR TITLE
fix: add missing strip-ansi dep for pi-coding-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -443,6 +443,13 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "packageExtensions": {
+      "@mariozechner/pi-coding-agent": {
+        "dependencies": {
+          "strip-ansi": "^7.2.0"
+        }
+      }
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ overrides:
   tar: 7.5.10
   tough-cookie: 4.1.3
 
+packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
+
 importers:
 
   .:
@@ -8368,6 +8370,7 @@ snapshots:
       marked: 15.0.12
       minimatch: 10.2.4
       proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
       yaml: 2.8.2
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.2


### PR DESCRIPTION
## Summary

- `@mariozechner/pi-coding-agent` imports `strip-ansi` but doesn't declare it in its `dependencies`
- pnpm's strict `node_modules` layout prevents resolving undeclared transitive deps, causing `ERR_MODULE_NOT_FOUND` at CLI startup
- Adds `pnpm.packageExtensions` to inject `strip-ansi@^7.2.0` into `@mariozechner/pi-coding-agent`

## Test plan

- [x] `pnpm install` completes successfully
- [x] `pnpm openclaw --help` starts without `ERR_MODULE_NOT_FOUND`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)