### PR TITLE
fix(voice-call): add missing speed and instructions to OpenAI TTS schema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -527,6 +527,14 @@
               },
               "voice": {
                 "type": "string"
+              },
+              "speed": {
+                "type": "number",
+                "minimum": 0.25,
+                "maximum": 4.0
+              },
+              "instructions": {
+                "type": "string"
               }
             }
           },


### PR DESCRIPTION
## Summary

- The OpenAI TTS provider schema has `additionalProperties: false` but only declares `apiKey`, `model`, and `voice`
- The TypeScript code (`tts-openai.ts:85-86`) and OpenAI API support two additional properties:
  - `speed` (number, 0.25-4.0) - speech speed multiplier
  - `instructions` (string) - speech style instructions for gpt-4o-mini-tts
- Users get JSON schema validation errors when configuring these in their config file

## Change

`extensions/voice-call/openclaw.plugin.json` (OpenAI TTS provider schema, ~line 530)

```diff
              "voice": {
                "type": "string"
-             }
+             },
+             "speed": {
+               "type": "number",
+               "minimum": 0.25,
+               "maximum": 4.0
+             },
+             "instructions": {
+               "type": "string"
+             }
```

## Test plan

- [ ] Config with `speed: 1.5` should pass validation
- [ ] Config with `instructions: "Speak slowly and clearly"` should pass validation
- [ ] Config without either should still work (both are optional)

Fixes #39192

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>