### PR TITLE
fix(tests): add missing headers to diffs index.test.ts localReq mock

### DIFF
--- a/extensions/diffs/index.test.ts
+++ b/extensions/diffs/index.test.ts
@@ -143,6 +143,7 @@ describe("diffs plugin registration", () => {
 function localReq(input: { method: string; url: string }): IncomingMessage {
   return {
     ...input,
+    headers: {},
     socket: { remoteAddress: "127.0.0.1" },
   } as unknown as IncomingMessage;
 }


### PR DESCRIPTION
## Summary

- **Problem**: `extensions/diffs/index.test.ts` throws `TypeError: Cannot read properties of undefined (reading 'x-forwarded-for')` in the `applies plugin-config defaults` test case.
- **Why it matters**: Every open PR currently fails the `checks (node, extensions)` CI job due to this, even when the PR doesn't touch extensions code. Blocks merge readiness assessment for unrelated PRs.
- **What changed**: Added `headers: {}` to the `localReq()` mock helper so `hasProxyForwardingHints()` can safely access `req.headers`.
- **What did NOT change**: No production code touched. Only the test mock helper in `index.test.ts`. The identical `localReq()` helper in `http.test.ts` already has this property (added in 44881b02).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related: 44881b02 (introduced `hasProxyForwardingHints()`, updated `http.test.ts` but missed `index.test.ts`)
- Unblocks: #38631, #38776, #39001 (and all other open PRs failing extensions CI)

## User-visible / Behavior Changes

None. Test-only change.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- CI runner (Ubuntu, node)
- Reproducible on any branch based on main after 44881b02

### Steps

1. Open any PR targeting main
2. Wait for `checks (node, extensions, pnpm test:extensions)` CI job
3. Observe failure in `extensions/diffs/index.test.ts`

### Expected

All 258 extension test files pass (2260 tests).

### Actual

1 test file fails, 257 pass. The specific failure:
```
TypeError: Cannot read properties of undefined (reading 'x-forwarded-for')
 at hasProxyForwardingHints  extensions/diffs/src/http.ts:180:9
 at resolveViewerAccess      extensions/diffs/src/http.ts:193:58
 at                          extensions/diffs/index.test.ts:124:27
```

## Evidence

Before (from PR #38631 CI run 22803165182):
```
FAIL extensions/diffs/index.test.ts > diffs plugin registration > applies plugin-config defaults
TypeError: Cannot read properties of undefined (reading 'x-forwarded-for')
Test Files  1 failed | 257 passed (258)
Tests       1 failed | 2258 passed | 1 skipped (2260)
```

After (PR #39047 CI run 22803786316):
```
checks (node, extensions, pnpm test:extensions)  pass  1m57s
```

## Human Verification (required)

- Verified the `localReq()` helper in `http.test.ts:235-244` already includes `headers: input.headers ?? {}` as the established pattern from the same commit (44881b02)
- Confirmed `index.test.ts`'s `localReq()` is the only other mock helper that was missed
- Checked the full `index.test.ts` file: `localReq()` is called once (line 125), always with `{ method, url }`, never needs custom headers
- CI confirms fix: extensions job now passes on this PR

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- Zero risk: only adds an empty object to a test mock

## Risks and Mitigations

None. Single-line addition to a test helper with no production code impact.