### PR TITLE
fix: return undefined from mediaKindFromMime for missing/unrecognized mime types

### DIFF
--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -3,11 +3,11 @@ export const MAX_AUDIO_BYTES = 16 * 1024 * 1024; // 16MB
 export const MAX_VIDEO_BYTES = 16 * 1024 * 1024; // 16MB
 export const MAX_DOCUMENT_BYTES = 100 * 1024 * 1024; // 100MB
 
-export type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
+export type MediaKind = "image" | "audio" | "video" | "document";
 
-export function mediaKindFromMime(mime?: string | null): MediaKind {
+export function mediaKindFromMime(mime?: string | null): MediaKind | undefined {
   if (!mime) {
-    return "unknown";
+    return undefined;
   }
   if (mime.startsWith("image/")) {
     return "image";
@@ -27,7 +27,7 @@ export function mediaKindFromMime(mime?: string | null): MediaKind {
   if (mime.startsWith("application/")) {
     return "document";
   }
-  return "unknown";
+  return undefined;
 }
 
 export function maxBytesForKind(kind: MediaKind): number {

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -187,6 +187,6 @@ export function imageMimeFromFormat(format?: string | null): string | undefined 
   }
 }
 
-export function kindFromMime(mime?: string | null): MediaKind {
+export function kindFromMime(mime?: string | null): MediaKind | undefined {
   return mediaKindFromMime(mime);
 }

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -324,7 +324,7 @@ async function loadWebMediaInternal(
   if (/^https?:\/\//i.test(mediaUrl)) {
     // Enforce a download cap during fetch to avoid unbounded memory usage.
     // For optimized images, allow fetching larger payloads before compression.
-    const defaultFetchCap = maxBytesForKind("unknown");
+    const defaultFetchCap = maxBytesForKind("document");
     const fetchCap =
       maxBytes === undefined
         ? defaultFetchCap

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -19,7 +19,7 @@ import { resolveUserPath } from "../utils.js";
 export type WebMediaResult = {
   buffer: Buffer;
   contentType?: string;
-  kind: MediaKind;
+  kind: MediaKind | undefined;
   fileName?: string;
 };
 
@@ -284,12 +284,12 @@ async function loadWebMediaInternal(
   const clampAndFinalize = async (params: {
     buffer: Buffer;
     contentType?: string;
-    kind: MediaKind;
+    kind: MediaKind | undefined;
     fileName?: string;
   }): Promise<WebMediaResult> => {
     // If caller explicitly provides maxBytes, trust it (for channels that handle large files).
     // Otherwise fall back to per-kind defaults.
-    const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind);
+    const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind ?? "document");
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
       if (isGif || !optimizeImages) {


### PR DESCRIPTION
## Problem

Empty Signal protocol events (reactions, typing indicators, read receipts) get surfaced to the agent as `<media:unknown>` messages. This creates phantom messages that the agent has to process and respond to, wasting tokens and confusing conversation flow.

**How it happens:** When a Signal user reacts to a message with an emoji, signal-cli sends a `dataMessage` with no body and no attachments. `mediaKindFromMime(undefined)` returns `"unknown"` (a truthy string), which becomes `<media:unknown>` through the placeholder template, passes the empty-body guard, and gets delivered as a real message.

**User impact:** On a moderately active Signal chat, this produces multiple phantom messages per hour that the agent treats as real input.

## Fix

Return `undefined` instead of `"unknown"` from `mediaKindFromMime()` when mime is missing or unrecognized. Since `undefined` is falsy, empty protocol events now correctly fall through to the `if (!bodyText) return` guard and get silently dropped.

All existing callers already use `if (kind)` guards, so this is a safe change with no behavioral difference for real attachments. Attachments with genuinely unknown mime types now fall through to the `<media:attachment>` path, which is more accurate than `<media:unknown>`.

## Changes

- `src/media/constants.ts` — `mediaKindFromMime` returns `undefined` instead of `"unknown"`; remove `"unknown"` from `MediaKind` union
- `src/media/mime.ts` — update `kindFromMime` return type to match
- `src/web/media.ts` — update types, add fallback for undefined kind in byte cap

## Testing

This fix has been running in production on a live OpenClaw instance with Signal channel for several hours. Confirmed working:

- ✅ Signal emoji reactions no longer produce `<media:unknown>` messages
- ✅ Signal typing indicators and read receipts remain silently filtered
- ✅ Real image/audio/video/document attachments still resolve to correct `<media:*>` placeholders
- ✅ Attachments with unrecognized mime types fall through to `<media:attachment>` (improved from `<media:unknown>`)
- ✅ `maxBytesForKind` callers handle undefined kind via existing default case

Fixes #38997