### PR TITLE
fix(synology-chat): respect SYNOLOGY_RATE_LIMIT=0 in env var parsing

### DIFF
--- a/extensions/synology-chat/src/accounts.test.ts
+++ b/extensions/synology-chat/src/accounts.test.ts
@@ -130,4 +130,11 @@ describe("resolveAccount", () => {
     const account = resolveAccount(cfg);
     expect(account.allowedUserIds).toEqual(["u1", "u2"]);
   });
+
+  it("respects SYNOLOGY_RATE_LIMIT=0 instead of defaulting to 30", () => {
+    process.env.SYNOLOGY_RATE_LIMIT = "0";
+    const cfg = { channels: { "synology-chat": {} } };
+    const account = resolveAccount(cfg);
+    expect(account.rateLimitPerMinute).toBe(0);
+  });
 });

--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -63,6 +63,8 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
   const envNasHost = process.env.SYNOLOGY_NAS_HOST ?? "localhost";
   const envAllowedUserIds = process.env.SYNOLOGY_ALLOWED_USER_IDS ?? "";
   const envRateLimit = process.env.SYNOLOGY_RATE_LIMIT;
+  const parsedRateLimit = envRateLimit != null ? parseInt(envRateLimit, 10) : NaN;
+  const envRateLimitValue = Number.isFinite(parsedRateLimit) ? parsedRateLimit : 30;
   const envBotName = process.env.OPENCLAW_BOT_NAME ?? "OpenClaw";
 
   // Merge: account override > base channel config > env var
@@ -78,9 +80,7 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
       accountOverride.allowedUserIds ?? channelCfg.allowedUserIds ?? envAllowedUserIds,
     ),
     rateLimitPerMinute:
-      accountOverride.rateLimitPerMinute ??
-      channelCfg.rateLimitPerMinute ??
-      (envRateLimit ? parseInt(envRateLimit, 10) || 30 : 30),
+      accountOverride.rateLimitPerMinute ?? channelCfg.rateLimitPerMinute ?? envRateLimitValue,
     botName: accountOverride.botName ?? channelCfg.botName ?? envBotName,
     allowInsecureSsl: accountOverride.allowInsecureSsl ?? channelCfg.allowInsecureSsl ?? false,
   };


### PR DESCRIPTION
## Summary
- Replace `parseInt(envRateLimit, 10) || 30` with a proper parse that uses `Number.isFinite()` to validate
- `parseInt("0", 10)` returns `0` which `||` treats as falsy, silently defaulting to `30`
- The new approach correctly handles both `0` (valid rate limit) and `NaN` (invalid input falls back to `30`)

## Test plan
- [x] Added test: `respects SYNOLOGY_RATE_LIMIT=0 instead of defaulting to 30`
- [x] All 12 synology-chat account tests pass

Fixes #39191

🤖 Generated with [Claude Code](https://claude.com/claude-code)