### PR TITLE
fix(ci): resolve pre-existing type errors on main

### DIFF
--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -122,12 +122,13 @@ describe("fetchBrowserJson loopback auth", () => {
   it("preserves dispatcher error context while keeping no-retry hint", async () => {
     mocks.dispatch.mockRejectedValueOnce(new Error("Chrome CDP handshake timeout"));
 
-    const thrown = await fetchBrowserJson<{ ok: boolean }>("/tabs").catch((err) => err as Error);
+    const thrown = await fetchBrowserJson<{ ok: boolean }>("/tabs").catch((err) => err);
 
     expect(thrown).toBeInstanceOf(Error);
-    expect(thrown.message).toContain("Chrome CDP handshake timeout");
-    expect(thrown.message).toContain("Do NOT retry the browser tool");
-    expect(thrown.message).not.toContain("Can't reach the OpenClaw browser control service");
+    const err = thrown as Error;
+    expect(err.message).toContain("Chrome CDP handshake timeout");
+    expect(err.message).toContain("Do NOT retry the browser tool");
+    expect(err.message).not.toContain("Can't reach the OpenClaw browser control service");
   });
 
   it("keeps absolute URL failures wrapped as reachability errors", async () => {
@@ -139,11 +140,12 @@ describe("fetchBrowserJson loopback auth", () => {
     );
 
     const thrown = await fetchBrowserJson<{ ok: boolean }>("http://example.com/").catch(
-      (err) => err as Error,
+      (err) => err,
     );
 
     expect(thrown).toBeInstanceOf(Error);
-    expect(thrown.message).toContain("Can't reach the OpenClaw browser control service");
-    expect(thrown.message).toContain("Do NOT retry the browser tool");
+    const err = thrown as Error;
+    expect(err.message).toContain("Can't reach the OpenClaw browser control service");
+    expect(err.message).toContain("Do NOT retry the browser tool");
   });
 });

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -59,7 +59,6 @@ export type AppViewState = {
   chatToolMessages: unknown[];
   chatStreamSegments: Array<{ text: string; ts: number }>;
   chatStream: string | null;
-  chatStreamSegments: Array<{ text: string; ts: number }>;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
   compactionStatus: CompactionStatus | null;


### PR DESCRIPTION
## Problem

Two pre-existing type errors on `main` cause `pnpm tsgo` (`check` CI job) to fail for all open PRs:

1. **Duplicate property** in `ui/src/ui/app-view-state.ts:60,62` - `chatStreamSegments` declared twice in `AppViewState` (likely from a merge of #39036 and #39128)
2. **Unnarowed union** in `src/browser/client-fetch.loopback-auth.test.ts:128-147` - `.catch((err) => err as Error)` produces `{ ok: boolean } | Error` but test assertions access `.message` without narrowing

## Fix

- Remove the duplicate `chatStreamSegments` property (1 line)
- Narrow the caught error type before accessing `.message` in test assertions (add `const err = thrown as Error` after the `toBeInstanceOf(Error)` guard)

## Verification

- `pnpm tsgo` passes clean (was 7 errors, now 0)
- All 7 tests in `client-fetch.loopback-auth.test.ts` pass
- No behaviour changes, test-only type narrowing