### PR TITLE
fix(voice-call): add missing speed and instructions to OpenAI TTS plugin schema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -527,6 +527,14 @@
               },
               "voice": {
                 "type": "string"
+              },
+              "speed": {
+                "type": "number",
+                "minimum": 0.25,
+                "maximum": 4
+              },
+              "instructions": {
+                "type": "string"
               }
             }
           },


### PR DESCRIPTION
## Summary
- Add `speed` (number, 0.25-4.0) and `instructions` (string) to the OpenAI TTS provider section in `openclaw.plugin.json`
- The schema has `additionalProperties: false` but these two properties accepted by the code were not declared, causing config validation to reject them

## Test plan
- [x] JSON schema validates correctly
- [x] Properties match `OpenAITTSConfig` interface in `tts-openai.ts`
- [x] Speed range matches OpenAI API docs (0.25 to 4.0)

Fixes #39192

🤖 Generated with [Claude Code](https://claude.com/claude-code)