### PR TITLE
tests: fix detect-secrets false positives

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12877,14 +12877,14 @@
         "filename": "src/pairing/setup-code.test.ts",
         "hashed_secret": "4914c103484773b5a8e18448b11919bb349cbff8",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "src/pairing/setup-code.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 370
+        "line_number": 357
       }
     ],
     "src/security/audit.test.ts": [
@@ -12971,7 +12971,7 @@
         "filename": "src/tui/gateway-chat.test.ts",
         "hashed_secret": "6255675480f681df08c1704b7b3cd2c49917f0e2",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 121
       }
     ],
     "src/web/login.test.ts": [
@@ -13011,5 +13011,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T18:01:25Z"
+  "generated_at": "2026-03-07T18:17:47Z"
 }

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -104,7 +104,7 @@ Brave provides paid plans; check the Brave API portal for the current limits and
       search: {
         enabled: true,
         provider: "brave",
-        apiKey: "BSA...", // optional if BRAVE_API_KEY is set
+        apiKey: "YOUR_BRAVE_API_KEY", // optional if BRAVE_API_KEY is set // pragma: allowlist secret
       },
     },
   },

--- a/extensions/feishu/src/onboarding.test.ts
+++ b/extensions/feishu/src/onboarding.test.ts
@@ -99,7 +99,7 @@ describe("feishuOnboardingAdapter.getStatus", () => {
             accounts: {
               main: {
                 appId: "",
-                appSecret: "secret_123",
+                appSecret: "sample-app-credential", // pragma: allowlist secret
               },
             },
           },
@@ -113,11 +113,11 @@ describe("feishuOnboardingAdapter.getStatus", () => {
 
   it("treats env SecretRef appId as not configured when env var is missing", async () => {
     const appIdKey = "FEISHU_APP_ID_STATUS_MISSING_TEST";
-    const appSecretKey = "FEISHU_APP_SECRET_STATUS_MISSING_TEST";
+    const appSecretKey = "FEISHU_APP_CREDENTIAL_STATUS_MISSING_TEST"; // pragma: allowlist secret
     await withEnvVars(
       {
         [appIdKey]: undefined,
-        [appSecretKey]: "secret_env_456",
+        [appSecretKey]: "env-credential-456", // pragma: allowlist secret
       },
       async () => {
         const status = await getStatusWithEnvRefs({ appIdKey, appSecretKey });
@@ -128,11 +128,11 @@ describe("feishuOnboardingAdapter.getStatus", () => {
 
   it("treats env SecretRef appId/appSecret as configured in status", async () => {
     const appIdKey = "FEISHU_APP_ID_STATUS_TEST";
-    const appSecretKey = "FEISHU_APP_SECRET_STATUS_TEST";
+    const appSecretKey = "FEISHU_APP_CREDENTIAL_STATUS_TEST"; // pragma: allowlist secret
     await withEnvVars(
       {
         [appIdKey]: "cli_env_123",
-        [appSecretKey]: "secret_env_456",
+        [appSecretKey]: "env-credential-456", // pragma: allowlist secret
       },
       async () => {
         const status = await getStatusWithEnvRefs({ appIdKey, appSecretKey });

--- a/extensions/googlechat/src/channel.outbound.test.ts
+++ b/extensions/googlechat/src/channel.outbound.test.ts
@@ -20,7 +20,7 @@ function createGoogleChatCfg(): OpenClawConfig {
         serviceAccount: {
           type: "service_account",
           client_email: "bot@example.com",
-          private_key: "test-key",
+          private_key: "test-key", // pragma: allowlist secret
           token_uri: "https://oauth2.googleapis.com/token",
         },
       },

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -149,7 +149,7 @@ function makeRemoteGatewayConfig(url: string, token = "rtok", localToken = "ltok
   };
 }
 
-function mockLocalTokenSecretRefConfig(secretId = "MISSING_GATEWAY_TOKEN") {
+function mockLocalTokenEnvRefConfig(envTokenId = "MISSING_GATEWAY_TOKEN") {
   loadConfig.mockReturnValueOnce({
     secrets: {
       providers: {
@@ -160,7 +160,7 @@ function mockLocalTokenSecretRefConfig(secretId = "MISSING_GATEWAY_TOKEN") {
       mode: "local",
       auth: {
         mode: "token",
-        token: { source: "env", provider: "default", id: secretId },
+        token: { source: "env", provider: "default", id: envTokenId },
       },
     },
   } as unknown as ReturnType<typeof loadConfig>);
@@ -204,7 +204,7 @@ describe("gateway-status command", () => {
   it("surfaces unresolved SecretRef auth diagnostics in warnings", async () => {
     const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
     await withEnvAsync({ MISSING_GATEWAY_TOKEN: undefined }, async () => {
-      mockLocalTokenSecretRefConfig();
+      mockLocalTokenEnvRefConfig();
 
       await runGatewayStatus(runtime, { timeout: "1000", json: true });
     });
@@ -232,7 +232,7 @@ describe("gateway-status command", () => {
         MISSING_GATEWAY_TOKEN: undefined,
       },
       async () => {
-        mockLocalTokenSecretRefConfig();
+        mockLocalTokenEnvRefConfig();
 
         await runGatewayStatus(runtime, { timeout: "1000", json: true });
       },

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -72,7 +72,7 @@ describe("pairing setup code", () => {
       },
       {
         env: {
-          GW_PASSWORD: "resolved-password",
+          GW_PASSWORD: "resolved-password", // pragma: allowlist secret
         },
       },
     );
@@ -104,7 +104,7 @@ describe("pairing setup code", () => {
       },
       {
         env: {
-          OPENCLAW_GATEWAY_PASSWORD: "password-from-env",
+          OPENCLAW_GATEWAY_PASSWORD: "password-from-env", // pragma: allowlist secret
         },
       },
     );
@@ -221,7 +221,7 @@ describe("pairing setup code", () => {
       },
       {
         env: {
-          OPENCLAW_GATEWAY_PASSWORD: "password-from-env",
+          OPENCLAW_GATEWAY_PASSWORD: "password-from-env", // pragma: allowlist secret
         },
       },
     );
@@ -275,7 +275,7 @@ describe("pairing setup code", () => {
         {
           env: {
             GW_TOKEN: "resolved-token",
-            GW_PASSWORD: "resolved-password",
+            GW_PASSWORD: "resolved-password", // pragma: allowlist secret
           },
         },
       ),
@@ -302,7 +302,7 @@ describe("pairing setup code", () => {
         },
         {
           env: {
-            GW_PASSWORD: "resolved-password",
+            GW_PASSWORD: "resolved-password", // pragma: allowlist secret
           },
         },
       ),


### PR DESCRIPTION
## Summary

- Problem: `detect-secrets` flagged test fixtures and a docs example as potential secrets, blocking the full repo scan.
- Why it matters: CI now runs the full `detect-secrets` scan on pushes, so these false positives create avoidable security-check noise.
- What changed: renamed one gateway-status helper, updated placeholder values, added targeted inline allowlists for intentional security-shaped fixtures, and refreshed `.secrets.baseline` line metadata.
- What did NOT change (scope boundary): no runtime behavior, auth flow, or production secret handling changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node/pnpm workspace not installed locally in this worktree
- Model/provider: N/A
- Integration/channel (if any): Feishu, Google Chat, gateway pairing docs/tests
- Relevant config (redacted): N/A

### Steps

1. Run `pre-commit run --all-files detect-secrets` on `main`.
2. Observe false positives in the listed tests/docs.
3. Run `pre-commit run --all-files detect-secrets` on this branch.

### Expected

- Full detect-secrets scan passes without these false positives.

### Actual

- Full detect-secrets scan passed locally after the targeted allowlist/fixture changes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pre-commit run --all-files detect-secrets` successfully after the fixes.
- Edge cases checked: confirmed the repo-wide scan only required baseline line-number refresh, then passed after staging the updated baseline.
- What you did **not** verify: skipped broader build/lint/test runs per request.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: touched tests/docs plus `.secrets.baseline`.
- Known bad symptoms reviewers should watch for: unexpected new `detect-secrets` findings in these fixtures/examples.

## Risks and Mitigations

- Risk: Inline allowlist comments can hide future real secrets if reused carelessly.
  - Mitigation: comments are limited to explicit test/doc fixture lines and one docs example, not broad file-level excludes.
