### PR TITLE
feat(hooks): add after_llm_call hook with deterministic Promise-based gate

### DIFF
--- a/src/agents/pi-embedded-runner/run/after-llm-call-gate.test.ts
+++ b/src/agents/pi-embedded-runner/run/after-llm-call-gate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  setAfterLlmCallGatePromise,
+  checkAfterLlmCallGate,
+  clearAfterLlmCallGate,
+} from "./after-llm-call-gate.js";
+
+describe("after-llm-call-gate (Promise-based)", () => {
+  const sessionId = "test-session";
+
+  beforeEach(() => {
+    clearAfterLlmCallGate(sessionId);
+  });
+
+  it("returns blocked: false when no gate is set", async () => {
+    const result = await checkAfterLlmCallGate(sessionId, "tool-1");
+    expect(result.blocked).toBe(false);
+  });
+
+  it("blocks all tools when hook sets block: true", async () => {
+    setAfterLlmCallGatePromise(sessionId, Promise.resolve({ block: true, blockReason: "policy" }));
+
+    const result = await checkAfterLlmCallGate(sessionId, "any-tool");
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toBe("policy");
+  });
+
+  it("filters tools by ID when hook provides toolCalls list", async () => {
+    setAfterLlmCallGatePromise(
+      sessionId,
+      Promise.resolve({ toolCalls: [{ id: "allowed-1" }, { id: "allowed-2" }] }),
+    );
+
+    expect((await checkAfterLlmCallGate(sessionId, "allowed-1")).blocked).toBe(false);
+    expect((await checkAfterLlmCallGate(sessionId, "allowed-2")).blocked).toBe(false);
+
+    const blocked = await checkAfterLlmCallGate(sessionId, "not-allowed");
+    expect(blocked.blocked).toBe(true);
+    expect(blocked.reason).toContain("filtered");
+  });
+
+  it("blocks tool calls with no ID when filter is active", async () => {
+    setAfterLlmCallGatePromise(sessionId, Promise.resolve({ toolCalls: [{ id: "only-this" }] }));
+
+    const result = await checkAfterLlmCallGate(sessionId, undefined);
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toContain("no ID");
+  });
+
+  it("first tool call awaits Promise; subsequent get cached result", async () => {
+    let resolved = false;
+    const slowPromise = new Promise<{ block: boolean }>((resolve) => {
+      setTimeout(() => {
+        resolved = true;
+        resolve({ block: false });
+      }, 50);
+    });
+
+    setAfterLlmCallGatePromise(sessionId, slowPromise);
+
+    // Start two checks concurrently
+    const [result1, result2] = await Promise.all([
+      checkAfterLlmCallGate(sessionId, "tool-1"),
+      checkAfterLlmCallGate(sessionId, "tool-2"),
+    ]);
+
+    expect(resolved).toBe(true);
+    expect(result1.blocked).toBe(false);
+    expect(result2.blocked).toBe(false);
+  });
+
+  it("clears gate on clearAfterLlmCallGate", async () => {
+    setAfterLlmCallGatePromise(sessionId, Promise.resolve({ block: true }));
+    expect((await checkAfterLlmCallGate(sessionId, "x")).blocked).toBe(true);
+
+    clearAfterLlmCallGate(sessionId);
+    expect((await checkAfterLlmCallGate(sessionId, "x")).blocked).toBe(false);
+  });
+
+  it("fails open when hook Promise rejects", async () => {
+    setAfterLlmCallGatePromise(sessionId, Promise.reject(new Error("hook error")));
+
+    // Should not throw, should return blocked: false
+    const result = await checkAfterLlmCallGate(sessionId, "tool-1");
+    expect(result.blocked).toBe(false);
+  });
+
+  it("isolates gates by sessionId", async () => {
+    const session1 = "session-1";
+    const session2 = "session-2";
+
+    setAfterLlmCallGatePromise(session1, Promise.resolve({ block: true }));
+    setAfterLlmCallGatePromise(session2, Promise.resolve({ block: false }));
+
+    expect((await checkAfterLlmCallGate(session1, "x")).blocked).toBe(true);
+    expect((await checkAfterLlmCallGate(session2, "x")).blocked).toBe(false);
+
+    clearAfterLlmCallGate(session1);
+    clearAfterLlmCallGate(session2);
+  });
+
+  it("returns blocked: false for empty/undefined hook result", async () => {
+    setAfterLlmCallGatePromise(sessionId, Promise.resolve(undefined));
+    expect((await checkAfterLlmCallGate(sessionId, "x")).blocked).toBe(false);
+
+    setAfterLlmCallGatePromise(sessionId, Promise.resolve({}));
+    expect((await checkAfterLlmCallGate(sessionId, "x")).blocked).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/after-llm-call-gate.ts
+++ b/src/agents/pi-embedded-runner/run/after-llm-call-gate.ts
@@ -1,0 +1,134 @@
+/**
+ * Promise-based gate bridge between after_llm_call and before_tool_call.
+ *
+ * after_llm_call fires from the streamFn wrapper inside agentLoop's
+ * async context. The hook result is stored as a Promise that the tool
+ * wrapper awaits before each tool.execute() call. This makes enforcement
+ * deterministic — the first tool call blocks until the hook resolves,
+ * and subsequent calls in the same turn get the cached result instantly.
+ *
+ * ## Why a Promise (not a sync value)?
+ *
+ * The hook fires synchronously when the LLM response stream completes,
+ * but the hook handlers may be async (e.g. network policy lookups).
+ * Storing the Promise immediately (before streamAssistantResponse returns)
+ * guarantees it's available when executeToolCalls starts, because both
+ * run in the same agentLoop async context:
+ *
+ *   streamAssistantResponse() → wrapper fires hook, stores Promise → returns
+ *   executeToolCalls() → tool.execute() → tool wrapper awaits Promise
+ *
+ * ## Previous design (replaced)
+ *
+ * The previous implementation used a synchronous mutable ref populated
+ * via .then() from a subscription callback (Agent's async context).
+ * This was "best-effort" — tools could execute before the gate was set.
+ * It required monotonic sequence counters and staleness detection to
+ * handle race conditions between turns.
+ *
+ * Keyed by sessionId so concurrent sessions don't interfere.
+ */
+
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+
+const log = createSubsystemLogger("hooks/after-llm-call-gate");
+
+export interface GateDecision {
+  /** Block ALL tool calls this turn. */
+  blocked: boolean;
+  blockReason?: string;
+  /** If set, only these tool call IDs are allowed. Others are blocked. */
+  allowedToolCallIds?: Set<string>;
+}
+
+const gates = new Map<string, Promise<GateDecision>>();
+
+/**
+ * Store the gate Promise for a session. Called synchronously from the
+ * streamFn wrapper when the LLM response completes.
+ *
+ * The promise resolves to a GateDecision when runAfterLlmCall completes.
+ * Errors are caught internally — a failed hook resolves to { blocked: false }
+ * (fail open) rather than rejecting.
+ */
+export function setAfterLlmCallGatePromise(
+  sessionId: string,
+  hookPromise: Promise<
+    { block?: boolean; blockReason?: string; toolCalls?: Array<{ id: string }> } | undefined
+  >,
+): void {
+  const gatePromise = hookPromise
+    .then((result) => {
+      if (!result || (!result.block && !result.toolCalls)) {
+        return { blocked: false } as GateDecision;
+      }
+      const decision: GateDecision = {
+        blocked: result.block ?? false,
+        blockReason: result.blockReason,
+        allowedToolCallIds: result.toolCalls
+          ? new Set(result.toolCalls.map((tc) => tc.id))
+          : undefined,
+      };
+      if (decision.blocked) {
+        log.debug(
+          `gate set: session=${sessionId} blocked=true reason=${decision.blockReason ?? "none"}`,
+        );
+      } else if (decision.allowedToolCallIds) {
+        log.debug(
+          `gate set: session=${sessionId} allowedTools=${decision.allowedToolCallIds.size}`,
+        );
+      }
+      return decision;
+    })
+    .catch((err) => {
+      log.warn(`after_llm_call hook error (failing open): ${String(err)}`);
+      return { blocked: false } as GateDecision;
+    });
+
+  gates.set(sessionId, gatePromise);
+}
+
+/**
+ * Check the gate for a tool call. Awaits the stored Promise so the first
+ * tool call blocks until the hook resolves. Subsequent calls in the same
+ * turn get the cached (already-resolved) Promise instantly.
+ *
+ * Returns { blocked: false } if no gate is set (no hooks registered or
+ * the message had no tool calls).
+ */
+export async function checkAfterLlmCallGate(
+  sessionId: string,
+  toolCallId?: string,
+): Promise<{ blocked: boolean; reason?: string }> {
+  const promise = gates.get(sessionId);
+  if (!promise) {
+    return { blocked: false };
+  }
+
+  const gate = await promise;
+
+  if (gate.blocked) {
+    return { blocked: true, reason: gate.blockReason ?? "Blocked by after_llm_call hook" };
+  }
+
+  if (gate.allowedToolCallIds) {
+    if (!toolCallId || !gate.allowedToolCallIds.has(toolCallId)) {
+      return {
+        blocked: true,
+        reason: toolCallId
+          ? `Tool call ${toolCallId} filtered by after_llm_call hook`
+          : "Tool call has no ID and cannot be verified against after_llm_call allowlist",
+      };
+    }
+  }
+
+  return { blocked: false };
+}
+
+/**
+ * Clear the gate for a session. Called at turn boundaries to prevent
+ * stale decisions from affecting the next turn.
+ */
+export function clearAfterLlmCallGate(sessionId: string): void {
+  gates.delete(sessionId);
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1380,6 +1380,30 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      // Hook context shared across hook invocations for this run.
+      const hookCtx: import("../../../plugins/hooks.js").PluginHookAgentContext = {
+        agentId: sessionAgentId,
+        sessionKey: sandboxSessionKey,
+        sessionId: params.sessionId,
+        trigger: params.trigger,
+        channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+      };
+
+      // Mutable ref so the wrapper always reads the current iteration count.
+      const hookIterationRef = { current: 0 };
+
+      // Wrap streamFn for before_llm_call hooks — must be the outermost
+      // wrapper so it sees the final context after all other transforms.
+      if (hookRunner?.hasHooks("before_llm_call")) {
+        const { wrapStreamFnWithHooks } = await import("./hook-stream-wrapper.js");
+        activeSession.agent.streamFn = wrapStreamFnWithHooks(activeSession.agent.streamFn, {
+          hookRunner,
+          agentCtx: hookCtx,
+          iterationRef: hookIterationRef,
+          modelId: params.modelId,
+        });
+      }
+
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,
@@ -1501,6 +1525,17 @@ export async function runEmbeddedAttempt(
           );
         });
       };
+
+      // Track LLM call iteration for hook context.
+      // Subscribes to turn_start to increment the mutable ref that the
+      // streamFn wrapper reads for before_llm_call event.iteration.
+      const hookIterationUnsub = hookRunner?.hasHooks("before_llm_call")
+        ? activeSession.subscribe((event) => {
+            if (event.type === "turn_start") {
+              hookIterationRef.current++;
+            }
+          })
+        : undefined;
 
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
@@ -1777,8 +1812,15 @@ export async function runEmbeddedAttempt(
             await abortable(activeSession.prompt(effectivePrompt));
           }
         } catch (err) {
-          promptError = err;
-          promptErrorSource = "prompt";
+          // BeforeLlmCallBlockError is a graceful hook-initiated block, not a failure.
+          // Suppress it — the run ends cleanly with no assistant response.
+          const { BeforeLlmCallBlockError } = await import("./hook-stream-wrapper.js");
+          if (err instanceof BeforeLlmCallBlockError) {
+            log.info(`LLM call blocked by before_llm_call hook: ${err.message}`);
+          } else {
+            promptError = err;
+            promptErrorSource = "prompt";
+          }
         } finally {
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
@@ -1972,6 +2014,7 @@ export async function runEmbeddedAttempt(
           );
         }
         try {
+          hookIterationUnsub?.();
           unsubscribe();
         } catch (err) {
           // unsubscribe() should never throw; if it does, it indicates a serious bug.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1392,15 +1392,17 @@ export async function runEmbeddedAttempt(
       // Mutable ref so the wrapper always reads the current iteration count.
       const hookIterationRef = { current: 0 };
 
-      // Wrap streamFn for before_llm_call hooks — must be the outermost
-      // wrapper so it sees the final context after all other transforms.
-      if (hookRunner?.hasHooks("before_llm_call")) {
+      // Wrap streamFn for before_llm_call and after_llm_call hooks — must be
+      // the outermost wrapper so it sees the final context after all other
+      // transforms (before_llm_call) and the complete response (after_llm_call).
+      if (hookRunner?.hasHooks("before_llm_call") || hookRunner?.hasHooks("after_llm_call")) {
         const { wrapStreamFnWithHooks } = await import("./hook-stream-wrapper.js");
         activeSession.agent.streamFn = wrapStreamFnWithHooks(activeSession.agent.streamFn, {
           hookRunner,
           agentCtx: hookCtx,
           iterationRef: hookIterationRef,
           modelId: params.modelId,
+          sessionId: params.sessionId,
         });
       }
 
@@ -1526,16 +1528,22 @@ export async function runEmbeddedAttempt(
         });
       };
 
-      // Track LLM call iteration for hook context.
-      // Subscribes to turn_start to increment the mutable ref that the
-      // streamFn wrapper reads for before_llm_call event.iteration.
-      const hookIterationUnsub = hookRunner?.hasHooks("before_llm_call")
-        ? activeSession.subscribe((event) => {
-            if (event.type === "turn_start") {
-              hookIterationRef.current++;
-            }
-          })
-        : undefined;
+      // Track LLM call iteration and clear after_llm_call gate at turn boundaries.
+      // Subscribes to turn_start to:
+      // 1. Increment the iteration ref for before_llm_call/after_llm_call event.iteration
+      // 2. Clear the after_llm_call gate to prevent stale decisions leaking between turns
+      const hookIterationUnsub =
+        hookRunner?.hasHooks("before_llm_call") || hookRunner?.hasHooks("after_llm_call")
+          ? activeSession.subscribe(async (event) => {
+              if (event.type === "turn_start") {
+                hookIterationRef.current++;
+                if (params.sessionId && hookRunner?.hasHooks("after_llm_call")) {
+                  const { clearAfterLlmCallGate } = await import("./after-llm-call-gate.js");
+                  clearAfterLlmCallGate(params.sessionId);
+                }
+              }
+            })
+          : undefined;
 
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,

--- a/src/agents/pi-embedded-runner/run/hook-stream-wrapper.test.ts
+++ b/src/agents/pi-embedded-runner/run/hook-stream-wrapper.test.ts
@@ -1,0 +1,236 @@
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type { Model, Api, Context } from "@mariozechner/pi-ai";
+/**
+ * Integration tests for wrapStreamFnWithHooks().
+ *
+ * Verifies that the hook-aware StreamFn wrapper correctly fires
+ * before_llm_call hooks, applies modifications,
+ * blocks calls, and is resilient to hook errors.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+import { wrapStreamFnWithHooks } from "./hook-stream-wrapper.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeMsg(role: string, content: string): AgentMessage {
+  return { role, content } as AgentMessage;
+}
+
+function makeMockHookRunner(
+  overrides: Partial<Record<keyof HookRunner, unknown>> = {},
+): HookRunner {
+  return {
+    hasHooks: vi.fn().mockReturnValue(true),
+    runBeforeAgentStart: vi.fn(),
+    runAgentEnd: vi.fn(),
+    runBeforeCompaction: vi.fn(),
+    runAfterCompaction: vi.fn(),
+    runMessageReceived: vi.fn(),
+    runMessageSending: vi.fn(),
+    runMessageSent: vi.fn(),
+    runBeforeToolCall: vi.fn(),
+    runAfterToolCall: vi.fn(),
+    runToolResultPersist: vi.fn(),
+    runSessionStart: vi.fn(),
+    runSessionEnd: vi.fn(),
+    runGatewayStart: vi.fn(),
+    runGatewayStop: vi.fn(),
+    runBeforeLlmCall: vi.fn().mockResolvedValue(undefined),
+    runAfterLlmCall: vi.fn(),
+    runLoopIterationStart: vi.fn(),
+    runLoopIterationEnd: vi.fn(),
+    runBeforeResponseEmit: vi.fn(),
+    getHookCount: vi.fn().mockReturnValue(0),
+    ...overrides,
+  } as unknown as HookRunner;
+}
+
+const agentCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+};
+
+const mockStream = Symbol("mock-stream");
+
+function makeBaseContext() {
+  return {
+    systemPrompt: "You are helpful.",
+    messages: [fakeMsg("user", "hello")] as unknown[],
+    tools: [
+      { name: "read", description: "Read files", parameters: {} },
+      { name: "exec", description: "Execute commands", parameters: {} },
+    ],
+  };
+}
+
+describe("wrapStreamFnWithHooks", () => {
+  let streamFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    streamFn = vi.fn().mockReturnValue(mockStream);
+  });
+
+  it("before_llm_call fires on every call", async () => {
+    const hookRunner = makeMockHookRunner();
+    const iterationRef = { current: 0 };
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef,
+      modelId: "gpt-4",
+    });
+
+    const context = makeBaseContext() as unknown as Context;
+    await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+    iterationRef.current = 1;
+    await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+
+    expect(hookRunner.runBeforeLlmCall).toHaveBeenCalledTimes(2);
+
+    // First call
+    const [event1] = (hookRunner.runBeforeLlmCall as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(event1).toMatchObject({
+      model: "gpt-4",
+      iteration: 0,
+      systemPrompt: "You are helpful.",
+    });
+
+    // Second call
+    const [event2] = (hookRunner.runBeforeLlmCall as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(event2).toMatchObject({
+      model: "gpt-4",
+      iteration: 1,
+    });
+  });
+
+  it("before_llm_call can modify context", async () => {
+    const modifiedMessages = [fakeMsg("user", "sanitized")];
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        systemPrompt: "modified prompt",
+        messages: modifiedMessages,
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    expect(streamFn).toHaveBeenCalledOnce();
+    const passedContext = streamFn.mock.calls[0][1];
+    expect(passedContext.systemPrompt).toBe("modified prompt");
+    expect(passedContext.messages).toBe(modifiedMessages);
+  });
+
+  it("before_llm_call can filter tools", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        tools: [{ name: "read" }],
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    expect(streamFn).toHaveBeenCalledOnce();
+    const passedContext = streamFn.mock.calls[0][1];
+    // Only the "read" tool should remain (filtered by allowed names)
+    expect(passedContext.tools).toHaveLength(1);
+    expect(passedContext.tools[0].name).toBe("read");
+  });
+
+  it("before_llm_call can block", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        block: true,
+        blockReason: "tainted context",
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await expect(
+      wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {}),
+    ).rejects.toThrow("LLM call blocked by plugin: tainted context");
+    expect(streamFn).not.toHaveBeenCalled();
+  });
+
+  it("before_llm_call error does not break stream", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockRejectedValue(new Error("hook kaboom")),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    const result = await wrapped(
+      "gpt-4" as unknown as Model<Api>,
+      makeBaseContext() as unknown as Context,
+      {},
+    );
+
+    // Should still call the underlying streamFn and return its result
+    expect(streamFn).toHaveBeenCalledOnce();
+    expect(result).toBe(mockStream);
+  });
+
+  it("passes through to underlying streamFn when no hooks", async () => {
+    const hookRunner = makeMockHookRunner({
+      hasHooks: vi.fn().mockReturnValue(false),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    const context = makeBaseContext() as unknown as Context;
+    const result = await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+
+    // before_llm_call should not be called when no hooks registered
+    expect(hookRunner.runBeforeLlmCall).not.toHaveBeenCalled();
+    // Underlying streamFn receives original context unchanged
+    expect(streamFn).toHaveBeenCalledWith("gpt-4", context, {});
+    expect(result).toBe(mockStream);
+  });
+
+  it("treats messages:[] as explicit override (clears history)", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({ messages: [] }),
+    });
+
+    const streamFn = vi.fn().mockResolvedValue(mockStream);
+    const wrapped = wrapStreamFnWithHooks(streamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 1 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    // messages: [] is an explicit "clear history" — not "no change"
+    const passedContext = streamFn.mock.calls[0][1];
+    expect(passedContext.messages).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
+++ b/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
@@ -1,0 +1,107 @@
+/**
+ * Wraps a StreamFn to emit before_llm_call plugin hooks.
+ *
+ * Uses the same streamFn wrapping pattern as cache-trace.ts and
+ * anthropic-payload-log.ts — outermost wrapper sees the full context before
+ * delegating to the underlying (possibly wrapped) streamFn.
+ */
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Message } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+
+const log = createSubsystemLogger("hooks/stream");
+
+/**
+ * Sentinel error thrown when before_llm_call blocks the LLM call.
+ * Distinct from generic errors so the agent loop can handle it gracefully
+ * (suppress the run without surfacing an error) rather than treating it
+ * as a run failure.
+ */
+export class BeforeLlmCallBlockError extends Error {
+  readonly isBeforeLlmCallBlock = true;
+  constructor(reason: string) {
+    super(`LLM call blocked by plugin: ${reason}`);
+    this.name = "BeforeLlmCallBlockError";
+  }
+}
+
+export interface HookStreamWrapperParams {
+  hookRunner: HookRunner;
+  agentCtx: PluginHookAgentContext;
+  /** Mutable ref so the wrapper always reads the current iteration count */
+  iterationRef: { current: number };
+  /** Model identifier string */
+  modelId: string;
+}
+
+export function wrapStreamFnWithHooks(
+  streamFn: StreamFn,
+  params: HookStreamWrapperParams,
+): StreamFn {
+  const { hookRunner, agentCtx, iterationRef, modelId } = params;
+  const wrapped: StreamFn = async (model, context, options) => {
+    // --- before_llm_call ---
+    let effectiveContext: Context = context;
+    if (hookRunner.hasHooks("before_llm_call")) {
+      try {
+        const toolDefs = (context.tools ?? []).map((t) => ({
+          name: t.name,
+          description: t.description,
+        }));
+        const result = await hookRunner.runBeforeLlmCall(
+          {
+            messages: context.messages as AgentMessage[],
+            systemPrompt: context.systemPrompt ?? "",
+            model: modelId,
+            iteration: iterationRef.current,
+            tools: toolDefs,
+          },
+          agentCtx,
+        );
+
+        if (result?.block) {
+          const reason = result.blockReason ?? "blocked by before_llm_call hook";
+          log.warn(`before_llm_call: blocked LLM call: ${reason}`);
+          throw new BeforeLlmCallBlockError(reason);
+        }
+
+        // Apply modifications — only create new context if something changed
+        // Use !== undefined consistently: any explicit value (including [] or "")
+        // means the hook wants that exact value. Return undefined for "no change".
+        if (
+          result?.messages !== undefined ||
+          result?.systemPrompt !== undefined ||
+          result?.tools !== undefined
+        ) {
+          let filteredTools = context.tools;
+          if (result.tools !== undefined) {
+            const allowedNames = new Set(result.tools.map((t) => t.name));
+            filteredTools = (context.tools ?? []).filter((t) => allowedNames.has(t.name));
+          }
+          // Spread original context to preserve any extra fields (e.g. provider
+          // metadata) that upstream wrappers may have attached. Only override
+          // the fields the hook explicitly modified.
+          effectiveContext = {
+            ...context,
+            systemPrompt: result.systemPrompt ?? context.systemPrompt,
+            messages: (result.messages ?? context.messages) as Message[],
+            tools: filteredTools,
+          };
+        }
+      } catch (err) {
+        // Re-throw explicit block errors (sentinel class, not string matching)
+        if (err instanceof BeforeLlmCallBlockError) {
+          throw err;
+        }
+        log.warn(`before_llm_call hook failed: ${String(err)}`);
+      }
+    }
+
+    // --- actual LLM call ---
+    // streamFn may return sync EventStream or Promise<EventStream>.
+    return streamFn(model, effectiveContext, options);
+  };
+
+  return wrapped;
+}

--- a/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
+++ b/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
@@ -1,14 +1,27 @@
 /**
- * Wraps a StreamFn to emit before_llm_call plugin hooks.
+ * Wraps a StreamFn to emit before_llm_call and after_llm_call plugin hooks.
  *
  * Uses the same streamFn wrapping pattern as cache-trace.ts and
  * anthropic-payload-log.ts — outermost wrapper sees the full context before
  * delegating to the underlying (possibly wrapped) streamFn.
+ *
+ * ## after_llm_call: deterministic gate via response interception
+ *
+ * The wrapper intercepts the LLM response stream's completion event.
+ * When the response contains tool calls, it fires runAfterLlmCall and
+ * stores the resulting Promise in the gate (after-llm-call-gate.ts).
+ *
+ * This runs inside streamAssistantResponse() in agentLoop's async context.
+ * Since executeToolCalls() is called sequentially after streamAssistantResponse()
+ * returns, the Promise is guaranteed to exist when tools start executing.
+ * The tool wrapper (pi-tools.before-tool-call.ts) awaits the Promise,
+ * making enforcement deterministic.
  */
 import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
-import type { Context, Message } from "@mariozechner/pi-ai";
+import type { AssistantMessageEvent, Context, Message } from "@mariozechner/pi-ai";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+import { setAfterLlmCallGatePromise, clearAfterLlmCallGate } from "./after-llm-call-gate.js";
 
 const log = createSubsystemLogger("hooks/stream");
 
@@ -33,6 +46,8 @@ export interface HookStreamWrapperParams {
   iterationRef: { current: number };
   /** Model identifier string */
   modelId: string;
+  /** Session ID for after_llm_call gate keying. Required when after_llm_call hooks are registered. */
+  sessionId?: string;
 }
 
 export function wrapStreamFnWithHooks(
@@ -100,8 +115,113 @@ export function wrapStreamFnWithHooks(
 
     // --- actual LLM call ---
     // streamFn may return sync EventStream or Promise<EventStream>.
-    return streamFn(model, effectiveContext, options);
+    const responseStream = await Promise.resolve(streamFn(model, effectiveContext, options));
+
+    // --- after_llm_call: intercept response completion ---
+    // Wrap the async iterator to detect the final message and fire the hook.
+    // The gate Promise is set synchronously (before this function returns),
+    // guaranteeing it exists when executeToolCalls starts.
+    if (hookRunner.hasHooks("after_llm_call") && params.sessionId) {
+      const sessionId = params.sessionId;
+      // Clear any stale gate from a previous turn/message_end in this session.
+      clearAfterLlmCallGate(sessionId);
+
+      const originalIterator = responseStream[Symbol.asyncIterator]();
+      const wrappedIterator: AsyncIterator<AssistantMessageEvent> = {
+        async next() {
+          const result = await originalIterator.next();
+          if (!result.done) {
+            const event = result.value as AssistantMessageEvent & {
+              type: string;
+              partial?: AgentMessage;
+            };
+            // Detect response completion (done/error events carry the final message).
+            if (event.type === "done" || event.type === "error") {
+              const finalMessage =
+                event.type === "done"
+                  ? (event as unknown as { message: AgentMessage }).message
+                  : undefined;
+              if (finalMessage) {
+                fireAfterLlmCallGate(
+                  hookRunner,
+                  agentCtx,
+                  finalMessage,
+                  iterationRef.current,
+                  modelId,
+                  sessionId,
+                );
+              }
+            }
+          }
+          return result;
+        },
+        return: originalIterator.return?.bind(originalIterator),
+        throw: originalIterator.throw?.bind(originalIterator),
+      };
+
+      // Replace the async iterator on the stream object.
+      (responseStream as unknown as Record<symbol, () => AsyncIterator<AssistantMessageEvent>>)[
+        Symbol.asyncIterator
+      ] = () => wrappedIterator;
+    }
+
+    return responseStream as ReturnType<StreamFn> extends Promise<infer R>
+      ? R
+      : ReturnType<StreamFn>;
   };
 
   return wrapped;
+}
+
+/** Helper to detect tool call content blocks in an assistant message. */
+function isToolCallBlockType(type: unknown): boolean {
+  return type === "toolCall" || type === "tool_call" || type === "tool_use";
+}
+
+/**
+ * Extract tool calls from the final assistant message and fire the
+ * after_llm_call hook. The resulting Promise is stored in the gate
+ * synchronously — before streamAssistantResponse returns.
+ */
+function fireAfterLlmCallGate(
+  hookRunner: HookRunner,
+  agentCtx: PluginHookAgentContext,
+  finalMessage: AgentMessage,
+  iteration: number,
+  modelId: string,
+  sessionId: string,
+): void {
+  // Extract tool calls from the message content.
+  const toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }> = [];
+  const msg = finalMessage as unknown as { content?: Array<Record<string, unknown>> };
+  if (Array.isArray(msg.content)) {
+    for (const part of msg.content) {
+      if (part && isToolCallBlockType(part.type)) {
+        toolCalls.push({
+          id: (part.id as string) ?? "",
+          name: (part.name as string) ?? "",
+          arguments: (part.arguments as Record<string, unknown>) ?? {},
+        });
+      }
+    }
+  }
+
+  if (toolCalls.length === 0) {
+    return; // No tools to gate — skip hook entirely.
+  }
+
+  // Fire the hook and store the Promise in the gate. The Promise is set
+  // synchronously here (before streamAssistantResponse returns), even though
+  // the hook itself may be async. The tool wrapper will await it.
+  const hookPromise = hookRunner.runAfterLlmCall(
+    {
+      response: finalMessage,
+      toolCalls,
+      iteration,
+      model: modelId,
+    },
+    agentCtx,
+  );
+
+  setAfterLlmCallGatePromise(sessionId, hookPromise);
 }

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -97,6 +97,19 @@ export async function runBeforeToolCallHook(args: {
   const toolName = normalizeToolName(args.toolName || "tool");
   const params = args.params;
 
+  // Check after_llm_call gate — if the hook blocked this turn's tool execution
+  // or filtered this specific tool call, block before we even run other checks.
+  // The gate is a Promise that resolves when the hook completes. First tool
+  // call waits for resolution; subsequent calls get the cached result instantly.
+  if (args.ctx?.sessionId) {
+    const { checkAfterLlmCallGate } =
+      await import("./pi-embedded-runner/run/after-llm-call-gate.js");
+    const gateResult = await checkAfterLlmCallGate(args.ctx.sessionId, args.toolCallId);
+    if (gateResult.blocked) {
+      return { blocked: true, reason: gateResult.reason ?? "Blocked by after_llm_call hook" };
+    }
+  }
+
   if (args.ctx?.sessionKey) {
     const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop, recordToolCall } =
       await loadBeforeToolCallRuntime();

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -13,11 +13,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
-import {
-  clearInternalHooks,
-  createInternalHookEvent,
-  triggerInternalHook,
-} from "../hooks/internal-hooks.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
@@ -110,8 +106,9 @@ export async function startGatewaySidecars(params: {
 
   // Load internal hook handlers from configuration and directory discovery.
   try {
-    // Clear any previously registered hooks to ensure fresh loading
-    clearInternalHooks();
+    // NOTE: clearInternalHooks() is called earlier in server.impl.ts, before
+    // plugins register.  Do NOT clear here — plugin hooks are already registered
+    // and must be preserved.
     const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
     if (loadedCount > 0) {
       params.logHooks.info(

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,6 +21,7 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { clearInternalHooks } from "../hooks/internal-hooks.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -465,6 +466,13 @@ export async function startGatewayServer(
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
   const baseMethods = listGatewayMethods();
+
+  // Clear any previously registered internal hooks before plugins or bundled
+  // hooks register.  This ensures a clean slate on restart/reload.
+  // Plugins register first (during loadGatewayPlugins), then bundled hooks
+  // register later (during startGatewaySidecars → loadInternalHooks).
+  clearInternalHooks();
+
   const emptyPluginRegistry = createEmptyPluginRegistry();
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway
     ? { pluginRegistry: emptyPluginRegistry, gatewayMethods: baseMethods }

--- a/src/plugins/hooks.extended.test.ts
+++ b/src/plugins/hooks.extended.test.ts
@@ -10,6 +10,7 @@ import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookAgentContext,
   PluginHookBeforeLlmCallEvent,
+  PluginHookAfterLlmCallEvent,
   PluginHookRegistration,
 } from "./types.js";
 
@@ -175,3 +176,95 @@ describe("before_llm_call hook", () => {
 // ---------------------------------------------------------------------------
 // after_llm_call (modifying, sequential)
 // ---------------------------------------------------------------------------
+
+describe("after_llm_call hook", () => {
+  const baseEvent: PluginHookAfterLlmCallEvent = {
+    response: { role: "assistant", content: [], timestamp: Date.now() } as AgentMessage,
+    toolCalls: [
+      { id: "tc1", name: "read", arguments: { path: "/a" } },
+      { id: "tc2", name: "write", arguments: { path: "/b" } },
+    ],
+    iteration: 1,
+    model: "test-model",
+  };
+
+  it("merges block from multiple handlers (one-way latch)", async () => {
+    const hooks: PluginHookRegistration[] = [
+      {
+        pluginId: "a",
+        hookName: "after_llm_call",
+        handler: async () => ({ block: false }),
+        priority: 10,
+        source: "test",
+      },
+      {
+        pluginId: "b",
+        hookName: "after_llm_call",
+        handler: async () => ({ block: true, blockReason: "policy" }),
+        priority: 5,
+        source: "test",
+      },
+    ];
+    const runner = createHookRunner(makeRegistry(hooks));
+    const result = await runner.runAfterLlmCall(baseEvent, agentCtx);
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("policy");
+  });
+
+  it("uses first blockReason (first-writer-wins)", async () => {
+    const hooks: PluginHookRegistration[] = [
+      {
+        pluginId: "a",
+        hookName: "after_llm_call",
+        handler: async () => ({ block: true, blockReason: "reason A" }),
+        priority: 10,
+        source: "test",
+      },
+      {
+        pluginId: "b",
+        hookName: "after_llm_call",
+        handler: async () => ({ block: true, blockReason: "reason B" }),
+        priority: 5,
+        source: "test",
+      },
+    ];
+    const runner = createHookRunner(makeRegistry(hooks));
+    const result = await runner.runAfterLlmCall(baseEvent, agentCtx);
+    expect(result?.blockReason).toBe("reason A");
+  });
+
+  it("intersects toolCalls from multiple handlers", async () => {
+    const hooks: PluginHookRegistration[] = [
+      {
+        pluginId: "a",
+        hookName: "after_llm_call",
+        handler: async () => ({
+          toolCalls: [
+            { id: "tc1", name: "read", arguments: {} },
+            { id: "tc2", name: "write", arguments: {} },
+          ],
+        }),
+        priority: 10,
+        source: "test",
+      },
+      {
+        pluginId: "b",
+        hookName: "after_llm_call",
+        handler: async () => ({
+          toolCalls: [{ id: "tc1", name: "read", arguments: {} }],
+        }),
+        priority: 5,
+        source: "test",
+      },
+    ];
+    const runner = createHookRunner(makeRegistry(hooks));
+    const result = await runner.runAfterLlmCall(baseEvent, agentCtx);
+    expect(result?.toolCalls?.map((t) => t.id)).toEqual(["tc1"]);
+  });
+
+  it("returns undefined when no handlers registered", async () => {
+    const runner = createHookRunner(makeRegistry([]));
+    const result = await runner.runAfterLlmCall(baseEvent, agentCtx);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/plugins/hooks.extended.test.ts
+++ b/src/plugins/hooks.extended.test.ts
@@ -1,0 +1,177 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+/**
+ * Unit tests for before_llm_call hook merge semantics.
+ *
+ * See hooks.context-loop.test.ts for context_assembled and loop_iteration tests.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import type { PluginRegistry } from "./registry.js";
+import type {
+  PluginHookAgentContext,
+  PluginHookBeforeLlmCallEvent,
+  PluginHookRegistration,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRegistry(hooks: PluginHookRegistration[]) {
+  return { typedHooks: hooks } as unknown as PluginRegistry;
+}
+
+const agentCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+};
+
+function fakeMsg(role: string, content: string): AgentMessage {
+  return { role, content } as AgentMessage;
+}
+
+// ---------------------------------------------------------------------------
+// before_llm_call (modifying, sequential)
+// ---------------------------------------------------------------------------
+
+describe("before_llm_call hook", () => {
+  const baseEvent: PluginHookBeforeLlmCallEvent = {
+    messages: [fakeMsg("user", "hello")],
+    systemPrompt: "You are helpful.",
+    model: "gpt-4",
+    iteration: 0,
+    tools: [{ name: "read", description: "Read files" }, { name: "exec" }],
+    tokenEstimate: 100,
+  };
+
+  it("fires handler with correct event shape", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    await runner.runBeforeLlmCall(baseEvent, agentCtx);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [event, ctx] = handler.mock.calls[0];
+    expect(event).toMatchObject({
+      messages: baseEvent.messages,
+      systemPrompt: "You are helpful.",
+      model: "gpt-4",
+      iteration: 0,
+      tools: baseEvent.tools,
+      tokenEstimate: 100,
+    });
+    expect(ctx).toBe(agentCtx);
+  });
+
+  it("returns modified messages when handler provides them", async () => {
+    const newMsgs = [fakeMsg("user", "modified")];
+    const handler = vi.fn().mockResolvedValue({ messages: newMsgs });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.messages).toBe(newMsgs);
+  });
+
+  it("returns modified systemPrompt when handler provides it", async () => {
+    const handler = vi.fn().mockResolvedValue({ systemPrompt: "new prompt" });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.systemPrompt).toBe("new prompt");
+  });
+
+  it("returns filtered tools when handler provides them", async () => {
+    const handler = vi.fn().mockResolvedValue({ tools: [{ name: "read" }] });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.tools).toEqual([{ name: "read" }]);
+  });
+
+  it("returns block=true and blockReason when handler blocks", async () => {
+    const handler = vi.fn().mockResolvedValue({ block: true, blockReason: "too many tokens" });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("too many tokens");
+  });
+
+  it("merges results from multiple handlers in registration order (FIFO)", async () => {
+    const first = vi
+      .fn()
+      .mockResolvedValue({ systemPrompt: "first prompt", tools: [{ name: "exec" }] });
+    const second = vi.fn().mockResolvedValue({ systemPrompt: "second prompt" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "first",
+          hookName: "before_llm_call",
+          handler: first,
+          source: "test",
+        },
+        {
+          pluginId: "second",
+          hookName: "before_llm_call",
+          handler: second,
+          source: "test",
+        },
+      ]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    // First-writer-wins for messages/systemPrompt: first plugin to set wins
+    expect(result?.tools).toEqual([{ name: "exec" }]);
+    // first runs first and provides systemPrompt → its value wins (security-first)
+    expect(result?.systemPrompt).toBe("first prompt");
+    // first ran before second (registration order)
+    expect(first).toHaveBeenCalledBefore(second);
+  });
+
+  it("continues on handler error when catchErrors=true", async () => {
+    const badHandler = vi.fn().mockRejectedValue(new Error("boom"));
+    const goodHandler = vi.fn().mockResolvedValue({ systemPrompt: "survived" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "bad",
+          hookName: "before_llm_call",
+          handler: badHandler,
+
+          source: "test",
+        },
+        {
+          pluginId: "good",
+          hookName: "before_llm_call",
+          handler: goodHandler,
+
+          source: "test",
+        },
+      ]),
+      { catchErrors: true },
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.systemPrompt).toBe("survived");
+  });
+
+  it("skips when no handlers registered (returns undefined)", async () => {
+    const runner = createHookRunner(makeRegistry([]));
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// after_llm_call (modifying, sequential)
+// ---------------------------------------------------------------------------

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -52,6 +52,8 @@ import type {
   PluginHookBeforeMessageWriteResult,
   PluginHookBeforeLlmCallEvent,
   PluginHookBeforeLlmCallResult,
+  PluginHookAfterLlmCallEvent,
+  PluginHookAfterLlmCallResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -741,6 +743,33 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     );
   }
 
+  /**
+   * Run after_llm_call hook.
+   * Fires after the LLM response is received, before tool execution.
+   * Allows plugins to block all tool execution or filter individual tool calls.
+   * Results are stored as a Promise in the gate and enforced deterministically
+   * by the tool wrapper.
+   */
+  async function runAfterLlmCall(
+    event: PluginHookAfterLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookAfterLlmCallResult | undefined> {
+    return runModifyingHook<"after_llm_call", PluginHookAfterLlmCallResult>(
+      "after_llm_call",
+      event,
+      ctx,
+      (acc, next) => ({
+        block: next.block || acc?.block,
+        blockReason: acc?.blockReason ?? next.blockReason,
+        // Intersection: if both handlers provide tool lists, keep only tools in both.
+        toolCalls:
+          acc?.toolCalls !== undefined && next.toolCalls !== undefined
+            ? next.toolCalls.filter((t) => acc.toolCalls!.some((a) => a.id === t.id))
+            : (next.toolCalls ?? acc?.toolCalls),
+      }),
+    );
+  }
+
   // =========================================================================
   // Utility
   // =========================================================================
@@ -792,6 +821,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runGatewayStop,
     // LLM call hooks
     runBeforeLlmCall,
+    runAfterLlmCall,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -50,6 +50,8 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookBeforeLlmCallEvent,
+  PluginHookBeforeLlmCallResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -705,6 +707,41 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // LLM Call Hooks
+  // =========================================================================
+
+  /**
+   * Run before_llm_call hook.
+   * Fires before every LLM API call within the agent loop.
+   * Allows plugins to inspect/modify context, filter tools, or block the call.
+   * Runs sequentially, merging results across handlers.
+   */
+  async function runBeforeLlmCall(
+    event: PluginHookBeforeLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeLlmCallResult | undefined> {
+    return runModifyingHook<"before_llm_call", PluginHookBeforeLlmCallResult>(
+      "before_llm_call",
+      event,
+      ctx,
+      (acc, next) => ({
+        // First-writer-wins for messages/systemPrompt: once a higher-priority
+        // security plugin sanitizes inputs, later plugins cannot override them.
+        messages: acc?.messages ?? next.messages,
+        systemPrompt: acc?.systemPrompt ?? next.systemPrompt,
+        // Intersection latch: if both handlers provide tools, only keep tools
+        // present in both lists. Prevents a later handler from widening the allowlist.
+        tools:
+          acc?.tools !== undefined && next.tools !== undefined
+            ? next.tools.filter((t) => acc.tools!.some((a) => a.name === t.name))
+            : (next.tools ?? acc?.tools),
+        block: next.block || acc?.block,
+        blockReason: acc?.blockReason ?? next.blockReason,
+      }),
+    );
+  }
+
+  // =========================================================================
   // Utility
   // =========================================================================
 
@@ -753,6 +790,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // LLM call hooks
+    runBeforeLlmCall,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -336,7 +336,8 @@ export type PluginHookName =
   | "subagent_spawned"
   | "subagent_ended"
   | "gateway_start"
-  | "gateway_stop";
+  | "gateway_stop"
+  | "before_llm_call";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -363,6 +364,7 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_ended",
   "gateway_start",
   "gateway_stop",
+  "before_llm_call",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -777,6 +779,28 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+// ============================================================================
+// LLM Call Hooks
+// ============================================================================
+
+// before_llm_call hook (modifying — sequential)
+export type PluginHookBeforeLlmCallEvent = {
+  messages: AgentMessage[];
+  systemPrompt: string;
+  model: string;
+  iteration: number;
+  tools: Array<{ name: string; description?: string }>;
+  tokenEstimate?: number;
+};
+
+export type PluginHookBeforeLlmCallResult = {
+  messages?: AgentMessage[];
+  systemPrompt?: string;
+  tools?: Array<{ name: string }>;
+  block?: boolean;
+  blockReason?: string;
+};
+
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
   before_model_resolve: (
@@ -875,6 +899,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookGatewayStopEvent,
     ctx: PluginHookGatewayContext,
   ) => Promise<void> | void;
+  before_llm_call: (
+    event: PluginHookBeforeLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeLlmCallResult | void> | PluginHookBeforeLlmCallResult | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -337,7 +337,8 @@ export type PluginHookName =
   | "subagent_ended"
   | "gateway_start"
   | "gateway_stop"
-  | "before_llm_call";
+  | "before_llm_call"
+  | "after_llm_call";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -365,6 +366,7 @@ export const PLUGIN_HOOK_NAMES = [
   "gateway_start",
   "gateway_stop",
   "before_llm_call",
+  "after_llm_call",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -801,6 +803,29 @@ export type PluginHookBeforeLlmCallResult = {
   blockReason?: string;
 };
 
+// after_llm_call hook (modifying — sequential)
+// Runs after the LLM response is received. Plugins can block all tool execution
+// or filter individual tool calls. Decisions are stored as a Promise and
+// enforced deterministically by the tool wrapper before each tool executes.
+export type PluginHookAfterLlmCallEvent = {
+  response: AgentMessage;
+  toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+  iteration: number;
+  model: string;
+  /** Wall-clock LLM call duration. Reserved for future use — not yet populated. */
+  latencyMs?: number;
+  /** Token usage for this call. Reserved for future use — not yet populated. */
+  tokenUsage?: { input: number; output: number };
+};
+
+export type PluginHookAfterLlmCallResult = {
+  /** If true, block ALL tool execution for this turn. */
+  block?: boolean;
+  blockReason?: string;
+  /** Filtered tool calls — only these will be allowed to execute. Omit to allow all. */
+  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+};
+
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
   before_model_resolve: (
@@ -903,6 +928,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeLlmCallEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeLlmCallResult | void> | PluginHookBeforeLlmCallResult | void;
+  after_llm_call: (
+    event: PluginHookAfterLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookAfterLlmCallResult | void> | PluginHookAfterLlmCallResult | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {


### PR DESCRIPTION
## TL;DR

Adds the `after_llm_call` modifying hook — fires after the LLM response is received, before tool execution. Plugins can block all tool calls or filter specific calls by ID.

**Split from #33916** (2 of 3). **Depends on #39195** (`before_llm_call`) — merge that first.

## Key design: deterministic Promise-based gate

This PR completely redesigns the after_llm_call enforcement mechanism. The previous design (in #33916) used:

- A synchronous mutable ref populated via `.then()` from a subscription callback
- Monotonic sequence counters for staleness detection
- "Best-effort" enforcement — tools could execute before the gate was set

**New design:**

1. The `streamFn` wrapper intercepts the LLM response completion (`done`/`error` event)
2. Extracts tool calls from the final message
3. Fires `runAfterLlmCall()` and stores the **Promise** in the gate (synchronously, before `streamAssistantResponse` returns)
4. The tool wrapper (`pi-tools.before-tool-call.ts`) **awaits** the gate Promise

**Why it's deterministic:**

```
agentLoop async context:
  streamAssistantResponse()
    └── streamFn wrapper fires, stores Promise ← synchronous
    └── returns
  executeToolCalls()
    └── tool.execute()
        └── wrapToolWithBeforeToolCallHook
            └── await checkAfterLlmCallGate() ← first call blocks until hook resolves
```

The Promise is guaranteed to exist before `executeToolCalls()` starts because both happen in the same agentLoop async context, sequentially.

## What was deleted (vs #33916)

- All subscription-based `after_llm_call` handling from `attempt.ts`
- `hookTurnIteration`, `hookMessageEndSeq` monotonic counters
- All staleness detection logic (`eventIteration !== hookTurnIteration`, etc.)
- The "best-effort" comment/caveat

## Hook contract

| Field | Type | Semantics |
|-------|------|-----------|
| `block` | `boolean` | One-way latch: once blocked, stays blocked |
| `blockReason` | `string` | First-writer-wins |
| `toolCalls` | `Array<{ id }>` | Intersection: later handlers can only narrow the allowlist |

## Testing

- 9 Promise-based gate tests (block, filter, isolation, async behavior, fail-open)
- 4 merge semantics tests (block latch, intersection, first-writer-wins)
- 7 stream wrapper tests (retained from PR 1)
- `pnpm check` clean

## AI-Assisted Development 🤖

Developed with AI assistance (Claude/OpenClaw agent "Tank"). All changes reviewed and directed by Eddie Abrams.