### PR TITLE
fix(plugin-sdk): add legacy keyed-async-queue export alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,10 @@
       "types": "./dist/plugin-sdk/keyed-async-queue.d.ts",
       "default": "./dist/plugin-sdk/keyed-async-queue.js"
     },
+    "./plugin-sdk/index.js/keyed-async-queue": {
+      "types": "./dist/plugin-sdk/keyed-async-queue.d.ts",
+      "default": "./dist/plugin-sdk/keyed-async-queue.js"
+    },
     "./cli-entry": "./openclaw.mjs"
   },
   "scripts": {

--- a/src/plugin-sdk/exports-map.test.ts
+++ b/src/plugin-sdk/exports-map.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("plugin-sdk package exports map", () => {
+  it("keeps legacy keyed-async-queue subpath alias for published plugins", () => {
+    const packageJsonPath = resolve(import.meta.dirname, "../../package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const exportsMap = packageJson.exports as Record<string, { default?: string; types?: string }>;
+
+    expect(exportsMap["./plugin-sdk/index.js/keyed-async-queue"]).toEqual({
+      types: "./dist/plugin-sdk/keyed-async-queue.d.ts",
+      default: "./dist/plugin-sdk/keyed-async-queue.js",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: Some Matrix plugin installs resolve `openclaw/plugin-sdk/index.js/keyed-async-queue` and fail when that legacy subpath is not exported.
- Why it matters: Matrix plugin startup can crash with `Cannot find module .../plugin-sdk/index.js/keyed-async-queue`, blocking channel initialization.
- What changed: Added a backwards-compatible package export alias `./plugin-sdk/index.js/keyed-async-queue` to the same keyed queue dist artifacts.
- What did NOT change (scope boundary): No runtime queue logic changes; no channel behavior changes beyond subpath resolution compatibility.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39236
- Related #39149

## User-visible / Behavior Changes

Legacy import path `openclaw/plugin-sdk/index.js/keyed-async-queue` now resolves to the keyed queue implementation instead of failing module resolution.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Matrix plugin-sdk import path
- Relevant config (redacted): none

### Steps

1. Add legacy alias export in package.json for `./plugin-sdk/index.js/keyed-async-queue`.
2. Add focused regression test asserting alias entry exists and maps to keyed queue artifacts.
3. Run `pnpm --dir . exec vitest run src/plugin-sdk/exports-map.test.ts`.

### Expected

- Legacy subpath is present in package exports.
- Regression test passes.

### Actual

- ✅ Alias present.
- ✅ Test passed locally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before (repro from issue):

```text
Error: Cannot find module '/.../openclaw/dist/plugin-sdk/index.js/keyed-async-queue'
```

After (local validation):

```bash
pnpm --dir /home/chen/.openclaw/workspace/tmp-openclaw exec vitest run src/plugin-sdk/exports-map.test.ts
# 1 passed
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: export map includes legacy keyed queue alias.
- Edge cases checked: alias points to the same JS + DTS artifacts as canonical `./plugin-sdk/keyed-async-queue`.
- What you did **not** verify: end-to-end plugin load on a globally installed 2026.3.x binary.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `package.json`, `src/plugin-sdk/exports-map.test.ts`.
- Known bad symptoms reviewers should watch for: none expected; only extra export map key.

## Risks and Mitigations

- Risk: Very low risk of export map bloat/confusion.
  - Mitigation: Alias maps to existing keyed queue artifacts and is covered by a focused regression test.
