### PR TITLE
fix(signal): forward all inbound attachments instead of only the first

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -1,3 +1,9 @@
+import type {
+  SignalEnvelope,
+  SignalEventHandlerDeps,
+  SignalReactionMessage,
+  SignalReceivePayload,
+} from "./event-handler.types.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
@@ -49,12 +55,6 @@ import {
 } from "../identity.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
-import type {
-  SignalEnvelope,
-  SignalEventHandlerDeps,
-  SignalReactionMessage,
-  SignalReceivePayload,
-} from "./event-handler.types.js";
 import { renderSignalMentions } from "./mentions.js";
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   type SignalInboundEntry = {
@@ -71,6 +71,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     messageId?: string;
     mediaPath?: string;
     mediaType?: string;
+    mediaPaths?: string[];
+    mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
   };
@@ -170,6 +172,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaPath: entry.mediaPath,
       MediaType: entry.mediaType,
       MediaUrl: entry.mediaPath,
+      MediaPaths: entry.mediaPaths,
+      MediaUrls: entry.mediaPaths,
+      MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
       OriginatingChannel: "signal" as const,
@@ -311,7 +316,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return shouldDebounceTextInbound({
         text: entry.bodyText,
         cfg: deps.cfg,
-        hasMedia: Boolean(entry.mediaPath || entry.mediaType),
+        hasMedia: Boolean(entry.mediaPath || entry.mediaType || entry.mediaPaths?.length),
       });
     },
     onFlush: async (entries) => {
@@ -335,6 +340,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         bodyText: combinedText,
         mediaPath: undefined,
         mediaType: undefined,
+        mediaPaths: undefined,
+        mediaTypes: undefined,
       });
     },
     onError: (err) => {
@@ -655,32 +662,55 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
 
     let mediaPath: string | undefined;
     let mediaType: string | undefined;
+    const mediaPaths: string[] = [];
+    const mediaTypes: string[] = [];
     let placeholder = "";
-    const firstAttachment = dataMessage.attachments?.[0];
-    if (firstAttachment?.id && !deps.ignoreAttachments) {
-      try {
-        const fetched = await deps.fetchAttachment({
-          baseUrl: deps.baseUrl,
-          account: deps.account,
-          attachment: firstAttachment,
-          sender: senderRecipient,
-          groupId,
-          maxBytes: deps.mediaMaxBytes,
-        });
-        if (fetched) {
-          mediaPath = fetched.path;
-          mediaType = fetched.contentType ?? firstAttachment.contentType ?? undefined;
+    const attachments = dataMessage.attachments ?? [];
+    if (!deps.ignoreAttachments) {
+      for (const attachment of attachments) {
+        if (!attachment?.id) {
+          continue;
         }
-      } catch (err) {
-        deps.runtime.error?.(danger(`attachment fetch failed: ${String(err)}`));
+        try {
+          const fetched = await deps.fetchAttachment({
+            baseUrl: deps.baseUrl,
+            account: deps.account,
+            attachment,
+            sender: senderRecipient,
+            groupId,
+            maxBytes: deps.mediaMaxBytes,
+          });
+          if (fetched) {
+            mediaPaths.push(fetched.path);
+            mediaTypes.push(
+              fetched.contentType ?? attachment.contentType ?? "application/octet-stream",
+            );
+            if (!mediaPath) {
+              mediaPath = fetched.path;
+              mediaType = fetched.contentType ?? attachment.contentType ?? undefined;
+            }
+          }
+        } catch (err) {
+          deps.runtime.error?.(danger(`attachment fetch failed: ${String(err)}`));
+        }
       }
     }
 
-    const kind = kindFromMime(mediaType ?? undefined);
-    if (kind) {
-      placeholder = `<media:${kind}>`;
-    } else if (dataMessage.attachments?.length) {
-      placeholder = "<media:attachment>";
+    if (mediaPaths.length > 1) {
+      const kindCounts = new Map<string, number>();
+      for (const mt of mediaTypes) {
+        const k = kindFromMime(mt) ?? "attachment";
+        kindCounts.set(k, (kindCounts.get(k) ?? 0) + 1);
+      }
+      const parts = [...kindCounts.entries()].map(([k, n]) => `${n} ${k}${n > 1 ? "s" : ""}`);
+      placeholder = `[${parts.join(" + ")} attached]`;
+    } else {
+      const kind = kindFromMime(mediaType ?? undefined);
+      if (kind) {
+        placeholder = `<media:${kind}>`;
+      } else if (attachments.length) {
+        placeholder = "<media:attachment>";
+      }
     }
 
     const bodyText = messageText || placeholder || dataMessage.quote?.text?.trim() || "";
@@ -730,6 +760,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       messageId,
       mediaPath,
       mediaType,
+      mediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+      mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
     });


### PR DESCRIPTION
## Problem

When a user sends multiple images (or other media) in a single Signal message, only the first attachment is downloaded and forwarded to the agent. The rest are silently dropped.

**Root cause:** `event-handler.ts` fetched only `dataMessage.attachments?.[0]` and passed a single `mediaPath` through the pipeline.

## Fix

- **Iterate all attachments**: Loop over the full `dataMessage.attachments` array, fetching each one sequentially
- **Add `mediaPaths`/`mediaTypes` arrays**: New fields alongside existing singular `mediaPath`/`mediaType` (backward compatible)
- **Pass arrays through debouncer**: `MediaPaths`, `MediaUrls`, `MediaTypes` added to the debounced entry output
- **Better placeholder text**: Multi-attachment messages show `[3 images + 1 video attached]` instead of generic `<media:image>`
- **Backward compatible**: Single-attachment messages work exactly as before; `mediaPath` (singular) still set to the first attachment

## Changes

`src/signal/monitor/event-handler.ts` — 1 file changed, single commit