### PR TITLE
fix(ui): auto-create agent config entry so agents-page edits mark form dirty

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -13,6 +13,8 @@ import { loadChannels } from "./controllers/channels.ts";
 import { loadChatHistory } from "./controllers/chat.ts";
 import {
   applyConfig,
+  ensureAgentConfigEntry,
+  findAgentConfigEntryIndex,
   loadConfig,
   runUpdate,
   saveConfig,
@@ -166,6 +168,8 @@ export function renderApp(state: AppViewState) {
     state.agentsList?.defaultId ??
     state.agentsList?.agents?.[0]?.id ??
     null;
+  const findAgentIndex = (agentId: string) => findAgentConfigEntryIndex(configValue, agentId);
+  const ensureAgentIndex = (agentId: string) => ensureAgentConfigEntry(state, agentId, configValue);
   const cronAgentSuggestions = sortLocaleStrings(
     new Set(
       [
@@ -663,20 +667,8 @@ export function renderApp(state: AppViewState) {
                   void saveAgentFile(state, resolvedAgentId, name, content);
                 },
                 onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index =
+                    profile || clearAllow ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
                   if (index < 0) {
                     return;
                   }
@@ -691,20 +683,10 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index =
+                    alsoAllow.length > 0 || deny.length > 0
+                      ? ensureAgentIndex(agentId)
+                      : findAgentIndex(agentId);
                   if (index < 0) {
                     return;
                   }
@@ -731,24 +713,15 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onAgentSkillToggle: (agentId, skillName, enabled) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = ensureAgentIndex(agentId);
                   if (index < 0) {
                     return;
                   }
-                  const entry = list[index] as { skills?: unknown };
+                  const list = (configValue as { agents?: { list?: unknown[] } } | null)?.agents
+                    ?.list;
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { skills?: unknown })
+                    : undefined;
                   const normalizedSkill = skillName.trim();
                   if (!normalizedSkill) {
                     return;
@@ -756,7 +729,7 @@ export function renderApp(state: AppViewState) {
                   const allSkills =
                     state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
                     [];
-                  const existing = Array.isArray(entry.skills)
+                  const existing = Array.isArray(entry?.skills)
                     ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
                     : undefined;
                   const base = existing ?? allSkills;
@@ -769,69 +742,34 @@ export function renderApp(state: AppViewState) {
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
                 },
                 onAgentSkillsClear: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = findAgentIndex(agentId);
                   if (index < 0) {
                     return;
                   }
                   removeConfigFormValue(state, ["agents", "list", index, "skills"]);
                 },
                 onAgentSkillsDisableAll: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = ensureAgentIndex(agentId);
                   if (index < 0) {
                     return;
                   }
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
                 },
                 onModelChange: (agentId, modelId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = modelId ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
                   if (index < 0) {
                     return;
                   }
+                  const list = (configValue as { agents?: { list?: unknown[] } } | null)?.agents
+                    ?.list;
                   const basePath = ["agents", "list", index, "model"];
                   if (!modelId) {
                     removeConfigFormValue(state, basePath);
                     return;
                   }
-                  const entry = list[index] as { model?: unknown };
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { model?: unknown })
+                    : undefined;
                   const existing = entry?.model;
                   if (existing && typeof existing === "object" && !Array.isArray(existing)) {
                     const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
@@ -845,27 +783,19 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onModelFallbacksChange: (agentId, fallbacks) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
+                  const index =
+                    normalized.length > 0 ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
                   if (index < 0) {
                     return;
                   }
+                  const list = (configValue as { agents?: { list?: unknown[] } } | null)?.agents
+                    ?.list;
                   const basePath = ["agents", "list", index, "model"];
-                  const entry = list[index] as { model?: unknown };
-                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const existing = entry.model;
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { model?: unknown })
+                    : undefined;
+                  const existing = entry?.model;
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {
                       return existing.trim() || null;

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyConfigSnapshot,
   applyConfig,
+  ensureAgentConfigEntry,
+  findAgentConfigEntryIndex,
   runUpdate,
   saveConfig,
   updateConfigFormValue,
@@ -143,6 +145,68 @@ describe("updateConfigFormValue", () => {
     expect(state.configRaw).toBe(
       '{\n  "gateway": {\n    "mode": "local",\n    "port": 18789\n  }\n}\n',
     );
+  });
+});
+
+describe("agent config helpers", () => {
+  it("finds explicit agent entries", () => {
+    expect(
+      findAgentConfigEntryIndex(
+        {
+          agents: {
+            list: [{ id: "main" }, { id: "assistant" }],
+          },
+        },
+        "assistant",
+      ),
+    ).toBe(1);
+  });
+
+  it("creates an agent override entry when editing an inherited agent", () => {
+    const state = createState();
+    state.configSnapshot = {
+      config: {
+        agents: {
+          defaults: { model: "openai/gpt-5" },
+        },
+        tools: { profile: "messaging" },
+      },
+      valid: true,
+      issues: [],
+      raw: "{\n}\n",
+    };
+
+    const index = ensureAgentConfigEntry(state, "main");
+
+    expect(index).toBe(0);
+    expect(state.configFormDirty).toBe(true);
+    expect(state.configForm).toEqual({
+      agents: {
+        defaults: { model: "openai/gpt-5" },
+        list: [{ id: "main" }],
+      },
+      tools: { profile: "messaging" },
+    });
+  });
+
+  it("reuses the existing agent entry instead of duplicating it", () => {
+    const state = createState();
+    state.configSnapshot = {
+      config: {
+        agents: {
+          list: [{ id: "main", model: "openai/gpt-5" }],
+        },
+      },
+      valid: true,
+      issues: [],
+      raw: "{\n}\n",
+    };
+
+    const index = ensureAgentConfigEntry(state, "main");
+
+    expect(index).toBe(0);
+    expect(state.configFormDirty).toBe(false);
+    expect(state.configForm).toBeNull();
   });
 });
 

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -217,3 +217,45 @@ export function removeConfigFormValue(state: ConfigState, path: Array<string | n
     state.configRaw = serializeConfigForm(base);
   }
 }
+
+export function findAgentConfigEntryIndex(
+  config: Record<string, unknown> | null,
+  agentId: string,
+): number {
+  const normalizedAgentId = agentId.trim();
+  if (!normalizedAgentId) {
+    return -1;
+  }
+  const list = (config as { agents?: { list?: unknown[] } } | null)?.agents?.list;
+  if (!Array.isArray(list)) {
+    return -1;
+  }
+  return list.findIndex(
+    (entry) =>
+      entry &&
+      typeof entry === "object" &&
+      "id" in entry &&
+      (entry as { id?: string }).id === normalizedAgentId,
+  );
+}
+
+export function ensureAgentConfigEntry(
+  state: ConfigState,
+  agentId: string,
+  config?: Record<string, unknown> | null,
+): number {
+  const normalizedAgentId = agentId.trim();
+  if (!normalizedAgentId) {
+    return -1;
+  }
+  const source =
+    config ?? state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null);
+  const existingIndex = findAgentConfigEntryIndex(source, normalizedAgentId);
+  if (existingIndex >= 0) {
+    return existingIndex;
+  }
+  const list = (source as { agents?: { list?: unknown[] } } | null)?.agents?.list;
+  const nextIndex = Array.isArray(list) ? list.length : 0;
+  updateConfigFormValue(state, ["agents", "list", nextIndex, "id"], normalizedAgentId);
+  return nextIndex;
+}


### PR DESCRIPTION
## Summary

- **Problem:** On the gateway GUI agents page, toggling any setting (model, tool profile, tool override, skill) leaves the Save button permanently grayed out. Changes are silently lost.
- **Why it matters:** This blocks all GUI-based agent configuration for users who don't edit YAML — a core workflow. Reported on current release 2026.3.2.
- **What changed:** Added `findAgentConfigEntryIndex()` and `ensureAgentConfigEntry()` helpers in `controllers/config.ts`. All seven agents-page change callbacks in `app-render.ts` now use these helpers instead of inline list-search + early-return guards. When the selected agent has no explicit `agents.list` entry (e.g. the default "main" agent inheriting global/defaults), `ensureAgentConfigEntry` seeds a minimal `{ id }` entry via `updateConfigFormValue`, which correctly marks the form dirty and triggers a Lit re-render.
- **What did NOT change (scope boundary):** No server-side changes. No config schema changes. No migration. The config-form dirty-state mechanism itself (`updateConfigFormValue`, `removeConfigFormValue`, `@state() configFormDirty`) was already correct — the bug was that callbacks never reached those functions for inherited agents.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39268

## User-visible / Behavior Changes

- Changing any agent setting on the GUI agents page (model, tool profile, tool overrides, skills) now correctly enables the Save button.
- For inherited agents without an explicit `agents.list` entry, the first edit auto-creates a minimal `{ id: "<agentId>" }` entry in the config form. This entry is written to disk only when the user clicks Save.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (platform-independent — Lit templates)
- Runtime/container: Node v24, pnpm 10.23
- Model/provider: N/A (UI-only)
- Integration/channel: Gateway web dashboard
- Relevant config: Default config with no explicit `agents.list` entries

### Steps

1. Open gateway GUI, navigate to Agents page
2. Select the default "main" agent
3. Change any setting: model dropdown, tool profile preset, individual tool toggle, or skill toggle
4. Observe: Save button now enables (was previously stuck disabled)
5. Click Save, config persists, reload page, setting retained

### Expected

Save button enables after any change; config persists on save.

### Actual (before fix)

Save button stays permanently grayed out; changes silently lost.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**New tests added in `controllers/config.test.ts`:**
- `finds explicit agent entries` — verifies `findAgentConfigEntryIndex` locates existing entries
- `creates an agent override entry when editing an inherited agent` — verifies `ensureAgentConfigEntry` seeds `{ id }`, sets `configFormDirty = true`
- `reuses the existing agent entry instead of duplicating it` — verifies no double-create when entry already exists

**All checks pass:**
- `pnpm check` (format + tsgo + lint + all lint gates) ✅
- `pnpm build` ✅
- `pnpm ui:build` ✅
- `pnpm --dir ui test` (targeted: config.test.ts + agents-panels-tools-skills.browser.test.ts — 16 tests) ✅

## Human Verification (required)

- **Verified scenarios:** Code-path analysis confirming that all seven change callbacks (`onModelChange`, `onModelFallbacksChange`, `onToolsProfileChange`, `onToolsOverridesChange`, `onAgentSkillToggle`, `onAgentSkillsClear`, `onAgentSkillsDisableAll`) now reach `updateConfigFormValue`/`removeConfigFormValue` for both inherited and explicit agents.
- **Edge cases checked:** Agent with no `agents.list` at all (empty config); agent already in list (no duplicate entry created); clearing model on inherited agent (no-op when entry doesn't exist, clean removal when it does).
- **What I did NOT verify:** Manual browser testing against a live gateway instance with real agent configs. The reporter was on Windows 11 — not tested on Windows specifically.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit.
- Files/config to restore: `ui/src/ui/app-render.ts`, `ui/src/ui/controllers/config.ts`, `ui/src/ui/controllers/config.test.ts`
- Known bad symptoms reviewers should watch for: If the auto-created `{ id }` entry causes unexpected config serialization, the config file would gain a new `agents.list` array entry after saving — this is correct behavior (it is the explicit override the user intended), but reviewers should confirm it does not produce invalid config shapes.

## Risks and Mitigations

- Risk: Auto-creating the agent entry could produce an `agents.list` with a minimal `{ id }` entry that the gateway config validator rejects.
  - Mitigation: `updateConfigFormValue` (the existing mechanism used for all other config edits) handles form serialization and coercion. The `{ id }` stub is the minimal valid shape. The validator is tested separately and accepts entries with only `id` set.
- Risk: On configs that already have an explicit `agents.list` entry, the `findAgentConfigEntryIndex` lookup could mismatch.
  - Mitigation: The find logic is identical to the previous inline code — same `entry.id === agentId` comparison. New unit test confirms correct index resolution.
