### PR TITLE
Fix browser timeout propagation for local actions and CLI commands

### DIFF
--- a/src/browser/pw-session.abort-fallback.test.ts
+++ b/src/browser/pw-session.abort-fallback.test.ts
@@ -1,0 +1,95 @@
+import { chromium } from "playwright-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as cdpHelpers from "./cdp.helpers.js";
+import * as chromeModule from "./chrome.js";
+import {
+  closePlaywrightBrowserConnection,
+  forceDisconnectPlaywrightForTarget,
+  getPageForTargetId,
+} from "./pw-session.js";
+
+const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
+const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
+const fetchJsonSpy = vi.spyOn(cdpHelpers, "fetchJson");
+const withCdpSocketSpy = vi.spyOn(cdpHelpers, "withCdpSocket");
+
+function installMultiPageBrowserMocks() {
+  const pageOne = {
+    on: vi.fn(),
+  } as unknown as import("playwright-core").Page;
+  const pageTwo = {
+    on: vi.fn(),
+  } as unknown as import("playwright-core").Page;
+
+  const context = {
+    pages: () => [pageOne, pageTwo],
+    on: vi.fn(),
+  } as unknown as import("playwright-core").BrowserContext;
+
+  const browserClose = vi.fn(async () => {});
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  connectOverCdpSpy.mockResolvedValue(browser);
+  getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+  return { browserClose };
+}
+
+afterEach(async () => {
+  fetchJsonSpy.mockReset();
+  withCdpSocketSpy.mockReset();
+  connectOverCdpSpy.mockReset();
+  getChromeWebSocketUrlSpy.mockReset();
+  await closePlaywrightBrowserConnection().catch(() => {});
+});
+
+describe("forceDisconnectPlaywrightForTarget", () => {
+  it("keeps a multi-page shared connection alive when target-local termination succeeds", async () => {
+    const { browserClose } = installMultiPageBrowserMocks();
+    fetchJsonSpy.mockResolvedValue([
+      {
+        id: "target-1",
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+      },
+    ]);
+    withCdpSocketSpy.mockImplementation(async (_wsUrl, work) => {
+      await work(async () => ({}));
+    });
+
+    await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9222" });
+    await forceDisconnectPlaywrightForTarget({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "target-1",
+    });
+
+    expect(browserClose).not.toHaveBeenCalled();
+  });
+
+  it("falls back to shared disconnect when target-local termination fails", async () => {
+    const { browserClose } = installMultiPageBrowserMocks();
+    fetchJsonSpy.mockResolvedValue([
+      {
+        id: "target-1",
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+      },
+    ]);
+    withCdpSocketSpy.mockImplementation(async (_wsUrl, work) => {
+      await work(async () => {
+        throw new Error("Runtime.terminateExecution unsupported");
+      });
+    });
+
+    await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9222" });
+    await forceDisconnectPlaywrightForTarget({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "target-1",
+    });
+
+    expect(browserClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -582,7 +582,7 @@ function cdpSocketNeedsAttach(wsUrl: string): boolean {
 async function tryTerminateExecutionViaCdp(opts: {
   cdpUrl: string;
   targetId: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const cdpHttpBase = normalizeCdpHttpBaseForJsonEndpoints(opts.cdpUrl);
   const listUrl = appendCdpPath(cdpHttpBase, "/json/list");
 
@@ -593,16 +593,17 @@ async function tryTerminateExecutionViaCdp(opts: {
     }>
   >(listUrl, 2000).catch(() => null);
   if (!pages || pages.length === 0) {
-    return;
+    return false;
   }
 
   const target = pages.find((p) => String(p.id ?? "").trim() === opts.targetId);
   const wsUrlRaw = String(target?.webSocketDebuggerUrl ?? "").trim();
   if (!wsUrlRaw) {
-    return;
+    return false;
   }
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, cdpHttpBase);
   const needsAttach = cdpSocketNeedsAttach(wsUrl);
+  let terminated = false;
 
   const runWithTimeout = async <T>(work: Promise<T>, ms: number): Promise<T> => {
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -633,6 +634,7 @@ async function tryTerminateExecutionViaCdp(opts: {
           }
         }
         await runWithTimeout(send("Runtime.terminateExecution", undefined, sessionId), 1500);
+        terminated = true;
         if (sessionId) {
           // Best-effort cleanup; not required for termination to take effect.
           void send("Target.detachFromTarget", { sessionId }).catch(() => {});
@@ -643,6 +645,8 @@ async function tryTerminateExecutionViaCdp(opts: {
     },
     { handshakeTimeoutMs: 2000 },
   ).catch(() => {});
+
+  return terminated;
 }
 
 /**
@@ -679,9 +683,12 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
   // consider disconnecting Playwright's shared CDP connection.
   const targetId = opts.targetId?.trim() || "";
   if (targetId) {
-    await tryTerminateExecutionViaCdp({ cdpUrl: normalized, targetId }).catch(() => {});
+    const terminated = await tryTerminateExecutionViaCdp({
+      cdpUrl: normalized,
+      targetId,
+    }).catch(() => false);
     const pages = await getAllPages(cur.browser).catch(() => []);
-    if (pages.length > 1) {
+    if (pages.length > 1 && terminated) {
       return;
     }
   }

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -671,31 +671,36 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
   reason?: string;
 }): Promise<void> {
   const normalized = normalizeCdpUrl(opts.cdpUrl);
-  if (cached?.cdpUrl !== normalized) {
+  const cur = cached;
+  if (cur?.cdpUrl !== normalized) {
     return;
   }
-  const cur = cached;
-  cached = null;
+  // Best-effort: kill any stuck JS to unblock the target's execution context before we
+  // consider disconnecting Playwright's shared CDP connection.
+  const targetId = opts.targetId?.trim() || "";
+  if (targetId) {
+    await tryTerminateExecutionViaCdp({ cdpUrl: normalized, targetId }).catch(() => {});
+    const pages = await getAllPages(cur.browser).catch(() => []);
+    if (pages.length > 1) {
+      return;
+    }
+  }
+
+  if (cached?.browser === cur.browser) {
+    cached = null;
+  }
   // Also clear `connecting` so the next call does a fresh connectOverCDP
   // rather than awaiting a stale promise.
   connecting = null;
-  if (cur) {
-    // Remove the "disconnected" listener to prevent the old browser's teardown
-    // from racing with a fresh connection and nulling the new `cached`.
-    if (cur.onDisconnected && typeof cur.browser.off === "function") {
-      cur.browser.off("disconnected", cur.onDisconnected);
-    }
 
-    // Best-effort: kill any stuck JS to unblock the target's execution context before we
-    // disconnect Playwright's CDP connection.
-    const targetId = opts.targetId?.trim() || "";
-    if (targetId) {
-      await tryTerminateExecutionViaCdp({ cdpUrl: normalized, targetId }).catch(() => {});
-    }
-
-    // Fire-and-forget: don't await because browser.close() may hang on the stuck CDP pipe.
-    cur.browser.close().catch(() => {});
+  // Remove the "disconnected" listener to prevent the old browser's teardown
+  // from racing with a fresh connection and nulling the new `cached`.
+  if (cur.onDisconnected && typeof cur.browser.off === "function") {
+    cur.browser.off("disconnected", cur.onDisconnected);
   }
+
+  // Fire-and-forget: don't await because browser.close() may hang on the stuck CDP pipe.
+  cur.browser.close().catch(() => {});
 }
 
 /**

--- a/src/browser/pw-tools-core.interactions.abort.test.ts
+++ b/src/browser/pw-tools-core.interactions.abort.test.ts
@@ -72,4 +72,45 @@ describe("clickViaPlaywright (abort)", () => {
       }),
     );
   });
+
+  it("rejects immediately on abort even if disconnect cleanup is still pending", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    let resolveClick!: () => void;
+    let resolveDisconnect!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingClick = new Promise<void>((resolve) => {
+      resolveClick = resolve;
+    });
+    forceDisconnectPlaywrightForTarget.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveDisconnect = resolve;
+        }),
+    );
+
+    page = {};
+    locator = {
+      click: vi.fn(() => {
+        resolveStarted();
+        return pendingClick;
+      }),
+    };
+
+    const promise = clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      ref: "e1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("abort should win"));
+    resolveClick();
+
+    await expect(promise).rejects.toThrow("abort should win");
+    resolveDisconnect();
+  });
 });

--- a/src/browser/pw-tools-core.interactions.abort.test.ts
+++ b/src/browser/pw-tools-core.interactions.abort.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let page: Record<string, unknown> | null = null;
+let locator: { click: ReturnType<typeof vi.fn> } | null = null;
+
+const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+const getPageForTargetId = vi.fn(async () => {
+  if (!page) {
+    throw new Error("test: page not set");
+  }
+  return page;
+});
+const ensurePageState = vi.fn(() => {});
+const restoreRoleRefsForTarget = vi.fn(() => {});
+const refLocator = vi.fn(() => {
+  if (!locator) {
+    throw new Error("test: locator not set");
+  }
+  return locator;
+});
+
+vi.mock("./pw-session.js", () => ({
+  ensurePageState,
+  forceDisconnectPlaywrightForTarget,
+  getPageForTargetId,
+  refLocator,
+  restoreRoleRefsForTarget,
+}));
+
+let clickViaPlaywright: typeof import("./pw-tools-core.interactions.js").clickViaPlaywright;
+
+describe("clickViaPlaywright (abort)", () => {
+  beforeAll(async () => {
+    ({ clickViaPlaywright } = await import("./pw-tools-core.interactions.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disconnects the target when a click is aborted after it starts", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingClick = new Promise<void>(() => {});
+
+    page = {};
+    locator = {
+      click: vi.fn(() => {
+        resolveStarted();
+        return pendingClick;
+      }),
+    };
+
+    const promise = clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      ref: "e1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("aborted by test"));
+
+    await expect(promise).rejects.toThrow("aborted by test");
+    expect(forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "page-1",
+      }),
+    );
+  });
+});

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -22,6 +22,66 @@ async function getRestoredPageForTarget(opts: TargetOpts) {
   return page;
 }
 
+async function runAbortablePlaywrightAction<T>(
+  opts: TargetOpts & { signal?: AbortSignal },
+  work: () => Promise<T>,
+): Promise<T> {
+  const signal = opts.signal;
+  if (!signal) {
+    return await work();
+  }
+
+  const abortReason = () => signal.reason ?? new Error("aborted");
+  const disconnect = async () => {
+    await forceDisconnectPlaywrightForTarget({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      reason: "abort browser action",
+    }).catch(() => {});
+  };
+
+  if (signal.aborted) {
+    await disconnect();
+    throw abortReason();
+  }
+
+  let completed = false;
+  let abortTriggered = false;
+  let abortListener: (() => void) | undefined;
+  const abortPromise: Promise<never> = new Promise((_, reject) => {
+    abortListener = () => {
+      if (completed || abortTriggered) {
+        return;
+      }
+      abortTriggered = true;
+      void disconnect().finally(() => reject(abortReason()));
+    };
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+
+  if (signal.aborted) {
+    abortListener?.();
+  }
+  if (abortTriggered) {
+    return await abortPromise;
+  }
+
+  const workPromise = work().finally(() => {
+    completed = true;
+  });
+
+  try {
+    return await Promise.race([workPromise, abortPromise]);
+  } catch (err) {
+    void workPromise.catch(() => {});
+    throw err;
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
 function resolveInteractionTimeoutMs(timeoutMs?: number): number {
   return Math.max(500, Math.min(60_000, Math.floor(timeoutMs ?? 8000)));
 }
@@ -64,28 +124,31 @@ export async function clickViaPlaywright(opts: {
   button?: "left" | "right" | "middle";
   modifiers?: Array<"Alt" | "Control" | "ControlOrMeta" | "Meta" | "Shift">;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getRestoredPageForTarget(opts);
-  const ref = requireRef(opts.ref);
-  const locator = refLocator(page, ref);
-  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
-  try {
-    if (opts.doubleClick) {
-      await locator.dblclick({
-        timeout,
-        button: opts.button,
-        modifiers: opts.modifiers,
-      });
-    } else {
-      await locator.click({
-        timeout,
-        button: opts.button,
-        modifiers: opts.modifiers,
-      });
+  await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getRestoredPageForTarget(opts);
+    const ref = requireRef(opts.ref);
+    const locator = refLocator(page, ref);
+    const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+    try {
+      if (opts.doubleClick) {
+        await locator.dblclick({
+          timeout,
+          button: opts.button,
+          modifiers: opts.modifiers,
+        });
+      } else {
+        await locator.click({
+          timeout,
+          button: opts.button,
+          modifiers: opts.modifiers,
+        });
+      }
+    } catch (err) {
+      throw toAIFriendlyError(err, ref);
     }
-  } catch (err) {
-    throw toAIFriendlyError(err, ref);
-  }
+  });
 }
 
 export async function hoverViaPlaywright(opts: {
@@ -93,16 +156,19 @@ export async function hoverViaPlaywright(opts: {
   targetId?: string;
   ref: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const ref = requireRef(opts.ref);
-  const page = await getRestoredPageForTarget(opts);
-  try {
-    await refLocator(page, ref).hover({
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
-  } catch (err) {
-    throw toAIFriendlyError(err, ref);
-  }
+  await runAbortablePlaywrightAction(opts, async () => {
+    const ref = requireRef(opts.ref);
+    const page = await getRestoredPageForTarget(opts);
+    try {
+      await refLocator(page, ref).hover({
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      });
+    } catch (err) {
+      throw toAIFriendlyError(err, ref);
+    }
+  });
 }
 
 export async function dragViaPlaywright(opts: {
@@ -111,20 +177,23 @@ export async function dragViaPlaywright(opts: {
   startRef: string;
   endRef: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const startRef = requireRef(opts.startRef);
-  const endRef = requireRef(opts.endRef);
-  if (!startRef || !endRef) {
-    throw new Error("startRef and endRef are required");
-  }
-  const page = await getRestoredPageForTarget(opts);
-  try {
-    await refLocator(page, startRef).dragTo(refLocator(page, endRef), {
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
-  } catch (err) {
-    throw toAIFriendlyError(err, `${startRef} -> ${endRef}`);
-  }
+  await runAbortablePlaywrightAction(opts, async () => {
+    const startRef = requireRef(opts.startRef);
+    const endRef = requireRef(opts.endRef);
+    if (!startRef || !endRef) {
+      throw new Error("startRef and endRef are required");
+    }
+    const page = await getRestoredPageForTarget(opts);
+    try {
+      await refLocator(page, startRef).dragTo(refLocator(page, endRef), {
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      });
+    } catch (err) {
+      throw toAIFriendlyError(err, `${startRef} -> ${endRef}`);
+    }
+  });
 }
 
 export async function selectOptionViaPlaywright(opts: {
@@ -133,19 +202,22 @@ export async function selectOptionViaPlaywright(opts: {
   ref: string;
   values: string[];
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const ref = requireRef(opts.ref);
-  if (!opts.values?.length) {
-    throw new Error("values are required");
-  }
-  const page = await getRestoredPageForTarget(opts);
-  try {
-    await refLocator(page, ref).selectOption(opts.values, {
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
-  } catch (err) {
-    throw toAIFriendlyError(err, ref);
-  }
+  await runAbortablePlaywrightAction(opts, async () => {
+    const ref = requireRef(opts.ref);
+    if (!opts.values?.length) {
+      throw new Error("values are required");
+    }
+    const page = await getRestoredPageForTarget(opts);
+    try {
+      await refLocator(page, ref).selectOption(opts.values, {
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      });
+    } catch (err) {
+      throw toAIFriendlyError(err, ref);
+    }
+  });
 }
 
 export async function pressKeyViaPlaywright(opts: {
@@ -153,15 +225,18 @@ export async function pressKeyViaPlaywright(opts: {
   targetId?: string;
   key: string;
   delayMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const key = String(opts.key ?? "").trim();
-  if (!key) {
-    throw new Error("key is required");
-  }
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  await page.keyboard.press(key, {
-    delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
+  await runAbortablePlaywrightAction(opts, async () => {
+    const key = String(opts.key ?? "").trim();
+    if (!key) {
+      throw new Error("key is required");
+    }
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    await page.keyboard.press(key, {
+      delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
+    });
   });
 }
 
@@ -173,25 +248,28 @@ export async function typeViaPlaywright(opts: {
   submit?: boolean;
   slowly?: boolean;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const text = String(opts.text ?? "");
-  const page = await getRestoredPageForTarget(opts);
-  const ref = requireRef(opts.ref);
-  const locator = refLocator(page, ref);
-  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
-  try {
-    if (opts.slowly) {
-      await locator.click({ timeout });
-      await locator.type(text, { timeout, delay: 75 });
-    } else {
-      await locator.fill(text, { timeout });
+  await runAbortablePlaywrightAction(opts, async () => {
+    const text = String(opts.text ?? "");
+    const page = await getRestoredPageForTarget(opts);
+    const ref = requireRef(opts.ref);
+    const locator = refLocator(page, ref);
+    const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+    try {
+      if (opts.slowly) {
+        await locator.click({ timeout });
+        await locator.type(text, { timeout, delay: 75 });
+      } else {
+        await locator.fill(text, { timeout });
+      }
+      if (opts.submit) {
+        await locator.press("Enter", { timeout });
+      }
+    } catch (err) {
+      throw toAIFriendlyError(err, ref);
     }
-    if (opts.submit) {
-      await locator.press("Enter", { timeout });
-    }
-  } catch (err) {
-    throw toAIFriendlyError(err, ref);
-  }
+  });
 }
 
 export async function fillFormViaPlaywright(opts: {
@@ -199,39 +277,42 @@ export async function fillFormViaPlaywright(opts: {
   targetId?: string;
   fields: BrowserFormField[];
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getRestoredPageForTarget(opts);
-  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
-  for (const field of opts.fields) {
-    const ref = field.ref.trim();
-    const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
-    const rawValue = field.value;
-    const value =
-      typeof rawValue === "string"
-        ? rawValue
-        : typeof rawValue === "number" || typeof rawValue === "boolean"
-          ? String(rawValue)
-          : "";
-    if (!ref) {
-      continue;
-    }
-    const locator = refLocator(page, ref);
-    if (type === "checkbox" || type === "radio") {
-      const checked =
-        rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
+  await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getRestoredPageForTarget(opts);
+    const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+    for (const field of opts.fields) {
+      const ref = field.ref.trim();
+      const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
+      const rawValue = field.value;
+      const value =
+        typeof rawValue === "string"
+          ? rawValue
+          : typeof rawValue === "number" || typeof rawValue === "boolean"
+            ? String(rawValue)
+            : "";
+      if (!ref) {
+        continue;
+      }
+      const locator = refLocator(page, ref);
+      if (type === "checkbox" || type === "radio") {
+        const checked =
+          rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
+        try {
+          await locator.setChecked(checked, { timeout });
+        } catch (err) {
+          throw toAIFriendlyError(err, ref);
+        }
+        continue;
+      }
       try {
-        await locator.setChecked(checked, { timeout });
+        await locator.fill(value, { timeout });
       } catch (err) {
         throw toAIFriendlyError(err, ref);
       }
-      continue;
     }
-    try {
-      await locator.fill(value, { timeout });
-    } catch (err) {
-      throw toAIFriendlyError(err, ref);
-    }
-  }
+  });
 }
 
 export async function evaluateViaPlaywright(opts: {
@@ -369,17 +450,20 @@ export async function scrollIntoViewViaPlaywright(opts: {
   targetId?: string;
   ref: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getRestoredPageForTarget(opts);
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
+  await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getRestoredPageForTarget(opts);
+    const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
 
-  const ref = requireRef(opts.ref);
-  const locator = refLocator(page, ref);
-  try {
-    await locator.scrollIntoViewIfNeeded({ timeout });
-  } catch (err) {
-    throw toAIFriendlyError(err, ref);
-  }
+    const ref = requireRef(opts.ref);
+    const locator = refLocator(page, ref);
+    try {
+      await locator.scrollIntoViewIfNeeded({ timeout });
+    } catch (err) {
+      throw toAIFriendlyError(err, ref);
+    }
+  });
 }
 
 export async function waitForViaPlaywright(opts: {
@@ -393,47 +477,50 @@ export async function waitForViaPlaywright(opts: {
   loadState?: "load" | "domcontentloaded" | "networkidle";
   fn?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
+  await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
 
-  if (typeof opts.timeMs === "number" && Number.isFinite(opts.timeMs)) {
-    await page.waitForTimeout(Math.max(0, opts.timeMs));
-  }
-  if (opts.text) {
-    await page.getByText(opts.text).first().waitFor({
-      state: "visible",
-      timeout,
-    });
-  }
-  if (opts.textGone) {
-    await page.getByText(opts.textGone).first().waitFor({
-      state: "hidden",
-      timeout,
-    });
-  }
-  if (opts.selector) {
-    const selector = String(opts.selector).trim();
-    if (selector) {
-      await page.locator(selector).first().waitFor({ state: "visible", timeout });
+    if (typeof opts.timeMs === "number" && Number.isFinite(opts.timeMs)) {
+      await page.waitForTimeout(Math.max(0, opts.timeMs));
     }
-  }
-  if (opts.url) {
-    const url = String(opts.url).trim();
-    if (url) {
-      await page.waitForURL(url, { timeout });
+    if (opts.text) {
+      await page.getByText(opts.text).first().waitFor({
+        state: "visible",
+        timeout,
+      });
     }
-  }
-  if (opts.loadState) {
-    await page.waitForLoadState(opts.loadState, { timeout });
-  }
-  if (opts.fn) {
-    const fn = String(opts.fn).trim();
-    if (fn) {
-      await page.waitForFunction(fn, { timeout });
+    if (opts.textGone) {
+      await page.getByText(opts.textGone).first().waitFor({
+        state: "hidden",
+        timeout,
+      });
     }
-  }
+    if (opts.selector) {
+      const selector = String(opts.selector).trim();
+      if (selector) {
+        await page.locator(selector).first().waitFor({ state: "visible", timeout });
+      }
+    }
+    if (opts.url) {
+      const url = String(opts.url).trim();
+      if (url) {
+        await page.waitForURL(url, { timeout });
+      }
+    }
+    if (opts.loadState) {
+      await page.waitForLoadState(opts.loadState, { timeout });
+    }
+    if (opts.fn) {
+      const fn = String(opts.fn).trim();
+      if (fn) {
+        await page.waitForFunction(fn, { timeout });
+      }
+    }
+  });
 }
 
 export async function takeScreenshotViaPlaywright(opts: {
@@ -443,32 +530,35 @@ export async function takeScreenshotViaPlaywright(opts: {
   element?: string;
   fullPage?: boolean;
   type?: "png" | "jpeg";
+  signal?: AbortSignal;
 }): Promise<{ buffer: Buffer }> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
-  const type = opts.type ?? "png";
-  if (opts.ref) {
-    if (opts.fullPage) {
-      throw new Error("fullPage is not supported for element screenshots");
+  return await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+    const type = opts.type ?? "png";
+    if (opts.ref) {
+      if (opts.fullPage) {
+        throw new Error("fullPage is not supported for element screenshots");
+      }
+      const locator = refLocator(page, opts.ref);
+      const buffer = await locator.screenshot({ type });
+      return { buffer };
     }
-    const locator = refLocator(page, opts.ref);
-    const buffer = await locator.screenshot({ type });
-    return { buffer };
-  }
-  if (opts.element) {
-    if (opts.fullPage) {
-      throw new Error("fullPage is not supported for element screenshots");
+    if (opts.element) {
+      if (opts.fullPage) {
+        throw new Error("fullPage is not supported for element screenshots");
+      }
+      const locator = page.locator(opts.element).first();
+      const buffer = await locator.screenshot({ type });
+      return { buffer };
     }
-    const locator = page.locator(opts.element).first();
-    const buffer = await locator.screenshot({ type });
+    const buffer = await page.screenshot({
+      type,
+      fullPage: Boolean(opts.fullPage),
+    });
     return { buffer };
-  }
-  const buffer = await page.screenshot({
-    type,
-    fullPage: Boolean(opts.fullPage),
   });
-  return { buffer };
 }
 
 export async function screenshotWithLabelsViaPlaywright(opts: {
@@ -477,125 +567,128 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   refs: Record<string, { role: string; name?: string; nth?: number }>;
   maxLabels?: number;
   type?: "png" | "jpeg";
+  signal?: AbortSignal;
 }): Promise<{ buffer: Buffer; labels: number; skipped: number }> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
-  const type = opts.type ?? "png";
-  const maxLabels =
-    typeof opts.maxLabels === "number" && Number.isFinite(opts.maxLabels)
-      ? Math.max(1, Math.floor(opts.maxLabels))
-      : 150;
+  return await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+    const type = opts.type ?? "png";
+    const maxLabels =
+      typeof opts.maxLabels === "number" && Number.isFinite(opts.maxLabels)
+        ? Math.max(1, Math.floor(opts.maxLabels))
+        : 150;
 
-  const viewport = await page.evaluate(() => ({
-    scrollX: window.scrollX || 0,
-    scrollY: window.scrollY || 0,
-    width: window.innerWidth || 0,
-    height: window.innerHeight || 0,
-  }));
+    const viewport = await page.evaluate(() => ({
+      scrollX: window.scrollX || 0,
+      scrollY: window.scrollY || 0,
+      width: window.innerWidth || 0,
+      height: window.innerHeight || 0,
+    }));
 
-  const refs = Object.keys(opts.refs ?? {});
-  const boxes: Array<{ ref: string; x: number; y: number; w: number; h: number }> = [];
-  let skipped = 0;
+    const refs = Object.keys(opts.refs ?? {});
+    const boxes: Array<{ ref: string; x: number; y: number; w: number; h: number }> = [];
+    let skipped = 0;
 
-  for (const ref of refs) {
-    if (boxes.length >= maxLabels) {
-      skipped += 1;
-      continue;
-    }
-    try {
-      const box = await refLocator(page, ref).boundingBox();
-      if (!box) {
+    for (const ref of refs) {
+      if (boxes.length >= maxLabels) {
         skipped += 1;
         continue;
       }
-      const x0 = box.x;
-      const y0 = box.y;
-      const x1 = box.x + box.width;
-      const y1 = box.y + box.height;
-      const vx0 = viewport.scrollX;
-      const vy0 = viewport.scrollY;
-      const vx1 = viewport.scrollX + viewport.width;
-      const vy1 = viewport.scrollY + viewport.height;
-      if (x1 < vx0 || x0 > vx1 || y1 < vy0 || y0 > vy1) {
-        skipped += 1;
-        continue;
-      }
-      boxes.push({
-        ref,
-        x: x0 - viewport.scrollX,
-        y: y0 - viewport.scrollY,
-        w: Math.max(1, box.width),
-        h: Math.max(1, box.height),
-      });
-    } catch {
-      skipped += 1;
-    }
-  }
-
-  try {
-    if (boxes.length > 0) {
-      await page.evaluate((labels) => {
-        const existing = document.querySelectorAll("[data-openclaw-labels]");
-        existing.forEach((el) => el.remove());
-
-        const root = document.createElement("div");
-        root.setAttribute("data-openclaw-labels", "1");
-        root.style.position = "fixed";
-        root.style.left = "0";
-        root.style.top = "0";
-        root.style.zIndex = "2147483647";
-        root.style.pointerEvents = "none";
-        root.style.fontFamily =
-          '"SF Mono","SFMono-Regular",Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace';
-
-        const clamp = (value: number, min: number, max: number) =>
-          Math.min(max, Math.max(min, value));
-
-        for (const label of labels) {
-          const box = document.createElement("div");
-          box.setAttribute("data-openclaw-labels", "1");
-          box.style.position = "absolute";
-          box.style.left = `${label.x}px`;
-          box.style.top = `${label.y}px`;
-          box.style.width = `${label.w}px`;
-          box.style.height = `${label.h}px`;
-          box.style.border = "2px solid #ffb020";
-          box.style.boxSizing = "border-box";
-
-          const tag = document.createElement("div");
-          tag.setAttribute("data-openclaw-labels", "1");
-          tag.textContent = label.ref;
-          tag.style.position = "absolute";
-          tag.style.left = `${label.x}px`;
-          tag.style.top = `${clamp(label.y - 18, 0, 20000)}px`;
-          tag.style.background = "#ffb020";
-          tag.style.color = "#1a1a1a";
-          tag.style.fontSize = "12px";
-          tag.style.lineHeight = "14px";
-          tag.style.padding = "1px 4px";
-          tag.style.borderRadius = "3px";
-          tag.style.boxShadow = "0 1px 2px rgba(0,0,0,0.35)";
-          tag.style.whiteSpace = "nowrap";
-
-          root.appendChild(box);
-          root.appendChild(tag);
+      try {
+        const box = await refLocator(page, ref).boundingBox();
+        if (!box) {
+          skipped += 1;
+          continue;
         }
-
-        document.documentElement.appendChild(root);
-      }, boxes);
+        const x0 = box.x;
+        const y0 = box.y;
+        const x1 = box.x + box.width;
+        const y1 = box.y + box.height;
+        const vx0 = viewport.scrollX;
+        const vy0 = viewport.scrollY;
+        const vx1 = viewport.scrollX + viewport.width;
+        const vy1 = viewport.scrollY + viewport.height;
+        if (x1 < vx0 || x0 > vx1 || y1 < vy0 || y0 > vy1) {
+          skipped += 1;
+          continue;
+        }
+        boxes.push({
+          ref,
+          x: x0 - viewport.scrollX,
+          y: y0 - viewport.scrollY,
+          w: Math.max(1, box.width),
+          h: Math.max(1, box.height),
+        });
+      } catch {
+        skipped += 1;
+      }
     }
 
-    const buffer = await page.screenshot({ type });
-    return { buffer, labels: boxes.length, skipped };
-  } finally {
-    await page
-      .evaluate(() => {
-        const existing = document.querySelectorAll("[data-openclaw-labels]");
-        existing.forEach((el) => el.remove());
-      })
-      .catch(() => {});
-  }
+    try {
+      if (boxes.length > 0) {
+        await page.evaluate((labels) => {
+          const existing = document.querySelectorAll("[data-openclaw-labels]");
+          existing.forEach((el) => el.remove());
+
+          const root = document.createElement("div");
+          root.setAttribute("data-openclaw-labels", "1");
+          root.style.position = "fixed";
+          root.style.left = "0";
+          root.style.top = "0";
+          root.style.zIndex = "2147483647";
+          root.style.pointerEvents = "none";
+          root.style.fontFamily =
+            '"SF Mono","SFMono-Regular",Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace';
+
+          const clamp = (value: number, min: number, max: number) =>
+            Math.min(max, Math.max(min, value));
+
+          for (const label of labels) {
+            const box = document.createElement("div");
+            box.setAttribute("data-openclaw-labels", "1");
+            box.style.position = "absolute";
+            box.style.left = `${label.x}px`;
+            box.style.top = `${label.y}px`;
+            box.style.width = `${label.w}px`;
+            box.style.height = `${label.h}px`;
+            box.style.border = "2px solid #ffb020";
+            box.style.boxSizing = "border-box";
+
+            const tag = document.createElement("div");
+            tag.setAttribute("data-openclaw-labels", "1");
+            tag.textContent = label.ref;
+            tag.style.position = "absolute";
+            tag.style.left = `${label.x}px`;
+            tag.style.top = `${clamp(label.y - 18, 0, 20000)}px`;
+            tag.style.background = "#ffb020";
+            tag.style.color = "#1a1a1a";
+            tag.style.fontSize = "12px";
+            tag.style.lineHeight = "14px";
+            tag.style.padding = "1px 4px";
+            tag.style.borderRadius = "3px";
+            tag.style.boxShadow = "0 1px 2px rgba(0,0,0,0.35)";
+            tag.style.whiteSpace = "nowrap";
+
+            root.appendChild(box);
+            root.appendChild(tag);
+          }
+
+          document.documentElement.appendChild(root);
+        }, boxes);
+      }
+
+      const buffer = await page.screenshot({ type });
+      return { buffer, labels: boxes.length, skipped };
+    } finally {
+      await page
+        .evaluate(() => {
+          const existing = document.querySelectorAll("[data-openclaw-labels]");
+          existing.forEach((el) => el.remove());
+        })
+        .catch(() => {});
+    }
+  });
 }
 
 export async function setInputFilesViaPlaywright(opts: {

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -32,8 +32,8 @@ async function runAbortablePlaywrightAction<T>(
   }
 
   const abortReason = () => signal.reason ?? new Error("aborted");
-  const disconnect = async () => {
-    await forceDisconnectPlaywrightForTarget({
+  const disconnect = () => {
+    void forceDisconnectPlaywrightForTarget({
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
       reason: "abort browser action",
@@ -41,7 +41,7 @@ async function runAbortablePlaywrightAction<T>(
   };
 
   if (signal.aborted) {
-    await disconnect();
+    disconnect();
     throw abortReason();
   }
 
@@ -54,7 +54,8 @@ async function runAbortablePlaywrightAction<T>(
         return;
       }
       abortTriggered = true;
-      void disconnect().finally(() => reject(abortReason()));
+      disconnect();
+      reject(abortReason());
     };
     signal.addEventListener("abort", abortListener, { once: true });
   });

--- a/src/browser/pw-tools-core.snapshot.abort.test.ts
+++ b/src/browser/pw-tools-core.snapshot.abort.test.ts
@@ -1,0 +1,65 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let page: Record<string, unknown> | null = null;
+
+const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+const getPageForTargetId = vi.fn(async () => {
+  if (!page) {
+    throw new Error("test: page not set");
+  }
+  return page;
+});
+const ensurePageState = vi.fn(() => {});
+const storeRoleRefsForTarget = vi.fn(() => {});
+
+vi.mock("./pw-session.js", () => ({
+  ensurePageState,
+  forceDisconnectPlaywrightForTarget,
+  getPageForTargetId,
+  storeRoleRefsForTarget,
+}));
+
+let snapshotAiViaPlaywright: typeof import("./pw-tools-core.snapshot.js").snapshotAiViaPlaywright;
+
+describe("snapshotAiViaPlaywright (abort)", () => {
+  beforeAll(async () => {
+    ({ snapshotAiViaPlaywright } = await import("./pw-tools-core.snapshot.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disconnects the target when an AI snapshot is aborted after it starts", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingSnapshot = new Promise(() => {});
+
+    page = {
+      _snapshotForAI: vi.fn(() => {
+        resolveStarted();
+        return pendingSnapshot;
+      }),
+    };
+
+    const promise = snapshotAiViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("snapshot aborted"));
+
+    await expect(promise).rejects.toThrow("snapshot aborted");
+    expect(forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "page-1",
+      }),
+    );
+  });
+});

--- a/src/browser/pw-tools-core.snapshot.abort.test.ts
+++ b/src/browser/pw-tools-core.snapshot.abort.test.ts
@@ -62,4 +62,43 @@ describe("snapshotAiViaPlaywright (abort)", () => {
       }),
     );
   });
+
+  it("rejects immediately on abort even if snapshot disconnect cleanup is still pending", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    let resolveSnapshot!: () => void;
+    let resolveDisconnect!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingSnapshot = new Promise((resolve) => {
+      resolveSnapshot = () => resolve(undefined);
+    });
+    forceDisconnectPlaywrightForTarget.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveDisconnect = resolve;
+        }),
+    );
+
+    page = {
+      _snapshotForAI: vi.fn(() => {
+        resolveStarted();
+        return pendingSnapshot;
+      }),
+    };
+
+    const promise = snapshotAiViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("snapshot abort should win"));
+    resolveSnapshot();
+
+    await expect(promise).rejects.toThrow("snapshot abort should win");
+    resolveDisconnect();
+  });
 });

--- a/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -75,4 +75,36 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     expect(goto).toHaveBeenCalledTimes(2);
     expect(result.url).toBe("https://example.com/recovered");
   });
+
+  it("does not retry navigation after the request aborts", async () => {
+    const ctrl = new AbortController();
+    const goto = vi.fn(async () => {
+      ctrl.abort(new Error("navigate aborted"));
+      throw new Error("Target page, context or browser has been closed");
+    });
+    setPwToolsCoreCurrentPage({
+      goto,
+      url: vi.fn(() => "https://example.com/aborted"),
+    });
+
+    await expect(
+      mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        url: "https://example.com/aborted",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        signal: ctrl.signal,
+      }),
+    ).rejects.toThrow("navigate aborted");
+
+    expect(goto).toHaveBeenCalledTimes(1);
+    expect(getPwToolsCoreSessionMocks().getPageForTargetId).toHaveBeenCalledTimes(1);
+    expect(
+      getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget,
+    ).not.toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      reason: "retry navigate after detached frame",
+    });
+  });
 });

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -20,28 +20,97 @@ import {
   type WithSnapshotForAI,
 } from "./pw-session.js";
 
+type SnapshotTargetOpts = {
+  cdpUrl: string;
+  targetId?: string;
+  signal?: AbortSignal;
+};
+
+async function runAbortableSnapshotWork<T>(
+  opts: SnapshotTargetOpts,
+  work: () => Promise<T>,
+): Promise<T> {
+  const signal = opts.signal;
+  if (!signal) {
+    return await work();
+  }
+
+  const abortReason = () => signal.reason ?? new Error("aborted");
+  const disconnect = async () => {
+    await forceDisconnectPlaywrightForTarget({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      reason: "abort browser snapshot",
+    }).catch(() => {});
+  };
+
+  if (signal.aborted) {
+    await disconnect();
+    throw abortReason();
+  }
+
+  let completed = false;
+  let abortTriggered = false;
+  let abortListener: (() => void) | undefined;
+  const abortPromise: Promise<never> = new Promise((_, reject) => {
+    abortListener = () => {
+      if (completed || abortTriggered) {
+        return;
+      }
+      abortTriggered = true;
+      void disconnect().finally(() => reject(abortReason()));
+    };
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+
+  if (signal.aborted) {
+    abortListener?.();
+  }
+  if (abortTriggered) {
+    return await abortPromise;
+  }
+
+  const workPromise = work().finally(() => {
+    completed = true;
+  });
+
+  try {
+    return await Promise.race([workPromise, abortPromise]);
+  } catch (err) {
+    void workPromise.catch(() => {});
+    throw err;
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
 export async function snapshotAriaViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   limit?: number;
+  signal?: AbortSignal;
 }): Promise<{ nodes: AriaSnapshotNode[] }> {
-  const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
-  const page = await getPageForTargetId({
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
+  return await runAbortableSnapshotWork(opts, async () => {
+    const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
+    const page = await getPageForTargetId({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+    });
+    ensurePageState(page);
+    const session = await page.context().newCDPSession(page);
+    try {
+      await session.send("Accessibility.enable").catch(() => {});
+      const res = (await session.send("Accessibility.getFullAXTree")) as {
+        nodes?: RawAXNode[];
+      };
+      const nodes = Array.isArray(res?.nodes) ? res.nodes : [];
+      return { nodes: formatAriaSnapshot(nodes, limit) };
+    } finally {
+      await session.detach().catch(() => {});
+    }
   });
-  ensurePageState(page);
-  const session = await page.context().newCDPSession(page);
-  try {
-    await session.send("Accessibility.enable").catch(() => {});
-    const res = (await session.send("Accessibility.getFullAXTree")) as {
-      nodes?: RawAXNode[];
-    };
-    const nodes = Array.isArray(res?.nodes) ? res.nodes : [];
-    return { nodes: formatAriaSnapshot(nodes, limit) };
-  } finally {
-    await session.detach().catch(() => {});
-  }
 }
 
 export async function snapshotAiViaPlaywright(opts: {
@@ -49,43 +118,46 @@ export async function snapshotAiViaPlaywright(opts: {
   targetId?: string;
   timeoutMs?: number;
   maxChars?: number;
+  signal?: AbortSignal;
 }): Promise<{ snapshot: string; truncated?: boolean; refs: RoleRefMap }> {
-  const page = await getPageForTargetId({
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-  });
-  ensurePageState(page);
+  return await runAbortableSnapshotWork(opts, async () => {
+    const page = await getPageForTargetId({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+    });
+    ensurePageState(page);
 
-  const maybe = page as unknown as WithSnapshotForAI;
-  if (!maybe._snapshotForAI) {
-    throw new Error("Playwright _snapshotForAI is not available. Upgrade playwright-core.");
-  }
+    const maybe = page as unknown as WithSnapshotForAI;
+    if (!maybe._snapshotForAI) {
+      throw new Error("Playwright _snapshotForAI is not available. Upgrade playwright-core.");
+    }
 
-  const result = await maybe._snapshotForAI({
-    timeout: Math.max(500, Math.min(60_000, Math.floor(opts.timeoutMs ?? 5000))),
-    track: "response",
-  });
-  let snapshot = String(result?.full ?? "");
-  const maxChars = opts.maxChars;
-  const limit =
-    typeof maxChars === "number" && Number.isFinite(maxChars) && maxChars > 0
-      ? Math.floor(maxChars)
-      : undefined;
-  let truncated = false;
-  if (limit && snapshot.length > limit) {
-    snapshot = `${snapshot.slice(0, limit)}\n\n[...TRUNCATED - page too large]`;
-    truncated = true;
-  }
+    const result = await maybe._snapshotForAI({
+      timeout: Math.max(500, Math.min(60_000, Math.floor(opts.timeoutMs ?? 5000))),
+      track: "response",
+    });
+    let snapshot = String(result?.full ?? "");
+    const maxChars = opts.maxChars;
+    const limit =
+      typeof maxChars === "number" && Number.isFinite(maxChars) && maxChars > 0
+        ? Math.floor(maxChars)
+        : undefined;
+    let truncated = false;
+    if (limit && snapshot.length > limit) {
+      snapshot = `${snapshot.slice(0, limit)}\n\n[...TRUNCATED - page too large]`;
+      truncated = true;
+    }
 
-  const built = buildRoleSnapshotFromAiSnapshot(snapshot);
-  storeRoleRefsForTarget({
-    page,
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-    refs: built.refs,
-    mode: "aria",
+    const built = buildRoleSnapshotFromAiSnapshot(snapshot);
+    storeRoleRefsForTarget({
+      page,
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      refs: built.refs,
+      mode: "aria",
+    });
+    return truncated ? { snapshot, truncated, refs: built.refs } : { snapshot, refs: built.refs };
   });
-  return truncated ? { snapshot, truncated, refs: built.refs } : { snapshot, refs: built.refs };
 }
 
 export async function snapshotRoleViaPlaywright(opts: {
@@ -95,69 +167,72 @@ export async function snapshotRoleViaPlaywright(opts: {
   frameSelector?: string;
   refsMode?: "role" | "aria";
   options?: RoleSnapshotOptions;
+  signal?: AbortSignal;
 }): Promise<{
   snapshot: string;
   refs: Record<string, { role: string; name?: string; nth?: number }>;
   stats: { lines: number; chars: number; refs: number; interactive: number };
 }> {
-  const page = await getPageForTargetId({
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-  });
-  ensurePageState(page);
-
-  if (opts.refsMode === "aria") {
-    if (opts.selector?.trim() || opts.frameSelector?.trim()) {
-      throw new Error("refs=aria does not support selector/frame snapshots yet.");
-    }
-    const maybe = page as unknown as WithSnapshotForAI;
-    if (!maybe._snapshotForAI) {
-      throw new Error("refs=aria requires Playwright _snapshotForAI support.");
-    }
-    const result = await maybe._snapshotForAI({
-      timeout: 5000,
-      track: "response",
+  return await runAbortableSnapshotWork(opts, async () => {
+    const page = await getPageForTargetId({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
     });
-    const built = buildRoleSnapshotFromAiSnapshot(String(result?.full ?? ""), opts.options);
+    ensurePageState(page);
+
+    if (opts.refsMode === "aria") {
+      if (opts.selector?.trim() || opts.frameSelector?.trim()) {
+        throw new Error("refs=aria does not support selector/frame snapshots yet.");
+      }
+      const maybe = page as unknown as WithSnapshotForAI;
+      if (!maybe._snapshotForAI) {
+        throw new Error("refs=aria requires Playwright _snapshotForAI support.");
+      }
+      const result = await maybe._snapshotForAI({
+        timeout: 5000,
+        track: "response",
+      });
+      const built = buildRoleSnapshotFromAiSnapshot(String(result?.full ?? ""), opts.options);
+      storeRoleRefsForTarget({
+        page,
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        refs: built.refs,
+        mode: "aria",
+      });
+      return {
+        snapshot: built.snapshot,
+        refs: built.refs,
+        stats: getRoleSnapshotStats(built.snapshot, built.refs),
+      };
+    }
+
+    const frameSelector = opts.frameSelector?.trim() || "";
+    const selector = opts.selector?.trim() || "";
+    const locator = frameSelector
+      ? selector
+        ? page.frameLocator(frameSelector).locator(selector)
+        : page.frameLocator(frameSelector).locator(":root")
+      : selector
+        ? page.locator(selector)
+        : page.locator(":root");
+
+    const ariaSnapshot = await locator.ariaSnapshot();
+    const built = buildRoleSnapshotFromAriaSnapshot(String(ariaSnapshot ?? ""), opts.options);
     storeRoleRefsForTarget({
       page,
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
       refs: built.refs,
-      mode: "aria",
+      frameSelector: frameSelector || undefined,
+      mode: "role",
     });
     return {
       snapshot: built.snapshot,
       refs: built.refs,
       stats: getRoleSnapshotStats(built.snapshot, built.refs),
     };
-  }
-
-  const frameSelector = opts.frameSelector?.trim() || "";
-  const selector = opts.selector?.trim() || "";
-  const locator = frameSelector
-    ? selector
-      ? page.frameLocator(frameSelector).locator(selector)
-      : page.frameLocator(frameSelector).locator(":root")
-    : selector
-      ? page.locator(selector)
-      : page.locator(":root");
-
-  const ariaSnapshot = await locator.ariaSnapshot();
-  const built = buildRoleSnapshotFromAriaSnapshot(String(ariaSnapshot ?? ""), opts.options);
-  storeRoleRefsForTarget({
-    page,
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-    refs: built.refs,
-    frameSelector: frameSelector || undefined,
-    mode: "role",
   });
-  return {
-    snapshot: built.snapshot,
-    refs: built.refs,
-    stats: getRoleSnapshotStats(built.snapshot, built.refs),
-  };
 }
 
 export async function navigateViaPlaywright(opts: {
@@ -166,6 +241,7 @@ export async function navigateViaPlaywright(opts: {
   url: string;
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<{ url: string }> {
   const isRetryableNavigateError = (err: unknown): boolean => {
     const msg =
@@ -180,40 +256,42 @@ export async function navigateViaPlaywright(opts: {
     );
   };
 
-  const url = String(opts.url ?? "").trim();
-  if (!url) {
-    throw new Error("url is required");
-  }
-  await assertBrowserNavigationAllowed({
-    url,
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
-  });
-  const timeout = Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000));
-  let page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  try {
-    await page.goto(url, { timeout });
-  } catch (err) {
-    if (!isRetryableNavigateError(err)) {
-      throw err;
+  return await runAbortableSnapshotWork(opts, async () => {
+    const url = String(opts.url ?? "").trim();
+    if (!url) {
+      throw new Error("url is required");
     }
-    // Extension relays can briefly drop CDP during renderer swaps/navigation.
-    // Force a clean reconnect, then retry once on the refreshed page handle.
-    await forceDisconnectPlaywrightForTarget({
-      cdpUrl: opts.cdpUrl,
-      targetId: opts.targetId,
-      reason: "retry navigate after detached frame",
-    }).catch(() => {});
-    page = await getPageForTargetId(opts);
+    await assertBrowserNavigationAllowed({
+      url,
+      ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+    });
+    const timeout = Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000));
+    let page = await getPageForTargetId(opts);
     ensurePageState(page);
-    await page.goto(url, { timeout });
-  }
-  const finalUrl = page.url();
-  await assertBrowserNavigationResultAllowed({
-    url: finalUrl,
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+    try {
+      await page.goto(url, { timeout });
+    } catch (err) {
+      if (!isRetryableNavigateError(err)) {
+        throw err;
+      }
+      // Extension relays can briefly drop CDP during renderer swaps/navigation.
+      // Force a clean reconnect, then retry once on the refreshed page handle.
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        reason: "retry navigate after detached frame",
+      }).catch(() => {});
+      page = await getPageForTargetId(opts);
+      ensurePageState(page);
+      await page.goto(url, { timeout });
+    }
+    const finalUrl = page.url();
+    await assertBrowserNavigationResultAllowed({
+      url: finalUrl,
+      ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+    });
+    return { url: finalUrl };
   });
-  return { url: finalUrl };
 }
 
 export async function resizeViewportViaPlaywright(opts: {
@@ -242,9 +320,12 @@ export async function closePageViaPlaywright(opts: {
 export async function pdfViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  signal?: AbortSignal;
 }): Promise<{ buffer: Buffer }> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  const buffer = await page.pdf({ printBackground: true });
-  return { buffer };
+  return await runAbortableSnapshotWork(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    const buffer = await page.pdf({ printBackground: true });
+    return { buffer };
+  });
 }

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -274,6 +274,9 @@ export async function navigateViaPlaywright(opts: {
       if (!isRetryableNavigateError(err)) {
         throw err;
       }
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason ?? new Error("aborted");
+      }
       // Extension relays can briefly drop CDP during renderer swaps/navigation.
       // Force a clean reconnect, then retry once on the refreshed page handle.
       await forceDisconnectPlaywrightForTarget({
@@ -281,6 +284,9 @@ export async function navigateViaPlaywright(opts: {
         targetId: opts.targetId,
         reason: "retry navigate after detached frame",
       }).catch(() => {});
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason ?? new Error("aborted");
+      }
       page = await getPageForTargetId(opts);
       ensurePageState(page);
       await page.goto(url, { timeout });

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -36,8 +36,8 @@ async function runAbortableSnapshotWork<T>(
   }
 
   const abortReason = () => signal.reason ?? new Error("aborted");
-  const disconnect = async () => {
-    await forceDisconnectPlaywrightForTarget({
+  const disconnect = () => {
+    void forceDisconnectPlaywrightForTarget({
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
       reason: "abort browser snapshot",
@@ -45,7 +45,7 @@ async function runAbortableSnapshotWork<T>(
   };
 
   if (signal.aborted) {
-    await disconnect();
+    disconnect();
     throw abortReason();
   }
 
@@ -58,7 +58,8 @@ async function runAbortableSnapshotWork<T>(
         return;
       }
       abortTriggered = true;
-      void disconnect().finally(() => reject(abortReason()));
+      disconnect();
+      reject(abortReason());
     };
     signal.addEventListener("abort", abortListener, { once: true });
   });

--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -68,6 +68,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               ref,
               doubleClick,
+              signal: req.signal,
             };
             if (button) {
               clickRequest.button = button;
@@ -100,6 +101,7 @@ export function registerBrowserAgentActRoutes(
               text,
               submit,
               slowly,
+              signal: req.signal,
             };
             if (timeoutMs) {
               typeRequest.timeoutMs = timeoutMs;
@@ -118,6 +120,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               key,
               delayMs: delayMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -132,6 +135,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               ref,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -145,6 +149,7 @@ export function registerBrowserAgentActRoutes(
               cdpUrl,
               targetId: tab.targetId,
               ref,
+              signal: req.signal,
             };
             if (timeoutMs) {
               scrollRequest.timeoutMs = timeoutMs;
@@ -165,6 +170,7 @@ export function registerBrowserAgentActRoutes(
               startRef,
               endRef,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -181,6 +187,7 @@ export function registerBrowserAgentActRoutes(
               ref,
               values,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -203,6 +210,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               fields,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -271,6 +279,7 @@ export function registerBrowserAgentActRoutes(
               loadState,
               fn,
               timeoutMs,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -105,6 +105,7 @@ export function registerBrowserAgentSnapshotRoutes(
           cdpUrl,
           targetId: tab.targetId,
           url,
+          signal: req.signal,
           ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
         });
         const currentTargetId = await resolveTargetIdAfterNavigate({
@@ -130,6 +131,7 @@ export function registerBrowserAgentSnapshotRoutes(
         const pdf = await pw.pdfViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
+          signal: req.signal,
         });
         await saveBrowserMediaResponse({
           res,
@@ -179,6 +181,7 @@ export function registerBrowserAgentSnapshotRoutes(
             element,
             fullPage,
             type,
+            signal: req.signal,
           });
           buffer = snap.buffer;
         } else {
@@ -270,6 +273,7 @@ export function registerBrowserAgentSnapshotRoutes(
         const roleSnapshotArgs = {
           cdpUrl: profileCtx.profile.cdpUrl,
           targetId: tab.targetId,
+          signal: req.signal,
           selector: selectorValue,
           frameSelector: frameSelectorValue,
           refsMode,
@@ -286,6 +290,7 @@ export function registerBrowserAgentSnapshotRoutes(
               .snapshotAiViaPlaywright({
                 cdpUrl: profileCtx.profile.cdpUrl,
                 targetId: tab.targetId,
+                signal: req.signal,
                 ...(typeof resolvedMaxChars === "number" ? { maxChars: resolvedMaxChars } : {}),
               })
               .catch(async (err) => {
@@ -301,6 +306,7 @@ export function registerBrowserAgentSnapshotRoutes(
             targetId: tab.targetId,
             refs: "refs" in snap ? snap.refs : {},
             type: "png",
+            signal: req.signal,
           });
           const normalized = await normalizeBrowserScreenshot(labeled.buffer, {
             maxSide: DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
@@ -350,6 +356,7 @@ export function registerBrowserAgentSnapshotRoutes(
                   cdpUrl: profileCtx.profile.cdpUrl,
                   targetId: tab.targetId,
                   limit,
+                  signal: req.signal,
                 });
               });
             })()

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -51,12 +51,15 @@ describe("browser control server", () => {
         values: ["a", "b"],
       });
       expect(select.ok).toBe(true);
-      expect(pwMocks.selectOptionViaPlaywright).toHaveBeenCalledWith({
-        cdpUrl: state.cdpBaseUrl,
-        targetId: "abcd1234",
-        ref: "5",
-        values: ["a", "b"],
-      });
+      expect(pwMocks.selectOptionViaPlaywright).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cdpUrl: state.cdpBaseUrl,
+          targetId: "abcd1234",
+          ref: "5",
+          values: ["a", "b"],
+          signal: expect.any(AbortSignal),
+        }),
+      );
 
       const fillCases: Array<{
         input: Record<string, unknown>;
@@ -81,11 +84,14 @@ describe("browser control server", () => {
           fields: [input],
         });
         expect(fill.ok).toBe(true);
-        expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
-          cdpUrl: state.cdpBaseUrl,
-          targetId: "abcd1234",
-          fields: [expected],
-        });
+        expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cdpUrl: state.cdpBaseUrl,
+            targetId: "abcd1234",
+            fields: [expected],
+            signal: expect.any(AbortSignal),
+          }),
+        );
       }
 
       const resize = await postJson<{ ok: boolean }>(`${base}/act`, {
@@ -106,13 +112,16 @@ describe("browser control server", () => {
         timeMs: 5,
       });
       expect(wait.ok).toBe(true);
-      expect(pwMocks.waitForViaPlaywright).toHaveBeenCalledWith({
-        cdpUrl: state.cdpBaseUrl,
-        targetId: "abcd1234",
-        timeMs: 5,
-        text: undefined,
-        textGone: undefined,
-      });
+      expect(pwMocks.waitForViaPlaywright).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cdpUrl: state.cdpBaseUrl,
+          targetId: "abcd1234",
+          timeMs: 5,
+          text: undefined,
+          textGone: undefined,
+          signal: expect.any(AbortSignal),
+        }),
+      );
 
       const evalRes = await postJson<{ ok: boolean; result?: string }>(`${base}/act`, {
         kind: "evaluate",

--- a/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -42,6 +42,7 @@ describe("browser control server", () => {
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
       maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
+      signal: expect.any(AbortSignal),
     });
 
     const snapAiZero = (await realFetch(`${base}/snapshot?format=ai&maxChars=0`).then((r) =>
@@ -53,6 +54,7 @@ describe("browser control server", () => {
     expect(lastCall).toEqual({
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -69,6 +71,7 @@ describe("browser control server", () => {
         cdpUrl: state.cdpBaseUrl,
         targetId: "abcd1234",
         url: "https://example.com",
+        signal: expect.any(AbortSignal),
         ssrfPolicy: {
           dangerouslyAllowPrivateNetwork: true,
         },
@@ -82,14 +85,18 @@ describe("browser control server", () => {
       modifiers: ["Shift"],
     });
     expect(click.ok).toBe(true);
-    expect(pwMocks.clickViaPlaywright).toHaveBeenNthCalledWith(1, {
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      ref: "1",
-      doubleClick: false,
-      button: "left",
-      modifiers: ["Shift"],
-    });
+    expect(pwMocks.clickViaPlaywright).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cdpUrl: state.cdpBaseUrl,
+        targetId: "abcd1234",
+        ref: "1",
+        doubleClick: false,
+        button: "left",
+        modifiers: ["Shift"],
+        signal: expect.any(AbortSignal),
+      }),
+    );
 
     const clickSelector = await realFetch(`${base}/act`, {
       method: "POST",
@@ -107,47 +114,60 @@ describe("browser control server", () => {
       text: "",
     });
     expect(type.ok).toBe(true);
-    expect(pwMocks.typeViaPlaywright).toHaveBeenNthCalledWith(1, {
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      ref: "1",
-      text: "",
-      submit: false,
-      slowly: false,
-    });
+    expect(pwMocks.typeViaPlaywright).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cdpUrl: state.cdpBaseUrl,
+        targetId: "abcd1234",
+        ref: "1",
+        text: "",
+        submit: false,
+        slowly: false,
+        signal: expect.any(AbortSignal),
+      }),
+    );
 
     const press = await postJson<{ ok: boolean }>(`${base}/act`, {
       kind: "press",
       key: "Enter",
     });
     expect(press.ok).toBe(true);
-    expect(pwMocks.pressKeyViaPlaywright).toHaveBeenCalledWith({
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      key: "Enter",
-    });
+    expect(pwMocks.pressKeyViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: state.cdpBaseUrl,
+        targetId: "abcd1234",
+        key: "Enter",
+        signal: expect.any(AbortSignal),
+      }),
+    );
 
     const hover = await postJson<{ ok: boolean }>(`${base}/act`, {
       kind: "hover",
       ref: "2",
     });
     expect(hover.ok).toBe(true);
-    expect(pwMocks.hoverViaPlaywright).toHaveBeenCalledWith({
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      ref: "2",
-    });
+    expect(pwMocks.hoverViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: state.cdpBaseUrl,
+        targetId: "abcd1234",
+        ref: "2",
+        signal: expect.any(AbortSignal),
+      }),
+    );
 
     const scroll = await postJson<{ ok: boolean }>(`${base}/act`, {
       kind: "scrollIntoView",
       ref: "2",
     });
     expect(scroll.ok).toBe(true);
-    expect(pwMocks.scrollIntoViewViaPlaywright).toHaveBeenCalledWith({
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      ref: "2",
-    });
+    expect(pwMocks.scrollIntoViewViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: state.cdpBaseUrl,
+        targetId: "abcd1234",
+        ref: "2",
+        signal: expect.any(AbortSignal),
+      }),
+    );
 
     const drag = await postJson<{ ok: boolean }>(`${base}/act`, {
       kind: "drag",
@@ -155,11 +175,14 @@ describe("browser control server", () => {
       endRef: "4",
     });
     expect(drag.ok).toBe(true);
-    expect(pwMocks.dragViaPlaywright).toHaveBeenCalledWith({
-      cdpUrl: state.cdpBaseUrl,
-      targetId: "abcd1234",
-      startRef: "3",
-      endRef: "4",
-    });
+    expect(pwMocks.dragViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: state.cdpBaseUrl,
+        targetId: "abcd1234",
+        startRef: "3",
+        endRef: "4",
+        signal: expect.any(AbortSignal),
+      }),
+    );
   });
 });

--- a/src/cli/browser-cli-actions-input/register.navigation.ts
+++ b/src/cli/browser-cli-actions-input/register.navigation.ts
@@ -2,7 +2,11 @@ import type { Command } from "commander";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import { runBrowserResizeWithOutput } from "../browser-cli-resize.js";
-import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "../browser-cli-shared.js";
 import { requireRef, resolveBrowserActionContext } from "./shared.js";
 
 export function registerBrowserNavigationCommands(
@@ -28,7 +32,11 @@ export function registerBrowserNavigationCommands(
               targetId: opts.targetId?.trim() || undefined,
             },
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (parent?.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));
@@ -56,7 +64,9 @@ export function registerBrowserNavigationCommands(
           width,
           height,
           targetId: opts.targetId,
-          timeoutMs: 20000,
+          timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+            fallbackMs: 20_000,
+          }),
           successMessage: `resized to ${width}x${height}`,
         });
       } catch (err) {

--- a/src/cli/browser-cli-actions-input/shared.ts
+++ b/src/cli/browser-cli-actions-input/shared.ts
@@ -6,7 +6,11 @@ import {
 } from "../../browser/form-fields.js";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
-import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "../browser-cli-shared.js";
 
 export type BrowserActionContext = {
   parent: BrowserParentOpts;
@@ -36,7 +40,12 @@ export async function callBrowserAct<T = unknown>(params: {
       query: params.profile ? { profile: params.profile } : undefined,
       body: params.body,
     },
-    { timeoutMs: params.timeoutMs ?? 20000 },
+    {
+      timeoutMs: resolveBrowserRequestTimeoutMs(params.parent, {
+        explicitMs: params.timeoutMs,
+        fallbackMs: 20_000,
+      }),
+    },
   );
 }
 

--- a/src/cli/browser-cli-actions-observe.ts
+++ b/src/cli/browser-cli-actions-observe.ts
@@ -2,7 +2,11 @@ import type { Command } from "commander";
 import { danger } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
-import { callBrowserRequest, type BrowserParentOpts } from "./browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 
 function runBrowserObserve(action: () => Promise<void>) {
@@ -36,7 +40,11 @@ export function registerBrowserActionObserveCommands(
               profile,
             },
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (parent?.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));
@@ -62,7 +70,11 @@ export function registerBrowserActionObserveCommands(
             query: profile ? { profile } : undefined,
             body: { targetId: opts.targetId?.trim() || undefined },
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (parent?.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));
@@ -104,7 +116,12 @@ export function registerBrowserActionObserveCommands(
               maxChars,
             },
           },
-          { timeoutMs: timeoutMs ?? 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              explicitMs: timeoutMs,
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (parent?.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));

--- a/src/cli/browser-cli-inspect.test.ts
+++ b/src/cli/browser-cli-inspect.test.ts
@@ -43,9 +43,13 @@ const sharedMocks = vi.hoisted(() => ({
     },
   ),
 }));
-vi.mock("./browser-cli-shared.js", () => ({
-  callBrowserRequest: sharedMocks.callBrowserRequest,
-}));
+vi.mock("./browser-cli-shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./browser-cli-shared.js")>();
+  return {
+    ...actual,
+    callBrowserRequest: sharedMocks.callBrowserRequest,
+  };
+});
 
 const runtime = {
   log: vi.fn(),

--- a/src/cli/browser-cli-inspect.ts
+++ b/src/cli/browser-cli-inspect.ts
@@ -4,7 +4,11 @@ import { loadConfig } from "../config/config.js";
 import { danger } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
-import { callBrowserRequest, type BrowserParentOpts } from "./browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
 
 export function registerBrowserInspectCommands(
   browser: Command,
@@ -36,7 +40,11 @@ export function registerBrowserInspectCommands(
               type: opts.type === "jpeg" ? "jpeg" : "png",
             },
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (parent?.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));
@@ -94,7 +102,11 @@ export function registerBrowserInspectCommands(
             path: "/snapshot",
             query,
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
 
         if (opts.out) {

--- a/src/cli/browser-cli-manage.timeout-option.test.ts
+++ b/src/cli/browser-cli-manage.timeout-option.test.ts
@@ -33,9 +33,13 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("./browser-cli-shared.js", () => ({
-  callBrowserRequest: mocks.callBrowserRequest,
-}));
+vi.mock("./browser-cli-shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./browser-cli-shared.js")>();
+  return {
+    ...actual,
+    callBrowserRequest: mocks.callBrowserRequest,
+  };
+});
 
 vi.mock("./cli-utils.js", () => ({
   runCommandWithRuntime: async (

--- a/src/cli/browser-cli-manage.timeout-option.test.ts
+++ b/src/cli/browser-cli-manage.timeout-option.test.ts
@@ -80,4 +80,19 @@ describe("browser manage start timeout option", () => {
     expect(startCall?.[0]).toMatchObject({ timeout: "60000" });
     expect(startCall?.[2]).toBeUndefined();
   });
+
+  it("keeps the shorter status default when parent timeout is still implicit", async () => {
+    const program = createProgram();
+    await program.parseAsync(["browser", "status"], { from: "user" });
+
+    const statusCall = mocks.callBrowserRequest.mock.calls.find(
+      (call) => ((call[1] ?? {}) as { path?: string }).path === "/",
+    ) as
+      | [Record<string, unknown>, { path?: string }, { timeoutMs?: number } | undefined]
+      | undefined;
+
+    expect(statusCall).toBeDefined();
+    expect(statusCall?.[0]).toMatchObject({ timeout: "30000", timeoutSource: "default" });
+    expect(statusCall?.[2]).toEqual({ timeoutMs: 1500 });
+  });
 });

--- a/src/cli/browser-cli-manage.ts
+++ b/src/cli/browser-cli-manage.ts
@@ -10,7 +10,11 @@ import type {
 import { danger, info } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
-import { callBrowserRequest, type BrowserParentOpts } from "./browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 
 function resolveProfileQuery(profile?: string) {
@@ -38,7 +42,11 @@ async function callTabAction(
       query: resolveProfileQuery(profile),
       body,
     },
-    { timeoutMs: 10_000 },
+    {
+      timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+        fallbackMs: 10_000,
+      }),
+    },
   );
 }
 
@@ -54,7 +62,9 @@ async function fetchBrowserStatus(
       query: resolveProfileQuery(profile),
     },
     {
-      timeoutMs: 1500,
+      timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+        fallbackMs: 1500,
+      }),
     },
   );
 }
@@ -168,7 +178,11 @@ export function registerBrowserManageCommands(
             path: "/reset-profile",
             query: resolveProfileQuery(profile),
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (printJsonResult(parent, result)) {
           return;
@@ -196,7 +210,11 @@ export function registerBrowserManageCommands(
             path: "/tabs",
             query: resolveProfileQuery(profile),
           },
-          { timeoutMs: 3000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 3000,
+            }),
+          },
         );
         const tabs = result.tabs ?? [];
         logBrowserTabs(tabs, parent?.json);
@@ -220,7 +238,11 @@ export function registerBrowserManageCommands(
               action: "list",
             },
           },
-          { timeoutMs: 10_000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 10_000,
+            }),
+          },
         );
         const tabs = result.tabs ?? [];
         logBrowserTabs(tabs, parent?.json);
@@ -305,7 +327,11 @@ export function registerBrowserManageCommands(
             query: resolveProfileQuery(profile),
             body: { url },
           },
-          { timeoutMs: 15000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 15_000,
+            }),
+          },
         );
         if (printJsonResult(parent, tab)) {
           return;
@@ -330,7 +356,11 @@ export function registerBrowserManageCommands(
             query: resolveProfileQuery(profile),
             body: { targetId },
           },
-          { timeoutMs: 5000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 5000,
+            }),
+          },
         );
         if (printJsonResult(parent, { ok: true })) {
           return;
@@ -355,7 +385,11 @@ export function registerBrowserManageCommands(
               path: `/tabs/${encodeURIComponent(targetId.trim())}`,
               query: resolveProfileQuery(profile),
             },
-            { timeoutMs: 5000 },
+            {
+              timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+                fallbackMs: 5000,
+              }),
+            },
           );
         } else {
           await callBrowserRequest(
@@ -366,7 +400,11 @@ export function registerBrowserManageCommands(
               query: resolveProfileQuery(profile),
               body: { kind: "close" },
             },
-            { timeoutMs: 20000 },
+            {
+              timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+                fallbackMs: 20_000,
+              }),
+            },
           );
         }
         if (printJsonResult(parent, { ok: true })) {
@@ -389,7 +427,11 @@ export function registerBrowserManageCommands(
             method: "GET",
             path: "/profiles",
           },
-          { timeoutMs: 3000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 3000,
+            }),
+          },
         );
         const profiles = result.profiles ?? [];
         if (printJsonResult(parent, { profiles })) {
@@ -437,7 +479,11 @@ export function registerBrowserManageCommands(
                 driver: opts.driver === "extension" ? "extension" : undefined,
               },
             },
-            { timeoutMs: 10_000 },
+            {
+              timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+                fallbackMs: 10_000,
+              }),
+            },
           );
           if (printJsonResult(parent, result)) {
             return;
@@ -467,7 +513,11 @@ export function registerBrowserManageCommands(
             method: "DELETE",
             path: `/profiles/${encodeURIComponent(opts.name)}`,
           },
-          { timeoutMs: 20_000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (printJsonResult(parent, result)) {
           return;

--- a/src/cli/browser-cli-resize.ts
+++ b/src/cli/browser-cli-resize.ts
@@ -1,6 +1,10 @@
 import { danger } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
-import { callBrowserResize, type BrowserParentOpts } from "./browser-cli-shared.js";
+import {
+  callBrowserResize,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
 
 export async function runBrowserResizeWithOutput(params: {
   parent: BrowserParentOpts;
@@ -26,7 +30,12 @@ export async function runBrowserResizeWithOutput(params: {
       height,
       targetId: params.targetId,
     },
-    { timeoutMs: params.timeoutMs ?? 20000 },
+    {
+      timeoutMs: resolveBrowserRequestTimeoutMs(params.parent, {
+        explicitMs: params.timeoutMs,
+        fallbackMs: 20_000,
+      }),
+    },
   );
 
   if (params.parent?.json) {

--- a/src/cli/browser-cli-shared.call.test.ts
+++ b/src/cli/browser-cli-shared.call.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayFromCli = vi.fn(async () => ({ ok: true }));
+
+vi.mock("./gateway-rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("./gateway-rpc.js")>("./gateway-rpc.js");
+  return {
+    ...actual,
+    callGatewayFromCli,
+  };
+});
+
+const { callBrowserRequest } = await import("./browser-cli-shared.js");
+
+describe("callBrowserRequest", () => {
+  beforeEach(() => {
+    callGatewayFromCli.mockClear();
+    callGatewayFromCli.mockResolvedValue({ ok: true });
+  });
+
+  it("propagates the implicit CLI default timeout when no browser fallback is provided", async () => {
+    await callBrowserRequest(
+      {
+        timeout: "30000",
+        timeoutSource: "default",
+      },
+      {
+        method: "POST",
+        path: "/start",
+      },
+    );
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "browser.request",
+      expect.objectContaining({ timeout: "30000" }),
+      expect.objectContaining({ timeoutMs: 30000, path: "/start" }),
+      expect.objectContaining({ progress: undefined }),
+    );
+  });
+
+  it("keeps command-specific timeout overrides ahead of the implicit CLI default", async () => {
+    await callBrowserRequest(
+      {
+        timeout: "30000",
+        timeoutSource: "default",
+      },
+      {
+        method: "GET",
+        path: "/",
+      },
+      {
+        timeoutMs: 1500,
+      },
+    );
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "browser.request",
+      expect.objectContaining({ timeout: "1500" }),
+      expect.objectContaining({ timeoutMs: 1500, path: "/" }),
+      expect.objectContaining({ progress: undefined }),
+    );
+  });
+});

--- a/src/cli/browser-cli-shared.test.ts
+++ b/src/cli/browser-cli-shared.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveBrowserRequestTimeoutMs } from "./browser-cli-shared.js";
+
+describe("resolveBrowserRequestTimeoutMs", () => {
+  it("keeps command-specific fallbacks when parent timeout is still the CLI default", () => {
+    expect(
+      resolveBrowserRequestTimeoutMs(
+        { timeout: "30000", timeoutSource: "default" },
+        { fallbackMs: 1500 },
+      ),
+    ).toBe(1500);
+  });
+
+  it("uses the parent browser timeout when it was explicitly provided", () => {
+    expect(
+      resolveBrowserRequestTimeoutMs(
+        { timeout: "60000", timeoutSource: "cli" },
+        { fallbackMs: 1500 },
+      ),
+    ).toBe(60000);
+  });
+});

--- a/src/cli/browser-cli-shared.ts
+++ b/src/cli/browser-cli-shared.ts
@@ -34,8 +34,11 @@ function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
     : undefined;
 }
 
-function parseParentTimeoutMs(opts: BrowserParentOpts): number | undefined {
-  if (opts.timeoutSource === "default") {
+function parseParentTimeoutMs(
+  opts: BrowserParentOpts,
+  params?: { includeDefault?: boolean },
+): number | undefined {
+  if (!params?.includeDefault && opts.timeoutSource === "default") {
     return undefined;
   }
   return typeof opts.timeout === "string"
@@ -62,7 +65,8 @@ export async function callBrowserRequest<T>(
   const resolvedTimeout = resolveBrowserRequestTimeoutMs(opts, {
     explicitMs: extra?.timeoutMs,
   });
-  const timeout = typeof resolvedTimeout === "number" ? String(resolvedTimeout) : opts.timeout;
+  const requestTimeout = resolvedTimeout ?? parseParentTimeoutMs(opts, { includeDefault: true });
+  const timeout = typeof requestTimeout === "number" ? String(requestTimeout) : opts.timeout;
   const payload = await callGatewayFromCli(
     "browser.request",
     { ...opts, timeout },
@@ -71,7 +75,7 @@ export async function callBrowserRequest<T>(
       path: params.path,
       query: normalizeQuery(params.query),
       body: params.body,
-      timeoutMs: resolvedTimeout,
+      timeoutMs: requestTimeout,
     },
     { progress: extra?.progress },
   );

--- a/src/cli/browser-cli-shared.ts
+++ b/src/cli/browser-cli-shared.ts
@@ -4,6 +4,7 @@ import { callGatewayFromCli } from "./gateway-rpc.js";
 export type BrowserParentOpts = GatewayRpcOpts & {
   json?: boolean;
   browserProfile?: string;
+  timeoutSource?: string;
 };
 
 type BrowserRequestParams = {
@@ -34,6 +35,9 @@ function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
 }
 
 function parseParentTimeoutMs(opts: BrowserParentOpts): number | undefined {
+  if (opts.timeoutSource === "default") {
+    return undefined;
+  }
   return typeof opts.timeout === "string"
     ? normalizeTimeoutMs(Number.parseInt(opts.timeout, 10))
     : undefined;

--- a/src/cli/browser-cli-shared.ts
+++ b/src/cli/browser-cli-shared.ts
@@ -27,21 +27,37 @@ function normalizeQuery(query: BrowserRequestParams["query"]): Record<string, st
   return Object.keys(out).length ? out : undefined;
 }
 
+function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
+    ? Math.max(1, Math.floor(timeoutMs))
+    : undefined;
+}
+
+function parseParentTimeoutMs(opts: BrowserParentOpts): number | undefined {
+  return typeof opts.timeout === "string"
+    ? normalizeTimeoutMs(Number.parseInt(opts.timeout, 10))
+    : undefined;
+}
+
+export function resolveBrowserRequestTimeoutMs(
+  opts: BrowserParentOpts,
+  params?: { explicitMs?: number; fallbackMs?: number },
+): number | undefined {
+  return (
+    normalizeTimeoutMs(params?.explicitMs) ??
+    parseParentTimeoutMs(opts) ??
+    normalizeTimeoutMs(params?.fallbackMs)
+  );
+}
+
 export async function callBrowserRequest<T>(
   opts: BrowserParentOpts,
   params: BrowserRequestParams,
   extra?: { timeoutMs?: number; progress?: boolean },
 ): Promise<T> {
-  const resolvedTimeoutMs =
-    typeof extra?.timeoutMs === "number" && Number.isFinite(extra.timeoutMs)
-      ? Math.max(1, Math.floor(extra.timeoutMs))
-      : typeof opts.timeout === "string"
-        ? Number.parseInt(opts.timeout, 10)
-        : undefined;
-  const resolvedTimeout =
-    typeof resolvedTimeoutMs === "number" && Number.isFinite(resolvedTimeoutMs)
-      ? resolvedTimeoutMs
-      : undefined;
+  const resolvedTimeout = resolveBrowserRequestTimeoutMs(opts, {
+    explicitMs: extra?.timeoutMs,
+  });
   const timeout = typeof resolvedTimeout === "number" ? String(resolvedTimeout) : opts.timeout;
   const payload = await callGatewayFromCli(
     "browser.request",

--- a/src/cli/browser-cli-state.cookies-storage.ts
+++ b/src/cli/browser-cli-state.cookies-storage.ts
@@ -1,7 +1,11 @@
 import type { Command } from "commander";
 import { danger } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
-import { callBrowserRequest, type BrowserParentOpts } from "./browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
 import { inheritOptionFromParent } from "./command-options.js";
 
 function resolveUrl(opts: { url?: string }, command: Command): string | undefined {
@@ -34,7 +38,11 @@ async function runMutationRequest(params: {
   successMessage: string;
 }) {
   try {
-    const result = await callBrowserRequest(params.parent, params.request, { timeoutMs: 20000 });
+    const result = await callBrowserRequest(params.parent, params.request, {
+      timeoutMs: resolveBrowserRequestTimeoutMs(params.parent, {
+        fallbackMs: 20_000,
+      }),
+    });
     if (params.parent?.json) {
       defaultRuntime.log(JSON.stringify(result, null, 2));
       return;
@@ -69,7 +77,11 @@ export function registerBrowserCookiesAndStorageCommands(
               profile,
             },
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (parent?.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));
@@ -162,7 +174,11 @@ export function registerBrowserCookiesAndStorageCommands(
                 profile,
               },
             },
-            { timeoutMs: 20000 },
+            {
+              timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+                fallbackMs: 20_000,
+              }),
+            },
           );
           if (parent?.json) {
             defaultRuntime.log(JSON.stringify(result, null, 2));

--- a/src/cli/browser-cli-state.option-collisions.test.ts
+++ b/src/cli/browser-cli-state.option-collisions.test.ts
@@ -12,9 +12,13 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("./browser-cli-shared.js", () => ({
-  callBrowserRequest: mocks.callBrowserRequest,
-}));
+vi.mock("./browser-cli-shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./browser-cli-shared.js")>();
+  return {
+    ...actual,
+    callBrowserRequest: mocks.callBrowserRequest,
+  };
+});
 
 vi.mock("./browser-cli-resize.js", () => ({
   runBrowserResizeWithOutput: mocks.runBrowserResizeWithOutput,

--- a/src/cli/browser-cli-state.ts
+++ b/src/cli/browser-cli-state.ts
@@ -3,7 +3,11 @@ import { danger } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { runBrowserResizeWithOutput } from "./browser-cli-resize.js";
-import { callBrowserRequest, type BrowserParentOpts } from "./browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  resolveBrowserRequestTimeoutMs,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
 import { registerBrowserCookiesAndStorageCommands } from "./browser-cli-state.cookies-storage.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 
@@ -35,7 +39,11 @@ async function runBrowserSetRequest(params: {
         query: profile ? { profile } : undefined,
         body: params.body,
       },
-      { timeoutMs: 20000 },
+      {
+        timeoutMs: resolveBrowserRequestTimeoutMs(params.parent, {
+          fallbackMs: 20_000,
+        }),
+      },
     );
     if (params.parent?.json) {
       defaultRuntime.log(JSON.stringify(result, null, 2));
@@ -69,7 +77,9 @@ export function registerBrowserStateCommands(
           width,
           height,
           targetId: opts.targetId,
-          timeoutMs: 20000,
+          timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+            fallbackMs: 20_000,
+          }),
           successMessage: `viewport set: ${width}x${height}`,
         });
       });
@@ -136,7 +146,11 @@ export function registerBrowserStateCommands(
               targetId: opts.targetId?.trim() || undefined,
             },
           },
-          { timeoutMs: 20000 },
+          {
+            timeoutMs: resolveBrowserRequestTimeoutMs(parent, {
+              fallbackMs: 20_000,
+            }),
+          },
         );
         if (parent?.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));

--- a/src/cli/browser-cli-test-helpers.ts
+++ b/src/cli/browser-cli-test-helpers.ts
@@ -14,6 +14,17 @@ export function createBrowserProgram(params?: { withGatewayUrl?: boolean }): {
   if (params?.withGatewayUrl) {
     browser.option("--url <url>", "Gateway WebSocket URL");
   }
-  const parentOpts = (cmd: Command) => cmd.parent?.opts?.() as BrowserParentOpts;
+  const parentOpts = (cmd: Command) => {
+    const parent = cmd.parent;
+    const opts = parent?.opts?.() ?? {};
+    const timeoutSource =
+      typeof parent?.getOptionValueSource === "function"
+        ? parent.getOptionValueSource("timeout")
+        : undefined;
+    return {
+      ...opts,
+      ...(timeoutSource ? { timeoutSource } : {}),
+    };
+  };
   return { program, browser, parentOpts };
 }

--- a/src/cli/browser-cli.timeout-option.test.ts
+++ b/src/cli/browser-cli.timeout-option.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerBrowserActionInputCommands } from "./browser-cli-actions-input.js";
+import { registerBrowserInspectCommands } from "./browser-cli-inspect.js";
+import { createBrowserProgram } from "./browser-cli-test-helpers.js";
+
+const mocks = vi.hoisted(() => ({
+  callBrowserRequest: vi.fn(
+    async (_opts: unknown, req: { path?: string }, _extra?: { timeoutMs?: number }) => {
+      if (req.path === "/snapshot") {
+        return {
+          ok: true,
+          format: "ai",
+          targetId: "t1",
+          url: "https://example.com",
+          snapshot: "ok",
+        };
+      }
+      return {
+        ok: true,
+        targetId: "t1",
+        url: "https://example.com",
+      };
+    },
+  ),
+  loadConfig: vi.fn(() => ({ browser: {} })),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("./browser-cli-shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./browser-cli-shared.js")>();
+  return {
+    ...actual,
+    callBrowserRequest: mocks.callBrowserRequest,
+  };
+});
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("browser CLI timeout forwarding", () => {
+  function createProgram() {
+    const { program, browser, parentOpts } = createBrowserProgram();
+    browser.option("--timeout <ms>", "Timeout in ms", "30000");
+    registerBrowserActionInputCommands(browser, parentOpts);
+    registerBrowserInspectCommands(browser, parentOpts);
+    return program;
+  }
+
+  beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
+    mocks.loadConfig.mockClear();
+    mocks.loadConfig.mockReturnValue({ browser: {} });
+    mocks.runtime.log.mockClear();
+    mocks.runtime.error.mockClear();
+    mocks.runtime.exit.mockClear();
+  });
+
+  it("uses parent --timeout for click", async () => {
+    const program = createProgram();
+    await program.parseAsync(["browser", "--timeout", "1234", "click", "e1"], { from: "user" });
+
+    const clickCall = mocks.callBrowserRequest.mock.calls.at(-1);
+    expect(clickCall?.[2]).toEqual({ timeoutMs: 1234 });
+  });
+
+  it("uses parent --timeout for snapshot", async () => {
+    const program = createProgram();
+    await program.parseAsync(["browser", "--timeout", "2345", "snapshot"], { from: "user" });
+
+    const snapshotCall = mocks.callBrowserRequest.mock.calls.at(-1);
+    expect(snapshotCall?.[2]).toEqual({ timeoutMs: 2345 });
+  });
+
+  it("prefers command-specific timeout over the parent timeout", async () => {
+    const program = createProgram();
+    await program.parseAsync(
+      ["browser", "--timeout", "2345", "scrollintoview", "e1", "--timeout-ms", "456"],
+      { from: "user" },
+    );
+
+    const scrollCall = mocks.callBrowserRequest.mock.calls.at(-1);
+    expect(scrollCall?.[2]).toEqual({ timeoutMs: 456 });
+    expect(
+      (scrollCall?.[1] as { body?: { timeoutMs?: number } } | undefined)?.body?.timeoutMs,
+    ).toBe(456);
+  });
+});

--- a/src/cli/browser-cli.ts
+++ b/src/cli/browser-cli.ts
@@ -43,7 +43,18 @@ export function registerBrowserCli(program: Command) {
 
   addGatewayClientOptions(browser);
 
-  const parentOpts = (cmd: Command) => cmd.parent?.opts?.() as BrowserParentOpts;
+  const parentOpts = (cmd: Command) => {
+    const parent = cmd.parent;
+    const opts = parent?.opts?.() ?? {};
+    const timeoutSource =
+      typeof parent?.getOptionValueSource === "function"
+        ? parent.getOptionValueSource("timeout")
+        : undefined;
+    return {
+      ...opts,
+      ...(timeoutSource ? { timeoutSource } : {}),
+    };
+  };
 
   registerBrowserManageCommands(browser, parentOpts);
   registerBrowserExtensionCommands(browser, parentOpts);

--- a/src/gateway/server-methods/browser.local-timeout.test.ts
+++ b/src/gateway/server-methods/browser.local-timeout.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createBrowserControlContext: vi.fn(() => ({})),
+  createBrowserRouteDispatcher: vi.fn(),
+  isNodeCommandAllowed: vi.fn(),
+  loadConfig: vi.fn(),
+  resolveNodeCommandAllowlist: vi.fn(),
+  startBrowserControlServiceFromConfig: vi.fn(),
+}));
+
+vi.mock("../../browser/control-service.js", () => ({
+  createBrowserControlContext: mocks.createBrowserControlContext,
+  startBrowserControlServiceFromConfig: mocks.startBrowserControlServiceFromConfig,
+}));
+
+vi.mock("../../browser/routes/dispatcher.js", () => ({
+  createBrowserRouteDispatcher: mocks.createBrowserRouteDispatcher,
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../node-command-policy.js", () => ({
+  isNodeCommandAllowed: mocks.isNodeCommandAllowed,
+  resolveNodeCommandAllowlist: mocks.resolveNodeCommandAllowlist,
+}));
+
+import { browserHandlers } from "./browser.js";
+
+type RespondCall = [boolean, unknown?, { code: number; message: string }?];
+
+describe("browser.request local timeout handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfig.mockReturnValue({
+      gateway: { nodes: { browser: { mode: "auto" } } },
+    });
+    mocks.resolveNodeCommandAllowlist.mockReturnValue([]);
+    mocks.isNodeCommandAllowed.mockReturnValue({ ok: true });
+    mocks.startBrowserControlServiceFromConfig.mockResolvedValue(true);
+  });
+
+  it("passes an AbortSignal into local dispatch and returns a timeout error", async () => {
+    const dispatch = vi.fn(
+      async ({ signal }: { signal?: AbortSignal }) =>
+        await new Promise((_resolve, reject) => {
+          if (signal?.aborted) {
+            reject(signal.reason ?? new Error("aborted"));
+            return;
+          }
+          const onAbort = () => reject(signal?.reason ?? new Error("aborted"));
+          signal?.addEventListener("abort", onAbort, { once: true });
+        }),
+    );
+    mocks.createBrowserRouteDispatcher.mockReturnValue({ dispatch });
+
+    const respond = vi.fn();
+    await browserHandlers["browser.request"]({
+      params: {
+        method: "POST",
+        path: "/act",
+        body: { kind: "click", ref: "e1" },
+        timeoutMs: 10,
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          listConnected: vi.fn(() => []),
+        },
+      } as never,
+      client: null,
+      req: { type: "req", id: "req-1", method: "browser.request" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/act",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.message).toContain("browser request timed out");
+  });
+});

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -6,6 +6,7 @@ import {
 import { applyBrowserProxyPaths, persistBrowserProxyFiles } from "../../browser/proxy-files.js";
 import { createBrowserRouteDispatcher } from "../../browser/routes/dispatcher.js";
 import { loadConfig } from "../../config/config.js";
+import { withTimeout } from "../../node-host/with-timeout.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import type { NodeSession } from "../node-registry.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
@@ -244,12 +245,24 @@ export const browserHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const result = await dispatcher.dispatch({
-      method: methodRaw,
-      path,
-      query,
-      body,
-    });
+    let result;
+    try {
+      result = await withTimeout(
+        async (signal) =>
+          await dispatcher.dispatch({
+            method: methodRaw,
+            path,
+            query,
+            body,
+            signal,
+          }),
+        timeoutMs,
+        "browser request",
+      );
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+      return;
+    }
 
     if (result.status >= 400) {
       const message =


### PR DESCRIPTION
AI-assisted: yes (Codex).
Testing: focused regression tests + `pnpm build`; `pnpm check` is still blocked by unrelated pre-existing repo failures.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: local `browser.request` timeouts only stopped the caller; the in-process Playwright work kept running, and several browser CLI subcommands also overrode the parent `browser --timeout` with hardcoded defaults.
- Why it matters: once a slow `type` / `click` / `snapshot` path timed out, later interactive browser requests could degrade into more timeouts against the same attached session, and users could not reliably tune CLI timeout behavior.
- What changed: propagate timeout/abort through local browser dispatch, thread `req.signal` through browser route handlers and Playwright helpers, force-disconnect the target CDP session when an action/snapshot is aborted, and make browser CLI timeout resolution consistent (`--timeout-ms` > parent `browser --timeout` > fallback default).
- What did NOT change (scope boundary): this does not add new browser capabilities, new timeout flags, or change the remote browser request protocol beyond honoring the existing timeout/abort semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #39007
- Related #39090
- Related #38852
- Related #39144

## User-visible / Behavior Changes

- Timed out local browser actions/snapshots now abort more cleanly instead of leaving the attached Playwright/CDP target stuck for follow-up requests.
- Parent `browser --timeout` now applies consistently across browser CLI subcommands unless a more specific `--timeout-ms` flag is provided.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux arm64 (Raspberry Pi host for the live repro) and local Linux dev environment for source validation
- Runtime/container: Node.js workspace via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): local browser gateway; original end-to-end repro came through Telegram
- Relevant config (redacted): attached Chromium session (`attachOnly: true`), persistent `openclaw` profile, local CDP endpoint, local gateway websocket

### Steps

1. Attach OpenClaw to a persistent Chromium/CDP session and confirm `browser status`, `browser tabs`, and `browser snapshot` succeed.
2. Run an interactive browser action such as `browser act kind=type ... --submit` on Gemini or `browser act kind=click ...` on `http://example.com/`.
3. Observe the timeout/abort path and then retry follow-up browser actions against the same attached tab/session.

### Expected

- Timed out browser work should abort cleanly, and follow-up actions should still be able to reuse the session.
- Parent browser CLI timeouts should flow through to subcommands unless explicitly overridden.

### Actual

- Before this change, the caller timed out first while the local Playwright work could continue in the background, which left later interactive requests prone to more timeouts.
- Several browser CLI subcommands kept using hardcoded timeout defaults even when `browser --timeout` was set.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: the equivalent runtime hotfix was exercised end-to-end against a live attached Chromium session on Raspberry Pi (Gemini `snapshot` + `type --submit`, plus `example.com` click flows), and the source changes were covered by focused regression tests plus `pnpm build`.
- Edge cases checked: local gateway timeout forwarding, route-level signal propagation for actions and snapshots, abort-triggered Playwright disconnect/recovery, parent CLI `browser --timeout` precedence, and explicit subcommand `--timeout-ms` override behavior.
- What you did **not** verify: full `pnpm check` is still blocked by unrelated pre-existing `tsgo` errors in other packages/extensions, and I did not do a new cross-platform browser matrix beyond the reproduced Linux arm64 attach-only flow.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit; the behavior is isolated to browser timeout propagation, abort handling, and CLI timeout resolution.
- Files/config to restore: the touched browser gateway, browser route/helper, and browser CLI files in this PR.
- Known bad symptoms reviewers should watch for: aborted browser actions unexpectedly dropping a healthy session, or CLI browser subcommands ignoring an explicit parent timeout again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: force-disconnecting the Playwright/CDP target on abort could drop transient in-flight browser state for that target.
  - Mitigation: the disconnect is only triggered for aborted work, is scoped to the current target, and is preferable to leaving the session wedged for follow-up requests.
- Risk: users who implicitly relied on subcommand hardcoded defaults may notice the parent `browser --timeout` now taking effect.
  - Mitigation: explicit per-command `--timeout-ms` still wins, and the new precedence matches the documented/top-level CLI behavior.

