### PR TITLE
feat(hooks): add before_llm_call plugin hook for LLM input interception

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1380,6 +1380,30 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      // Hook context shared across hook invocations for this run.
+      const hookCtx: import("../../../plugins/hooks.js").PluginHookAgentContext = {
+        agentId: sessionAgentId,
+        sessionKey: sandboxSessionKey,
+        sessionId: params.sessionId,
+        trigger: params.trigger,
+        channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+      };
+
+      // Mutable ref so the wrapper always reads the current iteration count.
+      const hookIterationRef = { current: 0 };
+
+      // Wrap streamFn for before_llm_call hooks — must be the outermost
+      // wrapper so it sees the final context after all other transforms.
+      if (hookRunner?.hasHooks("before_llm_call")) {
+        const { wrapStreamFnWithHooks } = await import("./hook-stream-wrapper.js");
+        activeSession.agent.streamFn = wrapStreamFnWithHooks(activeSession.agent.streamFn, {
+          hookRunner,
+          agentCtx: hookCtx,
+          iterationRef: hookIterationRef,
+          modelId: params.modelId,
+        });
+      }
+
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,
@@ -1501,6 +1525,17 @@ export async function runEmbeddedAttempt(
           );
         });
       };
+
+      // Track LLM call iteration for hook context.
+      // Subscribes to turn_start to increment the mutable ref that the
+      // streamFn wrapper reads for before_llm_call event.iteration.
+      const hookIterationUnsub = hookRunner?.hasHooks("before_llm_call")
+        ? activeSession.subscribe((event) => {
+            if (event.type === "turn_start") {
+              hookIterationRef.current++;
+            }
+          })
+        : undefined;
 
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
@@ -1777,8 +1812,15 @@ export async function runEmbeddedAttempt(
             await abortable(activeSession.prompt(effectivePrompt));
           }
         } catch (err) {
-          promptError = err;
-          promptErrorSource = "prompt";
+          // BeforeLlmCallBlockError is a graceful hook-initiated block, not a failure.
+          // Suppress it — the run ends cleanly with no assistant response.
+          const { BeforeLlmCallBlockError } = await import("./hook-stream-wrapper.js");
+          if (err instanceof BeforeLlmCallBlockError) {
+            log.info(`LLM call blocked by before_llm_call hook: ${err.message}`);
+          } else {
+            promptError = err;
+            promptErrorSource = "prompt";
+          }
         } finally {
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
@@ -1972,6 +2014,7 @@ export async function runEmbeddedAttempt(
           );
         }
         try {
+          hookIterationUnsub?.();
           unsubscribe();
         } catch (err) {
           // unsubscribe() should never throw; if it does, it indicates a serious bug.

--- a/src/agents/pi-embedded-runner/run/hook-stream-wrapper.test.ts
+++ b/src/agents/pi-embedded-runner/run/hook-stream-wrapper.test.ts
@@ -1,0 +1,236 @@
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type { Model, Api, Context } from "@mariozechner/pi-ai";
+/**
+ * Integration tests for wrapStreamFnWithHooks().
+ *
+ * Verifies that the hook-aware StreamFn wrapper correctly fires
+ * before_llm_call hooks, applies modifications,
+ * blocks calls, and is resilient to hook errors.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+import { wrapStreamFnWithHooks } from "./hook-stream-wrapper.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeMsg(role: string, content: string): AgentMessage {
+  return { role, content } as AgentMessage;
+}
+
+function makeMockHookRunner(
+  overrides: Partial<Record<keyof HookRunner, unknown>> = {},
+): HookRunner {
+  return {
+    hasHooks: vi.fn().mockReturnValue(true),
+    runBeforeAgentStart: vi.fn(),
+    runAgentEnd: vi.fn(),
+    runBeforeCompaction: vi.fn(),
+    runAfterCompaction: vi.fn(),
+    runMessageReceived: vi.fn(),
+    runMessageSending: vi.fn(),
+    runMessageSent: vi.fn(),
+    runBeforeToolCall: vi.fn(),
+    runAfterToolCall: vi.fn(),
+    runToolResultPersist: vi.fn(),
+    runSessionStart: vi.fn(),
+    runSessionEnd: vi.fn(),
+    runGatewayStart: vi.fn(),
+    runGatewayStop: vi.fn(),
+    runBeforeLlmCall: vi.fn().mockResolvedValue(undefined),
+    runAfterLlmCall: vi.fn(),
+    runLoopIterationStart: vi.fn(),
+    runLoopIterationEnd: vi.fn(),
+    runBeforeResponseEmit: vi.fn(),
+    getHookCount: vi.fn().mockReturnValue(0),
+    ...overrides,
+  } as unknown as HookRunner;
+}
+
+const agentCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+};
+
+const mockStream = Symbol("mock-stream");
+
+function makeBaseContext() {
+  return {
+    systemPrompt: "You are helpful.",
+    messages: [fakeMsg("user", "hello")] as unknown[],
+    tools: [
+      { name: "read", description: "Read files", parameters: {} },
+      { name: "exec", description: "Execute commands", parameters: {} },
+    ],
+  };
+}
+
+describe("wrapStreamFnWithHooks", () => {
+  let streamFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    streamFn = vi.fn().mockReturnValue(mockStream);
+  });
+
+  it("before_llm_call fires on every call", async () => {
+    const hookRunner = makeMockHookRunner();
+    const iterationRef = { current: 0 };
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef,
+      modelId: "gpt-4",
+    });
+
+    const context = makeBaseContext() as unknown as Context;
+    await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+    iterationRef.current = 1;
+    await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+
+    expect(hookRunner.runBeforeLlmCall).toHaveBeenCalledTimes(2);
+
+    // First call
+    const [event1] = (hookRunner.runBeforeLlmCall as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(event1).toMatchObject({
+      model: "gpt-4",
+      iteration: 0,
+      systemPrompt: "You are helpful.",
+    });
+
+    // Second call
+    const [event2] = (hookRunner.runBeforeLlmCall as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(event2).toMatchObject({
+      model: "gpt-4",
+      iteration: 1,
+    });
+  });
+
+  it("before_llm_call can modify context", async () => {
+    const modifiedMessages = [fakeMsg("user", "sanitized")];
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        systemPrompt: "modified prompt",
+        messages: modifiedMessages,
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    expect(streamFn).toHaveBeenCalledOnce();
+    const passedContext = streamFn.mock.calls[0][1];
+    expect(passedContext.systemPrompt).toBe("modified prompt");
+    expect(passedContext.messages).toBe(modifiedMessages);
+  });
+
+  it("before_llm_call can filter tools", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        tools: [{ name: "read" }],
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    expect(streamFn).toHaveBeenCalledOnce();
+    const passedContext = streamFn.mock.calls[0][1];
+    // Only the "read" tool should remain (filtered by allowed names)
+    expect(passedContext.tools).toHaveLength(1);
+    expect(passedContext.tools[0].name).toBe("read");
+  });
+
+  it("before_llm_call can block", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        block: true,
+        blockReason: "tainted context",
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await expect(
+      wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {}),
+    ).rejects.toThrow("LLM call blocked by plugin: tainted context");
+    expect(streamFn).not.toHaveBeenCalled();
+  });
+
+  it("before_llm_call error does not break stream", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockRejectedValue(new Error("hook kaboom")),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    const result = await wrapped(
+      "gpt-4" as unknown as Model<Api>,
+      makeBaseContext() as unknown as Context,
+      {},
+    );
+
+    // Should still call the underlying streamFn and return its result
+    expect(streamFn).toHaveBeenCalledOnce();
+    expect(result).toBe(mockStream);
+  });
+
+  it("passes through to underlying streamFn when no hooks", async () => {
+    const hookRunner = makeMockHookRunner({
+      hasHooks: vi.fn().mockReturnValue(false),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    const context = makeBaseContext() as unknown as Context;
+    const result = await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+
+    // before_llm_call should not be called when no hooks registered
+    expect(hookRunner.runBeforeLlmCall).not.toHaveBeenCalled();
+    // Underlying streamFn receives original context unchanged
+    expect(streamFn).toHaveBeenCalledWith("gpt-4", context, {});
+    expect(result).toBe(mockStream);
+  });
+
+  it("treats messages:[] as explicit override (clears history)", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({ messages: [] }),
+    });
+
+    const streamFn = vi.fn().mockResolvedValue(mockStream);
+    const wrapped = wrapStreamFnWithHooks(streamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 1 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    // messages: [] is an explicit "clear history" — not "no change"
+    const passedContext = streamFn.mock.calls[0][1];
+    expect(passedContext.messages).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
+++ b/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
@@ -1,0 +1,107 @@
+/**
+ * Wraps a StreamFn to emit before_llm_call plugin hooks.
+ *
+ * Uses the same streamFn wrapping pattern as cache-trace.ts and
+ * anthropic-payload-log.ts — outermost wrapper sees the full context before
+ * delegating to the underlying (possibly wrapped) streamFn.
+ */
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Message } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+
+const log = createSubsystemLogger("hooks/stream");
+
+/**
+ * Sentinel error thrown when before_llm_call blocks the LLM call.
+ * Distinct from generic errors so the agent loop can handle it gracefully
+ * (suppress the run without surfacing an error) rather than treating it
+ * as a run failure.
+ */
+export class BeforeLlmCallBlockError extends Error {
+  readonly isBeforeLlmCallBlock = true;
+  constructor(reason: string) {
+    super(`LLM call blocked by plugin: ${reason}`);
+    this.name = "BeforeLlmCallBlockError";
+  }
+}
+
+export interface HookStreamWrapperParams {
+  hookRunner: HookRunner;
+  agentCtx: PluginHookAgentContext;
+  /** Mutable ref so the wrapper always reads the current iteration count */
+  iterationRef: { current: number };
+  /** Model identifier string */
+  modelId: string;
+}
+
+export function wrapStreamFnWithHooks(
+  streamFn: StreamFn,
+  params: HookStreamWrapperParams,
+): StreamFn {
+  const { hookRunner, agentCtx, iterationRef, modelId } = params;
+  const wrapped: StreamFn = async (model, context, options) => {
+    // --- before_llm_call ---
+    let effectiveContext: Context = context;
+    if (hookRunner.hasHooks("before_llm_call")) {
+      try {
+        const toolDefs = (context.tools ?? []).map((t) => ({
+          name: t.name,
+          description: t.description,
+        }));
+        const result = await hookRunner.runBeforeLlmCall(
+          {
+            messages: context.messages as AgentMessage[],
+            systemPrompt: context.systemPrompt ?? "",
+            model: modelId,
+            iteration: iterationRef.current,
+            tools: toolDefs,
+          },
+          agentCtx,
+        );
+
+        if (result?.block) {
+          const reason = result.blockReason ?? "blocked by before_llm_call hook";
+          log.warn(`before_llm_call: blocked LLM call: ${reason}`);
+          throw new BeforeLlmCallBlockError(reason);
+        }
+
+        // Apply modifications — only create new context if something changed
+        // Use !== undefined consistently: any explicit value (including [] or "")
+        // means the hook wants that exact value. Return undefined for "no change".
+        if (
+          result?.messages !== undefined ||
+          result?.systemPrompt !== undefined ||
+          result?.tools !== undefined
+        ) {
+          let filteredTools = context.tools;
+          if (result.tools !== undefined) {
+            const allowedNames = new Set(result.tools.map((t) => t.name));
+            filteredTools = (context.tools ?? []).filter((t) => allowedNames.has(t.name));
+          }
+          // Spread original context to preserve any extra fields (e.g. provider
+          // metadata) that upstream wrappers may have attached. Only override
+          // the fields the hook explicitly modified.
+          effectiveContext = {
+            ...context,
+            systemPrompt: result.systemPrompt ?? context.systemPrompt,
+            messages: (result.messages ?? context.messages) as Message[],
+            tools: filteredTools,
+          };
+        }
+      } catch (err) {
+        // Re-throw explicit block errors (sentinel class, not string matching)
+        if (err instanceof BeforeLlmCallBlockError) {
+          throw err;
+        }
+        log.warn(`before_llm_call hook failed: ${String(err)}`);
+      }
+    }
+
+    // --- actual LLM call ---
+    // streamFn may return sync EventStream or Promise<EventStream>.
+    return streamFn(model, effectiveContext, options);
+  };
+
+  return wrapped;
+}

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -13,11 +13,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
-import {
-  clearInternalHooks,
-  createInternalHookEvent,
-  triggerInternalHook,
-} from "../hooks/internal-hooks.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
@@ -110,8 +106,9 @@ export async function startGatewaySidecars(params: {
 
   // Load internal hook handlers from configuration and directory discovery.
   try {
-    // Clear any previously registered hooks to ensure fresh loading
-    clearInternalHooks();
+    // NOTE: clearInternalHooks() is called earlier in server.impl.ts, before
+    // plugins register.  Do NOT clear here — plugin hooks are already registered
+    // and must be preserved.
     const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
     if (loadedCount > 0) {
       params.logHooks.info(

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,6 +21,7 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { clearInternalHooks } from "../hooks/internal-hooks.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -465,6 +466,13 @@ export async function startGatewayServer(
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
   const baseMethods = listGatewayMethods();
+
+  // Clear any previously registered internal hooks before plugins or bundled
+  // hooks register.  This ensures a clean slate on restart/reload.
+  // Plugins register first (during loadGatewayPlugins), then bundled hooks
+  // register later (during startGatewaySidecars → loadInternalHooks).
+  clearInternalHooks();
+
   const emptyPluginRegistry = createEmptyPluginRegistry();
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway
     ? { pluginRegistry: emptyPluginRegistry, gatewayMethods: baseMethods }

--- a/src/plugins/hooks.extended.test.ts
+++ b/src/plugins/hooks.extended.test.ts
@@ -1,0 +1,177 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+/**
+ * Unit tests for before_llm_call hook merge semantics.
+ *
+ * See hooks.context-loop.test.ts for context_assembled and loop_iteration tests.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import type { PluginRegistry } from "./registry.js";
+import type {
+  PluginHookAgentContext,
+  PluginHookBeforeLlmCallEvent,
+  PluginHookRegistration,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRegistry(hooks: PluginHookRegistration[]) {
+  return { typedHooks: hooks } as unknown as PluginRegistry;
+}
+
+const agentCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+};
+
+function fakeMsg(role: string, content: string): AgentMessage {
+  return { role, content } as AgentMessage;
+}
+
+// ---------------------------------------------------------------------------
+// before_llm_call (modifying, sequential)
+// ---------------------------------------------------------------------------
+
+describe("before_llm_call hook", () => {
+  const baseEvent: PluginHookBeforeLlmCallEvent = {
+    messages: [fakeMsg("user", "hello")],
+    systemPrompt: "You are helpful.",
+    model: "gpt-4",
+    iteration: 0,
+    tools: [{ name: "read", description: "Read files" }, { name: "exec" }],
+    tokenEstimate: 100,
+  };
+
+  it("fires handler with correct event shape", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    await runner.runBeforeLlmCall(baseEvent, agentCtx);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [event, ctx] = handler.mock.calls[0];
+    expect(event).toMatchObject({
+      messages: baseEvent.messages,
+      systemPrompt: "You are helpful.",
+      model: "gpt-4",
+      iteration: 0,
+      tools: baseEvent.tools,
+      tokenEstimate: 100,
+    });
+    expect(ctx).toBe(agentCtx);
+  });
+
+  it("returns modified messages when handler provides them", async () => {
+    const newMsgs = [fakeMsg("user", "modified")];
+    const handler = vi.fn().mockResolvedValue({ messages: newMsgs });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.messages).toBe(newMsgs);
+  });
+
+  it("returns modified systemPrompt when handler provides it", async () => {
+    const handler = vi.fn().mockResolvedValue({ systemPrompt: "new prompt" });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.systemPrompt).toBe("new prompt");
+  });
+
+  it("returns filtered tools when handler provides them", async () => {
+    const handler = vi.fn().mockResolvedValue({ tools: [{ name: "read" }] });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.tools).toEqual([{ name: "read" }]);
+  });
+
+  it("returns block=true and blockReason when handler blocks", async () => {
+    const handler = vi.fn().mockResolvedValue({ block: true, blockReason: "too many tokens" });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("too many tokens");
+  });
+
+  it("merges results from multiple handlers in registration order (FIFO)", async () => {
+    const first = vi
+      .fn()
+      .mockResolvedValue({ systemPrompt: "first prompt", tools: [{ name: "exec" }] });
+    const second = vi.fn().mockResolvedValue({ systemPrompt: "second prompt" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "first",
+          hookName: "before_llm_call",
+          handler: first,
+          source: "test",
+        },
+        {
+          pluginId: "second",
+          hookName: "before_llm_call",
+          handler: second,
+          source: "test",
+        },
+      ]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    // First-writer-wins for messages/systemPrompt: first plugin to set wins
+    expect(result?.tools).toEqual([{ name: "exec" }]);
+    // first runs first and provides systemPrompt → its value wins (security-first)
+    expect(result?.systemPrompt).toBe("first prompt");
+    // first ran before second (registration order)
+    expect(first).toHaveBeenCalledBefore(second);
+  });
+
+  it("continues on handler error when catchErrors=true", async () => {
+    const badHandler = vi.fn().mockRejectedValue(new Error("boom"));
+    const goodHandler = vi.fn().mockResolvedValue({ systemPrompt: "survived" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "bad",
+          hookName: "before_llm_call",
+          handler: badHandler,
+
+          source: "test",
+        },
+        {
+          pluginId: "good",
+          hookName: "before_llm_call",
+          handler: goodHandler,
+
+          source: "test",
+        },
+      ]),
+      { catchErrors: true },
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.systemPrompt).toBe("survived");
+  });
+
+  it("skips when no handlers registered (returns undefined)", async () => {
+    const runner = createHookRunner(makeRegistry([]));
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// after_llm_call (modifying, sequential)
+// ---------------------------------------------------------------------------

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -50,6 +50,8 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookBeforeLlmCallEvent,
+  PluginHookBeforeLlmCallResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -705,6 +707,41 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // LLM Call Hooks
+  // =========================================================================
+
+  /**
+   * Run before_llm_call hook.
+   * Fires before every LLM API call within the agent loop.
+   * Allows plugins to inspect/modify context, filter tools, or block the call.
+   * Runs sequentially, merging results across handlers.
+   */
+  async function runBeforeLlmCall(
+    event: PluginHookBeforeLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeLlmCallResult | undefined> {
+    return runModifyingHook<"before_llm_call", PluginHookBeforeLlmCallResult>(
+      "before_llm_call",
+      event,
+      ctx,
+      (acc, next) => ({
+        // First-writer-wins for messages/systemPrompt: once a higher-priority
+        // security plugin sanitizes inputs, later plugins cannot override them.
+        messages: acc?.messages ?? next.messages,
+        systemPrompt: acc?.systemPrompt ?? next.systemPrompt,
+        // Intersection latch: if both handlers provide tools, only keep tools
+        // present in both lists. Prevents a later handler from widening the allowlist.
+        tools:
+          acc?.tools !== undefined && next.tools !== undefined
+            ? next.tools.filter((t) => acc.tools!.some((a) => a.name === t.name))
+            : (next.tools ?? acc?.tools),
+        block: next.block || acc?.block,
+        blockReason: acc?.blockReason ?? next.blockReason,
+      }),
+    );
+  }
+
+  // =========================================================================
   // Utility
   // =========================================================================
 
@@ -753,6 +790,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // LLM call hooks
+    runBeforeLlmCall,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -336,7 +336,8 @@ export type PluginHookName =
   | "subagent_spawned"
   | "subagent_ended"
   | "gateway_start"
-  | "gateway_stop";
+  | "gateway_stop"
+  | "before_llm_call";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -363,6 +364,7 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_ended",
   "gateway_start",
   "gateway_stop",
+  "before_llm_call",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -777,6 +779,28 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+// ============================================================================
+// LLM Call Hooks
+// ============================================================================
+
+// before_llm_call hook (modifying — sequential)
+export type PluginHookBeforeLlmCallEvent = {
+  messages: AgentMessage[];
+  systemPrompt: string;
+  model: string;
+  iteration: number;
+  tools: Array<{ name: string; description?: string }>;
+  tokenEstimate?: number;
+};
+
+export type PluginHookBeforeLlmCallResult = {
+  messages?: AgentMessage[];
+  systemPrompt?: string;
+  tools?: Array<{ name: string }>;
+  block?: boolean;
+  blockReason?: string;
+};
+
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
   before_model_resolve: (
@@ -875,6 +899,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookGatewayStopEvent,
     ctx: PluginHookGatewayContext,
   ) => Promise<void> | void;
+  before_llm_call: (
+    event: PluginHookBeforeLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeLlmCallResult | void> | PluginHookBeforeLlmCallResult | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {


### PR DESCRIPTION
## TL;DR

Adds the `before_llm_call` modifying plugin hook — fires before every LLM API call, allowing plugins to inspect/modify the message context, filter tools, or block the call.

**Split from #33916** (1 of 3). This PR covers input interception only. Tool-call gating (`after_llm_call`) and output policies (`before_response_emit`) follow in stacked PRs.

## Hook contract

| Field | Type | Semantics |
|-------|------|-----------|
| `messages` | `AgentMessage[]` | First-writer-wins: security plugins can't be overridden |
| `systemPrompt` | `string` | First-writer-wins |
| `tools` | `Array<{ name }>` | Intersection latch: later handlers can only narrow, never widen |
| `block` | `boolean` | One-way latch: once blocked, stays blocked |
| `blockReason` | `string` | First-writer-wins |

## Architecture

Uses the `streamFn` wrapper pattern — the hook runs inside `streamAssistantResponse()` in the `agentLoop`'s own async context. This is the outermost wrapper, so it sees the final context after all other transforms (cache trace, Ollama compat, xAI decode, Anthropic logging).

`BeforeLlmCallBlockError` is a sentinel class that propagates through `pi-agent-core`'s error handling and is caught gracefully in `attempt.ts` — the run ends cleanly with no assistant response rather than surfacing an error.

## Infrastructure fix

Moves `clearInternalHooks()` from `server-startup.ts` to `server.impl.ts` (before plugin registration). Without this, plugin hooks registered during `loadGatewayPlugins` would be cleared when bundled hooks load later in `startGatewaySidecars`.

## Testing

- 7 stream wrapper tests (block, modify, pass-through, error handling)
- 8 merge semantics tests (first-writer-wins, intersection latch, block latch)
- `pnpm check` clean (pre-existing streamSegments type mismatch excluded)

## AI-Assisted Development 🤖

Developed with AI assistance (Claude/OpenClaw agent "Tank"). All changes reviewed and directed by Eddie Abrams.