### PR TITLE
fix(providers): parse stringified tool args from glm-5

### DIFF
--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -107,7 +107,7 @@ describe("pi tool definition adapter", () => {
       parameters: Type.Object({ key: Type.String() }),
       execute: async (_callId: string, params: unknown) => {
         receivedParams = params;
-        return { content: [{ type: "text" as const, text: "ok" }] };
+        return { content: [{ type: "text" as const, text: "ok" }], details: {} };
       },
     } satisfies AgentTool;
 

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -1,7 +1,7 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { describe, expect, it } from "vitest";
-import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import { toClientToolDefinitions, toToolDefinitions } from "./pi-tool-definition-adapter.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
@@ -96,5 +96,49 @@ describe("pi tool definition adapter", () => {
     });
     expect(result.content[0]).toMatchObject({ type: "text" });
     expect((result.content[0] as { text?: string }).text).toContain('"count"');
+  });
+
+  it("parses stringified tool args from glm-5 (internal tools)", async () => {
+    let receivedParams: unknown;
+    const tool = {
+      name: "test_tool",
+      label: "Test Tool",
+      description: "captures params",
+      parameters: Type.Object({ key: Type.String() }),
+      execute: async (_callId: string, params: unknown) => {
+        receivedParams = params;
+        return { content: [{ type: "text" as const, text: "ok" }] };
+      },
+    } satisfies AgentTool;
+
+    const defs = toToolDefinitions([tool]);
+    const def = defs[0];
+    // Simulate GLM-5: the SDK passes args as a JSON string instead of an object
+    const stringifiedArgs = JSON.stringify({ key: "value" });
+    await def.execute("call_glm5", stringifiedArgs, undefined, undefined, extensionContext);
+    expect(receivedParams).toEqual({ key: "value" });
+  });
+
+  it("parses stringified tool args from glm-5 (client tools)", async () => {
+    let capturedParams: Record<string, unknown> | undefined;
+    const clientTools = [
+      {
+        type: "function" as const,
+        function: {
+          name: "get_weather",
+          description: "gets weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        },
+      },
+    ];
+
+    const defs = toClientToolDefinitions(clientTools, (name, params) => {
+      capturedParams = params;
+    });
+    const def = defs[0];
+    // Simulate GLM-5: args arrive as a JSON string
+    const stringifiedArgs = JSON.stringify({ city: "Seattle" });
+    await def.execute("call_glm5_client", stringifiedArgs, undefined, undefined, extensionContext);
+    expect(capturedParams).toEqual({ city: "Seattle" });
   });
 });

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -49,6 +49,23 @@ function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteA
   return isAbortSignal(fifth);
 }
 
+/**
+ * GLM-5 (and potentially other OpenAI-compatible models) may return tool call
+ * arguments as a JSON-encoded string instead of a parsed object.  Detect that
+ * case and parse it so downstream consumers always receive an object.
+ */
+function ensureParsedToolArgs(args: unknown): unknown {
+  if (typeof args !== "string") {
+    return args;
+  }
+  try {
+    const parsed = JSON.parse(args);
+    return typeof parsed === "object" && parsed !== null ? parsed : args;
+  } catch {
+    return args;
+  }
+}
+
 function describeToolExecutionError(err: unknown): {
   message: string;
   stack?: string;
@@ -146,18 +163,18 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       parameters: tool.parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
-        let executeParams = params;
+        let executeParams = ensureParsedToolArgs(params);
         try {
           if (!beforeHookWrapped) {
             const hookOutcome = await runBeforeToolCallHook({
               toolName: name,
-              params,
+              params: executeParams,
               toolCallId,
             });
             if (hookOutcome.blocked) {
               throw new Error(hookOutcome.reason);
             }
-            executeParams = hookOutcome.params;
+            executeParams = ensureParsedToolArgs(hookOutcome.params);
           }
           const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
           const result = normalizeToolExecutionResult({
@@ -211,7 +228,7 @@ export function toClientToolDefinitions(
         const { toolCallId, params } = splitToolExecuteArgs(args);
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,
-          params,
+          params: ensureParsedToolArgs(params),
           toolCallId,
           ctx: hookContext,
         });


### PR DESCRIPTION
## Summary

- GLM-5 (and potentially other OpenAI-compatible models) may return tool call arguments as a JSON-encoded string instead of a parsed object, causing `400 Expected dict in tool call arguments` errors
- Adds `ensureParsedToolArgs()` guard in the tool definition adapter so both internal and client tool paths receive properly parsed arguments
- Includes regression tests for both code paths

## Change Type

Bug fix

## Scope

`src/agents/pi-tool-definition-adapter.ts` - single file change plus colocated test

## Security Impact

- **Does this change handle user input?** No
- **Does this change affect authentication/authorization?** No
- **Does this change introduce new dependencies?** No
- **Does this change expose new API endpoints?** No
- **Does this change modify security-sensitive code?** No

## Repro

1. Configure an agent to use `opencode-go/glm-5`
2. Trigger a cron that invokes client tools (OpenResponses hosted tools)
3. ~30-50% of runs fail with: `400 Expected dict in tool call arguments, got <class 'str'>`

## Evidence

New test cases prove the fix:
- `parses stringified tool args from glm-5 (internal tools)` - verifies `toToolDefinitions` parses string args
- `parses stringified tool args from glm-5 (client tools)` - verifies `toClientToolDefinitions` parses string args

## Human Verification

- [x] `pnpm test -- src/agents/pi-tool-definition-adapter.test.ts` passes (6/6)
- [x] Related tests (`after-tool-call`, `fires-once`) still pass (7/7)
- [x] Format check passes on changed files

## Failure Recovery

If `JSON.parse` fails on the string argument, the guard falls through and returns the original value unchanged - no behavior change for well-formed providers.

Closes #39327

🤖 Generated with [Claude Code](https://claude.com/claude-code)