### PR TITLE
Fix macOS LaunchAgent restart path leaving gateway unloaded after bootout

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -134,7 +134,9 @@ describe("launchd bootstrap repair", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
+    const serviceId = `${domain}/${label}`;
 
+    expect(state.launchctlCalls).toContainEqual(["enable", serviceId]);
     expect(state.launchctlCalls).toContainEqual(["bootstrap", domain, plistPath]);
     expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", `${domain}/${label}`]);
   });
@@ -218,6 +220,9 @@ describe("launchd install", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
+    const enableIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "enable" && c[1] === `${domain}/${label}`,
+    );
     const bootoutIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
     );
@@ -228,10 +233,12 @@ describe("launchd install", () => {
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
     );
 
+    expect(enableIndex).toBeGreaterThanOrEqual(0);
     expect(bootoutIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
     expect(bootoutIndex).toBeLessThan(bootstrapIndex);
+    expect(enableIndex).toBeLessThan(bootstrapIndex);
     expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -206,6 +206,7 @@ export async function repairLaunchAgentBootstrap(args: {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
+  await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     return { ok: false, detail: (boot.stderr || boot.stdout).trim() || undefined };
@@ -465,6 +466,8 @@ export async function restartLaunchAgent({
     await waitForPidExit(previousPid);
   }
 
+  // launchd can persist "disabled" state across prior bootout/unload cycles.
+  await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();


### PR DESCRIPTION
## Summary

- Problem: on macOS, `openclaw gateway restart` could stop the gateway but leave `ai.openclaw.gateway` unloaded afterward.
- Why it matters: this breaks the local gateway until the user manually reinstalls or bootstraps the LaunchAgent.
- What changed: add `launchctl enable gui/$UID/<label>` before `bootstrap` in the LaunchAgent restart and repair paths.
- What did NOT change (scope boundary): no plist format changes, no config changes, no port/env changes, no non-macOS service behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39211
- Related #

## User-visible / Behavior Changes

- `openclaw gateway restart` is more robust on macOS LaunchAgent installs.
- `repairLaunchAgentBootstrap()` now also clears persisted disabled state before bootstrap.
- No user-facing config/default changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node / LaunchAgent
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): standard local gateway LaunchAgent on `ai.openclaw.gateway`

### Steps

1. Install and run OpenClaw gateway as a macOS LaunchAgent.
2. Run `openclaw gateway restart`.
3. Observe that, in the failing case before this patch, the gateway shuts down and the LaunchAgent remains unloaded.

### Expected

- Restart should leave the LaunchAgent loaded and the gateway reachable.

### Actual

- Before this patch, restart could leave launchd reporting:
  - `Could not find service "ai.openclaw.gateway" in domain for user gui: 501`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - reproduced the local failure mode on macOS
  - confirmed gateway log recorded `SIGTERM` shutdown followed by unloaded LaunchAgent state
  - applied patch and verified `openclaw gateway status` returned `LaunchAgent (loaded)` and gateway health was `OK`
- Edge cases checked:
  - targeted launchd unit tests for install/restart/repair path ordering
- What you did **not** verify:
  - full cross-platform daemon/service regression
  - broad end-to-end suite across unrelated gateway features

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR
  - as an operational workaround, run `openclaw gateway install` or `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.plist`
- Files/config to restore:
  - none
- Known bad symptoms reviewers should watch for:
  - unexpected launchctl errors during restart/bootstrap on macOS

## Risks and Mitigations

- Risk:
  - `launchctl enable` before bootstrap could be redundant on already healthy agents
  - Mitigation:
  - install path already does this today; this change only aligns restart/repair with existing install behavior

- Risk:
  - issue may have another contributing cause beyond persisted disabled state
  - Mitigation:
  - change is narrow, low-risk, and directly addresses the restart/install inconsistency without changing unrelated service behavior
