### PR TITLE
fix(gateway): remove duplicate webchat chat fanout

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -100,7 +100,7 @@ describe("abortChatRunById", () => {
       }),
     );
     expect((payload.message as { timestamp?: unknown }).timestamp).toEqual(expect.any(Number));
-    expect(ops.nodeSendToSession).toHaveBeenCalledWith(sessionKey, "chat", payload);
+    expect(ops.nodeSendToSession).not.toHaveBeenCalled();
   });
 
   it("omits aborted message when buffered text is empty", () => {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -67,7 +67,6 @@ function broadcastChatAborted(
       : undefined,
   };
   ops.broadcast("chat", payload);
-  ops.nodeSendToSession(sessionKey, "chat", payload);
 }
 
 export function abortChatRunById(

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -170,7 +170,7 @@ describe("agent event handler", () => {
     };
     expect(payload.state).toBe("delta");
     expect(payload.message?.content?.[0]?.text).toBe("Hello world");
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy?.mockRestore();
   });
 
@@ -185,7 +185,7 @@ describe("agent event handler", () => {
       message?: { content?: Array<{ text?: string }> };
     };
     expect(payload.message?.content?.[0]?.text).toBe("Hello  world ");
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy?.mockRestore();
   });
 
@@ -216,7 +216,7 @@ describe("agent event handler", () => {
 
     const payload = expectSingleFinalChatPayload(broadcast) as { message?: unknown };
     expect(payload.message).toBeUndefined();
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy?.mockRestore();
   });
 
@@ -239,7 +239,7 @@ describe("agent event handler", () => {
 
     const payload = expectSingleFinalChatPayload(broadcast) as { message?: unknown };
     expect(payload.message).toBeUndefined();
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy?.mockRestore();
   });
 
@@ -262,7 +262,7 @@ describe("agent event handler", () => {
       message?: { content?: Array<{ text?: string }> };
     };
     expect(payload.message?.content?.[0]?.text).toBe("No");
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy?.mockRestore();
   });
 
@@ -306,7 +306,7 @@ describe("agent event handler", () => {
     expect(secondPayload.state).toBe("delta");
     expect(secondPayload.message?.content?.[0]?.text).toBe("Hello world");
     expect(thirdPayload.state).toBe("final");
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(3);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy.mockRestore();
   });
 
@@ -352,7 +352,7 @@ describe("agent event handler", () => {
     expect(secondPayload.message?.content?.[0]?.text).toBe("Before tool call\nAfter tool call");
     expect(finalPayload.state).toBe("final");
     expect(finalPayload.message?.content?.[0]?.text).toBe("Before tool call\nAfter tool call");
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(3);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy.mockRestore();
   });
 
@@ -398,7 +398,7 @@ describe("agent event handler", () => {
     expect(flushPayload.message?.content?.[0]?.text).toBe("Before tool call\nAfter tool call");
     expect(finalPayload.state).toBe("final");
     expect(finalPayload.message?.content?.[0]?.text).toBe("Before tool call\nAfter tool call");
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(3);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy.mockRestore();
   });
 
@@ -437,7 +437,7 @@ describe("agent event handler", () => {
       "delta",
       "final",
     ]);
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(3);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
     nowSpy.mockRestore();
   });
 
@@ -528,7 +528,7 @@ describe("agent event handler", () => {
     };
     expect(flushedPayload.state).toBe("delta");
     expect(flushedPayload.message?.content?.[0]?.text).toBe("Before tool expanded");
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(2);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
 
     expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
     const flushCallOrder = broadcast.mock.invocationCallOrder[1] ?? 0;
@@ -783,7 +783,7 @@ describe("agent event handler", () => {
 
     const finalPayload = expectSingleFinalChatPayload(broadcast) as { message?: unknown };
     expect(finalPayload.message).toBeUndefined();
-    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
   });
 
   it("keeps heartbeat alert text in final chat output when remainder exceeds ackMaxChars", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -387,7 +387,6 @@ export function createAgentEventHandler({
       },
     };
     broadcast("chat", payload, { dropIfSlow: true });
-    nodeSendToSession(sessionKey, "chat", payload);
   };
 
   const flushBufferedChatDeltaIfNeeded = (
@@ -439,7 +438,6 @@ export function createAgentEventHandler({
       },
     };
     broadcast("chat", flushPayload, { dropIfSlow: true });
-    nodeSendToSession(sessionKey, "chat", flushPayload);
     chatRunState.deltaLastBroadcastLen.set(clientRunId, text.length);
     chatRunState.deltaSentAt.set(clientRunId, now);
   };
@@ -489,7 +487,6 @@ export function createAgentEventHandler({
             : undefined,
       };
       broadcast("chat", payload);
-      nodeSendToSession(sessionKey, "chat", payload);
       return;
     }
     const payload = {
@@ -500,7 +497,6 @@ export function createAgentEventHandler({
       errorMessage: error ? formatForLog(error) : undefined,
     };
     broadcast("chat", payload);
-    nodeSendToSession(sessionKey, "chat", payload);
   };
 
   const resolveToolVerboseLevel = (runId: string, sessionKey?: string) => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -661,7 +661,7 @@ function nextChatSeq(context: { agentRunSeq: Map<string, number> }, runId: strin
 }
 
 function broadcastChatFinal(params: {
-  context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
+  context: Pick<GatewayRequestContext, "broadcast" | "agentRunSeq">;
   runId: string;
   sessionKey: string;
   message?: Record<string, unknown>;
@@ -678,12 +678,11 @@ function broadcastChatFinal(params: {
     message: stripInlineDirectiveTagsFromMessageForDisplay(strippedEnvelopeMessage),
   };
   params.context.broadcast("chat", payload);
-  params.context.nodeSendToSession(params.sessionKey, "chat", payload);
   params.context.agentRunSeq.delete(params.runId);
 }
 
 function broadcastChatError(params: {
-  context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
+  context: Pick<GatewayRequestContext, "broadcast" | "agentRunSeq">;
   runId: string;
   sessionKey: string;
   errorMessage?: string;
@@ -697,7 +696,6 @@ function broadcastChatError(params: {
     errorMessage: params.errorMessage,
   };
   params.context.broadcast("chat", payload);
-  params.context.nodeSendToSession(params.sessionKey, "chat", payload);
   params.context.agentRunSeq.delete(params.runId);
 }
 
@@ -1236,7 +1234,6 @@ export const chatHandlers: GatewayRequestHandlers = {
       ),
     };
     context.broadcast("chat", chatPayload);
-    context.nodeSendToSession(rawSessionKey, "chat", chatPayload);
 
     respond(true, { ok: true, messageId: appended.messageId });
   },


### PR DESCRIPTION
## Summary
- remove the redundant session-targeted `chat` fanout from the gateway chat paths
- keep the fix scoped to chat events only; do not change broader `agent` delivery behavior
- update focused gateway tests to prove chat payloads are no longer duplicated through both paths

## Root cause
The gateway chat flow was emitting the same logical `chat` payload twice on `main`:
- once through websocket `broadcast("chat", ...)`
- again through `nodeSendToSession(..., "chat", ...)`

That duplicate fanout affected Webchat/control-ui chat delivery. This PR removes only the redundant `chat` session fanout while leaving unrelated event paths alone.

This is intentionally the isolated duplicate-fanout fix split out from broader/unrelated work.

Closes #39289.

## Testing
- `corepack pnpm exec vitest run src/gateway/server-chat.agent-events.test.ts src/gateway/chat-abort.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts`
- `git diff --check`
