### PR TITLE
fix(tts): recognize bare [[tts]] tag in parseTtsDirectives

### DIFF
--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -128,6 +128,14 @@ export function parseTtsDirectives(
     return "";
   });
 
+  // Bare [[tts]] tag — the system prompt instructs the model to use this as a TTS signal.
+  // Recognize it as a directive (sets hasDirective=true) and strip it from visible text.
+  const bareTagRegex = /\[\[tts\]\]/gi;
+  cleanedText = cleanedText.replace(bareTagRegex, () => {
+    hasDirective = true;
+    return "";
+  });
+
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -308,6 +308,27 @@ describe("tts", () => {
       expect(result.overrides.openai?.voice).toBeUndefined();
       expect(result.warnings).toContain('invalid OpenAI voice "kokoro-chinese"');
     });
+
+    it("recognizes bare [[tts]] tag and sets hasDirective without overrides", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello world [[tts]]";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.cleanedText).toBe("Hello world ");
+      expect(result.overrides).toEqual({});
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("recognizes [[tts]] alongside other content and strips it from visible text", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "[[tts]] This should be spoken aloud.";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.cleanedText).toBe(" This should be spoken aloud.");
+      expect(result.ttsText).toBeUndefined();
+    });
   });
 
   describe("summarizeText", () => {


### PR DESCRIPTION
## Summary

Fixes #38937

The system prompt hint for tagged auto mode tells the model to use `[[tts]]` or `[[tts:text]]` tags, but `parseTtsDirectives` only matched `[[tts:text]]...[[/tts:text]]` blocks and `[[tts:KEY=VALUE]]` directives. A bare `[[tts]]` tag matched neither regex, so `hasDirective` stayed `false` and tagged-mode TTS was silently skipped on every reply where the AI used the bare form.

## Changes

- `src/tts/tts-core.ts`: add `bareTagRegex` pass that strips `[[tts]]` from visible text and sets `hasDirective=true` (no overrides attached — bare tag is intent-only)
- `src/tts/tts.test.ts`: two new test cases covering bare `[[tts]]` recognition and text stripping

---
🤖 Generated with Claude Code