### PR TITLE
fix(status): handle unresolved channel SecretRefs in security audit

### DIFF
--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -7,9 +7,10 @@ import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
 
 const trackedTempDirs: string[] = [];
+const cleanupRunPrefix = `hooks-mapping-test-${Date.now()}-${process.pid}-`;
 
 function trackedMkdtempSync(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${cleanupRunPrefix}${prefix}`));
   trackedTempDirs.push(dir);
   return dir;
 }
@@ -20,6 +21,7 @@ afterEach(() => {
     if (!dir) {
       continue;
     }
+    expect(path.basename(dir)).toContain(cleanupRunPrefix);
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -1,10 +1,28 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
+
+const trackedTempDirs: string[] = [];
+
+function trackedMkdtempSync(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  trackedTempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (trackedTempDirs.length > 0) {
+    const dir = trackedTempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("hooks mapping", () => {
   const gmailPayload = { messages: [{ subject: "Hello" }] };
@@ -145,7 +163,7 @@ describe("hooks mapping", () => {
   });
 
   it("runs transform module", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-"));
+    const configDir = trackedMkdtempSync("openclaw-config-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "transform.mjs");
@@ -183,7 +201,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transform module traversal outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
+    const configDir = trackedMkdtempSync("openclaw-config-traversal-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -203,7 +221,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects absolute transform module path outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-abs-"));
+    const configDir = trackedMkdtempSync("openclaw-config-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const outside = path.join(os.tmpdir(), "evil.mjs");
@@ -224,7 +242,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir traversal outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-trav-"));
+    const configDir = trackedMkdtempSync("openclaw-config-xformdir-trav-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -245,7 +263,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir absolute path outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-abs-"));
+    const configDir = trackedMkdtempSync("openclaw-config-xformdir-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -266,7 +284,7 @@ describe("hooks mapping", () => {
   });
 
   it("accepts transformsDir subdirectory within the transforms root", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-ok-"));
+    const configDir = trackedMkdtempSync("openclaw-config-xformdir-ok-");
     const result = await applyNullTransformFromTempConfig({ configDir, transformsDir: "subdir" });
     expectSkippedTransformResult(result);
   });
@@ -274,10 +292,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transform module symlink escape outside transformsDir",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-module-"));
+      const configDir = trackedMkdtempSync("openclaw-config-symlink-module-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-module-"));
+      const outsideDir = trackedMkdtempSync("openclaw-outside-module-");
       const outsideModule = path.join(outsideDir, "evil.mjs");
       fs.writeFileSync(outsideModule, 'export default () => ({ kind: "wake", text: "owned" });');
       fs.symlinkSync(outsideModule, path.join(transformsRoot, "linked.mjs"));
@@ -301,10 +319,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transformsDir symlink escape outside transforms root",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-dir-"));
+      const configDir = trackedMkdtempSync("openclaw-config-symlink-dir-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-dir-"));
+      const outsideDir = trackedMkdtempSync("openclaw-outside-dir-");
       fs.writeFileSync(path.join(outsideDir, "transform.mjs"), "export default () => null;");
       fs.symlinkSync(outsideDir, path.join(transformsRoot, "escape"), "dir");
       expect(() =>
@@ -326,7 +344,7 @@ describe("hooks mapping", () => {
   );
 
   it.runIf(process.platform !== "win32")("accepts in-root transform module symlink", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-ok-"));
+    const configDir = trackedMkdtempSync("openclaw-config-symlink-ok-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     const nestedDir = path.join(transformsRoot, "nested");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -357,7 +375,7 @@ describe("hooks mapping", () => {
   });
 
   it("treats null transform as a handled skip", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-skip-"));
+    const configDir = trackedMkdtempSync("openclaw-config-skip-");
     const result = await applyNullTransformFromTempConfig({ configDir });
     expectSkippedTransformResult(result);
   });
@@ -407,7 +425,7 @@ describe("hooks mapping", () => {
   });
 
   it("caches transform functions by module path and export name", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-export-"));
+    const configDir = trackedMkdtempSync("openclaw-hooks-export-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "multi-export.mjs");

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -279,7 +279,25 @@ export async function collectChannelSecurityFindings(params: {
         plugin.id,
         accountId,
       );
-      const { account, enabled, configured } = await resolveChannelAuditAccount(plugin, accountId);
+      let account: unknown;
+      let enabled = true;
+      let configured = true;
+      try {
+        ({ account, enabled, configured } = await resolveChannelAuditAccount(plugin, accountId));
+      } catch (error) {
+        const detail = String(error);
+        const accountNote =
+          orderedAccountIds.length > 1 || hasExplicitAccountPath ? ` (account: ${accountId})` : "";
+        findings.push({
+          checkId: `channels.${plugin.id}.account.resolve_failed`,
+          severity: "warn",
+          title: `${plugin.meta.label ?? plugin.id} account config could not be resolved${accountNote}`,
+          detail,
+          remediation:
+            "Resolve unresolved SecretRef values (or run this command against an active gateway runtime snapshot) and retry.",
+        });
+        continue;
+      }
       if (!enabled) {
         continue;
       }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2533,6 +2533,47 @@ description: test skill
     });
   });
 
+  it("does not throw when channel account resolution fails on unresolved SecretRef", async () => {
+    const throwingTelegramPlugin = stubChannelPlugin({
+      id: "telegram",
+      label: "Telegram",
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ config: {} }),
+    });
+
+    Object.assign(throwingTelegramPlugin.config, {
+      inspectAccount: () => ({}),
+      isConfigured: () => {
+        throw new Error(
+          'channels.telegram.accounts.default.botToken: unresolved SecretRef "env:default:TG_TOKEN"',
+        );
+      },
+    });
+
+    const res = await runSecurityAudit({
+      config: {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      },
+      includeFilesystem: false,
+      includeChannelSecurity: true,
+      plugins: [throwingTelegramPlugin],
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "channels.telegram.account.resolve_failed",
+          severity: "warn",
+          detail: expect.stringContaining("unresolved SecretRef"),
+        }),
+      ]),
+    );
+  });
+
   it("adds probe_failed warnings for deep probe failure modes", async () => {
     const cfg: OpenClawConfig = { gateway: { mode: "local" } };
     const cases: Array<{


### PR DESCRIPTION
This fixes #38973.

`openclaw status` can fail when channel account inspection/configuration resolution throws (for example unresolved SecretRef scenarios in read-only status paths). The failure currently bubbles out of channel security audit collection.

What changed:
- Wrapped per-account channel audit resolution in `collectChannelSecurityFindings()` with error handling.
- When resolution fails, the audit now emits a warning finding (`channels.<provider>.account.resolve_failed`) and continues with other channels/accounts.
- Added a regression test to verify unresolved SecretRef-like resolution failures do not crash the audit and are surfaced as findings.

Verification:
- `pnpm vitest run --config vitest.unit.config.ts src/security/audit.test.ts` ✅ (96 passed)

This keeps `openclaw status` usable while still reporting actionable diagnostics.
