### PR TITLE
fix(feishu): support v2 card format, streaming cards, and interactive message type parsing

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -46,10 +46,14 @@ vi.mock("./reply-dispatcher.js", () => ({
   createFeishuReplyDispatcher: mockCreateFeishuReplyDispatcher,
 }));
 
-vi.mock("./send.js", () => ({
-  sendMessageFeishu: mockSendMessageFeishu,
-  getMessageFeishu: mockGetMessageFeishu,
-}));
+vi.mock("./send.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    sendMessageFeishu: mockSendMessageFeishu,
+    getMessageFeishu: mockGetMessageFeishu,
+  };
+});
 
 vi.mock("./media.js", () => ({
   downloadMessageResourceFeishu: mockDownloadMessageResourceFeishu,
@@ -941,6 +945,45 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
         BodyForAgent: "[message_id: msg-message-id-line]\nou-msgid: hello",
+      }),
+    );
+  });
+
+  it("parses interactive card content when received as direct message", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-card-sender",
+        },
+      },
+      message: {
+        message_id: "msg-interactive-direct",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "interactive",
+        content: JSON.stringify({
+          header: { title: { content: "Card Title" } },
+          elements: [{ tag: "markdown", content: "card body text" }],
+        }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent:
+          "[message_id: msg-interactive-direct]\nou-card-sender: Card Title\ncard body text",
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -29,7 +29,7 @@ import {
 import { parsePostContent } from "./post.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { getMessageFeishu, parseInteractiveCardContent, sendMessageFeishu } from "./send.js";
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -341,6 +341,9 @@ function parseMessageContent(content: string, messageType: string): string {
     if (messageType === "merge_forward") {
       // Return placeholder; actual content fetched asynchronously in handleFeishuMessage
       return "[Merged and Forwarded Message - loading...]";
+    }
+    if (messageType === "interactive") {
+      return parseInteractiveCardContent(parsed);
     }
     return content;
   } catch {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,6 +1,6 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getMessageFeishu } from "./send.js";
+import { getMessageFeishu, parseInteractiveCardContent } from "./send.js";
 
 const { mockClientGet, mockCreateFeishuClient, mockResolveFeishuAccount } = vi.hoisted(() => ({
   mockClientGet: vi.fn(),
@@ -164,5 +164,62 @@ describe("getMessageFeishu", () => {
         content: "single payload",
       }),
     );
+  });
+});
+
+describe("parseInteractiveCardContent", () => {
+  it("extracts content from streaming card that has header and elements", () => {
+    // A streaming card reference that also carries inline content should extract it
+    const card = {
+      type: "card",
+      data: { card_id: "card_streaming_123" },
+      header: { title: { content: "Stream Title" } },
+      elements: [{ tag: "markdown", content: "streamed content" }],
+    };
+    expect(parseInteractiveCardContent(card)).toBe("Stream Title\nstreamed content");
+  });
+
+  it("returns [Streaming Card] for card_id reference with no inline content", () => {
+    const card = { type: "card", data: { card_id: "card_streaming_456" } };
+    expect(parseInteractiveCardContent(card)).toBe("[Streaming Card]");
+  });
+
+  it("falls back to non-empty locale when zh_cn is empty array", () => {
+    const card = {
+      i18n_elements: {
+        zh_cn: [],
+        en_us: [{ tag: "markdown", content: "english content" }],
+      },
+    };
+    expect(parseInteractiveCardContent(card)).toBe("english content");
+  });
+
+  it("prefers zh_cn when it is a non-empty array", () => {
+    const card = {
+      i18n_elements: {
+        zh_cn: [{ tag: "markdown", content: "中文内容" }],
+        en_us: [{ tag: "markdown", content: "english content" }],
+      },
+    };
+    expect(parseInteractiveCardContent(card)).toBe("中文内容");
+  });
+
+  it("extracts template variable values", () => {
+    const card = {
+      type: "template",
+      data: {
+        template_variable: {
+          title: "Template Title",
+          content: "Template Body",
+          num: 42,
+        },
+      },
+    };
+    expect(parseInteractiveCardContent(card)).toBe("Template Title\nTemplate Body");
+  });
+
+  it("returns [Interactive Card] for null/undefined input", () => {
+    expect(parseInteractiveCardContent(null)).toBe("[Interactive Card]");
+    expect(parseInteractiveCardContent(undefined)).toBe("[Interactive Card]");
   });
 });

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -222,4 +222,54 @@ describe("parseInteractiveCardContent", () => {
     expect(parseInteractiveCardContent(null)).toBe("[Interactive Card]");
     expect(parseInteractiveCardContent(undefined)).toBe("[Interactive Card]");
   });
+
+  it("ignores malformed elements and still extracts nested valid text", () => {
+    const card = {
+      header: { title: { content: "Malformed Card" } },
+      body: {
+        elements: [
+          null,
+          "bad-element",
+          { tag: "markdown", content: 42 },
+          {
+            tag: "column_set",
+            columns: [
+              null,
+              { elements: "bad-elements" },
+              {
+                elements: [
+                  { tag: "markdown", content: "nested markdown" },
+                  { tag: "div", text: { content: "nested div" } },
+                ],
+              },
+            ],
+          },
+          {
+            tag: "form",
+            elements: [
+              { tag: "markdown", content: "form markdown" },
+              { tag: "div", text: { content: "form div" } },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(parseInteractiveCardContent(card)).toBe(
+      "Malformed Card\nnested markdown\nnested div\nform markdown\nform div",
+    );
+  });
+
+  it("falls back to [Interactive Card] when all extractable fields are malformed", () => {
+    const card = {
+      header: { title: { content: "   " } },
+      elements: [
+        { tag: "div", text: { content: 123 } },
+        { tag: "markdown", content: { bad: true } },
+        { tag: "column_set", columns: [{ elements: "bad-elements" }] },
+      ],
+    };
+
+    expect(parseInteractiveCardContent(card)).toBe("[Interactive Card]");
+  });
 });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -85,18 +85,15 @@ export type FeishuMessageInfo = {
   createTime?: number;
 };
 
-function parseInteractiveCardContent(parsed: unknown): string {
-  if (!parsed || typeof parsed !== "object") {
-    return "[Interactive Card]";
-  }
-
-  const candidate = parsed as { elements?: unknown };
-  if (!Array.isArray(candidate.elements)) {
-    return "[Interactive Card]";
-  }
-
+/**
+ * Extract readable text from an array of Feishu card elements.
+ * Handles div, markdown, column_set, and nested elements (form, collapsible).
+ *
+ * This is the leaf-level extractor used by {@link parseInteractiveCardContent}.
+ */
+function extractTextsFromElements(elements: unknown[]): string[] {
   const texts: string[] = [];
-  for (const element of candidate.elements) {
+  for (const element of elements) {
     if (!element || typeof element !== "object") {
       continue;
     }
@@ -104,6 +101,8 @@ function parseInteractiveCardContent(parsed: unknown): string {
       tag?: string;
       content?: string;
       text?: { content?: string };
+      columns?: unknown[];
+      elements?: unknown[];
     };
     if (item.tag === "div" && typeof item.text?.content === "string") {
       texts.push(item.text.content);
@@ -111,11 +110,116 @@ function parseInteractiveCardContent(parsed: unknown): string {
     }
     if (item.tag === "markdown" && typeof item.content === "string") {
       texts.push(item.content);
+      continue;
+    }
+    // column_set → recurse into each column's elements
+    if (item.tag === "column_set" && Array.isArray(item.columns)) {
+      for (const col of item.columns) {
+        if (
+          col &&
+          typeof col === "object" &&
+          Array.isArray((col as { elements?: unknown[] }).elements)
+        ) {
+          texts.push(...extractTextsFromElements((col as { elements: unknown[] }).elements));
+        }
+      }
+      continue;
+    }
+    // Generic nested elements (e.g. form, collapsible)
+    if (Array.isArray(item.elements)) {
+      texts.push(...extractTextsFromElements(item.elements));
     }
   }
+  return texts;
+}
+
+/**
+ * Parse interactive card (message_type=interactive) into readable text.
+ *
+ * Data flow for quoted messages:
+ *   event webhook → parentId → getMessageFeishu (API fetch) →
+ *   parseQuotedMessageContent → parseInteractiveCardContent
+ *
+ * Data flow for direct interactive messages:
+ *   event webhook → parseMessageContent (bot.ts) → parseInteractiveCardContent
+ *
+ * Feishu interactive cards come in several shapes:
+ * 1. Flat v1: `{ "elements": [...] }`
+ * 2. With header: `{ "header": { "title": { "content": "..." } }, "elements": [...] }`
+ * 3. Body wrapper (card kit v2 / schema 2.0): `{ "body": { "elements": [...] } }`
+ * 4. i18n: `{ "i18n_elements": { "zh_cn": [...] } }`
+ * 5. Template: `{ "type": "template", "data": { "template_variable": {...} } }`
+ * 6. Streaming card ref: `{ "type": "card", "data": { "card_id": "..." } }`
+ *    — card_id references point to a server-side card; content may not be inline.
+ *      We still attempt to extract header/elements if present before falling back.
+ */
+export function parseInteractiveCardContent(parsed: unknown): string {
+  if (!parsed || typeof parsed !== "object") {
+    return "[Interactive Card]";
+  }
+
+  const card = parsed as {
+    header?: { title?: { content?: string } };
+    elements?: unknown[];
+    i18n_elements?: { zh_cn?: unknown[]; [locale: string]: unknown[] | undefined };
+    body?: { elements?: unknown[] };
+    type?: string;
+    data?: { template_variable?: Record<string, unknown>; card_id?: string };
+  };
+
+  const texts: string[] = [];
+
+  // Extract header title if present
+  if (typeof card.header?.title?.content === "string" && card.header.title.content.trim()) {
+    texts.push(card.header.title.content);
+  }
+
+  // Resolve the elements array from multiple possible locations
+  let elements: unknown[] | undefined = card.elements;
+  if (!Array.isArray(elements)) {
+    // Try body.elements (card kit v2 / schema 2.0)
+    elements = card.body?.elements;
+  }
+  if (!Array.isArray(elements)) {
+    // Try i18n_elements — pick zh_cn first (if non-empty array), then first available locale
+    if (card.i18n_elements && typeof card.i18n_elements === "object") {
+      const zhCn = card.i18n_elements.zh_cn;
+      elements =
+        (Array.isArray(zhCn) && zhCn.length > 0 ? zhCn : undefined) ??
+        (Object.values(card.i18n_elements).find((v) => Array.isArray(v) && v.length > 0) as
+          | unknown[]
+          | undefined);
+    }
+  }
+
+  if (Array.isArray(elements)) {
+    texts.push(...extractTextsFromElements(elements));
+  }
+
+  // Template cards: extract template_variable values as last resort
+  if (texts.length === 0 && card.type === "template" && card.data?.template_variable) {
+    const vars = card.data.template_variable;
+    for (const val of Object.values(vars)) {
+      if (typeof val === "string" && val.trim()) {
+        texts.push(val);
+      }
+    }
+  }
+
+  // Streaming card reference — only use placeholder when no content was extracted
+  if (texts.length === 0 && card.type === "card" && card.data?.card_id) {
+    return "[Streaming Card]";
+  }
+
   return texts.join("\n").trim() || "[Interactive Card]";
 }
 
+/**
+ * Parse the raw content string of a quoted (replied-to) Feishu message.
+ *
+ * Called by {@link getMessageFeishu} after fetching the original message via API.
+ * For interactive cards, delegates to {@link parseInteractiveCardContent}.
+ */
 function parseQuotedMessageContent(rawContent: string, msgType: string): string {
   if (!rawContent) {
     return "";


### PR DESCRIPTION
## Summary / 概要

Fix three Feishu interactive-card parsing gaps and strengthen regression coverage for malformed payloads.

修复飞书 interactive card 解析的三个缺口，并补强 malformed payload 的回归测试覆盖。

### What this PR fixes / 修复内容

1. **v2 card format support**: `parseInteractiveCardContent` now handles schema 2.0 cards that store content under `body.elements`, not only v1 cards with top-level `elements`.
2. **Streaming card references**: content like `{"type":"card","data":{...}}` is parsed more usefully — extract inline text when available, otherwise fall back safely.
3. **Direct interactive messages in bot.ts**: when Feishu sends an `interactive` message as the primary message (not just quoted content), `bot.ts` now parses it into readable text instead of returning raw JSON.

### Safety note / 安全说明

This PR is intended to be merged and consumed through the normal OpenClaw build/release flow.

**Do not copy source files from a development branch into a live installed OpenClaw package.**
Please avoid hand-patching `~/.npm-global/lib/node_modules/openclaw/...` or any running production install with repo source files.

本 PR 应通过正常的构建 / 发布流程进入版本。
**不要把开发分支源码直接复制到正在运行的 OpenClaw 安装目录中。**
请不要手工 patch `~/.npm-global/lib/node_modules/openclaw/...` 或任何线上运行中的安装包。

### Implementation details / 实现细节

**`extensions/feishu/src/send.ts`**
- Extract helper `extractTextsFromElements` for recursive traversal
- Support:
  - v1 `elements`
  - v2 `body.elements`
  - header title extraction
  - `i18n_elements` locale fallback with `zh_cn` preference
  - template card variable extraction
  - nested elements such as `column_set`, form-like and collapsible structures
  - streaming card references with inline-content extraction when possible
- Tighten `i18n_elements` typing for better type safety

**`extensions/feishu/src/bot.ts`**
- Reuse `parseInteractiveCardContent` for direct `interactive` message parsing

### Tests / 测试

Focused regression coverage now includes:

- v2 `body.elements`
- v1 `elements`
- header + elements
- streaming card with inline content
- streaming card with only `card_id`
- `i18n_elements` locale preference and empty-array fallback
- template variable extraction
- null / undefined input
- direct `interactive` message parsing in `bot.ts`
- malformed mixed payloads still extracting valid nested content
- malformed payloads safely falling back to `[Interactive Card]`

Ran:

- `pnpm vitest run extensions/feishu/src/send.test.ts extensions/feishu/src/bot.test.ts --config vitest.extensions.config.ts`
- `pnpm format:check -- extensions/feishu/src/send.ts extensions/feishu/src/bot.ts extensions/feishu/src/send.test.ts extensions/feishu/src/bot.test.ts`

### Reviewer follow-up / 对 review 意见的回应

- Added focused regression tests around the changed `send.ts` / `bot.ts` execution paths
- Added malformed-input edge-case coverage instead of changing behavior unnecessarily
- Kept the implementation scoped and low-risk

### Related / 相关

- Closes #32023
- Related to #34571
- Supersedes #38776, #34736, #32742