### PR TITLE
fix(telegram): re-upload webhook certificate on channel restart

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -504,6 +504,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookUrl: account.config.webhookUrl,
         webhookSecret: account.config.webhookSecret,
         webhookPath: account.config.webhookPath,
+        webhookCertPath: account.config.webhookCertPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
       });

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -136,6 +136,8 @@ export type TelegramAccountConfig = {
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;
+  /** Optional PEM certificate file uploaded on every setWebhook call (required for self-signed cert webhook endpoints). */
+  webhookCertPath?: string;
   /** Local webhook listener bind host (default: 127.0.0.1). */
   webhookHost?: string;
   /** Local webhook listener bind port (default: 8787). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -207,6 +207,12 @@ export const TelegramAccountSchemaBase = z
       .describe(
         "Local webhook route path served by the gateway listener. Defaults to /telegram-webhook.",
       ),
+    webhookCertPath: z
+      .string()
+      .optional()
+      .describe(
+        "Optional PEM certificate file path uploaded during setWebhook registration (use for self-signed webhook certificates).",
+      ),
     webhookHost: z
       .string()
       .optional()

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -27,6 +27,7 @@ export type MonitorTelegramOpts = {
   webhookPath?: string;
   webhookPort?: number;
   webhookSecret?: string;
+  webhookCertPath?: string;
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
@@ -167,6 +168,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         path: opts.webhookPath,
         port: opts.webhookPort,
         secret: opts.webhookSecret ?? account.config.webhookSecret,
+        certPath: opts.webhookCertPath ?? account.config.webhookCertPath,
         host: opts.webhookHost ?? account.config.webhookHost,
         runtime: opts.runtime as RuntimeEnv,
         fetch: proxyFetch,

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import { once } from "node:events";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { request, type IncomingMessage } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { startTelegramWebhook } from "./webhook.js";
@@ -414,6 +417,39 @@ describe("startTelegramWebhook", () => {
         );
       },
     );
+  });
+
+  it("uploads configured webhook certificate during setWebhook", async () => {
+    setWebhookSpy.mockClear();
+    const certDir = await mkdtemp(join(tmpdir(), "openclaw-telegram-cert-"));
+    const certPath = join(certDir, "telegram-cert.pem");
+    await writeFile(
+      certPath,
+      "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+      "utf8",
+    );
+
+    try {
+      await withStartedWebhook(
+        {
+          secret: TELEGRAM_SECRET,
+          path: TELEGRAM_WEBHOOK_PATH,
+          certPath,
+        },
+        async () => {
+          expect(setWebhookSpy).toHaveBeenCalledTimes(1);
+          expect(setWebhookSpy).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              secret_token: TELEGRAM_SECRET,
+              certificate: expect.any(Object),
+            }),
+          );
+        },
+      );
+    } finally {
+      await rm(certDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps webhook payload readable when callback delays body read", async () => {

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -1,5 +1,6 @@
+import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";
-import { webhookCallback } from "grammy";
+import { InputFile, webhookCallback } from "grammy";
 import type { OpenClawConfig } from "../config/config.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -82,6 +83,7 @@ export async function startTelegramWebhook(opts: {
   port?: number;
   host?: string;
   secret?: string;
+  certPath?: string;
   runtime?: RuntimeEnv;
   fetch?: typeof fetch;
   abortSignal?: AbortSignal;
@@ -233,6 +235,14 @@ export async function startTelegramWebhook(opts: {
     port,
   });
 
+  const certPath = typeof opts.certPath === "string" ? opts.certPath.trim() : "";
+  const certificate = certPath
+    ? new InputFile(
+        await readFile(certPath),
+        certPath.split(/[\\/]/).pop() || "telegram-webhook-cert.pem",
+      )
+    : undefined;
+
   try {
     await withTelegramApiErrorLogging({
       operation: "setWebhook",
@@ -241,6 +251,7 @@ export async function startTelegramWebhook(opts: {
         bot.api.setWebhook(publicUrl, {
           secret_token: secret,
           allowed_updates: resolveTelegramAllowedUpdates(),
+          ...(certificate ? { certificate } : {}),
         }),
     });
   } catch (err) {

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -236,14 +236,15 @@ export async function startTelegramWebhook(opts: {
   });
 
   const certPath = typeof opts.certPath === "string" ? opts.certPath.trim() : "";
-  const certificate = certPath
-    ? new InputFile(
-        await readFile(certPath),
-        certPath.split(/[\\/]/).pop() || "telegram-webhook-cert.pem",
-      )
-    : undefined;
 
   try {
+    const certificate = certPath
+      ? new InputFile(
+          await readFile(certPath),
+          certPath.split(/[\\/]/).pop() || "telegram-webhook-cert.pem",
+        )
+      : undefined;
+
     await withTelegramApiErrorLogging({
       operation: "setWebhook",
       runtime,


### PR DESCRIPTION
## Summary\n- Problem: Telegram webhook mode re-registers  on channel restarts but never re-uploads a self-signed certificate.\n- Why it matters:  can flip to false after restart, causing Telegram to stop delivering webhook updates for direct-IP/self-signed deployments.\n- What changed: added , threaded it through telegram monitor/channel startup, and attach that PEM file to every  call in webhook mode.\n- What did NOT change (scope boundary): no changes to long-polling behavior, no changes to stale-socket policy logic, and no global cert auto-discovery.\n\n## Change Type (select all)\n- [x] Bug fix\n- [ ] Feature\n- [ ] Refactor\n- [ ] Docs\n- [ ] Security hardening\n- [ ] Chore/infra\n\n## Scope (select all touched areas)\n- [x] Gateway / orchestration\n- [x] Integrations\n- [x] API / contracts\n- [ ] Skills / tool execution\n- [ ] Auth / tokens\n- [ ] Memory / storage\n- [ ] UI / DX\n- [ ] CI/CD / infra\n\n## Linked Issue/PR\n- Closes #39303\n\n## User-visible / Behavior Changes\n- New optional config field:  (and per-account override) for PEM cert upload during webhook registration.\n\n## Security Impact (required)\n- New permissions/capabilities? ()\n- Secrets/tokens handling changed? ()\n- New/changed network calls? ()\n- Command/tool execution surface changed? ()\n- Data access scope changed? ()\n\n## Repro + Verification\n### Environment\n- OS: Linux (WSL2)\n- Runtime/container: Node 22, pnpm\n- Integration/channel: Telegram\n\n### Steps\n1. Configure Telegram webhook mode with a self-signed cert endpoint and set .\n2. Restart Telegram channel (or health-monitor restart).\n3. Verify Telegram webhook remains registered with custom cert.\n\n### Expected\n-  includes certificate and Telegram keeps  after restarts.\n\n### Actual\n- Before fix, re-registration could omit cert and lose custom-cert webhook delivery.\n\n## Evidence\n- [x] Failing test/log before + passing after\n\n## Human Verification (required)\n- Verified scenarios:\n  -  passes with webhook option passthrough.\n  -  passes with webhook startup path.\n  -  includes new assertion that webhook cert is attached in  when configured.\n- Edge cases checked:\n  - no cert path configured => webhook registration unchanged.\n  - cert path configured => certificate object present in  payload.\n- What you did **not** verify:\n  - Live Telegram bot against production endpoint in this CI environment.\n\n## Compatibility / Migration\n- Backward compatible? ()\n- Config/env changes? ()\n- Migration needed? ()\n\n## Failure Recovery (if this breaks)\n- How to disable/revert this change quickly:\n  - Remove  from config, or revert this PR.\n- Known bad symptoms reviewers should watch for:\n  - startup failure if configured cert path is invalid/unreadable.\n\n## Risks and Mitigations\n- Risk: Invalid cert path breaks Telegram webhook startup.\n  - Mitigation: keep field optional; failures are explicit during startup and config can be rolled back quickly.\n