### PR TITLE
fix(acpx): pass MCP server configuration to ACP sessions

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -34,6 +34,29 @@
       "queueOwnerTtlSeconds": {
         "type": "number",
         "minimum": 0
+      },
+      "mcpServers": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Command to run the MCP server"
+            },
+            "args": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Arguments to pass to the command"
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "Environment variables for the MCP server"
+            }
+          },
+          "required": ["command"]
+        }
       }
     }
   },
@@ -71,6 +94,11 @@
     "queueOwnerTtlSeconds": {
       "label": "Queue Owner TTL Seconds",
       "help": "Idle queue-owner TTL for acpx prompt turns. Keep this short in OpenClaw to avoid delayed completion after each turn.",
+      "advanced": true
+    },
+    "mcpServers": {
+      "label": "MCP Servers",
+      "help": "MCP server configurations to make available to ACP sessions. Each entry should have a command and optional args and env.",
       "advanced": true
     }
   }

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -21,6 +21,7 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.allowPluginLocalInstall).toBe(true);
     expect(resolved.cwd).toBe(path.resolve("/tmp/workspace"));
     expect(resolved.strictWindowsCmdWrapper).toBe(true);
+    expect(resolved.mcpServers).toEqual({});
   });
 
   it("accepts command override and disables plugin-local auto-install", () => {
@@ -131,5 +132,227 @@ describe("acpx plugin config parsing", () => {
         workspaceDir: "/tmp/workspace",
       }),
     ).toThrow("strictWindowsCmdWrapper must be a boolean");
+  });
+});
+
+describe("acpx plugin mcpServers config parsing", () => {
+  it("accepts mcpServers with command-only configuration", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        mcpServers: {
+          canva: {
+            command: "npx",
+          },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.mcpServers).toEqual({
+      canva: {
+        command: "npx",
+      },
+    });
+  });
+
+  it("accepts mcpServers with command and args", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        mcpServers: {
+          canva: {
+            command: "npx",
+            args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+          },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.mcpServers).toEqual({
+      canva: {
+        command: "npx",
+        args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+      },
+    });
+  });
+
+  it("accepts mcpServers with command, args, and env", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        mcpServers: {
+          canva: {
+            command: "npx",
+            args: ["-y", "mcp-remote@latest"],
+            env: {
+              API_KEY: "secret123",
+            },
+          },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.mcpServers).toEqual({
+      canva: {
+        command: "npx",
+        args: ["-y", "mcp-remote@latest"],
+        env: {
+          API_KEY: "secret123",
+        },
+      },
+    });
+  });
+
+  it("accepts multiple mcpServers", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        mcpServers: {
+          canva: {
+            command: "npx",
+            args: ["mcp-remote@latest", "https://mcp.canva.com/mcp"],
+          },
+          github: {
+            command: "npx",
+            args: ["-y", "@github/mcp-server"],
+            env: {
+              GITHUB_TOKEN: "token123",
+            },
+          },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(Object.keys(resolved.mcpServers)).toHaveLength(2);
+    expect(resolved.mcpServers.canva).toBeDefined();
+    expect(resolved.mcpServers.github).toBeDefined();
+  });
+
+  it("rejects mcpServers with missing command", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          mcpServers: {
+            canva: {
+              args: ["-y"],
+            },
+          },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("mcpServers.canva must have a command string, optional args array, and optional env object");
+  });
+
+  it("rejects mcpServers with non-string command", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          mcpServers: {
+            canva: {
+              command: 123,
+            },
+          },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("mcpServers.canva must have a command string, optional args array, and optional env object");
+  });
+
+  it("rejects mcpServers with non-array args", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          mcpServers: {
+            canva: {
+              command: "npx",
+              args: "-y",
+            },
+          },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("mcpServers.canva must have a command string, optional args array, and optional env object");
+  });
+
+  it("rejects mcpServers with non-string args items", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          mcpServers: {
+            canva: {
+              command: "npx",
+              args: ["-y", 123],
+            },
+          },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("mcpServers.canva must have a command string, optional args array, and optional env object");
+  });
+
+  it("rejects mcpServers with non-object env", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          mcpServers: {
+            canva: {
+              command: "npx",
+              env: "API_KEY=secret",
+            },
+          },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("mcpServers.canva must have a command string, optional args array, and optional env object");
+  });
+
+  it("rejects mcpServers with non-string env values", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          mcpServers: {
+            canva: {
+              command: "npx",
+              env: {
+                API_KEY: 123,
+              },
+            },
+          },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("mcpServers.canva must have a command string, optional args array, and optional env object");
+  });
+
+  it("schema accepts valid mcpServers config", () => {
+    const schema = createAcpxPluginConfigSchema();
+    if (!schema.safeParse) {
+      throw new Error("acpx config schema missing safeParse");
+    }
+    const parsed = schema.safeParse({
+      mcpServers: {
+        canva: {
+          command: "npx",
+          args: ["-y", "mcp-remote@latest"],
+          env: {
+            API_KEY: "secret",
+          },
+        },
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("schema rejects mcpServers with invalid structure", () => {
+    const schema = createAcpxPluginConfigSchema();
+    if (!schema.safeParse) {
+      throw new Error("acpx config schema missing safeParse");
+    }
+    const parsed = schema.safeParse({
+      mcpServers: "invalid",
+    });
+
+    expect(parsed.success).toBe(false);
   });
 });

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -18,6 +18,13 @@ export function buildAcpxLocalInstallCommand(version: string = ACPX_PINNED_VERSI
 }
 export const ACPX_LOCAL_INSTALL_COMMAND = buildAcpxLocalInstallCommand();
 
+// MCP server configuration type
+export type McpServerConfig = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
+
 export type AcpxPluginConfig = {
   command?: string;
   expectedVersion?: string;
@@ -27,6 +34,7 @@ export type AcpxPluginConfig = {
   strictWindowsCmdWrapper?: boolean;
   timeoutSeconds?: number;
   queueOwnerTtlSeconds?: number;
+  mcpServers?: Record<string, McpServerConfig>;
 };
 
 export type ResolvedAcpxPluginConfig = {
@@ -40,6 +48,7 @@ export type ResolvedAcpxPluginConfig = {
   strictWindowsCmdWrapper: boolean;
   timeoutSeconds?: number;
   queueOwnerTtlSeconds: number;
+  mcpServers: Record<string, McpServerConfig>;
 };
 
 const DEFAULT_PERMISSION_MODE: AcpxPermissionMode = "approve-reads";
@@ -65,6 +74,30 @@ function isNonInteractivePermissionPolicy(
   return ACPX_NON_INTERACTIVE_POLICIES.includes(value as AcpxNonInteractivePermissionPolicy);
 }
 
+function isMcpServerConfig(value: unknown): value is McpServerConfig {
+  if (!isRecord(value)) return false;
+  const command = value.command;
+  if (typeof command !== "string" || command.trim() === "") return false;
+  
+  // Validate args if present
+  if (value.args !== undefined) {
+    if (!Array.isArray(value.args)) return false;
+    for (const arg of value.args) {
+      if (typeof arg !== "string") return false;
+    }
+  }
+  
+  // Validate env if present
+  if (value.env !== undefined) {
+    if (!isRecord(value.env)) return false;
+    for (const [key, val] of Object.entries(value.env)) {
+      if (typeof val !== "string") return false;
+    }
+  }
+  
+  return true;
+}
+
 function parseAcpxPluginConfig(value: unknown): ParseResult {
   if (value === undefined) {
     return { ok: true, value: undefined };
@@ -81,6 +114,7 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
     "strictWindowsCmdWrapper",
     "timeoutSeconds",
     "queueOwnerTtlSeconds",
+    "mcpServers",
   ]);
   for (const key of Object.keys(value)) {
     if (!allowedKeys.has(key)) {
@@ -152,6 +186,19 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
     return { ok: false, message: "queueOwnerTtlSeconds must be a non-negative number" };
   }
 
+  // Validate mcpServers if present
+  const mcpServers = value.mcpServers;
+  if (mcpServers !== undefined) {
+    if (!isRecord(mcpServers)) {
+      return { ok: false, message: "mcpServers must be an object" };
+    }
+    for (const [key, serverConfig] of Object.entries(mcpServers)) {
+      if (!isMcpServerConfig(serverConfig)) {
+        return { ok: false, message: `mcpServers.${key} must have a command string, optional args array, and optional env object` };
+      }
+    }
+  }
+
   return {
     ok: true,
     value: {
@@ -166,6 +213,7 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
       timeoutSeconds: typeof timeoutSeconds === "number" ? timeoutSeconds : undefined,
       queueOwnerTtlSeconds:
         typeof queueOwnerTtlSeconds === "number" ? queueOwnerTtlSeconds : undefined,
+      mcpServers: mcpServers as Record<string, McpServerConfig> | undefined,
     },
   };
 }
@@ -219,6 +267,24 @@ export function createAcpxPluginConfigSchema(): OpenClawPluginConfigSchema {
         strictWindowsCmdWrapper: { type: "boolean" },
         timeoutSeconds: { type: "number", minimum: 0.001 },
         queueOwnerTtlSeconds: { type: "number", minimum: 0 },
+        mcpServers: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              command: { type: "string" },
+              args: {
+                type: "array",
+                items: { type: "string" },
+              },
+              env: {
+                type: "object",
+                additionalProperties: { type: "string" },
+              },
+            },
+            required: ["command"],
+          },
+        },
       },
     },
   };
@@ -260,5 +326,6 @@ export function resolveAcpxPluginConfig(params: {
       normalized.strictWindowsCmdWrapper ?? DEFAULT_STRICT_WINDOWS_CMD_WRAPPER,
     timeoutSeconds: normalized.timeoutSeconds,
     queueOwnerTtlSeconds: normalized.queueOwnerTtlSeconds ?? DEFAULT_QUEUE_OWNER_TTL_SECONDS,
+    mcpServers: normalized.mcpServers ?? {},
   };
 }

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -12,7 +12,7 @@ import type {
   PluginLogger,
 } from "openclaw/plugin-sdk/acpx";
 import { AcpRuntimeError } from "openclaw/plugin-sdk/acpx";
-import { type ResolvedAcpxPluginConfig } from "./config.js";
+import { type ResolvedAcpxPluginConfig, type McpServerConfig } from "./config.js";
 import { checkAcpxVersion } from "./ensure.js";
 import {
   parseJsonLines,
@@ -222,6 +222,7 @@ export class AcpxRuntime implements AcpRuntime {
         }),
         cwd,
         fallbackCode: "ACP_SESSION_INIT_FAILED",
+        mcpServers: this.config.mcpServers,
       });
       ensuredEvent = events.find(
         (event) =>
@@ -614,11 +615,20 @@ export class AcpxRuntime implements AcpRuntime {
     fallbackCode: AcpRuntimeErrorCode;
     ignoreNoSession?: boolean;
     signal?: AbortSignal;
+    mcpServers?: Record<string, McpServerConfig>;
   }): Promise<AcpxJsonObject[]> {
+    let args = params.args;
+    
+    // Add --mcpServers flag if mcpServers are provided and non-empty
+    if (params.mcpServers && Object.keys(params.mcpServers).length > 0) {
+      const mcpServersJson = JSON.stringify(params.mcpServers);
+      args = [...args, "--mcpServers", mcpServersJson];
+    }
+    
     const result = await spawnAndCollect(
       {
         command: this.config.command,
-        args: params.args,
+        args,
         cwd: params.cwd,
       },
       this.spawnCommandOptions,

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -59,8 +59,11 @@ export function createAcpxRuntimeService(
       });
       const expectedVersionLabel = pluginConfig.expectedVersion ?? "any";
       const installLabel = pluginConfig.allowPluginLocalInstall ? "enabled" : "disabled";
+      const mcpServersLabel = Object.keys(pluginConfig.mcpServers).length > 0 
+        ? `, mcpServers: ${Object.keys(pluginConfig.mcpServers).length}` 
+        : "";
       ctx.logger.info(
-        `acpx runtime backend registered (command: ${pluginConfig.command}, expectedVersion: ${expectedVersionLabel}, pluginLocalInstall: ${installLabel})`,
+        `acpx runtime backend registered (command: ${pluginConfig.command}, expectedVersion: ${expectedVersionLabel}, pluginLocalInstall: ${installLabel}${mcpServersLabel})`,
       );
 
       lifecycleRevision += 1;


### PR DESCRIPTION
## Problem

The ACPX runtime was ignoring MCP server configurations, always passing `mcpServers: []` to the underlying acpx CLI. This prevented users from using external MCP servers like Canva's MCP with OpenClaw's ACP runtime.

## Solution

This PR adds support for configuring MCP servers in the ACPX plugin configuration and passes them to the acpx CLI when creating new sessions.

## Changes

- Added `McpServerConfig` type and validation
- Updated runtime to pass MCP servers to acpx CLI
- Updated service logging
- Added config schema for MCP servers
- Added comprehensive tests

## Testing

- Added `config.test.ts` with tests for config validation
- Verified that mcpServers are correctly passed to acpx

Fixes #39225