### PR TITLE
fix(voice-call): use ?? instead of || for TTS speed config default

### DIFF
--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -82,7 +82,7 @@ export class OpenAITTSProvider {
     this.model = config.model || "gpt-4o-mini-tts";
     // Default to coral - good balance of quality and natural tone
     this.voice = (config.voice as OpenAITTSVoice) || "coral";
-    this.speed = config.speed || 1.0;
+    this.speed = config.speed ?? 1.0;
     this.instructions = config.instructions;
 
     if (!this.apiKey) {


### PR DESCRIPTION
Fixes #39285

Use nullish coalescing operator (??) instead of logical OR (||) for TTS speed config default value.

This allows users to set speed to 0, which is a valid value, without it being treated as falsy and falling back to the default.