### PR TITLE
fix(kimi-coding): normalize anthropic tools for api.kimi.com/v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - ACP/stop reason mapping: resolve gateway chat `state: "error"` completions as ACP `end_turn` instead of `refusal` so transient backend failures are not surfaced as deliberate refusals. (#41187) thanks @pejmanjohn.
 - ACP/setSessionMode: propagate gateway `sessions.patch` failures back to ACP clients so rejected mode changes no longer return silent success. (#41185) thanks @pejmanjohn.
 - Agents/embedded logs: add structured, sanitized lifecycle and failover observation events so overload and provider failures are easier to tail and filter. (#41336) thanks @altaywtf.
+- Models/Kimi Anthropic compat: normalize `anthropic-messages` tool payloads for custom `api.kimi.com` root and `/v1` endpoints without rewriting native `kimi-coding` `/coding` requests, so cron and isolated runs stop failing `tools[].function` validation. Fixes #39134. (#39140) Thanks @Avi974.
 - iOS/gateway foreground recovery: reconnect immediately on foreground return after stale background sockets are torn down, so the app no longer stays disconnected until a later wake path happens. (#41384) Thanks @mbelinky.
 - Cron/subagent followup: do not misclassify empty or `NO_REPLY` cron responses as interim acknowledgements that need a rerun, so deliberately silent cron jobs are no longer retried. (#41383) thanks @jackal092927.
 - Auth/cooldowns: reset expired auth-profile cooldown error counters before computing the next backoff so stale on-disk counters do not re-escalate into long cooldown loops after expiry. (#41028) thanks @zerone0x.

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -53,9 +53,43 @@ function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
   return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
 }
 
+function isKimiRootAnthropicCompatEndpoint(model: {
+  api?: unknown;
+  provider?: unknown;
+  baseUrl?: unknown;
+}): boolean {
+  if (model.api !== "anthropic-messages") {
+    return false;
+  }
+
+  const provider = typeof model.provider === "string" ? model.provider.trim().toLowerCase() : "";
+  if (provider === "kimi-coding") {
+    return false;
+  }
+
+  if (typeof model.baseUrl !== "string" || !model.baseUrl.trim()) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(model.baseUrl);
+    const host = parsed.hostname.toLowerCase();
+    if (host !== "kimi.com" && !host.endsWith(".kimi.com")) {
+      return false;
+    }
+
+    const pathname = parsed.pathname.toLowerCase();
+    return pathname === "/" || pathname === "/v1" || pathname.startsWith("/v1/");
+  } catch {
+    const normalized = model.baseUrl.trim().toLowerCase().replace(/\/+$/, "");
+    return normalized === "https://api.kimi.com" || normalized.startsWith("https://api.kimi.com/v1");
+  }
+}
+
 function requiresAnthropicToolPayloadCompatibilityForModel(model: {
   api?: unknown;
   provider?: unknown;
+  baseUrl?: unknown;
   compat?: unknown;
 }): boolean {
   if (model.api !== "anthropic-messages") {
@@ -66,6 +100,10 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
     typeof model.provider === "string" &&
     requiresOpenAiCompatibleAnthropicToolPayload(model.provider)
   ) {
+    return true;
+  }
+
+  if (isKimiRootAnthropicCompatEndpoint(model)) {
     return true;
   }
 
@@ -81,9 +119,14 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
 
 function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
   provider?: unknown;
+  baseUrl?: unknown;
+  api?: unknown;
   compat?: unknown;
 }): boolean {
   if (typeof model.provider === "string" && usesOpenAiFunctionAnthropicToolSchema(model.provider)) {
+    return true;
+  }
+  if (isKimiRootAnthropicCompatEndpoint(model)) {
     return true;
   }
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
@@ -97,12 +140,17 @@ function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
 
 function usesOpenAiStringModeAnthropicToolChoiceForModel(model: {
   provider?: unknown;
+  baseUrl?: unknown;
+  api?: unknown;
   compat?: unknown;
 }): boolean {
   if (
     typeof model.provider === "string" &&
     usesOpenAiStringModeAnthropicToolChoice(model.provider)
   ) {
+    return true;
+  }
+  if (isKimiRootAnthropicCompatEndpoint(model)) {
     return true;
   }
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {

--- a/src/agents/pi-embedded-runner/extra-params.kimi-coding-tool-schema.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.kimi-coding-tool-schema.test.ts
@@ -1,0 +1,194 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+type ToolPayloadCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"anthropic-messages">;
+};
+
+function runToolPayloadCase(params: ToolPayloadCase): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    tools: [
+      {
+        name: "read",
+        description: "Read a file",
+        input_schema: {
+          type: "object",
+          properties: {
+            filePath: { type: "string" },
+          },
+          required: ["filePath"],
+        },
+      },
+      {
+        type: "function",
+        name: "message",
+        parameters: {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+          required: ["text"],
+        },
+      },
+    ],
+    tool_choice: {
+      type: "tool",
+      name: "read",
+    },
+  };
+
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload, _model);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, undefined, params.applyProvider, params.applyModelId);
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, {});
+
+  return payload;
+}
+
+describe("extra-params: Kimi anthropic tool schema wrapper", () => {
+  it("normalizes tools for the api.kimi.com root anthropic endpoint", () => {
+    const payload = runToolPayloadCase({
+      applyProvider: "custom",
+      applyModelId: "k2p5",
+      model: {
+        api: "anthropic-messages",
+        provider: "custom",
+        id: "k2p5",
+        baseUrl: "https://api.kimi.com",
+      } as Model<"anthropic-messages">,
+    });
+
+    expect(payload.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read a file",
+          parameters: {
+            type: "object",
+            properties: {
+              filePath: { type: "string" },
+            },
+            required: ["filePath"],
+          },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "message",
+          parameters: {
+            type: "object",
+            properties: {
+              text: { type: "string" },
+            },
+            required: ["text"],
+          },
+        },
+      },
+    ]);
+    expect(payload.tool_choice).toEqual({
+      type: "function",
+      function: { name: "read" },
+    });
+  });
+
+  it("normalizes tools for api.kimi.com/v1 anthropic endpoints", () => {
+    const payload = runToolPayloadCase({
+      applyProvider: "custom",
+      applyModelId: "k2p5",
+      model: {
+        api: "anthropic-messages",
+        provider: "custom",
+        id: "k2p5",
+        baseUrl: "https://api.kimi.com/v1",
+      } as Model<"anthropic-messages">,
+    });
+
+    expect(payload.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read a file",
+          parameters: {
+            type: "object",
+            properties: {
+              filePath: { type: "string" },
+            },
+            required: ["filePath"],
+          },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "message",
+          parameters: {
+            type: "object",
+            properties: {
+              text: { type: "string" },
+            },
+            required: ["text"],
+          },
+        },
+      },
+    ]);
+    expect(payload.tool_choice).toEqual({
+      type: "function",
+      function: { name: "read" },
+    });
+  });
+
+  it("does not normalize tools for non-kimi anthropic endpoints", () => {
+    const payload = runToolPayloadCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4",
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4",
+        baseUrl: "https://api.anthropic.com",
+      } as Model<"anthropic-messages">,
+    });
+
+    const tools = payload.tools as Array<Record<string, unknown>>;
+    expect(tools[0]?.name).toBe("read");
+    expect(tools[0]?.function).toBeUndefined();
+    expect(payload.tool_choice).toEqual({
+      type: "tool",
+      name: "read",
+    });
+  });
+
+  it("does not normalize tools for suffix-matching non-kimi hosts", () => {
+    const payload = runToolPayloadCase({
+      applyProvider: "custom",
+      applyModelId: "k2p5",
+      model: {
+        api: "anthropic-messages",
+        provider: "custom",
+        id: "k2p5",
+        baseUrl: "https://api.notkimi.com/v1",
+      } as Model<"anthropic-messages">,
+    });
+
+    const tools = payload.tools as Array<Record<string, unknown>>;
+    expect(tools[0]?.name).toBe("read");
+    expect(tools[0]?.function).toBeUndefined();
+    expect(payload.tool_choice).toEqual({
+      type: "tool",
+      name: "read",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Handle Kimi anthropic endpoints that use api.kimi.com without a /coding path so tool payload normalization always adds OpenAI-style tools[].function.

## Changes
- Broaden Kimi endpoint detection in extra-params wrapper to include api.kimi.com root and /v1 paths
- Keep non-Kimi anthropic endpoints unchanged
- Add regression test for api.kimi.com/v1 payload normalization and tool_choice conversion

## Testing
- pnpm vitest run src/agents/pi-embedded-runner/extra-params.kimi-coding-tool-schema.test.ts

Fixes #39134