### PR TITLE
feat: add onRawInbound hook for WhatsApp channel

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -78,6 +78,12 @@ type WhatsAppSharedConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Optional JSONL file path for logging raw inbound messages.
+   * When set, ALL incoming messages (including those that fail access control) are logged to this file.
+   * This is an observe-only hook for debugging and analytics.
+   */
+  rawInboundFeedPath?: string;
 };
 
 type WhatsAppConfigCore = {

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -110,6 +110,8 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
   authDir: z.string().optional(),
   mediaMaxMb: z.number().int().positive().optional(),
+  /** Path to append raw inbound message feed (JSONL format). */
+  rawInboundFeedPath: z.string().optional(),
 }).strict();
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -147,7 +147,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
-    rawInboundFeedPath: accountCfg?.rawInboundFeedPath,
+    rawInboundFeedPath: accountCfg?.rawInboundFeedPath ?? rootCfg?.rawInboundFeedPath,
   };
 }
 

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -29,6 +29,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  rawInboundFeedPath?: string;
 };
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_MB = 50;
@@ -146,6 +147,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
+    rawInboundFeedPath: accountCfg?.rawInboundFeedPath,
   };
 }
 

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -211,7 +211,7 @@ export async function monitorWebChannel(
       },
       onRawInbound: account.rawInboundFeedPath
         ? (msg) => {
-            const feedPath = account.rawInboundFeedPath;
+            const feedPath = account.rawInboundFeedPath!;
             try {
               const line = JSON.stringify(msg) + "\n";
               import("node:fs/promises")

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -209,6 +209,21 @@ export async function monitorWebChannel(
         _lastInboundMsg = msg;
         await onMessage(msg);
       },
+      onRawInbound: account.rawInboundFeedPath
+        ? (msg) => {
+            const feedPath = account.rawInboundFeedPath;
+            try {
+              const line = JSON.stringify(msg) + "\n";
+              import("node:fs/promises")
+                .then((fs) => fs.appendFile(feedPath, line, "utf-8"))
+                .catch((err) => {
+                  logVerbose(`Failed to write raw inbound to ${feedPath}: ${String(err)}`);
+                });
+            } catch (err) {
+              logVerbose(`onRawInbound handler error: ${String(err)}`);
+            }
+          }
+        : undefined,
     });
 
     Object.assign(status, createConnectedChannelStatusPatch());

--- a/src/web/inbound/monitor.raw-inbound.test.ts
+++ b/src/web/inbound/monitor.raw-inbound.test.ts
@@ -1,0 +1,347 @@
+import "../monitor-inbox.test-harness.js";
+import { describe, expect, it, vi } from "vitest";
+import { monitorWebInbox } from "../inbound.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  getAuthDir,
+  getSock,
+  installWebMonitorInboxUnitTestHooks,
+  mockLoadConfig,
+} from "../monitor-inbox.test-harness.js";
+import type { RawInboundMessage } from "./types.js";
+
+describe("monitorWebInbox - onRawInbound hook", () => {
+  installWebMonitorInboxUnitTestHooks();
+
+  async function tick() {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  it("should call onRawInbound for messages that PASS access control", async () => {
+    const onRawInbound = vi.fn();
+    const onMessage = vi.fn();
+
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          allowFrom: ["+111"], // Allow this sender
+        },
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+      },
+    });
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+      onMessage,
+      onRawInbound,
+    });
+
+    const sock = getSock();
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            remoteJid: "111@s.whatsapp.net",
+            id: "test-msg-1",
+            fromMe: false,
+          },
+          message: {
+            conversation: "Hello, this should be allowed",
+          },
+          pushName: "Sender One",
+          messageTimestamp: 1234567890,
+        },
+      ],
+    });
+
+    await tick();
+
+    expect(onRawInbound).toHaveBeenCalledTimes(1);
+    const rawMsg: RawInboundMessage = onRawInbound.mock.calls[0][0];
+    expect(rawMsg.channel).toBe("whatsapp");
+    expect(rawMsg.accountId).toBe(DEFAULT_ACCOUNT_ID);
+    expect(rawMsg.chatId).toBe("111@s.whatsapp.net");
+    expect(rawMsg.group).toBe(false);
+    expect(rawMsg.body).toBe("Hello, this should be allowed");
+    expect(rawMsg.fromMe).toBe(false);
+    expect(rawMsg.accessAllowed).toBe(false);
+
+    await listener.close();
+  });
+
+  it("should call onRawInbound for messages that FAIL access control", async () => {
+    const onRawInbound = vi.fn();
+    const onMessage = vi.fn();
+
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          allowFrom: ["+111"], // Only allow +111, block others
+        },
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+      },
+    });
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+      onMessage,
+      onRawInbound,
+    });
+
+    const sock = getSock();
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            remoteJid: "999@s.whatsapp.net",
+            id: "test-msg-blocked",
+            fromMe: false,
+          },
+          message: {
+            conversation: "This should be blocked",
+          },
+          pushName: "Blocked User",
+          messageTimestamp: 1234567890,
+        },
+      ],
+    });
+
+    await tick();
+
+    // onRawInbound should have been called
+    expect(onRawInbound).toHaveBeenCalledTimes(1);
+    const rawMsg: RawInboundMessage = onRawInbound.mock.calls[0][0];
+    expect(rawMsg.body).toBe("This should be blocked");
+
+    // onMessage should NOT have been called (access control blocked it)
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("should NOT call onRawInbound for status/broadcast messages", async () => {
+    const onRawInbound = vi.fn();
+    const onMessage = vi.fn();
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+      onMessage,
+      onRawInbound,
+    });
+
+    const sock = getSock();
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            remoteJid: "status@broadcast",
+            id: "status-msg",
+            fromMe: false,
+          },
+          message: {
+            conversation: "Status update",
+          },
+        },
+      ],
+    });
+
+    await tick();
+
+    // onRawInbound should NOT have been called for status messages
+    expect(onRawInbound).not.toHaveBeenCalled();
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("should handle onRawInbound errors gracefully without breaking message flow", async () => {
+    const onRawInbound = vi.fn(() => {
+      throw new Error("onRawInbound error");
+    });
+    const onMessage = vi.fn();
+
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          allowFrom: ["+111"],
+        },
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+      },
+    });
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+      onMessage,
+      onRawInbound,
+    });
+
+    const sock = getSock();
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            remoteJid: "111@s.whatsapp.net",
+            id: "test-msg-error",
+            fromMe: false,
+          },
+          message: {
+            conversation: "Test error handling",
+          },
+          pushName: "Sender One",
+          messageTimestamp: 1234567890,
+        },
+      ],
+    });
+
+    await tick();
+
+    // onRawInbound was called and threw
+    expect(onRawInbound).toHaveBeenCalledTimes(1);
+
+    // But normal message flow should still work (onMessage should be called)
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
+  it("should extract group information for group messages", async () => {
+    const onRawInbound = vi.fn();
+    const onMessage = vi.fn();
+
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          allowFrom: ["*"],
+          groupPolicy: "open",
+        },
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+      },
+    });
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+      onMessage,
+      onRawInbound,
+    });
+
+    const sock = getSock();
+
+    // Mock groupMetadata for this group
+    sock.groupMetadata = vi.fn().mockResolvedValue({
+      subject: "Test Group",
+      participants: [{ id: "111@s.whatsapp.net" }],
+    }) as unknown as typeof sock.groupMetadata;
+
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            remoteJid: "123456789@g.us",
+            participant: "111@s.whatsapp.net",
+            id: "group-msg-1",
+            fromMe: false,
+          },
+          message: {
+            conversation: "Hello from group",
+          },
+          pushName: "Group Sender",
+          messageTimestamp: 1234567890,
+        },
+      ],
+    });
+
+    await tick();
+
+    expect(onRawInbound).toHaveBeenCalledTimes(1);
+    const rawMsg: RawInboundMessage = onRawInbound.mock.calls[0][0];
+    expect(rawMsg.group).toBe(true);
+    expect(rawMsg.chatId).toBe("123456789@g.us");
+    expect(rawMsg.groupSubject).toBe("Test Group");
+    expect(rawMsg.senderJid).toBe("111@s.whatsapp.net");
+
+    await listener.close();
+  });
+
+  it("should set senderJid to remoteJid for DM messages", async () => {
+    const onRawInbound = vi.fn();
+    const onMessage = vi.fn();
+
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          allowFrom: ["+111"],
+        },
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+      },
+    });
+
+    const listener = await monitorWebInbox({
+      verbose: false,
+      accountId: DEFAULT_ACCOUNT_ID,
+      authDir: getAuthDir(),
+      onMessage,
+      onRawInbound,
+    });
+
+    const sock = getSock();
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            remoteJid: "111@s.whatsapp.net",
+            id: "dm-msg-1",
+            fromMe: false,
+            // DM messages don't have participant field
+          },
+          message: {
+            conversation: "Hello from DM",
+          },
+          pushName: "DM Sender",
+          messageTimestamp: 1234567890,
+        },
+      ],
+    });
+
+    await tick();
+
+    expect(onRawInbound).toHaveBeenCalledTimes(1);
+    const rawMsg: RawInboundMessage = onRawInbound.mock.calls[0][0];
+    expect(rawMsg.group).toBe(false);
+    expect(rawMsg.chatId).toBe("111@s.whatsapp.net");
+    // For DM messages, senderJid should be set to remoteJid
+    expect(rawMsg.senderJid).toBe("111@s.whatsapp.net");
+    expect(rawMsg.senderE164).toBe("+111");
+
+    await listener.close();
+  });
+});

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -416,6 +416,8 @@ export async function monitorWebInbox(options: {
           const rawBody = extractText(msg.message ?? undefined) || "";
           const remoteJid = msg.key?.remoteJid;
           const rawMsgId = msg.key?.id;
+          // Share the same dedupe cache as normal processing, but with a `raw:` prefix
+          // to distinguish raw hook calls. This is acceptable for expected message volume.
           const rawDedupeKey = rawMsgId
             ? `raw:${options.accountId}:${remoteJid}:${rawMsgId}`
             : undefined;

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -20,7 +20,7 @@ import {
 } from "./extract.js";
 import { downloadInboundMedia } from "./media.js";
 import { createWebSendApi } from "./send-api.js";
-import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
+import type { RawInboundMessage, WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
 export async function monitorWebInbox(options: {
   verbose: boolean;
@@ -34,6 +34,11 @@ export async function monitorWebInbox(options: {
   debounceMs?: number;
   /** Optional debounce gating predicate. */
   shouldDebounce?: (msg: WebInboundMessage) => boolean;
+  /**
+   * Optional callback fired for EVERY incoming message, before access control filtering.
+   * This is observe-only and cannot influence routing or response.
+   */
+  onRawInbound?: (msg: RawInboundMessage) => void;
 }) {
   const inboundLogger = getChildLogger({ module: "web-inbound" });
   const inboundConsoleLog = createSubsystemLogger("gateway/channels/whatsapp").child("inbound");
@@ -404,6 +409,58 @@ export async function monitorWebInbox(options: {
         accountId: options.accountId,
         direction: "inbound",
       });
+
+      // Fire raw inbound hook before any filtering (with lightweight dedup)
+      if (options.onRawInbound) {
+        try {
+          const rawBody = extractText(msg.message ?? undefined) || "";
+          const remoteJid = msg.key?.remoteJid;
+          const rawMsgId = msg.key?.id;
+          const rawDedupeKey = rawMsgId
+            ? `raw:${options.accountId}:${remoteJid}:${rawMsgId}`
+            : undefined;
+          if (rawDedupeKey && isRecentInboundMessage(rawDedupeKey)) {
+            // Already emitted this message, skip
+          } else if (
+            remoteJid &&
+            !remoteJid.endsWith("@status") &&
+            !remoteJid.endsWith("@broadcast")
+          ) {
+            const isGroup = isJidGroup(remoteJid) === true;
+            const participantJid = msg.key?.participant ?? undefined;
+            const senderE164 = isGroup
+              ? participantJid
+                ? await resolveInboundJid(participantJid)
+                : null
+              : await resolveInboundJid(remoteJid);
+
+            let groupSubject: string | undefined;
+            if (isGroup) {
+              const meta = await getGroupMeta(remoteJid);
+              groupSubject = meta.subject;
+            }
+
+            options.onRawInbound({
+              channel: "whatsapp",
+              accountId: options.accountId,
+              chatId: remoteJid,
+              group: isGroup,
+              groupSubject,
+              senderJid: isGroup ? participantJid : remoteJid,
+              senderE164: senderE164 ?? undefined,
+              senderName: msg.pushName ?? undefined,
+              body: rawBody,
+              timestampMs: msg.messageTimestamp ? Number(msg.messageTimestamp) * 1000 : undefined,
+              messageId: msg.key?.id ?? undefined,
+              fromMe: Boolean(msg.key?.fromMe),
+              accessAllowed: false,
+            });
+          }
+        } catch (err) {
+          logVerbose(`onRawInbound hook error: ${String(err)}`);
+        }
+      }
+
       const inbound = await normalizeInboundMessage(msg);
       if (!inbound) {
         continue;

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -7,6 +7,39 @@ export type WebListenerCloseReason = {
   error?: unknown;
 };
 
+/**
+ * Raw inbound message emitted BEFORE access control filtering.
+ * This is an observe-only hook; it cannot influence message routing or responses.
+ */
+export type RawInboundMessage = {
+  /** Channel this message came from */
+  channel: "whatsapp";
+  /** Account ID */
+  accountId: string;
+  /** Chat JID (group or individual) */
+  chatId: string;
+  /** Whether this is a group message */
+  group: boolean;
+  /** Group subject/name if available */
+  groupSubject?: string;
+  /** Sender JID */
+  senderJid?: string;
+  /** Sender E164 phone number if resolved */
+  senderE164?: string;
+  /** Sender push name */
+  senderName?: string;
+  /** Message body text (extracted) */
+  body: string;
+  /** Message timestamp (ms) */
+  timestampMs?: number;
+  /** Message ID */
+  messageId?: string;
+  /** Whether message was from the bot itself */
+  fromMe: boolean;
+  /** Always `false` in the current implementation — this hook fires before access control runs. Reserved for future use. */
+  accessAllowed: boolean;
+};
+
 export type WebInboundMessage = {
   id?: string;
   from: string; // conversation id: E.164 for direct chats, group JID for groups

--- a/src/web/monitor-inbox.test-harness.ts
+++ b/src/web/monitor-inbox.test-harness.ts
@@ -38,6 +38,7 @@ export type MockSock = {
   sendMessage: AnyMockFn;
   readMessages: AnyMockFn;
   updateMediaMessage: AnyMockFn;
+  groupMetadata?: AnyMockFn;
   logger: Record<string, unknown>;
   signalRepository: {
     lidMapping: {
@@ -88,6 +89,7 @@ vi.mock("../media/store.js", () => ({
     size: 1,
     contentType: "image/jpeg",
   }),
+  MEDIA_MAX_BYTES: 5 * 1024 * 1024,
 }));
 
 vi.mock("../config/config.js", async (importOriginal) => {


### PR DESCRIPTION
## Summary

- **Problem:** Plugins using `before_prompt_build` only see messages that pass access control. There is no way to passively observe all incoming WhatsApp traffic for analytics, logging, or debugging.
- **Why it matters:** Users need message-level observability for monitoring, building allow/blocklists, and debugging access control issues without modifying routing logic.
- **What changed:**
  - Added `onRawInbound` callback option to `monitorWebInbox` that fires before access control
  - Added `RawInboundMessage` type with channel, chat, sender, and body metadata
  - Added `rawInboundFeedPath` config option to write raw messages to JSONL file
  - Propagated config through Zod schema, TypeScript types, and `resolveWhatsAppAccount`
  - Added lightweight dedup via `isRecentInboundMessage` to prevent duplicate emissions
  - Correct sender resolution: `remoteJid` for DMs, `participant` for groups
- **What did NOT change:** Access control logic, message routing, and response handling are untouched. This hook is observe-only.

## Change Type
- [x] Feature

## Scope
- [x] Integrations (WhatsApp channel)
- [x] API / contracts (new config option, new type)

## Linked Issue/PR
- Closes #39232

## User-visible / Behavior Changes
- New optional config: `channels.whatsapp.rawInboundFeedPath` — when set, all incoming messages are logged to a JSONL file before access control filtering.

## Security Impact
- New permissions/capabilities? No (observe-only, no routing influence)
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — raw messages (including from non-allowed senders) are written to a local file when configured. Risk is minimal: requires explicit opt-in via config, file is local, and the data is the same as what WhatsApp delivers to the socket.

## Reproduction / Testing

Tests included (`src/web/inbound/monitor.raw-inbound.test.ts`):
1. Hook fires for messages that pass access control
2. Hook fires for messages that fail access control
3. Hook does NOT fire for status/broadcast messages
4. Errors in hook do not break normal message flow
5. Group metadata extraction works correctly

**To test manually:**
```yaml
channels:
  whatsapp:
    rawInboundFeedPath: /var/log/openclaw/raw-inbound.jsonl
```
Send messages from allowed and non-allowed numbers. Check that all appear in the JSONL file.

---

*This PR was developed with AI assistance (Claude). All code has been reviewed, tested, and iterated based on automated review feedback from Codex and Greptile. The author understands the implementation.*