### PR TITLE
fix(telegram): confirm persisted offset before polling and detect stalls

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -22,6 +22,10 @@ const api = {
   sendDocument: vi.fn(),
   setWebhook: vi.fn(),
   deleteWebhook: vi.fn(),
+  getUpdates: vi.fn(async () => []),
+  config: {
+    use: vi.fn(),
+  },
 };
 const { initSpy, runSpy, loadConfig } = vi.hoisted(() => ({
   initSpy: vi.fn(async () => undefined),
@@ -66,6 +70,9 @@ const { createdBotStops } = vi.hoisted(() => ({
 const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
   computeBackoff: vi.fn(() => 0),
   sleepWithAbort: vi.fn(async () => undefined),
+}));
+const { readTelegramUpdateOffsetSpy } = vi.hoisted(() => ({
+  readTelegramUpdateOffsetSpy: vi.fn(async () => null as number | null),
 }));
 const { startTelegramWebhookSpy } = vi.hoisted(() => ({
   startTelegramWebhookSpy: vi.fn(async () => ({ server: { close: vi.fn() }, stop: vi.fn() })),
@@ -183,6 +190,11 @@ vi.mock("./webhook.js", () => ({
   startTelegramWebhook: startTelegramWebhookSpy,
 }));
 
+vi.mock("./update-offset-store.js", () => ({
+  readTelegramUpdateOffset: readTelegramUpdateOffsetSpy,
+  writeTelegramUpdateOffset: vi.fn(async () => undefined),
+}));
+
 vi.mock("../auto-reply/reply.js", () => ({
   getReplyFromConfig: async (ctx: { Body?: string }) => ({
     text: `echo:${ctx.Body}`,
@@ -198,6 +210,8 @@ describe("monitorTelegramProvider (grammY)", () => {
       channels: { telegram: {} },
     });
     initSpy.mockClear();
+    readTelegramUpdateOffsetSpy.mockReset().mockResolvedValue(null);
+    api.getUpdates.mockReset().mockResolvedValue([]);
     runSpy.mockReset().mockImplementation(() =>
       makeRunnerStub({
         task: () => Promise.reject(new Error("runSpy called without explicit test stub")),
@@ -218,9 +232,11 @@ describe("monitorTelegramProvider (grammY)", () => {
   });
 
   it("processes a DM and sends reply", async () => {
-    Object.values(api).forEach((fn) => {
-      fn?.mockReset?.();
-    });
+    for (const v of Object.values(api)) {
+      if (typeof v === "function" && "mockReset" in v) {
+        (v as ReturnType<typeof vi.fn>).mockReset();
+      }
+    }
     await monitorWithAutoAbort();
     expect(handlers.message).toBeDefined();
     await handlers.message?.({
@@ -260,9 +276,11 @@ describe("monitorTelegramProvider (grammY)", () => {
   });
 
   it("requires mention in groups by default", async () => {
-    Object.values(api).forEach((fn) => {
-      fn?.mockReset?.();
-    });
+    for (const v of Object.values(api)) {
+      if (typeof v === "function" && "mockReset" in v) {
+        (v as ReturnType<typeof vi.fn>).mockReset();
+      }
+    }
     await monitorWithAutoAbort();
     await handlers.message?.({
       message: {
@@ -465,6 +483,86 @@ describe("monitorTelegramProvider (grammY)", () => {
     abort.abort();
     await monitor;
     expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it("force-restarts polling when getUpdates stalls (watchdog)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    let running = true;
+    let releaseTask: (() => void) | undefined;
+    const stop = vi.fn(async () => {
+      running = false;
+      releaseTask?.();
+    });
+
+    runSpy
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () =>
+            new Promise<void>((resolve) => {
+              releaseTask = resolve;
+            }),
+          stop,
+          isRunning: () => running,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: async () => {
+            abort.abort();
+          },
+        }),
+      );
+
+    const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+    await vi.waitFor(() => expect(runSpy).toHaveBeenCalledTimes(1));
+
+    // Advance time past the stall threshold (90s) + watchdog interval (30s)
+    vi.advanceTimersByTime(120_000);
+    await monitor;
+
+    expect(stop.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(computeBackoff).toHaveBeenCalled();
+    expect(runSpy).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("confirms persisted offset with Telegram before starting runner", async () => {
+    readTelegramUpdateOffsetSpy.mockResolvedValueOnce(549076203);
+    const abort = new AbortController();
+    const order: string[] = [];
+    api.getUpdates.mockReset();
+    api.getUpdates.mockImplementationOnce(async () => {
+      order.push("getUpdates");
+      return [];
+    });
+    api.deleteWebhook.mockReset();
+    api.deleteWebhook.mockImplementationOnce(async () => {
+      order.push("deleteWebhook");
+      return true;
+    });
+    runSpy.mockImplementationOnce(() => {
+      order.push("run");
+      return makeAbortRunner(abort);
+    });
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    expect(api.getUpdates).toHaveBeenCalledWith({ offset: 549076204, limit: 0, timeout: 0 });
+    expect(order).toEqual(["deleteWebhook", "getUpdates", "run"]);
+  });
+
+  it("skips offset confirmation when no persisted offset exists", async () => {
+    readTelegramUpdateOffsetSpy.mockResolvedValueOnce(null);
+    const abort = new AbortController();
+    api.getUpdates.mockReset();
+    api.deleteWebhook.mockReset();
+    api.deleteWebhook.mockResolvedValueOnce(true);
+    mockRunOnceAndAbort(abort);
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    expect(api.getUpdates).not.toHaveBeenCalled();
   });
 
   it("falls back to configured webhookSecret when not passed explicitly", async () => {

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -548,7 +548,7 @@ describe("monitorTelegramProvider (grammY)", () => {
 
     await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
 
-    expect(api.getUpdates).toHaveBeenCalledWith({ offset: 549076204, limit: 0, timeout: 0 });
+    expect(api.getUpdates).toHaveBeenCalledWith({ offset: 549076204, limit: 1, timeout: 0 });
     expect(order).toEqual(["deleteWebhook", "getUpdates", "run"]);
   });
 

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -269,7 +269,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         return;
       }
       try {
-        await bot.api.getUpdates({ offset: lastUpdateId + 1, limit: 0, timeout: 0 });
+        await bot.api.getUpdates({ offset: lastUpdateId + 1, limit: 1, timeout: 0 });
       } catch {
         // Non-fatal: runner middleware still skips duplicates via shouldSkipUpdate.
       }

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -61,6 +61,12 @@ const TELEGRAM_POLL_RESTART_POLICY = {
   jitter: 0.25,
 };
 
+// Polling stall detection: if no getUpdates call is seen for this long,
+// assume the runner is stuck and force-restart it.
+// Default fetch timeout is 30s, so 3x gives ample margin for slow responses.
+const POLL_STALL_THRESHOLD_MS = 90_000;
+const POLL_WATCHDOG_INTERVAL_MS = 30_000;
+
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
 const isGetUpdatesConflict = (err: unknown) => {
@@ -258,10 +264,35 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
     };
 
+    const confirmPersistedOffset = async (bot: TelegramBot): Promise<void> => {
+      if (lastUpdateId === null) {
+        return;
+      }
+      try {
+        await bot.api.getUpdates({ offset: lastUpdateId + 1, limit: 0, timeout: 0 });
+      } catch {
+        // Non-fatal: runner middleware still skips duplicates via shouldSkipUpdate.
+      }
+    };
+
     const runPollingCycle = async (bot: TelegramBot): Promise<"continue" | "exit"> => {
+      // Confirm the persisted offset with Telegram so the runner (which starts
+      // at offset 0) does not re-fetch already-processed updates on restart.
+      await confirmPersistedOffset(bot);
+
+      // Track getUpdates calls to detect polling stalls.
+      let lastGetUpdatesAt = Date.now();
+      bot.api.config.use((prev, method, payload, signal) => {
+        if (method === "getUpdates") {
+          lastGetUpdatesAt = Date.now();
+        }
+        return prev(method, payload, signal);
+      });
+
       const runner = run(bot, runnerOptions);
       activeRunner = runner;
       let stopPromise: Promise<void> | undefined;
+      let stalledRestart = false;
       const stopRunner = () => {
         stopPromise ??= Promise.resolve(runner.stop())
           .then(() => undefined)
@@ -282,6 +313,22 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           void stopRunner();
         }
       };
+
+      // Watchdog: detect when getUpdates calls have stalled and force-restart.
+      const watchdog = setInterval(() => {
+        if (opts.abortSignal?.aborted) {
+          return;
+        }
+        const elapsed = Date.now() - lastGetUpdatesAt;
+        if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
+          stalledRestart = true;
+          log(
+            `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
+          );
+          void stopRunner();
+        }
+      }, POLL_WATCHDOG_INTERVAL_MS);
+
       opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
       try {
         // runner.task() returns a promise that resolves when the runner stops
@@ -289,9 +336,11 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         if (opts.abortSignal?.aborted) {
           return "exit";
         }
-        const reason = forceRestarted
-          ? "unhandled network error"
-          : "runner stopped (maxRetryTime exceeded or graceful stop)";
+        const reason = stalledRestart
+          ? "polling stall detected"
+          : forceRestarted
+            ? "unhandled network error"
+            : "runner stopped (maxRetryTime exceeded or graceful stop)";
         forceRestarted = false;
         const shouldRestart = await waitBeforeRestart(
           (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
@@ -314,6 +363,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         );
         return shouldRestart ? "continue" : "exit";
       } finally {
+        clearInterval(watchdog);
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
         await stopBot();


### PR DESCRIPTION
## Summary

Fixes #39088 — two fixes for Telegram message duplication on restart:

- **Confirm persisted offset before starting runner:** The grammY runner starts at offset 0 internally, so on restart Telegram re-delivers all buffered updates. By calling `getUpdates(offset=lastUpdateId+1, limit=0)` before the runner starts, we confirm already-processed updates with Telegram so they are never re-fetched.
- **Polling stall watchdog:** Detects when `getUpdates` calls haven't occurred for 90 seconds and force-restarts the runner, addressing the ~2-hour polling freeze.

## Test plan

- [x] Existing monitor tests pass (17 tests)
- [x] New tests verify offset confirmation is called with correct offset before runner starts
- [x] New test verifies offset confirmation is skipped when no persisted offset exists
- [x] Stall watchdog test verifies forced restart on polling stall
- [x] Bot tests pass (46 tests)
- [x] TypeScript type-check passes