### PR TITLE
fix(schtasks): recognize localized Windows Task Scheduler status strings

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -35,6 +35,33 @@ describe("scheduled task runtime derivation", () => {
     ).toEqual({ status: "running" });
   });
 
+  it("treats German localized 'Wird ausgeführt' as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Wird ausgeführt",
+        lastRunResult: "0x41301",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
+  it("treats French localized 'En cours d'exécution' as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "En cours d'exécution",
+        lastRunResult: "0x41301",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
+  it("treats Spanish localized 'Ejecutando' as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Ejecutando",
+        lastRunResult: "0x41301",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
   it("treats Running + decimal 267009 as running", () => {
     expect(
       deriveScheduledTaskRuntimeStatus({

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -163,7 +163,40 @@ export function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
   if (!statusRaw) {
     return { status: "unknown" };
   }
-  if (statusRaw !== "running") {
+  // Windows Task Scheduler localizes the "Running" status.
+  // English: "running"
+  // German: "wird ausgeführt"
+  // French: "en cours d'exécution"
+  // Spanish: "ejecutando"
+  // Italian: "in esecuzione"
+  // Portuguese (Brazil): "executando"
+  // Japanese: "実行中"
+  // Chinese (Simplified): "正在运行"
+  // Chinese (Traditional): "正在執行"
+  // Korean: "실행 중"
+  // Russian: "Выполняется"
+  // Polish: "Działający"
+  // Dutch: "Wordt uitgevoerd"
+  // Swedish: "Körs"
+  const runningPatterns = [
+    "running",
+    "wird ausgeführt", // German
+    "en cours d'exécution", // French
+    "en cours d'execution", // French (no accent)
+    "ejecutando", // Spanish
+    "in esecuzione", // Italian
+    "executando", // Portuguese
+    "実行中", // Japanese
+    "正在运行", // Chinese Simplified
+    "正在執行", // Chinese Traditional
+    "실행 중", // Korean
+    "выполняется", // Russian
+    "działający", // Polish
+    "wordt uitgevoerd", // Dutch
+    "körs", // Swedish
+  ];
+  const isRunning = runningPatterns.some((pattern) => statusRaw === pattern);
+  if (!isRunning) {
     return { status: "stopped" };
   }
 


### PR DESCRIPTION
## Problem

On non-English Windows systems, the Task Scheduler returns localized status strings. For example, German Windows returns `Wird ausgeführt` instead of `Running`. This caused `openclaw node status` to incorrectly report the service as "stopped" when it was actually running.

From the bug report:
```
Service: Scheduled Task (registered)
Runtime: stopped (state Wird ausgeführt)
```

"Wird ausgeführt" is German for "Running", but the status parser didn't recognize it and defaulted to "stopped".

## Solution

Add recognition for common localized "Running" status strings in major languages:
- German: `wird ausgeführt`
- French: `en cours d'exécution`
- Spanish: `ejecutando`
- Italian: `in esecuzione`
- Portuguese: `executando`
- Japanese: `実行中`
- Chinese (Simplified): `正在运行`
- Chinese (Traditional): `正在執行`
- Korean: `실행 중`
- Russian: `выполняется`
- Polish: `działający`
- Dutch: `wordt uitgevoerd`
- Swedish: `körs`

## Testing

- Added 3 new tests for German, French, and Spanish locales
- All 21 tests pass
- Build succeeds

Fixes #39057

---

🤖 AI-assisted PR
- Testing: fully tested
- I understand what this code does: ✅