### PR TITLE
fix(exec): warn when pty:true is silently disabled in sandbox

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -464,6 +464,9 @@ export function createExecTool(
         : (explicitTimeoutSec ?? defaultTimeoutSec);
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
+      if (params.pty === true && sandbox) {
+        warnings.push("pty is not supported in sandbox mode and will be ignored");
+      }
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.


### PR DESCRIPTION
## Summary

- Add a warning message when `pty: true` is set but silently disabled due to sandbox mode
- Previously, PTY was silently suppressed in sandbox mode with no indication to the user, making it difficult to debug why interactive CLI tools fail

Fixes #38601

## Test plan

- [ ] Verify warning appears in exec output when `pty: true` is set in sandbox mode
- [ ] Verify no warning when `pty: true` is set without sandbox
- [ ] Verify no warning when `pty` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)