### PR TITLE
fix(skills): use maxCandidatesPerRoot for workspace skill discovery window

### DIFF
--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -234,6 +234,51 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(prompt).toContain("Does demo things");
     expect(prompt).toContain(path.join(skillDir, "SKILL.md"));
   });
+
+  it("discovers workspace skills beyond maxSkillsLoadedPerSource when within maxCandidatesPerRoot", async () => {
+    // Regression test for #38886: skill discovery was using maxSkillsLoadedPerSource
+    // (the loaded-skills cap) to truncate the candidate directory window instead of
+    // maxCandidatesPerRoot.  Skills alphabetically after the Nth folder were silently
+    // skipped even though they were within the allowed scan window.
+    const workspaceDir = await makeWorkspace();
+
+    // aa-skill (position 1) — has SKILL.md, discovered in both old and new code
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "aa-skill"),
+      name: "aa-skill",
+      description: "First skill",
+      body: "# AA Skill\n",
+    });
+
+    // bb-not-a-skill (position 2) — no SKILL.md, occupies a candidate slot
+    await fs.mkdir(path.join(workspaceDir, "skills", "bb-not-a-skill"), { recursive: true });
+
+    // cc-skill (position 3) — has SKILL.md; with the old bug it was excluded because
+    // the candidate window was capped at maxSkillsLoadedPerSource=2, skipping position 3.
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "cc-skill"),
+      name: "cc-skill",
+      description: "Third skill",
+      body: "# CC Skill\n",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      ...resolveTestSkillDirs(workspaceDir),
+      config: {
+        skills: {
+          limits: {
+            maxCandidatesPerRoot: 3, // scan window: allow all 3 dirs
+            maxSkillsLoadedPerSource: 2, // load cap: allow up to 2 skills
+          },
+        },
+      },
+    });
+
+    const names = entries.map((e) => e.skill.name);
+    expect(names).toContain("aa-skill");
+    // cc-skill must be discovered even though it is past position maxSkillsLoadedPerSource
+    expect(names).toContain("cc-skill");
+  });
 });
 
 describe("applySkillEnvOverrides", () => {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -270,13 +270,6 @@ function loadSkillEntries(
         maxCandidatesPerRoot: limits.maxCandidatesPerRoot,
         maxSkillsLoadedPerSource: limits.maxSkillsLoadedPerSource,
       });
-    } else if (childDirs.length > maxCandidates) {
-      skillsLogger.warn("Skills root has many entries, truncating discovery.", {
-        dir: params.dir,
-        baseDir,
-        childDirCount: childDirs.length,
-        maxSkillsLoadedPerSource: limits.maxSkillsLoadedPerSource,
-      });
     }
 
     const loadedSkills: Skill[] = [];

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -259,7 +259,7 @@ function loadSkillEntries(
     const childDirs = listChildDirectories(baseDir);
     const suspicious = childDirs.length > limits.maxCandidatesPerRoot;
 
-    const maxCandidates = Math.max(0, limits.maxSkillsLoadedPerSource);
+    const maxCandidates = Math.max(0, limits.maxCandidatesPerRoot);
     const limitedChildren = childDirs.slice().sort().slice(0, maxCandidates);
 
     if (suspicious) {


### PR DESCRIPTION
## Summary

Fixes #38886

Workspace skill discovery was silently truncating the candidate directory window using `maxSkillsLoadedPerSource` (the cap on how many skills to *load*) instead of `maxCandidatesPerRoot` (the cap on how many directories to *scan*).

## Root Cause

In `loadSkillEntries` (src/agents/skills/workspace.ts line 262):

```ts
// Before (bug): uses the load cap to limit the scan window
const maxCandidates = Math.max(0, limits.maxSkillsLoadedPerSource); // 200

// After (fix): uses the correct scan-window cap
const maxCandidates = Math.max(0, limits.maxCandidatesPerRoot);     // 300
```

When a skills root (e.g. `~/.openclaw/workspace/skills/`) contains more directories than `maxSkillsLoadedPerSource` (default: 200) but fewer than `maxCandidatesPerRoot` (default: 300), any skill folder sorted alphabetically past position 200 was never inspected, even though it was within the allowed scan window.

This is why users adding new skill folders to a populated workspace would see them missing from `openclaw skills list`, `openclaw skills check`, and the Control UI Skills page.

The existing per-skill load cap (`maxSkillsLoadedPerSource`) is still applied correctly inside the loop and as a post-filter — this PR only fixes the candidate *window*, not the load *cap*.

## Tests

Added a regression test in `src/agents/skills.test.ts`:
- Creates 3 skill directories with `maxCandidatesPerRoot: 3, maxSkillsLoadedPerSource: 2`
- The 3rd directory (alphabetically) contains a valid SKILL.md
- Verifies that both the 1st and 3rd skill are discovered (2nd slot is occupied by a non-skill folder)
- Without the fix, only the 1st skill is found (3rd is outside the truncated window)