### PR TITLE
feat(web-search): add Tavily as native search provider

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -7,6 +7,7 @@ const {
   normalizeFreshness,
   normalizeToIsoDate,
   isoToPerplexityDate,
+  resolveTavilyApiKey,
   resolveGrokApiKey,
   resolveGrokModel,
   resolveGrokInlineCitations,
@@ -19,6 +20,7 @@ const {
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
 const moonshotApiKeyEnv = ["MOONSHOT_API", "KEY"].join("_");
+const tavilyApiKeyEnv = ["TAVILY_API", "KEY"].join("_");
 
 describe("web_search brave language param normalization", () => {
   it("normalizes and auto-corrects swapped Brave language params", () => {
@@ -132,6 +134,26 @@ describe("web_search grok config resolution", () => {
   it("respects inlineCitations config", () => {
     expect(resolveGrokInlineCitations({ inlineCitations: true })).toBe(true);
     expect(resolveGrokInlineCitations({ inlineCitations: false })).toBe(false);
+  });
+});
+
+describe("web_search tavily config resolution", () => {
+  it("uses config apiKey when provided", () => {
+    expect(resolveTavilyApiKey({ apiKey: "tavily-test-key" })).toBe("tavily-test-key"); // pragma: allowlist secret
+  });
+
+  it("falls back to TAVILY_API_KEY", () => {
+    const tavilyEnvValue = "tavily-env"; // pragma: allowlist secret
+    withEnv({ [tavilyApiKeyEnv]: tavilyEnvValue }, () => {
+      expect(resolveTavilyApiKey({})).toBe(tavilyEnvValue);
+    });
+  });
+
+  it("returns undefined when no Tavily key is configured", () => {
+    withEnv({ TAVILY_API_KEY: undefined }, () => {
+      expect(resolveTavilyApiKey({})).toBeUndefined();
+      expect(resolveTavilyApiKey(undefined)).toBeUndefined();
+    });
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1103,6 +1103,20 @@ async function runTavilySearch(params: {
     topic: params.freshness ? "news" : "general",
   };
 
+  // Map freshness recency values to Tavily's `days` parameter for the news topic.
+  if (params.freshness) {
+    const FRESHNESS_TO_DAYS: Record<string, number> = {
+      day: 1,
+      week: 7,
+      month: 30,
+      year: 365,
+    };
+    const days = FRESHNESS_TO_DAYS[params.freshness];
+    if (days !== undefined) {
+      body.days = days;
+    }
+  }
+
   if (params.country) {
     body.country = params.country;
   }

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -21,12 +21,13 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "tavily", "grok", "gemini", "kimi"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
+const TAVILY_SEARCH_ENDPOINT = "https://api.tavily.com/search";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
@@ -253,6 +254,11 @@ type PerplexityConfig = {
 
 type PerplexityApiKeySource = "config" | "perplexity_env" | "none";
 
+type TavilyConfig = {
+  apiKey?: string;
+  searchDepth?: "basic" | "advanced";
+};
+
 type GrokConfig = {
   apiKey?: string;
   model?: string;
@@ -335,6 +341,20 @@ type PerplexitySearchApiResult = {
 type PerplexitySearchApiResponse = {
   results?: PerplexitySearchApiResult[];
   id?: string;
+};
+
+type TavilySearchResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+  score?: number;
+  published_date?: string;
+};
+
+type TavilySearchResponse = {
+  query?: string;
+  answer?: string;
+  results?: TavilySearchResult[];
 };
 
 function extractGrokContent(data: GrokSearchResponse): {
@@ -459,6 +479,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "tavily") {
+    return {
+      error: "missing_tavily_api_key",
+      message:
+        "web_search (tavily) needs an API key. Set TAVILY_API_KEY in the Gateway environment, or configure tools.web.search.tavily.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   if (provider === "gemini") {
     return {
       error: "missing_gemini_api_key",
@@ -490,6 +518,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   if (raw === "perplexity") {
     return "perplexity";
   }
+  if (raw === "tavily") {
+    return "tavily";
+  }
   if (raw === "grok") {
     return "grok";
   }
@@ -514,14 +545,22 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "perplexity";
     }
-    // 2. Brave
+    // 2. Tavily
+    const tavilyConfig = resolveTavilyConfig(search);
+    if (resolveTavilyApiKey(tavilyConfig)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "tavily" from available API keys',
+      );
+      return "tavily";
+    }
+    // 3. Brave
     if (resolveSearchApiKey(search)) {
       logVerbose(
         'web_search: no provider configured, auto-detected "brave" from available API keys',
       );
       return "brave";
     }
-    // 3. Gemini
+    // 4. Gemini
     const geminiConfig = resolveGeminiConfig(search);
     if (resolveGeminiApiKey(geminiConfig)) {
       logVerbose(
@@ -529,7 +568,7 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "gemini";
     }
-    // 4. Grok
+    // 5. Grok
     const grokConfig = resolveGrokConfig(search);
     if (resolveGrokApiKey(grokConfig)) {
       logVerbose(
@@ -537,7 +576,7 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "grok";
     }
-    // 5. Kimi
+    // 6. Kimi
     const kimiConfig = resolveKimiConfig(search);
     if (resolveKimiApiKey(kimiConfig)) {
       logVerbose(
@@ -580,6 +619,30 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
 
 function normalizeApiKey(key: unknown): string {
   return normalizeSecretInput(key);
+}
+
+function resolveTavilyConfig(search?: WebSearchConfig): TavilyConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const tavily = "tavily" in search ? search.tavily : undefined;
+  if (!tavily || typeof tavily !== "object") {
+    return {};
+  }
+  return tavily as TavilyConfig;
+}
+
+function resolveTavilyApiKey(tavily?: TavilyConfig): string | undefined {
+  const fromConfig = normalizeApiKey(tavily?.apiKey);
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = normalizeApiKey(process.env.TAVILY_API_KEY);
+  return fromEnv || undefined;
+}
+
+function resolveTavilySearchDepth(tavily?: TavilyConfig): "basic" | "advanced" {
+  return tavily?.searchDepth === "advanced" ? "advanced" : "basic";
 }
 
 function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
@@ -866,11 +929,17 @@ function normalizeFreshness(
   const lower = trimmed.toLowerCase();
 
   if (BRAVE_FRESHNESS_SHORTCUTS.has(lower)) {
-    return provider === "brave" ? lower : FRESHNESS_TO_RECENCY[lower];
+    if (provider === "brave") {
+      return lower;
+    }
+    return FRESHNESS_TO_RECENCY[lower];
   }
 
   if (PERPLEXITY_RECENCY_VALUES.has(lower)) {
-    return provider === "perplexity" ? lower : RECENCY_TO_FRESHNESS[lower];
+    if (provider === "perplexity" || provider === "tavily") {
+      return lower;
+    }
+    return RECENCY_TO_FRESHNESS[lower];
   }
 
   // Brave date range support
@@ -1001,6 +1070,81 @@ async function runPerplexitySearchApi(params: {
           siteName: resolveSiteName(url) || undefined,
         };
       });
+    },
+  );
+}
+
+async function runTavilySearch(params: {
+  query: string;
+  apiKey: string;
+  count: number;
+  timeoutSeconds: number;
+  country?: string;
+  freshness?: string;
+  searchDepth: "basic" | "advanced";
+}): Promise<{
+  answer?: string;
+  results: Array<{
+    title: string;
+    url: string;
+    description: string;
+    published?: string;
+    siteName?: string;
+    score?: number;
+  }>;
+}> {
+  const body: Record<string, unknown> = {
+    api_key: params.apiKey,
+    query: params.query,
+    max_results: params.count,
+    search_depth: params.searchDepth,
+    include_answer: true,
+    include_raw_content: false,
+    topic: params.freshness ? "news" : "general",
+  };
+
+  if (params.country) {
+    body.country = params.country;
+  }
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: TAVILY_SEARCH_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        return await throwWebSearchApiError(res, "Tavily");
+      }
+
+      const data = (await res.json()) as TavilySearchResponse;
+      const results = Array.isArray(data.results) ? data.results : [];
+
+      return {
+        answer:
+          typeof data.answer === "string" ? wrapWebContent(data.answer, "web_search") : undefined,
+        results: results.map((entry) => {
+          const title = entry.title ?? "";
+          const url = entry.url ?? "";
+          const snippet = entry.content ?? "";
+          return {
+            title: title ? wrapWebContent(title, "web_search") : "",
+            url,
+            description: snippet ? wrapWebContent(snippet, "web_search") : "",
+            published: entry.published_date ?? undefined,
+            siteName: resolveSiteName(url) || undefined,
+            score: typeof entry.score === "number" ? entry.score : undefined,
+          };
+        }),
+      };
     },
   );
 }
@@ -1230,6 +1374,7 @@ async function runWebSearch(params: {
   searchDomainFilter?: string[];
   maxTokens?: number;
   maxTokensPerPage?: number;
+  tavilySearchDepth?: "basic" | "advanced";
   grokModel?: string;
   grokInlineCitations?: boolean;
   geminiModel?: string;
@@ -1239,11 +1384,13 @@ async function runWebSearch(params: {
   const providerSpecificKey =
     params.provider === "grok"
       ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
-      : params.provider === "gemini"
-        ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
-        : params.provider === "kimi"
-          ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-          : "";
+      : params.provider === "tavily"
+        ? (params.tavilySearchDepth ?? "basic")
+        : params.provider === "gemini"
+          ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
+          : params.provider === "kimi"
+            ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
+            : "";
   const cacheKey = normalizeCacheKey(
     `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
@@ -1281,6 +1428,35 @@ async function runWebSearch(params: {
         provider: params.provider,
         wrapped: true,
       },
+      results,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
+  if (params.provider === "tavily") {
+    const { answer, results } = await runTavilySearch({
+      query: params.query,
+      apiKey: params.apiKey,
+      count: params.count,
+      timeoutSeconds: params.timeoutSeconds,
+      country: params.country,
+      freshness: params.freshness,
+      searchDepth: params.tavilySearchDepth ?? "basic",
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: results.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      answer,
       results,
     };
     writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
@@ -1462,6 +1638,7 @@ export function createWebSearchTool(options?: {
 
   const provider = resolveSearchProvider(search);
   const perplexityConfig = resolvePerplexityConfig(search);
+  const tavilyConfig = resolveTavilyConfig(search);
   const grokConfig = resolveGrokConfig(search);
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
@@ -1469,13 +1646,15 @@ export function createWebSearchTool(options?: {
   const description =
     provider === "perplexity"
       ? "Search the web using the Perplexity Search API. Returns structured results (title, URL, snippet) for fast research. Supports domain, region, language, and freshness filtering."
-      : provider === "grok"
-        ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
-        : provider === "kimi"
-          ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
-          : provider === "gemini"
-            ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+      : provider === "tavily"
+        ? "Search the web using Tavily Search. Returns structured results (title, URL, snippet, score) plus an AI-synthesized answer when available. Supports country filtering and freshness via news search."
+        : provider === "grok"
+          ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
+          : provider === "kimi"
+            ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
+            : provider === "gemini"
+              ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
+              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1488,13 +1667,15 @@ export function createWebSearchTool(options?: {
       const apiKey =
         provider === "perplexity"
           ? perplexityAuth?.apiKey
-          : provider === "grok"
-            ? resolveGrokApiKey(grokConfig)
-            : provider === "kimi"
-              ? resolveKimiApiKey(kimiConfig)
-              : provider === "gemini"
-                ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+          : provider === "tavily"
+            ? resolveTavilyApiKey(tavilyConfig)
+            : provider === "grok"
+              ? resolveGrokApiKey(grokConfig)
+              : provider === "kimi"
+                ? resolveKimiApiKey(kimiConfig)
+                : provider === "gemini"
+                  ? resolveGeminiApiKey(geminiConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -1504,10 +1685,10 @@ export function createWebSearchTool(options?: {
       const count =
         readNumberParam(params, "count", { integer: true }) ?? search?.maxResults ?? undefined;
       const country = readStringParam(params, "country");
-      if (country && provider !== "brave" && provider !== "perplexity") {
+      if (country && provider !== "brave" && provider !== "perplexity" && provider !== "tavily") {
         return jsonResult({
           error: "unsupported_country",
-          message: `country filtering is not supported by the ${provider} provider. Only Brave and Perplexity support country filtering.`,
+          message: `country filtering is not supported by the ${provider} provider. Only Brave, Perplexity, and Tavily support country filtering.`,
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
@@ -1551,10 +1732,15 @@ export function createWebSearchTool(options?: {
       const resolvedSearchLang = normalizedBraveLanguageParams.search_lang;
       const resolvedUiLang = normalizedBraveLanguageParams.ui_lang;
       const rawFreshness = readStringParam(params, "freshness");
-      if (rawFreshness && provider !== "brave" && provider !== "perplexity") {
+      if (
+        rawFreshness &&
+        provider !== "brave" &&
+        provider !== "perplexity" &&
+        provider !== "tavily"
+      ) {
         return jsonResult({
           error: "unsupported_freshness",
-          message: `freshness filtering is not supported by the ${provider} provider. Only Brave and Perplexity support freshness.`,
+          message: `freshness filtering is not supported by the ${provider} provider. Only Brave, Perplexity, and Tavily support freshness.`,
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
@@ -1655,6 +1841,7 @@ export function createWebSearchTool(options?: {
         searchDomainFilter: domainFilter,
         maxTokens: maxTokens ?? undefined,
         maxTokensPerPage: maxTokensPerPage ?? undefined,
+        tavilySearchDepth: resolveTavilySearchDepth(tavilyConfig),
         grokModel: resolveGrokModel(grokConfig),
         grokInlineCitations: resolveGrokInlineCitations(grokConfig),
         geminiModel: resolveGeminiModel(geminiConfig),
@@ -1675,6 +1862,7 @@ export const __testing = {
   SEARCH_CACHE,
   FRESHNESS_TO_RECENCY,
   RECENCY_TO_FRESHNESS,
+  resolveTavilyApiKey,
   resolveGrokApiKey,
   resolveGrokModel,
   resolveGrokInlineCitations,

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -10,7 +10,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
-export type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi";
+export type SearchProvider = "perplexity" | "brave" | "tavily" | "gemini" | "grok" | "kimi";
 
 type SearchProviderEntry = {
   value: SearchProvider;
@@ -37,6 +37,14 @@ export const SEARCH_PROVIDER_OPTIONS: readonly SearchProviderEntry[] = [
     envKeys: ["BRAVE_API_KEY"],
     placeholder: "BSA...",
     signupUrl: "https://brave.com/search/api/",
+  },
+  {
+    value: "tavily",
+    label: "Tavily Search",
+    hint: "Structured results · AI answer · relevance scores",
+    envKeys: ["TAVILY_API_KEY"],
+    placeholder: "tvly-...",
+    signupUrl: "https://app.tavily.com/home",
   },
   {
     value: "gemini",
@@ -75,6 +83,8 @@ function rawKeyValue(config: OpenClawConfig, provider: SearchProvider): unknown 
       return search?.apiKey;
     case "perplexity":
       return search?.perplexity?.apiKey;
+    case "tavily":
+      return search?.tavily?.apiKey;
     case "gemini":
       return search?.gemini?.apiKey;
     case "grok":
@@ -134,6 +144,9 @@ export function applySearchKey(
       break;
     case "perplexity":
       search.perplexity = { ...search.perplexity, apiKey: key };
+      break;
+    case "tavily":
+      search.tavily = { ...search.tavily, apiKey: key };
       break;
     case "gemini":
       search.gemini = { ...search.gemini, apiKey: key };

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -48,6 +48,21 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts tavily provider and config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "tavily",
+        providerConfig: {
+          apiKey: "test-key", // pragma: allowlist secret
+          searchDepth: "advanced",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
 });
 
 describe("web search provider auto-detection", () => {
@@ -59,6 +74,7 @@ describe("web search provider auto-detection", () => {
     delete process.env.KIMI_API_KEY;
     delete process.env.MOONSHOT_API_KEY;
     delete process.env.PERPLEXITY_API_KEY;
+    delete process.env.TAVILY_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
     delete process.env.XAI_API_KEY;
     delete process.env.KIMI_API_KEY;
@@ -92,6 +108,11 @@ describe("web search provider auto-detection", () => {
   it("auto-detects perplexity when only PERPLEXITY_API_KEY is set", () => {
     process.env.PERPLEXITY_API_KEY = "test-perplexity-key"; // pragma: allowlist secret
     expect(resolveSearchProvider({})).toBe("perplexity");
+  });
+
+  it("auto-detects tavily when only TAVILY_API_KEY is set", () => {
+    process.env.TAVILY_API_KEY = "test-tavily-key"; // pragma: allowlist secret
+    expect(resolveSearchProvider({})).toBe("tavily");
   });
 
   it("auto-detects grok when only XAI_API_KEY is set", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -645,7 +645,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider":
-    'Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). Auto-detected from available API keys if omitted.',
+    'Search provider ("brave", "perplexity", "tavily", "grok", "gemini", or "kimi"). Auto-detected from available API keys if omitted.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -441,8 +441,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("brave", "perplexity", "tavily", "grok", "gemini", or "kimi"). */
+      provider?: "brave" | "perplexity" | "tavily" | "grok" | "gemini" | "kimi";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */
@@ -459,6 +459,13 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
         model?: string;
+      };
+      /** Tavily-specific configuration (used when provider="tavily"). */
+      tavily?: {
+        /** Tavily API key (defaults to TAVILY_API_KEY env var). */
+        apiKey?: SecretInput;
+        /** Search depth for Tavily requests (default: "basic"). */
+        searchDepth?: "basic" | "advanced";
       };
       /** Grok-specific configuration (used when provider="grok"). */
       grok?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -266,6 +266,7 @@ export const ToolsWebSearchSchema = z
       .union([
         z.literal("brave"),
         z.literal("perplexity"),
+        z.literal("tavily"),
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
@@ -282,6 +283,13 @@ export const ToolsWebSearchSchema = z
         // so existing configs don't fail validation. Ignored at runtime.
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    tavily: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        searchDepth: z.union([z.literal("basic"), z.literal("advanced")]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Adds [Tavily](https://tavily.com) as a sixth native `web_search` provider alongside Brave, Perplexity, Grok, Gemini, and Kimi.

### What's included

- **Config:** `tools.web.search.provider: "tavily"` with `tools.web.search.tavily.apiKey` (or `TAVILY_API_KEY` env var)
- **Optional:** `searchDepth: "basic" | "advanced"` (defaults to `basic`)
- **Results:** Structured results with title, URL, snippet, relevance `score` (0-1), and published date
- **AI answer:** Includes Tavily's synthesized `answer` field when available
- **Auto-detection:** When no provider is explicitly configured, auto-detected from `TAVILY_API_KEY` (priority: after Perplexity, before Brave)
- **Onboarding:** Added to `openclaw configure --section web` wizard
- **Tests:** Unit tests for API key resolution and provider auto-detection (all passing)

### Files changed (7)

| File | Change |
|------|--------|
| `src/agents/tools/web-search.ts` | Core Tavily search implementation |
| `src/agents/tools/web-search.test.ts` | API key resolution tests |
| `src/config/types.tools.ts` | TypeScript types for tavily config |
| `src/config/zod-schema.agent-runtime.ts` | Zod validation schema |
| `src/config/schema.help.ts` | Help text update |
| `src/config/config.web-search-provider.test.ts` | Provider selection tests |
| `src/commands/onboard-search.ts` | Configure wizard entry |

### Design decisions

- **Minimal scope:** Only adds Tavily. No changes to existing providers, no CHANGELOG edits, no wizard rewrites.
- **Follows existing patterns:** Implementation mirrors the Perplexity provider (structured results) with Tavily-specific additions (score, answer).
- **Body-based auth:** Tavily uses `api_key` in the request body rather than an auth header, matching their API spec.

### Testing

```bash
npx vitest run src/agents/tools/web-search.test.ts src/config/config.web-search-provider.test.ts
# 47/47 tests passing
```

### Related

Closes #12034, #23330, #32756
Refs #38315, #28164, #6743, #13370

---

*This is a heavily requested feature — there are 4 open PRs and 3+ open issues asking for Tavily support. This PR aims to be the clean, minimal, merge-ready version.*