### PR TITLE
fix(ui): preserve selected agent after config save on agents page

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -721,7 +721,18 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onConfigReload: () => loadConfig(state),
-                onConfigSave: () => saveConfig(state),
+                onConfigSave: async () => {
+                  const selectedBefore = state.agentsSelectedId;
+                  await saveConfig(state);
+                  await loadAgents(state);
+                  // Restore selection if the agent still exists after reload.
+                  if (
+                    selectedBefore &&
+                    state.agentsList?.agents.some((a) => a.id === selectedBefore)
+                  ) {
+                    state.agentsSelectedId = selectedBefore;
+                  }
+                },
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
                 onSkillsFilterChange: (next) => (state.skillsFilter = next),

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { loadToolsCatalog } from "./agents.ts";
+import { loadAgents, loadToolsCatalog } from "./agents.ts";
 import type { AgentsState } from "./agents.ts";
 
 function createState(): { state: AgentsState; request: ReturnType<typeof vi.fn> } {
@@ -19,6 +19,62 @@ function createState(): { state: AgentsState; request: ReturnType<typeof vi.fn> 
   };
   return { state, request };
 }
+
+describe("loadAgents", () => {
+  it("preserves selected agent when it still exists in the list", async () => {
+    const { state, request } = createState();
+    state.agentsSelectedId = "kimi";
+    request.mockResolvedValue({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [
+        { id: "main", name: "main" },
+        { id: "kimi", name: "kimi" },
+      ],
+    });
+
+    await loadAgents(state);
+
+    expect(state.agentsSelectedId).toBe("kimi");
+  });
+
+  it("resets to default when selected agent is removed", async () => {
+    const { state, request } = createState();
+    state.agentsSelectedId = "removed-agent";
+    request.mockResolvedValue({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [
+        { id: "main", name: "main" },
+        { id: "kimi", name: "kimi" },
+      ],
+    });
+
+    await loadAgents(state);
+
+    expect(state.agentsSelectedId).toBe("main");
+  });
+
+  it("sets default when no agent is selected", async () => {
+    const { state, request } = createState();
+    state.agentsSelectedId = null;
+    request.mockResolvedValue({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [
+        { id: "main", name: "main" },
+        { id: "kimi", name: "kimi" },
+      ],
+    });
+
+    await loadAgents(state);
+
+    expect(state.agentsSelectedId).toBe("main");
+  });
+});
 
 describe("loadToolsCatalog", () => {
   it("loads catalog and stores result", async () => {


### PR DESCRIPTION
## Summary

Fixes #39254.

When editing a non-default agent on the `/agents` page and saving config changes, the UI resets back to the default agent instead of staying on the edited agent.

**Root cause:** The `onConfigSave` handler for the agents page called `saveConfig(state)` without reloading the agents list or preserving the selected agent ID. When the config save triggers a gateway reconnect cycle, the agent selection could be lost.

**Fix:** The agents page `onConfigSave` handler now:
1. Captures the currently selected agent ID before save
2. Saves config (which internally reloads the config snapshot)
3. Reloads the agents list to pick up any config-driven changes
4. Restores the selected agent ID if the agent still exists in the refreshed list

This mirrors the pattern used by `handleChannelConfigSave` which also reloads related data after config saves.

## Test plan

- Added unit tests for `loadAgents` verifying:
  - Selected agent is preserved when it still exists in the list
  - Selection resets to default when the selected agent is removed
  - Default agent is selected when no agent was previously selected
- `pnpm test` passes
- `pnpm check` passes