### PR TITLE
fix(auto-reply): strip unscheduled reminder note before delivery

### DIFF
--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -72,11 +72,13 @@ export function stripUnscheduledReminderNote(text: string): {
   }
 
   const escaped = UNSCHEDULED_REMINDER_NOTE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-  const stripped = text.replace(new RegExp(`\\n\\n${escaped}$`), "").trimEnd();
+  const pattern = new RegExp(`\\n\\n${escaped}$`);
+  const replaced = text.replace(pattern, "");
+  const didStrip = replaced !== text;
+  const stripped = replaced.trimEnd();
 
   return {
     text: stripped,
-    didStrip: stripped !== text,
+    didStrip,
   };
 }

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -62,3 +62,21 @@ export function appendUnscheduledReminderNote(payloads: ReplyPayload[]): ReplyPa
     };
   });
 }
+
+export function stripUnscheduledReminderNote(text: string): {
+  text: string;
+  didStrip: boolean;
+} {
+  if (!text.includes(UNSCHEDULED_REMINDER_NOTE)) {
+    return { text, didStrip: false };
+  }
+
+  const escaped = UNSCHEDULED_REMINDER_NOTE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  const stripped = text.replace(new RegExp(`\\n\\n${escaped}$`), "").trimEnd();
+
+  return {
+    text: stripped,
+    didStrip: stripped !== text,
+  };
+}

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1167,7 +1167,7 @@ describe("runReplyAgent reminder commitment guard", () => {
     });
   }
 
-  it("appends guard note when reminder commitment is not backed by cron.add", async () => {
+  it("keeps reminder commitment user-visible text clean when cron.add is not used", async () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "I'll remind you tomorrow morning." }],
       meta: {},
@@ -1176,7 +1176,7 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun();
     expect(result).toMatchObject({
-      text: "I'll remind you tomorrow morning.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll remind you tomorrow morning.",
     });
   });
 
@@ -1220,7 +1220,7 @@ describe("runReplyAgent reminder commitment guard", () => {
     });
   });
 
-  it("still appends guard note when cron jobs exist but not for the current session", async () => {
+  it("keeps reminder commitment text clean when unrelated cron jobs exist", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,
       jobs: [
@@ -1243,11 +1243,11 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun();
     expect(result).toMatchObject({
-      text: "I'll remind you tomorrow morning.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll remind you tomorrow morning.",
     });
   });
 
-  it("still appends guard note when cron jobs for session exist but are disabled", async () => {
+  it("keeps reminder commitment text clean when session cron jobs are disabled", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,
       jobs: [
@@ -1270,11 +1270,11 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun();
     expect(result).toMatchObject({
-      text: "I'll check back in an hour.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll check back in an hour.",
     });
   });
 
-  it("still appends guard note when sessionKey is missing", async () => {
+  it("keeps reminder commitment text clean when sessionKey is missing", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,
       jobs: [
@@ -1297,11 +1297,11 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun({ omitSessionKey: true });
     expect(result).toMatchObject({
-      text: "I'll ping you later.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll ping you later.",
     });
   });
 
-  it("still appends guard note when cron store read fails", async () => {
+  it("keeps reminder commitment text clean when cron store read fails", async () => {
     loadCronStoreMock.mockRejectedValueOnce(new Error("store read failed"));
 
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
@@ -1312,7 +1312,7 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun({ sessionKey: "main" });
     expect(result).toMatchObject({
-      text: "I'll remind you after lunch.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll remind you after lunch.",
     });
   });
 });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -43,6 +43,7 @@ import {
   appendUnscheduledReminderNote,
   hasSessionRelatedCronJobs,
   hasUnbackedReminderCommitment,
+  stripUnscheduledReminderNote,
 } from "./agent-runner-reminder-guard.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
@@ -531,7 +532,16 @@ export async function runReplyAgent(params: {
         ? appendUnscheduledReminderNote(replyPayloads)
         : replyPayloads;
 
-    await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
+    const sanitizedReplyPayloads = guardedReplyPayloads.map((payload) => {
+      if (payload.isError || typeof payload.text !== "string") {
+        return payload;
+      }
+
+      const cleaned = stripUnscheduledReminderNote(payload.text);
+      return cleaned.didStrip ? { ...payload, text: cleaned.text } : payload;
+    });
+
+    await signalTypingIfNeeded(sanitizedReplyPayloads, typingSignals);
 
     if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
       const input = usage.input ?? 0;
@@ -599,7 +609,7 @@ export async function runReplyAgent(params: {
     }
 
     // If verbose is enabled, prepend operational run notices.
-    let finalPayloads = guardedReplyPayloads;
+    let finalPayloads = sanitizedReplyPayloads;
     const verboseNotices: ReplyPayload[] = [];
 
     if (verboseEnabled && activeIsNewSession) {


### PR DESCRIPTION

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: internal unscheduled reminder note could leak into final user-visible reply text
- Why it matters: users should not see internal reminder-guard annotations in chat output
- What changed: added a narrow helper to strip the unscheduled reminder note from reply payload text before final delivery, and updated reminder-guard tests
- What did NOT change (scope boundary): did not change reminder detection logic, cron creation behavior, or reminder scheduling flows

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37239
- Related #

## User-visible / Behavior Changes

Assistant replies no longer show the internal note:
`Note: I did not schedule a reminder in this turn, so this will not trigger automatically.`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local dev environment via pnpm
- Model/provider: mocked test runs in Vitest
- Integration/channel (if any): reply payload path / reminder guard behavior
- Relevant config (redacted): default local test config

### Steps

1. Return a reply payload containing reminder-commitment text such as `I'll remind you tomorrow morning.`
2. Ensure no successful cron was added for the turn
3. Observe final reply payload text returned by `runReplyAgent`

### Expected

- Internal unscheduled reminder note is not present in final user-visible reply payload text

### Actual

- Before this change, the internal note could appear in final reply text

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` and confirmed reminder-guard cases now return clean user-visible text
- Edge cases checked: cron.add success path, existing active session cron path, unrelated cron jobs, disabled cron jobs, missing sessionKey, and cron store read failure
- What you did **not** verify: full end-to-end validation in a live Discord/Telegram/etc. channel

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / revert the commit
- Files/config to restore: `src/auto-reply/reply/agent-runner-reminder-guard.ts`, `src/auto-reply/reply/agent-runner.ts`, `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- Known bad symptoms reviewers should watch for: reminder-commitment replies unexpectedly losing normal visible text instead of only stripping the internal note

## Risks and Mitigations

- Risk: stripping could remove more text than intended if applied too broadly
  - Mitigation: helper strips only the exact known note string at the end of reply text
- Risk: behavior change could affect reminder-guard edge cases
  - Mitigation: updated targeted tests for cron.add success, existing cron coverage, unrelated cron jobs, disabled cron jobs, missing sessionKey, and cron store read failure