### PR TITLE
[codex] BlueBubbles: force private API for Tahoe text sends

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -10852,28 +10852,28 @@
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 82
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 93
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "db1530e1ea43af094d3d75b8dbaf19a4a182a318",
         "is_verified": false,
-        "line_number": 154
+        "line_number": 157
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
         "is_verified": false,
-        "line_number": 260
+        "line_number": 263
       }
     ],
     "extensions/bluebubbles/src/chat.test.ts": [
@@ -11002,7 +11002,7 @@
         "filename": "extensions/bluebubbles/src/send.test.ts",
         "hashed_secret": "faacad0ce4ea1c19b46e128fd79679d37d3d331d",
         "is_verified": false,
-        "line_number": 757
+        "line_number": 783
       }
     ],
     "extensions/bluebubbles/src/targets.test.ts": [
@@ -12158,7 +12158,7 @@
         "filename": "src/agents/models-config.providers.kilocode.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 14
       }
     ],
     "src/agents/models-config.providers.kimi-coding.test.ts": [
@@ -12342,21 +12342,21 @@
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "0091061a3babbe6f11d48aa0142e22341b3ea446",
         "is_verified": false,
-        "line_number": 665
+        "line_number": 700
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
         "is_verified": false,
-        "line_number": 811
+        "line_number": 846
       },
       {
         "type": "Secret Keyword",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 1490
+        "line_number": 1525
       }
     ],
     "src/agents/sandbox/browser.novnc-url.test.ts": [
@@ -13026,14 +13026,14 @@
         "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
         "hashed_secret": "01800a0712a2a1aa928b95c4745e9ee06673925b",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 153
       },
       {
         "type": "Secret Keyword",
         "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
         "hashed_secret": "8d2ce71c6723bf46f6c166984b4ddb597f92322a",
         "is_verified": false,
-        "line_number": 190
+        "line_number": 180
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -14725,5 +14725,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T11:12:54Z"
+  "generated_at": "2026-03-07T17:17:29Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Quick Setup presentation: skip automatic Quick Setup when a gateway is already configured (active connect config, last-known connection, preferred gateway, or manual host), so reconnecting installs no longer get prompted to connect again. (#38964) Thanks @ngutman.
 - CLI/Docs memory help accuracy: clarify `openclaw memory status --deep` behavior and align memory command examples/docs with the current search options. (#31803) Thanks @JasonOA888 and @Avi974.
 - Security/Nostr: harden profile mutation/import loopback guards by failing closed on non-loopback forwarded client headers (`x-forwarded-for` / `x-real-ip`) and rejecting `sec-fetch-site: cross-site`; adds regression coverage for proxy-forwarded and browser cross-site mutation attempts.
+- BlueBubbles/Tahoe text sends: resolve Private API availability before send and set `method: "private-api"` for plain-text replies and tool-progress messages whenever BlueBubbles Private API is available, preventing BlueBubbles Server from falling back to AppleScript for ordinary text sends on macOS Tahoe.
 
 ## 2026.3.2
 

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -38,7 +38,7 @@ def maybe_decode_hex_keychain_secret(value)
 
     # `security find-generic-password -w` can return hex when the stored secret
     # includes newlines/non-printable bytes (like PEM files).
-    if decoded.include?("BEGIN PRIVATE KEY") || decoded.include?("END PRIVATE KEY")
+    if decoded.include?("BEGIN PRIVATE KEY") || decoded.include?("END PRIVATE KEY") # pragma: allowlist secret
       UI.message("Decoded hex-encoded ASC key content from Keychain.")
       return decoded
     end

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -2,7 +2,10 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-mocks.js";
 import { downloadBlueBubblesAttachment, sendBlueBubblesAttachment } from "./attachments.js";
-import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
+import {
+  getCachedBlueBubblesPrivateApiStatus,
+  resolveBlueBubblesPrivateApiStatus,
+} from "./probe.js";
 import { setBlueBubblesRuntime } from "./runtime.js";
 import {
   BLUE_BUBBLES_PRIVATE_API_STATUS,
@@ -338,6 +341,7 @@ describe("sendBlueBubblesAttachment", () => {
     fetchRemoteMediaMock.mockClear();
     setBlueBubblesRuntime(runtimeStub);
     vi.mocked(getCachedBlueBubblesPrivateApiStatus).mockReset();
+    vi.mocked(resolveBlueBubblesPrivateApiStatus).mockClear();
     mockBlueBubblesPrivateApiStatus(
       vi.mocked(getCachedBlueBubblesPrivateApiStatus),
       BLUE_BUBBLES_PRIVATE_API_STATUS.unknown,
@@ -406,6 +410,7 @@ describe("sendBlueBubblesAttachment", () => {
         opts: { serverUrl: "http://localhost:1234", password: "test" },
       }),
     ).rejects.toThrow("voice messages require audio");
+    expect(vi.mocked(resolveBlueBubblesPrivateApiStatus)).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -420,6 +425,21 @@ describe("sendBlueBubblesAttachment", () => {
         opts: { serverUrl: "http://localhost:1234", password: "test" },
       }),
     ).rejects.toThrow("require mp3 or caf");
+    expect(vi.mocked(resolveBlueBubblesPrivateApiStatus)).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed prefixed targets before probing private API", async () => {
+    await expect(
+      sendBlueBubblesAttachment({
+        to: "chat_id:not-a-number",
+        buffer: new Uint8Array([1, 2, 3]),
+        filename: "photo.jpg",
+        contentType: "image/jpeg",
+        opts: { serverUrl: "http://localhost:1234", password: "test" },
+      }),
+    ).rejects.toThrow("Invalid chat_id: not-a-number");
+    expect(vi.mocked(resolveBlueBubblesPrivateApiStatus)).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -4,8 +4,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
 import { resolveBlueBubblesServerAccount } from "./account-resolve.js";
 import { postMultipartFormData } from "./multipart.js";
 import {
-  getCachedBlueBubblesPrivateApiStatus,
   isBlueBubblesPrivateApiStatusEnabled,
+  resolveBlueBubblesPrivateApiStatus,
 } from "./probe.js";
 import { resolveRequestUrl } from "./request-url.js";
 import { getBlueBubblesRuntime, warnBlueBubbles } from "./runtime.js";
@@ -156,7 +156,12 @@ export async function sendBlueBubblesAttachment(params: {
   filename = sanitizeFilename(filename, fallbackName);
   contentType = contentType?.trim() || undefined;
   const { baseUrl, password, accountId } = resolveAccount(opts);
-  const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(accountId);
+  const privateApiStatus = await resolveBlueBubblesPrivateApiStatus({
+    baseUrl,
+    password,
+    accountId,
+    timeoutMs: opts.timeoutMs,
+  });
   const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
 
   // Validate voice memo format when requested (BlueBubbles converts MP3 -> CAF when isAudioMessage).

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -156,13 +156,6 @@ export async function sendBlueBubblesAttachment(params: {
   filename = sanitizeFilename(filename, fallbackName);
   contentType = contentType?.trim() || undefined;
   const { baseUrl, password, accountId } = resolveAccount(opts);
-  const privateApiStatus = await resolveBlueBubblesPrivateApiStatus({
-    baseUrl,
-    password,
-    accountId,
-    timeoutMs: opts.timeoutMs,
-  });
-  const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
 
   // Validate voice memo format when requested (BlueBubbles converts MP3 -> CAF when isAudioMessage).
   const isAudioMessage = wantsVoice;
@@ -185,6 +178,13 @@ export async function sendBlueBubblesAttachment(params: {
   }
 
   const target = resolveBlueBubblesSendTarget(to);
+  const privateApiStatus = await resolveBlueBubblesPrivateApiStatus({
+    baseUrl,
+    password,
+    accountId,
+    timeoutMs: opts.timeoutMs,
+  });
+  const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
   const chatGuid = await resolveChatGuidForTarget({
     baseUrl,
     password,

--- a/extensions/bluebubbles/src/probe.test.ts
+++ b/extensions/bluebubbles/src/probe.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearServerInfoCache,
+  resolveBlueBubblesPrivateApiStatus,
+  type BlueBubblesPrivateApiStatusParams,
+} from "./probe.js";
+
+const mockFetch = vi.fn();
+
+const probeParams: BlueBubblesPrivateApiStatusParams = {
+  baseUrl: "http://localhost:1234",
+  password: "test-password",
+  accountId: "default",
+  timeoutMs: 500,
+};
+
+describe("probe", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    clearServerInfoCache();
+  });
+
+  afterEach(() => {
+    clearServerInfoCache();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("coalesces concurrent private-api status probes", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as (value: Response) => void;
+        }),
+    );
+
+    const first = resolveBlueBubblesPrivateApiStatus(probeParams);
+    const second = resolveBlueBubblesPrivateApiStatus(probeParams);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resolveFetch?.({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toBeNull();
+  });
+
+  it("briefly caches unresolved private-api probes to avoid repeated retries", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-08T00:00:00.000Z"));
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    await expect(resolveBlueBubblesPrivateApiStatus(probeParams)).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await expect(resolveBlueBubblesPrivateApiStatus(probeParams)).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_001);
+
+    await expect(resolveBlueBubblesPrivateApiStatus(probeParams)).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/bluebubbles/src/probe.test.ts
+++ b/extensions/bluebubbles/src/probe.test.ts
@@ -9,7 +9,7 @@ const mockFetch = vi.fn();
 
 const probeParams: BlueBubblesPrivateApiStatusParams = {
   baseUrl: "http://localhost:1234",
-  password: "test-password",
+  password: "test-password", // pragma: allowlist secret
   accountId: "default",
   timeoutMs: 500,
 };
@@ -69,5 +69,35 @@ describe("probe", () => {
 
     await expect(resolveBlueBubblesPrivateApiStatus(probeParams)).resolves.toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the oldest unknown-status entries when the cache reaches capacity", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-08T00:00:00.000Z"));
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    for (let index = 0; index < 65; index += 1) {
+      await expect(
+        resolveBlueBubblesPrivateApiStatus({
+          ...probeParams,
+          accountId: `account-${index}`,
+        }),
+      ).resolves.toBeNull();
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(65);
+
+    await expect(
+      resolveBlueBubblesPrivateApiStatus({
+        ...probeParams,
+        accountId: "account-0",
+      }),
+    ).resolves.toBeNull();
+
+    expect(mockFetch).toHaveBeenCalledTimes(66);
   });
 });

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -16,11 +16,21 @@ export type BlueBubblesServerInfo = {
   computer_id?: string;
 };
 
+export type BlueBubblesPrivateApiStatusParams = {
+  baseUrl?: string | null;
+  password?: string | null;
+  accountId?: string;
+  timeoutMs?: number;
+};
+
 /** Cache server info by account ID to avoid repeated API calls.
  * Size-capped to prevent unbounded growth (#4948). */
 const MAX_SERVER_INFO_CACHE_SIZE = 64;
 const serverInfoCache = new Map<string, { info: BlueBubblesServerInfo; expires: number }>();
 const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const UNKNOWN_PRIVATE_API_STATUS_TTL_MS = 30_000;
+const unknownPrivateApiStatusCache = new Map<string, number>();
+const privateApiStatusProbeInflight = new Map<string, Promise<boolean | null>>();
 
 function buildCacheKey(accountId?: string): string {
   return accountId?.trim() || "default";
@@ -97,18 +107,63 @@ export function getCachedBlueBubblesPrivateApiStatus(accountId?: string): boolea
   return info.private_api;
 }
 
-export async function resolveBlueBubblesPrivateApiStatus(params: {
-  baseUrl?: string | null;
-  password?: string | null;
-  accountId?: string;
-  timeoutMs?: number;
-}): Promise<boolean | null> {
+function hasRecentUnknownPrivateApiStatus(accountId?: string): boolean {
+  const cacheKey = buildCacheKey(accountId);
+  const expires = unknownPrivateApiStatusCache.get(cacheKey);
+  if (expires === undefined) {
+    return false;
+  }
+  if (expires <= Date.now()) {
+    unknownPrivateApiStatusCache.delete(cacheKey);
+    return false;
+  }
+  return true;
+}
+
+function setUnknownPrivateApiStatus(accountId?: string): void {
+  unknownPrivateApiStatusCache.set(
+    buildCacheKey(accountId),
+    Date.now() + UNKNOWN_PRIVATE_API_STATUS_TTL_MS,
+  );
+}
+
+function clearUnknownPrivateApiStatus(accountId?: string): void {
+  unknownPrivateApiStatusCache.delete(buildCacheKey(accountId));
+}
+
+export async function resolveBlueBubblesPrivateApiStatus(
+  params: BlueBubblesPrivateApiStatusParams,
+): Promise<boolean | null> {
   const cached = getCachedBlueBubblesPrivateApiStatus(params.accountId);
   if (cached !== null) {
+    clearUnknownPrivateApiStatus(params.accountId);
     return cached;
   }
-  const info = await fetchBlueBubblesServerInfo(params);
-  return typeof info?.private_api === "boolean" ? info.private_api : null;
+  if (hasRecentUnknownPrivateApiStatus(params.accountId)) {
+    return null;
+  }
+  const cacheKey = buildCacheKey(params.accountId);
+  const inflight = privateApiStatusProbeInflight.get(cacheKey);
+  if (inflight) {
+    return await inflight;
+  }
+  const probePromise = (async () => {
+    const info = await fetchBlueBubblesServerInfo(params);
+    const status = typeof info?.private_api === "boolean" ? info.private_api : null;
+    if (status === null) {
+      // Avoid paying the full probe timeout on every send while the capability remains unknown.
+      setUnknownPrivateApiStatus(params.accountId);
+    } else {
+      clearUnknownPrivateApiStatus(params.accountId);
+    }
+    return status;
+  })();
+  privateApiStatusProbeInflight.set(cacheKey, probePromise);
+  try {
+    return await probePromise;
+  } finally {
+    privateApiStatusProbeInflight.delete(cacheKey);
+  }
 }
 
 export function isBlueBubblesPrivateApiStatusEnabled(status: boolean | null): boolean {
@@ -146,6 +201,8 @@ export function isMacOS26OrHigher(accountId?: string): boolean {
 /** Clear the server info cache (for testing) */
 export function clearServerInfoCache(): void {
   serverInfoCache.clear();
+  unknownPrivateApiStatusCache.clear();
+  privateApiStatusProbeInflight.clear();
 }
 
 export async function probeBlueBubbles(params: {

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -26,6 +26,7 @@ export type BlueBubblesPrivateApiStatusParams = {
 /** Cache server info by account ID to avoid repeated API calls.
  * Size-capped to prevent unbounded growth (#4948). */
 const MAX_SERVER_INFO_CACHE_SIZE = 64;
+const MAX_UNKNOWN_PRIVATE_API_STATUS_CACHE_SIZE = 64;
 const serverInfoCache = new Map<string, { info: BlueBubblesServerInfo; expires: number }>();
 const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const UNKNOWN_PRIVATE_API_STATUS_TTL_MS = 30_000;
@@ -121,10 +122,24 @@ function hasRecentUnknownPrivateApiStatus(accountId?: string): boolean {
 }
 
 function setUnknownPrivateApiStatus(accountId?: string): void {
-  unknownPrivateApiStatusCache.set(
-    buildCacheKey(accountId),
-    Date.now() + UNKNOWN_PRIVATE_API_STATUS_TTL_MS,
-  );
+  const cacheKey = buildCacheKey(accountId);
+  const now = Date.now();
+  for (const [key, expires] of unknownPrivateApiStatusCache) {
+    if (expires <= now) {
+      unknownPrivateApiStatusCache.delete(key);
+    }
+  }
+  if (unknownPrivateApiStatusCache.has(cacheKey)) {
+    unknownPrivateApiStatusCache.delete(cacheKey);
+  }
+  unknownPrivateApiStatusCache.set(cacheKey, now + UNKNOWN_PRIVATE_API_STATUS_TTL_MS);
+  while (unknownPrivateApiStatusCache.size > MAX_UNKNOWN_PRIVATE_API_STATUS_CACHE_SIZE) {
+    const oldest = unknownPrivateApiStatusCache.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    unknownPrivateApiStatusCache.delete(oldest);
+  }
 }
 
 function clearUnknownPrivateApiStatus(accountId?: string): void {

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -97,6 +97,20 @@ export function getCachedBlueBubblesPrivateApiStatus(accountId?: string): boolea
   return info.private_api;
 }
 
+export async function resolveBlueBubblesPrivateApiStatus(params: {
+  baseUrl?: string | null;
+  password?: string | null;
+  accountId?: string;
+  timeoutMs?: number;
+}): Promise<boolean | null> {
+  const cached = getCachedBlueBubblesPrivateApiStatus(params.accountId);
+  if (cached !== null) {
+    return cached;
+  }
+  const info = await fetchBlueBubblesServerInfo(params);
+  return typeof info?.private_api === "boolean" ? info.private_api : null;
+}
+
 export function isBlueBubblesPrivateApiStatusEnabled(status: boolean | null): boolean {
   return status === true;
 }

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -448,6 +448,32 @@ describe("send", () => {
       expect(body.method).toBeUndefined();
     });
 
+    it("uses private-api for plain text when BlueBubbles Private API is enabled", async () => {
+      mockBlueBubblesPrivateApiStatusOnce(
+        privateApiStatusMock,
+        BLUE_BUBBLES_PRIVATE_API_STATUS.enabled,
+      );
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-plain-private" } });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Plain text over REST", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+      });
+
+      expect(result.messageId).toBe("msg-uuid-plain-private");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      const sendCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.chatGuid).toBe("iMessage;-;+15551234567");
+      expect(body.message).toBe("Plain text over REST");
+      expect(body.method).toBe("private-api");
+      expect(body.selectedMessageGuid).toBeUndefined();
+      expect(body.partIndex).toBeUndefined();
+      expect(body.effectId).toBeUndefined();
+    });
+
     it("strips markdown formatting from outbound messages", async () => {
       mockResolvedHandleTarget();
       mockSendResponse({ data: { guid: "msg-uuid-stripped" } });

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -3,8 +3,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
 import { stripMarkdown } from "openclaw/plugin-sdk/bluebubbles";
 import { resolveBlueBubblesAccount } from "./accounts.js";
 import {
-  getCachedBlueBubblesPrivateApiStatus,
   isBlueBubblesPrivateApiStatusEnabled,
+  resolveBlueBubblesPrivateApiStatus,
 } from "./probe.js";
 import { warnBlueBubbles } from "./runtime.js";
 import { normalizeSecretInputString } from "./secret-input.js";
@@ -77,6 +77,7 @@ function resolveEffectId(raw?: string): string | undefined {
 }
 
 type PrivateApiDecision = {
+  usePrivateApiMethod: boolean;
   canUsePrivateApi: boolean;
   throwEffectDisabledError: boolean;
   warningMessage?: string;
@@ -89,11 +90,11 @@ function resolvePrivateApiDecision(params: {
 }): PrivateApiDecision {
   const { privateApiStatus, wantsReplyThread, wantsEffect } = params;
   const needsPrivateApi = wantsReplyThread || wantsEffect;
-  const canUsePrivateApi =
-    needsPrivateApi && isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+  const usePrivateApiMethod = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+  const canUsePrivateApi = needsPrivateApi && usePrivateApiMethod;
   const throwEffectDisabledError = wantsEffect && privateApiStatus === false;
   if (!needsPrivateApi || privateApiStatus !== null) {
-    return { canUsePrivateApi, throwEffectDisabledError };
+    return { usePrivateApiMethod, canUsePrivateApi, throwEffectDisabledError };
   }
   const requested = [
     wantsReplyThread ? "reply threading" : null,
@@ -102,6 +103,7 @@ function resolvePrivateApiDecision(params: {
     .filter(Boolean)
     .join(" + ");
   return {
+    usePrivateApiMethod,
     canUsePrivateApi,
     throwEffectDisabledError,
     warningMessage: `Private API status unknown; sending without ${requested}. Run a status probe to restore private-api features.`,
@@ -389,7 +391,12 @@ export async function sendMessageBlueBubbles(
   if (!password) {
     throw new Error("BlueBubbles password is required");
   }
-  const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);
+  const privateApiStatus = await resolveBlueBubblesPrivateApiStatus({
+    baseUrl,
+    password,
+    accountId: account.accountId,
+    timeoutMs: opts.timeoutMs,
+  });
 
   const target = resolveBlueBubblesSendTarget(to);
   const chatGuid = await resolveChatGuidForTarget({
@@ -435,7 +442,7 @@ export async function sendMessageBlueBubbles(
     tempGuid: crypto.randomUUID(),
     message: strippedText,
   };
-  if (privateApiDecision.canUsePrivateApi) {
+  if (privateApiDecision.usePrivateApiMethod) {
     payload.method = "private-api";
   }
 

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -1,5 +1,6 @@
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, vi } from "vitest";
+import type { BlueBubblesPrivateApiStatusParams } from "./probe.js";
 
 export const BLUE_BUBBLES_PRIVATE_API_STATUS = {
   enabled: true,
@@ -48,7 +49,7 @@ export function createBlueBubblesAccountsMockModule() {
 type BlueBubblesProbeMockModule = {
   getCachedBlueBubblesPrivateApiStatus: Mock<() => boolean | null>;
   resolveBlueBubblesPrivateApiStatus: Mock<
-    (params?: { accountId?: string }) => Promise<boolean | null>
+    (params: BlueBubblesPrivateApiStatusParams) => Promise<boolean | null>
   >;
   isBlueBubblesPrivateApiStatusEnabled: Mock<(status: boolean | null) => boolean>;
 };
@@ -59,8 +60,8 @@ export function createBlueBubblesProbeMockModule(): BlueBubblesProbeMockModule {
     .mockReturnValue(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown);
   return {
     getCachedBlueBubblesPrivateApiStatus,
-    resolveBlueBubblesPrivateApiStatus: vi.fn(async (params?: { accountId?: string }) =>
-      getCachedBlueBubblesPrivateApiStatus(params?.accountId),
+    resolveBlueBubblesPrivateApiStatus: vi.fn(async (params: BlueBubblesPrivateApiStatusParams) =>
+      getCachedBlueBubblesPrivateApiStatus(params.accountId),
     ),
     isBlueBubblesPrivateApiStatusEnabled: vi.fn((status: boolean | null) => status === true),
   };

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -47,14 +47,21 @@ export function createBlueBubblesAccountsMockModule() {
 
 type BlueBubblesProbeMockModule = {
   getCachedBlueBubblesPrivateApiStatus: Mock<() => boolean | null>;
+  resolveBlueBubblesPrivateApiStatus: Mock<
+    (params?: { accountId?: string }) => Promise<boolean | null>
+  >;
   isBlueBubblesPrivateApiStatusEnabled: Mock<(status: boolean | null) => boolean>;
 };
 
 export function createBlueBubblesProbeMockModule(): BlueBubblesProbeMockModule {
+  const getCachedBlueBubblesPrivateApiStatus = vi
+    .fn()
+    .mockReturnValue(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown);
   return {
-    getCachedBlueBubblesPrivateApiStatus: vi
-      .fn()
-      .mockReturnValue(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown),
+    getCachedBlueBubblesPrivateApiStatus,
+    resolveBlueBubblesPrivateApiStatus: vi.fn(async (params?: { accountId?: string }) =>
+      getCachedBlueBubblesPrivateApiStatus(params?.accountId),
+    ),
     isBlueBubblesPrivateApiStatusEnabled: vi.fn((status: boolean | null) => status === true),
   };
 }

--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -176,12 +176,16 @@ function isLoopbackClientIp(clientIp: string): boolean {
 }
 
 function hasProxyForwardingHints(req: IncomingMessage): boolean {
+  const headers = req.headers;
+  if (!headers) {
+    return false;
+  }
   return Boolean(
-    req.headers["x-forwarded-for"] ||
-    req.headers["x-real-ip"] ||
-    req.headers.forwarded ||
-    req.headers["x-forwarded-host"] ||
-    req.headers["x-forwarded-proto"],
+    headers["x-forwarded-for"] ||
+    headers["x-real-ip"] ||
+    headers.forwarded ||
+    headers["x-forwarded-host"] ||
+    headers["x-forwarded-proto"],
   );
 }
 

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -26,6 +26,26 @@ type DiscordConfig = NonNullable<
 >["discord"];
 type DiscordMessageEvent = import("./listeners.js").DiscordMessageEvent;
 type DiscordClient = import("@buape/carbon").Client;
+type DiscordMessage = import("@buape/carbon").Message;
+type DiscordMessageAuthor = DiscordMessage["author"];
+type DiscordMessageAttachment = NonNullable<DiscordMessage["attachments"]>[number];
+
+function createDiscordAuthor(author: {
+  id: string;
+  bot: boolean;
+  username: string;
+}): DiscordMessageAuthor {
+  return author as unknown as DiscordMessageAuthor;
+}
+
+function createDiscordAttachment(attachment: {
+  id: string;
+  url: string;
+  content_type: string;
+  filename: string;
+}): DiscordMessageAttachment {
+  return attachment as unknown as DiscordMessageAttachment;
+}
 
 function createThreadBinding(
   overrides?: Partial<
@@ -155,11 +175,11 @@ describe("preflightDiscordMessage", () => {
       mentionedUsers: [],
       mentionedRoles: [],
       mentionedEveryone: false,
-      author: {
+      author: createDiscordAuthor({
         id: "relay-bot-1",
         bot: true,
         username: "OpenClaw",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     const result = await preflightDiscordMessage({
@@ -241,11 +261,11 @@ describe("preflightDiscordMessage", () => {
       mentionedUsers: [],
       mentionedRoles: [],
       mentionedEveryone: false,
-      author: {
+      author: createDiscordAuthor({
         id: "relay-bot-1",
         bot: true,
         username: "Relay",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     registerSessionBindingAdapter({
@@ -332,11 +352,11 @@ describe("preflightDiscordMessage", () => {
       mentionedUsers: [],
       mentionedRoles: [],
       mentionedEveryone: false,
-      author: {
+      author: createDiscordAuthor({
         id: "relay-bot-1",
         bot: true,
         username: "Relay",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     registerSessionBindingAdapter({
@@ -400,11 +420,11 @@ describe("preflightDiscordMessage", () => {
       mentionedUsers: [],
       mentionedRoles: [],
       mentionedEveryone: false,
-      author: {
+      author: createDiscordAuthor({
         id: "relay-bot-1",
         bot: true,
         username: "Relay",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     const result = await preflightDiscordMessage({
@@ -542,11 +562,11 @@ describe("preflightDiscordMessage", () => {
       mentionedUsers: [{ id: "999" }],
       mentionedRoles: [],
       mentionedEveryone: false,
-      author: {
+      author: createDiscordAuthor({
         id: "user-1",
         bot: false,
         username: "Alice",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     const result = await preflightDiscordMessage({
@@ -619,11 +639,11 @@ describe("preflightDiscordMessage", () => {
       mentionedUsers: [],
       mentionedRoles: [],
       mentionedEveryone: true,
-      author: {
+      author: createDiscordAuthor({
         id: "user-1",
         bot: false,
         username: "Alice",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     const result = await preflightDiscordMessage({
@@ -697,11 +717,11 @@ describe("preflightDiscordMessage", () => {
       mentionedUsers: [],
       mentionedRoles: [],
       mentionedEveryone: true,
-      author: {
+      author: createDiscordAuthor({
         id: "relay-bot-1",
         bot: true,
         username: "Relay",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     const result = await preflightDiscordMessage({
@@ -773,21 +793,21 @@ describe("preflightDiscordMessage", () => {
       timestamp: new Date().toISOString(),
       channelId,
       attachments: [
-        {
+        createDiscordAttachment({
           id: "att-1",
           url: "https://cdn.discordapp.com/attachments/voice.ogg",
           content_type: "audio/ogg",
           filename: "voice.ogg",
-        },
+        }),
       ],
       mentionedUsers: [],
       mentionedRoles: [],
       mentionedEveryone: false,
-      author: {
+      author: createDiscordAuthor({
         id: "user-1",
         bot: false,
         username: "Alice",
-      },
+      }),
     } as unknown as import("@buape/carbon").Message;
 
     const result = await preflightDiscordMessage(

--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -16,6 +16,10 @@ vi.mock("./message-handler.process.js", () => ({
 
 const { createDiscordMessageHandler } = await import("./message-handler.js");
 
+function createSetStatusMock() {
+  return vi.fn<(patch: Record<string, unknown>) => void>();
+}
+
 function createDeferred<T = void>() {
   let resolve: (value: T | PromiseLike<T>) => void = () => {};
   const promise = new Promise<T>((innerResolve) => {
@@ -112,7 +116,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
 
-    const setStatus = vi.fn();
+    const setStatus = createSetStatusMock();
     createDiscordMessageHandler(createHandlerParams({ setStatus }));
 
     expect(setStatus).toHaveBeenCalledWith(
@@ -141,7 +145,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
         createPreflightContext(params.data.channel_id),
     );
 
-    const setStatus = vi.fn();
+    const setStatus = createSetStatusMock();
     const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
 
     await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
@@ -304,7 +308,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 
     try {
-      const setStatus = vi.fn();
+      const setStatus = createSetStatusMock();
       const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
       await expect(
         handler(createMessageData("m-1") as never, {} as never),
@@ -351,7 +355,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
         createPreflightContext(params.data.channel_id),
     );
 
-    const setStatus = vi.fn();
+    const setStatus = createSetStatusMock();
     const abortController = new AbortController();
     const handler = createDiscordMessageHandler(
       createHandlerParams({ setStatus, abortSignal: abortController.signal }),
@@ -386,7 +390,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
         createPreflightContext(params.data.channel_id),
     );
 
-    const setStatus = vi.fn();
+    const setStatus = createSetStatusMock();
     const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
 
     await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
@@ -498,7 +502,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
         createPreflightContext(params.data.channel_id),
     );
 
-    const setStatus = vi.fn();
+    const setStatus = createSetStatusMock();
     const handler = createDiscordMessageHandler(createHandlerParams({ setStatus }));
 
     await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -65,8 +65,13 @@ const { readAllowFromStoreMock, upsertPairingRequestMock } = vi.hoisted(() => ({
 
 let handleLineWebhookEvents: typeof import("./bot-handlers.js").handleLineWebhookEvents;
 let createLineWebhookReplayCache: typeof import("./bot-handlers.js").createLineWebhookReplayCache;
+type ProcessLineMessage = import("./bot-handlers.js").LineHandlerContext["processMessage"];
 
 const createRuntime = () => ({ log: vi.fn(), error: vi.fn(), exit: vi.fn() });
+
+function createProcessMessageMock() {
+  return vi.fn<ProcessLineMessage>(async () => undefined);
+}
 
 vi.mock("../pairing/pairing-store.js", () => ({
   readChannelAllowFromStore: readAllowFromStoreMock,
@@ -86,7 +91,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("blocks group messages when groupPolicy is disabled", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m1", type: "text", text: "hi" },
@@ -118,7 +123,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("blocks group messages when allowlist is empty", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m2", type: "text", text: "hi" },
@@ -150,7 +155,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("allows group messages when sender is in groupAllowFrom", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m3", type: "text", text: "hi" },
@@ -185,7 +190,7 @@ describe("handleLineWebhookEvents", () => {
 
   it("blocks group sender not in groupAllowFrom even when sender is paired in DM store", async () => {
     readAllowFromStoreMock.mockResolvedValueOnce(["user-store"]);
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m5", type: "text", text: "hi" },
@@ -221,7 +226,7 @@ describe("handleLineWebhookEvents", () => {
 
   it("does not authorize group messages from DM pairing-store entries when group allowlist is empty", async () => {
     readAllowFromStoreMock.mockResolvedValueOnce(["user-5"]);
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m5b", type: "text", text: "hi" },
@@ -258,7 +263,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("blocks group messages when wildcard group config disables groups", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m4", type: "text", text: "hi" },
@@ -290,7 +295,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("scopes DM pairing requests to accountId", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m5", type: "text", text: "hi" },
@@ -328,7 +333,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("does not authorize DM senders from another account's pairing-store entries", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     readAllowFromStoreMock.mockImplementation(async (...args: unknown[]) => {
       const accountId = args[2] as string | undefined;
       if (accountId === "work") {
@@ -376,7 +381,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("deduplicates replayed webhook events by webhookEventId before processing", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m-replay", type: "text", text: "hello" },
@@ -416,7 +421,7 @@ describe("handleLineWebhookEvents", () => {
     const firstDone = new Promise<void>((resolve) => {
       resolveFirst = resolve;
     });
-    const processMessage = vi.fn(async () => {
+    const processMessage = createProcessMessageMock().mockImplementation(async () => {
       await firstDone;
     });
     const event = {
@@ -461,7 +466,7 @@ describe("handleLineWebhookEvents", () => {
     const firstDone = new Promise<void>((_, reject) => {
       rejectFirst = reject;
     });
-    const processMessage = vi.fn(async () => {
+    const processMessage = createProcessMessageMock().mockImplementation(async () => {
       await firstDone;
     });
     const event = {
@@ -502,7 +507,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("deduplicates redeliveries by LINE message id when webhookEventId changes", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     const event = {
       type: "message",
       message: { id: "m-dup-1", type: "text", text: "hello" },
@@ -549,7 +554,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("deduplicates postback redeliveries by webhookEventId when replyToken changes", async () => {
-    const processMessage = vi.fn();
+    const processMessage = createProcessMessageMock();
     buildLinePostbackContextMock.mockResolvedValue({
       ctxPayload: { From: "line:user:user-postback" },
       route: { agentId: "default" },
@@ -600,8 +605,7 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("does not mark replay cache when event processing fails", async () => {
-    const processMessage = vi
-      .fn()
+    const processMessage = createProcessMessageMock()
       .mockRejectedValueOnce(new Error("transient failure"))
       .mockResolvedValueOnce(undefined);
     const event = {

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -12,6 +12,8 @@ type ResolveConfiguredAcpBindingRecordFn =
   typeof import("../acp/persistent-bindings.js").resolveConfiguredAcpBindingRecord;
 type EnsureConfiguredAcpBindingSessionFn =
   typeof import("../acp/persistent-bindings.js").ensureConfiguredAcpBindingSession;
+type ResolvedConfiguredAcpBinding =
+  import("../acp/persistent-bindings.js").ResolvedConfiguredAcpBinding;
 
 const persistentBindingMocks = vi.hoisted(() => ({
   resolveConfiguredAcpBindingRecord: vi.fn<ResolveConfiguredAcpBindingRecordFn>(() => null),
@@ -87,6 +89,32 @@ function createDeferred<T>() {
     resolve = res;
   });
   return { promise, resolve };
+}
+
+function createConfiguredTopicBinding(targetSessionKey: string): ResolvedConfiguredAcpBinding {
+  return {
+    spec: {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "-1001234567890:topic:42",
+      parentConversationId: "-1001234567890",
+      agentId: "codex",
+      mode: "persistent",
+    },
+    record: {
+      bindingId: "config:acp:telegram:default:-1001234567890:topic:42",
+      targetSessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-1001234567890:topic:42",
+        parentConversationId: "-1001234567890",
+      },
+      status: "active",
+      boundAt: 0,
+    },
+  } satisfies ResolvedConfiguredAcpBinding;
 }
 
 type TelegramCommandHandler = (ctx: unknown) => Promise<void>;
@@ -254,29 +282,9 @@ describe("registerTelegramNativeCommands — session metadata", () => {
 
   it("routes Telegram native commands through configured ACP topic bindings", async () => {
     const boundSessionKey = "agent:codex:acp:binding:telegram:default:feedface";
-    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue({
-      spec: {
-        channel: "telegram",
-        accountId: "default",
-        conversationId: "-1001234567890:topic:42",
-        parentConversationId: "-1001234567890",
-        agentId: "codex",
-        mode: "persistent",
-      },
-      record: {
-        bindingId: "config:acp:telegram:default:-1001234567890:topic:42",
-        targetSessionKey: boundSessionKey,
-        targetKind: "session",
-        conversation: {
-          channel: "telegram",
-          accountId: "default",
-          conversationId: "-1001234567890:topic:42",
-          parentConversationId: "-1001234567890",
-        },
-        status: "active",
-        boundAt: 0,
-      },
-    });
+    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue(
+      createConfiguredTopicBinding(boundSessionKey),
+    );
     persistentBindingMocks.ensureConfiguredAcpBindingSession.mockResolvedValue({
       ok: true,
       sessionKey: boundSessionKey,
@@ -359,29 +367,9 @@ describe("registerTelegramNativeCommands — session metadata", () => {
 
   it("aborts native command dispatch when configured ACP topic binding cannot initialize", async () => {
     const boundSessionKey = "agent:codex:acp:binding:telegram:default:feedface";
-    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue({
-      spec: {
-        channel: "telegram",
-        accountId: "default",
-        conversationId: "-1001234567890:topic:42",
-        parentConversationId: "-1001234567890",
-        agentId: "codex",
-        mode: "persistent",
-      },
-      record: {
-        bindingId: "config:acp:telegram:default:-1001234567890:topic:42",
-        targetSessionKey: boundSessionKey,
-        targetKind: "session",
-        conversation: {
-          channel: "telegram",
-          accountId: "default",
-          conversationId: "-1001234567890:topic:42",
-          parentConversationId: "-1001234567890",
-        },
-        status: "active",
-        boundAt: 0,
-      },
-    });
+    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue(
+      createConfiguredTopicBinding(boundSessionKey),
+    );
     persistentBindingMocks.ensureConfiguredAcpBindingSession.mockResolvedValue({
       ok: false,
       sessionKey: boundSessionKey,
@@ -405,29 +393,9 @@ describe("registerTelegramNativeCommands — session metadata", () => {
 
   it("keeps /new blocked in ACP-bound Telegram topics when sender is unauthorized", async () => {
     const boundSessionKey = "agent:codex:acp:binding:telegram:default:feedface";
-    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue({
-      spec: {
-        channel: "telegram",
-        accountId: "default",
-        conversationId: "-1001234567890:topic:42",
-        parentConversationId: "-1001234567890",
-        agentId: "codex",
-        mode: "persistent",
-      },
-      record: {
-        bindingId: "config:acp:telegram:default:-1001234567890:topic:42",
-        targetSessionKey: boundSessionKey,
-        targetKind: "session",
-        conversation: {
-          channel: "telegram",
-          accountId: "default",
-          conversationId: "-1001234567890:topic:42",
-          parentConversationId: "-1001234567890",
-        },
-        status: "active",
-        boundAt: 0,
-      },
-    });
+    persistentBindingMocks.resolveConfiguredAcpBindingRecord.mockReturnValue(
+      createConfiguredTopicBinding(boundSessionKey),
+    );
     persistentBindingMocks.ensureConfiguredAcpBindingSession.mockResolvedValue({
       ok: true,
       sessionKey: boundSessionKey,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: BlueBubbles plain-text sends did not include `method: "private-api"` unless reply-thread metadata or message effects were requested.
- Why it matters: on macOS 26 (Tahoe), BlueBubbles Server can fall back to the AppleScript send path for ordinary text messages, and that fallback is broken there.
- What changed: text sends now resolve BlueBubbles Private API availability before send and set `method: "private-api"` for plain replies and tool-progress messages whenever the Private API is available; the attachment path now uses the same capability-resolution helper.
- What did NOT change (scope boundary): this PR does not rewrite the separate legacy iMessage/AppleScript channel implementation; it fixes the BlueBubbles send path that all BlueBubbles text/tool-summary sends already reuse.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29389
- Related #16429

## User-visible / Behavior Changes

BlueBubbles plain-text replies and tool-progress messages now explicitly use BlueBubbles Private API when it is available, preventing ordinary text sends from falling back to AppleScript on macOS Tahoe. Cold-cache sends may do one extra BlueBubbles `server/info` capability lookup before the first send.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (Yes)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:
  On a cold capability cache, the send path may make one additional authenticated BlueBubbles `server/info` request before sending. The response is used only to determine whether the Private API is available, and the existing cache prevents repeated lookups once populated.

## Repro + Verification

### Environment

- OS: macOS 26 (Tahoe) for the reported failure; local verification on the repo test harness
- Runtime/container: Node 22 + pnpm/vitest
- Model/provider: N/A
- Integration/channel (if any): `@openclaw/bluebubbles`
- Relevant config (redacted): BlueBubbles server URL + password, Private API enabled

### Steps

1. Enable BlueBubbles Private API and route an outbound plain-text reply through the BlueBubbles extension.
2. Send a normal reply or tool-progress message that does not request reply-thread metadata or message effects.
3. Inspect the BlueBubbles REST request payload.

### Expected

- The outbound REST payload includes `method: "private-api"` whenever BlueBubbles Private API is available, so the send stays on the Private API path.

### Actual

- Before this change, plain-text sends omitted `method`, which allowed BlueBubbles Server to fall back to AppleScript on Tahoe.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted BlueBubbles tests for plain text send, attachment send, monitor reply flow, and media send.
- Edge cases checked: cold capability cache, Private API enabled/disabled/unknown states, reply-thread/effect gating still only adds private-api-only metadata when supported.
- What you did **not** verify: live end-to-end send on a Tahoe host with a real BlueBubbles server.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two commits in this PR.
- Files/config to restore: `extensions/bluebubbles/src/send.ts`, `extensions/bluebubbles/src/probe.ts`, `extensions/bluebubbles/src/attachments.ts`, `extensions/bluebubbles/src/test-harness.ts`, `extensions/bluebubbles/src/send.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: unexpected extra `server/info` lookups before first send, or reply/effect sends losing their existing private-api-only behavior.

## Risks and Mitigations

- Risk: the first send on a cold cache now depends on a successful `server/info` lookup before deciding whether to set `method`.
  - Mitigation: if the capability lookup cannot prove Private API availability, the code preserves existing behavior and still keeps reply-thread/effect fallback warnings/errors intact.
