### PR TITLE
fix(agents): apply turn-ordering sanitization for strict OpenAI-compatible providers

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -594,10 +594,19 @@ export async function sanitizeSessionHistory(params: {
     return sanitizedOpenAI;
   }
 
-  return applyGoogleTurnOrderingFix({
-    messages: sanitizedOpenAI,
-    modelApi: params.modelApi,
-    sessionManager: params.sessionManager,
-    sessionId: params.sessionId,
-  }).messages;
+  // Google models use the full wrapper with logging and session markers.
+  if (isGoogleModelApi(params.modelApi)) {
+    return applyGoogleTurnOrderingFix({
+      messages: sanitizedOpenAI,
+      modelApi: params.modelApi,
+      sessionManager: params.sessionManager,
+      sessionId: params.sessionId,
+    }).messages;
+  }
+
+  // Strict OpenAI-compatible providers (vLLM, Gemma, etc.) also reject
+  // conversations that start with an assistant turn (e.g. delivery-mirror
+  // messages after /new).  Apply the same ordering fix without the
+  // Google-specific session markers.  See #38962.
+  return sanitizeGoogleTurnOrdering(sanitizedOpenAI);
 }

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -120,6 +120,17 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.preserveSignatures).toBe(false);
   });
 
+  it("enables turn-ordering and assistant-merge for strict OpenAI-compatible providers (#38962)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "vllm",
+      modelId: "gemma-3-27b",
+      modelApi: "openai-completions",
+    });
+    expect(policy.applyGoogleTurnOrdering).toBe(true);
+    expect(policy.validateGeminiTurns).toBe(true);
+    expect(policy.validateAnthropicTurns).toBe(true);
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -127,8 +127,8 @@ export function resolveTranscriptPolicy(params: {
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,
-    applyGoogleTurnOrdering: !isOpenAi && isGoogle,
-    validateGeminiTurns: !isOpenAi && isGoogle,
+    applyGoogleTurnOrdering: !isOpenAi && (isGoogle || isStrictOpenAiCompatible),
+    validateGeminiTurns: !isOpenAi && (isGoogle || isStrictOpenAiCompatible),
     validateAnthropicTurns: !isOpenAi && (isAnthropic || isStrictOpenAiCompatible),
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
   };


### PR DESCRIPTION
## Summary
- Strict OpenAI-compatible providers (vLLM, Gemma, etc.) reject conversations that start with an assistant turn or contain consecutive assistant messages
- After `/new` or `/reset` on Telegram, a `delivery-mirror` assistant message is injected into the session transcript, causing a leading assistant turn that triggers a 400 "Conversation roles must alternate" error
- Enable `applyGoogleTurnOrdering` and `validateGeminiTurns` for `isStrictOpenAiCompatible` providers so the same turn-ordering sanitization that already works for Google models also applies here

## Changes
- `transcript-policy.ts`: Enable `applyGoogleTurnOrdering` and `validateGeminiTurns` for strict OpenAI-compatible providers
- `google.ts` (`sanitizeSessionHistory`): Add non-Google path that calls `sanitizeGoogleTurnOrdering` directly (since `applyGoogleTurnOrderingFix` has an internal `isGoogleModelApi` guard)
- `transcript-policy.test.ts`: Add test verifying vLLM/Gemma gets the correct policy flags

## Test plan
- [x] Added test for strict OpenAI-compatible provider (vLLM/Gemma) policy resolution
- [x] All 14 transcript-policy tests pass
- [x] All 25 turn-ordering/validation tests pass (existing behavior preserved)

Fixes #38962

🤖 Generated with [Claude Code](https://claude.com/claude-code)