### PR TITLE
fix(ci): exclude Fastlane private-key sentinels from detect-secrets

### DIFF
--- a/.detect-secrets.cfg
+++ b/.detect-secrets.cfg
@@ -10,7 +10,7 @@ pattern = (^|/)pnpm-lock\.yaml$
 
 [exclude-lines]
 # Fastlane checks for private key marker; not a real key.
-pattern = key_content\.include\?\("BEGIN PRIVATE KEY"\)
+pattern = (?:key_content|decoded)\.include\?\("BEGIN PRIVATE KEY"\)
 # UI label string for Anthropic auth mode.
 pattern = case \.apiKeyEnv: "API key \(env var\)"
 # CodingKeys mapping uses apiKey literal.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           - --exclude-files
           - '(^|/)pnpm-lock\.yaml$'
           - --exclude-lines
-          - 'key_content\.include\?\("BEGIN PRIVATE KEY"\)'
+          - '(?:key_content|decoded)\.include\?\("BEGIN PRIVATE KEY"\)'
           - --exclude-lines
           - 'case \.apiKeyEnv: "API key \(env var\)"'
           - --exclude-lines

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,7 +134,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_line",
       "pattern": [
-        "key_content\\.include\\?\\(\"BEGIN PRIVATE KEY\"\\)",
+        "(?:key_content|decoded)\\.include\\?\\(\"BEGIN PRIVATE KEY\"\\)",
         "case \\.apiKeyEnv: \"API key \\(env var\\)\"",
         "case apikey = \"apiKey\"",
         "\"gateway\\.remote\\.password\"",
@@ -12158,7 +12158,7 @@
         "filename": "src/agents/models-config.providers.kilocode.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 14
       }
     ],
     "src/agents/models-config.providers.kimi-coding.test.ts": [
@@ -12342,21 +12342,21 @@
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "0091061a3babbe6f11d48aa0142e22341b3ea446",
         "is_verified": false,
-        "line_number": 665
+        "line_number": 700
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
         "is_verified": false,
-        "line_number": 811
+        "line_number": 846
       },
       {
         "type": "Secret Keyword",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 1490
+        "line_number": 1525
       }
     ],
     "src/agents/sandbox/browser.novnc-url.test.ts": [
@@ -13026,14 +13026,14 @@
         "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
         "hashed_secret": "01800a0712a2a1aa928b95c4745e9ee06673925b",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 153
       },
       {
         "type": "Secret Keyword",
         "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
         "hashed_secret": "8d2ce71c6723bf46f6c166984b4ddb597f92322a",
         "is_verified": false,
-        "line_number": 190
+        "line_number": 180
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -14725,5 +14725,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T11:12:54Z"
+  "generated_at": "2026-03-07T17:04:44Z"
 }


### PR DESCRIPTION
## Summary

- Problem: the detect-secrets excludes only matched `key_content.include?("BEGIN PRIVATE KEY")`, but recent Fastlane code now checks the same PEM sentinel through `decoded.include?(...)`.
- Why it matters: PRs that fell back to all-files secret scanning could fail on a false positive in `apps/ios/fastlane/Fastfile`, even when the PR itself did not touch Fastlane or secrets handling.
- What changed: the detect-secrets exclusion pattern now covers both `key_content` and `decoded`, and the baseline was refreshed after rerunning the scan.
- What did NOT change (scope boundary): this does not relax `detect-private-key`, does not change any runtime auth behavior, and does not alter Fastlane key loading logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

None.

This PR only changes secret-scan maintenance behavior:

- `detect-secrets` no longer flags the Fastlane PEM sentinel check as a potential private key when it appears via `decoded.include?(...)`.
- `.secrets.baseline` is refreshed to match the current repository state after rerunning the scan.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Python venv + pre-commit
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): repository `.pre-commit-config.yaml`, `.detect-secrets.cfg`, `.secrets.baseline`

### Steps

1. Run `pre-commit run --all-files detect-secrets` on `upstream/main`.
2. Observe the false positive against `apps/ios/fastlane/Fastfile:41` for the string sentinel check around `"BEGIN PRIVATE KEY"`.
3. Update the exclude pattern to match both `key_content.include?(...)` and `decoded.include?(...)`.
4. Re-run `detect-secrets` and refresh `.secrets.baseline`.

### Expected

- The Fastlane PEM sentinel check is treated as a false positive and no longer trips `detect-secrets`.
- `detect-private-key` remains unchanged and still passes.

### Actual

- Before this change, all-files `detect-secrets` scans could fail on `apps/ios/fastlane/Fastfile:41` because the exclude pattern only matched the older `key_content` form.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran `pre-commit run --all-files detect-secrets` and reproduced the Fastfile false positive before the fix.
  - Re-ran `pre-commit run --all-files detect-secrets` after the fix and baseline refresh.
  - Ran `pre-commit run --all-files detect-private-key` to confirm the stronger private-key check still passes unchanged.
- Edge cases checked:
  - The exclude remains narrowly scoped to the PEM marker sentinel line.
  - The baseline refresh is mechanical and limited to updated filters / line metadata.
- What you did **not** verify:
  - Any unrelated CI jobs outside secret scanning.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR.
- Files/config to restore:
  - `.pre-commit-config.yaml`
  - `.detect-secrets.cfg`
  - `.secrets.baseline`
- Known bad symptoms reviewers should watch for:
  - `detect-secrets` starts flagging the Fastlane PEM sentinel check again on all-files scans.

## Risks and Mitigations

- Risk:
  - The exclude could accidentally become broader than intended.
  - Mitigation:
    - The regex is still narrowly scoped to the exact PEM marker sentinel check and only expands the variable name from `key_content` to `decoded`.
- Risk:
  - The baseline refresh could hide unrelated secret findings if not reviewed carefully.
  - Mitigation:
    - The functional change is isolated to the Fastlane sentinel pattern; the remaining baseline diff is mechanical line-number/filter sync from rerunning `detect-secrets`.
