### PR TITLE
Fix duplicated provider prefix in model refs for non-OpenRouter providers

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -149,13 +149,21 @@ describe("model-selection", () => {
     });
 
     it("strips duplicated provider prefix for non-openrouter refs", () => {
-      expect(parseModelRef("gemini/gemini-2.0-flash", "openai")).toEqual({
+      expect(parseModelRef("gemini/gemini/gemini-2.0-flash", "openai")).toEqual({
         provider: "gemini",
         model: "gemini-2.0-flash",
       });
       expect(parseModelRef("openai/openai/gpt-5.2", "anthropic")).toEqual({
         provider: "openai",
         model: "gpt-5.2",
+      });
+      expect(parseModelRef("anthropic/anthropic/claude-sonnet-4-5", "openai")).toEqual({
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+      });
+      expect(parseModelRef("google/google/gemini-2.0-flash", "openai")).toEqual({
+        provider: "google",
+        model: "gemini-2.0-flash",
       });
     });
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -148,6 +148,17 @@ describe("model-selection", () => {
       });
     });
 
+    it("strips duplicated provider prefix for non-openrouter refs", () => {
+      expect(parseModelRef("gemini/gemini-2.0-flash", "openai")).toEqual({
+        provider: "gemini",
+        model: "gemini-2.0-flash",
+      });
+      expect(parseModelRef("openai/openai/gpt-5.2", "anthropic")).toEqual({
+        provider: "openai",
+        model: "gpt-5.2",
+      });
+    });
+
     it("normalizes Vercel Claude shorthand to anthropic-prefixed model ids", () => {
       expect(parseModelRef("vercel-ai-gateway/claude-opus-4.6", "openai")).toEqual({
         provider: "vercel-ai-gateway",

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -136,6 +136,18 @@ function normalizeProviderModelId(provider: string, model: string): string {
   if (provider === "google") {
     return normalizeGoogleModelId(model);
   }
+
+  // For non-OpenRouter providers, tolerate accidental "provider/model" input
+  // when a provider is already selected. This keeps API payloads model-only
+  // (e.g. "gemini-2.0-flash" instead of "gemini/gemini-2.0-flash").
+  if (provider !== "openrouter") {
+    const lower = model.toLowerCase();
+    const ownPrefix = `${provider}/`;
+    if (lower.startsWith(ownPrefix)) {
+      return model.slice(ownPrefix.length);
+    }
+  }
+
   // OpenRouter-native models (e.g. "openrouter/aurora-alpha") need the full
   // "openrouter/<name>" as the model ID sent to the API. Models from external
   // providers already contain a slash (e.g. "anthropic/claude-sonnet-4-5") and

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -123,39 +123,41 @@ function normalizeAnthropicModelId(model: string): string {
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {
-  if (provider === "anthropic") {
-    return normalizeAnthropicModelId(model);
-  }
-  if (provider === "vercel-ai-gateway" && !model.includes("/")) {
-    // Allow Vercel-specific Claude refs without an upstream prefix.
-    const normalizedAnthropicModel = normalizeAnthropicModelId(model);
-    if (normalizedAnthropicModel.startsWith("claude-")) {
-      return `anthropic/${normalizedAnthropicModel}`;
-    }
-  }
-  if (provider === "google") {
-    return normalizeGoogleModelId(model);
-  }
+  let normalizedModel = model;
 
   // For non-OpenRouter providers, tolerate accidental "provider/model" input
   // when a provider is already selected. This keeps API payloads model-only
   // (e.g. "gemini-2.0-flash" instead of "gemini/gemini-2.0-flash").
   if (provider !== "openrouter") {
-    const lower = model.toLowerCase();
+    const lower = normalizedModel.toLowerCase();
     const ownPrefix = `${provider}/`;
     if (lower.startsWith(ownPrefix)) {
-      return model.slice(ownPrefix.length);
+      normalizedModel = normalizedModel.slice(ownPrefix.length);
     }
+  }
+
+  if (provider === "anthropic") {
+    return normalizeAnthropicModelId(normalizedModel);
+  }
+  if (provider === "vercel-ai-gateway" && !normalizedModel.includes("/")) {
+    // Allow Vercel-specific Claude refs without an upstream prefix.
+    const normalizedAnthropicModel = normalizeAnthropicModelId(normalizedModel);
+    if (normalizedAnthropicModel.startsWith("claude-")) {
+      return `anthropic/${normalizedAnthropicModel}`;
+    }
+  }
+  if (provider === "google") {
+    return normalizeGoogleModelId(normalizedModel);
   }
 
   // OpenRouter-native models (e.g. "openrouter/aurora-alpha") need the full
   // "openrouter/<name>" as the model ID sent to the API. Models from external
   // providers already contain a slash (e.g. "anthropic/claude-sonnet-4-5") and
   // are passed through as-is (#12924).
-  if (provider === "openrouter" && !model.includes("/")) {
-    return `openrouter/${model}`;
+  if (provider === "openrouter" && !normalizedModel.includes("/")) {
+    return `openrouter/${normalizedModel}`;
   }
-  return model;
+  return normalizedModel;
 }
 
 export function normalizeModelRef(provider: string, model: string): ModelRef {


### PR DESCRIPTION
## Summary
- strip duplicated `provider/` prefix from model ids when a non-OpenRouter provider is already selected
- keep OpenRouter behavior unchanged so native `openrouter/<model>` ids and routed provider ids still work
- add regression coverage for duplicated provider-prefixed refs (including `gemini/gemini-2.0-flash`)

## Reproducible issue linkage
Fixes #39253

## Validation
- `NO_COLOR=1 pnpm -C /home/chen/.openclaw/workspace/tmp-openclaw test src/agents/model-selection.test.ts`