### PR TITLE
fix(agent): notify user when context compaction produces empty response

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -132,6 +132,59 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(result.meta.error?.kind).toBe("context_overflow");
   });
 
+  it("returns compaction notice when post-compaction retry produces empty payloads", async () => {
+    const overflowError = makeOverflowError();
+    // First attempt: overflow
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ promptError: overflowError }),
+    );
+    // Compaction succeeds
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 150000,
+      }),
+    );
+    // Retry after compaction: no assistant text (empty payloads)
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ promptError: null, assistantTexts: [] }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(result.payloads).toHaveLength(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("compacted");
+  });
+
+  it("skips compaction notice when messaging tool already delivered a response", async () => {
+    const overflowError = makeOverflowError();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ promptError: overflowError }),
+    );
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 150000,
+      }),
+    );
+    // Retry: no assistant text but messaging tool sent a response
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        assistantTexts: [],
+        didSendViaMessagingTool: true,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    // Should NOT return compaction notice since messaging tool already handled it
+    expect(result.payloads).toBeUndefined();
+  });
+
   it("returns retry_limit when repeated retries never converge", async () => {
     mockedRunEmbeddedAttempt.mockClear();
     mockedCompactDirect.mockClear();

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -240,6 +240,32 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(result.payloads).toBeUndefined();
   });
 
+  it("skips compaction notice when assistant intentionally replied NO_REPLY", async () => {
+    const overflowError = makeOverflowError();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ promptError: overflowError }),
+    );
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 150000,
+      }),
+    );
+    // Retry: assistant intentionally said NO_REPLY (heartbeat/selective-reply)
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        assistantTexts: ["NO_REPLY"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    // Should NOT return compaction notice — assistant intentionally stayed silent
+    expect(result.payloads).toBeUndefined();
+  });
+
   it("returns retry_limit when repeated retries never converge", async () => {
     mockedRunEmbeddedAttempt.mockClear();
     mockedCompactDirect.mockClear();

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -185,6 +185,61 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(result.payloads).toBeUndefined();
   });
 
+  it("skips compaction notice when run was aborted", async () => {
+    const overflowError = makeOverflowError();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ promptError: overflowError }),
+    );
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 150000,
+      }),
+    );
+    // Retry: aborted with no assistant text
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        assistantTexts: [],
+        aborted: true,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    // Should NOT return compaction notice since run was cancelled
+    expect(result.payloads).toBeUndefined();
+  });
+
+  it("skips compaction notice when messaging tool delivered media only", async () => {
+    const overflowError = makeOverflowError();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ promptError: overflowError }),
+    );
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 150000,
+      }),
+    );
+    // Retry: no assistant text, didSendViaMessagingTool=false, but media was sent
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        assistantTexts: [],
+        didSendViaMessagingTool: false,
+        messagingToolSentMediaUrls: ["https://example.com/image.png"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    // Should NOT return compaction notice since media was already delivered
+    expect(result.payloads).toBeUndefined();
+  });
+
   it("returns retry_limit when repeated retries never converge", async () => {
     mockedRunEmbeddedAttempt.mockClear();
     mockedCompactDirect.mockClear();

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1441,8 +1441,16 @@ export async function runEmbeddedPiAgent(
 
           // Context compaction can leave the retry without any assistant payloads.
           // Emit an explicit notice so the user knows compaction occurred instead
-          // of seeing complete silence.
-          if (autoCompactionCount > 0 && payloads.length === 0) {
+          // of seeing complete silence. Skip when messaging tools already delivered
+          // a response, when a client tool call is pending, or during timeouts
+          // (handled by the timeout guard above).
+          if (
+            autoCompactionCount > 0 &&
+            payloads.length === 0 &&
+            !timedOut &&
+            !attempt.didSendViaMessagingTool &&
+            !attempt.clientToolCall
+          ) {
             return {
               payloads: [
                 {
@@ -1450,6 +1458,7 @@ export async function runEmbeddedPiAgent(
                     "Context was compacted to free up space. " +
                     "Some earlier conversation details may have been summarized. " +
                     "Please resend your last message or rephrase your request.",
+                  isError: true,
                 },
               ],
               meta: {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1439,6 +1439,33 @@ export async function runEmbeddedPiAgent(
             };
           }
 
+          // Context compaction can leave the retry without any assistant payloads.
+          // Emit an explicit notice so the user knows compaction occurred instead
+          // of seeing complete silence.
+          if (autoCompactionCount > 0 && payloads.length === 0) {
+            return {
+              payloads: [
+                {
+                  text:
+                    "Context was compacted to free up space. " +
+                    "Some earlier conversation details may have been summarized. " +
+                    "Please resend your last message or rephrase your request.",
+                },
+              ],
+              meta: {
+                durationMs: Date.now() - started,
+                agentMeta,
+                aborted,
+                systemPromptReport: attempt.systemPromptReport,
+              },
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              messagingToolSentTexts: attempt.messagingToolSentTexts,
+              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+              messagingToolSentTargets: attempt.messagingToolSentTargets,
+              successfulCronAdds: attempt.successfulCronAdds,
+            };
+          }
+
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1441,19 +1441,28 @@ export async function runEmbeddedPiAgent(
 
           // Context compaction can leave the retry without any assistant payloads.
           // Emit an explicit notice so the user knows compaction occurred instead
-          // of seeing complete silence. Skip when the run was aborted, timed out
-          // (handled above), messaging tools already delivered text or media, or
-          // a client tool call is pending.
+          // of seeing complete silence. Skip when:
+          // - the run was aborted or timed out (handled above)
+          // - messaging tools already delivered text or media
+          // - a client tool call is pending
+          // - the assistant intentionally produced a silent reply (NO_REPLY)
+          //   which buildEmbeddedRunPayloads filters out on purpose
           const messagingToolDeliveredContent =
             attempt.didSendViaMessagingTool ||
             (attempt.messagingToolSentMediaUrls?.length ?? 0) > 0;
+          // Inline NO_REPLY check to avoid importing from auto-reply/tokens.ts
+          // (which pulls in escapeRegExp from utils.js, breaking mocked test suites).
+          const assistantIntentionallySilent = attempt.assistantTexts.some(
+            (t) => t.trim().toUpperCase() === "NO_REPLY",
+          );
           if (
             autoCompactionCount > 0 &&
             payloads.length === 0 &&
             !aborted &&
             !timedOut &&
             !messagingToolDeliveredContent &&
-            !attempt.clientToolCall
+            !attempt.clientToolCall &&
+            !assistantIntentionallySilent
           ) {
             return {
               payloads: [

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1441,14 +1441,18 @@ export async function runEmbeddedPiAgent(
 
           // Context compaction can leave the retry without any assistant payloads.
           // Emit an explicit notice so the user knows compaction occurred instead
-          // of seeing complete silence. Skip when messaging tools already delivered
-          // a response, when a client tool call is pending, or during timeouts
-          // (handled by the timeout guard above).
+          // of seeing complete silence. Skip when the run was aborted, timed out
+          // (handled above), messaging tools already delivered text or media, or
+          // a client tool call is pending.
+          const messagingToolDeliveredContent =
+            attempt.didSendViaMessagingTool ||
+            (attempt.messagingToolSentMediaUrls?.length ?? 0) > 0;
           if (
             autoCompactionCount > 0 &&
             payloads.length === 0 &&
+            !aborted &&
             !timedOut &&
-            !attempt.didSendViaMessagingTool &&
+            !messagingToolDeliveredContent &&
             !attempt.clientToolCall
           ) {
             return {


### PR DESCRIPTION
## Summary

I kept running into this — after context compaction, the bot just goes completely silent. No error, no notification, nothing. Had to manually figure out that compaction happened and resend my message every time.

The issue is in the run loop: when auto-compaction succeeds but the retry attempt produces no assistant payloads (model has no text to return after the compacted context), `payloads` is empty and the return becomes `payloads: undefined`. Callers treat this as "nothing to send" and the user gets silence.

There's already a similar guard for timeouts (line 1418) that returns an explicit error payload instead of `undefined`. This PR adds the same pattern for post-compaction empty responses.

### Changes

- **`src/agents/pi-embedded-runner/run.ts`**: After the timeout empty-payload check, add a compaction-aware check: when `autoCompactionCount > 0` and `payloads.length === 0`, return an explicit payload telling the user that context was compacted and asking them to resend their message.

## Test plan

- [x] All 246 pi-embedded-runner tests pass
- [x] Overflow compaction tests pass (5/5)
- [x] TypeScript clean
- [ ] Manual test: trigger compaction via long conversation, verify user receives notification instead of silence