### PR TITLE
fix(pre-commit): use single pytest dependency specifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
         name: skills python tests
         entry: pytest -q skills
         language: python
-        additional_dependencies: [pytest>=8, <9]
+        additional_dependencies: ["pytest>=8,<9"]
         pass_filenames: false
         files: "^skills/.*\\.py$"
 


### PR DESCRIPTION
## Summary

- **Problem:** The pre-commit config had `additional_dependencies: [pytest>=8, <9]`. In YAML this is parsed as two list items (`pytest>=8` and `<9`), so pip tries to install a package named `<9` and fails with `Invalid requirement: '<9': Expected package name at the start of dependency specifier`.
- **Why it matters:** Pre-commit environment setup fails for anyone running hooks; the skills-python-tests hook cannot install.
- **What changed:** Single specifier as one string: `["pytest>=8,<9"]` so pip receives a valid PEP 440 range.
- **What did NOT change (scope boundary):** No other files; no voice-call or other plugin changes. (Schema fixes are in #38892.)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #39109 (closed as duplicate for voice-call; this PR is the pre-commit-only fix from that contribution)
- Related #

## User-visible / Behavior Changes

**None.** Pre-commit hook env install succeeds; no runtime behavior change.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: any
- pre-commit with the skills-python-tests hook

### Steps

1. Run `pre-commit run --all-files` or trigger a commit that runs hooks.
2. Before: install step fails with invalid requirement `<9`.
3. After: dependency installs; hook can run (or skip if no skills/*.py changed).

### Expected

Pre-commit installs the local hook env without error.

### Actual

As expected after the fix.

## Evidence

- [x] Single-line YAML fix; pip accepts `pytest>=8,<9` as one specifier.
- [ ] Trace/log snippets: N/A
- [ ] Screenshot/recording: N/A

## Human Verification (required)

- **Verified scenarios:** Changed to `["pytest>=8,<9"]`; confirmed YAML list has one element and pip install succeeds.
- **Edge cases checked:** N/A.
- **What you did not verify:** Full pre-commit matrix on all platforms.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- Revert the single line in `.pre-commit-config.yaml`.
- No config to restore.

## Risks and Mitigations

**None.** One-string dependency spec; no behavior change beyond fixing install.

## Real behavior proof
Behavior or issue addressed: The `skills-python-tests` pre-commit hook now carries one valid pytest dependency string instead of a YAML list that splits into `pytest>=8` and an invalid standalone `<9`.

Real environment tested: Local checkout of the PR branch in a real terminal session.

Exact steps or command run after this patch:
```bash
sed -n '104,116p' .pre-commit-config.yaml
ruby -e 'require "yaml"; data = YAML.load_file(".pre-commit-config.yaml"); hook = data["repos"].find { |r| r["repo"] == "local" }["hooks"].find { |h| h["id"] == "skills-python-tests" }; p hook["additional_dependencies"]'
```

Evidence after fix:
```text
$ sed -n '104,116p' .pre-commit-config.yaml
  - repo: local
    hooks:
      - id: skills-python-tests
        name: skills python tests
        entry: pytest -q skills
        language: python
        additional_dependencies: ["pytest>=8,<9"]
        pass_filenames: false
        files: "^skills/.*\\.py$"
```

```text
$ ruby -e 'require "yaml"; data = YAML.load_file(".pre-commit-config.yaml"); hook = data["repos"].find { |r| r["repo"] == "local" }["hooks"].find { |h| h["id"] == "skills-python-tests" }; p hook["additional_dependencies"]'
["pytest>=8,<9"]
```

Observed result after fix: The hook definition on this branch loads as a single dependency entry, so pre-commit no longer forwards a bogus standalone `<9` requirement to pip.

What was not tested: A full end-to-end `pre-commit run --all-files` install in a fresh environment on every platform.
