### PR TITLE
fix(media): honor zero-value channel media limits

### DIFF
--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -41,7 +41,7 @@ const bluebubblesAccountSchema = z
     dmHistoryLimit: z.number().int().min(0).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     sendReadReceipts: z.boolean().optional(),
     allowPrivateNetwork: z.boolean().optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -164,7 +164,7 @@ const FeishuSharedConfigShape = {
   textChunkLimit: z.number().int().positive().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema,
-  mediaMaxMb: z.number().positive().optional(),
+  mediaMaxMb: z.number().nonnegative().optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,

--- a/src/channels/plugins/media-limits.test.ts
+++ b/src/channels/plugins/media-limits.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveChannelMediaMaxBytes } from "./media-limits.js";
+
+const MB = 1024 * 1024;
+
+describe("resolveChannelMediaMaxBytes", () => {
+  it("returns channel limit in bytes", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: {} as OpenClawConfig,
+      resolveChannelLimitMb: () => 10,
+    });
+    expect(result).toBe(10 * MB);
+  });
+
+  it("returns 0 bytes when channel limit is explicitly 0", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: { agents: { defaults: { mediaMaxMb: 50 } } } as OpenClawConfig,
+      resolveChannelLimitMb: () => 0,
+    });
+    expect(result).toBe(0);
+  });
+
+  it("falls back to agents.defaults.mediaMaxMb", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: { agents: { defaults: { mediaMaxMb: 25 } } } as OpenClawConfig,
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBe(25 * MB);
+  });
+
+  it("returns 0 bytes when default limit is explicitly 0", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: { agents: { defaults: { mediaMaxMb: 0 } } } as OpenClawConfig,
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBe(0);
+  });
+
+  it("returns undefined when no limit is configured", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: {} as OpenClawConfig,
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/channels/plugins/media-limits.ts
+++ b/src/channels/plugins/media-limits.ts
@@ -15,11 +15,12 @@ export function resolveChannelMediaMaxBytes(params: {
     cfg: params.cfg,
     accountId,
   });
-  if (channelLimit) {
+  if (channelLimit !== undefined) {
     return channelLimit * MB;
   }
-  if (params.cfg.agents?.defaults?.mediaMaxMb) {
-    return params.cfg.agents.defaults.mediaMaxMb * MB;
+  const defaultLimit = params.cfg.agents?.defaults?.mediaMaxMb;
+  if (defaultLimit !== undefined) {
+    return defaultLimit * MB;
   }
   return undefined;
 }

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,7 +153,7 @@ export const AgentDefaultsSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     humanDelay: HumanDelaySchema.optional(),
     timeoutSeconds: z.number().int().positive().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     imageMaxDimensionPx: z.number().int().positive().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -332,7 +332,7 @@ export const ReplyRuntimeConfigSchemaShape = {
   blockStreaming: z.boolean().optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
   responsePrefix: z.string().optional(),
-  mediaMaxMb: z.number().positive().optional(),
+  mediaMaxMb: z.number().nonnegative().optional(),
 };
 
 export const BlockStreamingChunkSchema = z

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -179,7 +179,7 @@ export const TelegramAccountSchemaBase = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     // Legacy key kept for automatic migration to `streaming`.
     streamMode: z.enum(["off", "partial", "block"]).optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z
@@ -439,7 +439,7 @@ export const DiscordAccountSchema = z
     streamMode: z.enum(["partial", "block", "off"]).optional(),
     draftChunk: BlockStreamingChunkSchema.optional(),
     maxLinesPerMessage: z.number().int().positive().optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     retry: RetryConfigSchema,
     actions: z
       .object({
@@ -730,7 +730,7 @@ export const GoogleChatAccountSchema = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     streamMode: z.enum(["replace", "status_final", "append"]).optional().default("replace"),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     replyToMode: ReplyToModeSchema.optional(),
     actions: z
       .object({
@@ -819,7 +819,7 @@ export const SlackAccountSchema = z
     streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
     nativeStreaming: z.boolean().optional(),
     streamMode: z.enum(["replace", "status_final", "append"]).optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),
@@ -966,7 +966,7 @@ export const SignalAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     actions: z
@@ -1088,7 +1088,7 @@ export const IrcAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     responsePrefix: z.string().optional(),
   })
@@ -1198,7 +1198,7 @@ export const IMessageAccountSchemaBase = z
     remoteAttachmentRoots: z
       .array(z.string().refine(isValidInboundPathRootPattern, "expected absolute path root"))
       .optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
@@ -1321,7 +1321,7 @@ export const BlueBubblesAccountSchemaBase = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
-    mediaMaxMb: z.number().int().positive().optional(),
+    mediaMaxMb: z.number().int().nonnegative().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     sendReadReceipts: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
@@ -1440,7 +1440,7 @@ export const MSTeamsConfigSchema = z
     replyStyle: MSTeamsReplyStyleSchema.optional(),
     teams: z.record(z.string(), MSTeamsTeamSchema.optional()).optional(),
     /** Max media size in MB (default: 100MB for OneDrive upload support). */
-    mediaMaxMb: z.number().positive().optional(),
+    mediaMaxMb: z.number().nonnegative().optional(),
     /** SharePoint site ID for file uploads in group chats/channels (e.g., "contoso.sharepoint.com,guid1,guid2") */
     sharePointSiteId: z.string().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -109,13 +109,13 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   enabled: z.boolean().optional(),
   /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
   authDir: z.string().optional(),
-  mediaMaxMb: z.number().int().positive().optional(),
+  mediaMaxMb: z.number().int().nonnegative().optional(),
 }).strict();
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({
   accounts: z.record(z.string(), WhatsAppAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
-  mediaMaxMb: z.number().int().positive().optional().default(50),
+  mediaMaxMb: z.number().int().nonnegative().optional().default(50),
   actions: z
     .object({
       reactions: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- `resolveChannelMediaMaxBytes` used truthy checks on `channelLimit` and `agents.defaults.mediaMaxMb`
- A limit of `0` (valid config for disabling media uploads) was silently ignored, falling through to defaults
- Changed both checks from truthy (`if (channelLimit)`) to strict (`if (channelLimit !== undefined)`)
- **Updated all Zod schemas** for `mediaMaxMb` from `.positive()` to `.nonnegative()` so that `0` passes validation and reaches this code path

## Changes
- `media-limits.ts`: Use `!== undefined` for both channel-specific and default limit checks
- `media-limits.test.ts`: New test file covering zero-value, normal, fallback, and undefined cases
- `zod-schema.agent-defaults.ts`, `zod-schema.core.ts`, `zod-schema.providers-core.ts`, `zod-schema.providers-whatsapp.ts`: `.positive()` → `.nonnegative()` for all `mediaMaxMb` fields
- `extensions/bluebubbles/src/config-schema.ts`, `extensions/feishu/src/config-schema.ts`: Same schema update

## Test plan
- [x] All 5 media-limits tests pass, including regression tests for `channelLimit: 0` and `mediaMaxMb: 0`
- [x] All 716 config schema tests pass
- [x] All 43 outbound delivery tests pass
- [x] Zod schemas now allow `mediaMaxMb: 0` end-to-end