### PR TITLE
Channels: omit redundant not-configured status error

### DIFF
--- a/src/commands/channels.omits-redundant-not-configured-error-status-output.test.ts
+++ b/src/commands/channels.omits-redundant-not-configured-error-status-output.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { formatGatewayChannelsStatusLines } from "./channels/status.js";
+
+const feishuTestPlugin = {
+  ...createChannelTestPluginBase({
+    id: "feishu",
+    label: "Feishu",
+    docsPath: "/channels/feishu",
+  }),
+} as ChannelPlugin;
+
+describe("channels status output", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "feishu",
+          source: "test",
+          plugin: feishuTestPlugin,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("omits redundant not-configured runtime error text", () => {
+    const lines = formatGatewayChannelsStatusLines({
+      channelAccounts: {
+        feishu: [
+          {
+            accountId: "default",
+            enabled: true,
+            configured: false,
+            running: false,
+            lastError: "not configured",
+          },
+        ],
+      },
+    });
+    const joined = lines.join("\n");
+    expect(joined).toContain("Feishu default: enabled, not configured, stopped");
+    expect(joined).not.toContain("error:not configured");
+  });
+});

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -31,6 +31,20 @@ export type ChannelsStatusOptions = {
   timeout?: string;
 };
 
+function shouldAppendLastErrorBit(account: Record<string, unknown>, lastError: string): boolean {
+  const normalized = lastError.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized === "not configured" && account.configured === false) {
+    return false;
+  }
+  if (normalized === "disabled" && account.enabled === false) {
+    return false;
+  }
+  return true;
+}
+
 function appendEnabledConfiguredLinkedBits(bits: string[], account: Record<string, unknown>) {
   if (typeof account.enabled === "boolean") {
     bits.push(account.enabled ? "enabled" : "disabled");
@@ -168,7 +182,10 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
       if (audit && typeof audit.ok === "boolean") {
         bits.push(audit.ok ? "audit ok" : "audit failed");
       }
-      if (typeof account.lastError === "string" && account.lastError) {
+      if (
+        typeof account.lastError === "string" &&
+        shouldAppendLastErrorBit(account, account.lastError)
+      ) {
         bits.push(`error:${account.lastError}`);
       }
       return buildChannelAccountLine(provider, account, bits);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw channels status` could print `error:not configured` even when the same account line already showed `not configured`.
- Why it matters: This duplicates the same state as both status and error, making Feishu default output look like a runtime failure.
- What changed: `src/commands/channels/status.ts` now suppresses redundant generic errors (`not configured` / `disabled`) when those states are already represented by status bits.
- What did NOT change (scope boundary): Runtime/account lifecycle behavior and real channel runtime error reporting are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39005
- Related #

## User-visible / Behavior Changes

`openclaw channels status` no longer appends `error:not configured` when an account already shows `not configured`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm local dev
- Model/provider: N/A
- Integration/channel (if any): channels status formatting
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw channels status` with an account snapshot that is `configured=false` and `lastError="not configured"`.
2. Inspect the rendered account line.

### Expected

- Line includes `not configured` state without duplicating `error:not configured`.

### Actual

- After fix, redundant error text is omitted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands (exact) and outcomes:

- `pnpm exec oxfmt --check src/commands/channels/status.ts src/commands/channels.omits-redundant-not-configured-error-status-output.test.ts` -> pass
- `pnpm test -- src/commands/channels.omits-redundant-not-configured-error-status-output.test.ts src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts` -> pass (2 files, 3 tests)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added and ran a regression test that asserts the account line omits `error:not configured` when `configured` is false.
- Edge cases checked: Re-ran existing Signal/iMessage runtime-error status-output tests to confirm real runtime errors are still surfaced.
- What you did **not** verify: Full `pnpm test` suite and live gateway/channel runtime behavior.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/commands/channels/status.ts`
- Known bad symptoms reviewers should watch for: If broken, `channels status` may hide legitimate runtime errors unexpectedly.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-suppressing useful errors when text equals a generic state.
  - Mitigation: Suppression is restricted to exact generic strings (`not configured`, `disabled`) and only when matching state flags are already present.
