### PR TITLE
fix(tests): add missing headers to diffs index.test.ts localReq mock

### DIFF
--- a/extensions/diffs/index.test.ts
+++ b/extensions/diffs/index.test.ts
@@ -140,9 +140,14 @@ describe("diffs plugin registration", () => {
   });
 });
 
-function localReq(input: { method: string; url: string }): IncomingMessage {
+function localReq(input: {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+}): IncomingMessage {
   return {
     ...input,
+    headers: input.headers ?? {},
     socket: { remoteAddress: "127.0.0.1" },
   } as unknown as IncomingMessage;
 }


### PR DESCRIPTION
## Summary

- **Problem**: `extensions/diffs/index.test.ts` throws `TypeError: Cannot read properties of undefined (reading x-forwarded-for)` in the `applies plugin-config defaults` test case.
- **Why it matters**: Every open PR currently fails the `checks (node, extensions)` CI job due to this.
- **What changed**: Added `headers: input.headers ?? {}` to the `localReq()` mock helper.

## Changes

- Modified `extensions/diffs/index.test.ts` to add `headers` property to `localReq()` function, matching the pattern already used in `http.test.ts` (commit 44881b02).

## Testing

The fix resolves:
```
TypeError: Cannot read properties of undefined (reading x-forwarded-for)
 at hasProxyForwardingHints extensions/diffs/src/http.ts:180:9
 at resolveViewerAccess extensions/diffs/src/http.ts:193:58
 at extensions/diffs/index.test.ts:124:27
```

## Compatibility

- Backward compatible: Yes
- No production code changed: Only test mock helper

Fixes openclaw/openclaw#39047