### PR TITLE
fix(ws): forward maxTokens: 0 in WebSocket response.create

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -636,6 +636,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
     releaseWsSession("sess-tools");
     releaseWsSession("sess-store-default");
     releaseWsSession("sess-store-compat");
+    releaseWsSession("sess-max-tokens-zero");
   });
 
   it("connects to the WebSocket on first call", async () => {
@@ -1006,6 +1007,36 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent.type).toBe("response.create");
     expect(sent.temperature).toBe(0.3);
     expect(sent.max_output_tokens).toBe(256);
+  });
+
+  it("forwards maxTokens: 0 to response.create as max_output_tokens", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-max-tokens-zero");
+    const opts = { maxTokens: 0 };
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+      opts as Parameters<typeof streamFn>[2],
+    );
+    await new Promise<void>((resolve, reject) => {
+      queueMicrotask(async () => {
+        try {
+          await new Promise((r) => setImmediate(r));
+          MockManager.lastInstance!.simulateEvent({
+            type: "response.completed",
+            response: makeResponseObject("resp-max-zero", "Done"),
+          });
+          for await (const _ of await resolveStream(stream)) {
+            /* consume */
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    const sent = MockManager.lastInstance!.sentEvents[0] as Record<string, unknown>;
+    expect(sent.type).toBe("response.create");
+    expect(sent.max_output_tokens).toBe(0);
   });
 
   it("forwards reasoningEffort/reasoningSummary to response.create reasoning block", async () => {

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -569,7 +569,7 @@ export function createOpenAIWebSocketStreamFn(
       if (streamOpts?.temperature !== undefined) {
         extraParams.temperature = streamOpts.temperature;
       }
-      if (streamOpts?.maxTokens) {
+      if (streamOpts?.maxTokens !== undefined) {
         extraParams.max_output_tokens = streamOpts.maxTokens;
       }
       if (streamOpts?.topP !== undefined) {


### PR DESCRIPTION
## Summary
- The WS stream path used a truthy check (`if (streamOpts?.maxTokens)`) to decide whether to include `max_output_tokens` in the `response.create` payload
- This silently dropped `maxTokens: 0`, which is a valid value — the HTTP path in `extra-params.ts` already handles it correctly with `typeof ... === "number"`
- All other WS stream options (`temperature`, `topP`) already use `!== undefined`; this aligns `maxTokens` with the same pattern

## Changes
- `openai-ws-stream.ts`: Changed `if (streamOpts?.maxTokens)` → `if (streamOpts?.maxTokens !== undefined)`
- `openai-ws-stream.test.ts`: Added regression test verifying `maxTokens: 0` is forwarded as `max_output_tokens: 0`

## Test plan
- [x] All 43 existing WS stream tests pass
- [x] New test verifies `maxTokens: 0` produces `max_output_tokens: 0` in the sent event