### PR TITLE
fix(security): include top-level channels.discord.allowFrom in audit check

### DIFF
--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -428,8 +428,10 @@ export async function collectChannelSecurityFindings(params: {
           });
           const dmAllowFromRaw = (discordCfg.dm as { allowFrom?: unknown } | undefined)?.allowFrom;
           const dmAllowFrom = Array.isArray(dmAllowFromRaw) ? dmAllowFromRaw : [];
+          const topLevelAllowFromRaw = discordCfg.allowFrom as unknown[] | undefined;
+          const topLevelAllowFrom = Array.isArray(topLevelAllowFromRaw) ? topLevelAllowFromRaw : [];
           const ownerAllowFromConfigured =
-            normalizeAllowFromList([...dmAllowFrom, ...storeAllowFrom]).length > 0;
+            normalizeAllowFromList([...dmAllowFrom, ...topLevelAllowFrom, ...storeAllowFrom]).length > 0;
 
           const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;
           if (


### PR DESCRIPTION
## Summary

Fixes false positive security audit warning when top-level `channels.discord.allowFrom` is configured.

## Problem

The security audit code at `src/security/audit-channel.ts` only checked:
- `discordCfg.dm.allowFrom`
- `storeAllowFrom`

But NOT the top-level `discordCfg.allowFrom`.

This caused a false positive warning: "Discord slash commands have no allowlists" even when users had configured `channels.discord.allowFrom` with valid user IDs.

## Solution

Added `discordCfg.allowFrom` to the `ownerAllowFromConfigured` check, consistent with how Telegram channel is audited.

## Changes

- `src/security/audit-channel.ts`: Include top-level `discordCfg.allowFrom` in allowlist validation

## Related

Fixes #39341