### PR TITLE
fix(config): add firecrawl and readability to web fetch schema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -329,6 +329,7 @@ export const ToolsWebFetchSchema = z
         baseUrl: z.string().optional(),
         onlyMainContent: z.boolean().optional(),
         maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -321,6 +321,17 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Adds `firecrawl` object and `readability` boolean to `ToolsWebFetchSchema` in the Zod config schema
- Aligns schema with the TypeScript type definition in `types.tools.ts`

## Problem

`ToolsWebFetchSchema` uses `.strict()` but is missing `firecrawl` and `readability` fields that are defined in the TypeScript type and used at runtime. Users who configure `tools.web.fetch.firecrawl` get a schema validation error (`Unrecognized key`), making Firecrawl fallback impossible to configure through the config file.

The `firecrawl` sub-object supports:
- `enabled` — enable/disable Firecrawl fallback
- `apiKey` — Firecrawl API key (defaults to `FIRECRAWL_API_KEY` env var)
- `baseUrl` — custom Firecrawl API URL
- `onlyMainContent` — extract only main content
- `maxAgeMs` — cache TTL

Fixes #20442 (schema part)

## Test plan

- [x] Zod schema tests pass (12/12)
- [ ] `openclaw config set 'tools.web.fetch.firecrawl.enabled' true` should be accepted
- [ ] `openclaw config set 'tools.web.fetch.readability' false` should be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)