### PR TITLE
fix: resolve native addon bindings failure in jiti plugin loader

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -41,6 +41,12 @@ export type PluginLoadOptions = {
   runtimeOptions?: CreatePluginRuntimeOptions;
   cache?: boolean;
   mode?: "full" | "validate";
+  /**
+   * Additional module names to load via Node's native require instead of
+   * jiti's transpiler. Useful for plugins that depend on native addons not
+   * covered by the built-in list (e.g. "sharp", "canvas", "node-hid").
+   */
+  additionalNativeModules?: string[];
 };
 
 const registryCache = new Map<string, PluginRegistry>();
@@ -200,9 +206,11 @@ export const __testing = {
 function buildCacheKey(params: {
   workspaceDir?: string;
   plugins: NormalizedPluginsConfig;
+  additionalNativeModules?: string[];
 }): string {
   const workspaceKey = params.workspaceDir ? resolveUserPath(params.workspaceDir) : "";
-  return `${workspaceKey}::${JSON.stringify(params.plugins)}`;
+  const nativeModulesKey = JSON.stringify([...(params.additionalNativeModules ?? [])].sort());
+  return `${workspaceKey}::${JSON.stringify(params.plugins)}::${nativeModulesKey}`;
 }
 
 function validatePluginConfig(params: {
@@ -487,6 +495,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
     plugins: normalized,
+    additionalNativeModules: options.additionalNativeModules,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
@@ -581,6 +590,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+      // Native addon resolver packages locate .node binaries relative to
+      // module.filename/__dirname. When jiti transpiles these modules it sets
+      // module.filename to its own path, so the lookup fails. Listing the
+      // resolvers here delegates them to Node's native require, preserving
+      // correct path resolution for any addon that depends on them.
+      // See: https://github.com/openclaw/openclaw/issues/21676
+      nativeModules: ["bindings", "node-gyp-build", ...(options.additionalNativeModules ?? [])],
       ...(Object.keys(aliasMap).length > 0
         ? {
             alias: aliasMap,


### PR DESCRIPTION
## Summary

Plugins that depend on native addons (e.g. `sqlite3` via [`bindings`](https://www.npmjs.com/package/bindings), or `better-sqlite3` via [`node-gyp-build`](https://www.npmjs.com/package/node-gyp-build)) fail to load because jiti sets `module.filename` to its own path. These resolver packages walk up from `module.filename` to find `build/Release/*.node`, but since the path points to jiti internals they never find the binary.

## Changes

**1. Add resolver packages to jiti's `nativeModules`**

Adding `bindings` and `node-gyp-build` to `nativeModules` delegates them to Node's native `require`, preserving correct `module.filename`/`__dirname`. Targeting the two resolver packages (rather than individual addons like `sqlite3`) covers any current or future addon using either resolver — no list maintenance required.

**2. Expose `additionalNativeModules` on `PluginLoadOptions`**

For plugins using native addons with other resolution strategies, callers can extend the list:

```ts
loadOpenClawPlugins({
  additionalNativeModules: ["sharp", "canvas"],
  // ...
});
```

`additionalNativeModules` is also included as a first-class param in `buildCacheKey` so varying the option across calls in the same process never returns a stale registry.

## Error fixed

```
Error: Could not locate the bindings file. Tried:
 → /path/to/openclaw/node_modules/jiti/build/Release/node_sqlite3.node
 → /path/to/openclaw/node_modules/jiti/lib/binding/node-v127-darwin-arm64/node_sqlite3.node
 … (all under jiti's directory instead of the plugin's)
```

## Test plan

- [ ] Verify `openclaw-mem0` plugin (uses `sqlite3` via `bindings`) loads without errors
- [ ] Verify existing plugins without native addons load correctly
- [ ] Verify gateway starts cleanly

Fixes #21676

🤖 Generated with [Claude Code](https://claude.com/claude-code)