### PR TITLE
fix(browser): preserve dispatcher errors instead of wrapping as 'can't reach service'

### DIFF
--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -165,11 +165,13 @@ export async function fetchBrowserJson<T>(
   init?: RequestInit & { timeoutMs?: number },
 ): Promise<T> {
   const timeoutMs = init?.timeoutMs ?? 5000;
+  let isDispatcherPath = false;
   try {
     if (isAbsoluteHttp(url)) {
       const httpInit = withLoopbackBrowserAuth(url, init);
       return await fetchHttpJson<T>(url, { ...httpInit, timeoutMs });
     }
+    isDispatcherPath = true;
     const started = await startBrowserControlServiceFromConfig();
     if (!started) {
       throw new Error("browser control disabled");
@@ -249,6 +251,11 @@ export async function fetchBrowserJson<T>(
     return result.body as T;
   } catch (err) {
     if (err instanceof BrowserServiceError) {
+      throw err;
+    }
+    // For dispatcher paths, timeout/abort errors indicate service operation failure,
+    // not network unreachability. Preserve the original error for clearer diagnosis.
+    if (isDispatcherPath) {
       throw err;
     }
     throw enhanceBrowserFetchError(url, err, timeoutMs);


### PR DESCRIPTION
## Problem

When browser control service dispatcher operations time out (e.g., during slow Chrome launch), the error is wrapped as "Can't reach the OpenClaw browser control service" even when the service is reachable. This misleads users into thinking the gateway needs to be restarted, when the actual issue is an operation timeout inside the service (Chrome launch, CDP readiness, etc.).

## Solution

Preserve the original error for dispatcher (in-process) paths. Only apply the "Can't reach..." wrapper for network errors on HTTP paths. This makes the actual timeout/failure cause visible to users.

## Testing

- Quality gate: all checks pass
- Behavior: dispatcher timeouts now surface the real error (e.g., "Chrome CDP websocket not reachable after start") instead of the misleading "Can't reach the browser control service"

Fixes #39007