### PR TITLE
fix(gateway): detect provider reference object in password auth config

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import {
+  assertGatewayAuthConfigured,
   authorizeGatewayConnect,
   authorizeHttpGatewayConnect,
   authorizeWsControlUiGatewayConnect,
@@ -366,6 +367,25 @@ describe("gateway auth", () => {
     expect(res.reason).toBe("password_mismatch");
     expect(limiter.check).toHaveBeenCalledWith(undefined, "custom-scope");
     expect(limiter.recordFailure).toHaveBeenCalledWith(undefined, "custom-scope");
+  });
+
+  it("throws specific error when password is a provider reference object", () => {
+    const auth = resolveGatewayAuth({
+      authConfig: { mode: "password", password: { source: "exec", provider: "op", id: "pw" } as never },
+    });
+    expect(() =>
+      assertGatewayAuthConfigured(auth, {
+        mode: "password",
+        password: { source: "exec", provider: "op", id: "pw" } as never,
+      }),
+    ).toThrow(/provider reference object/);
+  });
+
+  it("throws generic error when password mode has no password at all", () => {
+    const auth = resolveGatewayAuth({ authConfig: { mode: "password" } });
+    expect(() => assertGatewayAuthConfigured(auth, { mode: "password" })).toThrow(
+      "gateway auth mode is password, but no password was configured",
+    );
   });
 });
 

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -291,7 +291,10 @@ export function resolveGatewayAuth(params: {
   };
 }
 
-export function assertGatewayAuthConfigured(auth: ResolvedGatewayAuth): void {
+export function assertGatewayAuthConfigured(
+  auth: ResolvedGatewayAuth,
+  rawAuthConfig?: GatewayAuthConfig | null,
+): void {
   if (auth.mode === "token" && !auth.token) {
     if (auth.allowTailscale) {
       return;
@@ -301,6 +304,11 @@ export function assertGatewayAuthConfigured(auth: ResolvedGatewayAuth): void {
     );
   }
   if (auth.mode === "password" && !auth.password) {
+    if (rawAuthConfig?.password != null && typeof rawAuthConfig.password !== "string") {
+      throw new Error(
+        "gateway auth mode is password, but gateway.auth.password contains a provider reference object instead of a resolved string — bootstrap secrets (gateway.auth.password) must be plaintext strings or set via the OPENCLAW_GATEWAY_PASSWORD environment variable because the secrets provider system has not initialised yet at gateway startup",
+      );
+    }
     throw new Error("gateway auth mode is password, but no password was configured");
   }
   if (auth.mode === "trusted-proxy") {

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -121,7 +121,7 @@ export async function resolveGatewayRuntimeConfig(params: {
   const dangerouslyAllowHostHeaderOriginFallback =
     params.cfg.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true;
 
-  assertGatewayAuthConfigured(resolvedAuth);
+  assertGatewayAuthConfigured(resolvedAuth, params.cfg.gateway?.auth);
   if (tailscaleMode === "funnel" && authMode !== "password") {
     throw new Error(
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",


### PR DESCRIPTION
## Summary

Fixes #39024: when `gateway.auth.password` is set to an exec provider reference object (e.g. `{"source": "exec", "provider": "op-gateway-password", "id": "value"}`), the gateway now throws a specific error explaining that bootstrap secrets can't use provider references, instead of the misleading generic "no password was configured" message.

## Root cause

`resolveGatewayAuth()` detects the SecretRef object at line 248 and silently coerces it to `undefined` (since the secrets provider system hasn't initialised yet at gateway startup). `assertGatewayAuthConfigured()` then sees a falsy password and throws the generic error, which obscures the actual problem.

## Changes

- `auth.ts`: added optional `rawAuthConfig` parameter to `assertGatewayAuthConfigured()` so it can detect when the original config value was an object (provider reference) vs genuinely missing
- `server-runtime-config.ts`: passes raw auth config to the assertion
- `auth.test.ts`: two new tests covering both the provider-reference-object and the genuinely-missing-password paths

## Test plan

- [x] New test: `throws specific error when password is a provider reference object`
- [x] New test: `throws generic error when password mode has no password at all`
- [x] All 34 tests in `auth.test.ts` pass
- [ ] CI green

Fixes #39024