### PR TITLE
fix(synology-chat): use nullish coalescing for SYNOLOGY_RATE_LIMIT=0

### DIFF
--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -80,7 +80,7 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
     rateLimitPerMinute:
       accountOverride.rateLimitPerMinute ??
       channelCfg.rateLimitPerMinute ??
-      (envRateLimit ? parseInt(envRateLimit, 10) || 30 : 30),
+      (envRateLimit ? parseInt(envRateLimit, 10) ?? 30 : 30),
     botName: accountOverride.botName ?? channelCfg.botName ?? envBotName,
     allowInsecureSsl: accountOverride.allowInsecureSsl ?? channelCfg.allowInsecureSsl ?? false,
   };

--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -64,6 +64,7 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
   const envAllowedUserIds = process.env.SYNOLOGY_ALLOWED_USER_IDS ?? "";
   const envRateLimit = process.env.SYNOLOGY_RATE_LIMIT;
   const envBotName = process.env.OPENCLAW_BOT_NAME ?? "OpenClaw";
+  const parsedRate = envRateLimit ? parseInt(envRateLimit, 10) : NaN;
 
   // Merge: account override > base channel config > env var
   return {
@@ -80,7 +81,7 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
     rateLimitPerMinute:
       accountOverride.rateLimitPerMinute ??
       channelCfg.rateLimitPerMinute ??
-      (envRateLimit ? parseInt(envRateLimit, 10) ?? 30 : 30),
+      (Number.isNaN(parsedRate) ? 30 : parsedRate),
     botName: accountOverride.botName ?? channelCfg.botName ?? envBotName,
     allowInsecureSsl: accountOverride.allowInsecureSsl ?? channelCfg.allowInsecureSsl ?? false,
   };


### PR DESCRIPTION
## Summary

- `parseInt("0", 10)` returns `0`, and `0 || 30` evaluates to `30`, silently ignoring the user's explicit rate limit of 0
- Switch from `||` to `??` (nullish coalescing) so only `undefined`/`null` triggers the default

## Change

`extensions/synology-chat/src/accounts.ts:83`

```diff
- (envRateLimit ? parseInt(envRateLimit, 10) || 30 : 30)
+ (envRateLimit ? parseInt(envRateLimit, 10) ?? 30 : 30)
```

## Test plan

- [ ] Setting `SYNOLOGY_RATE_LIMIT=0` should produce `rateLimitPerMinute: 0`
- [ ] Setting `SYNOLOGY_RATE_LIMIT=60` should still produce `rateLimitPerMinute: 60`
- [ ] Omitting `SYNOLOGY_RATE_LIMIT` should still default to `30`

Fixes #39191

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>