### PR TITLE
docs: fix session-tool subagent spawn policy drift

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -173,7 +173,7 @@ Behavior:
 
 - Starts a new `agent:<agentId>:subagent:<uuid>` session with `deliver: false`.
 - Sub-agents default to the full tool set **minus session tools** (configurable via `tools.subagents.tools`).
-- Sub-agents are not allowed to call `sessions_spawn` (no sub-agent → sub-agent spawning).
+- By default (`maxSpawnDepth: 1`), sub-agents cannot call `sessions_spawn`. When `maxSpawnDepth >= 2`, depth-1 orchestrator sub-agents get access to `sessions_spawn`, `subagents`, `sessions_list`, and `sessions_history` so they can manage their own children. Depth-2 (and deeper) sub-agents are always leaf-only and cannot spawn further children. See [Sub-Agents: Nested Sub-Agents](/tools/subagents#nested-sub-agents) for details.
 - Always non-blocking: returns `{ status: "accepted", runId, childSessionKey }` immediately.
 - With `thread=true`, channel plugins can bind delivery/routing to a thread target (Discord support is controlled by `session.threadBindings.*` and `channels.discord.threadBindings.*`).
 - After completion, OpenClaw runs a sub-agent **announce step** and posts the result to the requester chat channel.

--- a/docs/zh-CN/concepts/session-tool.md
+++ b/docs/zh-CN/concepts/session-tool.md
@@ -172,7 +172,7 @@ x-i18n:
 
 - 使用 `deliver: false` 启动新的 `agent:<agentId>:subagent:<uuid>` 会话。
 - 子智能体默认使用完整工具集**减去会话工具**（可通过 `tools.subagents.tools` 配置）。
-- 子智能体不允许调用 `sessions_spawn`（无子智能体 → 子智能体生成）。
+- 默认情况下（`maxSpawnDepth: 1`），子智能体不能调用 `sessions_spawn`。当 `maxSpawnDepth >= 2` 时，深度 1 的编排者子智能体可以访问 `sessions_spawn`、`subagents`、`sessions_list` 和 `sessions_history`，以管理自己的子代。深度 2（及更深层）的子智能体始终为叶节点，不能再生成子代。详见 [子智能体：嵌套子智能体](/tools/subagents#nested-sub-agents)。
 - 始终非阻塞：立即返回 `{ status: "accepted", runId, childSessionKey }`。
 - 完成后，OpenClaw 运行子智能体**通告步骤**并将结果发布到请求者聊天渠道。
 - 在通告步骤中精确回复 `ANNOUNCE_SKIP` 以保持静默。


### PR DESCRIPTION
## Summary

Fix documentation drift between `docs/concepts/session-tool.md` and `docs/tools/subagents.md` regarding sub-agent spawning capabilities.

## Problem

`session-tool.md` stated:
> "Sub-agents are not allowed to call `sessions_spawn` (no sub-agent → sub-agent spawning)."

This contradicts `docs/tools/subagents.md` which documents nested orchestration via `maxSpawnDepth >= 2`, where depth-1 orchestrator sub-agents **can** call `sessions_spawn`.

## Changes

- Updated `docs/concepts/session-tool.md` (en) to describe the default policy (`maxSpawnDepth: 1`, no spawning) and the exception (`maxSpawnDepth >= 2` grants depth-1 orchestrators access to session tools).
- Updated `docs/zh-CN/concepts/session-tool.md` with the equivalent Chinese translation.
- Added cross-link to `docs/tools/subagents.md#nested-sub-agents`.

Closes #39110