### PR TITLE
fix(gateway): pass CLI --bind to control-ui origin seeder

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -459,6 +459,7 @@ export async function startGatewayServer(
     config: cfgAtStart,
     writeConfig: writeConfigFile,
     log,
+    bind: opts.bind,
   });
 
   initSubagentRegistry();

--- a/src/gateway/startup-control-ui-origins.test.ts
+++ b/src/gateway/startup-control-ui-origins.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-origins.js";
+
+describe("maybeSeedControlUiAllowedOriginsAtStartup", () => {
+  const noopLog = { info: vi.fn(), warn: vi.fn() };
+
+  it("seeds allowedOrigins when CLI --bind lan is provided but config has no bind", async () => {
+    const writeConfig = vi.fn();
+    const config = { gateway: {} } as OpenClawConfig;
+    const result = await maybeSeedControlUiAllowedOriginsAtStartup({
+      config,
+      writeConfig,
+      log: noopLog,
+      bind: "lan",
+    });
+    // The seeded config should have allowedOrigins populated
+    expect(result.gateway?.controlUi?.allowedOrigins).toBeDefined();
+    expect(result.gateway?.controlUi?.allowedOrigins?.length).toBeGreaterThan(0);
+    expect(writeConfig).toHaveBeenCalled();
+  });
+
+  it("does not seed when bind is loopback (default)", async () => {
+    const writeConfig = vi.fn();
+    const config = { gateway: {} } as OpenClawConfig;
+    const result = await maybeSeedControlUiAllowedOriginsAtStartup({
+      config,
+      writeConfig,
+      log: noopLog,
+    });
+    expect(result).toBe(config);
+    expect(writeConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not seed when config already has allowedOrigins", async () => {
+    const writeConfig = vi.fn();
+    const config = {
+      gateway: {
+        bind: "lan",
+        controlUi: { allowedOrigins: ["http://custom:18789"] },
+      },
+    } as OpenClawConfig;
+    const result = await maybeSeedControlUiAllowedOriginsAtStartup({
+      config,
+      writeConfig,
+      log: noopLog,
+      bind: "lan",
+    });
+    // Should keep original config with user-specified origins
+    expect(result).toBe(config);
+    expect(writeConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/startup-control-ui-origins.ts
+++ b/src/gateway/startup-control-ui-origins.ts
@@ -3,13 +3,25 @@ import {
   ensureControlUiAllowedOriginsForNonLoopbackBind,
   type GatewayNonLoopbackBindMode,
 } from "../config/gateway-control-ui-origins.js";
+import type { GatewayBindMode } from "../config/types.gateway.js";
 
 export async function maybeSeedControlUiAllowedOriginsAtStartup(params: {
   config: OpenClawConfig;
   writeConfig: (config: OpenClawConfig) => Promise<void>;
   log: { info: (msg: string) => void; warn: (msg: string) => void };
+  /** CLI --bind override; merged into config before checking origins. */
+  bind?: string;
 }): Promise<OpenClawConfig> {
-  const seeded = ensureControlUiAllowedOriginsForNonLoopbackBind(params.config);
+  // Merge CLI bind override so --bind lan (without config-file entry) is
+  // recognised before the first resolveGatewayRuntimeConfig call.
+  const configForSeed =
+    params.bind && !params.config.gateway?.bind
+      ? {
+          ...params.config,
+          gateway: { ...params.config.gateway, bind: params.bind as GatewayBindMode },
+        }
+      : params.config;
+  const seeded = ensureControlUiAllowedOriginsForNonLoopbackBind(configForSeed);
   if (!seeded.seededOrigins || !seeded.bind) {
     return params.config;
   }


### PR DESCRIPTION
## Summary
- When starting the gateway with `--bind lan` as a CLI flag only (no `gateway.bind` in the config file), `maybeSeedControlUiAllowedOriginsAtStartup` never saw the bind mode because CLI args were merged *after* the seed check
- This caused `ensureControlUiAllowedOriginsForNonLoopbackBind` to treat the bind as loopback, skipping the seed — the subsequent CORS check then rejected the Control UI request, crash-looping the gateway in Docker containers
- Pass the CLI `bind` value into `maybeSeedControlUiAllowedOriginsAtStartup` so it can merge the override before checking

## Test plan
- [x] Added `startup-control-ui-origins.test.ts` with 3 tests covering:
  - CLI `--bind lan` without config-file entry seeds origins (the crash-loop scenario)
  - Loopback bind (default) does not seed
  - Existing user-specified `allowedOrigins` are not overwritten
- [x] All 3 tests pass

Fixes #39228

🤖 Generated with [Claude Code](https://claude.com/claude-code)