### PR TITLE
fix(ui): persist selected agent after config save/reload

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -720,8 +720,14 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, [...basePath, "deny"]);
                   }
                 },
-                onConfigReload: () => loadConfig(state),
-                onConfigSave: () => saveConfig(state),
+                onConfigReload: async () => {
+                  await loadConfig(state);
+                  await loadAgents(state);
+                },
+                onConfigSave: async () => {
+                  await saveConfig(state);
+                  await loadAgents(state);
+                },
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
                 onSkillsFilterChange: (next) => (state.skillsFilter = next),


### PR DESCRIPTION
## Summary
- After saving or reloading config on the `/agents` page, call `loadAgents()` to refresh the agents list so the previously selected agent ID remains valid
- This prevents the UI from silently resetting to the default agent after every save
- Follows the same pattern already used by the channels page (`handleChannelConfigSave`)

## Test plan
- [ ] Go to `/agents`, select a non-default agent, change a setting, save — verify the selected agent persists
- [ ] Reload config on agents page — verify selected agent persists
- [ ] Verify channels page still works correctly (unchanged code path)

Fixes #39254