### PR TITLE
feat(pairing): add owner notification on new pairing requests

### DIFF
--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -24,6 +24,7 @@ import type {
 } from "./types.messages.js";
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
+import type { PairingConfig } from "./types.pairing.js";
 import type { PluginsConfig } from "./types.plugins.js";
 import type { SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
@@ -113,6 +114,7 @@ export type OpenClawConfig = {
   approvals?: ApprovalsConfig;
   session?: SessionConfig;
   web?: WebConfig;
+  pairing?: PairingConfig;
   channels?: ChannelsConfig;
   cron?: CronConfig;
   hooks?: HooksConfig;

--- a/src/config/types.pairing.ts
+++ b/src/config/types.pairing.ts
@@ -1,0 +1,21 @@
+export type PairingNotifyConfig = {
+  /** Enable owner notifications for new pairing requests. Default: true when target is set. */
+  enabled?: boolean;
+  /**
+   * Notification target: the owner's address on the notification channel.
+   * e.g., phone number for iMessage/WhatsApp/Signal, user ID for Telegram/Discord/Slack.
+   */
+  target?: string;
+  /**
+   * Channel to send notifications through (e.g., "imessage", "telegram", "whatsapp").
+   * Default: "imessage".
+   */
+  channel?: string;
+  /** Account ID when using multi-account channel setups. */
+  accountId?: string;
+};
+
+export type PairingConfig = {
+  /** Owner notification settings for new pairing requests. */
+  notify?: PairingNotifyConfig;
+};

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -911,6 +911,20 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    pairing: z
+      .object({
+        notify: z
+          .object({
+            enabled: z.boolean().optional(),
+            target: z.string().optional(),
+            channel: z.string().optional(),
+            accountId: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     plugins: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -10,6 +10,7 @@ import {
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
 import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
 import type { CliDeps } from "../cli/deps.js";
+import { createOutboundSendDepsFromCliSource } from "../cli/outbound-send-mapping.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
@@ -20,6 +21,7 @@ import {
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { registerPairingNotifyHook } from "../pairing/notify-owner.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
@@ -120,6 +122,16 @@ export async function startGatewaySidecars(params: {
     }
   } catch (err) {
     params.logHooks.error(`failed to load hooks: ${String(err)}`);
+  }
+
+  // Register pairing request owner notification hook.
+  try {
+    registerPairingNotifyHook({
+      cfg: params.cfg,
+      sendDeps: createOutboundSendDepsFromCliSource(params.deps),
+    });
+  } catch (err) {
+    params.log.warn(`pairing notify hook registration failed: ${String(err)}`);
   }
 
   // Launch configured channels so gateway replies via the surface the message came from.

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,13 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "pairing";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -154,6 +160,29 @@ export type MessagePreprocessedHookEvent = InternalHookEvent & {
   type: "message";
   action: "preprocessed";
   context: MessagePreprocessedHookContext;
+};
+
+// ============================================================================
+// Pairing Hook Events
+// ============================================================================
+
+export type PairingRequestHookContext = {
+  /** Channel the pairing request came from (e.g., "telegram", "whatsapp") */
+  channelId: string;
+  /** Requester identifier (phone number, user ID, etc.) */
+  requesterId: string;
+  /** Auto-generated pairing code */
+  code: string;
+  /** Account ID for multi-account setups */
+  accountId?: string;
+  /** Additional metadata from the pairing request (name, phone, etc.) */
+  meta?: Record<string, string>;
+};
+
+export type PairingRequestHookEvent = InternalHookEvent & {
+  type: "pairing";
+  action: "request";
+  context: PairingRequestHookContext;
 };
 
 export interface InternalHookEvent {
@@ -404,6 +433,21 @@ export function isMessageTranscribedEvent(
   }
   return (
     hasStringContextField(context, "transcript") && hasStringContextField(context, "channelId")
+  );
+}
+
+export function isPairingRequestEvent(event: InternalHookEvent): event is PairingRequestHookEvent {
+  if (!isHookEventTypeAndAction(event, "pairing", "request")) {
+    return false;
+  }
+  const context = getHookContext<PairingRequestHookContext>(event);
+  if (!context) {
+    return false;
+  }
+  return (
+    hasStringContextField(context, "channelId") &&
+    hasStringContextField(context, "requesterId") &&
+    hasStringContextField(context, "code")
   );
 }
 

--- a/src/pairing/notify-owner.test.ts
+++ b/src/pairing/notify-owner.test.ts
@@ -39,6 +39,18 @@ describe("sanitizeField", () => {
   it("handles empty string", () => {
     expect(sanitizeField("", 10)).toBe("");
   });
+
+  it("strips bidi isolate characters (U+2066-U+2069)", () => {
+    expect(sanitizeField("a\u2066b\u2067c\u2068d\u2069e", 64)).toBe("abcde");
+  });
+
+  it("strips C1 control characters (U+0080-U+009F)", () => {
+    expect(sanitizeField("hello\u0080\u009Bworld", 64)).toBe("helloworld");
+  });
+
+  it("strips newlines to prevent message injection", () => {
+    expect(sanitizeField("line1\nline2\rline3", 64)).toBe("line1line2line3");
+  });
 });
 
 describe("buildNotificationText", () => {

--- a/src/pairing/notify-owner.test.ts
+++ b/src/pairing/notify-owner.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  clearInternalHooks,
+  createInternalHookEvent,
+  triggerInternalHook,
+} from "../hooks/internal-hooks.js";
+import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
+import {
+  buildNotificationText,
+  registerPairingNotifyHook,
+  resolvePairingNotifyConfig,
+  sanitizeField,
+  unregisterPairingNotifyHook,
+} from "./notify-owner.js";
+
+beforeEach(() => {
+  clearInternalHooks();
+});
+
+afterEach(() => {
+  unregisterPairingNotifyHook();
+  clearInternalHooks();
+});
+
+describe("sanitizeField", () => {
+  it("strips control characters", () => {
+    expect(sanitizeField("hello\x00world\x1f!", 64)).toBe("helloworld!");
+  });
+
+  it("strips zero-width characters", () => {
+    expect(sanitizeField("test\u200bvalue\ufeff", 64)).toBe("testvalue");
+  });
+
+  it("truncates to max length", () => {
+    expect(sanitizeField("abcdef", 3)).toBe("abc");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeField("", 10)).toBe("");
+  });
+});
+
+describe("buildNotificationText", () => {
+  it("formats with name from meta", () => {
+    const text = buildNotificationText({
+      requesterId: "+14155551234",
+      channelId: "whatsapp",
+      code: "ABCD1234",
+      meta: { name: "Alice" },
+    });
+    expect(text).toBe("Pairing request: Alice (+14155551234) via whatsapp — code ABCD1234");
+  });
+
+  it("formats with displayName from meta", () => {
+    const text = buildNotificationText({
+      requesterId: "123456",
+      channelId: "telegram",
+      code: "XYZ789",
+      meta: { displayName: "Bob" },
+    });
+    expect(text).toBe("Pairing request: Bob (123456) via telegram — code XYZ789");
+  });
+
+  it("falls back to 'unknown' when no name in meta", () => {
+    const text = buildNotificationText({
+      requesterId: "+14155551234",
+      channelId: "imessage",
+      code: "CODE1234",
+    });
+    expect(text).toBe("Pairing request: unknown (+14155551234) via imessage — code CODE1234");
+  });
+
+  it("sanitizes injection attempts in name", () => {
+    const text = buildNotificationText({
+      requesterId: "+14155551234",
+      channelId: "whatsapp",
+      code: "ABCD1234",
+      meta: { name: "Evil\x00Name\u200b" },
+    });
+    expect(text).toContain("EvilName");
+    expect(text).not.toContain("\x00");
+    expect(text).not.toContain("\u200b");
+  });
+});
+
+describe("resolvePairingNotifyConfig", () => {
+  it("returns null when no pairing config", () => {
+    expect(resolvePairingNotifyConfig({})).toBeNull();
+  });
+
+  it("returns null when no notify config", () => {
+    expect(resolvePairingNotifyConfig({ pairing: {} })).toBeNull();
+  });
+
+  it("returns null when no target", () => {
+    expect(resolvePairingNotifyConfig({ pairing: { notify: {} } })).toBeNull();
+  });
+
+  it("returns null when target is whitespace only", () => {
+    expect(resolvePairingNotifyConfig({ pairing: { notify: { target: "   " } } })).toBeNull();
+  });
+
+  it("returns null when explicitly disabled", () => {
+    expect(
+      resolvePairingNotifyConfig({
+        pairing: { notify: { target: "+14155551234", enabled: false } },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns config when target is set", () => {
+    const cfg: OpenClawConfig = {
+      pairing: { notify: { target: "+14155551234", channel: "imessage" } },
+    };
+    const result = resolvePairingNotifyConfig(cfg);
+    expect(result).toEqual({ target: "+14155551234", channel: "imessage" });
+  });
+
+  it("returns config when target is set and enabled is true", () => {
+    const cfg: OpenClawConfig = {
+      pairing: { notify: { target: "+14155551234", enabled: true } },
+    };
+    const result = resolvePairingNotifyConfig(cfg);
+    expect(result).toEqual({ target: "+14155551234", enabled: true });
+  });
+});
+
+describe("registerPairingNotifyHook", () => {
+  it("does not register when no target configured", () => {
+    const sendIMessage = vi.fn().mockResolvedValue({ messageId: "m1" });
+    registerPairingNotifyHook({
+      cfg: {},
+      sendDeps: { sendIMessage } as unknown as OutboundSendDeps,
+    });
+
+    const event = createInternalHookEvent("pairing", "request", "", {
+      channelId: "whatsapp",
+      requesterId: "+14155551234",
+      code: "ABCD1234",
+    });
+    void triggerInternalHook(event);
+    expect(sendIMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends iMessage notification on pairing:request event", async () => {
+    const sendIMessage = vi.fn().mockResolvedValue({ messageId: "m1" });
+    registerPairingNotifyHook({
+      cfg: {
+        pairing: { notify: { target: "+14158605055", channel: "imessage" } },
+      },
+      sendDeps: { sendIMessage } as unknown as OutboundSendDeps,
+    });
+
+    const event = createInternalHookEvent("pairing", "request", "", {
+      channelId: "whatsapp",
+      requesterId: "+14155551234",
+      code: "ABCD1234",
+      meta: { name: "Alice" },
+    });
+    await triggerInternalHook(event);
+
+    expect(sendIMessage).toHaveBeenCalledOnce();
+    const [to, text] = sendIMessage.mock.calls[0];
+    expect(to).toBe("+14158605055");
+    expect(text).toContain("Alice");
+    expect(text).toContain("+14155551234");
+    expect(text).toContain("whatsapp");
+    expect(text).toContain("ABCD1234");
+  });
+
+  it("sends Telegram notification when configured", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "t1" });
+    registerPairingNotifyHook({
+      cfg: {
+        pairing: { notify: { target: "12345", channel: "telegram" } },
+      },
+      sendDeps: { sendTelegram } as unknown as OutboundSendDeps,
+    });
+
+    const event = createInternalHookEvent("pairing", "request", "", {
+      channelId: "discord",
+      requesterId: "user#1234",
+      code: "XYZ789",
+    });
+    await triggerInternalHook(event);
+
+    expect(sendTelegram).toHaveBeenCalledOnce();
+    expect(sendTelegram.mock.calls[0][0]).toBe("12345");
+  });
+
+  it("does not fire on non-pairing events", async () => {
+    const sendIMessage = vi.fn().mockResolvedValue({ messageId: "m1" });
+    registerPairingNotifyHook({
+      cfg: {
+        pairing: { notify: { target: "+14158605055" } },
+      },
+      sendDeps: { sendIMessage } as unknown as OutboundSendDeps,
+    });
+
+    const event = createInternalHookEvent("message", "received", "test-session", {
+      from: "+14155551234",
+      channelId: "whatsapp",
+    });
+    await triggerInternalHook(event);
+
+    expect(sendIMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when send fails", async () => {
+    const sendIMessage = vi.fn().mockRejectedValue(new Error("send failed"));
+    registerPairingNotifyHook({
+      cfg: {
+        pairing: { notify: { target: "+14158605055" } },
+      },
+      sendDeps: { sendIMessage } as unknown as OutboundSendDeps,
+    });
+
+    const event = createInternalHookEvent("pairing", "request", "", {
+      channelId: "whatsapp",
+      requesterId: "+14155551234",
+      code: "ABCD1234",
+    });
+    // Should not throw.
+    await triggerInternalHook(event);
+    expect(sendIMessage).toHaveBeenCalledOnce();
+  });
+
+  it("unregisters cleanly", async () => {
+    const sendIMessage = vi.fn().mockResolvedValue({ messageId: "m1" });
+    registerPairingNotifyHook({
+      cfg: {
+        pairing: { notify: { target: "+14158605055" } },
+      },
+      sendDeps: { sendIMessage } as unknown as OutboundSendDeps,
+    });
+    unregisterPairingNotifyHook();
+
+    const event = createInternalHookEvent("pairing", "request", "", {
+      channelId: "whatsapp",
+      requesterId: "+14155551234",
+      code: "ABCD1234",
+    });
+    await triggerInternalHook(event);
+    expect(sendIMessage).not.toHaveBeenCalled();
+  });
+
+  it("passes accountId from config to send function", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "t1" });
+    registerPairingNotifyHook({
+      cfg: {
+        pairing: {
+          notify: { target: "12345", channel: "telegram", accountId: "bot-2" },
+        },
+      },
+      sendDeps: { sendTelegram } as unknown as OutboundSendDeps,
+    });
+
+    const event = createInternalHookEvent("pairing", "request", "", {
+      channelId: "whatsapp",
+      requesterId: "+14155551234",
+      code: "ABCD1234",
+    });
+    await triggerInternalHook(event);
+
+    expect(sendTelegram).toHaveBeenCalledOnce();
+    const opts = sendTelegram.mock.calls[0][2];
+    expect(opts).toEqual({ accountId: "bot-2" });
+  });
+});

--- a/src/pairing/notify-owner.ts
+++ b/src/pairing/notify-owner.ts
@@ -40,7 +40,10 @@ function buildNotificationText(params: {
 function sanitizeField(value: string, maxLength: number): string {
   // Strip C0/C1 control chars and zero-width/bidi chars that could be used for injection.
   // eslint-disable-next-line no-control-regex -- intentional: sanitizing untrusted input
-  const cleaned = value.replace(/[\u0000-\u001F\u007F\u200B-\u200F\u2028-\u202F\uFEFF]/g, "");
+  const cleaned = value.replace(
+    /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202F\uFEFF]/g,
+    "",
+  );
   return cleaned.slice(0, maxLength);
 }
 
@@ -53,7 +56,6 @@ async function sendNotification(params: {
   notifyConfig: PairingNotifyConfig;
   text: string;
   sendDeps?: OutboundSendDeps;
-  cfg?: OpenClawConfig;
 }): Promise<void> {
   const { notifyConfig, text, sendDeps } = params;
   const target = notifyConfig.target?.trim();
@@ -119,6 +121,12 @@ async function sendNotification(params: {
       await send(target, text, { accountId });
       break;
     }
+    case "matrix":
+    case "msteams":
+      log.error(
+        `pairing-notify: channel "${channel}" is not yet supported — notification not sent`,
+      );
+      break;
     default:
       log.warn(`pairing-notify: unsupported notification channel "${channel}"`);
   }
@@ -171,7 +179,6 @@ export function registerPairingNotifyHook(deps: PairingNotifyDeps): void {
         notifyConfig,
         text,
         sendDeps: deps.sendDeps,
-        cfg: deps.cfg,
       });
     } catch (err) {
       log.warn(
@@ -182,8 +189,10 @@ export function registerPairingNotifyHook(deps: PairingNotifyDeps): void {
 
   registeredHandler = handler;
   registerInternalHook("pairing:request", handler);
+  const target = notifyConfig.target!; // Guaranteed by resolvePairingNotifyConfig
+  const maskedTarget = target.length > 4 ? `***${target.slice(-4)}` : "****";
   log.info(
-    `pairing-notify: hook registered (channel=${notifyConfig.channel || "imessage"}, target=${notifyConfig.target})`,
+    `pairing-notify: hook registered (channel=${notifyConfig.channel || "imessage"}, target=${maskedTarget})`,
   );
 }
 

--- a/src/pairing/notify-owner.ts
+++ b/src/pairing/notify-owner.ts
@@ -41,9 +41,9 @@ function buildNotificationText(params: {
 /** Truncate and strip control characters from untrusted input. */
 function sanitizeField(value: string, maxLength: number): string {
   // Strip C0/C1 control chars and zero-width/bidi chars that could be used for injection.
-  // oxlint-disable-next-line eslint/no-control-regex -- intentional: sanitizing untrusted input
   // eslint-disable-next-line no-control-regex -- intentional: sanitizing untrusted input
   const cleaned = value.replace(
+    // oxlint-disable-next-line eslint/no-control-regex -- intentional: sanitizing untrusted input
     /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202F\u2066-\u2069\uFEFF]/g,
     "",
   );

--- a/src/pairing/notify-owner.ts
+++ b/src/pairing/notify-owner.ts
@@ -15,6 +15,8 @@ import {
   type InternalHookHandler,
 } from "../hooks/internal-hooks.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
+
+type ChannelSendFn = (target: string, text: string, opts?: { accountId?: string }) => Promise<void>;
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("pairing-notify");
@@ -39,9 +41,10 @@ function buildNotificationText(params: {
 /** Truncate and strip control characters from untrusted input. */
 function sanitizeField(value: string, maxLength: number): string {
   // Strip C0/C1 control chars and zero-width/bidi chars that could be used for injection.
+  // oxlint-disable-next-line eslint/no-control-regex -- intentional: sanitizing untrusted input
   // eslint-disable-next-line no-control-regex -- intentional: sanitizing untrusted input
   const cleaned = value.replace(
-    /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202F\uFEFF]/g,
+    /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202F\u2066-\u2069\uFEFF]/g,
     "",
   );
   return cleaned.slice(0, maxLength);
@@ -68,7 +71,7 @@ async function sendNotification(params: {
 
   switch (channel) {
     case "imessage": {
-      const send = sendDeps?.sendIMessage;
+      const send = sendDeps?.sendIMessage as ChannelSendFn | undefined;
       if (!send) {
         log.warn("pairing-notify: iMessage send function not available");
         return;
@@ -77,7 +80,7 @@ async function sendNotification(params: {
       break;
     }
     case "telegram": {
-      const send = sendDeps?.sendTelegram;
+      const send = sendDeps?.sendTelegram as ChannelSendFn | undefined;
       if (!send) {
         log.warn("pairing-notify: Telegram send function not available");
         return;
@@ -86,7 +89,7 @@ async function sendNotification(params: {
       break;
     }
     case "whatsapp": {
-      const send = sendDeps?.sendWhatsApp;
+      const send = sendDeps?.sendWhatsApp as ChannelSendFn | undefined;
       if (!send) {
         log.warn("pairing-notify: WhatsApp send function not available");
         return;
@@ -95,7 +98,7 @@ async function sendNotification(params: {
       break;
     }
     case "discord": {
-      const send = sendDeps?.sendDiscord;
+      const send = sendDeps?.sendDiscord as ChannelSendFn | undefined;
       if (!send) {
         log.warn("pairing-notify: Discord send function not available");
         return;
@@ -104,7 +107,7 @@ async function sendNotification(params: {
       break;
     }
     case "signal": {
-      const send = sendDeps?.sendSignal;
+      const send = sendDeps?.sendSignal as ChannelSendFn | undefined;
       if (!send) {
         log.warn("pairing-notify: Signal send function not available");
         return;
@@ -113,7 +116,7 @@ async function sendNotification(params: {
       break;
     }
     case "slack": {
-      const send = sendDeps?.sendSlack;
+      const send = sendDeps?.sendSlack as ChannelSendFn | undefined;
       if (!send) {
         log.warn("pairing-notify: Slack send function not available");
         return;

--- a/src/pairing/notify-owner.ts
+++ b/src/pairing/notify-owner.ts
@@ -1,0 +1,199 @@
+/**
+ * Pairing request owner notification.
+ *
+ * Sends a direct notification to the owner when a new pairing request arrives.
+ * The notification bypasses the AI agent context entirely to prevent injection
+ * attacks from requester-controlled metadata (name, contact info, etc.).
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+import type { PairingNotifyConfig } from "../config/types.pairing.js";
+import {
+  isPairingRequestEvent,
+  registerInternalHook,
+  unregisterInternalHook,
+  type InternalHookHandler,
+} from "../hooks/internal-hooks.js";
+import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("pairing-notify");
+
+/**
+ * Build a safe, fixed-format notification string.
+ * All fields are treated as untrusted and truncated to prevent abuse.
+ */
+function buildNotificationText(params: {
+  requesterId: string;
+  channelId: string;
+  code: string;
+  meta?: Record<string, string>;
+}): string {
+  const name = sanitizeField(params.meta?.name || params.meta?.displayName || "unknown", 64);
+  const contact = sanitizeField(params.requesterId, 64);
+  const channel = sanitizeField(params.channelId, 32);
+  const code = sanitizeField(params.code, 16);
+  return `Pairing request: ${name} (${contact}) via ${channel} — code ${code}`;
+}
+
+/** Truncate and strip control characters from untrusted input. */
+function sanitizeField(value: string, maxLength: number): string {
+  // Strip C0/C1 control chars and zero-width/bidi chars that could be used for injection.
+  // eslint-disable-next-line no-control-regex -- intentional: sanitizing untrusted input
+  const cleaned = value.replace(/[\u0000-\u001F\u007F\u200B-\u200F\u2028-\u202F\uFEFF]/g, "");
+  return cleaned.slice(0, maxLength);
+}
+
+export type PairingNotifyDeps = {
+  cfg: OpenClawConfig;
+  sendDeps?: OutboundSendDeps;
+};
+
+async function sendNotification(params: {
+  notifyConfig: PairingNotifyConfig;
+  text: string;
+  sendDeps?: OutboundSendDeps;
+  cfg?: OpenClawConfig;
+}): Promise<void> {
+  const { notifyConfig, text, sendDeps } = params;
+  const target = notifyConfig.target?.trim();
+  if (!target) {
+    return;
+  }
+
+  const channel = notifyConfig.channel?.trim().toLowerCase() || "imessage";
+  const accountId = notifyConfig.accountId?.trim();
+
+  switch (channel) {
+    case "imessage": {
+      const send = sendDeps?.sendIMessage;
+      if (!send) {
+        log.warn("pairing-notify: iMessage send function not available");
+        return;
+      }
+      await send(target, text, { accountId });
+      break;
+    }
+    case "telegram": {
+      const send = sendDeps?.sendTelegram;
+      if (!send) {
+        log.warn("pairing-notify: Telegram send function not available");
+        return;
+      }
+      await send(target, text, { accountId });
+      break;
+    }
+    case "whatsapp": {
+      const send = sendDeps?.sendWhatsApp;
+      if (!send) {
+        log.warn("pairing-notify: WhatsApp send function not available");
+        return;
+      }
+      await send(target, text, { accountId });
+      break;
+    }
+    case "discord": {
+      const send = sendDeps?.sendDiscord;
+      if (!send) {
+        log.warn("pairing-notify: Discord send function not available");
+        return;
+      }
+      await send(target, text, { accountId });
+      break;
+    }
+    case "signal": {
+      const send = sendDeps?.sendSignal;
+      if (!send) {
+        log.warn("pairing-notify: Signal send function not available");
+        return;
+      }
+      await send(target, text, { accountId });
+      break;
+    }
+    case "slack": {
+      const send = sendDeps?.sendSlack;
+      if (!send) {
+        log.warn("pairing-notify: Slack send function not available");
+        return;
+      }
+      await send(target, text, { accountId });
+      break;
+    }
+    default:
+      log.warn(`pairing-notify: unsupported notification channel "${channel}"`);
+  }
+}
+
+function resolvePairingNotifyConfig(cfg: OpenClawConfig): PairingNotifyConfig | null {
+  const notify = cfg.pairing?.notify;
+  if (!notify) {
+    return null;
+  }
+  if (!notify.target?.trim()) {
+    return null;
+  }
+  if (notify.enabled === false) {
+    return null;
+  }
+  return notify;
+}
+
+let registeredHandler: InternalHookHandler | null = null;
+
+/**
+ * Register the pairing notification hook.
+ * Call once at gateway startup after config and send deps are available.
+ */
+export function registerPairingNotifyHook(deps: PairingNotifyDeps): void {
+  // Unregister any previous handler (e.g., on config reload).
+  unregisterPairingNotifyHook();
+
+  const notifyConfig = resolvePairingNotifyConfig(deps.cfg);
+  if (!notifyConfig) {
+    log.info("pairing-notify: no notification target configured; hook not registered");
+    return;
+  }
+
+  const handler: InternalHookHandler = async (event) => {
+    if (!isPairingRequestEvent(event)) {
+      return;
+    }
+
+    const text = buildNotificationText({
+      requesterId: event.context.requesterId,
+      channelId: event.context.channelId,
+      code: event.context.code,
+      meta: event.context.meta,
+    });
+
+    try {
+      await sendNotification({
+        notifyConfig,
+        text,
+        sendDeps: deps.sendDeps,
+        cfg: deps.cfg,
+      });
+    } catch (err) {
+      log.warn(
+        `pairing-notify: failed to send notification: ${String((err as Error)?.message ?? err)}`,
+      );
+    }
+  };
+
+  registeredHandler = handler;
+  registerInternalHook("pairing:request", handler);
+  log.info(
+    `pairing-notify: hook registered (channel=${notifyConfig.channel || "imessage"}, target=${notifyConfig.target})`,
+  );
+}
+
+/** Unregister the pairing notification hook. */
+export function unregisterPairingNotifyHook(): void {
+  if (registeredHandler) {
+    unregisterInternalHook("pairing:request", registeredHandler);
+    registeredHandler = null;
+  }
+}
+
+// Exported for testing.
+export { buildNotificationText, sanitizeField, resolvePairingNotifyConfig, sendNotification };

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -5,10 +5,15 @@ import path from "node:path";
 import { getPairingAdapter } from "../channels/plugins/pairing.js";
 import type { ChannelId, ChannelPairingAdapter } from "../channels/plugins/types.js";
 import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
+import { fireAndForgetHook } from "../hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { withFileLock as withPathLock } from "../infra/file-lock.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { readJsonFileWithFallback, writeJsonFileAtomically } from "../plugin-sdk/json-store.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+
+const pairingLog = createSubsystemLogger("pairing-store");
 
 const PAIRING_CODE_LENGTH = 8;
 const PAIRING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -791,6 +796,24 @@ export async function upsertChannelPairingRequest(params: {
         version: 1,
         requests: [...reqs, next],
       } satisfies PairingStore);
+
+      // Fire pairing:request hook for new requests (fire-and-forget, never blocks).
+      fireAndForgetHook(
+        triggerInternalHook(
+          createInternalHookEvent("pairing", "request", "", {
+            channelId: String(params.channel),
+            requesterId: id,
+            code,
+            accountId: normalizedAccountId,
+            meta: meta ? { ...meta } : undefined,
+          }),
+        ),
+        "upsertChannelPairingRequest: pairing:request hook failed",
+        (message) => {
+          pairingLog.warn(message);
+        },
+      );
+
       return { code, created: true };
     },
   );


### PR DESCRIPTION
## Summary
Adds secure owner notifications when new pairing requests arrive. Notifications bypass the AI agent context entirely to prevent injection attacks from untrusted requester data.

## Changes
- Added `pairing.notify` config section with target, channel, accountId options
- Added `pairing:request` internal hook fired on new pairing requests
- Added `notify-owner.ts` with sanitization and multi-channel send support
- Sanitizes all untrusted fields (control chars, zero-width, bidi, length limits)
- Supports: iMessage, Telegram, WhatsApp, Discord, Signal, Slack

## Configuration
```yaml
pairing:
  notify:
    enabled: true
    target: '+14155551234'
    channel: imessage
```

## Security Design
- Notification goes directly to owner via configured channel — never enters AI agent context
- All requester-controlled fields are sanitized
- Fixed notification format prevents injection
- Fire-and-forget: notification errors log but never block pairing flow

## Testing
- 22 new tests covering sanitization, config resolution, hook lifecycle, channel routing
- All existing tests pass