### PR TITLE
fix(feishu): preserve sender identity and resolve mentions in merge_forward messages

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -214,6 +214,11 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
     msg_type?: string;
     body?: { content?: string };
     sender?: { id?: string };
+    mentions?: Array<{
+      key?: string;
+      id?: string | { open_id?: string; user_id?: string; union_id?: string };
+      name?: string;
+    }>;
     upper_message_id?: string;
     create_time?: string;
   }>;
@@ -238,7 +243,27 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
 
   const lines = ["[Merged and Forwarded Messages]"];
   for (const item of subMessages.slice(0, maxMessages)) {
-    lines.push(`- ${formatSubMessageContent(item.body?.content || "", item.msg_type || "text")}`);
+    const formatted = formatSubMessageContent(item.body?.content || "", item.msg_type || "text");
+    const senderId = item.sender?.id || "unknown";
+
+    // Resolve @_user_N placeholders using item.mentions from Feishu API
+    let resolved = formatted;
+    if (item.mentions && item.mentions.length > 0) {
+      // Sort by key length descending to avoid @_user_1 matching inside @_user_10
+      const sorted = [...item.mentions].sort((a, b) => (b.key?.length ?? 0) - (a.key?.length ?? 0));
+      for (const m of sorted) {
+        if (m.key) {
+          const mId =
+            typeof m.id === "string"
+              ? m.id
+              : m.id?.open_id || m.id?.user_id || m.id?.union_id || "";
+          const display = m.name && mId ? `${m.name}(${mId})` : m.name || mId || m.key;
+          resolved = resolved.replaceAll(m.key, () => `@${display}`);
+        }
+      }
+    }
+
+    lines.push(`- [${senderId}] ${resolved}`);
   }
   if (subMessages.length > maxMessages) {
     lines.push(`... and ${subMessages.length - maxMessages} more messages`);

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1898,6 +1898,7 @@ describe("handleFeishuMessage command authorization", () => {
             upper_message_id: "container",
             msg_type: "file",
             body: { content: JSON.stringify({ file_name: "report.pdf" }) },
+            sender: { id: "ou-bob" },
             create_time: "2000",
           },
           {
@@ -1905,6 +1906,7 @@ describe("handleFeishuMessage command authorization", () => {
             upper_message_id: "container",
             msg_type: "text",
             body: { content: JSON.stringify({ text: "alpha" }) },
+            sender: { id: "ou-alice" },
             create_time: "1000",
           },
         ],
@@ -1954,7 +1956,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
         BodyForAgent: expect.stringContaining(
-          "[Merged and Forwarded Messages]\n- alpha\n- [File: report.pdf]",
+          "[Merged and Forwarded Messages]\n- [ou-alice] alpha\n- [ou-bob] [File: report.pdf]",
         ),
       }),
     );


### PR DESCRIPTION
## Summary

When users forward merged chat messages (合并转发) to a Feishu bot, the formatted output currently loses two critical pieces of information:

1. **Sender identity** — each sub-message's `sender.id` (open_id) is available in the API response but discarded during formatting
2. **@mention resolution** — Feishu replaces real user references with `@_user_N` placeholders in forwarded content, but the API provides a `mentions` array on each item that maps these placeholders back to real names and IDs

### Before
```
[Merged and Forwarded Messages]
- 这个方案可行吗？
- @_user_1 @_user_2 帮忙看一下
- 我觉得没问题，可以推进
```

### After
```
[Merged and Forwarded Messages]
- [ou_aaa111] 这个方案可行吗？
- [ou_bbb222] @张三(ou_ccc333) @李四(ou_ddd444) 帮忙看一下
- [ou_eee555] 我觉得没问题，可以推进
```

## Changes

**`extensions/feishu/src/bot.ts`** — `parseMergeForwardContent()`

- Added `mentions` to the item type definition (the Feishu `im.message.get` API already returns this field, it was just not declared)
- Prepend `[sender.id]` to each sub-message line
- Resolve `@_user_N` placeholders using each item's `mentions` array, displaying as `@name(open_id)`

## How it works

The Feishu API (`/im/v1/messages/:message_id`) returns merge_forward items with this structure:

```json
{
  "sender": { "id": "ou_aaa111" },
  "mentions": [
    { "key": "@_user_1", "id": "ou_ccc333", "name": "张三" },
    { "key": "@_user_2", "id": "ou_ddd444", "name": "李四" }
  ],
  "body": { "content": "..." },
  "msg_type": "text"
}
```

The `mentions` array maps each `@_user_N` placeholder back to the real user. This PR uses that mapping to restore the original user references.

## Test plan

- [x] Tested with real Feishu merge_forward messages containing @mentions — placeholders correctly resolved to `@name(open_id)`
- [x] Tested with merge_forward messages without @mentions — no regression, sender ID still shown
- [x] Verified `mentions` field structure via debug logging against live Feishu API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)