### PR TITLE
fix(config): sanitize validation log output to prevent control character injection

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -13,6 +13,7 @@ import {
   shouldDeferShellEnvFallback,
   shouldEnableShellEnvFallback,
 } from "../infra/shell-env.js";
+import { sanitizeTerminalText } from "../terminal/safe-text.js";
 import { VERSION } from "../version.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
 import { maintainConfigBackups } from "./backup-rotation.js";
@@ -714,7 +715,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const validated = validateConfigObjectWithPlugins(resolvedConfig);
       if (!validated.ok) {
         const details = validated.issues
-          .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
+          .map(
+            (iss) =>
+              `- ${sanitizeTerminalText(iss.path || "<root>")}: ${sanitizeTerminalText(iss.message)}`,
+          )
           .join("\n");
         if (!loggedInvalidConfigs.has(configPath)) {
           loggedInvalidConfigs.add(configPath);
@@ -727,7 +731,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       if (validated.warnings.length > 0) {
         const details = validated.warnings
-          .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
+          .map(
+            (iss) =>
+              `- ${sanitizeTerminalText(iss.path || "<root>")}: ${sanitizeTerminalText(iss.message)}`,
+          )
           .join("\n");
         deps.logger.warn(`Config warnings:\\n${details}`);
       }


### PR DESCRIPTION
## Summary

- Wraps config validation issue `path` and `message` fields with `sanitizeTerminalText()` before they are logged
- Prevents ANSI escape sequences, control characters (newlines, carriage returns, tabs), and C1 control characters from being injected into log output via crafted config values
- Uses the existing `sanitizeTerminalText` utility from `src/terminal/safe-text.ts`

**Before:** Validation issue paths/messages are logged raw — a config with embedded ANSI codes or control characters could corrupt terminal output or inject misleading log lines.

**After:** All untrusted issue content is sanitized before logging, while the Error object still contains the raw details for programmatic use.

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Confirm config validation errors still display correctly in logs
- [ ] Verify that a config with embedded control characters (e.g. `\x1b[31m` in a field name) produces clean log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)