### PR TITLE
fix(signal): skip <media:unknown> placeholder for events with no real media

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -634,7 +634,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         }
         const firstContentType = dataMessage.attachments?.[0]?.contentType;
         const pendingKind = kindFromMime(firstContentType ?? undefined);
-        return pendingKind ? `<media:${pendingKind}>` : "<media:attachment>";
+        return pendingKind && pendingKind !== "unknown"
+          ? `<media:${pendingKind}>`
+          : "<media:attachment>";
       })();
       const pendingBodyText = messageText || pendingPlaceholder || quoteText;
       const historyKey = groupId ?? "unknown";
@@ -677,7 +679,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const kind = kindFromMime(mediaType ?? undefined);
-    if (kind) {
+    if (kind && kind !== "unknown") {
       placeholder = `<media:${kind}>`;
     } else if (dataMessage.attachments?.length) {
       placeholder = "<media:attachment>";


### PR DESCRIPTION
## Summary

Fixes #38997

`kindFromMime(undefined)` returns the string `"unknown"` (truthy), so the guard `if (kind)` fired even when `mediaType` was never set — which happens for read receipts, typing indicators, and emoji reactions that carry no attachment. These events ended up with `placeholder="<media:unknown>"`, which then passed the `if (!bodyText) return` guard and were delivered to the agent as chat messages.

## Changes

- `src/signal/monitor/event-handler.ts`: add `kind !== "unknown"` check in both placeholder-building branches. Events without real media now fall through to the `else if (attachments.length)` path (returning `<media:attachment>`) or leave placeholder empty, and are correctly dropped by the `if (!bodyText) return` guard.

---
🤖 Generated with Claude Code