### PR TITLE
fix(models): ignore cancelled token prompts

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -3,10 +3,16 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const mocks = vi.hoisted(() => ({
+  clackCancel: vi.fn(),
+  clackConfirm: vi.fn(),
+  clackIsCancel: vi.fn((value: unknown) => value === Symbol.for("clack:cancel")),
+  clackSelect: vi.fn(),
+  clackText: vi.fn(),
   resolveDefaultAgentId: vi.fn(),
   resolveAgentDir: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(),
   resolveDefaultAgentWorkspaceDir: vi.fn(),
+  upsertAuthProfile: vi.fn(),
   resolvePluginProviders: vi.fn(),
   createClackPrompter: vi.fn(),
   loginOpenAICodexOAuth: vi.fn(),
@@ -17,10 +23,22 @@ const mocks = vi.hoisted(() => ({
   openUrl: vi.fn(),
 }));
 
+vi.mock("@clack/prompts", () => ({
+  cancel: mocks.clackCancel,
+  confirm: mocks.clackConfirm,
+  isCancel: mocks.clackIsCancel,
+  select: mocks.clackSelect,
+  text: mocks.clackText,
+}));
+
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: mocks.resolveDefaultAgentId,
   resolveAgentDir: mocks.resolveAgentDir,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  upsertAuthProfile: mocks.upsertAuthProfile,
 }));
 
 vi.mock("../../agents/workspace.js", () => ({
@@ -64,13 +82,24 @@ vi.mock("../onboard-helpers.js", () => ({
   openUrl: mocks.openUrl,
 }));
 
-const { modelsAuthLoginCommand } = await import("./auth.js");
+const { modelsAuthLoginCommand, modelsAuthPasteTokenCommand, modelsAuthSetupTokenCommand } =
+  await import("./auth.js");
 
 function createRuntime(): RuntimeEnv {
   return {
     log: vi.fn(),
     error: vi.fn(),
     exit: vi.fn(),
+  };
+}
+
+function createExitThrowingRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`exit:${code}`);
+    }),
   };
 }
 
@@ -108,6 +137,14 @@ describe("modelsAuthLoginCommand", () => {
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.resolveDefaultAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.loadValidConfigOrThrow.mockImplementation(async () => currentConfig);
+    mocks.clackCancel.mockReset();
+    mocks.clackConfirm.mockReset();
+    mocks.clackIsCancel.mockImplementation(
+      (value: unknown) => value === Symbol.for("clack:cancel"),
+    );
+    mocks.clackSelect.mockReset();
+    mocks.clackText.mockReset();
+    mocks.upsertAuthProfile.mockReset();
     mocks.updateConfig.mockImplementation(
       async (mutator: (cfg: OpenClawConfig) => OpenClawConfig) => {
         lastUpdatedConfig = mutator(currentConfig);
@@ -157,7 +194,7 @@ describe("modelsAuthLoginCommand", () => {
       "Auth profile: openai-codex:user@example.com (openai-codex/oauth)",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Default model available: openai-codex/gpt-5.3-codex (use --set-default to apply)",
+      "Default model available: openai-codex/gpt-5.4 (use --set-default to apply)",
     );
   });
 
@@ -167,9 +204,9 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthLoginCommand({ provider: "openai-codex", setDefault: true }, runtime);
 
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
-      primary: "openai-codex/gpt-5.3-codex",
+      primary: "openai-codex/gpt-5.4",
     });
-    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.3-codex");
+    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.4");
   });
 
   it("keeps existing plugin error behavior for non built-in providers", async () => {
@@ -178,5 +215,31 @@ describe("modelsAuthLoginCommand", () => {
     await expect(modelsAuthLoginCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
       "No provider plugins found.",
     );
+  });
+
+  it("does not persist a cancelled manual token entry", async () => {
+    const runtime = createExitThrowingRuntime();
+    mocks.clackText.mockResolvedValue(Symbol.for("clack:cancel"));
+
+    await expect(modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
+      "exit:0",
+    );
+
+    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
+  });
+
+  it("does not persist a cancelled setup-token entry", async () => {
+    const runtime = createExitThrowingRuntime();
+    mocks.clackText.mockResolvedValue(Symbol.for("clack:cancel"));
+
+    await expect(
+      modelsAuthSetupTokenCommand({ provider: "anthropic", yes: true }, runtime),
+    ).rejects.toThrow("exit:0");
+
+    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1,20 +1,30 @@
-import { confirm as clackConfirm, select as clackSelect, text as clackText } from "@clack/prompts";
+import {
+  cancel as clackCancel,
+  confirm as clackConfirm,
+  isCancel,
+  select as clackSelect,
+  text as clackText,
+} from "@clack/prompts";
+import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
+import type { ProviderAuthResult, ProviderPlugin } from "../../plugins/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import { upsertAuthProfile } from "../../agents/auth-profiles.js";
-import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { resolvePluginProviders } from "../../plugins/providers.js";
-import type { ProviderAuthResult, ProviderPlugin } from "../../plugins/types.js";
-import type { RuntimeEnv } from "../../runtime.js";
-import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
+import {
+  stylePromptHint,
+  stylePromptMessage,
+  stylePromptTitle,
+} from "../../terminal/prompt-style.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { validateAnthropicSetupToken } from "../auth-token.js";
 import { isRemoteEnvironment } from "../oauth-env.js";
@@ -53,6 +63,15 @@ const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
     ),
   });
 
+function guardPromptCancel<T>(value: T | symbol, runtime: RuntimeEnv): T {
+  if (isCancel(value)) {
+    clackCancel(stylePromptTitle("Auth setup cancelled.") ?? "Auth setup cancelled.");
+    runtime.exit(0);
+    throw new Error("unreachable");
+  }
+  return value;
+}
+
 type TokenProvider = "anthropic";
 
 function resolveTokenProvider(raw?: string): TokenProvider | "custom" | null {
@@ -85,19 +104,25 @@ export async function modelsAuthSetupTokenCommand(
   }
 
   if (!opts.yes) {
-    const proceed = await confirm({
-      message: "Have you run `claude setup-token` and copied the token?",
-      initialValue: true,
-    });
+    const proceed = guardPromptCancel(
+      await confirm({
+        message: "Have you run `claude setup-token` and copied the token?",
+        initialValue: true,
+      }),
+      runtime,
+    );
     if (!proceed) {
       return;
     }
   }
 
-  const tokenInput = await text({
-    message: "Paste Anthropic setup-token",
-    validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
-  });
+  const tokenInput = guardPromptCancel(
+    await text({
+      message: "Paste Anthropic setup-token",
+      validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
+    }),
+    runtime,
+  );
   const token = String(tokenInput ?? "").trim();
   const profileId = resolveDefaultTokenProfileId(provider);
 
@@ -137,10 +162,13 @@ export async function modelsAuthPasteTokenCommand(
   const provider = normalizeProviderId(rawProvider);
   const profileId = opts.profileId?.trim() || resolveDefaultTokenProfileId(provider);
 
-  const tokenInput = await text({
-    message: `Paste token for ${provider}`,
-    validate: (value) => (value?.trim() ? undefined : "Required"),
-  });
+  const tokenInput = guardPromptCancel(
+    await text({
+      message: `Paste token for ${provider}`,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    }),
+    runtime,
+  );
   const token = String(tokenInput ?? "").trim();
 
   const expires =
@@ -165,41 +193,50 @@ export async function modelsAuthPasteTokenCommand(
 }
 
 export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime: RuntimeEnv) {
-  const provider = (await select({
-    message: "Token provider",
-    options: [
-      { value: "anthropic", label: "anthropic" },
-      { value: "custom", label: "custom (type provider id)" },
-    ],
-  })) as TokenProvider | "custom";
+  const provider = guardPromptCancel(
+    await select({
+      message: "Token provider",
+      options: [
+        { value: "anthropic", label: "anthropic" },
+        { value: "custom", label: "custom (type provider id)" },
+      ],
+    }),
+    runtime,
+  );
 
   const providerId =
     provider === "custom"
       ? normalizeProviderId(
           String(
-            await text({
-              message: "Provider id",
-              validate: (value) => (value?.trim() ? undefined : "Required"),
-            }),
+            guardPromptCancel(
+              await text({
+                message: "Provider id",
+                validate: (value) => (value?.trim() ? undefined : "Required"),
+              }),
+              runtime,
+            ),
           ),
         )
       : provider;
 
-  const method = (await select({
-    message: "Token method",
-    options: [
-      ...(providerId === "anthropic"
-        ? [
-            {
-              value: "setup-token",
-              label: "setup-token (claude)",
-              hint: "Paste a setup-token from `claude setup-token`",
-            },
-          ]
-        : []),
-      { value: "paste", label: "paste token" },
-    ],
-  })) as "setup-token" | "paste";
+  const method = guardPromptCancel(
+    await select({
+      message: "Token method",
+      options: [
+        ...(providerId === "anthropic"
+          ? [
+              {
+                value: "setup-token",
+                label: "setup-token (claude)",
+                hint: "Paste a setup-token from `claude setup-token`",
+              },
+            ]
+          : []),
+        { value: "paste", label: "paste token" },
+      ],
+    }),
+    runtime,
+  ) as "setup-token" | "paste";
 
   if (method === "setup-token") {
     await modelsAuthSetupTokenCommand({ provider: providerId }, runtime);
@@ -208,31 +245,40 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
 
   const profileIdDefault = resolveDefaultTokenProfileId(providerId);
   const profileId = String(
-    await text({
-      message: "Profile id",
-      initialValue: profileIdDefault,
-      validate: (value) => (value?.trim() ? undefined : "Required"),
-    }),
+    guardPromptCancel(
+      await text({
+        message: "Profile id",
+        initialValue: profileIdDefault,
+        validate: (value) => (value?.trim() ? undefined : "Required"),
+      }),
+      runtime,
+    ),
   ).trim();
 
-  const wantsExpiry = await confirm({
-    message: "Does this token expire?",
-    initialValue: false,
-  });
+  const wantsExpiry = guardPromptCancel(
+    await confirm({
+      message: "Does this token expire?",
+      initialValue: false,
+    }),
+    runtime,
+  );
   const expiresIn = wantsExpiry
     ? String(
-        await text({
-          message: "Expires in (duration)",
-          initialValue: "365d",
-          validate: (value) => {
-            try {
-              parseDurationMs(String(value ?? ""), { defaultUnit: "d" });
-              return undefined;
-            } catch {
-              return "Invalid duration (e.g. 365d, 12h, 30m)";
-            }
-          },
-        }),
+        guardPromptCancel(
+          await text({
+            message: "Expires in (duration)",
+            initialValue: "365d",
+            validate: (value) => {
+              try {
+                parseDurationMs(String(value ?? ""), { defaultUnit: "d" });
+                return undefined;
+              } catch {
+                return "Invalid duration (e.g. 365d, 12h, 30m)";
+              }
+            },
+          }),
+          runtime,
+        ),
       ).trim()
     : undefined;
 


### PR DESCRIPTION
## Summary
- stop treating cancelled clack token prompts as real token strings
- exit cleanly before writing auth profiles or config
- add regressions for both paste-token and setup-token flows

## Problem
Cancelling a manual token prompt can currently persist `Symbol(clack:cancel)` into `auth-profiles.json`, which leaves the auth profile in a broken state.

## Verification
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH vitest run src/commands/models/auth.test.ts`
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH oxfmt --check src/commands/models/auth.ts src/commands/models/auth.test.ts`
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH oxlint src/commands/models/auth.ts src/commands/models/auth.test.ts`

Closes #38928