### PR TITLE
fix CI: add missing mode property and secret scan pragmas in tests

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -234,7 +234,7 @@ describe("models-config", () => {
       const parsed = await runCustomProviderMergeTest({
         seedProvider: {
           baseUrl: "https://agent.example/v1",
-          apiKey: "AGENT_KEY",
+          apiKey: "AGENT_KEY", // pragma: allowlist secret
           api: "openai-responses",
           models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
         },
@@ -414,7 +414,7 @@ describe("models-config", () => {
             providers: {
               openai: {
                 baseUrl: "https://api.openai.com/v1",
-                apiKey: "sk-plaintext-should-not-appear", // already resolved by loadConfig
+                apiKey: "sk-plaintext-should-not-appear", // already resolved by loadConfig  pragma: allowlist secret
                 api: "openai-completions",
                 models: [
                   {

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -77,7 +77,7 @@ describe("normalizeProviders", () => {
   it("replaces resolved env var value with env var name to prevent plaintext persistence", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
     const original = process.env.OPENAI_API_KEY;
-    process.env.OPENAI_API_KEY = "sk-test-secret-value-12345";
+    process.env.OPENAI_API_KEY = "sk-test-secret-value-12345"; // pragma: allowlist secret
     try {
       const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
         openai: {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -83,6 +83,7 @@ function makeResolvedDelivery(): Extract<DeliveryTargetResolution, { ok: true }>
     to: "123456",
     accountId: undefined,
     threadId: undefined,
+    mode: "explicit",
   };
 }
 


### PR DESCRIPTION
The delivery dispatch test helper was missing the `mode` property after the type was updated, causing `tsc` to fail. Also added missing `pragma: allowlist secret` comments on a few test fixture strings that were tripping the secret scanner.

- Add `mode: "explicit"` to `makeResolvedDelivery()` in `delivery-dispatch.double-announce.test.ts`
- Add secret scan pragmas to test API key fixtures in `models-config` tests