### PR TITLE
fix(gateway): suppress NO_REPLY lead fragment in chat final message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/chat: suppress buffered `NO_REPLY` lead fragments in final Control UI chat payloads only after a streamed silent-token prefix proves provenance, so intentional uppercase `NO` replies stay visible. Carries forward #39350. Thanks @MumuTW.
 - Control UI/Agents: redact tool-call args, partial/final results, derived exec output, and configured custom secret patterns before streaming tool events to the Control UI, so tool output cannot expose provider or channel credentials. Fixes #72283. (#72319) Thanks @volcano303 and @BunsDev.
 - Models/fallbacks: treat user-selected session models as exact choices, so `/model ollama/...` and model-picker switches fail visibly when the selected provider is unreachable instead of answering from an unrelated configured fallback. Fixes #73023. Thanks @pavelyortho-cyber.
 - CLI/model probes: fail local `infer model run` probes when the provider returns no text output, so unreachable local providers and empty completions no longer look like successful smoke tests. Refs #73023. Thanks @pavelyortho-cyber.

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -67,6 +67,7 @@ export type ChatRunState = {
   registry: ChatRunRegistry;
   rawBuffers: Map<string, string>;
   buffers: Map<string, string>;
+  suppressedLeadFragmentBuffers: Map<string, string>;
   deltaSentAt: Map<string, number>;
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
@@ -78,6 +79,7 @@ export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const rawBuffers = new Map<string, string>();
   const buffers = new Map<string, string>();
+  const suppressedLeadFragmentBuffers = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
@@ -86,6 +88,7 @@ export function createChatRunState(): ChatRunState {
     registry.clear();
     rawBuffers.clear();
     buffers.clear();
+    suppressedLeadFragmentBuffers.clear();
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     abortedRuns.clear();
@@ -95,6 +98,7 @@ export function createChatRunState(): ChatRunState {
     registry,
     rawBuffers,
     buffers,
+    suppressedLeadFragmentBuffers,
     deltaSentAt,
     deltaLastBroadcastLen,
     abortedRuns,

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -67,7 +67,7 @@ export type ChatRunState = {
   registry: ChatRunRegistry;
   rawBuffers: Map<string, string>;
   buffers: Map<string, string>;
-  suppressedLeadFragmentBuffers: Map<string, string>;
+  suppressedLeadFragmentRuns: Set<string>;
   deltaSentAt: Map<string, number>;
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
@@ -79,7 +79,7 @@ export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const rawBuffers = new Map<string, string>();
   const buffers = new Map<string, string>();
-  const suppressedLeadFragmentBuffers = new Map<string, string>();
+  const suppressedLeadFragmentRuns = new Set<string>();
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
@@ -88,7 +88,7 @@ export function createChatRunState(): ChatRunState {
     registry.clear();
     rawBuffers.clear();
     buffers.clear();
-    suppressedLeadFragmentBuffers.clear();
+    suppressedLeadFragmentRuns.clear();
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     abortedRuns.clear();
@@ -98,7 +98,7 @@ export function createChatRunState(): ChatRunState {
     registry,
     rawBuffers,
     buffers,
-    suppressedLeadFragmentBuffers,
+    suppressedLeadFragmentRuns,
     deltaSentAt,
     deltaLastBroadcastLen,
     abortedRuns,

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -340,6 +340,58 @@ describe("agent event handler", () => {
     },
   );
 
+  it("suppresses partial NO_REPLY lead fragment in final when lifecycle ends at underscore fragment", () => {
+    const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
+      now: 2_150,
+    });
+    chatRunState.registry.add("run-partial", {
+      sessionKey: "session-partial",
+      clientRunId: "client-partial",
+    });
+
+    // Only a partial token arrives before lifecycle end, but the underscore
+    // distinguishes it from an intentional uppercase "NO" reply.
+    handler({
+      runId: "run-partial",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "NO_" },
+    });
+    emitLifecycleEnd(handler, "run-partial");
+
+    const payload = expectSingleFinalChatPayload(broadcast) as { message?: unknown };
+    expect(payload.message).toBeUndefined();
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
+  it("keeps final uppercase 'NO' replies when no control-token provenance arrives", () => {
+    const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
+      now: 2_175,
+    });
+    chatRunState.registry.add("run-uppercase-no", {
+      sessionKey: "session-uppercase-no",
+      clientRunId: "client-uppercase-no",
+    });
+
+    handler({
+      runId: "run-uppercase-no",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "NO" },
+    });
+    emitLifecycleEnd(handler, "run-uppercase-no");
+
+    const payload = expectSingleFinalChatPayload(broadcast) as {
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(payload.message?.content?.[0]?.text).toBe("NO");
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
   it("keeps final short replies like 'No' even when lead-fragment deltas are suppressed", () => {
     const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
       now: 2_200,

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -340,7 +340,7 @@ describe("agent event handler", () => {
     },
   );
 
-  it("suppresses partial NO_REPLY lead fragment in final when lifecycle ends at underscore fragment", () => {
+  it("suppresses buffered NO_REPLY lead fragment in final when lifecycle ends at underscore fragment", () => {
     const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
       now: 2_150,
     });
@@ -366,7 +366,7 @@ describe("agent event handler", () => {
     nowSpy?.mockRestore();
   });
 
-  it("keeps final uppercase 'NO' replies when no control-token provenance arrives", () => {
+  it("keeps final uppercase 'NO' replies when no NO_REPLY lead-fragment provenance arrives", () => {
     const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
       now: 2_175,
     });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -153,6 +153,7 @@ export type ChatRunState = {
   registry: ChatRunRegistry;
   rawBuffers: Map<string, string>;
   buffers: Map<string, string>;
+  suppressedLeadFragmentBuffers: Map<string, string>;
   deltaSentAt: Map<string, number>;
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
@@ -164,6 +165,7 @@ export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const rawBuffers = new Map<string, string>();
   const buffers = new Map<string, string>();
+  const suppressedLeadFragmentBuffers = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
@@ -172,6 +174,7 @@ export function createChatRunState(): ChatRunState {
     registry.clear();
     rawBuffers.clear();
     buffers.clear();
+    suppressedLeadFragmentBuffers.clear();
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     abortedRuns.clear();
@@ -181,6 +184,7 @@ export function createChatRunState(): ChatRunState {
     registry,
     rawBuffers,
     buffers,
+    suppressedLeadFragmentBuffers,
     deltaSentAt,
     deltaLastBroadcastLen,
     abortedRuns,
@@ -446,6 +450,7 @@ export function createAgentEventHandler({
   const clearBufferedChatState = (clientRunId: string) => {
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
+    chatRunState.suppressedLeadFragmentBuffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
   };
@@ -658,6 +663,11 @@ export function createAgentEventHandler({
     const projected = projectLiveAssistantBufferedText(mergedRawText);
     const mergedText = projected.text;
     chatRunState.buffers.set(clientRunId, mergedText);
+    if (projected.pendingLeadFragment && mergedText.includes("_")) {
+      chatRunState.suppressedLeadFragmentBuffers.set(clientRunId, mergedText.trim());
+    } else if (!projected.suppress) {
+      chatRunState.suppressedLeadFragmentBuffers.delete(clientRunId);
+    }
     if (projected.suppress) {
       return;
     }
@@ -702,9 +712,13 @@ export function createAgentEventHandler({
     const projected = projectLiveAssistantBufferedText(normalizedHeartbeatText.text.trim(), {
       suppressLeadFragments: options?.suppressLeadFragments,
     });
+    const suppressedLeadFragmentText = chatRunState.suppressedLeadFragmentBuffers.get(clientRunId);
+    const shouldSuppressLeadFragment =
+      Boolean(suppressedLeadFragmentText) && projected.text.trim() === suppressedLeadFragmentText;
     return {
       text: projected.text.trim(),
-      shouldSuppressSilent: normalizedHeartbeatText.suppress || projected.suppress,
+      shouldSuppressSilent:
+        normalizedHeartbeatText.suppress || projected.suppress || shouldSuppressLeadFragment,
     };
   };
 
@@ -769,6 +783,7 @@ export function createAgentEventHandler({
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
+    chatRunState.suppressedLeadFragmentBuffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {
       const payload = {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -153,7 +153,7 @@ export type ChatRunState = {
   registry: ChatRunRegistry;
   rawBuffers: Map<string, string>;
   buffers: Map<string, string>;
-  suppressedLeadFragmentBuffers: Map<string, string>;
+  suppressedLeadFragmentRuns: Set<string>;
   deltaSentAt: Map<string, number>;
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
@@ -165,7 +165,7 @@ export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const rawBuffers = new Map<string, string>();
   const buffers = new Map<string, string>();
-  const suppressedLeadFragmentBuffers = new Map<string, string>();
+  const suppressedLeadFragmentRuns = new Set<string>();
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
@@ -174,7 +174,7 @@ export function createChatRunState(): ChatRunState {
     registry.clear();
     rawBuffers.clear();
     buffers.clear();
-    suppressedLeadFragmentBuffers.clear();
+    suppressedLeadFragmentRuns.clear();
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     abortedRuns.clear();
@@ -184,7 +184,7 @@ export function createChatRunState(): ChatRunState {
     registry,
     rawBuffers,
     buffers,
-    suppressedLeadFragmentBuffers,
+    suppressedLeadFragmentRuns,
     deltaSentAt,
     deltaLastBroadcastLen,
     abortedRuns,
@@ -450,7 +450,7 @@ export function createAgentEventHandler({
   const clearBufferedChatState = (clientRunId: string) => {
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
-    chatRunState.suppressedLeadFragmentBuffers.delete(clientRunId);
+    chatRunState.suppressedLeadFragmentRuns.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
   };
@@ -664,9 +664,9 @@ export function createAgentEventHandler({
     const mergedText = projected.text;
     chatRunState.buffers.set(clientRunId, mergedText);
     if (projected.pendingLeadFragment && mergedText.includes("_")) {
-      chatRunState.suppressedLeadFragmentBuffers.set(clientRunId, mergedText.trim());
+      chatRunState.suppressedLeadFragmentRuns.add(clientRunId);
     } else if (!projected.suppress) {
-      chatRunState.suppressedLeadFragmentBuffers.delete(clientRunId);
+      chatRunState.suppressedLeadFragmentRuns.delete(clientRunId);
     }
     if (projected.suppress) {
       return;
@@ -712,9 +712,7 @@ export function createAgentEventHandler({
     const projected = projectLiveAssistantBufferedText(normalizedHeartbeatText.text.trim(), {
       suppressLeadFragments: options?.suppressLeadFragments,
     });
-    const suppressedLeadFragmentText = chatRunState.suppressedLeadFragmentBuffers.get(clientRunId);
-    const shouldSuppressLeadFragment =
-      Boolean(suppressedLeadFragmentText) && projected.text.trim() === suppressedLeadFragmentText;
+    const shouldSuppressLeadFragment = chatRunState.suppressedLeadFragmentRuns.has(clientRunId);
     return {
       text: projected.text.trim(),
       shouldSuppressSilent:
@@ -783,7 +781,7 @@ export function createAgentEventHandler({
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
-    chatRunState.suppressedLeadFragmentBuffers.delete(clientRunId);
+    chatRunState.suppressedLeadFragmentRuns.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {
       const payload = {


### PR DESCRIPTION
## Summary

- Fix `NO_REPLY` partial fragment ("NO") leaking into webchat UI when the final chat event is emitted
- The delta throttle correctly suppresses lead fragments via `isSilentReplyLeadFragment`, but the final message emission only checked `isSilentReplyText` (exact token match) — a partial buffer like "NO" passed through as a visible final message
- Add `isSilentReplyPrefixText` check to the final message guard, which correctly distinguishes uppercase-only protocol fragments ("NO", "NO_") from legitimate short replies ("No", "No problem")

Closes #39335

## Test plan

- [x] Added test: partial "NO" in buffer at lifecycle end → final message is `undefined`
- [x] Existing test: mixed-case "No" reply is preserved in final
- [x] Existing test: full "NO_REPLY" sequence → final suppressed
- [x] `pnpm vitest run src/gateway/server-chat.agent-events.test.ts` — 23/23 pass
- [x] `pnpm vitest run src/auto-reply/tokens.test.ts` — 19/19 pass