### PR TITLE
fix(voice-call): add staleCallReaperSeconds to plugin configSchema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -157,6 +157,10 @@
     "responseTimeoutMs": {
       "label": "Response Timeout (ms)",
       "advanced": true
+    },
+    "staleCallReaperSeconds": {
+      "label": "Stale Call Reaper Timeout (sec)",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -248,6 +252,10 @@
       "maxDurationSeconds": {
         "type": "integer",
         "minimum": 1
+      },
+      "staleCallReaperSeconds": {
+        "type": "integer",
+        "minimum": 0
       },
       "silenceTimeoutMs": {
         "type": "integer",


### PR DESCRIPTION
## Summary

- Adds the `staleCallReaperSeconds` property to `openclaw.plugin.json` configSchema (type integer, minimum 0) and uiHints (label + advanced flag)
- The property is already defined in the TypeScript config schema (`extensions/voice-call/src/config.ts:297`) and used in `webhook.ts` and `stale-call-reaper.ts`, but was missing from the JSON plugin schema
- Without this, the UI cannot validate or display this configuration option, and schema-based config management may reject valid configs

Closes #39101

## Test plan

- [ ] Verify `openclaw.plugin.json` parses as valid JSON
- [ ] Confirm `staleCallReaperSeconds` appears in plugin config UI when voice-call is enabled
- [ ] Confirm setting `staleCallReaperSeconds: 120` in config passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)