### PR TITLE
fix(telegram): resolve env SecretRefs in account-inspect for status command

### DIFF
--- a/src/telegram/account-inspect.ts
+++ b/src/telegram/account-inspect.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "../config/config.js";
-import { hasConfiguredSecretInput, normalizeSecretInputString } from "../config/types.secrets.js";
+import {
+  coerceSecretRef,
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+} from "../config/types.secrets.js";
 import type { TelegramAccountConfig } from "../config/types.telegram.js";
 import { resolveAccountWithDefaultFallback } from "../plugin-sdk/account-resolution.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
@@ -57,7 +61,7 @@ function inspectTokenFile(pathValue: unknown): {
 
 function inspectTokenValue(value: unknown): {
   token: string;
-  tokenSource: "config" | "none";
+  tokenSource: "config" | "env" | "none";
   tokenStatus: TelegramCredentialStatus;
 } | null {
   const token = normalizeSecretInputString(value);
@@ -66,6 +70,23 @@ function inspectTokenValue(value: unknown): {
       token,
       tokenSource: "config",
       tokenStatus: "available",
+    };
+  }
+  // Try to resolve env-based SecretRefs from process.env for read-only inspection
+  const ref = coerceSecretRef(value);
+  if (ref?.source === "env") {
+    const envValue = process.env[ref.id];
+    if (envValue && envValue.trim()) {
+      return {
+        token: envValue.trim(),
+        tokenSource: "env",
+        tokenStatus: "available",
+      };
+    }
+    return {
+      token: "",
+      tokenSource: "env",
+      tokenStatus: "configured_unavailable",
     };
   }
   if (hasConfiguredSecretInput(value)) {


### PR DESCRIPTION
## Problem

When running `openclaw status`, Telegram accounts configured with env-based SecretRefs were failing with 'unresolved SecretRef' errors even when the environment variables were present in the process environment.

```
[openclaw] Failed to start CLI: Error: channels.telegram.accounts.stock_expert.botToken: unresolved SecretRef "env:default:TG_TOKEN_1". Resolve this command against an active gateway runtime snapshot before reading it.
```

## Root Cause

The `inspectTokenValue()` function in `account-inspect.ts` only checked if a SecretRef was configured (`hasConfiguredSecretInput`), but never resolved env-based refs from `process.env`. This meant the status command (which uses read-only inspection) couldn't verify token availability.

## Solution

Add env resolution to `inspectTokenValue()` by:
1. Using `coerceSecretRef()` to check if the value is a SecretRef
2. If it's an env-based SecretRef, reading directly from `process.env[ref.id]`
3. Returning the resolved value with `tokenSource: "env"`

This is a synchronous operation that doesn't require the gateway runtime, making it safe for the status command's read-only inspection path.

## Testing

- Build succeeds
- Change is minimal and targeted

Fixes #38973

---

🤖 AI-assisted PR
- Testing: build verified
- I understand what this code does: ✅