### PR TITLE
fix(release-check): validate packaged control UI locale chunks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
           use-sticky-disk: "true"
 
       - name: Build dist
-        run: pnpm build
+        run: |
+          pnpm build
+          pnpm ui:build
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -4,6 +4,7 @@ import { execSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "../ui/src/i18n/lib/registry.ts";
 import { sparkleBuildFloorsFromShortVersion, type SparkleBuildFloors } from "./sparkle-build.ts";
 
 type PackFile = { path: string };
@@ -12,6 +13,7 @@ type PackResult = { files?: PackFile[] };
 const requiredPathGroups = [
   ["dist/index.js", "dist/index.mjs"],
   ["dist/entry.js", "dist/entry.mjs"],
+  "dist/control-ui/index.html",
   "dist/plugin-sdk/index.js",
   "dist/plugin-sdk/index.d.ts",
   "dist/plugin-sdk/core.js",
@@ -317,6 +319,22 @@ function checkPluginSdkExports() {
   }
 }
 
+export function collectMissingControlUiLocaleChunkErrors(
+  paths: Iterable<string>,
+  supportedLocales: readonly string[] = SUPPORTED_LOCALES,
+): string[] {
+  const packPaths = Array.from(paths);
+  return supportedLocales
+    .filter((locale) => locale !== DEFAULT_LOCALE)
+    .flatMap((locale) => {
+      const prefix = `dist/control-ui/assets/${locale}-`;
+      const hasChunk = packPaths.some((path) => path.startsWith(prefix) && path.endsWith(".js"));
+      return hasChunk
+        ? []
+        : [`control-ui locale '${locale}' is missing its lazy chunk in npm pack.`];
+    });
+}
+
 function main() {
   checkPluginVersions();
   checkAppcastSparkleVersions();
@@ -337,8 +355,9 @@ function main() {
   const forbidden = [...paths].filter((path) =>
     forbiddenPrefixes.some((prefix) => path.startsWith(prefix)),
   );
+  const missingControlUiLocaleChunks = collectMissingControlUiLocaleChunkErrors(paths);
 
-  if (missing.length > 0 || forbidden.length > 0) {
+  if (missing.length > 0 || forbidden.length > 0 || missingControlUiLocaleChunks.length > 0) {
     if (missing.length > 0) {
       console.error("release-check: missing files in npm pack:");
       for (const path of missing) {
@@ -349,6 +368,12 @@ function main() {
       console.error("release-check: forbidden files in npm pack:");
       for (const path of forbidden) {
         console.error(`  - ${path}`);
+      }
+    }
+    if (missingControlUiLocaleChunks.length > 0) {
+      console.error("release-check: missing control-ui locale chunks in npm pack:");
+      for (const error of missingControlUiLocaleChunks) {
+        console.error(`  - ${error}`);
       }
     }
     process.exit(1);

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { collectAppcastSparkleVersionErrors } from "../scripts/release-check.ts";
+import {
+  collectAppcastSparkleVersionErrors,
+  collectMissingControlUiLocaleChunkErrors,
+} from "../scripts/release-check.ts";
 
 function makeItem(shortVersion: string, sparkleVersion: string): string {
   return `<item><title>${shortVersion}</title><sparkle:shortVersionString>${shortVersion}</sparkle:shortVersionString><sparkle:version>${sparkleVersion}</sparkle:version></item>`;
@@ -24,5 +27,45 @@ describe("collectAppcastSparkleVersionErrors", () => {
     const xml = `<rss><channel>${makeItem("2026.3.1", "2026030190")}</channel></rss>`;
 
     expect(collectAppcastSparkleVersionErrors(xml)).toEqual([]);
+  });
+});
+
+describe("collectMissingControlUiLocaleChunkErrors", () => {
+  it("accepts one lazy chunk per supported non-default locale", () => {
+    const paths = [
+      "dist/control-ui/index.html",
+      "dist/control-ui/assets/de-Bm0iuKxz.js",
+      "dist/control-ui/assets/es-ABCD1234.js",
+      "dist/control-ui/assets/pt-BR-C2uaHesk.js",
+      "dist/control-ui/assets/zh-CN-CqPGpAps.js",
+      "dist/control-ui/assets/zh-TW-Cyl5GDQh.js",
+    ];
+
+    expect(
+      collectMissingControlUiLocaleChunkErrors(paths, [
+        "en",
+        "de",
+        "es",
+        "pt-BR",
+        "zh-CN",
+        "zh-TW",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("reports every lazy locale chunk missing from the npm pack", () => {
+    const paths = [
+      "dist/control-ui/index.html",
+      "dist/control-ui/assets/de-Bm0iuKxz.js",
+      "dist/control-ui/assets/es-ABCD1234.css",
+    ];
+
+    expect(
+      collectMissingControlUiLocaleChunkErrors(paths, ["en", "de", "es", "pt-BR", "zh-CN"]),
+    ).toEqual([
+      "control-ui locale 'es' is missing its lazy chunk in npm pack.",
+      "control-ui locale 'pt-BR' is missing its lazy chunk in npm pack.",
+      "control-ui locale 'zh-CN' is missing its lazy chunk in npm pack.",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `release-check` validated core `dist/` artifacts, but it did not treat Control UI output as a release invariant.
- Why it matters: a release can publish without `dist/control-ui/index.html` or one of the lazy locale chunks and still pass the current pack check path.
- What changed: the release artifact build now includes `pnpm ui:build`, and `release-check` derives required lazy locale chunks from the UI locale registry before validating `npm pack` contents.
- What did NOT change (scope boundary): no translation strings, locale resolution logic, or runtime UI behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #39125

## User-visible / Behavior Changes

- None at runtime.
- Release validation now fails if the packaged npm tarball is missing the Control UI entrypoint or any supported lazy locale chunk.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.7.4
- Runtime/container: Node v22.22.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build only the core release artifacts (`pnpm build`) and inspect the release-check path.
2. Observe that the previous release guard had no Control UI artifact invariant, so missing `dist/control-ui` assets were invisible to the pack validator.
3. On this branch, run `pnpm build && pnpm ui:build && pnpm release:check`.

### Expected

- Release validation should fail if the npm tarball is missing the Control UI entrypoint or any lazy locale chunk registered by the UI.
- Release validation should pass once both the core build and Control UI build are present.

### Actual

- Before this change, the release-check path only guarded core `dist/` files.
- After this change, release-check enforces both `dist/control-ui/index.html` and one JS chunk per supported non-default locale.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before tightening the workflow, a release-check run without the Control UI build reports missing `dist/control-ui/index.html` and missing locale chunks.

After this patch, I verified locally:

- `pnpm exec vitest run --config vitest.unit.config.ts test/release-check.test.ts`
- `pnpm exec oxfmt --check scripts/release-check.ts test/release-check.test.ts`
- `pnpm build && pnpm ui:build && pnpm release:check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `collectMissingControlUiLocaleChunkErrors` accepts one JS chunk per supported lazy locale.
  - `collectMissingControlUiLocaleChunkErrors` rejects missing chunks and ignores the default `en` locale.
  - A full local build plus `ui:build` passes `release-check`.
- Edge cases checked:
  - A locale-matching CSS file does not satisfy the JS chunk requirement.
  - The locale list comes from `SUPPORTED_LOCALES`, so adding a new supported locale automatically updates the release guard.
- What you did **not** verify:
  - I did not wait for GitHub Actions on this branch yet.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR to restore the previous release-check behavior.
- Files/config to restore:
  - `.github/workflows/ci.yml`
  - `scripts/release-check.ts`
- Known bad symptoms reviewers should watch for:
  - Release-check failing because the release artifact path skipped `pnpm ui:build`.
  - Release-check failing after a future bundler naming change that no longer emits `locale-hash.js` lazy chunks.

## Risks and Mitigations

- Risk:
  - The pack validator is now coupled to the current lazy-locale chunk naming convention.
  - Mitigation:
    - The check derives locale names from `SUPPORTED_LOCALES` instead of a second allowlist, and it only validates the existing Vite chunk contract already used by the runtime.
- Risk:
  - The release artifact job gets a small amount of extra work from `pnpm ui:build`.
  - Mitigation:
    - The added step runs only on the artifact path already used for `release-check`, and it closes a real release-validation blind spot.

## AI Assistance

- AI-assisted: Yes (Codex)
- Degree of testing: fully tested for the touched paths listed above
- I reviewed the generated changes and verified the release-check behavior locally before opening this PR.
