### PR TITLE
fix(ui): allow editing default agent tool overrides

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -696,7 +696,14 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const index = ensureAgentConfigEntry(state, agentId);
+                  const index = ensureAgentConfigEntry(
+                    state,
+                    agentId,
+                    alsoAllow.length > 0 || deny.length > 0,
+                  );
+                  if (index < 0) {
+                    return;
+                  }
                   const basePath = ["agents", "list", index, "tools"];
                   if (alsoAllow.length > 0) {
                     updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,10 +1,10 @@
 import { html, nothing } from "lit";
+import type { AppViewState } from "./app-view-state.ts";
 import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
-import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
@@ -13,11 +13,12 @@ import { loadChannels } from "./controllers/channels.ts";
 import { loadChatHistory } from "./controllers/chat.ts";
 import {
   applyConfig,
+  ensureAgentConfigEntry,
   loadConfig,
+  removeConfigFormValue,
   runUpdate,
   saveConfig,
   updateConfigFormValue,
-  removeConfigFormValue,
 } from "./controllers/config.ts";
 import {
   loadCronRuns,
@@ -667,16 +668,17 @@ export function renderApp(state: AppViewState) {
                     return;
                   }
                   const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const existingIndex = Array.isArray(list)
+                    ? list.findIndex(
+                        (entry) =>
+                          entry &&
+                          typeof entry === "object" &&
+                          "id" in entry &&
+                          (entry as { id?: string }).id === agentId,
+                      )
+                    : -1;
+                  const index =
+                    profile || clearAllow ? ensureAgentConfigEntry(state, agentId) : existingIndex;
                   if (index < 0) {
                     return;
                   }
@@ -694,20 +696,7 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
+                  const index = ensureAgentConfigEntry(state, agentId);
                   const basePath = ["agents", "list", index, "tools"];
                   if (alsoAllow.length > 0) {
                     updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
@@ -734,18 +723,11 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const index = ensureAgentConfigEntry(state, agentId);
+                  const list = (
+                    (state.configForm ?? configValue) as { agents?: { list?: unknown[] } }
+                  ).agents?.list;
                   if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
                     return;
                   }
                   const entry = list[index] as { skills?: unknown };
@@ -792,20 +774,7 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
+                  const index = ensureAgentConfigEntry(state, agentId);
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
                 },
                 onModelChange: (agentId, modelId) => {
@@ -813,16 +782,16 @@ export function renderApp(state: AppViewState) {
                     return;
                   }
                   const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const existingIndex = Array.isArray(list)
+                    ? list.findIndex(
+                        (entry) =>
+                          entry &&
+                          typeof entry === "object" &&
+                          "id" in entry &&
+                          (entry as { id?: string }).id === agentId,
+                      )
+                    : -1;
+                  const index = modelId ? ensureAgentConfigEntry(state, agentId) : existingIndex;
                   if (index < 0) {
                     return;
                   }
@@ -831,7 +800,12 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, basePath);
                     return;
                   }
-                  const entry = list[index] as { model?: unknown };
+                  const nextList = (
+                    (state.configForm ?? configValue) as { agents?: { list?: unknown[] } }
+                  ).agents?.list;
+                  const entry = (Array.isArray(nextList) ? nextList[index] : undefined) as
+                    | { model?: unknown }
+                    | undefined;
                   const existing = entry?.model;
                   if (existing && typeof existing === "object" && !Array.isArray(existing)) {
                     const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
@@ -848,24 +822,30 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
+                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
                   const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const existingIndex = Array.isArray(list)
+                    ? list.findIndex(
+                        (entry) =>
+                          entry &&
+                          typeof entry === "object" &&
+                          "id" in entry &&
+                          (entry as { id?: string }).id === agentId,
+                      )
+                    : -1;
+                  const index =
+                    normalized.length > 0 ? ensureAgentConfigEntry(state, agentId) : existingIndex;
                   if (index < 0) {
                     return;
                   }
                   const basePath = ["agents", "list", index, "model"];
-                  const entry = list[index] as { model?: unknown };
-                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const existing = entry.model;
+                  const nextList = (
+                    (state.configForm ?? configValue) as { agents?: { list?: unknown[] } }
+                  ).agents?.list;
+                  const entry = (Array.isArray(nextList) ? nextList[index] : undefined) as
+                    | { model?: unknown }
+                    | undefined;
+                  const existing = entry?.model;
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {
                       return existing.trim() || null;

--- a/ui/src/ui/controllers/config.node.test.ts
+++ b/ui/src/ui/controllers/config.node.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { ensureAgentConfigEntry, type ConfigState } from "./config.ts";
+
+function createState(): ConfigState {
+  return {
+    applySessionKey: "main",
+    client: null,
+    configActiveSection: null,
+    configActiveSubsection: null,
+    configApplying: false,
+    configForm: null,
+    configFormDirty: false,
+    configFormMode: "form",
+    configFormOriginal: null,
+    configIssues: [],
+    configLoading: false,
+    configRaw: "",
+    configRawOriginal: "",
+    configSaving: false,
+    configSchema: null,
+    configSchemaLoading: false,
+    configSchemaVersion: null,
+    configSearchQuery: "",
+    configSnapshot: null,
+    configUiHints: {},
+    configValid: null,
+    connected: false,
+    lastError: null,
+    updateRunning: false,
+  };
+}
+
+describe("ensureAgentConfigEntry", () => {
+  it("does not create a missing agent entry when creation is disabled", () => {
+    const state = createState();
+    state.configSnapshot = {
+      config: { agents: { defaults: { workspace: "~/workspace" } } },
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    const index = ensureAgentConfigEntry(state, "main", false);
+
+    expect(index).toBe(-1);
+    expect(state.configFormDirty).toBe(false);
+    expect(state.configForm).toBeNull();
+  });
+});

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyConfigSnapshot,
   applyConfig,
+  ensureAgentConfigEntry,
   runUpdate,
   saveConfig,
   updateConfigFormValue,
@@ -143,6 +144,45 @@ describe("updateConfigFormValue", () => {
     expect(state.configRaw).toBe(
       '{\n  "gateway": {\n    "mode": "local",\n    "port": 18789\n  }\n}\n',
     );
+  });
+});
+
+describe("ensureAgentConfigEntry", () => {
+  it("adds a missing agent entry from snapshot-backed form state", () => {
+    const state = createState();
+    state.configSnapshot = {
+      config: { agents: { defaults: { workspace: "~/workspace" } } },
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    const index = ensureAgentConfigEntry(state, "main");
+
+    expect(index).toBe(0);
+    expect(state.configFormDirty).toBe(true);
+    expect(state.configForm).toEqual({
+      agents: {
+        defaults: { workspace: "~/workspace" },
+        list: [{ id: "main" }],
+      },
+    });
+  });
+
+  it("reuses an existing agent entry without dirtying the form", () => {
+    const state = createState();
+    state.configSnapshot = {
+      config: { agents: { list: [{ id: "main", tools: { profile: "messaging" } }] } },
+      valid: true,
+      issues: [],
+      raw: "{}",
+    };
+
+    const index = ensureAgentConfigEntry(state, "main");
+
+    expect(index).toBe(0);
+    expect(state.configFormDirty).toBe(false);
+    expect(state.configForm).toBeNull();
   });
 });
 

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -208,6 +208,43 @@ export function updateConfigFormValue(
   }
 }
 
+export function ensureAgentConfigEntry(state: ConfigState, agentId: string): number {
+  const trimmedAgentId = agentId.trim();
+  const current = (state.configForm ?? state.configSnapshot?.config ?? {}) as {
+    agents?: { list?: unknown[] };
+  };
+  const existingList = current.agents?.list;
+  if (Array.isArray(existingList)) {
+    const existingIndex = existingList.findIndex(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        "id" in entry &&
+        typeof (entry as { id?: unknown }).id === "string" &&
+        (entry as { id: string }).id === trimmedAgentId,
+    );
+    if (existingIndex >= 0) {
+      return existingIndex;
+    }
+  }
+
+  const base = cloneConfigObject(current);
+  const next = base as { agents?: { list?: Array<Record<string, unknown>> } };
+  if (!next.agents || typeof next.agents !== "object") {
+    next.agents = {};
+  }
+  if (!Array.isArray(next.agents.list)) {
+    next.agents.list = [];
+  }
+  next.agents.list.push({ id: trimmedAgentId });
+  state.configForm = base;
+  state.configFormDirty = true;
+  if (state.configFormMode === "form") {
+    state.configRaw = serializeConfigForm(base);
+  }
+  return next.agents.list.length - 1;
+}
+
 export function removeConfigFormValue(state: ConfigState, path: Array<string | number>) {
   const base = cloneConfigObject(state.configForm ?? state.configSnapshot?.config ?? {});
   removePathValue(base, path);

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -208,7 +208,11 @@ export function updateConfigFormValue(
   }
 }
 
-export function ensureAgentConfigEntry(state: ConfigState, agentId: string): number {
+export function ensureAgentConfigEntry(
+  state: ConfigState,
+  agentId: string,
+  createIfMissing = true,
+): number {
   const trimmedAgentId = agentId.trim();
   const current = (state.configForm ?? state.configSnapshot?.config ?? {}) as {
     agents?: { list?: unknown[] };
@@ -226,6 +230,9 @@ export function ensureAgentConfigEntry(state: ConfigState, agentId: string): num
     if (existingIndex >= 0) {
       return existingIndex;
     }
+  }
+  if (!createIfMissing) {
+    return -1;
   }
 
   const base = cloneConfigObject(current);


### PR DESCRIPTION
## Summary
- create a minimal `agents.list` entry on demand before writing tool/model/skill overrides from the agent panels
- keep inherit/clear actions as no-ops when the default agent still has no explicit entry
- add regression coverage for the config helper that seeds missing agent entries

## Problem
Fresh installs can have a default `main` agent without an explicit `agents.list` entry. The agent panels were only writing changes back to `agents.list[index]`, so clicking `Enable All`, preset buttons, or similar controls for the default agent silently did nothing.

## Verification
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH oxfmt --check ui/src/ui/app-render.ts ui/src/ui/controllers/config.ts ui/src/ui/controllers/config.test.ts`
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH oxlint ui/src/ui/app-render.ts ui/src/ui/controllers/config.ts ui/src/ui/controllers/config.test.ts`
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH tsx -e "import assert from 'node:assert/strict'; import { ensureAgentConfigEntry } from './ui/src/ui/controllers/config.ts'; const mk = () => ({ applySessionKey:'main', client:null, configActiveSection:null, configActiveSubsection:null, configApplying:false, configForm:null, configFormDirty:false, configFormMode:'form', configFormOriginal:null, configIssues:[], configLoading:false, configRaw:'', configRawOriginal:'', configSaving:false, configSchema:null, configSchemaLoading:false, configSchemaVersion:null, configSearchQuery:'', configSnapshot:null, configUiHints:{}, configValid:null, connected:false, lastError:null, updateRunning:false }); const state1 = mk(); state1.configSnapshot = { config: { agents: { defaults: { workspace: '~/workspace' } } }, valid: true, issues: [], raw: '{}' }; assert.equal(ensureAgentConfigEntry(state1, 'main'), 0); const state2 = mk(); state2.configSnapshot = { config: { agents: { list: [{ id: 'main', tools: { profile: 'messaging' } }] } }, valid: true, issues: [], raw: '{}' }; assert.equal(ensureAgentConfigEntry(state2, 'main'), 0); console.log('ok');"`

Closes #39068