### PR TITLE
Fix: filter delivery-mirror messages to prevent role alternation errors

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -517,6 +517,19 @@ export function applyGoogleTurnOrderingFix(params: {
   return { messages: sanitized, didPrepend };
 }
 
+// Filter out delivery-mirror messages to prevent role alternation errors
+function isDeliveryMirrorMessage(message: AgentMessage): boolean {
+  const msg = message as unknown as Record<string, unknown>;
+  const api = typeof msg.api === "string" ? msg.api : undefined;
+  const provider = typeof msg.provider === "string" ? msg.provider : undefined;
+  const model = typeof msg.model === "string" ? msg.model : undefined;
+  return api === "openai-responses" && provider === "openclaw" && model === "delivery-mirror";
+}
+
+function filterDeliveryMirrorMessages(messages: AgentMessage[]): AgentMessage[] {
+  return messages.filter((msg) => !isDeliveryMirrorMessage(msg));
+}
+
 export async function sanitizeSessionHistory(params: {
   messages: AgentMessage[];
   modelApi?: string | null;
@@ -536,7 +549,9 @@ export async function sanitizeSessionHistory(params: {
       provider: params.provider,
       modelId: params.modelId,
     });
-  const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
+  // Filter out delivery-mirror messages to prevent role alternation errors
+  const filteredMessages = filterDeliveryMirrorMessages(params.messages);
+  const withInterSessionMarkers = annotateInterSessionUserMessages(filteredMessages);
   const sanitizedImages = await sanitizeSessionMessagesImages(
     withInterSessionMarkers,
     "session:history",


### PR DESCRIPTION
## Summary

Fixes issue #38962 - Telegram role alternation error by filtering out delivery-mirror messages before sending them to the AI model.

## Problem
When sending messages via Telegram, the session history includes delivery-mirror messages that cause role alternation errors.

## Solution
Added filtering in sanitizeSessionHistory() to remove delivery-mirror messages.

## Testing
All 6641 tests pass.