### PR TITLE
fix(gateway): include device token for fallback auth when shared token is configured

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -383,7 +383,7 @@ describe("GatewayClient connect auth payload", () => {
     );
   }
 
-  it("uses explicit shared token and does not inject stored device token", () => {
+  it("includes stored device token for fallback auth when explicit shared token is provided", () => {
     loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
     const client = new GatewayClient({
       url: "ws://127.0.0.1:18789",
@@ -398,7 +398,7 @@ describe("GatewayClient connect auth payload", () => {
     expect(connectFrameFrom(ws)).toMatchObject({
       token: "shared-token",
     });
-    expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
+    expect(connectFrameFrom(ws).deviceToken).toBe("stored-device-token");
     client.stop();
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -253,10 +253,10 @@ export class GatewayClient {
     const storedToken = this.opts.deviceIdentity
       ? loadDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role })?.token
       : null;
-    // Keep shared gateway credentials explicit. Persisted per-device tokens only
-    // participate when no explicit shared token is provided.
-    const resolvedDeviceToken =
-      explicitDeviceToken ?? (!explicitGatewayToken ? (storedToken ?? undefined) : undefined);
+    // Always include the device token when available. The server uses auth.deviceToken
+    // as a fallback when auth.token fails shared auth validation (e.g., when gateway.auth.token
+    // is configured but the client sends its per-device token from paired.json).
+    const resolvedDeviceToken = explicitDeviceToken ?? storedToken ?? undefined;
     // Legacy compatibility: keep `auth.token` populated for device-token auth when
     // no explicit shared token is present.
     const authToken = explicitGatewayToken ?? resolvedDeviceToken;


### PR DESCRIPTION
## Problem

When `gateway.auth.token` is manually configured in `openclaw.json`, the CLI cannot connect to the Gateway with `token_mismatch` error, even though the device was successfully paired via `openclaw pair`.

**Root Cause:** The client was excluding the stored device token from `auth.deviceToken` when an explicit shared token was provided. This prevented the server from falling back to device-token authentication when shared token validation failed.

**Impact:** Paired CLI devices cannot authenticate when `gateway.auth.token` is manually configured, breaking all CLI commands.

## Root Cause

In `src/gateway/client.ts`, the `resolvedDeviceToken` was set to `undefined` when `explicitGatewayToken` was present:

```typescript
// Before (broken):
const resolvedDeviceToken =
  explicitDeviceToken ?? (!explicitGatewayToken ? (storedToken ?? undefined) : undefined);
```

This meant `auth.deviceToken` was never sent to the server when a shared token was configured, so the server couldn't use device-token auth as a fallback.

## Fix

Always include the stored device token when available:

```typescript
// After (fixed):
const resolvedDeviceToken = explicitDeviceToken ?? (storedToken ?? undefined);
```

The server already supports using `auth.deviceToken` as a fallback when `auth.token` fails shared auth validation. This fix ensures the client sends both tokens, allowing the server to authenticate via the device token when the shared token doesn't match.

## Testing

- Updated existing test to verify the new behavior
- All gateway auth tests pass (`pnpm test -- src/gateway/client.test.ts src/gateway/auth.test.ts src/gateway/server/ws-connection/auth-context.test.ts`)

Fixes #38617

@greptile-apps please review