### PR TITLE
AI-assisted: Gateway hook event routing respects target agent session

### DIFF
--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
+import { resolveAgentMainSessionKey, resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { drainSystemEvents, peekSystemEvents } from "../infra/system-events.js";
 import {
   cronIsolatedRun,
@@ -12,7 +12,20 @@ import {
 installGatewayTestHooks({ scope: "suite" });
 
 const resolveMainKey = () => resolveMainSessionKeyFromConfig();
+const resolveHooksMainKey = () => resolveAgentMainSessionKey({ agentId: "hooks" });
 const HOOK_TOKEN = "hook-secret";
+
+async function waitForEventsForSession(sessionKey: string, timeoutMs = 2_000): Promise<string[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const events = peekSystemEvents(sessionKey);
+    if (events.length > 0) {
+      return events;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timeout waiting for system event in ${sessionKey}`);
+}
 
 function buildHookJsonHeaders(options?: {
   token?: string | null;
@@ -98,12 +111,14 @@ describe("gateway server hooks", () => {
         agentId: "hooks",
       });
       expect(resAgentWithId.status).toBe(200);
-      await waitForSystemEvent();
+      const hookEvents = await waitForEventsForSession(resolveHooksMainKey());
+      expect(hookEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };
       expect(routedCall?.job?.agentId).toBe("hooks");
-      drainSystemEvents(resolveMainKey());
+      drainSystemEvents(resolveHooksMainKey());
 
       mockIsolatedRunOkOnce();
       const resAgentUnknown = await postHook(port, "/hooks/agent", {
@@ -264,14 +279,15 @@ describe("gateway server hooks", () => {
         sessionKey: "agent:hooks:slack:channel:c123",
       });
       expect(resAgent.status).toBe(200);
-      await waitForSystemEvent();
+      await waitForEventsForSession(resolveHooksMainKey());
 
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string; job?: { agentId?: string } }
         | undefined;
       expect(routedCall?.job?.agentId).toBe("hooks");
       expect(routedCall?.sessionKey).toBe("slack:channel:c123");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
+      drainSystemEvents(resolveHooksMainKey());
     });
   });
 
@@ -307,12 +323,13 @@ describe("gateway server hooks", () => {
         agentId: "hooks",
       });
       expect(resAllowed.status).toBe(200);
-      await waitForSystemEvent();
+      await waitForEventsForSession(resolveHooksMainKey());
       const allowedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };
       expect(allowedCall?.job?.agentId).toBe("hooks");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
+      drainSystemEvents(resolveHooksMainKey());
 
       const resDenied = await postHook(port, "/hooks/agent", {
         message: "Denied",

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { CliDeps } from "../../cli/deps.js";
 import { loadConfig } from "../../config/config.js";
-import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
+import {
+  resolveAgentMainSessionKey,
+  resolveMainSessionKey,
+  resolveMainSessionKeyFromConfig,
+} from "../../config/sessions.js";
 import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
 import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
@@ -38,7 +43,6 @@ export function createGatewayHooksRequestHandler(params: {
       sessionKey: value.sessionKey,
       targetAgentId: value.agentId,
     });
-    const mainSessionKey = resolveMainSessionKeyFromConfig();
     const jobId = randomUUID();
     const now = Date.now();
     const job: CronJob = {
@@ -69,6 +73,11 @@ export function createGatewayHooksRequestHandler(params: {
     void (async () => {
       try {
         const cfg = loadConfig();
+        const targetAgentId = value.agentId ?? resolveSessionAgentId({ sessionKey, config: cfg });
+        const systemEventSessionKey =
+          cfg.session?.scope === "global"
+            ? resolveMainSessionKey(cfg)
+            : resolveAgentMainSessionKey({ cfg, agentId: targetAgentId });
         const result = await runCronIsolatedAgentTurn({
           cfg,
           deps,
@@ -82,7 +91,7 @@ export function createGatewayHooksRequestHandler(params: {
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
         if (!result.delivered) {
           enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
-            sessionKey: mainSessionKey,
+            sessionKey: systemEventSessionKey,
           });
           if (value.wakeMode === "now") {
             requestHeartbeatNow({ reason: `hook:${jobId}` });
@@ -90,8 +99,14 @@ export function createGatewayHooksRequestHandler(params: {
         }
       } catch (err) {
         logHooks.warn(`hook agent failed: ${String(err)}`);
+        const cfg = loadConfig();
+        const targetAgentId = value.agentId ?? resolveSessionAgentId({ sessionKey, config: cfg });
+        const systemEventSessionKey =
+          cfg.session?.scope === "global"
+            ? resolveMainSessionKey(cfg)
+            : resolveAgentMainSessionKey({ cfg, agentId: targetAgentId });
         enqueueSystemEvent(`Hook ${value.name} (error): ${String(err)}`, {
-          sessionKey: mainSessionKey,
+          sessionKey: systemEventSessionKey,
         });
         if (value.wakeMode === "now") {
           requestHeartbeatNow({ reason: `hook:${jobId}:error` });


### PR DESCRIPTION
## Summary

- Problem: Hook completion and error system events were always enqueued to the default agent main session, even when the hook ran against another agent.
- Why it matters: In multi-agent setups this leaked hook summaries, including email-derived content, across agent boundaries.
- What changed: Hook system events now resolve the effective target agent and enqueue to that agent's main session; tests now assert `hooks`-targeted events stay out of the default session.
- What did NOT change (scope boundary): Hook execution, delivery behavior, and wake-hook routing were not otherwise changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24693
- Related #24016

## User-visible / Behavior Changes

Hook completion/error summaries now appear only in the target agent's main session instead of leaking into the default agent session.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  This reduces data exposure by scoping hook-generated system events to the intended agent session. No broader data access was added.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Hook gateway endpoints
- Relevant config (redacted): multi-agent config with default `main` agent and `hooks` agent

### Steps

1. Configure hooks with a target `agentId` of `hooks`.
2. Trigger `/hooks/agent` with a non-delivered hook run.
3. Inspect queued system events for `agent:main:main` and `agent:hooks:main`.

### Expected

- The hook summary is queued only in the target agent's main session.

### Actual

- Before this change it was queued in the default agent's main session.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: explicit `agentId: "hooks"`, agent-scoped request `sessionKey`, allowed-agent enforcement, wake hooks still landing in the default main session.
- Edge cases checked: fallback to default agent for unknown target agent IDs.
- What you did **not** verify: live Gmail hook traffic against a real multi-agent deployment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two commits in this PR.
- Files/config to restore: `src/gateway/server/hooks.ts` and `src/gateway/server.hooks.test.ts`
- Known bad symptoms reviewers should watch for: hook summaries not appearing in the target agent session, or wake hooks no longer reaching the default main session.

## Risks and Mitigations

- Risk: Hook runs that infer the effective agent from session key could misroute if the session key parsing changes elsewhere.
  - Mitigation: regression coverage now checks both explicit-agent and agent-scoped session-key flows.

AI-assisted: yes. Fully tested locally for the targeted hook suite and validated with `pnpm build`.
