### PR TITLE
fix(telegram): reset webhookCleared latch on 409 conflict to prevent infinite polling loop

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -591,6 +591,44 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(api.getUpdates).not.toHaveBeenCalled();
   });
 
+  it("resets webhookCleared latch on 409 conflict so deleteWebhook re-runs", async () => {
+    const abort = new AbortController();
+    api.deleteWebhook.mockReset();
+    api.deleteWebhook.mockResolvedValue(true);
+
+    const conflictError = Object.assign(
+      new Error("Conflict: terminated by other getUpdates request"),
+      {
+        error_code: 409,
+        method: "getUpdates",
+      },
+    );
+
+    let pollingCycle = 0;
+    runSpy
+      // First cycle: throw 409 conflict
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () => {
+            pollingCycle++;
+            return Promise.reject(conflictError);
+          },
+        }),
+      )
+      // Second cycle: succeed then abort
+      .mockImplementationOnce(() => {
+        pollingCycle++;
+        return makeAbortRunner(abort);
+      });
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    // deleteWebhook should be called twice: once on initial cleanup, once after 409 reset
+    expect(api.deleteWebhook).toHaveBeenCalledTimes(2);
+    expect(pollingCycle).toBe(2);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("falls back to configured webhookSecret when not passed explicitly", async () => {
     await monitorTelegramProvider({
       token: "tok",

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -373,6 +373,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           throw err;
         }
         const isConflict = isGetUpdatesConflict(err);
+        if (isConflict) {
+          webhookCleared = false;
+        }
         const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
         if (!isConflict && !isRecoverable) {
           throw err;


### PR DESCRIPTION
Fixes #20506

## Problem

`webhookCleared` is a one-shot latch scoped to `monitorTelegramProvider`. After the first successful `deleteWebhook` call, it is set to `true` and never reset.

If a 409 `getUpdates` conflict occurs later — caused by a stale-socket restart race or a prior webhook registration persisting — `ensureWebhookCleanup` skips `deleteWebhook` on every retry. The conflict never resolves. The `pending_update_count` queue builds indefinitely until a full channel restart.

## Fix

Reset `webhookCleared = false` in the 409 catch path so the next loop iteration re-runs `ensureWebhookCleanup` and calls `deleteWebhook` again.

```ts
const isConflict = isGetUpdatesConflict(err);
if (isConflict) webhookCleared = false; // reset so ensureWebhookCleanup re-runs deleteWebhook
const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
```

## Alternatives considered

- **Idempotent cleanup on every restart** (remove latch entirely, call `deleteWebhook` before each polling cycle): more robust but adds one extra API call per restart — excluded to minimize blast radius.
- **Call `deleteWebhook` directly in conflict path**: also valid; this approach reuses the existing `ensureWebhookCleanup` path instead.

## Test

Added scenario: initial cleanup succeeds → 409 conflict → verify `deleteWebhook` called again on next iteration → polling resumes.