### PR TITLE
feat(bootstrap): support arbitrary workspace files in bootstrap-extra-files hook

### DIFF
--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -24,18 +24,20 @@ describe("loadExtraBootstrapFiles", () => {
     }
   });
 
-  it("loads recognized bootstrap files from glob patterns", async () => {
+  it("loads all matching files from glob patterns including arbitrary names", async () => {
     const workspaceDir = await createWorkspaceDir("glob");
     const packageDir = path.join(workspaceDir, "packages", "core");
     await fs.mkdir(packageDir, { recursive: true });
     await fs.writeFile(path.join(packageDir, "TOOLS.md"), "tools", "utf-8");
-    await fs.writeFile(path.join(packageDir, "README.md"), "not bootstrap", "utf-8");
+    await fs.writeFile(path.join(packageDir, "README.md"), "readme content", "utf-8");
 
     const files = await loadExtraBootstrapFiles(workspaceDir, ["packages/*/*"]);
 
-    expect(files).toHaveLength(1);
-    expect(files[0]?.name).toBe("TOOLS.md");
-    expect(files[0]?.content).toBe("tools");
+    expect(files).toHaveLength(2);
+    const names = files.map((f) => f.name).toSorted();
+    expect(names).toEqual(["README.md", "TOOLS.md"]);
+    expect(files.find((f) => f.name === "TOOLS.md")?.content).toBe("tools");
+    expect(files.find((f) => f.name === "README.md")?.content).toBe("readme content");
   });
 
   it("keeps path-traversal attempts outside workspace excluded", async () => {
@@ -94,6 +96,20 @@ describe("loadExtraBootstrapFiles", () => {
 
     const files = await loadExtraBootstrapFiles(workspaceDir, ["AGENTS.md"]);
     expect(files).toHaveLength(0);
+  });
+
+  it("loads arbitrary workspace files by explicit path", async () => {
+    const workspaceDir = await createWorkspaceDir("arbitrary");
+    const hooksDir = path.join(workspaceDir, "hooks");
+    await fs.mkdir(hooksDir, { recursive: true });
+    await fs.writeFile(path.join(hooksDir, "REGISTRY.yaml"), "routes: []", "utf-8");
+    await fs.writeFile(path.join(workspaceDir, "VISION.md"), "our vision", "utf-8");
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["hooks/REGISTRY.yaml", "VISION.md"]);
+
+    expect(files).toHaveLength(2);
+    expect(files.find((f) => f.name === "REGISTRY.yaml")?.content).toBe("routes: []");
+    expect(files.find((f) => f.name === "VISION.md")?.content).toBe("our vision");
   });
 
   it("skips oversized bootstrap files and reports diagnostics", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -141,7 +141,7 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_MEMORY_ALT_FILENAME;
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  name: string;
   path: string;
   content?: string;
   missing: boolean;
@@ -164,19 +164,6 @@ type WorkspaceOnboardingState = {
   bootstrapSeededAt?: string;
   onboardingCompletedAt?: string;
 };
-
-/** Set of recognized bootstrap filenames for runtime validation */
-const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_TOOLS_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_USER_FILENAME,
-  DEFAULT_HEARTBEAT_FILENAME,
-  DEFAULT_BOOTSTRAP_FILENAME,
-  DEFAULT_MEMORY_FILENAME,
-  DEFAULT_MEMORY_ALT_FILENAME,
-]);
 
 async function writeFileIfMissing(filePath: string, content: string): Promise<boolean> {
   try {
@@ -614,23 +601,14 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   const diagnostics: ExtraBootstrapLoadDiagnostic[] = [];
   for (const relPath of resolvedPaths) {
     const filePath = path.resolve(resolvedDir, relPath);
-    // Only load files whose basename is a recognized bootstrap filename
     const baseName = path.basename(relPath);
-    if (!VALID_BOOTSTRAP_NAMES.has(baseName)) {
-      diagnostics.push({
-        path: filePath,
-        reason: "invalid-bootstrap-filename",
-        detail: `unsupported bootstrap basename: ${baseName}`,
-      });
-      continue;
-    }
     const loaded = await readWorkspaceFileWithGuards({
       filePath,
       workspaceDir: resolvedDir,
     });
     if (loaded.ok) {
       files.push({
-        name: baseName as WorkspaceBootstrapFileName,
+        name: baseName,
         path: filePath,
         content: loaded.content,
         missing: false,

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -73,6 +73,29 @@ describe("bootstrap-extra-files hook", () => {
     );
   });
 
+  it("loads arbitrary (non-bootstrap) files via configured paths", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-arbitrary-");
+    const hooksDir = path.join(tempDir, "hooks");
+    await fs.mkdir(hooksDir, { recursive: true });
+    await fs.writeFile(path.join(hooksDir, "REGISTRY.yaml"), "routes: []", "utf-8");
+
+    const cfg = createBootstrapExtraConfig(["hooks/REGISTRY.yaml"]);
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey: "agent:main:main",
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(2);
+    const registry = context.bootstrapFiles.find((f) => f.name === "REGISTRY.yaml");
+    expect(registry).toBeDefined();
+    expect(registry?.content).toBe("routes: []");
+  });
+
   it("re-applies subagent bootstrap allowlist after extras are added", async () => {
     const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-subagent-");
     const extraDir = path.join(tempDir, "packages", "persona");


### PR DESCRIPTION
## Summary

Remove the hardcoded `VALID_BOOTSTRAP_NAMES` allowlist check from `loadExtraBootstrapFilesWithDiagnostics()`, allowing the `bootstrap-extra-files` hook to inject **any** workspace file into session context at bootstrap time — not just the recognized bootstrap filenames (`AGENTS.md`, `SOUL.md`, etc.).

## Problem

Users with mature workspaces need custom context files (routing registries, project configs, strategic docs) available deterministically on every session. The existing `bootstrap-extra-files` hook already supports glob patterns and path resolution, but the basename allowlist silently rejects any file that isn't one of the ~9 recognized names.

This forces users to either:
- Embed custom context into `AGENTS.md` (mixing concerns)
- Spend a tool call reading files at session start (adding latency/cost, subject to attention decay)

## Solution

- **Remove** the `VALID_BOOTSTRAP_NAMES` check in `loadExtraBootstrapFilesWithDiagnostics()`
- **Widen** `WorkspaceBootstrapFile.name` type from a union of literal filenames to `string`
- **Preserve** all existing security guards:
  - `realpath` check ensures files stay inside the workspace
  - Size limits (`bootstrapMaxChars`, `bootstrapTotalMaxChars`) still apply
  - Subagent/cron session filtering via `MINIMAL_BOOTSTRAP_ALLOWLIST` is unchanged

## Usage

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "bootstrap-extra-files": {
          "paths": ["hooks/REGISTRY.yaml", "VISION.md", "config/*.json"]
        }
      }
    }
  }
}
```

## Tests

- Updated existing glob test to verify arbitrary filenames are now loaded
- Added test for loading arbitrary files by explicit path (`hooks/REGISTRY.yaml`, `VISION.md`)
- Added hook handler integration test for non-bootstrap filenames
- All 14 related tests pass

Closes #39120