### PR TITLE
fix(memory): set PRAGMA busy_timeout on every SQLite connection open

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -258,7 +258,12 @@ export abstract class MemoryManagerSyncOps {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    // busy_timeout is per-connection and resets to 0 on restart.
+    // Set it on every open so concurrent processes retry instead of
+    // failing immediately with SQLITE_BUSY.
+    db.exec("PRAGMA busy_timeout = 5000");
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1558,7 +1558,10 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
     // busy_timeout is per-connection; set it on every open so concurrent
     // processes retry instead of failing immediately with SQLITE_BUSY.
-    this.db.exec("PRAGMA busy_timeout = 5000");
+    // Use a lower value than the write path (5 s) because this read-only
+    // connection runs synchronous queries on the main thread via DatabaseSync.
+    // In WAL mode readers rarely block, so 1 s is a safe upper bound.
+    this.db.exec("PRAGMA busy_timeout = 1000");
     return this.db;
   }
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1556,8 +1556,9 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const { DatabaseSync } = requireNodeSqlite();
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
-    // Keep QMD recall responsive when the updater holds a write lock.
-    this.db.exec("PRAGMA busy_timeout = 1");
+    // busy_timeout is per-connection; set it on every open so concurrent
+    // processes retry instead of failing immediately with SQLITE_BUSY.
+    this.db.exec("PRAGMA busy_timeout = 5000");
     return this.db;
   }
 


### PR DESCRIPTION
## Summary

Fixes #39176

`PRAGMA busy_timeout` is per-connection and resets to 0 when the process restarts. With 10+ concurrent processes (gateway, cron agents, subagents) hitting the same SQLite file, a zero timeout means any concurrent write instantly fails with `SQLITE_BUSY` instead of retrying.

## Changes

- **`src/memory/manager-sync-ops.ts`**: Set `PRAGMA busy_timeout = 5000` in `openDatabaseAtPath()`, which is used by all write connection opens (initial, vacuum, reopen)
- **`src/memory/qmd-manager.ts`**: Raise `busy_timeout` from 1 ms to 5000 ms on the read-only QMD connection

## Test plan

- [x] `pnpm vitest run src/memory/index.test.ts` — 10 tests pass
- [x] `pnpm vitest run src/memory/qmd-manager.test.ts` — 56 tests pass
- [ ] Manual: restart gateway, verify `PRAGMA busy_timeout` returns 5000 on active connections