### PR TITLE
fix(config): add domain field to discovery.wideArea schema

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -549,6 +549,7 @@ export const OpenClawSchema = z
         wideArea: z
           .object({
             enabled: z.boolean().optional(),
+            domain: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

- Adds `domain` string field to the `discovery.wideArea` Zod schema

## Problem

The `wideArea` schema uses `.strict()` but is missing the `domain` field that is:
1. Defined in `types.gateway.ts:21` as `domain?: string`
2. Used across the codebase (gateway registration, DNS CLI, runtime discovery, status command, remote onboarding)

Users setting `discovery.wideArea.domain` for unicast DNS-SD configuration get a validation error.

Fixes #35614

## Test plan

- [x] Zod schema tests pass (12/12)
- [ ] Setting `discovery.wideArea.domain: "example.com"` should be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)