### PR TITLE
fix(discord): eliminate false '⚠️ Tried to set X but current model is Y' warning in model picker

### DIFF
--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -896,6 +896,11 @@ async function handleDiscordModelPickerInteraction(
       return;
     }
 
+    // The session store write happens asynchronously after the command dispatch
+    // completes. Give it a short window to flush before reading back the persisted
+    // value, otherwise the check races the write and reports a false mismatch.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
     const effectiveModelRef = resolveDiscordModelPickerCurrentModel({
       cfg: ctx.cfg,
       route,


### PR DESCRIPTION
## Problem

After selecting a model via the Discord model picker, users sometimes see:

> ⚠️ Tried to set `anthropic/claude-opus-4-6`, but current model is `anthropic/claude-sonnet-4-6`.

even though `/status` confirms the model was actually applied correctly.

## Root Cause

In the model picker's select handler (`native-command.ts`), after `dispatchDiscordCommandInteraction()` resolves, the code immediately reads the session store to verify the model persisted:

```ts
// dispatch completes (interaction processed)
const effectiveModelRef = resolveDiscordModelPickerCurrentModel({ ... });
const persisted = effectiveModelRef === resolvedModelRef;
```

The session store write (`applyModelOverrideToSessionEntry` → store flush) is asynchronous and may not have completed when the read-back fires. The store still contains the old model, so `persisted` is false and the warning is shown.

## Fix

Add a 250ms delay between dispatch completion and the store read-back. The interaction has already been acknowledged at this point so there is no perceived latency impact. 250ms is comfortably above the store write latency on any reasonably fast filesystem.

## Verification

Apply the patch, use the model picker, confirm the ✅ success message appears consistently.