### PR TITLE
fix: add nativeModules to jiti config for native addon resolution

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -581,6 +581,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+      // Native addon resolver packages locate .node binaries relative to
+      // module.filename/__dirname. When jiti transpiles these modules it sets
+      // module.filename to its own path, so the lookup fails. Listing the
+      // resolvers here delegates them to Node's native require, preserving
+      // correct path resolution for any addon that depends on them.
+      // See: https://github.com/openclaw/openclaw/issues/21676
+      nativeModules: ["bindings", "node-gyp-build"],
       ...(Object.keys(aliasMap).length > 0
         ? {
             alias: aliasMap,


### PR DESCRIPTION
## Summary

- Adds `nativeModules: ["bindings", "node-gyp-build"]` to the jiti config in `src/plugins/loader.ts`
- This delegates native addon resolver packages to Node's native `require` instead of transpiling them through jiti, preserving correct `module.filename`/`__dirname` resolution

## Problem

Plugins depending on packages with native `.node` addons (e.g. `sqlite3` via the [`bindings`](https://www.npmjs.com/package/bindings) package) fail to load because jiti sets `module.filename` to its own path. The `bindings` package walks up from `module.filename` to find `build/Release/*.node`, but since the path points to jiti's internals, it never finds the binary:

```
Error: Could not locate the bindings file. Tried:
 → /path/to/openclaw/node_modules/jiti/build/Release/node_sqlite3.node
 → /path/to/openclaw/node_modules/jiti/lib/binding/node-v127-darwin-arm64/node_sqlite3.node
 … (all under jiti's directory instead of the plugin's)
```

## Fix

jiti already supports `nativeModules` — modules listed there bypass jiti's transpiler and use Node's native `require`, which preserves correct `module.filename` and `__dirname`. 

Rather than listing individual native addon packages (sqlite3, better-sqlite3, etc.), we list the two **resolver packages** that virtually all native addons use:

- **`bindings`** — used by `sqlite3`, `canvas`, `bcrypt`, `keytar`, `node-pty`, `serialport`, etc.
- **`node-gyp-build`** — used by `better-sqlite3`, `lmdb`, `sodium-native`, `utf-8-validate`, `bufferutil`, etc.

This covers any current or future native addon that uses either resolver, rather than needing to maintain a growing list of individual packages.

## Test plan

- [ ] Verify `openclaw-mem0` plugin loads successfully with `sqlite3` dependency
- [ ] Verify existing plugins without native addons still load correctly
- [ ] Verify the gateway starts without plugin load errors

Fixes #21676

🤖 Generated with [Claude Code](https://claude.com/claude-code)