### PR TITLE
fix(voice-call): use nullish coalescing for TTS speed default

### DIFF
--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -82,7 +82,7 @@ export class OpenAITTSProvider {
     this.model = config.model || "gpt-4o-mini-tts";
     // Default to coral - good balance of quality and natural tone
     this.voice = (config.voice as OpenAITTSVoice) || "coral";
-    this.speed = config.speed || 1.0;
+    this.speed = config.speed ?? 1.0;
     this.instructions = config.instructions;
 
     if (!this.apiKey) {


### PR DESCRIPTION
## Summary

- `config.speed || 1.0` treats `0` as falsy, same class of bug as #39190 and #39191
- Switch from `||` to `??` for consistency and correctness
- While the current OpenAI API minimum speed is `0.25`, using `??` is defensive and aligns with the STT nullish coalescing fixes

## Change

`extensions/voice-call/src/providers/tts-openai.ts:85`

```diff
- this.speed = config.speed || 1.0;
+ this.speed = config.speed ?? 1.0;
```

## Test plan

- [ ] `speed: 0.25` should produce actual speed of `0.25`
- [ ] Omitting `speed` should still default to `1.0`

Fixes #39285
Related: #39190, #39191

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>