### PR TITLE
fix: Strip provider prefix from model ID and normalize proxy base URLs in Gemini PDF tool

### DIFF
--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -5,7 +5,7 @@ describe("geminiAnalyzePdf", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    // We cast to any because we only mock what we need
+    // We cast to unknown as Response because we only mock what we need
     fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
       json: () => Promise.resolve({ candidates: [{ content: { parts: [{ text: "success" }] } }] }),
       text: () => Promise.resolve(""),

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { geminiAnalyzePdf } from "./pdf-native-providers";
+
+describe("geminiAnalyzePdf", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // We cast to any because we only mock what we need
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: () => Promise.resolve({ candidates: [{ content: { parts: [{ text: "success" }] } }] }),
+      text: () => Promise.resolve(""),
+      status: 200,
+      ok: true,
+    } as unknown as Response);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips 'google/' provider prefix from modelId", async () => {
+    await geminiAnalyzePdf({
+      apiKey: "test-key",
+      modelId: "google/gemini-2.0-flash",
+      prompt: "test",
+      pdfs: [],
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain("/models/gemini-2.0-flash:generateContent");
+    expect(url).not.toContain("google/gemini-2.0-flash");
+  });
+
+  it("preserves nested paths in modelId without stripping too much", async () => {
+    await geminiAnalyzePdf({
+      apiKey: "test-key",
+      modelId: "google/tunedModels/my-model",
+      prompt: "test",
+      pdfs: [],
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain("/models/tunedModels%2Fmy-model:generateContent");
+  });
+
+  it("leaves modelId unchanged if no 'google/' prefix is present", async () => {
+    await geminiAnalyzePdf({
+      apiKey: "test-key",
+      modelId: "gemini-1.5-pro",
+      prompt: "test",
+      pdfs: [],
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain("/models/gemini-1.5-pro:generateContent");
+  });
+
+  it("normalizes baseUrl by stripping trailing slashes", async () => {
+    await geminiAnalyzePdf({
+      apiKey: "test-key",
+      modelId: "gemini-1.5-pro",
+      prompt: "test",
+      pdfs: [],
+      baseUrl: "https://my-proxy.com/",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).to.equal(
+      "https://my-proxy.com/v1beta/models/gemini-1.5-pro:generateContent?key=test-key",
+    );
+  });
+
+  it("normalizes baseUrl by stripping /v1 or /v1beta path segments to prevent double-versioning", async () => {
+    // Simulating Cloudflare AI Gateway or Litellm proxy URL
+    await geminiAnalyzePdf({
+      apiKey: "test-key",
+      modelId: "gemini-1.5-pro",
+      prompt: "test",
+      pdfs: [],
+      baseUrl: "https://gateway.ai.cloudflare.com/v1/my-acc/my-gate/google-ai-studio/v1beta",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const url = fetchSpy.mock.calls[0][0] as string;
+
+    // We expect the trailing /v1beta on the proxy URL to be stripped so that
+    // the hardcoded /v1beta/models/... path appended by the function doesn't duplicate it.
+    expect(url).to.equal(
+      "https://gateway.ai.cloudflare.com/v1/my-acc/my-gate/google-ai-studio/v1beta/models/gemini-1.5-pro:generateContent?key=test-key",
+    );
+  });
+
+  it("normalizes baseUrl by stripping /v1 path segment", async () => {
+    await geminiAnalyzePdf({
+      apiKey: "test-key",
+      modelId: "gemini-1.5-pro",
+      prompt: "test",
+      pdfs: [],
+      baseUrl: "https://my-proxy.com/v1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).to.equal(
+      "https://my-proxy.com/v1beta/models/gemini-1.5-pro:generateContent?key=test-key",
+    );
+  });
+});

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { geminiAnalyzePdf } from "./pdf-native-providers";
+import { geminiAnalyzePdf } from "./pdf-native-providers.js";
 
 describe("geminiAnalyzePdf", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -137,12 +137,10 @@ export async function geminiAnalyzePdf(params: {
   }
   parts.push({ text: params.prompt });
 
-  // Normalize baseUrl: strip trailing slashes and any API version path suffix.
-  // Some callers may pass a baseUrl that already includes /v1beta or /v1, which would
-  // cause duplication when we construct the full URL below.
-  let baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(/\/+$/, "");
-  // Strip API version paths if present (e.g., /v1beta, /v1)
-  baseUrl = baseUrl.replace(/\/v\d+(?:beta)?$/, "");
+  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
+    /\/+$/,
+    "",
+  );
 
   // Strip provider prefix if present (e.g., "google/gemini-2.0-flash" -> "gemini-2.0-flash").
   // We only strip "google/" specifically to avoid mangling nested model IDs like "tunedModels/my-model"

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -137,11 +137,20 @@ export async function geminiAnalyzePdf(params: {
   }
   parts.push({ text: params.prompt });
 
-  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
-    /\/+$/,
-    "",
-  );
-  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  // Normalize baseUrl: strip trailing slashes and any API version path suffix.
+  // Some callers may pass a baseUrl that already includes /v1beta or /v1, which would
+  // cause duplication when we construct the full URL below.
+  let baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(/\/+$/, "");
+  // Strip API version paths if present (e.g., /v1beta, /v1)
+  baseUrl = baseUrl.replace(/\/v\d+(?:beta)?$/, "");
+
+  // Strip provider prefix if present (e.g., "google/gemini-2.0-flash" -> "gemini-2.0-flash").
+  // We only strip "google/" specifically to avoid mangling nested model IDs like "tunedModels/my-model"
+  // which might be passed after the provider has already been stripped by the caller.
+  const actualModelId = params.modelId.startsWith("google/")
+    ? params.modelId.slice("google/".length)
+    : params.modelId;
+  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(actualModelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -137,10 +137,12 @@ export async function geminiAnalyzePdf(params: {
   }
   parts.push({ text: params.prompt });
 
-  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
-    /\/+$/,
-    "",
-  );
+  // Normalize baseUrl: strip trailing slashes and any API version path suffix.
+  // Some callers may pass a baseUrl that already includes /v1beta or /v1, which would
+  // cause duplication when we construct the full URL below.
+  let baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(/\/+$/, "");
+  // Strip API version paths if present (e.g., /v1beta, /v1)
+  baseUrl = baseUrl.replace(/\/v\d+(?:beta)?$/, "");
 
   // Strip provider prefix if present (e.g., "google/gemini-2.0-flash" -> "gemini-2.0-flash").
   // We only strip "google/" specifically to avoid mangling nested model IDs like "tunedModels/my-model"


### PR DESCRIPTION
## Summary
Fixes #39279

The Gemini PDF tool was failing with 404 when using provider-prefixed model IDs like `google/gemini-2.0-flash` and when custom baseUrls included version paths like `/v1beta`.

## Changes
- Strip the provider prefix from model IDs before constructing the Gemini API URL
- Use `slice()` instead of `split('/')[1]` to preserve full model paths (e.g., `google/foo/bar` → `foo/bar`)
- Normalize custom `baseUrl` configurations by stripping trailing slashes and any API version suffix (e.g. `/v1`, `/v1beta`) to prevent double-versioning like `/v1beta/v1beta/models/...` when constructing the final URL.

## Context on `baseUrl` normalization
This PR expands the scope slightly to normalize the `baseUrl`. Without this, users running through proxy services (like Cloudflare AI Gateway, Litellm, OpenRouter, etc.) that append their own `/v1` or `/v1beta` paths will encounter `404`s because the code explicitly appends `/v1beta` on top of the base URL. This fix ensures that any trailing version string is stripped prior to appending the correct `/v1beta/models/...` path.

## Testing
Manually verified the fix handles:
- `google/gemini-2.0-flash` → `gemini-2.0-flash`
- `google/foo/bar` → `foo/bar` (preserves multi-segment paths)
- `gemini-2.0-flash` → `gemini-2.0-flash` (no prefix, unchanged)
- Custom base URLs: `https://my-proxy.com/v1beta` → `https://my-proxy.com/v1beta/models/...` (preventing double version paths)

## AI-Assisted 🤖
- [x] Marked as AI-assisted
- [x] Fully tested with unit tests in `src/agents/tools/pdf-native-providers.test.ts`
- [x] Bot review conversations addressed