### PR TITLE
fix(tui): isolate /new sessions to prevent cross-client broadcast

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -120,11 +120,13 @@ describe("tui command handlers", () => {
 
     // /new creates a unique session key (isolates TUI client) (#39217)
     expect(setSessionMock).toHaveBeenCalledTimes(1);
-    expect(setSessionMock).toHaveBeenCalledWith(expect.stringMatching(/^tui-[a-f0-9]{8}$/));
+    expect(setSessionMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^tui-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/),
+    );
     // /reset still resets the shared session
     expect(resetSession).toHaveBeenCalledTimes(1);
     expect(resetSession).toHaveBeenCalledWith("agent:main:main", "reset");
-    expect(loadHistory).toHaveBeenCalledTimes(1); // Only /reset loads history
+    expect(loadHistory).toHaveBeenCalledTimes(1); // /reset calls loadHistory directly; /new does so indirectly via setSession
   });
 
   it("reports send failures and marks activity status as error", async () => {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -7,12 +7,14 @@ type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void)
 function createHarness(params?: {
   sendChat?: ReturnType<typeof vi.fn>;
   resetSession?: ReturnType<typeof vi.fn>;
+  setSession?: ReturnType<typeof vi.fn>;
   loadHistory?: LoadHistoryMock;
   setActivityStatus?: SetActivityStatusMock;
   isConnected?: boolean;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
   const resetSession = params?.resetSession ?? vi.fn().mockResolvedValue({ ok: true });
+  const setSession = params?.setSession ?? vi.fn().mockResolvedValue(undefined);
   const addUser = vi.fn();
   const addSystem = vi.fn();
   const requestRender = vi.fn();
@@ -36,7 +38,7 @@ function createHarness(params?: {
     closeOverlay: vi.fn(),
     refreshSessionInfo: vi.fn(),
     loadHistory,
-    setSession: vi.fn(),
+    setSession,
     refreshAgents: vi.fn(),
     abortActive: vi.fn(),
     setActivityStatus,
@@ -51,6 +53,7 @@ function createHarness(params?: {
     handleCommand,
     sendChat,
     resetSession,
+    setSession,
     addUser,
     addSystem,
     requestRender,
@@ -104,16 +107,24 @@ describe("tui command handlers", () => {
     expect(requestRender).toHaveBeenCalled();
   });
 
-  it("passes reset reason when handling /new and /reset", async () => {
+  it("creates unique session for /new and resets shared session for /reset", async () => {
     const loadHistory = vi.fn().mockResolvedValue(undefined);
-    const { handleCommand, resetSession } = createHarness({ loadHistory });
+    const setSessionMock = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, resetSession } = createHarness({
+      loadHistory,
+      setSession: setSessionMock,
+    });
 
     await handleCommand("/new");
     await handleCommand("/reset");
 
-    expect(resetSession).toHaveBeenNthCalledWith(1, "agent:main:main", "new");
-    expect(resetSession).toHaveBeenNthCalledWith(2, "agent:main:main", "reset");
-    expect(loadHistory).toHaveBeenCalledTimes(2);
+    // /new creates a unique session key (isolates TUI client) (#39217)
+    expect(setSessionMock).toHaveBeenCalledTimes(1);
+    expect(setSessionMock).toHaveBeenCalledWith(expect.stringMatching(/^tui-[a-f0-9]{8}$/));
+    // /reset still resets the shared session
+    expect(resetSession).toHaveBeenCalledTimes(1);
+    expect(resetSession).toHaveBeenCalledWith("agent:main:main", "reset");
+    expect(loadHistory).toHaveBeenCalledTimes(1); // Only /reset loads history
   });
 
   it("reports send failures and marks activity status as error", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -16,6 +16,7 @@ import {
   createSettingsList,
 } from "./components/selectors.js";
 import type { GatewayChatClient } from "./gateway-chat.js";
+import { sanitizeRenderableText } from "./tui-formatters.js";
 import { formatStatusSummary } from "./tui-status-summary.js";
 import type {
   AgentSummary,
@@ -431,7 +432,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           await setSession(uniqueKey);
           chatLog.addSystem(`new session: ${state.currentSessionKey}`);
         } catch (err) {
-          chatLog.addSystem(`new session failed: ${String(err)}`);
+          chatLog.addSystem(`new session failed: ${sanitizeRenderableText(String(err))}`);
         }
         break;
       case "reset":

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -423,6 +423,17 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
         break;
       case "new":
+        try {
+          // Generate unique session key to isolate this TUI client (#39217)
+          // This ensures /new creates a fresh session that doesn't broadcast
+          // to other connected TUI clients sharing the original session key.
+          const uniqueKey = `tui-${randomUUID().slice(0, 8)}`;
+          await setSession(uniqueKey);
+          chatLog.addSystem(`new session: ${state.currentSessionKey}`);
+        } catch (err) {
+          chatLog.addSystem(`new session failed: ${String(err)}`);
+        }
+        break;
       case "reset":
         try {
           // Clear token counts immediately to avoid stale display (#1523)

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -427,7 +427,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           // Generate unique session key to isolate this TUI client (#39217)
           // This ensures /new creates a fresh session that doesn't broadcast
           // to other connected TUI clients sharing the original session key.
-          const uniqueKey = `tui-${randomUUID().slice(0, 8)}`;
+          const uniqueKey = `tui-${randomUUID()}`;
           await setSession(uniqueKey);
           chatLog.addSystem(`new session: ${state.currentSessionKey}`);
         } catch (err) {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -425,12 +425,18 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "new":
         try {
+          // Clear token counts immediately to avoid stale display (#1523)
+          state.sessionInfo.inputTokens = null;
+          state.sessionInfo.outputTokens = null;
+          state.sessionInfo.totalTokens = null;
+          tui.requestRender();
+
           // Generate unique session key to isolate this TUI client (#39217)
           // This ensures /new creates a fresh session that doesn't broadcast
           // to other connected TUI clients sharing the original session key.
           const uniqueKey = `tui-${randomUUID()}`;
           await setSession(uniqueKey);
-          chatLog.addSystem(`new session: ${state.currentSessionKey}`);
+          chatLog.addSystem(`new session: ${uniqueKey}`);
         } catch (err) {
           chatLog.addSystem(`new session failed: ${sanitizeRenderableText(String(err))}`);
         }


### PR DESCRIPTION
## Summary

- **Problem:** When multiple TUI clients connect to the same agent and one calls `/new`, replies are broadcast to all connected clients because they share the same session key.
- **Root cause:** Both `/new` and `/reset` were using `client.resetSession()` which resets but doesn't change the session key, leaving all TUIs subscribed to the same session.
- **Fix:** Differentiate `/new` from `/reset`:
  - `/new`: Creates a unique session key (`tui-{uuid}`) to isolate the client
  - `/reset`: Resets the shared session (existing behavior preserved)

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39217

## User-visible / Behavior Changes

- `/new` now creates an isolated session per TUI client instead of resetting the shared session
- `/reset` retains existing behavior (resets shared session, messages still broadcast)
- TUI clients using `/new` will no longer see each other's messages

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Open TUI window A: `openclaw tui`, then `/agent main`
2. Open TUI window B: `openclaw tui`, then `/agent main`
3. In window A, type `/new`
4. Send a message in window A
5. **Before fix:** Reply appears in both windows
6. **After fix:** Reply only appears in window A

### Evidence

- [x] Updated test: `creates unique session for /new and resets shared session for /reset`
- [x] All 5 tests pass

## Human Verification

- Verified: Test harness updated to support setSession mock
- Edge cases: `/reset` still works as before (shared session reset)
- What I did not verify: Live multi-terminal TUI testing

## Compatibility / Migration

- Backward compatible? Yes (only `/new` behavior changes; `/reset` unchanged)
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to revert: Revert PR commit
- Known bad symptoms: `/new` failing to create session (test catches this)