### PR TITLE
fix(telegram): forward resolved cfg to send/delete/edit/sticker functions

### DIFF
--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -81,12 +81,13 @@ describe("handleTelegramAction", () => {
   }
 
   async function expectReactionAdded(reactionLevel: "minimal" | "extensive") {
-    await handleTelegramAction(defaultReactionAction, reactionConfig(reactionLevel));
+    const cfg = reactionConfig(reactionLevel);
+    await handleTelegramAction(defaultReactionAction, cfg);
     expect(reactMessageTelegram).toHaveBeenCalledWith(
       "123",
       456,
       "✅",
-      expect.objectContaining({ token: "tok", remove: false }),
+      expect.objectContaining({ cfg, token: "tok", remove: false }),
     );
   }
 
@@ -339,6 +340,19 @@ describe("handleTelegramAction", () => {
     expect(sendStickerTelegram).toHaveBeenCalledWith(
       "123",
       "sticker-id",
+      expect.objectContaining({ cfg, token: "tok" }),
+    );
+  });
+
+  it("forwards cfg to sendPollTelegram", async () => {
+    const cfg = telegramConfig();
+    await handleTelegramAction(
+      { action: "poll", to: "@testchannel", question: "Ready?", answers: ["Yes", "No"] },
+      cfg,
+    );
+    expect(sendPollTelegram).toHaveBeenCalledWith(
+      "@testchannel",
+      expect.any(Object),
       expect.objectContaining({ cfg, token: "tok" }),
     );
   });

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -18,6 +18,11 @@ const sendStickerTelegram = vi.fn(async () => ({
   chatId: "123",
 }));
 const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const editMessageTelegram = vi.fn(async () => ({
+  ok: true,
+  messageId: "456",
+  chatId: "123",
+}));
 let envSnapshot: ReturnType<typeof captureEnv>;
 
 vi.mock("../../telegram/send.js", () => ({
@@ -30,6 +35,8 @@ vi.mock("../../telegram/send.js", () => ({
     sendStickerTelegram(...args),
   deleteMessageTelegram: (...args: Parameters<typeof deleteMessageTelegram>) =>
     deleteMessageTelegram(...args),
+  editMessageTelegram: (...args: Parameters<typeof editMessageTelegram>) =>
+    editMessageTelegram(...args),
 }));
 
 describe("handleTelegramAction", () => {
@@ -90,6 +97,7 @@ describe("handleTelegramAction", () => {
     sendPollTelegram.mockClear();
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
+    editMessageTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
 
@@ -279,23 +287,60 @@ describe("handleTelegramAction", () => {
   });
 
   it("sends a text message", async () => {
+    const cfg = telegramConfig();
     const result = await handleTelegramAction(
       {
         action: "sendMessage",
         to: "@testchannel",
         content: "Hello, Telegram!",
       },
-      telegramConfig(),
+      cfg,
     );
     expect(sendMessageTelegram).toHaveBeenCalledWith(
       "@testchannel",
       "Hello, Telegram!",
-      expect.objectContaining({ token: "tok", mediaUrl: undefined }),
+      expect.objectContaining({ cfg, token: "tok", mediaUrl: undefined }),
     );
     expect(result.content).toContainEqual({
       type: "text",
       text: expect.stringContaining('"ok": true'),
     });
+  });
+
+  it("forwards cfg to deleteMessageTelegram", async () => {
+    const cfg = { channels: { telegram: { botToken: "tok" } } } as OpenClawConfig;
+    await handleTelegramAction({ action: "deleteMessage", chatId: "123", messageId: 456 }, cfg);
+    expect(deleteMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      456,
+      expect.objectContaining({ cfg, token: "tok" }),
+    );
+  });
+
+  it("forwards cfg to editMessageTelegram", async () => {
+    const cfg = telegramConfig();
+    await handleTelegramAction(
+      { action: "editMessage", chatId: "123", messageId: 456, content: "updated" },
+      cfg,
+    );
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      456,
+      "updated",
+      expect.objectContaining({ cfg, token: "tok" }),
+    );
+  });
+
+  it("forwards cfg to sendStickerTelegram", async () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { sticker: true } } },
+    } as OpenClawConfig;
+    await handleTelegramAction({ action: "sendSticker", to: "123", fileId: "sticker-id" }, cfg);
+    expect(sendStickerTelegram).toHaveBeenCalledWith(
+      "123",
+      "sticker-id",
+      expect.objectContaining({ cfg, token: "tok" }),
+    );
   });
 
   it("sends a poll", async () => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -237,6 +237,7 @@ export async function handleTelegramAction(
       );
     }
     const result = await sendMessageTelegram(to, content, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
       mediaUrl: mediaUrl || undefined,
@@ -327,6 +328,7 @@ export async function handleTelegramAction(
       );
     }
     await deleteMessageTelegram(chatId ?? "", messageId ?? 0, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
     });
@@ -367,6 +369,7 @@ export async function handleTelegramAction(
       );
     }
     const result = await editMessageTelegram(chatId ?? "", messageId ?? 0, content, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
       buttons,
@@ -399,6 +402,7 @@ export async function handleTelegramAction(
       );
     }
     const result = await sendStickerTelegram(to, fileId, {
+      cfg,
       token,
       accountId: accountId ?? undefined,
       replyToMessageId: replyToMessageId ?? undefined,

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -154,6 +154,7 @@ export async function handleTelegramAction(
     let reactionResult: Awaited<ReturnType<typeof reactMessageTelegram>>;
     try {
       reactionResult = await reactMessageTelegram(chatId ?? "", messageId ?? 0, emoji ?? "", {
+        cfg,
         token,
         remove,
         accountId: accountId ?? undefined,
@@ -294,6 +295,7 @@ export async function handleTelegramAction(
         durationHours: durationHours ?? undefined,
       },
       {
+        cfg,
         token,
         accountId: accountId ?? undefined,
         replyToMessageId: replyToMessageId ?? undefined,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -86,6 +86,8 @@ type TelegramReactionOpts = {
   remove?: boolean;
   verbose?: boolean;
   retry?: RetryConfig;
+  /** Optional config injection to avoid global loadConfig() (improves testability). */
+  cfg?: ReturnType<typeof loadConfig>;
 };
 
 function resolveTelegramMessageIdOrThrow(

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -809,6 +809,8 @@ type TelegramDeleteOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  /** Optional config injection to avoid global loadConfig() (improves testability). */
+  cfg?: ReturnType<typeof loadConfig>;
 };
 
 export async function deleteMessageTelegram(
@@ -972,6 +974,8 @@ type TelegramStickerOpts = {
   replyToMessageId?: number;
   /** Forum topic thread ID (for forum supergroups) */
   messageThreadId?: number;
+  /** Optional config injection to avoid global loadConfig() (improves testability). */
+  cfg?: ReturnType<typeof loadConfig>;
 };
 
 /**


### PR DESCRIPTION
Fixes #37909

## Problem
`handleTelegramAction` receives a resolved `cfg` as its second argument but never forwards it to `sendMessageTelegram`, `deleteMessageTelegram`, `editMessageTelegram`, or `sendStickerTelegram`. Those functions fall back to `opts.cfg ?? loadConfig()`, returning an unresolved config with raw `SecretRef`s — causing `assertSecretInputResolved` to throw since v2026.3.2.

## Fix
- Forward `cfg` in all 4 affected call sites in `telegram-actions.ts`
- Add `cfg?` field to `TelegramDeleteOpts` and `TelegramStickerOpts` in `send.ts` (matching the existing pattern in `TelegramEditOpts` and `TelegramSendOpts`)
- Add 4 test assertions verifying `cfg` is forwarded correctly
- Add `editMessageTelegram` to the test mock (was previously missing)

## Testing
43/43 tests passing in `telegram-actions.test.ts`

> AI-assisted (Claude) | Tests added and passing | Fix reviewed and understood