### PR TITLE
fix(voice-call): honor vadThreshold: 0 and silenceDurationMs: 0 in STT config

### DIFF
--- a/extensions/voice-call/src/providers/stt-openai-realtime.test.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { OpenAIRealtimeSTTProvider } from "./stt-openai-realtime.js";
+
+describe("OpenAIRealtimeSTTProvider constructor defaults", () => {
+  it("uses vadThreshold: 0 when explicitly configured (max sensitivity)", () => {
+    const provider = new OpenAIRealtimeSTTProvider({
+      apiKey: "sk-test",
+      vadThreshold: 0,
+    });
+    // Access private field via cast for testing
+    expect((provider as any).vadThreshold).toBe(0);
+  });
+
+  it("uses silenceDurationMs: 0 when explicitly configured", () => {
+    const provider = new OpenAIRealtimeSTTProvider({
+      apiKey: "sk-test",
+      silenceDurationMs: 0,
+    });
+    expect((provider as any).silenceDurationMs).toBe(0);
+  });
+
+  it("falls back to defaults when values are undefined", () => {
+    const provider = new OpenAIRealtimeSTTProvider({
+      apiKey: "sk-test",
+    });
+    expect((provider as any).vadThreshold).toBe(0.5);
+    expect((provider as any).silenceDurationMs).toBe(800);
+  });
+});

--- a/extensions/voice-call/src/providers/stt-openai-realtime.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.ts
@@ -62,8 +62,8 @@ export class OpenAIRealtimeSTTProvider {
     }
     this.apiKey = config.apiKey;
     this.model = config.model || "gpt-4o-transcribe";
-    this.silenceDurationMs = config.silenceDurationMs || 800;
-    this.vadThreshold = config.vadThreshold || 0.5;
+    this.silenceDurationMs = config.silenceDurationMs ?? 800;
+    this.vadThreshold = config.vadThreshold ?? 0.5;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace `||` with `??` for `vadThreshold` and `silenceDurationMs` defaults in `OpenAIRealtimeSTTProvider`
- `vadThreshold: 0` (max VAD sensitivity) and `silenceDurationMs: 0` are valid per the Zod schema but were silently replaced with defaults

## Test plan
- [x] Added 3 tests: explicit zero values respected, undefined falls back to defaults
- [x] All 3 tests pass

Fixes #39190

🤖 Generated with [Claude Code](https://claude.com/claude-code)