### PR TITLE
fix(context): show path basename instead of undefined for virtual bootstrap files

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -48,6 +48,40 @@ describe("buildBootstrapInjectionStats", () => {
       truncated: true,
     });
   });
+
+  it("falls back to path basename when file.name is undefined (virtual hook-injected files)", () => {
+    // Hooks can push files with only `path` and no `name` (e.g. virtual bootstrap files).
+    // buildBootstrapInjectionStats must not emit `undefined` as the name.
+    const bootstrapFiles = [
+      {
+        // name is intentionally omitted to simulate a virtual file from a hook
+        path: "/workspace/SELF_IMPROVEMENT_REMINDER.md",
+        content: "reminder content",
+        missing: false,
+      } as unknown as import("./workspace.js").WorkspaceBootstrapFile,
+    ];
+    const injectedFiles = [
+      { path: "/workspace/SELF_IMPROVEMENT_REMINDER.md", content: "reminder content" },
+    ];
+    const stats = buildBootstrapInjectionStats({ bootstrapFiles, injectedFiles });
+    expect(stats).toHaveLength(1);
+    expect(stats[0].name).toBe("SELF_IMPROVEMENT_REMINDER.md");
+    expect(typeof stats[0].name).toBe("string");
+    expect(stats[0].path).toBe("/workspace/SELF_IMPROVEMENT_REMINDER.md");
+    expect(stats[0].injectedChars).toBe("reminder content".length);
+  });
+
+  it("uses 'unknown' as final fallback when both name and path are absent", () => {
+    const bootstrapFiles = [
+      {
+        content: "some content",
+        missing: false,
+      } as unknown as import("./workspace.js").WorkspaceBootstrapFile,
+    ];
+    const stats = buildBootstrapInjectionStats({ bootstrapFiles, injectedFiles: [] });
+    expect(typeof stats[0].name).toBe("string");
+    expect(stats[0].name).toBe("unknown");
+  });
 });
 
 describe("analyzeBootstrapBudget", () => {

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -150,9 +150,14 @@ export function buildBootstrapInjectionStats(params: {
       injectedByBaseName.get(file.name);
     const injectedChars = injected ? injected.length : 0;
     const truncated = !file.missing && injectedChars < rawChars;
+    // For virtual files pushed via hooks, `file.name` may be undefined because
+    // the hook API only requires `path`. Fall back to the path basename so the
+    // display is useful rather than showing "undefined".
+    const nameFromPath = pathValue ? path.posix.basename(pathValue) || pathValue : undefined;
+    const resolvedName: string = file.name ?? nameFromPath ?? "unknown";
     return {
-      name: file.name,
-      path: pathValue || file.name,
+      name: resolvedName,
+      path: pathValue || file.name || resolvedName,
       missing: file.missing,
       rawChars,
       injectedChars,


### PR DESCRIPTION
## Summary

Fixes #39013 (Bug 1 — the session-memory echo issue is a separate problem)

Hook-authored bootstrap files created with only `{ path, content, virtual: true }` arrive with `file.name = undefined` at runtime (TypeScript types are checked at compile time, not at runtime). `buildBootstrapInjectionStats` passed that `undefined` through directly, causing `/context list` to render:

```
undefined: OK | raw 616 chars (~154 tok) | injected 616 chars
```

instead of the actual filename, e.g.:

```
SELF_IMPROVEMENT_REMINDER.md: OK | raw 616 chars (~154 tok) | injected 616 chars
```

## Changes

- `src/agents/bootstrap-budget.ts`: in `buildBootstrapInjectionStats`, derive `resolvedName` by falling back to the path basename when `file.name` is falsy, then the full path value, then the string `"unknown"` as a last resort
- `src/agents/bootstrap-budget.test.ts`: two new tests covering the virtual-file case and the no-name-no-path edge case

---
🤖 Generated with Claude Code