### PR TITLE
fix(bluebubbles): handle null text in debounce flush

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -48,7 +48,7 @@ function combineDebounceEntries(entries: BlueBubblesDebounceEntry[]): Normalized
   const textParts: string[] = [];
 
   for (const entry of entries) {
-    const text = entry.message.text.trim();
+    const text = (entry.message.text ?? "").trim();
     if (!text) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Fix crash in BlueBubbles debounce flush when `message.text` is `null` (attachment-only messages)
- Null-coalesce `text` before calling `.trim()` to prevent `TypeError: Cannot read properties of null (reading 'trim')`

Fixes #35777

## Test plan

- [ ] Verify BlueBubbles attachment-only messages no longer crash the debounce flush
- [ ] Verify text messages still merge correctly in debounce

🤖 Generated with [Claude Code](https://claude.com/claude-code)