### PR TITLE
fix(telegram): add editMessage and createForumTopic to actions schema

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -227,7 +227,9 @@ export const TelegramAccountSchemaBase = z
         sendMessage: z.boolean().optional(),
         poll: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        createForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- Adds `editMessage` and `createForumTopic` to the Telegram actions Zod schema
- Aligns schema with the TypeScript type definition `TelegramActionConfig` in `types.telegram.ts`

## Problem

The `TelegramActionConfig` type defines 7 fields (`reactions`, `sendMessage`, `poll`, `deleteMessage`, `editMessage`, `sticker`, `createForumTopic`) but the Zod schema only had 5 — missing `editMessage` and `createForumTopic`. Because the schema uses `.strict()`, users setting these documented config options get `Unrecognized key` validation errors.

Fixes #35497

## Test plan

- [x] Zod schema tests pass (12/12)
- [ ] Setting `channels.telegram.actions.editMessage: true` should be accepted
- [ ] Setting `channels.telegram.actions.createForumTopic: true` should be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)