### PR TITLE
fix: format near-million token counts as millions instead of 1000k

### DIFF
--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -12,6 +12,7 @@ describe("usage-format", () => {
     expect(formatTokenCount(999)).toBe("999");
     expect(formatTokenCount(1234)).toBe("1.2k");
     expect(formatTokenCount(12000)).toBe("12k");
+    expect(formatTokenCount(999_499)).toBe("999k");
     expect(formatTokenCount(999_500)).toBe("1.0m");
     expect(formatTokenCount(2_500_000)).toBe("2.5m");
   });

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -12,6 +12,7 @@ describe("usage-format", () => {
     expect(formatTokenCount(999)).toBe("999");
     expect(formatTokenCount(1234)).toBe("1.2k");
     expect(formatTokenCount(12000)).toBe("12k");
+    expect(formatTokenCount(999_500)).toBe("1.0m");
     expect(formatTokenCount(2_500_000)).toBe("2.5m");
   });
 

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -25,7 +25,12 @@ export function formatTokenCount(value?: number): string {
     return `${(safe / 1_000_000).toFixed(1)}m`;
   }
   if (safe >= 1_000) {
-    return `${(safe / 1_000).toFixed(safe >= 10_000 ? 0 : 1)}k`;
+    const precision = safe >= 10_000 ? 0 : 1;
+    const formattedThousands = (safe / 1_000).toFixed(precision);
+    if (Number(formattedThousands) >= 1_000) {
+      return `${(safe / 1_000_000).toFixed(1)}m`;
+    }
+    return `${formattedThousands}k`;
   }
   return String(Math.round(safe));
 }


### PR DESCRIPTION
## Summary

Fix token count formatting near the million boundary.

Previously, values such as `999_500` could round to `1000k`, which looks awkward and is less readable. This change promotes that rounded threshold to `1.0m` instead.

## Changes

- update `formatTokenCount()` to switch from `k` to `m` when rounded thousands reaches 1000
- add a regression test for `formatTokenCount(999_500)`

## Example

Before:
- `999_500` -> `1000k`

After:
- `999_500` -> `1.0m`

## Notes

I was not able to complete a clean local test run because the current repository workspace had unrelated environment/test setup noise in this machine, but this change is intentionally small and includes a focused regression test for the boundary case.
