### PR TITLE
fix(agents): filter internal tool-failure reasoning from subagent output

### DIFF
--- a/src/agents/subagent-announce.filter-tool-error-output.test.ts
+++ b/src/agents/subagent-announce.filter-tool-error-output.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readLatestAssistantReplyMock = vi.fn<(sessionKey: string) => Promise<string | undefined>>(
+  async (_sessionKey: string) => undefined,
+);
+const chatHistoryMock = vi.fn<(sessionKey: string) => Promise<{ messages?: Array<unknown> }>>(
+  async (_sessionKey: string) => ({ messages: [] }),
+);
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: unknown) => {
+    const typed = request as { method?: string; params?: { sessionKey?: string } };
+    if (typed.method === "chat.history") {
+      return await chatHistoryMock(typed.params?.sessionKey ?? "");
+    }
+    return {};
+  }),
+}));
+
+vi.mock("./tools/agent-step.js", () => ({
+  readLatestAssistantReply: readLatestAssistantReplyMock,
+}));
+
+describe("captureSubagentCompletionReply - tool error filtering (#39032)", () => {
+  let previousFastTestEnv: string | undefined;
+  let captureSubagentCompletionReply: (typeof import("./subagent-announce.js"))["captureSubagentCompletionReply"];
+
+  beforeAll(async () => {
+    previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    ({ captureSubagentCompletionReply } = await import("./subagent-announce.js"));
+  });
+
+  afterAll(() => {
+    if (previousFastTestEnv === undefined) {
+      delete process.env.OPENCLAW_TEST_FAST;
+      return;
+    }
+    process.env.OPENCLAW_TEST_FAST = previousFastTestEnv;
+  });
+
+  beforeEach(() => {
+    readLatestAssistantReplyMock.mockReset().mockResolvedValue(undefined);
+    chatHistoryMock.mockReset().mockResolvedValue({ messages: [] });
+  });
+
+  it("skips error tool results so internal failure text does not leak to parent", async () => {
+    vi.useFakeTimers();
+    readLatestAssistantReplyMock.mockResolvedValue(undefined);
+    chatHistoryMock.mockResolvedValueOnce({ messages: [] }).mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Task completed successfully." }],
+        },
+        {
+          role: "toolResult",
+          is_error: true,
+          content: [
+            {
+              type: "text",
+              text: "The message tool needs a Telegram chat ID, not a session key. agent:main:main is not a valid chat ID.",
+            },
+          ],
+        },
+      ],
+    });
+
+    const pending = captureSubagentCompletionReply("agent:main:subagent:child");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    // Should return the assistant text, NOT the error tool result
+    expect(result).toBe("Task completed successfully.");
+    vi.useRealTimers();
+  });
+
+  it("skips error tool results with isError field (camelCase variant)", async () => {
+    vi.useFakeTimers();
+    readLatestAssistantReplyMock.mockResolvedValue(undefined);
+    chatHistoryMock.mockResolvedValueOnce({ messages: [] }).mockResolvedValueOnce({
+      messages: [
+        {
+          role: "toolResult",
+          isError: true,
+          content: "Error: invalid session key format",
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer here." }],
+        },
+      ],
+    });
+
+    const pending = captureSubagentCompletionReply("agent:main:subagent:child");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBe("Final answer here.");
+    vi.useRealTimers();
+  });
+
+  it("still returns successful tool results as output", async () => {
+    vi.useFakeTimers();
+    readLatestAssistantReplyMock.mockResolvedValue(undefined);
+    chatHistoryMock.mockResolvedValueOnce({ messages: [] }).mockResolvedValueOnce({
+      messages: [
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "Successful tool output" }],
+        },
+      ],
+    });
+
+    const pending = captureSubagentCompletionReply("agent:main:subagent:child");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBe("Successful tool output");
+    vi.useRealTimers();
+  });
+
+  it("returns undefined when only error tool results exist and no assistant message", async () => {
+    vi.useFakeTimers();
+    readLatestAssistantReplyMock.mockResolvedValue(undefined);
+    chatHistoryMock.mockResolvedValue({
+      messages: [
+        {
+          role: "toolResult",
+          is_error: true,
+          content: "Internal error: session key is not a valid Telegram chat ID",
+        },
+      ],
+    });
+
+    const pending = captureSubagentCompletionReply("agent:main:subagent:child");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBeUndefined();
+    vi.useRealTimers();
+  });
+});

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -68,6 +68,8 @@ const DIRECT_ANNOUNCE_TRANSIENT_RETRY_DELAYS_MS = FAST_TEST_MODE
 type ToolResultMessage = {
   role?: unknown;
   content?: unknown;
+  is_error?: unknown;
+  isError?: unknown;
 };
 
 function resolveSubagentAnnounceTimeoutMs(cfg: ReturnType<typeof loadConfig>): number {
@@ -181,6 +183,10 @@ async function runAnnounceDeliveryWithRetry<T>(params: {
   }
 }
 
+function isToolResultError(message: ToolResultMessage): boolean {
+  return message.is_error === true || message.isError === true;
+}
+
 function extractToolResultText(content: unknown): string {
   if (typeof content === "string") {
     return sanitizeTextContent(content);
@@ -257,7 +263,14 @@ function extractSubagentOutputText(message: unknown): string {
     return "";
   }
   if (role === "toolResult" || role === "tool") {
-    return extractToolResultText((message as ToolResultMessage).content);
+    const toolMsg = message as ToolResultMessage;
+    // Skip error tool results - their content is internal debugging info
+    // (e.g. "session key is not a valid chat ID") that should not leak
+    // to the parent session as subagent output.
+    if (isToolResultError(toolMsg)) {
+      return "";
+    }
+    return extractToolResultText(toolMsg.content);
   }
   if (role == null) {
     if (typeof content === "string") {


### PR DESCRIPTION
## Summary

- Skip error tool result messages (`is_error: true` / `isError: true`) in `extractSubagentOutputText` so internal debugging text from failed tool calls does not leak to the parent session as subagent completion output
- Adds `isToolResultError` guard in the tool-result branch of `extractSubagentOutputText`
- Successful tool results and assistant text are still surfaced normally

## Change Type

Bug fix

## Scope

Agents - subagent completion output pipeline

## Motivation

When a subagent encounters a tool failure (e.g. calling `message` with a session key instead of a Telegram chat ID), the error content from the `toolResult` message was being picked up by `extractSubagentOutputText` and returned as the subagent's completion output. This leaked internal reasoning and debugging details to the requester session.

## Security Impact

Reduces information leakage - internal tool error messages, session keys, and implementation details are no longer forwarded to the parent session.

## Test plan

- [x] New regression test: `subagent-announce.filter-tool-error-output.test.ts` (4 cases)
- [x] Existing `subagent-announce.capture-completion-reply.test.ts` still passes (3 cases)

Closes #39032

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>