### PR TITLE
fix: apply contextTokens cap to model for auto-compaction threshold

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -173,6 +173,7 @@ vi.mock("../date-time.js", () => ({
 vi.mock("../defaults.js", () => ({
   DEFAULT_MODEL: "fake-model",
   DEFAULT_PROVIDER: "openai",
+  DEFAULT_CONTEXT_TOKENS: 128_000,
 }));
 
 vi.mock("../utils.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -376,6 +376,20 @@ export async function compactEmbeddedPiSessionDirect(
       sessionId: params.sessionId,
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
+    // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
+    // threshold uses the effective limit, not the native context window.
+    const ctxInfo = resolveContextWindowInfo({
+      cfg: params.config,
+      provider,
+      modelId,
+      modelContextWindow: model.contextWindow,
+      defaultTokens: DEFAULT_CONTEXT_TOKENS,
+    });
+    const effectiveModel =
+      ctxInfo.tokens < (model.contextWindow ?? Infinity)
+        ? { ...model, contextWindow: ctxInfo.tokens }
+        : model;
+
     const runAbortController = new AbortController();
     const toolsRaw = createOpenClawCodingTools({
       exec: {
@@ -398,7 +412,7 @@ export async function compactEmbeddedPiSessionDirect(
       abortSignal: runAbortController.signal,
       modelProvider: model.provider,
       modelId,
-      modelContextWindowTokens: model.contextWindow,
+      modelContextWindowTokens: ctxInfo.tokens,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config),
     });
     const tools = sanitizeToolsForGoogle({
@@ -594,7 +608,7 @@ export async function compactEmbeddedPiSessionDirect(
         agentDir,
         authStorage,
         modelRegistry,
-        model,
+        model: effectiveModel,
         thinkingLevel: mapThinkingLevel(params.thinkLevel),
         tools: builtInTools,
         customTools,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -375,6 +375,12 @@ export async function runEmbeddedPiAgent(
         modelContextWindow: model.contextWindow,
         defaultTokens: DEFAULT_CONTEXT_TOKENS,
       });
+      // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
+      // threshold uses the effective limit, not the native context window.
+      const effectiveModel =
+        ctxInfo.tokens < (model.contextWindow ?? Infinity)
+          ? { ...model, contextWindow: ctxInfo.tokens }
+          : model;
       const ctxGuard = evaluateContextWindowGuard({
         info: ctxInfo,
         warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
@@ -866,7 +872,7 @@ export async function runEmbeddedPiAgent(
             disableTools: params.disableTools,
             provider,
             modelId,
-            model,
+            model: effectiveModel,
             authProfileId: lastProfileId,
             authProfileIdSource: lockedProfileId ? "user" : "auto",
             authStorage,


### PR DESCRIPTION
## Summary

- Apply `agents.defaults.contextTokens` cap to the model object passed to `pi-coding-agent`, so the library's auto-compaction threshold uses the effective limit instead of the native model context window
- Without this fix, when `contextTokens` (e.g. 160k) is much smaller than the model's native context window (e.g. 1M for Gemini Flash), the library never triggers auto-compaction because `contextTokens > contextWindow - reserveTokens` is never true — the safeguard extension never fires and the compaction counter stays at 0
- Applies the same fix to both `run.ts` (main agent run path) and `compact.ts` (explicit `/compact` command path)

## Changes

- `src/agents/pi-embedded-runner/run.ts`: Create `effectiveModel` with capped `contextWindow` from `resolveContextWindowInfo`, pass it to `runEmbeddedAttempt` instead of the raw model
- `src/agents/pi-embedded-runner/compact.ts`: Same pattern — compute `effectiveModel` early, use it for both `createOpenClawCodingTools` (`modelContextWindowTokens`) and `createAgentSession`
- `src/agents/pi-embedded-runner/compact.hooks.test.ts`: Add missing `DEFAULT_CONTEXT_TOKENS` to the `defaults.js` mock

## Test plan

- [x] `pnpm test -- --run src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/context-window-guard.test.ts` — 12 tests pass
- [x] `pnpm test -- --run src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts` — 16 tests pass
- [x] `pnpm tsgo` — clean

Fixes #38905