### PR TITLE
fix(gateway): clear stale Slack socket state after disconnect

### DIFF
--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -174,7 +174,7 @@ describe("evaluateChannelHealth", () => {
       },
       {
         channelId: "slack",
-        now: 100_000,
+        now: 75_000,
         channelConnectGraceMs: 10_000,
         staleEventThresholdMs: 30_000,
       },
@@ -194,12 +194,32 @@ describe("evaluateChannelHealth", () => {
       },
       {
         channelId: "slack",
-        now: 100_000,
+        now: 75_000,
         channelConnectGraceMs: 10_000,
         staleEventThresholdMs: 30_000,
       },
     );
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("flags inherited event timestamps after the lifecycle exceeds the stale threshold", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 50_000,
+        lastEventAt: 10_000,
+      },
+      {
+        channelId: "slack",
+        now: 140_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -109,7 +109,11 @@ export function evaluateChannelHealth(
     snapshot.lastEventAt != null
   ) {
     if (lastStartAt != null && snapshot.lastEventAt < lastStartAt) {
-      return { healthy: true, reason: "healthy" };
+      const lifecycleEventGap = Math.max(0, policy.now - lastStartAt);
+      if (lifecycleEventGap <= policy.staleEventThresholdMs) {
+        return { healthy: true, reason: "healthy" };
+      }
+      return { healthy: false, reason: "stale-socket" };
     }
     const eventAge = policy.now - snapshot.lastEventAt;
     if (eventAge > policy.staleEventThresholdMs) {

--- a/src/slack/monitor/provider.reconnect.test.ts
+++ b/src/slack/monitor/provider.reconnect.test.ts
@@ -55,6 +55,21 @@ describe("slack socket reconnect helpers", () => {
     });
   });
 
+  it("clears connected state without error when socket mode disconnects cleanly", () => {
+    const setStatus = vi.fn();
+
+    __testing.publishSlackDisconnectedStatus(setStatus);
+
+    expect(setStatus).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith({
+      connected: false,
+      lastDisconnect: {
+        at: expect.any(Number),
+      },
+      lastError: null,
+    });
+  });
+
   it("resolves disconnect waiter on socket disconnect event", async () => {
     const client = new FakeEmitter();
     const app = { receiver: { client } };

--- a/src/slack/monitor/provider.reconnect.test.ts
+++ b/src/slack/monitor/provider.reconnect.test.ts
@@ -38,6 +38,23 @@ describe("slack socket reconnect helpers", () => {
     );
   });
 
+  it("clears connected state when socket mode disconnects", () => {
+    const setStatus = vi.fn();
+    const err = new Error("dns down");
+
+    __testing.publishSlackDisconnectedStatus(setStatus, err);
+
+    expect(setStatus).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith({
+      connected: false,
+      lastDisconnect: {
+        at: expect.any(Number),
+        error: "dns down",
+      },
+      lastError: "dns down",
+    });
+  });
+
   it("resolves disconnect waiter on socket disconnect event", async () => {
     const client = new FakeEmitter();
     const app = { receiver: { client } };

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -77,6 +77,22 @@ function publishSlackConnectedStatus(setStatus?: (next: Record<string, unknown>)
   });
 }
 
+function publishSlackDisconnectedStatus(
+  setStatus?: (next: Record<string, unknown>) => void,
+  error?: unknown,
+) {
+  if (!setStatus) {
+    return;
+  }
+  const at = Date.now();
+  const message = error ? formatUnknownError(error) : undefined;
+  setStatus({
+    connected: false,
+    lastDisconnect: message ? { at, error: message } : { at },
+    lastError: message ?? null,
+  });
+}
+
 export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const cfg = opts.config ?? loadConfig();
   const runtime: RuntimeEnv = opts.runtime ?? createNonExitingRuntime();
@@ -440,6 +456,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         if (opts.abortSignal?.aborted) {
           break;
         }
+        publishSlackDisconnectedStatus(opts.setStatus, disconnect.error);
 
         // Bail immediately on non-recoverable auth errors during reconnect too.
         if (disconnect.error && isNonRecoverableSlackAuthError(disconnect.error)) {
@@ -495,6 +512,7 @@ export { isNonRecoverableSlackAuthError } from "./reconnect-policy.js";
 
 export const __testing = {
   publishSlackConnectedStatus,
+  publishSlackDisconnectedStatus,
   resolveSlackRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   getSocketEmitter,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: PR 38643 seeded Slack socket liveness on connect, but Slack did not clear connected state when the socket later dropped, so runtime status could continue advertising a live socket during reconnect backoff.
- Why it matters: gateway health and operator-facing status could diverge from the real Slack connection state, and inherited pre-lifecycle event timestamps could suppress stale-socket recovery for too long.
- What changed: Slack now publishes a disconnect status patch when the socket drops, and the inherited `lastEventAt < lastStartAt` bypass only suppresses stale-socket checks for one stale-event window of the current lifecycle.
- What did NOT change (scope boundary): this does not change Telegram's stale-socket exclusion or the connect-time liveness seeding added in PR 38643.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #38643

## User-visible / Behavior Changes

- Slack accounts in socket mode now report disconnected state promptly after a socket drop instead of staying marked connected until process exit.
- Stale-socket recovery resumes after one stale-event window when a lifecycle inherits an older event timestamp from a previous run.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Slack socket mode, gateway health monitor
- Relevant config (redacted): N/A

### Steps

1. Start from the code after PR 38643 and drop a Slack socket connection after it has published connected status.
2. Observe runtime status and stale-socket evaluation across reconnect backoff and inherited status fields.
3. Apply this patch and rerun the focused gateway and Slack test coverage.

### Expected

- Slack status flips to disconnected when the socket drops.
- Inherited event timestamps only suppress stale-socket checks briefly for the new lifecycle.

### Actual

- Verified by focused tests listed below.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran focused gateway tests covering stale-socket policy and monitor behavior, plus Slack reconnect tests covering connect and disconnect status publication.
- Edge cases checked: channels without event tracking, channels without active connected sockets, inherited event timestamps before and after the stale-event window.
- What you did **not** verify: live Slack socket behavior against a real workspace.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0926572170` from this PR branch.
- Files/config to restore: `src/slack/monitor/provider.ts`, `src/gateway/channel-health-policy.ts`, and the associated tests.
- Known bad symptoms reviewers should watch for: Slack socket accounts remaining marked connected after disconnect, or stale-socket restarts never resuming after inherited event timestamps.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the lifecycle-bounded inherited-event rule could mark a legitimately quiet connected socket stale after the grace window if no fresh liveness timestamp is ever published.
  - Mitigation: the change only applies when `lastEventAt` predates `lastStartAt`, which indicates inherited state rather than current-lifecycle liveness, and focused tests cover both the temporary bypass and eventual stale classification.