### PR TITLE
fix(voice-call): add missing staleCallReaperSeconds and webhookSecurity to JSON schema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -157,6 +157,26 @@
     "responseTimeoutMs": {
       "label": "Response Timeout (ms)",
       "advanced": true
+    },
+    "staleCallReaperSeconds": {
+      "label": "Stale Call Reaper (sec)",
+      "help": "Maximum age of a call before automatic cleanup. Set to 0 to disable.",
+      "advanced": true
+    },
+    "webhookSecurity.allowedHosts": {
+      "label": "Webhook Allowed Hosts",
+      "help": "Allowed hostnames for webhook URL reconstruction.",
+      "advanced": true
+    },
+    "webhookSecurity.trustForwardingHeaders": {
+      "label": "Trust Forwarding Headers",
+      "help": "Trust X-Forwarded-* headers without hostname allowlist.",
+      "advanced": true
+    },
+    "webhookSecurity.trustedProxyIPs": {
+      "label": "Trusted Proxy IPs",
+      "help": "Trusted proxy IP addresses for forwarded headers.",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -248,6 +268,10 @@
       "maxDurationSeconds": {
         "type": "integer",
         "minimum": 1
+      },
+      "staleCallReaperSeconds": {
+        "type": "integer",
+        "minimum": 0
       },
       "silenceTimeoutMs": {
         "type": "integer",
@@ -349,6 +373,29 @@
       },
       "skipSignatureVerification": {
         "type": "boolean"
+      },
+      "webhookSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allowedHosts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "trustForwardingHeaders": {
+            "type": "boolean"
+          },
+          "trustedProxyIPs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
       },
       "stt": {
         "type": "object",


### PR DESCRIPTION
## Summary

This PR adds two missing configuration properties to the voice-call plugin's JSON schema that were already defined in the Zod schema but were missing from `openclaw.plugin.json`.

## Changes

- Added `staleCallReaperSeconds` (integer, minimum 0) - Maximum age of a call in seconds before automatic cleanup
- Added `webhookSecurity` (object) with:
  - `allowedHosts` (array of non-empty strings)
  - `trustForwardingHeaders` (boolean)
  - `trustedProxyIPs` (array of non-empty strings)

## Problem

Users trying to configure these options would receive:
`Invalid config at ~/.openclaw/openclaw.json: must NOT have additional properties`

This caused the gateway to crash-loop when these properties were set in the config.

## Testing

- JSON schema validates correctly
- Matches the Zod schema structure from `config.ts`

Closes #39101