### PR TITLE
fix(cron): prevent duplicate isolated runs from watchdog timer race

### DIFF
--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -63,4 +63,48 @@ describe("CronService", () => {
     cronB.stop();
     await store.cleanup();
   });
+
+  it("does not spawn duplicate sessions when watchdog recheck timer fires near job completion", async () => {
+    // Regression: avoid duplicate isolated spawns from watchdog recheck race.
+    // We force a long-running job so the recheck fires mid-run, then assert only one spawn.
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => {
+      // Exceed watchdog interval to trigger recheck while running.
+      await vi.advanceTimersByTimeAsync(65_000);
+      return { status: "ok" as const };
+    });
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+    const atMs = Date.parse("2025-12-13T00:00:01.000Z");
+    await cron.add({
+      name: "long isolated job",
+      enabled: true,
+      schedule: { kind: "at", at: new Date(atMs).toISOString() },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "run task" },
+    });
+
+    // Advance time past the job's scheduled fire time.
+    vi.setSystemTime(new Date("2025-12-13T00:00:01.000Z"));
+    // Run all pending timers (fires the scheduler tick + watchdog recheck).
+    await vi.runAllTimersAsync();
+
+    // The isolated job should have been spawned exactly once.
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+
+    cron.stop();
+    await store.cleanup();
+  });
 });

--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -66,7 +66,8 @@ describe("CronService", () => {
 
   it("does not spawn duplicate sessions when watchdog recheck timer fires near job completion", async () => {
     // Regression: avoid duplicate isolated spawns from watchdog recheck race.
-    // We force a long-running job so the recheck fires mid-run, then assert only one spawn.
+    // We schedule a one-shot job 60s in the future, then simulate a long-running
+    // job that exceeds the watchdog interval (60s) to trigger recheck mid-run.
     const store = await makeStorePath();
     const runIsolatedAgentJob = vi.fn(async () => {
       // Exceed watchdog interval to trigger recheck while running.
@@ -86,25 +87,26 @@ describe("CronService", () => {
     });
 
     await cron.start();
-    const atMs = Date.parse("2025-12-13T00:00:01.000Z");
     await cron.add({
       name: "long isolated job",
       enabled: true,
-      schedule: { kind: "at", at: new Date(atMs).toISOString() },
+      schedule: { kind: "at", at: "2025-12-13T00:01:00.000Z" },
       sessionTarget: "isolated",
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "run task" },
     });
 
-    // Advance time past the job's scheduled fire time.
-    vi.setSystemTime(new Date("2025-12-13T00:00:01.000Z"));
-    // Run all pending timers (fires the scheduler tick + watchdog recheck).
-    await vi.runAllTimersAsync();
+    // Advance time to when the job should fire and run all timers.
+    // The job runs for 65s, triggering the watchdog recheck timer during execution.
+    vi.setSystemTime(new Date("2025-12-13T00:01:00.000Z"));
 
-    // The isolated job should have been spawned exactly once.
-    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
-
-    cron.stop();
-    await store.cleanup();
+    try {
+      await vi.runAllTimersAsync();
+      // The isolated job should have been spawned exactly once.
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
   });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -673,6 +673,9 @@ export async function onTimer(state: CronServiceState) {
       });
     }
   } finally {
+    // Prevent watchdog/onTimer race that can duplicate runs.
+    stopTimer(state);
+
     // Piggyback session reaper on timer tick (self-throttled to every 5 min).
     // Placed in `finally` so the reaper runs even when a long-running job keeps
     // `state.running` true across multiple timer ticks — the early return at the


### PR DESCRIPTION
Summary

- Problem: Cron watchdog recheck could overlap with onTimer cleanup and queue a second tick while running was still true.
- Why it matters: That race can cause duplicate isolated session spawns for the same due job.
- What changed: Stop the watchdog timer at the start of onTimer’s finally block; add a regression test with a long-running job (> watchdog interval) and assert single spawn.
- What did NOT change (scope boundary): No changes to cron schedule semantics, payload format, delivery behavior, or model/auth routing.

Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

Linked Issue/PR

- Closes #25950
- Related #25950

User-visible / Behavior Changes

- Prevents duplicate isolated spawns for a single due cron tick under watchdog overlap conditions.
- No config/default changes.

Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

Repro + Verification

Environment

- OS: Linux
- Runtime/container: OpenClaw gateway runtime
- Model/provider: N/A (scheduler/orchestration path)
- Integration/channel (if any): N/A
- Relevant config (redacted): default watchdog/recheck behavior

Steps

1. Trigger a due isolated cron job.
2. Make the isolated run exceed watchdog interval (> watchdog threshold).
3. Observe recheck firing while run is active and assert total spawn count.

Expected

- Exactly one isolated spawn for one due tick.

Actual

- Before fix: second spawn could queue from recheck/onTimer overlap.
- After fix: single spawn only.

Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Human Verification (required)

- Verified scenarios:
- Long-running isolated run crossing watchdog interval.
- Single due tick results in single isolated spawn.
- Edge cases checked:
- Recheck firing during active running=true window.
- finally cleanup ordering.
- What you did not verify:
- Multi-node/distributed cron behavior (if applicable).

Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Revert this commit to restore prior timer behavior.
- Files/config to restore:
- Cron service file containing onTimer watchdog logic.
- Regression test file for duplicate-spawn race.
- Known bad symptoms reviewers should watch for:
- Duplicate isolated spawns for same due job.
- Missing recheck behavior after long-running jobs.

Risks and Mitigations

- Risk: Timer stop ordering could accidentally suppress a legitimate follow-up recheck in edge timing.
- Mitigation: Regression test asserts single-spawn race fix; verify subsequent ticks still execute normally.