### PR TITLE
fix(daemon): extract schtasks result code across Windows versions and locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 - Gateway/Control UI: keep dashboard auth tokens in session-scoped browser storage so same-tab refreshes preserve remote token auth without restoring long-lived localStorage token persistence, while scoping tokens to the selected gateway URL and fragment-only bootstrap flow. (#40892) thanks @velvet-shark.
+- Daemon/Windows schtasks locale parsing: add a numeric-value fallback for non-English locales where the result-code key is localised, harden the fallback to return undefined on ambiguous matches rather than trusting insertion order, and handle abbreviated `Last Run` key variants from older Windows locales. (#39312) Thanks @ademczuk.
 
 ## 2026.3.8
 

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -169,7 +169,6 @@ describe("scheduled task runtime derivation", () => {
       detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
     });
   });
-
 });
 
 describe("resolveTaskScriptPath", () => {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -85,6 +85,35 @@ describe("schtasks runtime parsing", () => {
     const parsed = parseSchtasksQuery(output);
     expect(parsed.lastRunResult).toBeUndefined();
   });
+
+  it("parses lastRunTime from abbreviated 'Last Run' key variant", () => {
+    // Some older Windows locales shorten "Last Run Time" to "Last Run" in verbose output.
+    const output = [
+      "TaskName: \\OpenClaw Gateway",
+      "Status: Ready",
+      "Last Run: 1/8/2026 1:23:45 AM",
+      "Last Run Result: 0x0",
+    ].join("\r\n");
+    expect(parseSchtasksQuery(output)).toEqual({
+      status: "Ready",
+      lastRunTime: "1/8/2026 1:23:45 AM",
+      lastRunResult: "0x0",
+    });
+  });
+
+  it("returns undefined from fallback when multiple numeric values are present (ambiguity guard)", () => {
+    // If two or more fields match RESULT_CODE_RE, the fallback cannot determine
+    // which is the result code and returns undefined rather than guessing.
+    const output = [
+      "Aufgabenname: \\OpenClaw Gateway",
+      "Status: Bereit",
+      "Letztes Ergebnis: 0x41301",
+      "Unbekannt: 267009",
+    ].join("\r\n");
+    const parsed = parseSchtasksQuery(output);
+    // Both "0x41301" and "267009" match RESULT_CODE_RE — ambiguous, so fallback yields undefined.
+    expect(parsed.lastRunResult).toBeUndefined();
+  });
 });
 
 describe("scheduled task runtime derivation", () => {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -23,6 +23,68 @@ describe("schtasks runtime parsing", () => {
       lastRunResult: "0x0",
     });
   });
+
+  it("parses Win 11 English output where key is 'Last Result' instead of 'Last Run Result'", () => {
+    const output = [
+      "Folder: \\",
+      "HostName: DESKTOP-ABC",
+      "TaskName: \\OpenClaw Gateway",
+      "Status: Running",
+      "Last Run Time: 05/03/2026 16:48:37",
+      "Last Result: 267009",
+      "Creator: DESKTOP-ABC\\user",
+    ].join("\r\n");
+    expect(parseSchtasksQuery(output)).toEqual({
+      status: "Running",
+      lastRunTime: "05/03/2026 16:48:37",
+      lastRunResult: "267009",
+    });
+  });
+
+  it("extracts result code from German locale output via numeric fallback", () => {
+    // German schtasks uses "Letztes Ergebnis" for the result code key.
+    const output = [
+      "Aufgabenname: \\OpenClaw Gateway",
+      "Status: Wird ausgeführt",
+      "Letzte Laufzeit: 08/03/2026 09:12:00",
+      "Letztes Ergebnis: 0x41301",
+    ].join("\r\n");
+    const parsed = parseSchtasksQuery(output);
+    expect(parsed.lastRunResult).toBe("0x41301");
+  });
+
+  it("extracts decimal result code from French locale output via numeric fallback", () => {
+    // French schtasks uses "Dernier résultat" for the result code key.
+    const output = [
+      "Nom de la tâche: \\OpenClaw Gateway",
+      "État: En cours d'exécution",
+      "Heure de dernière exécution: 08/03/2026 09:12:00",
+      "Dernier résultat: 267009",
+    ].join("\r\n");
+    const parsed = parseSchtasksQuery(output);
+    expect(parsed.lastRunResult).toBe("267009");
+  });
+
+  it("does not extract non-numeric values via fallback", () => {
+    // When all values are non-numeric strings, lastRunResult should be undefined.
+    const output = ["TaskName: \\OpenClaw Gateway", "Status: Ready", "Last Run Time: Never"].join(
+      "\r\n",
+    );
+    const parsed = parseSchtasksQuery(output);
+    expect(parsed.lastRunResult).toBeUndefined();
+  });
+
+  it("ignores small integers from unrelated fields like Instances or Priority", () => {
+    // "Instances: 1" and "Priority: 7" should not be captured as result codes.
+    const output = [
+      "Aufgabenname: \\OpenClaw Gateway",
+      "Status: Bereit",
+      "Instanzen: 1",
+      "Priorität: 7",
+    ].join("\r\n");
+    const parsed = parseSchtasksQuery(output);
+    expect(parsed.lastRunResult).toBeUndefined();
+  });
 });
 
 describe("scheduled task runtime derivation", () => {
@@ -107,6 +169,7 @@ describe("scheduled task runtime derivation", () => {
       detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
     });
   });
+
 });
 
 describe("resolveTaskScriptPath", () => {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -138,7 +138,7 @@ function findResultCodeFallback(entries: Record<string, string>): string | undef
   // numeric value (e.g. a port number appearing before the result code in a future
   // schtasks locale) doesn't silently shadow the real code.
   const matches = Object.values(entries).filter((v) => RESULT_CODE_RE.test(v.trim()));
-  return matches.length === 1 ? matches[0]!.trim() : undefined;
+  return matches.length === 1 ? matches[0].trim() : undefined;
 }
 
 export function parseSchtasksQuery(output: string): ScheduledTaskInfo {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -134,12 +134,11 @@ function findEntry(entries: Record<string, string>, ...keys: string[]): string |
 const RESULT_CODE_RE = /^(?:0x[0-9a-f]+|\d{3,10})$/i;
 
 function findResultCodeFallback(entries: Record<string, string>): string | undefined {
-  for (const value of Object.values(entries)) {
-    if (RESULT_CODE_RE.test(value.trim())) {
-      return value.trim();
-    }
-  }
-  return undefined;
+  // Collect all matches and only return when exactly one exists, so an unexpected
+  // numeric value (e.g. a port number appearing before the result code in a future
+  // schtasks locale) doesn't silently shadow the real code.
+  const matches = Object.values(entries).filter((v) => RESULT_CODE_RE.test(v.trim()));
+  return matches.length === 1 ? matches[0]!.trim() : undefined;
 }
 
 export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
@@ -149,6 +148,8 @@ export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   if (status) {
     info.status = status;
   }
+  // "last run" is a secondary lookup for locales/versions that abbreviate
+  // "Last Run Time" to "Last Run" in verbose LIST output.
   const lastRunTime = findEntry(entries, "last run time", "last run");
   if (lastRunTime) {
     info.lastRunTime = lastRunTime;

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -114,6 +114,34 @@ export type ScheduledTaskInfo = {
   lastRunResult?: string;
 };
 
+// Try multiple known key names; schtasks output varies by Windows version and locale.
+// Win 10 English: "Last Run Result", Win 11 English: "Last Result",
+// German: "Letztes Ergebnis", French: "Dernier résultat", etc.
+function findEntry(entries: Record<string, string>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = entries[key];
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+// Locale-independent fallback: the result code is the only schtasks /V /FO LIST
+// value that is purely numeric (decimal or 0x-prefixed hex).  Require 3+ decimal
+// digits to exclude unrelated small-integer fields like "Instances: 1" or "Priority: 7".
+// Missing codes 0-99 is harmless: they all map to "stopped" anyway.
+const RESULT_CODE_RE = /^(?:0x[0-9a-f]+|\d{3,10})$/i;
+
+function findResultCodeFallback(entries: Record<string, string>): string | undefined {
+  for (const value of Object.values(entries)) {
+    if (RESULT_CODE_RE.test(value.trim())) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
 export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   const entries = parseKeyValueOutput(output, ":");
   const info: ScheduledTaskInfo = {};
@@ -121,11 +149,12 @@ export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   if (status) {
     info.status = status;
   }
-  const lastRunTime = entries["last run time"];
+  const lastRunTime = findEntry(entries, "last run time", "last run");
   if (lastRunTime) {
     info.lastRunTime = lastRunTime;
   }
-  const lastRunResult = entries["last run result"];
+  const lastRunResult =
+    findEntry(entries, "last run result", "last result") ?? findResultCodeFallback(entries);
   if (lastRunResult) {
     info.lastRunResult = lastRunResult;
   }


### PR DESCRIPTION
## Summary

- **Problem**: `parseSchtasksQuery` hardcodes `"last run result"` as the key to extract the task result code from `schtasks /Query /V /FO LIST` output. Windows 11 English uses `"Last Result"` instead, and non-English locales use completely different keys (`"Letztes Ergebnis"`, `"Dernier résultat"`, etc.). Without the result code, `deriveScheduledTaskRuntimeStatus` falls back to `"unknown"` on every non-Win10-English system.
- **Why it matters**: The daemon scheduler can't determine whether a task succeeded or failed on Win 11, German, French, or any other non-standard locale. Users on these systems see perpetual "unknown" status.
- **What changed**: Added a two-tier lookup in `parseSchtasksQuery` - first tries known English key variants, then falls back to a locale-independent numeric pattern scan across all parsed values. Tests cover Win 10 English, Win 11 English, German, and French locale output.
- **What did NOT change** (scope boundary): No changes to `deriveScheduledTaskRuntimeStatus` logic, task scheduling, or any daemon behaviour outside result code extraction. Dark theme, gateway, TUI, and all other subsystems untouched.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Test
- [ ] CI / build
- [ ] Config / env

## Scope

- [x] Gateway
- [ ] TUI / CLI
- [ ] Agents / subagents
- [ ] UI / web
- [ ] Security
- [ ] Media
- [ ] Infrastructure

## Linked Issue/PR

- Fixes #39057
- Related #39451 (complementary fix for localised *running state* keys by @Narcooo)

## User-visible / Behaviour Changes

Users on Windows 11 and non-English Windows locales will see correct scheduled task status ("running", "stopped", etc.) instead of perpetual "unknown".

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 10/11 (English, German, French locales)
- Runtime: Node 22+
- Relevant config: `schtasks /Query /V /FO LIST` output format varies by OS version and locale

### Steps

1. Set Windows display language to German (or French, or use Win 11 English)
2. Run `openclaw gateway run` with a scheduled task configured
3. Check task status via `openclaw channels status`

### Expected

Task status shows the correct result code and derived state (running/stopped/error).

### Actual (before fix)

Status shows "unknown" because the hardcoded `"last run result"` key doesn't match the locale-specific output.

## Evidence

- [x] Unit/integration test added or updated (27 tests, 4 new locale/version scenarios)
- [ ] Trace/log output confirms fix
- [ ] Screenshot or recording (UI changes)

## Human Verification

- **Verified scenarios**: Win 10 English key match, Win 11 English key match, German locale fallback, French locale fallback, non-numeric value exclusion, small integer exclusion (Instances/Priority fields)
- **Edge cases checked**: Result codes 0-99 (excluded from fallback regex - harmless since they all map to "stopped"), hex result codes (`0x0`, `0x41301`), mixed-case key matching
- **What was NOT verified**: Full end-to-end on a real non-English Windows install. Tests use captured schtasks output from real systems, but I haven't run the gateway on a live German/French machine.

## Compatibility / Migration

- Backward compatible: Yes
- Config changes: None
- Migration needed: None

## Failure Recovery

- **Revert**: Revert this PR. No config or env changes to undo.
- **Files to restore**: `src/daemon/schtasks.ts`
- **Bad symptoms**: If the fallback regex is too greedy, it could pick up a non-result-code numeric field. The `\d{3,10}` constraint and hex prefix check minimise this risk.

## Risks and Mitigations

- Risk: Fallback regex picks up a non-result-code numeric value from an unexpected schtasks field on some Windows edition.
  - Mitigation: Regex requires 3+ digits or hex prefix, excluding all known small-integer fields (Instances, Priority). Worst case is an incorrect status, not a crash - and the primary key lookup path handles all known English variants without needing the fallback.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.