### PR TITLE
[codex] BlueBubbles: force private API for Tahoe text sends

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -819,7 +819,7 @@
         "filename": "docs/.i18n/zh-CN.tm.jsonl",
         "hashed_secret": "b0e551f8b6fbe0147169202fbc141c1a0478dfb2",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 82
       },
       {
         "type": "Hex High Entropy String",
@@ -896,7 +896,7 @@
         "filename": "docs/.i18n/zh-CN.tm.jsonl",
         "hashed_secret": "98facee0b1bf74672bacb855a27972851929dd78",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 93
       },
       {
         "type": "Hex High Entropy String",
@@ -1344,7 +1344,7 @@
         "filename": "docs/.i18n/zh-CN.tm.jsonl",
         "hashed_secret": "be61d29ac11ba55400fcaf405a1b404e269e528e",
         "is_verified": false,
-        "line_number": 154
+        "line_number": 157
       },
       {
         "type": "Hex High Entropy String",
@@ -2086,7 +2086,7 @@
         "filename": "docs/.i18n/zh-CN.tm.jsonl",
         "hashed_secret": "413654967fff8eae5dd1fece27756c957721d131",
         "is_verified": false,
-        "line_number": 260
+        "line_number": 263
       },
       {
         "type": "Hex High Entropy String",
@@ -13011,5 +13011,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T01:23:32Z"
+  "generated_at": "2026-03-08T01:38:26Z"
 }

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -2,7 +2,10 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-mocks.js";
 import { downloadBlueBubblesAttachment, sendBlueBubblesAttachment } from "./attachments.js";
-import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
+import {
+  getCachedBlueBubblesPrivateApiStatus,
+  resolveBlueBubblesPrivateApiStatus,
+} from "./probe.js";
 import { setBlueBubblesRuntime } from "./runtime.js";
 import {
   BLUE_BUBBLES_PRIVATE_API_STATUS,
@@ -338,6 +341,7 @@ describe("sendBlueBubblesAttachment", () => {
     fetchRemoteMediaMock.mockClear();
     setBlueBubblesRuntime(runtimeStub);
     vi.mocked(getCachedBlueBubblesPrivateApiStatus).mockReset();
+    vi.mocked(resolveBlueBubblesPrivateApiStatus).mockClear();
     mockBlueBubblesPrivateApiStatus(
       vi.mocked(getCachedBlueBubblesPrivateApiStatus),
       BLUE_BUBBLES_PRIVATE_API_STATUS.unknown,
@@ -406,6 +410,7 @@ describe("sendBlueBubblesAttachment", () => {
         opts: { serverUrl: "http://localhost:1234", password: "test" },
       }),
     ).rejects.toThrow("voice messages require audio");
+    expect(vi.mocked(resolveBlueBubblesPrivateApiStatus)).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -420,6 +425,21 @@ describe("sendBlueBubblesAttachment", () => {
         opts: { serverUrl: "http://localhost:1234", password: "test" },
       }),
     ).rejects.toThrow("require mp3 or caf");
+    expect(vi.mocked(resolveBlueBubblesPrivateApiStatus)).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed prefixed targets before probing private API", async () => {
+    await expect(
+      sendBlueBubblesAttachment({
+        to: "chat_id:not-a-number",
+        buffer: new Uint8Array([1, 2, 3]),
+        filename: "photo.jpg",
+        contentType: "image/jpeg",
+        opts: { serverUrl: "http://localhost:1234", password: "test" },
+      }),
+    ).rejects.toThrow("Invalid chat_id: not-a-number");
+    expect(vi.mocked(resolveBlueBubblesPrivateApiStatus)).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -4,8 +4,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
 import { resolveBlueBubblesServerAccount } from "./account-resolve.js";
 import { postMultipartFormData } from "./multipart.js";
 import {
-  getCachedBlueBubblesPrivateApiStatus,
   isBlueBubblesPrivateApiStatusEnabled,
+  resolveBlueBubblesPrivateApiStatus,
 } from "./probe.js";
 import { resolveRequestUrl } from "./request-url.js";
 import { getBlueBubblesRuntime, warnBlueBubbles } from "./runtime.js";
@@ -156,8 +156,6 @@ export async function sendBlueBubblesAttachment(params: {
   filename = sanitizeFilename(filename, fallbackName);
   contentType = contentType?.trim() || undefined;
   const { baseUrl, password, accountId } = resolveAccount(opts);
-  const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(accountId);
-  const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
 
   // Validate voice memo format when requested (BlueBubbles converts MP3 -> CAF when isAudioMessage).
   const isAudioMessage = wantsVoice;
@@ -180,6 +178,13 @@ export async function sendBlueBubblesAttachment(params: {
   }
 
   const target = resolveBlueBubblesSendTarget(to);
+  const privateApiStatus = await resolveBlueBubblesPrivateApiStatus({
+    baseUrl,
+    password,
+    accountId,
+    timeoutMs: opts.timeoutMs,
+  });
+  const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
   const chatGuid = await resolveChatGuidForTarget({
     baseUrl,
     password,

--- a/extensions/bluebubbles/src/probe.test.ts
+++ b/extensions/bluebubbles/src/probe.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearServerInfoCache,
+  resolveBlueBubblesPrivateApiStatus,
+  type BlueBubblesPrivateApiStatusParams,
+} from "./probe.js";
+
+const mockFetch = vi.fn();
+
+const probeParams: BlueBubblesPrivateApiStatusParams = {
+  baseUrl: "http://localhost:1234",
+  password: "test-password", // pragma: allowlist secret
+  accountId: "default",
+  timeoutMs: 500,
+};
+
+describe("probe", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    clearServerInfoCache();
+  });
+
+  afterEach(() => {
+    clearServerInfoCache();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("coalesces concurrent private-api status probes", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as (value: Response) => void;
+        }),
+    );
+
+    const first = resolveBlueBubblesPrivateApiStatus(probeParams);
+    const second = resolveBlueBubblesPrivateApiStatus(probeParams);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resolveFetch?.({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toBeNull();
+  });
+
+  it("briefly caches unresolved private-api probes to avoid repeated retries", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-08T00:00:00.000Z"));
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    await expect(resolveBlueBubblesPrivateApiStatus(probeParams)).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await expect(resolveBlueBubblesPrivateApiStatus(probeParams)).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_001);
+
+    await expect(resolveBlueBubblesPrivateApiStatus(probeParams)).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the oldest unknown-status entries when the cache reaches capacity", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-08T00:00:00.000Z"));
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    for (let index = 0; index < 65; index += 1) {
+      await expect(
+        resolveBlueBubblesPrivateApiStatus({
+          ...probeParams,
+          accountId: `account-${index}`,
+        }),
+      ).resolves.toBeNull();
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(65);
+
+    await expect(
+      resolveBlueBubblesPrivateApiStatus({
+        ...probeParams,
+        accountId: "account-0",
+      }),
+    ).resolves.toBeNull();
+
+    expect(mockFetch).toHaveBeenCalledTimes(66);
+  });
+});

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -16,11 +16,22 @@ export type BlueBubblesServerInfo = {
   computer_id?: string;
 };
 
+export type BlueBubblesPrivateApiStatusParams = {
+  baseUrl?: string | null;
+  password?: string | null;
+  accountId?: string;
+  timeoutMs?: number;
+};
+
 /** Cache server info by account ID to avoid repeated API calls.
  * Size-capped to prevent unbounded growth (#4948). */
 const MAX_SERVER_INFO_CACHE_SIZE = 64;
+const MAX_UNKNOWN_PRIVATE_API_STATUS_CACHE_SIZE = 64;
 const serverInfoCache = new Map<string, { info: BlueBubblesServerInfo; expires: number }>();
 const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const UNKNOWN_PRIVATE_API_STATUS_TTL_MS = 30_000;
+const unknownPrivateApiStatusCache = new Map<string, number>();
+const privateApiStatusProbeInflight = new Map<string, Promise<boolean | null>>();
 
 function buildCacheKey(accountId?: string): string {
   return accountId?.trim() || "default";
@@ -97,6 +108,79 @@ export function getCachedBlueBubblesPrivateApiStatus(accountId?: string): boolea
   return info.private_api;
 }
 
+function hasRecentUnknownPrivateApiStatus(accountId?: string): boolean {
+  const cacheKey = buildCacheKey(accountId);
+  const expires = unknownPrivateApiStatusCache.get(cacheKey);
+  if (expires === undefined) {
+    return false;
+  }
+  if (expires <= Date.now()) {
+    unknownPrivateApiStatusCache.delete(cacheKey);
+    return false;
+  }
+  return true;
+}
+
+function setUnknownPrivateApiStatus(accountId?: string): void {
+  const cacheKey = buildCacheKey(accountId);
+  const now = Date.now();
+  for (const [key, expires] of unknownPrivateApiStatusCache) {
+    if (expires <= now) {
+      unknownPrivateApiStatusCache.delete(key);
+    }
+  }
+  if (unknownPrivateApiStatusCache.has(cacheKey)) {
+    unknownPrivateApiStatusCache.delete(cacheKey);
+  }
+  unknownPrivateApiStatusCache.set(cacheKey, now + UNKNOWN_PRIVATE_API_STATUS_TTL_MS);
+  while (unknownPrivateApiStatusCache.size > MAX_UNKNOWN_PRIVATE_API_STATUS_CACHE_SIZE) {
+    const oldest = unknownPrivateApiStatusCache.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    unknownPrivateApiStatusCache.delete(oldest);
+  }
+}
+
+function clearUnknownPrivateApiStatus(accountId?: string): void {
+  unknownPrivateApiStatusCache.delete(buildCacheKey(accountId));
+}
+
+export async function resolveBlueBubblesPrivateApiStatus(
+  params: BlueBubblesPrivateApiStatusParams,
+): Promise<boolean | null> {
+  const cached = getCachedBlueBubblesPrivateApiStatus(params.accountId);
+  if (cached !== null) {
+    clearUnknownPrivateApiStatus(params.accountId);
+    return cached;
+  }
+  if (hasRecentUnknownPrivateApiStatus(params.accountId)) {
+    return null;
+  }
+  const cacheKey = buildCacheKey(params.accountId);
+  const inflight = privateApiStatusProbeInflight.get(cacheKey);
+  if (inflight) {
+    return await inflight;
+  }
+  const probePromise = (async () => {
+    const info = await fetchBlueBubblesServerInfo(params);
+    const status = typeof info?.private_api === "boolean" ? info.private_api : null;
+    if (status === null) {
+      // Avoid paying the full probe timeout on every send while the capability remains unknown.
+      setUnknownPrivateApiStatus(params.accountId);
+    } else {
+      clearUnknownPrivateApiStatus(params.accountId);
+    }
+    return status;
+  })();
+  privateApiStatusProbeInflight.set(cacheKey, probePromise);
+  try {
+    return await probePromise;
+  } finally {
+    privateApiStatusProbeInflight.delete(cacheKey);
+  }
+}
+
 export function isBlueBubblesPrivateApiStatusEnabled(status: boolean | null): boolean {
   return status === true;
 }
@@ -132,6 +216,8 @@ export function isMacOS26OrHigher(accountId?: string): boolean {
 /** Clear the server info cache (for testing) */
 export function clearServerInfoCache(): void {
   serverInfoCache.clear();
+  unknownPrivateApiStatusCache.clear();
+  privateApiStatusProbeInflight.clear();
 }
 
 export async function probeBlueBubbles(params: {

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -448,6 +448,32 @@ describe("send", () => {
       expect(body.method).toBeUndefined();
     });
 
+    it("uses private-api for plain text when BlueBubbles Private API is enabled", async () => {
+      mockBlueBubblesPrivateApiStatusOnce(
+        privateApiStatusMock,
+        BLUE_BUBBLES_PRIVATE_API_STATUS.enabled,
+      );
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-plain-private" } });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Plain text over REST", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+      });
+
+      expect(result.messageId).toBe("msg-uuid-plain-private");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      const sendCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.chatGuid).toBe("iMessage;-;+15551234567");
+      expect(body.message).toBe("Plain text over REST");
+      expect(body.method).toBe("private-api");
+      expect(body.selectedMessageGuid).toBeUndefined();
+      expect(body.partIndex).toBeUndefined();
+      expect(body.effectId).toBeUndefined();
+    });
+
     it("strips markdown formatting from outbound messages", async () => {
       mockResolvedHandleTarget();
       mockSendResponse({ data: { guid: "msg-uuid-stripped" } });

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -3,8 +3,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
 import { stripMarkdown } from "openclaw/plugin-sdk/bluebubbles";
 import { resolveBlueBubblesAccount } from "./accounts.js";
 import {
-  getCachedBlueBubblesPrivateApiStatus,
   isBlueBubblesPrivateApiStatusEnabled,
+  resolveBlueBubblesPrivateApiStatus,
 } from "./probe.js";
 import { warnBlueBubbles } from "./runtime.js";
 import { normalizeSecretInputString } from "./secret-input.js";
@@ -77,6 +77,7 @@ function resolveEffectId(raw?: string): string | undefined {
 }
 
 type PrivateApiDecision = {
+  usePrivateApiMethod: boolean;
   canUsePrivateApi: boolean;
   throwEffectDisabledError: boolean;
   warningMessage?: string;
@@ -89,11 +90,11 @@ function resolvePrivateApiDecision(params: {
 }): PrivateApiDecision {
   const { privateApiStatus, wantsReplyThread, wantsEffect } = params;
   const needsPrivateApi = wantsReplyThread || wantsEffect;
-  const canUsePrivateApi =
-    needsPrivateApi && isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+  const usePrivateApiMethod = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+  const canUsePrivateApi = needsPrivateApi && usePrivateApiMethod;
   const throwEffectDisabledError = wantsEffect && privateApiStatus === false;
   if (!needsPrivateApi || privateApiStatus !== null) {
-    return { canUsePrivateApi, throwEffectDisabledError };
+    return { usePrivateApiMethod, canUsePrivateApi, throwEffectDisabledError };
   }
   const requested = [
     wantsReplyThread ? "reply threading" : null,
@@ -102,6 +103,7 @@ function resolvePrivateApiDecision(params: {
     .filter(Boolean)
     .join(" + ");
   return {
+    usePrivateApiMethod,
     canUsePrivateApi,
     throwEffectDisabledError,
     warningMessage: `Private API status unknown; sending without ${requested}. Run a status probe to restore private-api features.`,
@@ -389,7 +391,12 @@ export async function sendMessageBlueBubbles(
   if (!password) {
     throw new Error("BlueBubbles password is required");
   }
-  const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);
+  const privateApiStatus = await resolveBlueBubblesPrivateApiStatus({
+    baseUrl,
+    password,
+    accountId: account.accountId,
+    timeoutMs: opts.timeoutMs,
+  });
 
   const target = resolveBlueBubblesSendTarget(to);
   const chatGuid = await resolveChatGuidForTarget({
@@ -435,7 +442,7 @@ export async function sendMessageBlueBubbles(
     tempGuid: crypto.randomUUID(),
     message: strippedText,
   };
-  if (privateApiDecision.canUsePrivateApi) {
+  if (privateApiDecision.usePrivateApiMethod) {
     payload.method = "private-api";
   }
 

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -1,5 +1,6 @@
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, vi } from "vitest";
+import type { BlueBubblesPrivateApiStatusParams } from "./probe.js";
 
 export const BLUE_BUBBLES_PRIVATE_API_STATUS = {
   enabled: true,
@@ -47,14 +48,21 @@ export function createBlueBubblesAccountsMockModule() {
 
 type BlueBubblesProbeMockModule = {
   getCachedBlueBubblesPrivateApiStatus: Mock<() => boolean | null>;
+  resolveBlueBubblesPrivateApiStatus: Mock<
+    (params: BlueBubblesPrivateApiStatusParams) => Promise<boolean | null>
+  >;
   isBlueBubblesPrivateApiStatusEnabled: Mock<(status: boolean | null) => boolean>;
 };
 
 export function createBlueBubblesProbeMockModule(): BlueBubblesProbeMockModule {
+  const getCachedBlueBubblesPrivateApiStatus = vi
+    .fn()
+    .mockReturnValue(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown);
   return {
-    getCachedBlueBubblesPrivateApiStatus: vi
-      .fn()
-      .mockReturnValue(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown),
+    getCachedBlueBubblesPrivateApiStatus,
+    resolveBlueBubblesPrivateApiStatus: vi.fn(async (params: BlueBubblesPrivateApiStatusParams) =>
+      getCachedBlueBubblesPrivateApiStatus(params.accountId),
+    ),
     isBlueBubblesPrivateApiStatusEnabled: vi.fn((status: boolean | null) => status === true),
   };
 }


### PR DESCRIPTION
Closes #29389

## Summary
- force BlueBubbles text sends to use the Private API REST path whenever the server reports the Private API is available
- apply the same private-api resolution path to attachment sends and cache unresolved probe results to avoid repeated slow probes
- add regression coverage for normal text sends, attachment validation ordering, and private-api probe caching

## Validation
- pnpm check
- corepack pnpm exec vitest run extensions/bluebubbles/src/attachments.test.ts extensions/bluebubbles/src/probe.test.ts extensions/bluebubbles/src/send.test.ts
- corepack pnpm exec oxlint extensions/bluebubbles/src/attachments.ts extensions/bluebubbles/src/probe.ts extensions/bluebubbles/src/send.ts extensions/bluebubbles/src/test-harness.ts

Supersedes #39011, which was auto-closed after unrelated CI-only fixes drifted into the branch.
