### PR TITLE
fix(daemon): enable LaunchAgent before bootstrap on restart

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -241,7 +241,7 @@ describe("launchd install", () => {
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
   });
 
-  it("restarts LaunchAgent with bootout-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
@@ -251,20 +251,26 @@ describe("launchd install", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
+    const serviceId = `${domain}/${label}`;
     const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
+      (c) => c[0] === "bootout" && c[1] === serviceId,
+    );
+    const enableIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "enable" && c[1] === serviceId,
     );
     const bootstrapIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
     );
     const kickstartIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
     expect(bootoutIndex).toBeGreaterThanOrEqual(0);
+    expect(enableIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(bootstrapIndex);
+    expect(bootoutIndex).toBeLessThan(enableIndex);
+    expect(enableIndex).toBeLessThan(bootstrapIndex);
     expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -156,7 +156,7 @@ describe("launchctl list detection", () => {
 });
 
 describe("launchd bootstrap repair", () => {
-  it("bootstraps and kickstarts the resolved label", async () => {
+  it("enables, bootstraps, and kickstarts the resolved label", async () => {
     const env: Record<string, string | undefined> = {
       HOME: "/Users/test",
       OPENCLAW_PROFILE: "default",
@@ -167,9 +167,23 @@ describe("launchd bootstrap repair", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
+    const serviceId = `${domain}/${label}`;
 
-    expect(state.launchctlCalls).toContainEqual(["bootstrap", domain, plistPath]);
-    expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", `${domain}/${label}`]);
+    const enableIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "enable" && c[1] === serviceId,
+    );
+    const bootstrapIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
+    );
+    const kickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
+    );
+
+    expect(enableIndex).toBeGreaterThanOrEqual(0);
+    expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(enableIndex).toBeLessThan(bootstrapIndex);
+    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
 });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -466,6 +466,9 @@ export async function restartLaunchAgent({
     await waitForPidExit(previousPid);
   }
 
+  // launchd can persist "disabled" state after bootout; clear it before bootstrap
+  // (matches the same guard in installLaunchAgent).
+  await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -207,6 +207,9 @@ export async function repairLaunchAgentBootstrap(args: {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
+  // launchd can persist "disabled" state after bootout; clear it before bootstrap
+  // (matches the same guard in installLaunchAgent and restartLaunchAgent).
+  await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     return { ok: false, detail: (boot.stderr || boot.stdout).trim() || undefined };


### PR DESCRIPTION
## Summary
- Add `launchctl enable` call before `bootstrap` in `restartLaunchAgent()`, matching the existing guard in `installLaunchAgent()`
- launchd can persist a "disabled" state after `bootout`, causing `bootstrap` to fail and leaving the gateway unloaded until manual reinstall

## Root cause
`installLaunchAgent` (line 414) already calls `enable` before `bootstrap` with the comment:
> launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.

But `restartLaunchAgent` was missing this step, leaving a window where bootstrap silently fails after bootout.

## Test plan
- [x] Updated existing test to verify `bootout → enable → bootstrap → kickstart` order
- [x] All 16 launchd tests pass

Fixes #39211

🤖 Generated with [Claude Code](https://claude.com/claude-code)