### PR TITLE
fix(ws-stream): respect compat.supportsStore=false in WebSocket payloads

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -589,10 +589,15 @@ export function createOpenAIWebSocketStreamFn(
         extraParams.reasoning = reasoning;
       }
 
+      // Omit `store` when the model explicitly disables it via compat.supportsStore = false
+      // (e.g., Azure OpenAI Responses API or non-OpenAI backends like Gemini via Cloudflare)
+      const modelCompat = model.compat && typeof model.compat === "object" ? model.compat : {};
+      const supportsStore = (modelCompat as { supportsStore?: boolean }).supportsStore;
+      const shouldIncludeStore = supportsStore !== false;
       const payload: Record<string, unknown> = {
         type: "response.create",
         model: model.id,
-        store: false,
+        ...(shouldIncludeStore ? { store: false } : {}),
         input: inputItems,
         instructions: context.systemPrompt ?? undefined,
         tools: tools.length > 0 ? tools : undefined,


### PR DESCRIPTION
## Problem

When using OpenAI-compatible endpoints (e.g., Gemini via Cloudflare AI Gateway), the `store: false` parameter was being sent even when the model was configured with `compat.supportsStore: false`. This caused 400 errors from strict API implementations that don't recognize the `store` field.

## Solution

Check the model's `compat.supportsStore` setting before including the `store` parameter in the WebSocket payload. This matches the behavior already implemented in `extra-params.ts` for HTTP streams.

## Changes

- `src/agents/openai-ws-stream.ts`: Conditionally include `store: false` only when `model.compat.supportsStore !== false`

## Testing

- All 40 tests in `openai-ws-stream.test.ts` pass
- Build succeeds

Fixes #39086

---

🤖 AI-assisted PR
- Testing: fully tested
- I understand what this code does: ✅