### PR TITLE
fix: billing misclassification and duplicate reply for multi-handle users

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -105,6 +105,8 @@ describe("isBillingErrorMessage", () => {
       "Payment Required",
       "HTTP 402 Payment Required",
       "plans & billing",
+      "You have reached your specified API usage limits. You will regain access on 2026-04-01 at 00:00 UTC.",
+      "LLM request rejected: You have reached your specified API usage limits. You will regain access on 2026-04-01 at 00:00 UTC.",
     ];
     for (const sample of samples) {
       expect(isBillingErrorMessage(sample)).toBe(true);
@@ -544,6 +546,12 @@ describe("classifyFailoverReason", () => {
       "billing",
     );
     expect(classifyFailoverReason(INSUFFICIENT_QUOTA_PAYLOAD)).toBe("billing");
+    // Anthropic usage limits error must be classified as billing, not rate_limit
+    expect(
+      classifyFailoverReason(
+        "LLM request rejected: You have reached your specified API usage limits. You will regain access on 2026-04-01 at 00:00 UTC.",
+      ),
+    ).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
     expect(classifyFailoverReason("request ended without sending any chunks")).toBe("timeout");
     expect(classifyFailoverReason("Connection error.")).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -611,6 +611,10 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
+  if (isBillingErrorMessage(raw)) {
+    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
+  }
+
   const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);
   if (transientCopy) {
     return transientCopy;
@@ -618,10 +622,6 @@ export function formatAssistantErrorText(
 
   if (isTimeoutErrorMessage(raw)) {
     return "LLM request timed out.";
-  }
-
-  if (isBillingErrorMessage(raw)) {
-    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
@@ -858,8 +858,11 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isModelNotFoundErrorMessage(raw)) {
     return "model_not_found";
   }
+  if (isBillingErrorMessage(raw)) {
+    return "billing";
+  }
   if (isPeriodicUsageLimitErrorMessage(raw)) {
-    return isBillingErrorMessage(raw) ? "billing" : "rate_limit";
+    return "rate_limit";
   }
   if (isRateLimitErrorMessage(raw)) {
     return "rate_limit";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -885,9 +885,6 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isCloudCodeAssistFormatError(raw)) {
     return "format";
   }
-  if (isBillingErrorMessage(raw)) {
-    return "billing";
-  }
   if (isTimeoutErrorMessage(raw)) {
     return "timeout";
   }

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -51,6 +51,8 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    /usage limits?.*regain access/i,
+    /reached your.*usage limits?/i,
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -180,12 +180,14 @@ export async function buildReplyPayloads(params: {
       originatingAccountId: params.accountId,
     }),
   });
-  // Only dedupe against messaging tool sends for the same origin target.
-  // Cross-target sends (for example posting to another channel) must not
-  // suppress the current conversation's final reply.
-  // If target metadata is unavailable, keep legacy dedupe behavior.
+  // Dedupe the final reply against texts already sent via the messaging tool.
+  // Always dedupe by text content when the messaging tool was used — this handles
+  // cases where the same person has multiple identifiers (e.g. email + phone)
+  // that don't match in target comparison but are the same conversation.
+  // Cross-channel sends are still safe: filterMessagingToolDuplicates only
+  // removes payloads whose text matches, so different-text replies go through.
   const dedupeMessagingToolPayloads =
-    suppressMessagingToolReplies || messagingToolSentTargets.length === 0;
+    suppressMessagingToolReplies || messagingToolSentTargets.length === 0 || messagingToolSentTexts.length > 0;
   const messagingToolSentMediaUrls = dedupeMessagingToolPayloads
     ? await normalizeSentMediaUrlsForDedupe({
         sentMediaUrls: params.messagingToolSentMediaUrls ?? [],

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -181,13 +181,13 @@ export async function buildReplyPayloads(params: {
     }),
   });
   // Dedupe the final reply against texts already sent via the messaging tool.
-  // Always dedupe by text content when the messaging tool was used — this handles
-  // cases where the same person has multiple identifiers (e.g. email + phone)
-  // that don't match in target comparison but are the same conversation.
-  // Cross-channel sends are still safe: filterMessagingToolDuplicates only
-  // removes payloads whose text matches, so different-text replies go through.
+  // Always dedupe by text when the tool was used — handles cases where the same
+  // person has multiple identifiers (e.g. email + phone) that don't match in
+  // target comparison. Cross-channel sends with different text are unaffected.
   const dedupeMessagingToolPayloads =
-    suppressMessagingToolReplies || messagingToolSentTargets.length === 0 || messagingToolSentTexts.length > 0;
+    suppressMessagingToolReplies ||
+    messagingToolSentTargets.length === 0 ||
+    messagingToolSentTexts.length > 0;
   const messagingToolSentMediaUrls = dedupeMessagingToolPayloads
     ? await normalizeSentMediaUrlsForDedupe({
         sentMediaUrls: params.messagingToolSentMediaUrls ?? [],


### PR DESCRIPTION
## Summary

Two bug fixes:

### 1. Anthropic "usage limits" errors misclassified as rate_limit

Anthropic returns "You have reached your specified API usage limits. You will regain access on ..." when billing limits are hit. This matches the rateLimit pattern "usage limit" and gets classified as rate_limit instead of billing, causing the failover system to retry (with backoff) instead of immediately skipping to the next provider.

**Fix:**
- Add billing patterns for Anthropic usage limit messages to failover-matches.ts
- Move isBillingErrorMessage check before isRateLimitErrorMessage in both classifyFailoverReason and formatAssistantErrorText

### 2. Duplicate final reply when messaging tool target != originating target

When the agent uses the message tool to send a reply, and the user has multiple identifiers (e.g. email and phone number), the target comparison in shouldSuppressMessagingToolReplies fails because the identifiers don't match. This causes dedupeMessagingToolPayloads to be false, skipping text-based dedup entirely, and the final reply is sent a second time.

**Fix:** Always allow text-based dedup when messagingToolSentTexts is non-empty. filterMessagingToolDuplicates only removes payloads whose text matches what was already sent, so cross-channel sends with different text are unaffected.

## Test plan

- [x] Existing billing test updated with Anthropic "usage limits" pattern
- [x] Existing classifyFailoverReason test updated to verify billing classification
- [ ] Verify no regressions in unit test suite
- [ ] Manual test: send message via iMessage from phone number, verify no duplicate reply

Generated with [Claude Code](https://claude.com/claude-code)