### PR TITLE
fix: add @tloncorp/api to pnpm onlyBuiltDependencies allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -435,6 +435,7 @@
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",
       "@napi-rs/canvas",
+      "@tloncorp/api",
       "@whiskeysockets/baileys",
       "authenticate-pam",
       "esbuild",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ onlyBuiltDependencies:
   - "@lydell/node-pty"
   - "@matrix-org/matrix-sdk-crypto-nodejs"
   - "@napi-rs/canvas"
+  - "@tloncorp/api"
   - "@whiskeysockets/baileys"
   - authenticate-pam
   - esbuild


### PR DESCRIPTION
## Summary

- Problem: `@tloncorp/api` is a git-hosted dep (Tlon extension) that runs a build script on install, but isn't in pnpm's `onlyBuiltDependencies` allowlist
- Why it matters: `pnpm install` fails on pnpm v10+ which enforces the allowlist strictly
- What changed: Added `@tloncorp/api` to the allowlist in `package.json` and `pnpm-workspace.yaml`
- What did NOT change: No runtime behavior, no new deps, no lockfile changes

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #38999

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (ARM)
- Runtime/container: Node 22, pnpm 10.29.3

### Steps

1. `git pull` on latest main
2. `pnpm install`
3. Install fails with `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` for `@tloncorp/api`

### Expected

- `pnpm install` completes successfully

### Actual

- Install blocked by pnpm's strict build-script policy

## Evidence

- [x] Failing test/log before + passing after

Error before:
```
ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED  Failed to prepare git-hosted package
fetched from "https://codeload.github.com/tloncorp/api-beta/tar.gz/...":
The git-hosted package "@tloncorp/api@0.0.2" needs to execute build scripts
but is not in the "onlyBuiltDependencies" allowlist.
```

## Human Verification (required)

- Verified scenarios: `pnpm install`, `pnpm build`, `pnpm check`, `pnpm test` (6644 tests passing), gateway restart
- Edge cases checked: Confirmed the dep is only used by `extensions/tlon`
- What you did **not** verify: CI (will rely on CI run)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the line from both files
- Known bad symptoms reviewers should watch for: None — purely additive allowlist entry

## Risks and Mitigations

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)