### PR TITLE
fix(voice-call): add missing staleCallReaperSeconds and webhookSecurity to plugin schema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -157,6 +157,23 @@
     "responseTimeoutMs": {
       "label": "Response Timeout (ms)",
       "advanced": true
+    },
+    "staleCallReaperSeconds": {
+      "label": "Stale Call Reaper (sec)",
+      "help": "Auto-reap calls stuck in unexpected states. 0 to disable.",
+      "advanced": true
+    },
+    "webhookSecurity.allowedHosts": {
+      "label": "Webhook Allowed Hosts",
+      "advanced": true
+    },
+    "webhookSecurity.trustForwardingHeaders": {
+      "label": "Trust Forwarding Headers",
+      "advanced": true
+    },
+    "webhookSecurity.trustedProxyIPs": {
+      "label": "Trusted Proxy IPs",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -249,6 +266,10 @@
         "type": "integer",
         "minimum": 1
       },
+      "staleCallReaperSeconds": {
+        "type": "integer",
+        "minimum": 0
+      },
       "silenceTimeoutMs": {
         "type": "integer",
         "minimum": 1
@@ -310,6 +331,29 @@
           },
           "allowNgrokFreeTierLoopbackBypass": {
             "type": "boolean"
+          }
+        }
+      },
+      "webhookSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allowedHosts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "trustForwardingHeaders": {
+            "type": "boolean"
+          },
+          "trustedProxyIPs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         }
       },


### PR DESCRIPTION
Fixes #39101

## Summary
- `staleCallReaperSeconds` and `webhookSecurity` are defined in the Zod schema (`config.ts`) but missing from the JSON Schema in `openclaw.plugin.json`
- Since the JSON Schema has `additionalProperties: false`, setting either property crash-loops the gateway
- Added both properties (and their nested fields) to the JSON Schema to match the Zod schema

## Changes
- `openclaw.plugin.json`: Added `staleCallReaperSeconds` (integer, min 0) and `webhookSecurity` object (with `allowedHosts`, `trustForwardingHeaders`, `trustedProxyIPs`)
- Added corresponding `uiHints` entries for the new fields

## Test plan
- [x] JSON Schema validates correctly
- [x] Schema shape matches the Zod schema in `config.ts`
- [x] Previously crash-looping config (`staleCallReaperSeconds: 60`) will now pass validation