### PR TITLE
fix(voice-call): use nullish coalescing for STT vadThreshold and silenceDurationMs

### DIFF
--- a/extensions/voice-call/src/providers/stt-openai-realtime.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.ts
@@ -62,8 +62,8 @@ export class OpenAIRealtimeSTTProvider {
     }
     this.apiKey = config.apiKey;
     this.model = config.model || "gpt-4o-transcribe";
-    this.silenceDurationMs = config.silenceDurationMs || 800;
-    this.vadThreshold = config.vadThreshold || 0.5;
+    this.silenceDurationMs = config.silenceDurationMs ?? 800;
+    this.vadThreshold = config.vadThreshold ?? 0.5;
   }
 
   /**


### PR DESCRIPTION
## Summary

- `vadThreshold: 0` (maximum VAD sensitivity) silently becomes `0.5` because `0 || 0.5` evaluates to `0.5`
- `silenceDurationMs: 0` (no silence padding) silently becomes `800` for the same reason
- Both values are valid per the schema `z.number().min(0)` and the OpenAI Realtime API

## Change

`extensions/voice-call/src/providers/stt-openai-realtime.ts:65-66`

```diff
- this.silenceDurationMs = config.silenceDurationMs || 800;
- this.vadThreshold = config.vadThreshold || 0.5;
+ this.silenceDurationMs = config.silenceDurationMs ?? 800;
+ this.vadThreshold = config.vadThreshold ?? 0.5;
```

## Test plan

- [ ] `vadThreshold: 0` should produce actual threshold of `0`
- [ ] `silenceDurationMs: 0` should produce actual duration of `0`
- [ ] Omitting both should still default to `0.5` and `800`

Fixes #39190

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>