### PR TITLE
fix(voice-call): add staleCallReaperSeconds and webhookSecurity to co…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
         name: skills python tests
         entry: pytest -q skills
         language: python
-        additional_dependencies: [pytest>=8, <9]
+        additional_dependencies: ["pytest>=8,<9"]
         pass_filenames: false
         files: "^skills/.*\\.py$"
 

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -249,6 +249,10 @@
         "type": "integer",
         "minimum": 1
       },
+      "staleCallReaperSeconds": {
+        "type": "integer",
+        "minimum": 0
+      },
       "silenceTimeoutMs": {
         "type": "integer",
         "minimum": 1
@@ -310,6 +314,23 @@
           },
           "allowNgrokFreeTierLoopbackBypass": {
             "type": "boolean"
+          }
+        }
+      },
+      "webhookSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allowedHosts": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "trustForwardingHeaders": {
+            "type": "boolean"
+          },
+          "trustedProxyIPs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
           }
         }
       },


### PR DESCRIPTION
## Summary

- **Problem:** `staleCallReaperSeconds` and `webhookSecurity` are defined in the voice-call Zod config (`extensions/voice-call/src/config.ts`) but were missing from the plugin’s `openclaw.plugin.json` configSchema. With `additionalProperties: false`, setting them in config caused "must NOT have additional properties" and gateway crash loops. Separately, the pre-commit config had `[pytest>=8, <9]`, so pip treated `<9` as a package name and failed.
- **Why it matters:** Users couldn’t use those voice-call options without crashing the gateway; pre-commit failed for anyone running the hooks.
- **What changed:** Added `staleCallReaperSeconds` and `webhookSecurity` to the voice-call plugin’s configSchema in `openclaw.plugin.json`. Fixed the pytest dependency to a single specifier `["pytest>=8,<9"]` in `.pre-commit-config.yaml`.
- **What did NOT change (scope boundary):** No runtime behavior change for voice-call or pre-commit; only schema and dependency declarations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #39101
- Related #

## User-visible / Behavior Changes

**None.** Config that was previously invalid (and crashed the gateway) is now valid. Defaults and runtime behavior are unchanged.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel: voice-call plugin config
- Relevant config (redacted): Added `staleCallReaperSeconds` and/or `webhookSecurity` under `plugins.entries.voice-call.config`.

### Steps

1. Set `staleCallReaperSeconds` or `webhookSecurity` in voice-call plugin config.
2. Start gateway (e.g. `openclaw gateway`).
3. Before: gateway crashes with "must NOT have additional properties". After: starts and accepts the config.

### Expected

Gateway starts and uses the new options when set.

### Actual

Before: crash. After: works as expected.

## Evidence

- [x] Failing case: config with `staleCallReaperSeconds`/`webhookSecurity` caused validation error and crash; after the change, same config is accepted and gateway runs.
- [ ] Trace/log snippets: N/A
- [ ] Screenshot/recording: N/A
- [ ] Perf numbers: N/A

## Human Verification (required)

- **Verified scenarios:** Edited `openclaw.plugin.json` to add the two properties; confirmed schema matches Zod (types, nesting for `webhookSecurity`). Confirmed pytest pre-commit dependency is a single string so pip install succeeds.
- **Edge cases checked:** `webhookSecurity` sub-properties (`allowedHosts`, `trustForwardingHeaders`, `trustedProxyIPs`) and `staleCallReaperSeconds` minimum 0.
- **What you did not verify:** Full voice-call flow with Twilio/Telnyx; pre-commit full run in a clean env (only dependency spec fix verified).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (existing valid config unchanged; previously invalid config now valid).
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the commit or remove the two new properties from configSchema and the pytest line change.
- Files/config to restore: `extensions/voice-call/openclaw.plugin.json`, `.pre-commit-config.yaml`.
- Known bad symptoms reviewers should watch for: None expected; change is additive and schema-only.

## Risks and Mitigations

**None.** Additive schema and dependency spec only; no new runtime behavior or security surface.
