### PR TITLE
fix(whatsapp): fall back to inbound context for reaction messageId

### DIFF
--- a/extensions/whatsapp/src/channel.test.ts
+++ b/extensions/whatsapp/src/channel.test.ts
@@ -1,5 +1,64 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/whatsapp";
 import { describe, expect, it, vi } from "vitest";
 import { whatsappPlugin } from "./channel.js";
+
+const handleWhatsAppAction = vi.fn(async () => ({ details: { ok: true } }));
+vi.mock("./runtime.js", () => ({
+  getWhatsAppRuntime: () => ({
+    channel: {
+      whatsapp: { handleWhatsAppAction },
+      text: { chunkText: (t: string) => [t] },
+    },
+  }),
+}));
+
+const reactCfg = {
+  channels: { whatsapp: { actions: { reactions: true } } },
+} as OpenClawConfig;
+
+describe("whatsappPlugin actions react", () => {
+  it("falls back to toolContext.currentMessageId when messageId is omitted", async () => {
+    handleWhatsAppAction.mockClear();
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { chatJid: "123@s.whatsapp.net", emoji: "👍" },
+      cfg: reactCfg,
+      toolContext: { currentMessageId: "msg-ctx-42" },
+    });
+    expect(handleWhatsAppAction).toHaveBeenCalledTimes(1);
+    expect(handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "msg-ctx-42" }),
+      reactCfg,
+    );
+  });
+
+  it("prefers explicit messageId over toolContext fallback", async () => {
+    handleWhatsAppAction.mockClear();
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { chatJid: "123@s.whatsapp.net", messageId: "explicit-1", emoji: "🔥" },
+      cfg: reactCfg,
+      toolContext: { currentMessageId: "ctx-fallback" },
+    });
+    expect(handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "explicit-1" }),
+      reactCfg,
+    );
+  });
+
+  it("rejects reaction when neither messageId nor toolContext is available", async () => {
+    await expect(
+      whatsappPlugin.actions!.handleAction!({
+        channel: "whatsapp",
+        action: "react",
+        params: { chatJid: "123@s.whatsapp.net", emoji: "✅" },
+        cfg: reactCfg,
+      }),
+    ).rejects.toThrow(/messageId required/);
+  });
+});
 
 describe("whatsappPlugin outbound sendMedia", () => {
   it("forwards mediaLocalRoots to sendMessageWhatsApp", async () => {

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -16,6 +16,7 @@ import {
   formatWhatsAppConfigAllowFromEntries,
   normalizeWhatsAppMessagingTarget,
   readStringParam,
+  resolveReactionMessageId,
   resolveDefaultWhatsAppAccountId,
   resolveWhatsAppOutboundTarget,
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -253,13 +254,16 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       return Array.from(actions);
     },
     supportsAction: ({ action }) => action === "react",
-    handleAction: async ({ action, params, cfg, accountId }) => {
+    handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
       if (action !== "react") {
         throw new Error(`Action ${action} is not supported for provider ${meta.id}.`);
       }
-      const messageId = readStringParam(params, "messageId", {
-        required: true,
-      });
+      const messageId = resolveReactionMessageId({ args: params, toolContext });
+      if (!messageId) {
+        throw new Error(
+          "messageId required. Provide messageId explicitly or react to the current inbound message.",
+        );
+      }
       const emoji = readStringParam(params, "emoji", { allowEmpty: true });
       const remove = typeof params.remove === "boolean" ? params.remove : undefined;
       return await getWhatsAppRuntime().channel.whatsapp.handleWhatsAppAction(

--- a/src/plugin-sdk/whatsapp.ts
+++ b/src/plugin-sdk/whatsapp.ts
@@ -55,5 +55,6 @@ export { collectWhatsAppStatusIssues } from "../channels/plugins/status-issues/w
 export { WhatsAppConfigSchema } from "../config/zod-schema.providers-whatsapp.js";
 
 export { createActionGate, readStringParam } from "../agents/tools/common.js";
+export { resolveReactionMessageId } from "../channels/plugins/actions/reaction-message-id.js";
 
 export { normalizeE164 } from "../utils.js";


### PR DESCRIPTION
## Summary

- Problem: WhatsApp `react` action requires an explicit `messageId` parameter, but the LLM schema marks it as optional and the inbound context maps the message ID to `MessageSid` — so agent-initiated reactions on inbound turns always fail with `messageId required`.
- Why it matters: WhatsApp reactions are completely broken for agent-initiated flows (ack reactions, auto-react). Telegram, Signal, and Discord already have this fallback and work correctly.
- What changed: The WhatsApp plugin `handleAction` now uses the shared `resolveReactionMessageId` helper (already used by Telegram/Signal/Discord) to fall back to `toolContext.currentMessageId` when `messageId` is not explicitly provided. Exported `resolveReactionMessageId` from the WhatsApp plugin SDK.
- What did NOT change (scope boundary): The internal `handleWhatsAppAction` function is untouched. Explicit `messageId` still takes priority. Multi-account routing, allowlist enforcement, and the Baileys reaction API call are all unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31303

## User-visible / Behavior Changes

WhatsApp reactions now work when `messageId` is omitted — the agent falls back to the current inbound message context, matching Telegram/Signal/Discord behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Integration/channel (if any): WhatsApp (Baileys web provider)
- Relevant config (redacted): `channels.whatsapp.actions.reactions: true`

### Steps

1. Enable WhatsApp channel with `actions.reactions: true`
2. Send a message from WhatsApp to the agent
3. Agent attempts to react with emoji (e.g. `action=react emoji=👍`)

### Expected

- Reaction succeeds using the inbound message ID from context

### Actual

- `messageId required` error — agent cannot react to inbound messages

## Evidence

- [x] Failing test/log before + passing after

3 new tests:
- `falls back to toolContext.currentMessageId when messageId is omitted`
- `prefers explicit messageId over toolContext fallback`
- `rejects reaction when neither messageId nor toolContext is available`

All existing tests pass (whatsapp-actions, reaction-message-id, channel actions).

## Human Verification (required)

- Verified scenarios: fallback path, explicit priority, missing-both error
- Edge cases checked: numeric messageId, snake_case `message_id` alias (handled by shared helper)
- What you did **not** verify: live WhatsApp reaction delivery (no test account available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single commit
- Files/config to restore: `extensions/whatsapp/src/channel.ts`, `src/plugin-sdk/whatsapp.ts`
- Known bad symptoms reviewers should watch for: reactions sent to wrong message (would require `toolContext.currentMessageId` to be wrong upstream)

## Risks and Mitigations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)