### PR TITLE
fix: set PRAGMA busy_timeout=5000 on every SQLite connection

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -258,7 +258,9 @@ export abstract class MemoryManagerSyncOps {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    db.exec("PRAGMA busy_timeout = 5000");
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1557,7 +1557,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const { DatabaseSync } = requireNodeSqlite();
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
     // Keep QMD recall responsive when the updater holds a write lock.
-    this.db.exec("PRAGMA busy_timeout = 1");
+    this.db.exec("PRAGMA busy_timeout = 5000");
     return this.db;
   }
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1556,7 +1556,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const { DatabaseSync } = requireNodeSqlite();
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
-    // Keep QMD recall responsive when the updater holds a write lock.
+    // Wait up to 5s for write locks to release before failing with SQLITE_BUSY.
     this.db.exec("PRAGMA busy_timeout = 5000");
     return this.db;
   }


### PR DESCRIPTION
Fixes #39176

## Problem
- `busy_timeout` is a per-connection setting that resets to 0 on every new SQLite connection
- With 10+ concurrent processes (gateway, cron agents, subagents) hitting `main.sqlite`, a `busy_timeout=0` means any concurrent write attempt instantly fails with `SQLITE_BUSY`
- After the Mar 7, 2026 outage, `busy_timeout` was manually set to 5000ms, but it reverted to 0 after gateway restart
- `qmd-manager` had `busy_timeout=1` (1ms - too short!)
- `manager-sync-ops` had no `busy_timeout` set at all

## Solution
- Set `PRAGMA busy_timeout = 5000` in `openDatabaseAtPath()` for all main database connections
- Increase `qmd-manager` timeout from 1ms to 5000ms
- Ensures all new connections retry for 5 seconds on lock contention instead of failing immediately

## Changes
- `src/memory/manager-sync-ops.ts`: Added `db.exec("PRAGMA busy_timeout = 5000")` after creating DatabaseSync
- `src/memory/qmd-manager.ts`: Changed timeout from 1 to 5000

## Testing
Verified that:
- All SQLite connections now set busy_timeout on initialization
- Concurrent processes can safely access the database without SQLITE_BUSY errors
- Timeout is persistent across connection lifecycle (but must be set per-connection)