### PR TITLE
fix(gateway): accept http aliases for loopback announce delivery

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -439,8 +439,10 @@ describe("isSecureWebSocketUrl", () => {
       // invalid URLs
       { input: "not-a-url", expected: false },
       { input: "", expected: false },
-      { input: "http://127.0.0.1:18789", expected: false },
-      { input: "https://127.0.0.1:18789", expected: false },
+      { input: "http://127.0.0.1:18789", expected: true },
+      { input: "https://127.0.0.1:18789", expected: true },
+      { input: "https://remote.example.com:18789", expected: true },
+      { input: "http://remote.example.com:18789", expected: false },
     ] as const;
 
     for (const testCase of cases) {
@@ -451,6 +453,7 @@ describe("isSecureWebSocketUrl", () => {
   it("allows private ws:// only when opt-in is enabled", () => {
     const allowedWhenOptedIn = [
       "ws://10.0.0.5:18789",
+      "http://10.0.0.5:18789",
       "ws://172.16.0.1:18789",
       "ws://192.168.1.100:18789",
       "ws://100.64.0.1:18789",

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -421,11 +421,17 @@ export function isSecureWebSocketUrl(
     return false;
   }
 
-  if (parsed.protocol === "wss:") {
+  // Node's ws client accepts http(s) URLs and normalizes them to ws(s).
+  // Treat those aliases the same way here so loopback cron announce delivery
+  // and TLS-backed https endpoints follow the same security policy.
+  const protocol =
+    parsed.protocol === "https:" ? "wss:" : parsed.protocol === "http:" ? "ws:" : parsed.protocol;
+
+  if (protocol === "wss:") {
     return true;
   }
 
-  if (parsed.protocol !== "ws:") {
+  if (protocol !== "ws:") {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- treat `http:` URLs like `ws:` and `https:` like `wss:` in the secure gateway URL validator
- preserve the existing loopback-only/default and private-network opt-in policy
- add regression coverage for loopback and private-network http aliases

## Problem
Cron announce delivery can target loopback gateways with `http://127.0.0.1:<port>`. The validator currently rejects those URLs before the ws client gets a chance to normalize them.

## Verification
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH vitest run src/gateway/net.test.ts`
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH oxfmt --check src/gateway/net.ts src/gateway/net.test.ts`

Closes #38882