### PR TITLE
fix(daemon): reject pid <= 0 in parseLaunchctlPrint

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -102,6 +102,26 @@ describe("launchd runtime parsing", () => {
       lastExitReason: "exited",
     });
   });
+
+  it("does not set pid when pid = 0", () => {
+    const output = ["state = running", "pid = 0"].join("\n");
+    const info = parseLaunchctlPrint(output);
+    expect(info.pid).toBeUndefined();
+    expect(info.state).toBe("running");
+  });
+
+  it("sets pid for positive values", () => {
+    const output = ["state = running", "pid = 1234"].join("\n");
+    const info = parseLaunchctlPrint(output);
+    expect(info.pid).toBe(1234);
+  });
+
+  it("does not set pid for negative values", () => {
+    const output = ["state = waiting", "pid = -1"].join("\n");
+    const info = parseLaunchctlPrint(output);
+    expect(info.pid).toBeUndefined();
+    expect(info.state).toBe("waiting");
+  });
 });
 
 describe("launchctl list detection", () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -128,7 +128,7 @@ export function parseLaunchctlPrint(output: string): LaunchctlPrintInfo {
   const pidValue = entries.pid;
   if (pidValue) {
     const pid = Number.parseInt(pidValue, 10);
-    if (Number.isFinite(pid)) {
+    if (Number.isFinite(pid) && pid > 0) {
       info.pid = pid;
     }
   }


### PR DESCRIPTION
## Summary

- `parseLaunchctlPrint()` only checks `Number.isFinite(pid)` before storing the PID
- The equivalent systemd parser at `src/daemon/systemd.ts:122` correctly checks `Number.isFinite(pid) && pid > 0`
- When `launchctl print` reports `pid = 0` (no running process), the launchd parser stores `pid: 0`, which is semantically incorrect (PID 0 is the kernel scheduler)

## Change

`src/daemon/launchd.ts:131`

```diff
- if (Number.isFinite(pid)) {
+ if (Number.isFinite(pid) && pid > 0) {
    info.pid = pid;
  }
```

Aligns with the systemd parser's guard at `src/daemon/systemd.ts:122`.

## Test plan

- [ ] `parseLaunchctlPrint` with `pid = 0` should not set `info.pid`
- [ ] `parseLaunchctlPrint` with `pid = 1234` should still set `info.pid = 1234`
- [ ] Negative PIDs should also be rejected

Fixes #39188

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>