### PR TITLE
fix(daemon): normalise whitespace in checkTokenDrift to prevent false-positive warning

### DIFF
--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -118,6 +118,24 @@ describe("checkTokenDrift", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when tokens match but service token has trailing newline", () => {
+    const result = checkTokenDrift({ serviceToken: "same-token\n", configToken: "same-token" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when tokens match but have surrounding whitespace", () => {
+    const result = checkTokenDrift({ serviceToken: "  same-token  ", configToken: "same-token" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both tokens have different whitespace padding", () => {
+    const result = checkTokenDrift({
+      serviceToken: "same-token\r\n",
+      configToken: " same-token ",
+    });
+    expect(result).toBeNull();
+  });
+
   it("detects drift when config has token but service has different token", () => {
     const result = checkTokenDrift({ serviceToken: "old-token", configToken: "new-token" });
     expect(result).not.toBeNull();

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -362,13 +362,19 @@ export function checkTokenDrift(params: {
 }): ServiceConfigIssue | null {
   const { serviceToken, configToken } = params;
 
+  // Normalise both tokens before comparing: service-file parsers (systemd,
+  // launchd) can return values with trailing newlines or whitespace that
+  // cause a false-positive mismatch against the config value.
+  const normService = serviceToken?.trim() || undefined;
+  const normConfig = configToken?.trim() || undefined;
+
   // No drift if both are undefined/empty
-  if (!serviceToken && !configToken) {
+  if (!normService && !normConfig) {
     return null;
   }
 
   // Drift: config has token, service has different or no token
-  if (configToken && serviceToken !== configToken) {
+  if (normConfig && normService !== normConfig) {
     return {
       code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
       message:


### PR DESCRIPTION
## Summary

- **Problem**: \`checkTokenDrift\` compares service and config gateway tokens with raw \`!==\`. Service-file parsers on Linux (systemd) and macOS (launchd) return token values with trailing newlines or whitespace. This causes a false-positive "Config token differs from service token" warning even when tokens are identical.
- **Why it matters**: Users on Linux/systemd see the warning on every \`openclaw doctor\` run and every gateway restart. Multiple reporters confirmed on the issue thread.
- **What changed**: Both tokens are now \`.trim()\`'d inside \`checkTokenDrift\` before comparison. Three test cases added covering trailing newline, surrounding spaces, and mixed CRLF padding.
- **What did NOT change**: The sibling \`auditGatewayToken\` function already trimmed both sides correctly. This fix brings \`checkTokenDrift\` in line with that pattern. No changes to lifecycle-core.ts, token resolution, or any other path.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue/PR

- Closes #26624
- Related #32560 (broader normalisation PR touching the same function plus unrelated usage changes)
- Related #26656 (prior attempt, auto-closed by barnacle for active PR limit)

## User-visible / Behavior Changes

The false-positive "Config token differs from service token" warning no longer fires when the tokens are logically identical but differ only in whitespace. No config changes, no new CLI flags.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No (tokens trimmed for comparison only, never modified in storage)
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

All 14 tests pass (11 existing + 3 new):
\`\`\`
✓ src/daemon/service-audit.test.ts (14 tests) 11ms
Test Files  1 passed (1)
Tests       14 passed (14)
\`\`\`

## Human Verification

- Verified: all existing checkTokenDrift tests still pass, new tests cover trailing \`\n\`, surrounding spaces, mixed \`\r\n\`
- Edge cases: empty string after trim converts to undefined via \`|| undefined\`, CRLF line endings
- Not verified: end-to-end on a running systemd service (unit test coverage is thorough for the comparison logic)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None. Whitespace-only token differences are never intentional. Both \`auditGatewayToken\` and the systemd parser already trim.