### PR TITLE
Fix stale provider baseUrl overriding explicit config in merge mode

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -60,18 +60,24 @@ function createMergeConfigProvider() {
   };
 }
 
-async function runCustomProviderMergeTest(seedProvider: {
-  baseUrl: string;
-  apiKey: string;
-  api: string;
-  models: Array<{ id: string; name: string; input: string[] }>;
+async function runCustomProviderMergeTest(params: {
+  seedProvider: {
+    baseUrl: string;
+    apiKey: string;
+    api: string;
+    models: Array<{ id: string; name: string; input: string[] }>;
+  };
+  existingProviderKey?: string;
+  configProviderKey?: string;
 }) {
-  await writeAgentModelsJson({ providers: { custom: seedProvider } });
+  const existingProviderKey = params.existingProviderKey ?? "custom";
+  const configProviderKey = params.configProviderKey ?? "custom";
+  await writeAgentModelsJson({ providers: { [existingProviderKey]: params.seedProvider } });
   await ensureOpenClawModelsJson({
     models: {
       mode: "merge",
       providers: {
-        custom: createMergeConfigProvider(),
+        [configProviderKey]: createMergeConfigProvider(),
       },
     },
   });
@@ -208,16 +214,35 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("preserves non-empty agent apiKey but lets explicit config baseUrl win in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
-        baseUrl: "https://agent.example/v1",
-        apiKey: "AGENT_KEY", // pragma: allowlist secret
-        api: "openai-responses",
-        models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+        seedProvider: {
+          baseUrl: "https://agent.example/v1",
+          apiKey: "AGENT_KEY", // pragma: allowlist secret
+          api: "openai-responses",
+          models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+        },
       });
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("lets explicit config baseUrl win in merge mode when the config provider key is normalized", async () => {
+    await withTempHome(async () => {
+      const parsed = await runCustomProviderMergeTest({
+        seedProvider: {
+          baseUrl: "https://agent.example/v1",
+          apiKey: "AGENT_KEY",
+          api: "openai-responses",
+          models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+        },
+        existingProviderKey: "custom",
+        configProviderKey: " custom ",
+      });
+      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 
@@ -249,7 +274,7 @@ describe("models-config", () => {
         providers: Record<string, { apiKey?: string; baseUrl?: string }>;
       }>();
       expect(parsed.providers.custom?.apiKey).toBe("CUSTOM_PROVIDER_API_KEY"); // pragma: allowlist secret
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 
@@ -335,10 +360,12 @@ describe("models-config", () => {
   it("uses config apiKey/baseUrl when existing agent values are empty", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
-        baseUrl: "",
-        apiKey: "",
-        api: "openai-responses",
-        models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+        seedProvider: {
+          baseUrl: "",
+          apiKey: "",
+          api: "openai-responses",
+          models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+        },
       });
       expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -149,8 +149,10 @@ function mergeWithExistingProviderSecrets(params: {
   nextProviders: Record<string, ProviderConfig>;
   existingProviders: Record<string, NonNullable<ModelsConfig["providers"]>[string]>;
   secretRefManagedProviders: ReadonlySet<string>;
+  explicitBaseUrlProviders: ReadonlySet<string>;
 }): Record<string, ProviderConfig> {
-  const { nextProviders, existingProviders, secretRefManagedProviders } = params;
+  const { nextProviders, existingProviders, secretRefManagedProviders, explicitBaseUrlProviders } =
+    params;
   const mergedProviders: Record<string, ProviderConfig> = {};
   for (const [key, entry] of Object.entries(existingProviders)) {
     mergedProviders[key] = entry;
@@ -175,7 +177,11 @@ function mergeWithExistingProviderSecrets(params: {
     ) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (
+      !explicitBaseUrlProviders.has(key) &&
+      typeof existing.baseUrl === "string" &&
+      existing.baseUrl
+    ) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };
@@ -188,6 +194,7 @@ async function resolveProvidersForMode(params: {
   targetPath: string;
   providers: Record<string, ProviderConfig>;
   secretRefManagedProviders: ReadonlySet<string>;
+  explicitBaseUrlProviders: ReadonlySet<string>;
 }): Promise<Record<string, ProviderConfig>> {
   if (params.mode !== "merge") {
     return params.providers;
@@ -204,6 +211,7 @@ async function resolveProvidersForMode(params: {
     nextProviders: params.providers,
     existingProviders,
     secretRefManagedProviders: params.secretRefManagedProviders,
+    explicitBaseUrlProviders: params.explicitBaseUrlProviders,
   });
 }
 
@@ -278,6 +286,15 @@ export async function ensureOpenClawModelsJson(
 
     const mode = cfg.models?.mode ?? DEFAULT_MODE;
     const secretRefManagedProviders = new Set<string>();
+    const explicitBaseUrlProviders = new Set(
+      Object.entries(cfg.models?.providers ?? {})
+        .map(([key, provider]) => [key.trim(), provider] as const)
+        .filter(
+          ([key, provider]) =>
+            Boolean(key) && typeof provider?.baseUrl === "string" && provider.baseUrl.trim(),
+        )
+        .map(([key]) => key),
+    );
 
     const normalizedProviders =
       normalizeProviders({
@@ -291,6 +308,7 @@ export async function ensureOpenClawModelsJson(
       targetPath,
       providers: normalizedProviders,
       secretRefManagedProviders,
+      explicitBaseUrlProviders,
     });
     const next = `${JSON.stringify({ providers: mergedProviders }, null, 2)}\n`;
     const existingRaw = await readRawFile(targetPath);


### PR DESCRIPTION
## Summary

This fixes a merge-mode bug where a stale provider `baseUrl` already stored in:

- `~/.openclaw/agents/<agent>/agent/models.json`

could override a newer explicit `baseUrl` from `openclaw.json`.

After this change, an explicit provider `baseUrl` from config wins over stale runtime state.

## Problem

In `models.mode: "merge"`, updating a provider endpoint in `openclaw.json` could appear to have no effect.

A typical failure mode was:

- runtime `models.json` still had an old provider URL
- `openclaw.json` was corrected
- OpenClaw continued using the stale runtime URL
- users had to manually edit or delete `models.json`

## Root Cause

`src/agents/models-config.ts` preserved stale provider values from existing runtime `models.json` during merge.

That meant later explicit config changes could be masked by old runtime state.

There is also a provider-key matching edge case here: explicit-config detection must stay consistent with trimmed /
normalized provider keys, so entries like `" custom "` still match runtime key `custom`.

## What Changed

- track which providers explicitly define `baseUrl` in the current config
- trim / normalize those provider keys consistently before merge comparison
- preserve existing runtime `baseUrl` only when the current config does **not** explicitly provide one
- keep the existing `apiKey` / SecretRef preservation behavior intact

## Tests

Updated regression coverage in:

- `src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`

Added coverage for:

- explicit config `baseUrl` overrides stale runtime `models.json` `baseUrl`
- the same behavior still works when the config provider key is written in a trimmed / normalized form (for example
`" custom "` -> `custom`)

Validated with:

```bash
pnpm vitest run src/agents/models-config*.test.ts
```

Result:

- `23` test files passed
- `89` tests passed

## User-visible Effect

After this patch:

- changing a provider endpoint in `openclaw.json` will correctly propagate into regenerated `models.json`
- OpenClaw will stop silently using a stale runtime provider URL
- explicit `baseUrl` config will still work correctly when provider keys need trimmed / normalized matching

## Reproduction Case

Concrete case that reproduced this bug:

- old runtime file had `http://192.168.1.8/v1`
- config was updated to `http://192.168.1.8:8317/v1`
- OpenClaw continued using the old runtime URL until `models.json` was manually fixed

This patch makes the explicit config URL win automatically.

## Related

This PR addresses the same bug family discussed in:

- #37309
- #38657

It is also closely related to earlier PR attempts:

- #37331
- #38518

My understanding is that those earlier PRs were addressing the same stale merge behavior family.

This patch focuses specifically on explicit provider `baseUrl` precedence in merge mode, and adds regression coverage for the trimmed / normalized provider-key matching case.

There is also prior provider-specific precedent in:

- #32722

This PR applies the same principle more generally to merge-mode provider `baseUrl` handling.