### PR TITLE
fix(daemon): reject pid 0 in launchctl print parser

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -102,6 +102,13 @@ describe("launchd runtime parsing", () => {
       lastExitReason: "exited",
     });
   });
+
+  it("rejects pid = 0 (no running process, consistent with systemd parser)", () => {
+    const output = ["state = waiting", "pid = 0"].join("\n");
+    const info = parseLaunchctlPrint(output);
+    expect(info.state).toBe("waiting");
+    expect(info.pid).toBeUndefined();
+  });
 });
 
 describe("launchctl list detection", () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -128,7 +128,7 @@ export function parseLaunchctlPrint(output: string): LaunchctlPrintInfo {
   const pidValue = entries.pid;
   if (pidValue) {
     const pid = Number.parseInt(pidValue, 10);
-    if (Number.isFinite(pid)) {
+    if (Number.isFinite(pid) && pid > 0) {
       info.pid = pid;
     }
   }


### PR DESCRIPTION
## Summary
- Add `pid > 0` guard to `parseLaunchctlPrint()` to match the equivalent check in `parseSystemdShowOutput()`
- When `launchctl print` reports `pid = 0` (no running process), the parser now correctly omits the PID field instead of storing the kernel PID

## Test plan
- [x] Added test: `rejects pid = 0 (no running process, consistent with systemd parser)`
- [x] All 17 launchd tests pass

Fixes #39188

🤖 Generated with [Claude Code](https://claude.com/claude-code)