### PR TITLE
fix(gateway): prevent browser rate-limit self-DoS on missing credentials

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -367,6 +367,58 @@ describe("gateway auth", () => {
     expect(limiter.check).toHaveBeenCalledWith(undefined, "custom-scope");
     expect(limiter.recordFailure).toHaveBeenCalledWith(undefined, "custom-scope");
   });
+
+  it("does not record rate-limit failure for missing token (misconfigured client, not brute-force)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: false },
+      connectAuth: null,
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("token_missing");
+    expect(limiter.recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("does not record rate-limit failure for missing password (misconfigured client, not brute-force)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: null,
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_missing");
+    expect(limiter.recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("still records rate-limit failure for wrong token (brute-force attempt)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: false },
+      connectAuth: { token: "wrong" },
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("token_mismatch");
+    expect(limiter.recordFailure).toHaveBeenCalled();
+  });
+
+  it("still records rate-limit failure for wrong password (brute-force attempt)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: { password: "wrong" },
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_mismatch");
+    expect(limiter.recordFailure).toHaveBeenCalled();
+  });
 });
 
 describe("trusted-proxy auth", () => {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -439,7 +439,9 @@ export async function authorizeGatewayConnect(
       return { ok: false, reason: "token_missing_config" };
     }
     if (!connectAuth?.token) {
-      limiter?.recordFailure(ip, rateLimitScope);
+      // Don't burn rate-limit slots for missing credentials — the client
+      // simply hasn't provided a token yet (e.g. bare browser open).
+      // Only actual *wrong* credentials should count as failures.
       return { ok: false, reason: "token_missing" };
     }
     if (!safeEqualSecret(connectAuth.token, auth.token)) {
@@ -456,7 +458,7 @@ export async function authorizeGatewayConnect(
       return { ok: false, reason: "password_missing_config" };
     }
     if (!password) {
-      limiter?.recordFailure(ip, rateLimitScope);
+      // Same as token_missing — don't penalize absent credentials.
       return { ok: false, reason: "password_missing" };
     }
     if (!safeEqualSecret(password, auth.password)) {

--- a/src/gateway/reconnect-gating.test.ts
+++ b/src/gateway/reconnect-gating.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { type GatewayErrorInfo, isNonRecoverableAuthError } from "../../ui/src/ui/gateway.ts";
+import { ConnectErrorDetailCodes } from "./protocol/connect-error-details.js";
+
+function makeError(detailCode: string): GatewayErrorInfo {
+  return { code: "connect_failed", message: "auth failed", details: { code: detailCode } };
+}
+
+describe("isNonRecoverableAuthError", () => {
+  it("returns false for undefined error (normal disconnect)", () => {
+    expect(isNonRecoverableAuthError(undefined)).toBe(false);
+  });
+
+  it("returns false for errors without detail codes (network issues)", () => {
+    expect(isNonRecoverableAuthError({ code: "connect_failed", message: "timeout" })).toBe(false);
+  });
+
+  it("blocks reconnect for AUTH_TOKEN_MISSING (misconfigured client)", () => {
+    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISSING))).toBe(
+      true,
+    );
+  });
+
+  it("blocks reconnect for AUTH_PASSWORD_MISSING", () => {
+    expect(
+      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING)),
+    ).toBe(true);
+  });
+
+  it("blocks reconnect for AUTH_PASSWORD_MISMATCH (wrong password won't self-correct)", () => {
+    expect(
+      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH)),
+    ).toBe(true);
+  });
+
+  it("blocks reconnect for AUTH_RATE_LIMITED (reconnecting burns more slots)", () => {
+    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_RATE_LIMITED))).toBe(
+      true,
+    );
+  });
+
+  it("allows reconnect for AUTH_TOKEN_MISMATCH (device-token fallback flow)", () => {
+    // Browser client fallback: stale device token → mismatch → sendConnect() clears it →
+    // next reconnect uses opts.token (shared gateway token). Blocking here breaks recovery.
+    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH))).toBe(
+      false,
+    );
+  });
+
+  it("allows reconnect for unrecognized detail codes (future-proof)", () => {
+    expect(isNonRecoverableAuthError(makeError("SOME_FUTURE_CODE"))).toBe(false);
+  });
+});

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -5,7 +5,10 @@ import {
   type GatewayClientMode,
   type GatewayClientName,
 } from "../../../src/gateway/protocol/client-info.js";
-import { readConnectErrorDetailCode } from "../../../src/gateway/protocol/connect-error-details.js";
+import {
+  ConnectErrorDetailCodes,
+  readConnectErrorDetailCode,
+} from "../../../src/gateway/protocol/connect-error-details.js";
 import { clearDeviceAuthToken, loadDeviceAuthToken, storeDeviceAuthToken } from "./device-auth.ts";
 import { loadOrCreateDeviceIdentity, signDevicePayload } from "./device-identity.ts";
 import { generateUUID } from "./uuid.ts";
@@ -48,6 +51,29 @@ export function resolveGatewayErrorDetailCode(
   error: { details?: unknown } | null | undefined,
 ): string | null {
   return readConnectErrorDetailCode(error?.details);
+}
+
+/**
+ * Auth errors that won't resolve without user action — don't auto-reconnect.
+ *
+ * NOTE: AUTH_TOKEN_MISMATCH is intentionally NOT included here because the
+ * browser client has a device-token fallback flow: a stale cached device token
+ * triggers a mismatch, sendConnect() clears it, and the next reconnect retries
+ * with opts.token (the shared gateway token). Blocking reconnect on mismatch
+ * would break that fallback. The rate limiter still catches persistent wrong
+ * tokens after N failures → AUTH_RATE_LIMITED stops the loop.
+ */
+export function isNonRecoverableAuthError(error: GatewayErrorInfo | undefined): boolean {
+  if (!error) {
+    return false;
+  }
+  const code = resolveGatewayErrorDetailCode(error);
+  return (
+    code === ConnectErrorDetailCodes.AUTH_TOKEN_MISSING ||
+    code === ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING ||
+    code === ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH ||
+    code === ConnectErrorDetailCodes.AUTH_RATE_LIMITED
+  );
 }
 
 export type GatewayHelloOk = {
@@ -135,7 +161,9 @@ export class GatewayBrowserClient {
       this.ws = null;
       this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
       this.opts.onClose?.({ code: ev.code, reason, error: connectError });
-      this.scheduleReconnect();
+      if (!isNonRecoverableAuthError(connectError)) {
+        this.scheduleReconnect();
+      }
     });
     this.ws.addEventListener("error", () => {
       // ignored; close handler will fire


### PR DESCRIPTION
## Problem

A single browser tab opening the web UI without a pre-configured token triggers an unrecoverable cascade:

1. Browser connects without token - `token_missing` - `recordFailure()` burns a rate-limit slot
2. Browser auto-reconnects unconditionally (800ms backoff, caps at 15s)
3. 10 failures in ~40 seconds - `browserRateLimiter` locks out ALL browser connections for 5 minutes
4. Even valid connections with correct tokens are rejected during lockout
5. Only recovery: restart gateway

This affects any self-hosted user who opens the web UI without `?token=` in the URL, clears browser data, uses incognito, or has a stale device token.

## Root cause

Two independent issues compound into the cascade:

**Layer 1:** `src/gateway/auth.ts:441-442` calls `recordFailure()` for `token_missing`, treating a misconfigured client identically to a brute-force probe. Missing credentials should not count as a failed auth attempt.

**Layer 2:** `ui/src/ui/gateway.ts:138` calls `scheduleReconnect()` on every WebSocket close, including auth failures and rate-limit rejections. No close-code checking.

## Fix

**Fix 1 - auth.ts:** Remove `recordFailure()` for `token_missing` and `password_missing`. Only actual credential mismatches (`token_mismatch`, `password_mismatch`) should burn rate-limit slots.

**Fix 2 - gateway.ts:** Gate `scheduleReconnect()` on error type. Don't auto-reconnect on non-recoverable auth errors:
- `AUTH_TOKEN_MISSING` - won't resolve without user action
- `AUTH_PASSWORD_MISSING` - same
- `AUTH_PASSWORD_MISMATCH` - wrong password won't self-correct
- `AUTH_RATE_LIMITED` - reconnecting burns more slots

`AUTH_TOKEN_MISMATCH` is intentionally **excluded** from the non-recoverable set. The browser client has a device-token fallback flow where `sendConnect()` clears a stale cached device token, and the next reconnect retries with the shared gateway token.

## Tests added

12 new tests covering both fixes:
- 4 tests verifying `token_missing` and `password_missing` do NOT call `recordFailure()`
- 4 tests verifying `token_mismatch` and `password_mismatch` still DO call `recordFailure()`
- 8 tests verifying reconnect gating behaviour for each error code

## NOT changed (intentionally)

- `browserRateLimiter` with `exemptLoopback: false` in `server.impl.ts` - valid defence-in-depth for remote attackers
- Rate limiter internals in `auth-rate-limit.ts` - unchanged
- Synthetic IP mapping in `message-handler.ts` - unchanged

## Scope

4 files, +139/-4 lines. No behavioural changes for properly-configured clients.

| File | Change |
|------|--------|
| `src/gateway/auth.ts` | Remove `recordFailure()` for missing credentials |
| `src/gateway/auth.test.ts` | 4 new tests for failure recording distinction |
| `ui/src/ui/gateway.ts` | Gate `scheduleReconnect()` on error type |
| `src/gateway/reconnect-gating.test.ts` | 8 new tests for reconnect gating |

Supersedes #36138 (closed - had unrelated extension changes mixed in). This version is strictly scoped to the rate-limit fix.