### PR TITLE
feat(exec): add bubblewrap namespace sandbox for safeBins commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -432,13 +432,14 @@
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [
+      "@discordjs/opus",
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",
       "@napi-rs/canvas",
+      "@tloncorp/tlon-skill",
       "@whiskeysockets/baileys",
       "authenticate-pam",
       "esbuild",
-      "koffi",
       "node-llama-cpp",
       "protobufjs",
       "sharp"

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  getOAuthApiKey: () => null,
+  getOAuthProviders: () => [],
+  loginOpenAICodex: () => undefined,
+}));
+
+import {
+  collectBwrapCommandBins,
+  shouldEnableBwrapSandbox,
+} from "./bash-tools.exec-host-gateway.js";
+
+describe("shouldEnableBwrapSandbox", () => {
+  it("requires the linux platform guard", () => {
+    expect(
+      shouldEnableBwrapSandbox({
+        matchedViaSafeBins: true,
+        pty: false,
+        nsSandboxMode: "bwrap",
+        hostSecurity: "allowlist",
+        analysisOk: true,
+        allowlistSatisfied: true,
+        platform: "darwin",
+        bwrapPath: "/usr/bin/bwrap",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldEnableBwrapSandbox({
+        matchedViaSafeBins: true,
+        pty: false,
+        nsSandboxMode: "bwrap",
+        hostSecurity: "allowlist",
+        analysisOk: true,
+        allowlistSatisfied: true,
+        platform: "linux",
+        bwrapPath: "/usr/bin/bwrap",
+      }),
+    ).toBe(true);
+  });
+
+  it("skips bwrap when host security is full (trust-window bypass)", () => {
+    expect(
+      shouldEnableBwrapSandbox({
+        matchedViaSafeBins: true,
+        pty: false,
+        nsSandboxMode: "bwrap",
+        hostSecurity: "full",
+        analysisOk: true,
+        allowlistSatisfied: true,
+        platform: "linux",
+        bwrapPath: "/usr/bin/bwrap",
+      }),
+    ).toBe(false);
+  });
+
+  it("skips bwrap for PTY commands or when bwrap is unavailable", () => {
+    expect(
+      shouldEnableBwrapSandbox({
+        matchedViaSafeBins: true,
+        pty: true,
+        nsSandboxMode: "bwrap",
+        hostSecurity: "allowlist",
+        analysisOk: true,
+        allowlistSatisfied: true,
+        platform: "linux",
+        bwrapPath: "/usr/bin/bwrap",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldEnableBwrapSandbox({
+        matchedViaSafeBins: true,
+        pty: false,
+        nsSandboxMode: "bwrap",
+        hostSecurity: "allowlist",
+        analysisOk: true,
+        allowlistSatisfied: true,
+        platform: "linux",
+        bwrapPath: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("collectBwrapCommandBins", () => {
+  it("collects lower-cased executable names from resolved command segments", () => {
+    const bins = collectBwrapCommandBins([
+      {
+        raw: "curl https://example.com",
+        argv: ["curl", "https://example.com"],
+        resolution: {
+          rawExecutable: "curl",
+          resolvedPath: "/usr/bin/curl",
+          executableName: "curl",
+        },
+      },
+      {
+        raw: "JQ .",
+        argv: ["jq", "."],
+        resolution: {
+          rawExecutable: "jq",
+          resolvedPath: "/usr/bin/jq",
+          executableName: "JQ",
+        },
+      },
+      {
+        raw: "echo hi",
+        argv: ["echo", "hi"],
+        resolution: null,
+      },
+    ]);
+
+    expect(Array.from(bins)).toEqual(["curl", "jq"]);
+  });
+});

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -2,6 +2,7 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import {
   addAllowlistEntry,
   type ExecAsk,
+  type ExecCommandSegment,
   type ExecSecurity,
   buildEnforcedShellCommand,
   evaluateShellAllowlist,
@@ -10,7 +11,7 @@ import {
   resolveAllowAlwaysPatterns,
 } from "../infra/exec-approvals.js";
 import type { BwrapExtraBind, BuildBwrapArgsParams } from "../infra/exec-bwrap-sandbox.js";
-import { isBwrapAvailable } from "../infra/exec-bwrap-sandbox.js";
+import { getBwrapPath } from "../infra/exec-bwrap-sandbox.js";
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
 import { logInfo } from "../logger.js";
@@ -72,6 +73,41 @@ export type ProcessGatewayAllowlistResult = {
   bwrapSandbox?: BuildBwrapArgsParams;
   pendingResult?: AgentToolResult<ExecToolDetails>;
 };
+
+export function shouldEnableBwrapSandbox(params: {
+  matchedViaSafeBins: boolean;
+  pty: boolean;
+  nsSandboxMode?: string;
+  hostSecurity: ExecSecurity;
+  analysisOk: boolean;
+  allowlistSatisfied: boolean;
+  platform: NodeJS.Platform;
+  bwrapPath: string | null;
+}): boolean {
+  return (
+    params.matchedViaSafeBins &&
+    !params.pty &&
+    params.nsSandboxMode === "bwrap" &&
+    params.hostSecurity === "allowlist" &&
+    params.analysisOk &&
+    params.allowlistSatisfied &&
+    params.platform === "linux" &&
+    params.bwrapPath != null
+  );
+}
+
+export function collectBwrapCommandBins(
+  segments: readonly ExecCommandSegment[],
+): ReadonlySet<string> {
+  const bins = new Set<string>();
+  for (const segment of segments) {
+    const name = segment.resolution?.executableName?.trim().toLowerCase();
+    if (name) {
+      bins.add(name);
+    }
+  }
+  return bins;
+}
 
 export async function processGatewayAllowlist(
   params: ProcessGatewayAllowlistParams,
@@ -153,15 +189,17 @@ export async function processGatewayAllowlist(
   const matchedViaSafeBins =
     allowlistEval.segmentSatisfiedBy.length > 0 &&
     allowlistEval.segmentSatisfiedBy.every((by) => by === "safeBins");
-  const bwrapEligible =
-    matchedViaSafeBins &&
-    !params.pty &&
-    params.nsSandboxMode === "bwrap" &&
-    hostSecurity === "allowlist" &&
-    analysisOk &&
-    allowlistSatisfied &&
-    process.platform === "linux" &&
-    isBwrapAvailable();
+  const bwrapPath = getBwrapPath();
+  const bwrapEligible = shouldEnableBwrapSandbox({
+    matchedViaSafeBins,
+    pty: params.pty,
+    nsSandboxMode: params.nsSandboxMode,
+    hostSecurity,
+    analysisOk,
+    allowlistSatisfied,
+    platform: process.platform,
+    bwrapPath,
+  });
   const makeBwrapParams = (): BuildBwrapArgsParams | undefined => {
     if (!bwrapEligible) {
       return undefined;
@@ -175,8 +213,10 @@ export async function processGatewayAllowlist(
       safeBins: params.safeBins,
       trustedSafeBinDirs: params.trustedSafeBinDirs ?? new Set(["/bin", "/usr/bin"]),
       workdir: params.workdir,
+      workspace: process.env.OPENCLAW_WORKSPACE_DIR,
       extraBinds: params.nsSandboxExtraBinds,
       extraShellBinaries: [shellBaseName],
+      commandBins: collectBwrapCommandBins(allowlistEval.segments),
     };
   };
 

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -9,6 +9,8 @@ import {
   requiresExecApproval,
   resolveAllowAlwaysPatterns,
 } from "../infra/exec-approvals.js";
+import type { BwrapExtraBind, BuildBwrapArgsParams } from "../infra/exec-bwrap-sandbox.js";
+import { isBwrapAvailable } from "../infra/exec-bwrap-sandbox.js";
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
 import { logInfo } from "../logger.js";
@@ -57,10 +59,16 @@ export type ProcessGatewayAllowlistParams = {
   maxOutput: number;
   pendingMaxOutput: number;
   trustedSafeBinDirs?: ReadonlySet<string>;
+  /** Namespace sandbox mode for safeBins commands ("none" | "bwrap"). */
+  nsSandboxMode?: string;
+  /** Extra bind mounts for namespace sandbox. */
+  nsSandboxExtraBinds?: readonly BwrapExtraBind[];
 };
 
 export type ProcessGatewayAllowlistResult = {
   execCommandOverride?: string;
+  /** bwrap sandbox params to pass to runExecProcess when safeBins matched and sandbox is enabled. */
+  bwrapSandbox?: BuildBwrapArgsParams;
   pendingResult?: AgentToolResult<ExecToolDetails>;
 };
 
@@ -327,5 +335,24 @@ export async function processGatewayAllowlist(
 
   recordMatchedAllowlistUse(allowlistEval.segments[0]?.resolution?.resolvedPath);
 
-  return { execCommandOverride: enforcedCommand };
+  // Build bwrap sandbox params when namespace sandboxing is enabled and command matched safeBins.
+  // Trust window already bypasses this path (sets hostSecurity = "full" above).
+  let bwrapSandbox: BuildBwrapArgsParams | undefined;
+  if (
+    params.nsSandboxMode === "bwrap" &&
+    hostSecurity === "allowlist" &&
+    analysisOk &&
+    allowlistSatisfied &&
+    process.platform === "linux" &&
+    isBwrapAvailable()
+  ) {
+    bwrapSandbox = {
+      safeBins: params.safeBins,
+      trustedSafeBinDirs: params.trustedSafeBinDirs ?? new Set(["/bin", "/usr/bin"]),
+      workdir: params.workdir,
+      extraBinds: params.nsSandboxExtraBinds,
+    };
+  }
+
+  return { execCommandOverride: enforcedCommand, bwrapSandbox };
 }

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -34,6 +34,7 @@ import {
   runExecProcess,
 } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import { getShellConfig } from "./shell-utils.js";
 
 export type ProcessGatewayAllowlistParams = {
   command: string;
@@ -146,7 +147,12 @@ export async function processGatewayAllowlist(
   }
 
   // Pre-compute bwrap eligibility for both approval and non-approval paths.
-  const matchedViaSafeBins = allowlistEval.segmentSatisfiedBy.some((by) => by === "safeBins");
+  // All segments must be satisfied by safeBins for bwrap to apply.
+  // A mixed command (some safeBins, some regular allowlist) would break because
+  // non-safeBins binaries aren't mounted inside the namespace.
+  const matchedViaSafeBins =
+    allowlistEval.segmentSatisfiedBy.length > 0 &&
+    allowlistEval.segmentSatisfiedBy.every((by) => by === "safeBins");
   const bwrapEligible =
     matchedViaSafeBins &&
     !params.pty &&
@@ -156,15 +162,23 @@ export async function processGatewayAllowlist(
     allowlistSatisfied &&
     process.platform === "linux" &&
     isBwrapAvailable();
-  const makeBwrapParams = (): BuildBwrapArgsParams | undefined =>
-    bwrapEligible
-      ? {
-          safeBins: params.safeBins,
-          trustedSafeBinDirs: params.trustedSafeBinDirs ?? new Set(["/bin", "/usr/bin"]),
-          workdir: params.workdir,
-          extraBinds: params.nsSandboxExtraBinds,
-        }
-      : undefined;
+  const makeBwrapParams = (): BuildBwrapArgsParams | undefined => {
+    if (!bwrapEligible) {
+      return undefined;
+    }
+    // Extract the shell binary name so bwrap mounts it inside the namespace.
+    const shellConfig = getShellConfig();
+    const shellBaseName = shellConfig.shell.includes("/")
+      ? shellConfig.shell.split("/").pop()!
+      : shellConfig.shell;
+    return {
+      safeBins: params.safeBins,
+      trustedSafeBinDirs: params.trustedSafeBinDirs ?? new Set(["/bin", "/usr/bin"]),
+      workdir: params.workdir,
+      extraBinds: params.nsSandboxExtraBinds,
+      extraShellBinaries: [shellBaseName],
+    };
+  };
 
   if (requiresAsk) {
     const {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -145,6 +145,27 @@ export async function processGatewayAllowlist(
     );
   }
 
+  // Pre-compute bwrap eligibility for both approval and non-approval paths.
+  const matchedViaSafeBins = allowlistEval.segmentSatisfiedBy.some((by) => by === "safeBins");
+  const bwrapEligible =
+    matchedViaSafeBins &&
+    !params.pty &&
+    params.nsSandboxMode === "bwrap" &&
+    hostSecurity === "allowlist" &&
+    analysisOk &&
+    allowlistSatisfied &&
+    process.platform === "linux" &&
+    isBwrapAvailable();
+  const makeBwrapParams = (): BuildBwrapArgsParams | undefined =>
+    bwrapEligible
+      ? {
+          safeBins: params.safeBins,
+          trustedSafeBinDirs: params.trustedSafeBinDirs ?? new Set(["/bin", "/usr/bin"]),
+          workdir: params.workdir,
+          extraBinds: params.nsSandboxExtraBinds,
+        }
+      : undefined;
+
   if (requiresAsk) {
     const {
       approvalId,
@@ -259,6 +280,7 @@ export async function processGatewayAllowlist(
           env: params.env,
           sandbox: undefined,
           containerWorkdir: null,
+          bwrapSandbox: makeBwrapParams(),
           usePty: params.pty,
           warnings: params.warnings,
           maxOutput: params.maxOutput,
@@ -335,24 +357,5 @@ export async function processGatewayAllowlist(
 
   recordMatchedAllowlistUse(allowlistEval.segments[0]?.resolution?.resolvedPath);
 
-  // Build bwrap sandbox params when namespace sandboxing is enabled and command matched safeBins.
-  // Trust window already bypasses this path (sets hostSecurity = "full" above).
-  let bwrapSandbox: BuildBwrapArgsParams | undefined;
-  if (
-    params.nsSandboxMode === "bwrap" &&
-    hostSecurity === "allowlist" &&
-    analysisOk &&
-    allowlistSatisfied &&
-    process.platform === "linux" &&
-    isBwrapAvailable()
-  ) {
-    bwrapSandbox = {
-      safeBins: params.safeBins,
-      trustedSafeBinDirs: params.trustedSafeBinDirs ?? new Set(["/bin", "/usr/bin"]),
-      workdir: params.workdir,
-      extraBinds: params.nsSandboxExtraBinds,
-    };
-  }
-
-  return { execCommandOverride: enforcedCommand, bwrapSandbox };
+  return { execCommandOverride: enforcedCommand, bwrapSandbox: makeBwrapParams() };
 }

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -10,10 +10,28 @@ vi.mock("../infra/system-events.js", () => ({
 
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
+import { buildBwrapShellArgs, emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
 
 const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
 const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
+
+describe("buildBwrapShellArgs", () => {
+  it("adds --norc and --noprofile for bash inside bwrap", () => {
+    expect(buildBwrapShellArgs("/usr/bin/bash", ["-c"])).toEqual(["--norc", "--noprofile", "-c"]);
+  });
+
+  it("does not duplicate bash init suppression flags", () => {
+    expect(buildBwrapShellArgs("bash", ["--norc", "--noprofile", "-c"])).toEqual([
+      "--norc",
+      "--noprofile",
+      "-c",
+    ]);
+  });
+
+  it("leaves non-bash shells unchanged", () => {
+    expect(buildBwrapShellArgs("/bin/sh", ["-c"])).toEqual(["-c"]);
+  });
+});
 
 describe("emitExecSystemEvent", () => {
   beforeEach(() => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { type ExecHost } from "../infra/exec-approvals.js";
+import type { BuildBwrapArgsParams } from "../infra/exec-bwrap-sandbox.js";
+import { buildBwrapArgs } from "../infra/exec-bwrap-sandbox.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
@@ -261,6 +263,12 @@ export async function runExecProcess(opts: {
   env: Record<string, string>;
   sandbox?: BashSandboxConfig;
   containerWorkdir?: string | null;
+  /**
+   * When set, wrap the command in a bubblewrap (bwrap) namespace sandbox.
+   * Only applied for host=gateway non-sandbox, non-PTY commands where safeBins matched.
+   * Trust windows bypass this entirely.
+   */
+  bwrapSandbox?: BuildBwrapArgsParams;
   usePty: boolean;
   warnings: string[];
   maxOutput: number;
@@ -380,6 +388,19 @@ export async function runExecProcess(opts: {
         ],
         env: process.env,
         stdinMode: opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const),
+      };
+    }
+    // Bubblewrap namespace sandbox: wrap the shell command in bwrap.
+    // Only applied for non-sandbox, non-PTY host=gateway commands that matched safeBins.
+    // PTY is not supported inside bwrap (terminal allocation inside namespaces is unreliable).
+    if (opts.bwrapSandbox && !opts.usePty) {
+      const { shell, args: shellArgs } = getShellConfig();
+      const bwrapPrefix = buildBwrapArgs(opts.bwrapSandbox);
+      return {
+        mode: "child" as const,
+        argv: [...bwrapPrefix, "--", shell, ...shellArgs, execCommand],
+        env: shellRuntimeEnv,
+        stdinMode: "pipe-closed" as const,
       };
     }
     const { shell, args: shellArgs } = getShellConfig();

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -254,6 +254,18 @@ export function emitExecSystemEvent(
   requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
 }
 
+export function buildBwrapShellArgs(shell: string, shellArgs: readonly string[]): string[] {
+  const shellName = path.basename(shell).toLowerCase();
+  if (shellName !== "bash") {
+    return [...shellArgs];
+  }
+  return [
+    "--norc",
+    "--noprofile",
+    ...shellArgs.filter((arg) => arg !== "--norc" && arg !== "--noprofile"),
+  ];
+}
+
 export async function runExecProcess(opts: {
   command: string;
   // Execute this instead of `command` (which is kept for display/session/logging).
@@ -398,8 +410,10 @@ export async function runExecProcess(opts: {
       const bwrapPrefix = buildBwrapArgs(opts.bwrapSandbox);
       return {
         mode: "child" as const,
-        argv: [...bwrapPrefix, "--", shell, ...shellArgs, execCommand],
+        argv: [...bwrapPrefix, "--", shell, ...buildBwrapShellArgs(shell, shellArgs), execCommand],
         env: shellRuntimeEnv,
+        // Current bwrap execution is shell-driven and closes stdin for non-PTY runs,
+        // so piped stdin into sandboxed commands is not supported yet.
         stdinMode: "pipe-closed" as const,
       };
     }

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -1,4 +1,5 @@
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
+import type { BwrapExtraBind, BwrapSandboxMode } from "../infra/exec-bwrap-sandbox.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
@@ -16,6 +17,11 @@ export type ExecToolDefaults = {
   timeoutSec?: number;
   approvalRunningNoticeMs?: number;
   sandbox?: BashSandboxConfig;
+  /** Namespace sandbox config for safeBins commands (Linux + bwrap). */
+  nsSandbox?: {
+    mode?: BwrapSandboxMode;
+    extraBinds?: BwrapExtraBind[];
+  };
   elevated?: ExecElevatedDefaults;
   allowBackground?: boolean;
   scopeKey?: string;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -230,6 +230,9 @@ export function createExecTool(
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
       const warnings: string[] = [];
       let execCommandOverride: string | undefined;
+      let bwrapSandboxParams:
+        | import("../infra/exec-bwrap-sandbox.js").BuildBwrapArgsParams
+        | undefined;
       const backgroundRequested = params.background === true;
       const yieldRequested = typeof params.yieldMs === "number";
       if (!allowBackground && (backgroundRequested || yieldRequested)) {
@@ -448,11 +451,14 @@ export function createExecTool(
           maxOutput,
           pendingMaxOutput,
           trustedSafeBinDirs,
+          nsSandboxMode: defaults?.nsSandbox?.mode,
+          nsSandboxExtraBinds: defaults?.nsSandbox?.extraBinds,
         });
         if (gatewayResult.pendingResult) {
           return gatewayResult.pendingResult;
         }
         execCommandOverride = gatewayResult.execCommandOverride;
+        bwrapSandboxParams = gatewayResult.bwrapSandbox;
       }
 
       const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
@@ -475,6 +481,7 @@ export function createExecTool(
         env,
         sandbox,
         containerWorkdir,
+        bwrapSandbox: bwrapSandboxParams,
         usePty,
         warnings,
         maxOutput,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -155,6 +155,7 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     notifyOnExitEmptySuccess:
       agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
     applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
+    nsSandbox: agentExec?.nsSandbox ?? globalExec?.nsSandbox,
   };
 }
 
@@ -401,6 +402,7 @@ export function createOpenClawCodingTools(options?: {
     safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
     safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
     safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
+    nsSandbox: options?.exec?.nsSandbox ?? execConfig.nsSandbox,
     agentId,
     cwd: workspaceRoot,
     allowBackground,

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -122,12 +122,14 @@ describe("fetchBrowserJson loopback auth", () => {
   it("preserves dispatcher error context while keeping no-retry hint", async () => {
     mocks.dispatch.mockRejectedValueOnce(new Error("Chrome CDP handshake timeout"));
 
-    const thrown = await fetchBrowserJson<{ ok: boolean }>("/tabs").catch((err) => err as Error);
+    const thrown = await fetchBrowserJson<{ ok: boolean }>("/tabs").catch((err: unknown) => err);
 
     expect(thrown).toBeInstanceOf(Error);
-    expect(thrown.message).toContain("Chrome CDP handshake timeout");
-    expect(thrown.message).toContain("Do NOT retry the browser tool");
-    expect(thrown.message).not.toContain("Can't reach the OpenClaw browser control service");
+    expect((thrown as Error).message).toContain("Chrome CDP handshake timeout");
+    expect((thrown as Error).message).toContain("Do NOT retry the browser tool");
+    expect((thrown as Error).message).not.toContain(
+      "Can't reach the OpenClaw browser control service",
+    );
   });
 
   it("keeps absolute URL failures wrapped as reachability errors", async () => {
@@ -139,11 +141,11 @@ describe("fetchBrowserJson loopback auth", () => {
     );
 
     const thrown = await fetchBrowserJson<{ ok: boolean }>("http://example.com/").catch(
-      (err) => err as Error,
+      (err: unknown) => err,
     );
 
     expect(thrown).toBeInstanceOf(Error);
-    expect(thrown.message).toContain("Can't reach the OpenClaw browser control service");
-    expect(thrown.message).toContain("Do NOT retry the browser tool");
+    expect((thrown as Error).message).toContain("Can't reach the OpenClaw browser control service");
+    expect((thrown as Error).message).toContain("Do NOT retry the browser tool");
   });
 });

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -1,4 +1,5 @@
 import type { ChatType } from "../channels/chat-type.js";
+import type { BwrapExtraBind, BwrapSandboxMode } from "../infra/exec-bwrap-sandbox.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import type { AgentElevatedAllowFromConfig, SessionSendPolicyAction } from "./types.base.js";
 import type { SecretInput } from "./types.secrets.js";
@@ -242,6 +243,19 @@ export type ExecToolConfig = {
   safeBinTrustedDirs?: string[];
   /** Optional custom safe-bin profiles for entries in tools.exec.safeBins. */
   safeBinProfiles?: Record<string, SafeBinProfileFixture>;
+  /**
+   * Namespace sandbox for safeBins commands (Linux only, requires bubblewrap).
+   * When mode is "bwrap", safeBins-approved commands run inside an unprivileged
+   * user namespace where only approved binaries are visible on the filesystem.
+   * Trust windows bypass the sandbox entirely.
+   * Default: { mode: "none" }.
+   */
+  nsSandbox?: {
+    /** Sandbox mode. "bwrap" = bubblewrap namespace isolation; "none" = disabled. */
+    mode?: BwrapSandboxMode;
+    /** Additional paths to bind-mount into the sandbox. */
+    extraBinds?: BwrapExtraBind[];
+  };
   /** Default time (ms) before an exec command auto-backgrounds. */
   backgroundMs?: number;
   /** Default timeout (seconds) before auto-killing exec commands. */

--- a/src/infra/exec-bwrap-sandbox.test.ts
+++ b/src/infra/exec-bwrap-sandbox.test.ts
@@ -1,17 +1,76 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type BuildBwrapArgsParams,
   buildBwrapArgs,
+  getBwrapPath,
   normalizeBwrapExtraBinds,
   normalizeBwrapSandboxMode,
   resetBwrapCache,
+  validateWorkdir,
 } from "./exec-bwrap-sandbox.js";
+
+const BWRAP_PATHS = new Set(["/usr/bin/bwrap", "/usr/local/bin/bwrap", "/bin/bwrap"]);
+
+function createTempDir(tempDirs: string[], prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeExecutable(dir: string, name: string) {
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, "#!/bin/sh\n", { mode: 0o755 });
+  return filePath;
+}
+
+function expectBind(args: string[], flag: "--bind" | "--ro-bind", src: string, dest: string) {
+  for (let i = 0; i < args.length - 2; i += 1) {
+    if (args[i] === flag && args[i + 1] === src && args[i + 2] === dest) {
+      return;
+    }
+  }
+  throw new Error(`Missing bind ${flag} ${src} ${dest} in argv: ${args.join(" ")}`);
+}
+
+function countBindDest(args: string[], dest: string) {
+  let count = 0;
+  for (let i = 0; i < args.length - 2; i += 1) {
+    if ((args[i] === "--bind" || args[i] === "--ro-bind") && args[i + 2] === dest) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function mockBwrapPath(availablePath: string | null) {
+  const originalAccessSync = fs.accessSync.bind(fs);
+  return vi.spyOn(fs, "accessSync").mockImplementation((target, mode) => {
+    const candidate = String(target);
+    if (BWRAP_PATHS.has(candidate)) {
+      if (candidate === availablePath) {
+        return;
+      }
+      const err = new Error(
+        `ENOENT: no such file or directory, access '${candidate}'`,
+      ) as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    }
+    return originalAccessSync(target, mode);
+  });
+}
+
+// Integration pattern: keep bwrap execution itself in Linux-only integration tests
+// that run against a real `bwrap` binary. These unit tests intentionally cover the
+// deterministic pieces here: binary detection, mount planning, path validation, and
+// sandbox argument construction.
 
 afterEach(() => {
   resetBwrapCache();
+  vi.restoreAllMocks();
 });
 
 describe("normalizeBwrapSandboxMode", () => {
@@ -59,113 +118,233 @@ describe("normalizeBwrapExtraBinds", () => {
   });
 });
 
-describe("buildBwrapArgs", () => {
-  const defaultParams: BuildBwrapArgsParams = {
-    safeBins: new Set(["curl", "jq"]),
-    trustedSafeBinDirs: new Set(["/usr/bin"]),
-    workdir: "/home/test/workspace",
-  };
+describe("getBwrapPath", () => {
+  it("detects, caches, and resets the known bwrap path probe", () => {
+    const accessSpy = mockBwrapPath("/usr/local/bin/bwrap");
 
-  it("starts with bwrap binary", () => {
-    const args = buildBwrapArgs(defaultParams);
-    expect(args[0]).toMatch(/bwrap$/);
+    expect(getBwrapPath()).toBe("/usr/local/bin/bwrap");
+    expect(getBwrapPath()).toBe("/usr/local/bin/bwrap");
+    expect(accessSpy).toHaveBeenCalledTimes(2);
+    expect(accessSpy).toHaveBeenNthCalledWith(1, "/usr/bin/bwrap", fs.constants.X_OK);
+    expect(accessSpy).toHaveBeenNthCalledWith(2, "/usr/local/bin/bwrap", fs.constants.X_OK);
+
+    resetBwrapCache();
+    accessSpy.mockReset();
+    mockBwrapPath("/bin/bwrap");
+
+    expect(getBwrapPath()).toBe("/bin/bwrap");
   });
 
-  it("includes shell binary mounts", () => {
+  it("returns null when bwrap is unavailable", () => {
+    mockBwrapPath(null);
+    expect(getBwrapPath()).toBeNull();
+  });
+});
+
+describe("validateWorkdir", () => {
+  it("rejects unsafe root-level workdirs", () => {
+    expect(() => validateWorkdir("/")).toThrow(/unsafe bwrap workdir/i);
+    expect(() => validateWorkdir("/home")).toThrow(/unsafe bwrap workdir/i);
+    expect(() => validateWorkdir("/root")).toThrow(/unsafe bwrap workdir/i);
+    expect(() => validateWorkdir("/tmp")).toThrow(/unsafe bwrap workdir/i);
+  });
+
+  it("rejects workdirs outside the provided workspace", () => {
+    expect(() => validateWorkdir("/tmp/project/work", "/tmp/workspace")).toThrow(
+      /outside workspace/i,
+    );
+  });
+
+  it("accepts nested workdirs inside the workspace", () => {
+    expect(validateWorkdir("/tmp/workspace/project", "/tmp/workspace")).toBe(
+      "/tmp/workspace/project",
+    );
+  });
+});
+
+describe("buildBwrapArgs", () => {
+  const tempDirs: string[] = [];
+  let trustedBinDir = "";
+  let defaultParams: BuildBwrapArgsParams;
+
+  beforeEach(() => {
+    mockBwrapPath("/usr/bin/bwrap");
+    trustedBinDir = createTempDir(tempDirs, "bwrap-bin-");
+    writeExecutable(trustedBinDir, "sh");
+    writeExecutable(trustedBinDir, "bash");
+    writeExecutable(trustedBinDir, "curl");
+    writeExecutable(trustedBinDir, "jq");
+    defaultParams = {
+      safeBins: new Set(["curl", "jq"]),
+      trustedSafeBinDirs: new Set([trustedBinDir]),
+      workdir: "/tmp/workspace/project",
+    };
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("starts with the detected bwrap binary", () => {
     const args = buildBwrapArgs(defaultParams);
-    const joined = args.join(" ");
-    expect(joined).toContain("--ro-bind");
+    expect(args[0]).toBe("/usr/bin/bwrap");
+  });
+
+  it("throws when bwrap is unavailable", () => {
+    resetBwrapCache();
+    vi.restoreAllMocks();
+    mockBwrapPath(null);
+    expect(() => buildBwrapArgs(defaultParams)).toThrow(/bubblewrap unavailable/i);
+  });
+
+  it("mounts shell binary defaults when they resolve", () => {
+    const shPath = path.join(trustedBinDir, "sh");
+    const bashPath = path.join(trustedBinDir, "bash");
+    const args = buildBwrapArgs(defaultParams);
+    expectBind(args, "--ro-bind", shPath, shPath);
+    expectBind(args, "--ro-bind", bashPath, bashPath);
+  });
+
+  it("skips unresolvable shell binaries", () => {
+    const args = buildBwrapArgs({
+      safeBins: new Set(["curl"]),
+      trustedSafeBinDirs: new Set([trustedBinDir]),
+      workdir: "/tmp/workspace/project",
+      extraShellBinaries: ["missing-shell"],
+    });
+    expect(args).not.toContain(path.join(trustedBinDir, "missing-shell"));
   });
 
   it("mounts safeBins binaries from trusted dirs", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bwrap-test-"));
-    const curlPath = path.join(tmpDir, "curl");
-    const jqPath = path.join(tmpDir, "jq");
-    fs.writeFileSync(curlPath, "#!/bin/sh\n", { mode: 0o755 });
-    fs.writeFileSync(jqPath, "#!/bin/sh\n", { mode: 0o755 });
-
-    try {
-      const args = buildBwrapArgs({
-        safeBins: new Set(["curl", "jq"]),
-        trustedSafeBinDirs: new Set([tmpDir]),
-        workdir: "/tmp/test",
-      });
-
-      const joined = args.join(" ");
-      expect(joined).toContain(`--ro-bind ${curlPath} ${curlPath}`);
-      expect(joined).toContain(`--ro-bind ${jqPath} ${jqPath}`);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true });
-    }
+    const curlPath = path.join(trustedBinDir, "curl");
+    const jqPath = path.join(trustedBinDir, "jq");
+    const args = buildBwrapArgs(defaultParams);
+    expectBind(args, "--ro-bind", curlPath, curlPath);
+    expectBind(args, "--ro-bind", jqPath, jqPath);
   });
 
   it("does not mount binaries not in safeBins", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bwrap-test-"));
-    const curlPath = path.join(tmpDir, "curl");
-    const rmPath = path.join(tmpDir, "rm");
-    fs.writeFileSync(curlPath, "#!/bin/sh\n", { mode: 0o755 });
-    fs.writeFileSync(rmPath, "#!/bin/sh\n", { mode: 0o755 });
-
-    try {
-      const args = buildBwrapArgs({
-        safeBins: new Set(["curl"]),
-        trustedSafeBinDirs: new Set([tmpDir]),
-        workdir: "/tmp/test",
-      });
-
-      const joined = args.join(" ");
-      expect(joined).toContain(`--ro-bind ${curlPath} ${curlPath}`);
-      expect(joined).not.toContain(`--ro-bind ${rmPath} ${rmPath}`);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true });
-    }
+    const rmPath = writeExecutable(trustedBinDir, "rm");
+    const args = buildBwrapArgs({
+      safeBins: new Set(["curl"]),
+      trustedSafeBinDirs: new Set([trustedBinDir]),
+      workdir: "/tmp/workspace/project",
+    });
+    expect(args).not.toContain(rmPath);
   });
 
-  it("mounts system library paths read-only", () => {
+  it("rejects symlinked binaries that escape trusted directories", () => {
+    const outsideDir = createTempDir(tempDirs, "bwrap-outside-");
+    const outsideTool = writeExecutable(outsideDir, "outside-tool");
+    const escapedLink = path.join(trustedBinDir, "escaped-tool");
+    fs.symlinkSync(outsideTool, escapedLink);
+
+    const args = buildBwrapArgs({
+      safeBins: new Set(["escaped-tool"]),
+      trustedSafeBinDirs: new Set([trustedBinDir]),
+      workdir: "/tmp/workspace/project",
+    });
+
+    expect(args).not.toContain(escapedLink);
+    expect(args).not.toContain(outsideTool);
+  });
+
+  it("allows symlinked binaries whose real path stays inside trusted directories", () => {
+    const realTool = writeExecutable(trustedBinDir, "real-tool");
+    const linkedTool = path.join(trustedBinDir, "linked-tool");
+    fs.symlinkSync(realTool, linkedTool);
+
+    const args = buildBwrapArgs({
+      safeBins: new Set(["linked-tool"]),
+      trustedSafeBinDirs: new Set([trustedBinDir]),
+      workdir: "/tmp/workspace/project",
+    });
+
+    expectBind(args, "--ro-bind", linkedTool, linkedTool);
+  });
+
+  it("mounts system library paths read-only when present", () => {
     const args = buildBwrapArgs(defaultParams);
-    const joined = args.join(" ");
     if (fs.existsSync("/usr/lib")) {
-      expect(joined).toContain("--ro-bind /usr/lib /usr/lib");
+      expectBind(args, "--ro-bind", "/usr/lib", "/usr/lib");
     }
   });
 
-  it("mounts working directory read-write", () => {
+  it("binds synthetic passwd and group files instead of the host ones", () => {
     const args = buildBwrapArgs(defaultParams);
-    const joined = args.join(" ");
-    expect(joined).toContain("--bind /home/test/workspace /home/test/workspace");
+    const passwdIndex = args.findIndex(
+      (arg, index) => arg === "--ro-bind" && args[index + 2] === "/etc/passwd",
+    );
+    const groupIndex = args.findIndex(
+      (arg, index) => arg === "--ro-bind" && args[index + 2] === "/etc/group",
+    );
+
+    expect(passwdIndex).toBeGreaterThanOrEqual(0);
+    expect(groupIndex).toBeGreaterThanOrEqual(0);
+    expect(args[passwdIndex + 1]).not.toBe("/etc/passwd");
+    expect(args[groupIndex + 1]).not.toBe("/etc/group");
   });
 
-  it("includes namespace isolation flags", () => {
+  it("mounts the working directory read-write and changes into it", () => {
+    const args = buildBwrapArgs(defaultParams);
+    expectBind(args, "--bind", "/tmp/workspace/project", "/tmp/workspace/project");
+    const chdirIndex = args.indexOf("--chdir");
+    expect(chdirIndex).toBeGreaterThanOrEqual(0);
+    expect(args[chdirIndex + 1]).toBe("/tmp/workspace/project");
+  });
+
+  it("includes namespace isolation flags and starts a new session", () => {
     const args = buildBwrapArgs(defaultParams);
     expect(args).toContain("--unshare-all");
     expect(args).toContain("--share-net");
-    expect(args).toContain("--die-with-parent");
+    const dieWithParentIndex = args.indexOf("--die-with-parent");
+    expect(dieWithParentIndex).toBeGreaterThanOrEqual(0);
+    expect(args[dieWithParentIndex + 1]).toBe("--new-session");
+  });
+
+  it("uses a local-only network profile when command bins do not require network", () => {
+    const args = buildBwrapArgs({
+      ...defaultParams,
+      commandBins: new Set(["jq"]),
+    });
+    expect(args).not.toContain("--share-net");
+  });
+
+  it("keeps network access when any command bin requires it", () => {
+    const args = buildBwrapArgs({
+      ...defaultParams,
+      commandBins: new Set(["jq", "curl"]),
+    });
+    expect(args).toContain("--share-net");
+  });
+
+  it("keeps network access when command bins are not provided", () => {
+    const args = buildBwrapArgs(defaultParams);
+    expect(args).toContain("--share-net");
   });
 
   it("includes pseudo-filesystems", () => {
     const args = buildBwrapArgs(defaultParams);
-    const joined = args.join(" ");
-    expect(joined).toContain("--proc /proc");
-    expect(joined).toContain("--dev /dev");
-    expect(joined).toContain("--tmpfs /tmp");
+    expect(args).toContain("--proc");
+    expect(args).toContain("/proc");
+    expect(args).toContain("--dev");
+    expect(args).toContain("/dev");
+    expect(args).toContain("--tmpfs");
+    expect(args).toContain("/tmp");
   });
 
-  it("adds extra read-only bind mounts", () => {
+  it("adds extra read-only and writable bind mounts", () => {
     const args = buildBwrapArgs({
       ...defaultParams,
-      extraBinds: [{ src: "/opt/data", writable: false }],
+      extraBinds: [
+        { src: "/opt/data", writable: false },
+        { src: "/opt/output", writable: true },
+      ],
     });
-    const joined = args.join(" ");
-    expect(joined).toContain("--ro-bind /opt/data /opt/data");
-  });
-
-  it("adds extra writable bind mounts", () => {
-    const args = buildBwrapArgs({
-      ...defaultParams,
-      extraBinds: [{ src: "/opt/output", writable: true }],
-    });
-    const joined = args.join(" ");
-    expect(joined).toContain("--bind /opt/output /opt/output");
+    expectBind(args, "--ro-bind", "/opt/data", "/opt/data");
+    expectBind(args, "--bind", "/opt/output", "/opt/output");
   });
 
   it("supports dest override in extra binds", () => {
@@ -173,42 +352,76 @@ describe("buildBwrapArgs", () => {
       ...defaultParams,
       extraBinds: [{ src: "/host/data", dest: "/sandbox/data" }],
     });
-    const joined = args.join(" ");
-    expect(joined).toContain("--ro-bind /host/data /sandbox/data");
+    expectBind(args, "--ro-bind", "/host/data", "/sandbox/data");
   });
 
-  it("resolves relative workdir to absolute", () => {
+  it("resolves relative workdir and extra bind sources to absolute paths", () => {
     const args = buildBwrapArgs({
       ...defaultParams,
-      workdir: "relative/path",
+      workdir: "relative/path/inside/workspace",
+      extraBinds: [{ src: "relative/input", dest: "/sandbox/input" }],
     });
-    const joined = args.join(" ");
-    const resolved = path.resolve("relative/path");
-    expect(joined).toContain(`--bind ${resolved} ${resolved}`);
+    const resolvedWorkdir = path.resolve("relative/path/inside/workspace");
+    const resolvedSrc = path.resolve("relative/input");
+    expectBind(args, "--bind", resolvedWorkdir, resolvedWorkdir);
+    expectBind(args, "--ro-bind", resolvedSrc, "/sandbox/input");
   });
 
-  it("does not duplicate shell binary mounts", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bwrap-test-"));
-    const shPath = path.join(tmpDir, "sh");
-    fs.writeFileSync(shPath, "#!/bin/sh\n", { mode: 0o755 });
+  it("does not duplicate mounts when multiple binds target the same destination", () => {
+    const args = buildBwrapArgs({
+      ...defaultParams,
+      extraBinds: [
+        { src: "/host/first", dest: "/sandbox/shared" },
+        { src: "/host/second", dest: "/sandbox/shared" },
+      ],
+    });
+    expect(countBindDest(args, "/sandbox/shared")).toBe(1);
+  });
 
-    try {
-      const args = buildBwrapArgs({
-        safeBins: new Set(["sh"]),
-        trustedSafeBinDirs: new Set([tmpDir]),
-        workdir: "/tmp/test",
-      });
+  it("does not duplicate shell binary mounts when a safeBin overlaps", () => {
+    const shPath = path.join(trustedBinDir, "sh");
+    const args = buildBwrapArgs({
+      safeBins: new Set(["sh"]),
+      trustedSafeBinDirs: new Set([trustedBinDir]),
+      workdir: "/tmp/workspace/project",
+    });
+    expect(countBindDest(args, shPath)).toBe(1);
+  });
 
-      // Count occurrences: sh should appear exactly once as --ro-bind source
-      const bindPairs: string[] = [];
-      for (let i = 0; i < args.length - 2; i++) {
-        if (args[i] === "--ro-bind" && args[i + 1] === shPath) {
-          bindPairs.push(args[i + 2]);
-        }
-      }
-      expect(bindPairs.length).toBe(1);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true });
-    }
+  it("handles spaces in workdir and rejects traversal-style bin names", () => {
+    const outsideDir = createTempDir(tempDirs, "bwrap-escape-");
+    const escapedTarget = writeExecutable(outsideDir, "evil");
+    const spacedWorkdir = "/tmp/workspace/project with spaces";
+
+    const args = buildBwrapArgs({
+      safeBins: new Set(["../evil"]),
+      trustedSafeBinDirs: new Set([trustedBinDir]),
+      workdir: spacedWorkdir,
+    });
+
+    expectBind(args, "--bind", spacedWorkdir, spacedWorkdir);
+    expect(args).not.toContain(escapedTarget);
+  });
+
+  it("warns and rejects denied extra bind paths", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    expect(() =>
+      buildBwrapArgs({
+        ...defaultParams,
+        extraBinds: [{ src: "/etc/shadow" }],
+      }),
+    ).toThrow(/denied bwrap extra bind/i);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Denied bwrap extra bind"));
+  });
+
+  it("warns and rejects denied destination bind paths", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    expect(() =>
+      buildBwrapArgs({
+        ...defaultParams,
+        extraBinds: [{ src: "/opt/data", dest: "/proc/self" }],
+      }),
+    ).toThrow(/denied bwrap extra bind/i);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("/proc/self"));
   });
 });

--- a/src/infra/exec-bwrap-sandbox.test.ts
+++ b/src/infra/exec-bwrap-sandbox.test.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type BuildBwrapArgsParams,
+  buildBwrapArgs,
+  normalizeBwrapExtraBinds,
+  normalizeBwrapSandboxMode,
+  resetBwrapCache,
+} from "./exec-bwrap-sandbox.js";
+
+afterEach(() => {
+  resetBwrapCache();
+});
+
+describe("normalizeBwrapSandboxMode", () => {
+  it("returns 'bwrap' for valid input", () => {
+    expect(normalizeBwrapSandboxMode("bwrap")).toBe("bwrap");
+    expect(normalizeBwrapSandboxMode("BWRAP")).toBe("bwrap");
+    expect(normalizeBwrapSandboxMode(" bwrap ")).toBe("bwrap");
+  });
+
+  it("returns 'none' for invalid or missing input", () => {
+    expect(normalizeBwrapSandboxMode("none")).toBe("none");
+    expect(normalizeBwrapSandboxMode(undefined)).toBe("none");
+    expect(normalizeBwrapSandboxMode(null)).toBe("none");
+    expect(normalizeBwrapSandboxMode("")).toBe("none");
+    expect(normalizeBwrapSandboxMode("docker")).toBe("none");
+    expect(normalizeBwrapSandboxMode("chroot")).toBe("none");
+  });
+});
+
+describe("normalizeBwrapExtraBinds", () => {
+  it("normalizes valid entries", () => {
+    const result = normalizeBwrapExtraBinds([
+      { src: "/data", dest: "/mnt/data", writable: true },
+      { src: "/opt/tools" },
+    ]);
+    expect(result).toEqual([
+      { src: "/data", dest: "/mnt/data", writable: true },
+      { src: "/opt/tools", dest: undefined, writable: false },
+    ]);
+  });
+
+  it("skips invalid entries", () => {
+    const result = normalizeBwrapExtraBinds([
+      { src: "" },
+      { src: 123 } as unknown as Record<string, unknown>,
+      null as unknown as Record<string, unknown>,
+      { src: "/valid" },
+    ]);
+    expect(result).toEqual([{ src: "/valid", dest: undefined, writable: false }]);
+  });
+
+  it("returns empty for null/undefined", () => {
+    expect(normalizeBwrapExtraBinds(undefined)).toEqual([]);
+    expect(normalizeBwrapExtraBinds(null)).toEqual([]);
+  });
+});
+
+describe("buildBwrapArgs", () => {
+  const defaultParams: BuildBwrapArgsParams = {
+    safeBins: new Set(["curl", "jq"]),
+    trustedSafeBinDirs: new Set(["/usr/bin"]),
+    workdir: "/home/test/workspace",
+  };
+
+  it("starts with bwrap binary", () => {
+    const args = buildBwrapArgs(defaultParams);
+    expect(args[0]).toMatch(/bwrap$/);
+  });
+
+  it("includes shell binary mounts", () => {
+    const args = buildBwrapArgs(defaultParams);
+    const joined = args.join(" ");
+    expect(joined).toContain("--ro-bind");
+  });
+
+  it("mounts safeBins binaries from trusted dirs", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bwrap-test-"));
+    const curlPath = path.join(tmpDir, "curl");
+    const jqPath = path.join(tmpDir, "jq");
+    fs.writeFileSync(curlPath, "#!/bin/sh\n", { mode: 0o755 });
+    fs.writeFileSync(jqPath, "#!/bin/sh\n", { mode: 0o755 });
+
+    try {
+      const args = buildBwrapArgs({
+        safeBins: new Set(["curl", "jq"]),
+        trustedSafeBinDirs: new Set([tmpDir]),
+        workdir: "/tmp/test",
+      });
+
+      const joined = args.join(" ");
+      expect(joined).toContain(`--ro-bind ${curlPath} ${curlPath}`);
+      expect(joined).toContain(`--ro-bind ${jqPath} ${jqPath}`);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("does not mount binaries not in safeBins", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bwrap-test-"));
+    const curlPath = path.join(tmpDir, "curl");
+    const rmPath = path.join(tmpDir, "rm");
+    fs.writeFileSync(curlPath, "#!/bin/sh\n", { mode: 0o755 });
+    fs.writeFileSync(rmPath, "#!/bin/sh\n", { mode: 0o755 });
+
+    try {
+      const args = buildBwrapArgs({
+        safeBins: new Set(["curl"]),
+        trustedSafeBinDirs: new Set([tmpDir]),
+        workdir: "/tmp/test",
+      });
+
+      const joined = args.join(" ");
+      expect(joined).toContain(`--ro-bind ${curlPath} ${curlPath}`);
+      expect(joined).not.toContain(`--ro-bind ${rmPath} ${rmPath}`);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("mounts system library paths read-only", () => {
+    const args = buildBwrapArgs(defaultParams);
+    const joined = args.join(" ");
+    if (fs.existsSync("/usr/lib")) {
+      expect(joined).toContain("--ro-bind /usr/lib /usr/lib");
+    }
+  });
+
+  it("mounts working directory read-write", () => {
+    const args = buildBwrapArgs(defaultParams);
+    const joined = args.join(" ");
+    expect(joined).toContain("--bind /home/test/workspace /home/test/workspace");
+  });
+
+  it("includes namespace isolation flags", () => {
+    const args = buildBwrapArgs(defaultParams);
+    expect(args).toContain("--unshare-all");
+    expect(args).toContain("--share-net");
+    expect(args).toContain("--die-with-parent");
+  });
+
+  it("includes pseudo-filesystems", () => {
+    const args = buildBwrapArgs(defaultParams);
+    const joined = args.join(" ");
+    expect(joined).toContain("--proc /proc");
+    expect(joined).toContain("--dev /dev");
+    expect(joined).toContain("--tmpfs /tmp");
+  });
+
+  it("adds extra read-only bind mounts", () => {
+    const args = buildBwrapArgs({
+      ...defaultParams,
+      extraBinds: [{ src: "/opt/data", writable: false }],
+    });
+    const joined = args.join(" ");
+    expect(joined).toContain("--ro-bind /opt/data /opt/data");
+  });
+
+  it("adds extra writable bind mounts", () => {
+    const args = buildBwrapArgs({
+      ...defaultParams,
+      extraBinds: [{ src: "/opt/output", writable: true }],
+    });
+    const joined = args.join(" ");
+    expect(joined).toContain("--bind /opt/output /opt/output");
+  });
+
+  it("supports dest override in extra binds", () => {
+    const args = buildBwrapArgs({
+      ...defaultParams,
+      extraBinds: [{ src: "/host/data", dest: "/sandbox/data" }],
+    });
+    const joined = args.join(" ");
+    expect(joined).toContain("--ro-bind /host/data /sandbox/data");
+  });
+
+  it("resolves relative workdir to absolute", () => {
+    const args = buildBwrapArgs({
+      ...defaultParams,
+      workdir: "relative/path",
+    });
+    const joined = args.join(" ");
+    const resolved = path.resolve("relative/path");
+    expect(joined).toContain(`--bind ${resolved} ${resolved}`);
+  });
+
+  it("does not duplicate shell binary mounts", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bwrap-test-"));
+    const shPath = path.join(tmpDir, "sh");
+    fs.writeFileSync(shPath, "#!/bin/sh\n", { mode: 0o755 });
+
+    try {
+      const args = buildBwrapArgs({
+        safeBins: new Set(["sh"]),
+        trustedSafeBinDirs: new Set([tmpDir]),
+        workdir: "/tmp/test",
+      });
+
+      // Count occurrences: sh should appear exactly once as --ro-bind source
+      const bindPairs: string[] = [];
+      for (let i = 0; i < args.length - 2; i++) {
+        if (args[i] === "--ro-bind" && args[i + 1] === shPath) {
+          bindPairs.push(args[i + 2]);
+        }
+      }
+      expect(bindPairs.length).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+});

--- a/src/infra/exec-bwrap-sandbox.ts
+++ b/src/infra/exec-bwrap-sandbox.ts
@@ -10,8 +10,8 @@
  * - bubblewrap (`bwrap`) installed (ships with Fedora/Ubuntu via Flatpak deps)
  */
 
-import { execFileSync, execFile } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -34,18 +34,45 @@ export interface BuildBwrapArgsParams {
   trustedSafeBinDirs: ReadonlySet<string>;
   /** Working directory (mounted read-write). */
   workdir: string;
+  /** Optional workspace root; when provided, workdir must stay under it. */
+  workspace?: string;
   /** Additional bind mounts. */
   extraBinds?: readonly BwrapExtraBind[];
   /** Extra shell binaries to mount (e.g. from getShellConfig). */
   extraShellBinaries?: readonly string[];
+  /**
+   * Actual command binaries used by the current command.
+   * When omitted, network access stays enabled as a safe default.
+   */
+  commandBins?: ReadonlySet<string>;
 }
 
 // ── Constants ──────────────────────────────────────────────────────
 
 /** Shell binaries that are always mounted (required for `sh -c`). */
-const SHELL_BINARIES = ["sh", "bash", "env"];
+const SHELL_BINARIES = ["sh", "bash"];
 
-/** System library paths mounted read-only for dynamic linking. */
+/** Commands that still need host networking inside this filesystem sandbox. */
+const NETWORK_REQUIRED_BINS = new Set([
+  "curl",
+  "git",
+  "pip3",
+  "npm",
+  "pnpm",
+  "node",
+  "python3",
+  "ollama",
+  "edge-tts",
+  "yt-dlp",
+  "gh",
+  "mcporter",
+  "systemctl",
+]);
+
+/** Known bubblewrap install locations, checked in order. */
+const BWRAP_PATH_CANDIDATES = ["/usr/bin/bwrap", "/usr/local/bin/bwrap", "/bin/bwrap"];
+
+/** Shell + tool library roots mounted read-only for dynamic linking. */
 const SYSTEM_LIB_PATHS = ["/lib", "/lib64", "/usr/lib", "/usr/lib64"];
 
 /** System config paths mounted read-only (SSL, DNS, locale, etc). */
@@ -56,63 +83,46 @@ const SYSTEM_CONFIG_PATHS = [
   "/etc/resolv.conf",
   "/etc/hosts",
   "/etc/nsswitch.conf",
-  "/etc/passwd",
-  "/etc/group",
   "/etc/localtime",
   "/etc/alternatives",
 ];
 
+const SYNTHETIC_PASSWD_CONTENT = "nobody:x:65534:65534:Nobody:/nonexistent:/usr/sbin/nologin\n";
+const SYNTHETIC_GROUP_CONTENT = "nogroup:x:65534:\n";
+
+const DENIED_BIND_PATHS = new Set([
+  "/etc/shadow",
+  "/etc/sudoers",
+  "/proc",
+  "/sys",
+  path.join(os.homedir(), ".ssh"),
+  path.join(os.homedir(), ".gnupg"),
+]);
+
 // ── Bwrap Detection (cached after first probe) ───────────────────
 
-let _bwrapPath: string | false | undefined;
+let _bwrapPath: string | null | undefined;
+let _syntheticIdentityDir: string | undefined;
 
 /**
- * Check if bwrap is available (sync, cached).
- * First call may block briefly; subsequent calls return immediately.
+ * Resolve the installed bwrap path (sync, cached).
+ * Returns null when bubblewrap is unavailable.
  */
-export function isBwrapAvailable(): boolean {
+export function getBwrapPath(): string | null {
   if (_bwrapPath !== undefined) {
-    return _bwrapPath !== false;
-  }
-  try {
-    const result = execFileSync("which", ["bwrap"], {
-      encoding: "utf8",
-      timeout: 3000,
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-    _bwrapPath = result || false;
-  } catch {
-    _bwrapPath = false;
-  }
-  return _bwrapPath !== false;
-}
-
-/**
- * Async variant of isBwrapAvailable — prefer this in hot paths
- * to avoid blocking the event loop on first probe.
- */
-export function isBwrapAvailableAsync(): Promise<boolean> {
-  if (_bwrapPath !== undefined) {
-    return Promise.resolve(_bwrapPath !== false);
-  }
-  return new Promise((resolve) => {
-    execFile("which", ["bwrap"], { timeout: 3000 }, (err, stdout) => {
-      if (err || !stdout?.trim()) {
-        _bwrapPath = false;
-        resolve(false);
-      } else {
-        _bwrapPath = stdout.trim();
-        resolve(true);
-      }
-    });
-  });
-}
-
-export function getBwrapPath(): string {
-  if (typeof _bwrapPath === "string") {
     return _bwrapPath;
   }
-  return "/usr/bin/bwrap";
+  for (const candidate of BWRAP_PATH_CANDIDATES) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      _bwrapPath = candidate;
+      return candidate;
+    } catch {
+      // Try the next known location.
+    }
+  }
+  _bwrapPath = null;
+  return null;
 }
 
 /** Reset cached bwrap detection (for testing). */
@@ -153,40 +163,62 @@ export function normalizeBwrapExtraBinds(value: unknown): BwrapExtraBind[] {
 /**
  * Build the argv prefix for a bwrap-sandboxed command.
  *
+ * This is filesystem-focused isolation only. Network access is still shared by
+ * default unless `commandBins` proves the current command only needs local-only
+ * tooling.
+ *
  * Returns an array like:
- *   ["bwrap", "--unshare-all", "--share-net", ...]
+ *   ["/usr/bin/bwrap", "--unshare-all", "--share-net", ...]
  *
  * The caller appends the separator and the actual command:
  *   [...buildBwrapArgs(params), "--", "sh", "-c", command]
  */
 export function buildBwrapArgs(params: BuildBwrapArgsParams): string[] {
-  const args: string[] = [getBwrapPath()];
-  const workdir = path.resolve(params.workdir);
+  const bwrapPath = getBwrapPath();
+  if (!bwrapPath) {
+    throw new Error("bubblewrap unavailable: bwrap not found in /usr/bin, /usr/local/bin, or /bin");
+  }
+
+  const args: string[] = [bwrapPath];
+  const workdir = validateWorkdir(params.workdir, params.workspace);
   const mounted = new Set<string>();
 
-  // Helper: add a bind mount, deduplicating by destination
+  // Helper: add a bind mount, deduplicating by normalized destination.
   const addBind = (src: string, dest: string, writable: boolean) => {
-    if (mounted.has(dest)) {
+    const normalizedDest = path.resolve(dest);
+    if (mounted.has(normalizedDest)) {
       return;
     }
-    mounted.add(dest);
+    mounted.add(normalizedDest);
     args.push(writable ? "--bind" : "--ro-bind", src, dest);
   };
 
   // ── Namespace isolation ──
-  args.push("--unshare-all", "--share-net", "--die-with-parent");
+  args.push("--unshare-all");
+  if (shouldShareNetwork(params.commandBins)) {
+    args.push("--share-net");
+  }
+  args.push("--die-with-parent", "--new-session");
+
+  // TODO(security): add a seccomp-bpf profile via `bwrap --seccomp <fd>`.
+  // Initial profile should keep common safe-bin workloads working while denying
+  // obviously dangerous kernel attack surface that this PR does not yet cover,
+  // including: ptrace, mount, umount2, bpf, kexec_load, kexec_file_load,
+  // pivot_root, swapon, and swapoff.
 
   // ── Pseudo-filesystems ──
   args.push("--proc", "/proc");
   args.push("--dev", "/dev");
+  // `/tmp` is intentionally a sandbox-local tmpfs, so host `/tmp` files are not
+  // visible inside the namespace unless explicitly mounted via `extraBinds`.
   args.push("--tmpfs", "/tmp");
 
   // ── Shell binaries (always needed for sh -c execution) ──
-  // Mount defaults plus any extra shells from getShellConfig()
+  // Mount defaults plus any extra shells from getShellConfig().
   const allShells = new Set(SHELL_BINARIES);
   if (params.extraShellBinaries) {
-    for (const s of params.extraShellBinaries) {
-      allShells.add(s);
+    for (const shellBinary of params.extraShellBinaries) {
+      allShells.add(shellBinary);
     }
   }
   for (const name of allShells) {
@@ -205,6 +237,9 @@ export function buildBwrapArgs(params: BuildBwrapArgsParams): string[] {
   }
 
   // ── System libraries (dynamic linker, shared objects) ──
+  // TODO(security): harden this further by mounting only the libraries required
+  // by the actually-mounted executables (e.g. `ldd`-scoped mounts) instead of
+  // exposing entire library roots.
   for (const libPath of SYSTEM_LIB_PATHS) {
     if (fs.existsSync(libPath)) {
       addBind(libPath, libPath, false);
@@ -218,14 +253,21 @@ export function buildBwrapArgs(params: BuildBwrapArgsParams): string[] {
     }
   }
 
+  const syntheticIdentityFiles = ensureSyntheticIdentityFiles();
+  addBind(syntheticIdentityFiles.passwd, "/etc/passwd", false);
+  addBind(syntheticIdentityFiles.group, "/etc/group", false);
+
   // ── Working directory (read-write) ──
   addBind(workdir, workdir, true);
+  args.push("--chdir", workdir);
 
   // ── Extra user-specified binds ──
   if (params.extraBinds) {
     for (const bind of params.extraBinds) {
-      const dest = bind.dest || bind.src;
-      addBind(bind.src, dest, bind.writable ?? false);
+      const src = resolveBindPath(bind.src);
+      const dest = bind.dest ? resolveBindPath(bind.dest) : src;
+      assertAllowedExtraBind(src, dest);
+      addBind(src, dest, bind.writable ?? false);
     }
   }
 
@@ -234,18 +276,115 @@ export function buildBwrapArgs(params: BuildBwrapArgsParams): string[] {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
+export function validateWorkdir(workdir: string, workspace?: string): string {
+  const resolvedWorkdir = path.resolve(workdir);
+  const segments = resolvedWorkdir.split(path.sep).filter(Boolean);
+
+  if (
+    resolvedWorkdir === path.parse(resolvedWorkdir).root ||
+    resolvedWorkdir === "/home" ||
+    resolvedWorkdir === "/root" ||
+    segments.length <= 1
+  ) {
+    throw new Error(`Refusing to mount unsafe bwrap workdir: ${resolvedWorkdir}`);
+  }
+
+  if (workspace) {
+    const resolvedWorkspace = path.resolve(workspace);
+    if (!isPathWithin(resolvedWorkdir, resolvedWorkspace)) {
+      throw new Error(
+        `Refusing to mount bwrap workdir outside workspace: ${resolvedWorkdir} (workspace: ${resolvedWorkspace})`,
+      );
+    }
+  }
+
+  return resolvedWorkdir;
+}
+
+function shouldShareNetwork(commandBins?: ReadonlySet<string>): boolean {
+  if (commandBins === undefined) {
+    return true;
+  }
+  for (const bin of commandBins) {
+    if (NETWORK_REQUIRED_BINS.has(bin.toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Resolve a binary name in trusted directories. Returns absolute path or null. */
 function resolveInDirs(name: string, dirs: ReadonlySet<string>): string | null {
+  const trustedDirs = Array.from(dirs, (dir) => resolveTrustedDir(dir));
   for (const dir of dirs) {
     const candidate = path.join(dir, name);
     try {
       const stat = fs.statSync(candidate);
-      if (stat.isFile()) {
-        return candidate;
+      if (!stat.isFile()) {
+        continue;
       }
+      const resolved = fs.realpathSync(candidate);
+      if (!trustedDirs.some((trustedDir) => isPathWithin(resolved, trustedDir))) {
+        continue;
+      }
+      return candidate;
     } catch {
-      // Not found in this dir, continue
+      // Not found in this dir, broken symlink, or escaped trusted roots.
     }
   }
   return null;
+}
+
+function resolveTrustedDir(dir: string): string {
+  try {
+    return fs.realpathSync(dir);
+  } catch {
+    return path.resolve(dir);
+  }
+}
+
+function ensureSyntheticIdentityFiles(): { passwd: string; group: string } {
+  if (!_syntheticIdentityDir) {
+    _syntheticIdentityDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bwrap-identity-"));
+  }
+  const passwdPath = path.join(_syntheticIdentityDir, "passwd");
+  const groupPath = path.join(_syntheticIdentityDir, "group");
+  fs.writeFileSync(passwdPath, SYNTHETIC_PASSWD_CONTENT, { mode: 0o644 });
+  fs.writeFileSync(groupPath, SYNTHETIC_GROUP_CONTENT, { mode: 0o644 });
+  return { passwd: passwdPath, group: groupPath };
+}
+
+function resolveBindPath(input: string): string {
+  return path.resolve(expandHomePrefix(input));
+}
+
+function expandHomePrefix(input: string): string {
+  if (input === "~") {
+    return os.homedir();
+  }
+  if (input.startsWith(`~${path.sep}`)) {
+    return path.join(os.homedir(), input.slice(2));
+  }
+  return input;
+}
+
+function assertAllowedExtraBind(src: string, dest: string): void {
+  if (isDeniedBindPath(src) || isDeniedBindPath(dest)) {
+    console.warn(`Denied bwrap extra bind: ${src} -> ${dest}`);
+    throw new Error(`Refusing denied bwrap extra bind: ${src} -> ${dest}`);
+  }
+}
+
+function isDeniedBindPath(candidate: string): boolean {
+  for (const deniedPath of DENIED_BIND_PATHS) {
+    if (isPathWithin(candidate, deniedPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isPathWithin(candidate: string, parent: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }

--- a/src/infra/exec-bwrap-sandbox.ts
+++ b/src/infra/exec-bwrap-sandbox.ts
@@ -10,7 +10,7 @@
  * - bubblewrap (`bwrap`) installed (ships with Fedora/Ubuntu via Flatpak deps)
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -36,6 +36,8 @@ export interface BuildBwrapArgsParams {
   workdir: string;
   /** Additional bind mounts. */
   extraBinds?: readonly BwrapExtraBind[];
+  /** Extra shell binaries to mount (e.g. from getShellConfig). */
+  extraShellBinaries?: readonly string[];
 }
 
 // ── Constants ──────────────────────────────────────────────────────
@@ -60,10 +62,14 @@ const SYSTEM_CONFIG_PATHS = [
   "/etc/alternatives",
 ];
 
-// ── Bwrap Detection (cached) ──────────────────────────────────────
+// ── Bwrap Detection (cached after first probe) ───────────────────
 
 let _bwrapPath: string | false | undefined;
 
+/**
+ * Check if bwrap is available (sync, cached).
+ * First call may block briefly; subsequent calls return immediately.
+ */
 export function isBwrapAvailable(): boolean {
   if (_bwrapPath !== undefined) {
     return _bwrapPath !== false;
@@ -79,6 +85,27 @@ export function isBwrapAvailable(): boolean {
     _bwrapPath = false;
   }
   return _bwrapPath !== false;
+}
+
+/**
+ * Async variant of isBwrapAvailable — prefer this in hot paths
+ * to avoid blocking the event loop on first probe.
+ */
+export function isBwrapAvailableAsync(): Promise<boolean> {
+  if (_bwrapPath !== undefined) {
+    return Promise.resolve(_bwrapPath !== false);
+  }
+  return new Promise((resolve) => {
+    execFile("which", ["bwrap"], { timeout: 3000 }, (err, stdout) => {
+      if (err || !stdout?.trim()) {
+        _bwrapPath = false;
+        resolve(false);
+      } else {
+        _bwrapPath = stdout.trim();
+        resolve(true);
+      }
+    });
+  });
 }
 
 export function getBwrapPath(): string {
@@ -127,9 +154,9 @@ export function normalizeBwrapExtraBinds(value: unknown): BwrapExtraBind[] {
  * Build the argv prefix for a bwrap-sandboxed command.
  *
  * Returns an array like:
- *   ["bwrap", "--unshare-all", "--share-net", ..., "--"]
+ *   ["bwrap", "--unshare-all", "--share-net", ...]
  *
- * The caller appends the actual command after "--":
+ * The caller appends the separator and the actual command:
  *   [...buildBwrapArgs(params), "--", "sh", "-c", command]
  */
 export function buildBwrapArgs(params: BuildBwrapArgsParams): string[] {
@@ -155,7 +182,14 @@ export function buildBwrapArgs(params: BuildBwrapArgsParams): string[] {
   args.push("--tmpfs", "/tmp");
 
   // ── Shell binaries (always needed for sh -c execution) ──
-  for (const name of SHELL_BINARIES) {
+  // Mount defaults plus any extra shells from getShellConfig()
+  const allShells = new Set(SHELL_BINARIES);
+  if (params.extraShellBinaries) {
+    for (const s of params.extraShellBinaries) {
+      allShells.add(s);
+    }
+  }
+  for (const name of allShells) {
     const resolved = resolveInDirs(name, params.trustedSafeBinDirs);
     if (resolved) {
       addBind(resolved, resolved, false);

--- a/src/infra/exec-bwrap-sandbox.ts
+++ b/src/infra/exec-bwrap-sandbox.ts
@@ -1,0 +1,217 @@
+/**
+ * Bubblewrap (bwrap) namespace sandbox for safeBins exec commands.
+ *
+ * Wraps commands in an unprivileged user namespace where only approved
+ * binaries, system libraries, and the working directory are visible.
+ * Trust windows bypass this entirely.
+ *
+ * Requirements:
+ * - Linux (user namespaces must be enabled)
+ * - bubblewrap (`bwrap`) installed (ships with Fedora/Ubuntu via Flatpak deps)
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type BwrapSandboxMode = "none" | "bwrap";
+
+export interface BwrapExtraBind {
+  /** Source path on the host. */
+  src: string;
+  /** Destination path inside the sandbox (defaults to src). */
+  dest?: string;
+  /** Mount read-write (default: false = read-only). */
+  writable?: boolean;
+}
+
+export interface BuildBwrapArgsParams {
+  /** Set of approved safe-bin names (e.g. "curl", "jq"). */
+  safeBins: ReadonlySet<string>;
+  /** Directories to search for safe-bin binaries. */
+  trustedSafeBinDirs: ReadonlySet<string>;
+  /** Working directory (mounted read-write). */
+  workdir: string;
+  /** Additional bind mounts. */
+  extraBinds?: readonly BwrapExtraBind[];
+}
+
+// ── Constants ──────────────────────────────────────────────────────
+
+/** Shell binaries that are always mounted (required for `sh -c`). */
+const SHELL_BINARIES = ["sh", "bash", "env"];
+
+/** System library paths mounted read-only for dynamic linking. */
+const SYSTEM_LIB_PATHS = ["/lib", "/lib64", "/usr/lib", "/usr/lib64"];
+
+/** System config paths mounted read-only (SSL, DNS, locale, etc). */
+const SYSTEM_CONFIG_PATHS = [
+  "/etc/ssl",
+  "/etc/pki",
+  "/etc/ca-certificates",
+  "/etc/resolv.conf",
+  "/etc/hosts",
+  "/etc/nsswitch.conf",
+  "/etc/passwd",
+  "/etc/group",
+  "/etc/localtime",
+  "/etc/alternatives",
+];
+
+// ── Bwrap Detection (cached) ──────────────────────────────────────
+
+let _bwrapPath: string | false | undefined;
+
+export function isBwrapAvailable(): boolean {
+  if (_bwrapPath !== undefined) {
+    return _bwrapPath !== false;
+  }
+  try {
+    const result = execFileSync("which", ["bwrap"], {
+      encoding: "utf8",
+      timeout: 3000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    _bwrapPath = result || false;
+  } catch {
+    _bwrapPath = false;
+  }
+  return _bwrapPath !== false;
+}
+
+export function getBwrapPath(): string {
+  if (typeof _bwrapPath === "string") {
+    return _bwrapPath;
+  }
+  return "/usr/bin/bwrap";
+}
+
+/** Reset cached bwrap detection (for testing). */
+export function resetBwrapCache(): void {
+  _bwrapPath = undefined;
+}
+
+// ── Config Normalization ──────────────────────────────────────────
+
+export function normalizeBwrapSandboxMode(value: unknown): BwrapSandboxMode {
+  if (typeof value === "string" && value.trim().toLowerCase() === "bwrap") {
+    return "bwrap";
+  }
+  return "none";
+}
+
+export function normalizeBwrapExtraBinds(value: unknown): BwrapExtraBind[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter(
+      (entry): entry is Record<string, unknown> =>
+        entry != null &&
+        typeof entry === "object" &&
+        typeof (entry as Record<string, unknown>).src === "string" &&
+        ((entry as Record<string, unknown>).src as string).length > 0,
+    )
+    .map((entry) => ({
+      src: entry.src as string,
+      dest: typeof entry.dest === "string" ? entry.dest : undefined,
+      writable: entry.writable === true,
+    }));
+}
+
+// ── Core: Build bwrap Arguments ───────────────────────────────────
+
+/**
+ * Build the argv prefix for a bwrap-sandboxed command.
+ *
+ * Returns an array like:
+ *   ["bwrap", "--unshare-all", "--share-net", ..., "--"]
+ *
+ * The caller appends the actual command after "--":
+ *   [...buildBwrapArgs(params), "--", "sh", "-c", command]
+ */
+export function buildBwrapArgs(params: BuildBwrapArgsParams): string[] {
+  const args: string[] = [getBwrapPath()];
+  const workdir = path.resolve(params.workdir);
+  const mounted = new Set<string>();
+
+  // Helper: add a bind mount, deduplicating by destination
+  const addBind = (src: string, dest: string, writable: boolean) => {
+    if (mounted.has(dest)) {
+      return;
+    }
+    mounted.add(dest);
+    args.push(writable ? "--bind" : "--ro-bind", src, dest);
+  };
+
+  // ── Namespace isolation ──
+  args.push("--unshare-all", "--share-net", "--die-with-parent");
+
+  // ── Pseudo-filesystems ──
+  args.push("--proc", "/proc");
+  args.push("--dev", "/dev");
+  args.push("--tmpfs", "/tmp");
+
+  // ── Shell binaries (always needed for sh -c execution) ──
+  for (const name of SHELL_BINARIES) {
+    const resolved = resolveInDirs(name, params.trustedSafeBinDirs);
+    if (resolved) {
+      addBind(resolved, resolved, false);
+    }
+  }
+
+  // ── SafeBins binaries ──
+  for (const name of params.safeBins) {
+    const resolved = resolveInDirs(name, params.trustedSafeBinDirs);
+    if (resolved) {
+      addBind(resolved, resolved, false);
+    }
+  }
+
+  // ── System libraries (dynamic linker, shared objects) ──
+  for (const libPath of SYSTEM_LIB_PATHS) {
+    if (fs.existsSync(libPath)) {
+      addBind(libPath, libPath, false);
+    }
+  }
+
+  // ── System config (SSL certs, DNS, locale) ──
+  for (const cfgPath of SYSTEM_CONFIG_PATHS) {
+    if (fs.existsSync(cfgPath)) {
+      addBind(cfgPath, cfgPath, false);
+    }
+  }
+
+  // ── Working directory (read-write) ──
+  addBind(workdir, workdir, true);
+
+  // ── Extra user-specified binds ──
+  if (params.extraBinds) {
+    for (const bind of params.extraBinds) {
+      const dest = bind.dest || bind.src;
+      addBind(bind.src, dest, bind.writable ?? false);
+    }
+  }
+
+  return args;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+/** Resolve a binary name in trusted directories. Returns absolute path or null. */
+function resolveInDirs(name: string, dirs: ReadonlySet<string>): string | null {
+  for (const dir of dirs) {
+    const candidate = path.join(dir, name);
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isFile()) {
+        return candidate;
+      }
+    } catch {
+      // Not found in this dir, continue
+    }
+  }
+  return null;
+}

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -59,7 +59,6 @@ export type AppViewState = {
   chatToolMessages: unknown[];
   chatStreamSegments: Array<{ text: string; ts: number }>;
   chatStream: string | null;
-  chatStreamSegments: Array<{ text: string; ts: number }>;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
   compactionStatus: CompactionStatus | null;


### PR DESCRIPTION
## What

Adds kernel-level filesystem isolation for safeBins-approved commands using [bubblewrap](https://github.com/containers/bubblewrap) (bwrap) unprivileged user namespaces on Linux.

## Why

The current safeBins fence validates command names but can't prevent absolute-path bypasses (e.g. `/usr/bin/rm`). With bwrap, the binary simply doesn't exist inside the sandbox — filesystem isolation is enforced by the kernel, not by argument parsing.

## How

When `tools.exec.nsSandbox.mode` is set to `"bwrap"`, commands that pass safeBins validation are wrapped in a bwrap namespace where only:

- **Approved binaries** — resolved from `trustedSafeBinDirs`, mounted read-only
- **Shell binaries** — `sh`, `bash`, `env` always available for `sh -c`
- **System libraries** — `/lib`, `/usr/lib` etc. for dynamic linking (read-only)
- **System config** — SSL certs, DNS, locale (read-only)
- **Working directory** — mounted read-write
- **Extra mounts** — configurable via `nsSandbox.extraBinds`

Everything else is invisible. Namespace isolation uses `--unshare-all --share-net --die-with-parent`.

### Interaction with other security layers

| State | Behavior |
|---|---|
| Trust window active | No sandbox (run directly) |
| No trust + safeBins match + bwrap enabled | Wrapped in bwrap namespace |
| No trust + safeBins match + bwrap disabled | Run directly (existing behavior) |
| No trust + not safeBins | Ask for approval (existing behavior) |
| Docker sandbox (`host=sandbox`) | Docker takes precedence, no bwrap |
| PTY requested | Skip bwrap (terminal allocation unreliable in namespaces) |

Composes cleanly with trust windows (PR #39126).

### Config

```jsonc
{
  "tools": {
    "exec": {
      "nsSandbox": {
        "mode": "bwrap",  // "bwrap" | "none" (default)
        "extraBinds": [
          { "src": "/opt/data", "writable": false },
          { "src": "/opt/output", "writable": true }
        ]
      }
    }
  }
}
```

Requires bubblewrap installed (`bwrap`). Ships with Fedora/Ubuntu via Flatpak deps. Falls back to no-sandbox gracefully if not available.

## Files changed (8)

| File | Change |
|---|---|
| `src/infra/exec-bwrap-sandbox.ts` | **New** — Core module: bwrap arg builder, detection, config normalization |
| `src/infra/exec-bwrap-sandbox.test.ts` | **New** — 18 unit tests |
| `src/config/types.tools.ts` | Add `nsSandbox` to `ExecToolConfig` |
| `src/agents/bash-tools.exec-types.ts` | Add `nsSandbox` to `ExecToolDefaults` |
| `src/agents/bash-tools.exec-runtime.ts` | Add bwrap spawn path in `runExecProcess` |
| `src/agents/bash-tools.exec-host-gateway.ts` | Build bwrap params when safeBins match |
| `src/agents/bash-tools.exec.ts` | Thread bwrap params from gateway → runtime |
| `src/agents/pi-tools.ts` | Thread `nsSandbox` config through defaults |

## Testing

- 18 new unit tests for bwrap module (arg building, mount dedup, config normalization, binary resolution)
- 47 existing safeBins tests still passing
- `tsc --noEmit` — zero errors from our changes
- Manual: bwrap v0.11.0 on Fedora 43

## AI Disclosure

AI-assisted (Tommy/Claude Opus 4.6). All code reviewed and understood by contributor.