### PR TITLE
fix(msteams): pass teamId into inbound route resolution

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -96,4 +96,110 @@ describe("msteams monitor handler authz", () => {
     });
     expect(conversationStore.upsert).not.toHaveBeenCalled();
   });
+
+  it("passes teamId into route resolution for channel messages", async () => {
+    const routeError = new Error("route-called");
+    const resolveAgentRoute = vi.fn(() => {
+      throw routeError;
+    });
+
+    setMSTeamsRuntime({
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        debounce: {
+          resolveInboundDebounceMs: () => 0,
+          createInboundDebouncer: <T>(params: {
+            onFlush: (entries: T[]) => Promise<void>;
+          }): { enqueue: (entry: T) => Promise<void> } => ({
+            enqueue: async (entry: T) => {
+              await params.onFlush([entry]);
+            },
+          }),
+        },
+        pairing: {
+          readAllowFromStore: vi.fn(async () => []),
+          upsertPairingRequest: vi.fn(async () => null),
+        },
+        text: {
+          hasControlCommand: () => false,
+        },
+        routing: {
+          resolveAgentRoute,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const deps: MSTeamsMessageHandlerDeps = {
+      cfg: {
+        channels: {
+          msteams: {
+            groupPolicy: "open",
+          },
+        },
+      } as OpenClawConfig,
+      runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+      appId: "test-app",
+      adapter: {} as MSTeamsMessageHandlerDeps["adapter"],
+      tokenProvider: {
+        getAccessToken: vi.fn(async () => "token"),
+      },
+      textLimit: 4000,
+      mediaMaxBytes: 1024 * 1024,
+      conversationStore: {
+        upsert: vi.fn(async () => undefined),
+      } as unknown as MSTeamsMessageHandlerDeps["conversationStore"],
+      pollStore: {
+        recordVote: vi.fn(async () => null),
+      } as unknown as MSTeamsMessageHandlerDeps["pollStore"],
+      log: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      } as unknown as MSTeamsMessageHandlerDeps["log"],
+    };
+
+    const handler = createMSTeamsMessageHandler(deps);
+
+    await expect(
+      handler({
+        activity: {
+          id: "msg-channel-1",
+          type: "message",
+          text: "hello from team channel",
+          from: {
+            id: "sender-id",
+            aadObjectId: "sender-aad",
+            name: "Sender",
+          },
+          recipient: {
+            id: "bot-id",
+            name: "Bot",
+          },
+          conversation: {
+            id: "19:channel@thread.tacv2",
+            conversationType: "channel",
+          },
+          channelData: {
+            team: {
+              id: "team-123",
+              name: "Android Team",
+            },
+          },
+          attachments: [],
+        },
+        sendActivity: vi.fn(async () => undefined),
+      } as unknown as Parameters<typeof handler>[0]),
+    ).rejects.toThrow(routeError);
+
+    expect(resolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "msteams",
+        teamId: "team-123",
+        peer: {
+          kind: "channel",
+          id: "19:channel@thread.tacv2",
+        },
+      }),
+    );
+  });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -386,6 +386,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     const route = core.channel.routing.resolveAgentRoute({
       cfg,
       channel: "msteams",
+      teamId,
       peer: {
         kind: isDirectMessage ? "direct" : isChannel ? "channel" : "group",
         id: isDirectMessage ? senderId : conversationId,


### PR DESCRIPTION
## Summary
- pass `teamId` into MSTeams inbound `resolveAgentRoute()` calls
- add a regression test covering channel messages with a team-scoped route

## Root cause
The MSTeams inbound handler already reads `activity.channelData?.team?.id`, and the shared routing layer already supports `teamId`-scoped bindings.

However, the handler did not forward `teamId` when calling `resolveAgentRoute()`. That caused channel messages to fall back to the default agent instead of matching configured team/channel bindings.

This looks like an implementation bug rather than an intentional product restriction because:
- the routing API explicitly supports `teamId`
- the route matcher already has a `binding.team` path
- the MSTeams handler already extracts and uses `teamId` elsewhere
- forwarding `teamId` restores the expected routing behavior without changing the routing model

## Validation
- added a regression test asserting that channel messages pass `teamId` into route resolution
- ran:
  - `pnpm test:extensions -- --run extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`
- result:
  - `261 passed`, including `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`

## Impact
This fixes MSTeams channel routing for deployments that rely on team-scoped bindings, so channel messages can resolve to the intended isolated agent instead of dropping back to the default agent.