### PR TITLE
fix(agents): strip store param from payload when supportsStore is false

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1387,7 +1387,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(false);
   });
 
-  it("does not force store for models that declare supportsStore=false", () => {
+  it("strips store from payload for models that declare supportsStore=false", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "azure-openai-responses",
       applyModelId: "gpt-4o",
@@ -1405,7 +1405,28 @@ describe("applyExtraParamsToAgent", () => {
         compat: { supportsStore: false },
       } as unknown as Model<"openai-responses">,
     });
-    expect(payload.store).toBe(false);
+    expect(payload).not.toHaveProperty("store");
+  });
+
+  it("strips store from payload for non-OpenAI responses providers with supportsStore=false", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-openai-responses",
+      applyModelId: "gemini-2.5-pro",
+      model: {
+        api: "openai-responses",
+        provider: "custom-openai-responses",
+        id: "gemini-2.5-pro",
+        name: "gemini-2.5-pro",
+        baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/openai",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_000_000,
+        maxTokens: 65_536,
+        compat: { supportsStore: false },
+      } as unknown as Model<"openai-responses">,
+    });
+    expect(payload).not.toHaveProperty("store");
   });
 
   it("auto-injects OpenAI Responses context_management compaction for direct OpenAI models", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -305,7 +305,14 @@ function createOpenAIResponsesContextManagementWrapper(
   return (model, context, options) => {
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
-    if (!forceStore && !useServerCompaction) {
+    // Strip `store` from the payload when the model declares supportsStore=false.
+    // pi-ai upstream hardcodes `store: false` for Responses API; strict
+    // OpenAI-compatible endpoints (e.g. Gemini via Cloudflare) reject it.
+    const stripStore =
+      !forceStore &&
+      OPENAI_RESPONSES_APIS.has(String(model.api ?? "")) &&
+      model.compat?.supportsStore === false;
+    if (!forceStore && !useServerCompaction && !stripStore) {
       return underlying(model, context, options);
     }
 
@@ -320,6 +327,9 @@ function createOpenAIResponsesContextManagementWrapper(
           const payloadObj = payload as Record<string, unknown>;
           if (forceStore) {
             payloadObj.store = true;
+          }
+          if (stripStore) {
+            delete payloadObj.store;
           }
           if (useServerCompaction && payloadObj.context_management === undefined) {
             payloadObj.context_management = [

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -311,7 +311,7 @@ function createOpenAIResponsesContextManagementWrapper(
     const stripStore =
       !forceStore &&
       OPENAI_RESPONSES_APIS.has(String(model.api ?? "")) &&
-      model.compat?.supportsStore === false;
+      (model as { compat?: { supportsStore?: boolean } }).compat?.supportsStore === false;
     if (!forceStore && !useServerCompaction && !stripStore) {
       return underlying(model, context, options);
     }


### PR DESCRIPTION
## Summary

Fixes bug #1 from #39086: when a model declares `compat: { supportsStore: false }`, the `store: false` field that pi-ai upstream hardcodes for Responses API payloads is now stripped before the request reaches the provider.

Previously, `createOpenAIResponsesContextManagementWrapper()` early-exited without installing an `onPayload` hook when neither `forceStore` nor `useServerCompaction` applied. This left the upstream-injected `store: false` in the payload, which strict OpenAI-compatible endpoints (e.g. Gemini via Cloudflare AI Gateway) reject as an unknown field with HTTP 400.

## Changes

- `extra-params.ts`: added `stripStore` condition that prevents the early exit and deletes `store` from the payload via `onPayload` when `supportsStore === false`
- Updated existing test to verify `store` is absent (not just not forced to `true`)
- Added new test for non-OpenAI provider (Gemini via Cloudflare) with `supportsStore: false`

## Scope

This PR addresses only bug #1 (store parameter). Bug #2 (custom headers dropped) from #39086 is a separate concern and intentionally excluded to keep the change small.

## Test plan

- [x] Existing test updated: `strips store from payload for models that declare supportsStore=false`
- [x] New test added: `strips store from payload for non-OpenAI responses providers with supportsStore=false`
- [x] All 57 tests in `pi-embedded-runner-extraparams.test.ts` pass
- [ ] CI green

Fixes #39086 (partial: bug #1 only)