### PR TITLE
fix: increment compaction counter on overflow-triggered compaction

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -40,11 +40,17 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
 
 export function handleAutoCompactionEnd(
   ctx: EmbeddedPiSubscribeContext,
-  evt: AgentEvent & { willRetry?: unknown },
+  evt: AgentEvent & { willRetry?: unknown; result?: unknown; aborted?: unknown },
 ) {
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
-  if (!willRetry) {
+  // Increment counter whenever compaction actually produced a result,
+  // regardless of willRetry.  Overflow-triggered compaction sets willRetry=true
+  // (the framework retries the LLM request), but the compaction itself succeeded
+  // and context was trimmed — the counter must reflect that.  (#38905)
+  const hasResult = evt.result != null;
+  const wasAborted = Boolean(evt.aborted);
+  if (hasResult && !wasAborted) {
     ctx.incrementCompactionCount?.();
   }
   if (willRetry) {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -38,11 +38,26 @@ describe("subscribeEmbeddedPiSession", () => {
     emit({ type: "auto_compaction_start" });
     expect(subscription.getCompactionCount()).toBe(0);
 
-    emit({ type: "auto_compaction_end", willRetry: true });
+    // willRetry with result — counter IS incremented (overflow compaction succeeded)
+    emit({ type: "auto_compaction_end", willRetry: true, result: { summary: "s" } });
+    expect(subscription.getCompactionCount()).toBe(1);
+
+    // willRetry=false with result — counter incremented again
+    emit({ type: "auto_compaction_end", willRetry: false, result: { summary: "s2" } });
+    expect(subscription.getCompactionCount()).toBe(2);
+  });
+
+  it("does not count compaction when result is absent", async () => {
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-compaction-no-result",
+    });
+
+    // No result (e.g. aborted or cancelled) — counter stays at 0
+    emit({ type: "auto_compaction_end", willRetry: false, result: undefined });
     expect(subscription.getCompactionCount()).toBe(0);
 
-    emit({ type: "auto_compaction_end", willRetry: false });
-    expect(subscription.getCompactionCount()).toBe(1);
+    emit({ type: "auto_compaction_end", willRetry: false, aborted: true });
+    expect(subscription.getCompactionCount()).toBe(0);
   });
 
   it("emits compaction events on the agent event bus", async () => {

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -100,6 +100,7 @@ describe("compaction hook wiring", () => {
       {
         type: "auto_compaction_end",
         willRetry: false,
+        result: { summary: "compacted" },
       } as never,
     );
 
@@ -122,7 +123,7 @@ describe("compaction hook wiring", () => {
     });
   });
 
-  it("does not call runAfterCompaction when willRetry is true", () => {
+  it("does not call runAfterCompaction when willRetry is true but still increments counter", () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
 
     const ctx = {
@@ -132,7 +133,8 @@ describe("compaction hook wiring", () => {
       noteCompactionRetry: vi.fn(),
       resetForCompactionRetry: vi.fn(),
       maybeResolveCompactionWait: vi.fn(),
-      getCompactionCount: () => 0,
+      incrementCompactionCount: vi.fn(),
+      getCompactionCount: () => 1,
     };
 
     handleAutoCompactionEnd(
@@ -140,10 +142,13 @@ describe("compaction hook wiring", () => {
       {
         type: "auto_compaction_end",
         willRetry: true,
+        result: { summary: "compacted" },
       } as never,
     );
 
     expect(hookMocks.runner.runAfterCompaction).not.toHaveBeenCalled();
+    // Counter is incremented even with willRetry — compaction succeeded (#38905)
+    expect(ctx.incrementCompactionCount).toHaveBeenCalledTimes(1);
     expect(ctx.noteCompactionRetry).toHaveBeenCalledTimes(1);
     expect(ctx.resetForCompactionRetry).toHaveBeenCalledTimes(1);
     expect(ctx.maybeResolveCompactionWait).not.toHaveBeenCalled();
@@ -152,6 +157,52 @@ describe("compaction hook wiring", () => {
       stream: "compaction",
       data: { phase: "end", willRetry: true },
     });
+  });
+
+  it("does not increment counter when compaction was aborted", () => {
+    const ctx = {
+      params: { runId: "r3b", session: { messages: [] } },
+      state: { compactionInFlight: true },
+      log: { debug: vi.fn(), warn: vi.fn() },
+      maybeResolveCompactionWait: vi.fn(),
+      incrementCompactionCount: vi.fn(),
+      getCompactionCount: () => 0,
+    };
+
+    handleAutoCompactionEnd(
+      ctx as never,
+      {
+        type: "auto_compaction_end",
+        willRetry: false,
+        result: undefined,
+        aborted: true,
+      } as never,
+    );
+
+    expect(ctx.incrementCompactionCount).not.toHaveBeenCalled();
+  });
+
+  it("does not increment counter when result is undefined", () => {
+    const ctx = {
+      params: { runId: "r3c", session: { messages: [] } },
+      state: { compactionInFlight: true },
+      log: { debug: vi.fn(), warn: vi.fn() },
+      maybeResolveCompactionWait: vi.fn(),
+      incrementCompactionCount: vi.fn(),
+      getCompactionCount: () => 0,
+    };
+
+    handleAutoCompactionEnd(
+      ctx as never,
+      {
+        type: "auto_compaction_end",
+        willRetry: false,
+        result: undefined,
+        aborted: false,
+      } as never,
+    );
+
+    expect(ctx.incrementCompactionCount).not.toHaveBeenCalled();
   });
 
   it("resets stale assistant usage after final compaction", () => {
@@ -183,6 +234,7 @@ describe("compaction hook wiring", () => {
       {
         type: "auto_compaction_end",
         willRetry: false,
+        result: { summary: "compacted" },
       } as never,
     );
 

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -182,6 +182,29 @@ describe("compaction hook wiring", () => {
     expect(ctx.incrementCompactionCount).not.toHaveBeenCalled();
   });
 
+  it("does not increment counter when compaction has result but was aborted", () => {
+    const ctx = {
+      params: { runId: "r3b2", session: { messages: [] } },
+      state: { compactionInFlight: true },
+      log: { debug: vi.fn(), warn: vi.fn() },
+      maybeResolveCompactionWait: vi.fn(),
+      incrementCompactionCount: vi.fn(),
+      getCompactionCount: () => 0,
+    };
+
+    handleAutoCompactionEnd(
+      ctx as never,
+      {
+        type: "auto_compaction_end",
+        willRetry: false,
+        result: { summary: "compacted" },
+        aborted: true,
+      } as never,
+    );
+
+    expect(ctx.incrementCompactionCount).not.toHaveBeenCalled();
+  });
+
   it("does not increment counter when result is undefined", () => {
     const ctx = {
       params: { runId: "r3c", session: { messages: [] } },


### PR DESCRIPTION
## Summary

Fixes #38905

When compaction is triggered by a context overflow, the framework sets `willRetry=true` (it retries the LLM request after trimming). The `handleAutoCompactionEnd` handler previously only incremented the compaction counter when `willRetry` was false, so overflow-triggered compactions were never counted — the `/status` Compactions counter stayed at 0 despite active context trimming.

**Root cause:** `handleAutoCompactionEnd` gated `incrementCompactionCount()` on `!willRetry`. Overflow compaction (the most common trigger in safeguard mode) always has `willRetry=true`.

**Fix:** Increment the counter based on whether the compaction actually produced a result (`evt.result != null && !evt.aborted`), regardless of `willRetry`. This correctly counts all successful compactions — both threshold-triggered (`willRetry=false`) and overflow-triggered (`willRetry=true`).

## Changes

- `src/agents/pi-embedded-subscribe.handlers.compaction.ts`: Gate counter increment on `hasResult && !wasAborted` instead of `!willRetry`
- Updated existing tests to pass `result` in events where compaction succeeded
- Added new tests for overflow compaction counting, aborted compaction, and absent result

## Test plan

- [x] Existing `wired-hooks-compaction.test.ts` tests pass (7 tests, 2 new)
- [x] Existing `waits-multiple-compaction-retries-before-resolving.test.ts` tests pass (8 tests, 1 new)  
- [x] All embedded subscribe handler tests pass (40 total)
- [x] New test: `willRetry=true` with result → counter incremented
- [x] New test: aborted compaction → counter NOT incremented
- [x] New test: absent result → counter NOT incremented