### PR TITLE
fix: preserve explicit speed values in voice-call OpenAI TTS

### DIFF
--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -82,7 +82,7 @@ export class OpenAITTSProvider {
     this.model = config.model || "gpt-4o-mini-tts";
     // Default to coral - good balance of quality and natural tone
     this.voice = (config.voice as OpenAITTSVoice) || "coral";
-    this.speed = config.speed || 1.0;
+    this.speed = config.speed ?? 1.0;
     this.instructions = config.instructions;
 
     if (!this.apiKey) {


### PR DESCRIPTION
## Summary

Fixes a fallback bug in the voice-call OpenAI TTS provider where `config.speed` used `||` and could overwrite valid falsy numeric values.

## Changes

- Replaced `config.speed || 1.0` with `config.speed ?? 1.0` in `extensions/voice-call/src/providers/tts-openai.ts`
- This keeps defaulting behavior for `undefined`/`null` while preserving explicitly provided values

## Testing

- Verified the code path and root cause from source
- Did not run full test suite for this one-line isolated fix

Fixes openclaw/openclaw#39285
