### PR TITLE
Harden provider secret loading and daemon gateway token persistence

### DIFF
--- a/src/agents/live-auth-keys.test.ts
+++ b/src/agents/live-auth-keys.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { collectProviderApiKeys } from "./live-auth-keys.js";
+
+describe("collectProviderApiKeys", () => {
+  it("reads OPENAI_API_KEY_FILE when OPENAI_API_KEY is unset", async () => {
+    await withEnvAsync(
+      {
+        OPENAI_API_KEY: undefined,
+        OPENAI_API_KEY_FILE: undefined,
+      },
+      async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-keys-"));
+        const file = path.join(dir, "openai.txt");
+        await fs.writeFile(file, "sk-file-openai-key\n", "utf8");
+
+        try {
+          process.env.OPENAI_API_KEY_FILE = file;
+          expect(collectProviderApiKeys("openai")).toEqual(["sk-file-openai-key"]);
+        } finally {
+          await fs.rm(dir, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+
+  it("prefers OPENAI_API_KEY over OPENAI_API_KEY_FILE", async () => {
+    await withEnvAsync(
+      {
+        OPENAI_API_KEY: undefined,
+        OPENAI_API_KEY_FILE: undefined,
+      },
+      async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-keys-"));
+        const file = path.join(dir, "openai.txt");
+        await fs.writeFile(file, "sk-file-openai-key\n", "utf8");
+
+        try {
+          process.env.OPENAI_API_KEY = "sk-direct-openai-key";
+          process.env.OPENAI_API_KEY_FILE = file;
+          expect(collectProviderApiKeys("openai")).toEqual(["sk-direct-openai-key"]);
+        } finally {
+          await fs.rm(dir, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+});

--- a/src/agents/live-auth-keys.ts
+++ b/src/agents/live-auth-keys.ts
@@ -1,3 +1,4 @@
+import { resolveSecretEnvValue } from "../utils/secret-env.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 const KEY_SPLIT_RE = /[\s,;]+/g;
@@ -56,7 +57,7 @@ function parseKeyList(raw?: string | null): string[] {
 function collectEnvPrefixedKeys(prefix: string): string[] {
   const keys: string[] = [];
   for (const [name, value] of Object.entries(process.env)) {
-    if (!name.startsWith(prefix)) {
+    if (!name.startsWith(prefix) || name.endsWith("_FILE")) {
       continue;
     }
     const trimmed = value?.trim();
@@ -100,17 +101,23 @@ function resolveProviderApiKeyConfig(provider: string): ProviderApiKeyConfig {
 export function collectProviderApiKeys(provider: string): string[] {
   const config = resolveProviderApiKeyConfig(provider);
 
-  const forcedSingle = config.liveSingle ? process.env[config.liveSingle]?.trim() : undefined;
+  const forcedSingle = config.liveSingle
+    ? resolveSecretEnvValue(config.liveSingle)?.value
+    : undefined;
   if (forcedSingle) {
     return [forcedSingle];
   }
 
-  const fromList = parseKeyList(config.listVar ? process.env[config.listVar] : undefined);
-  const primary = config.primaryVar ? process.env[config.primaryVar]?.trim() : undefined;
+  const fromList = parseKeyList(
+    config.listVar
+      ? (resolveSecretEnvValue(config.listVar)?.value ?? process.env[config.listVar])
+      : undefined,
+  );
+  const primary = config.primaryVar ? resolveSecretEnvValue(config.primaryVar)?.value : undefined;
   const fromPrefixed = config.prefixedVar ? collectEnvPrefixedKeys(config.prefixedVar) : [];
 
   const fallback = config.fallbackVars
-    .map((envVar) => process.env[envVar]?.trim())
+    .map((envVar) => resolveSecretEnvValue(envVar)?.value)
     .filter(Boolean) as string[];
 
   const seen = new Set<string>();

--- a/src/agents/model-auth.e2e.test.ts
+++ b/src/agents/model-auth.e2e.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { captureEnv } from "../test-utils/env.js";
+import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
 import { getApiKeyForModel, resolveApiKeyForProvider, resolveEnvApiKey } from "./model-auth.js";
 
@@ -404,6 +404,54 @@ describe("getApiKeyForModel", () => {
         process.env.ANTHROPIC_API_KEY = previous;
       }
     }
+  });
+
+  it("reads ANTHROPIC_API_KEY_FILE when ANTHROPIC_API_KEY is unset", async () => {
+    await withEnvAsync(
+      {
+        ANTHROPIC_API_KEY: undefined,
+        ANTHROPIC_API_KEY_FILE: undefined,
+      },
+      async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-file-"));
+        const file = path.join(dir, "anthropic.txt");
+        await fs.writeFile(file, "sk-ant-file-key\n", "utf8");
+
+        try {
+          process.env.ANTHROPIC_API_KEY_FILE = file;
+          const resolved = resolveEnvApiKey("anthropic");
+          expect(resolved?.apiKey).toBe("sk-ant-file-key");
+          expect(resolved?.source).toContain("ANTHROPIC_API_KEY_FILE");
+        } finally {
+          await fs.rm(dir, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+
+  it("prefers ANTHROPIC_API_KEY over ANTHROPIC_API_KEY_FILE", async () => {
+    await withEnvAsync(
+      {
+        ANTHROPIC_API_KEY: undefined,
+        ANTHROPIC_API_KEY_FILE: undefined,
+      },
+      async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-file-"));
+        const file = path.join(dir, "anthropic.txt");
+        await fs.writeFile(file, "sk-ant-file-key\n", "utf8");
+
+        try {
+          process.env.ANTHROPIC_API_KEY = "sk-ant-direct-key";
+          process.env.ANTHROPIC_API_KEY_FILE = file;
+          const resolved = resolveEnvApiKey("anthropic");
+          expect(resolved?.apiKey).toBe("sk-ant-direct-key");
+          expect(resolved?.source).toContain("ANTHROPIC_API_KEY");
+          expect(resolved?.source).not.toContain("_FILE");
+        } finally {
+          await fs.rm(dir, { recursive: true, force: true });
+        }
+      },
+    );
   });
 
   it("resolveEnvApiKey('huggingface') returns HUGGINGFACE_HUB_TOKEN when set", async () => {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalSecretInput,
   normalizeSecretInput,
 } from "../utils/normalize-secret-input.js";
+import { resolveSecretEnvValue } from "../utils/secret-env.js";
 import {
   type AuthProfileStore,
   ensureAuthProfileStore,
@@ -239,12 +240,12 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
   const normalized = normalizeProviderId(provider);
   const applied = new Set(getShellEnvAppliedKeys());
   const pick = (envVar: string): EnvApiKeyResult | null => {
-    const value = normalizeOptionalSecretInput(process.env[envVar]);
-    if (!value) {
+    const resolved = resolveSecretEnvValue(envVar, process.env);
+    if (!resolved) {
       return null;
     }
-    const source = applied.has(envVar) ? `shell env: ${envVar}` : `env: ${envVar}`;
-    return { apiKey: value, source };
+    const prefix = applied.has(envVar) ? "shell env" : resolved.source;
+    return { apiKey: resolved.value, source: `${prefix}: ${resolved.envVar}` };
   };
 
   if (normalized === "github-copilot") {

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadConfig = vi.fn(() => ({
+  gateway: {
+    auth: {
+      mode: "token",
+    },
+  },
+}));
+const readConfigFileSnapshot = vi.fn(async () => ({
+  exists: true,
+  valid: true,
+  config: {
+    gateway: {
+      auth: {
+        mode: "token",
+      },
+    },
+  },
+}));
+const writeConfigFile = vi.fn(async () => {});
+const resolveGatewayPort = vi.fn(() => 18789);
+const buildGatewayInstallPlan = vi.fn(async () => ({
+  programArguments: ["node", "dist/index.js", "gateway"],
+  workingDirectory: "/tmp/openclaw",
+  environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+}));
+const installDaemonServiceAndEmit = vi.fn(async ({ install }) => {
+  await install();
+});
+const emit = vi.fn();
+const fail = vi.fn();
+const service = {
+  loadedText: "loaded",
+  isLoaded: vi.fn(async () => false),
+  install: vi.fn(async () => {}),
+};
+
+vi.mock("../../commands/daemon-install-helpers.js", () => ({
+  buildGatewayInstallPlan: (params: unknown) => buildGatewayInstallPlan(params),
+}));
+
+vi.mock("../../commands/daemon-runtime.js", () => ({
+  DEFAULT_GATEWAY_DAEMON_RUNTIME: "node",
+  isGatewayDaemonRuntime: () => true,
+}));
+
+vi.mock("../../commands/onboard-helpers.js", () => ({
+  randomToken: () => "generated-token",
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => loadConfig(),
+  readConfigFileSnapshot: () => readConfigFileSnapshot(),
+  resolveGatewayPort: () => resolveGatewayPort(),
+  writeConfigFile: (cfg: unknown) => writeConfigFile(cfg),
+}));
+
+vi.mock("../../config/paths.js", () => ({
+  resolveIsNixMode: () => false,
+}));
+
+vi.mock("../../daemon/service.js", () => ({
+  resolveGatewayService: () => service,
+}));
+
+vi.mock("../../gateway/auth.js", () => ({
+  resolveGatewayAuth: () => ({
+    mode: "token",
+    token: process.env.OPENCLAW_GATEWAY_TOKEN,
+    allowTailscale: false,
+  }),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+  },
+}));
+
+vi.mock("./response.js", () => ({
+  buildDaemonServiceSnapshot: vi.fn(),
+  createDaemonActionContext: () => ({
+    stdout: process.stdout,
+    warnings: [],
+    emit,
+    fail,
+  }),
+  installDaemonServiceAndEmit: (params: unknown) => installDaemonServiceAndEmit(params as never),
+}));
+
+vi.mock("./shared.js", () => ({
+  parsePort: () => undefined,
+}));
+
+describe("runDaemonInstall", () => {
+  beforeEach(() => {
+    loadConfig.mockClear();
+    readConfigFileSnapshot.mockClear();
+    writeConfigFile.mockClear();
+    resolveGatewayPort.mockClear();
+    buildGatewayInstallPlan.mockClear();
+    installDaemonServiceAndEmit.mockClear();
+    emit.mockClear();
+    fail.mockClear();
+    service.isLoaded.mockClear();
+    service.install.mockClear();
+    service.isLoaded.mockResolvedValue(false);
+    service.install.mockResolvedValue(undefined);
+    vi.unstubAllEnvs();
+    vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "env-token");
+    vi.stubEnv("CLAWDBOT_GATEWAY_TOKEN", "");
+  });
+
+  it("persists env-backed gateway tokens into config before installing the service", async () => {
+    const { runDaemonInstall } = await import("./install.js");
+
+    await runDaemonInstall({});
+
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gateway: expect.objectContaining({
+          auth: expect.objectContaining({
+            mode: "token",
+            token: "env-token",
+          }),
+        }),
+      }),
+    );
+    expect(buildGatewayInstallPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: undefined,
+      }),
+    );
+    expect(service.install).toHaveBeenCalledTimes(1);
+    expect(fail).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -23,6 +23,55 @@ import {
 import { parsePort } from "./shared.js";
 import type { DaemonInstallOptions } from "./types.js";
 
+async function persistGatewayTokenToConfig(params: {
+  token: string;
+  json: boolean;
+  warnings: string[];
+}): Promise<{ tokenPersisted: boolean; config: ReturnType<typeof loadConfig> }> {
+  const { token, json, warnings } = params;
+
+  try {
+    const snapshot = await readConfigFileSnapshot();
+    if (snapshot.exists && !snapshot.valid) {
+      const msg = "Warning: config file exists but is invalid; skipping token persistence.";
+      if (json) {
+        warnings.push(msg);
+      } else {
+        defaultRuntime.log(msg);
+      }
+      return { tokenPersisted: false, config: loadConfig() };
+    }
+
+    const baseConfig = snapshot.exists ? snapshot.config : {};
+    const existingToken = baseConfig.gateway?.auth?.token?.trim();
+    if (existingToken) {
+      return { tokenPersisted: true, config: baseConfig };
+    }
+
+    const updatedConfig = {
+      ...baseConfig,
+      gateway: {
+        ...baseConfig.gateway,
+        auth: {
+          ...baseConfig.gateway?.auth,
+          mode: baseConfig.gateway?.auth?.mode ?? "token",
+          token,
+        },
+      },
+    };
+    await writeConfigFile(updatedConfig);
+    return { tokenPersisted: true, config: updatedConfig };
+  } catch (err) {
+    const msg = `Warning: could not persist token to config: ${String(err)}`;
+    if (json) {
+      warnings.push(msg);
+    } else {
+      defaultRuntime.log(msg);
+    }
+    return { tokenPersisted: false, config: loadConfig() };
+  }
+}
+
 export async function runDaemonInstall(opts: DaemonInstallOptions) {
   const json = Boolean(opts.json);
   const { stdout, warnings, emit, fail } = createDaemonActionContext({ action: "install", json });
@@ -32,7 +81,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     return;
   }
 
-  const cfg = loadConfig();
+  let cfg = loadConfig();
   const portOverride = parsePort(opts.port);
   if (opts.port !== undefined && portOverride === null) {
     fail("Invalid port");
@@ -81,8 +130,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     authConfig: cfg.gateway?.auth,
     tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
   });
-  const needsToken =
-    resolvedAuth.mode === "token" && !resolvedAuth.token && !resolvedAuth.allowTailscale;
+  const requiresPersistentTokenAuth = resolvedAuth.mode === "token" && !resolvedAuth.allowTailscale;
 
   let token: string | undefined =
     opts.token ||
@@ -90,7 +138,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     process.env.OPENCLAW_GATEWAY_TOKEN ||
     process.env.CLAWDBOT_GATEWAY_TOKEN;
 
-  if (!token && needsToken) {
+  if (!token && requiresPersistentTokenAuth) {
     token = randomToken();
     const warnMsg = "No gateway token found. Auto-generated one and saving to config.";
     if (json) {
@@ -98,55 +146,22 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     } else {
       defaultRuntime.log(warnMsg);
     }
+  }
 
-    // Persist to config file so the gateway reads it at runtime
-    // (launchd does not inherit shell env vars, and CLI tools also
-    // read gateway.auth.token from config for gateway calls).
-    try {
-      const snapshot = await readConfigFileSnapshot();
-      if (snapshot.exists && !snapshot.valid) {
-        // Config file exists but is corrupt/unparseable — don't risk overwriting.
-        // Token is still embedded in the plist EnvironmentVariables.
-        const msg = "Warning: config file exists but is invalid; skipping token persistence.";
-        if (json) {
-          warnings.push(msg);
-        } else {
-          defaultRuntime.log(msg);
-        }
-      } else {
-        const baseConfig = snapshot.exists ? snapshot.config : {};
-        if (!baseConfig.gateway?.auth?.token) {
-          await writeConfigFile({
-            ...baseConfig,
-            gateway: {
-              ...baseConfig.gateway,
-              auth: {
-                ...baseConfig.gateway?.auth,
-                mode: baseConfig.gateway?.auth?.mode ?? "token",
-                token,
-              },
-            },
-          });
-        } else {
-          // Another process wrote a token between loadConfig() and now.
-          token = baseConfig.gateway.auth.token;
-        }
-      }
-    } catch (err) {
-      // Non-fatal: token is still embedded in the plist EnvironmentVariables.
-      const msg = `Warning: could not persist token to config: ${String(err)}`;
-      if (json) {
-        warnings.push(msg);
-      } else {
-        defaultRuntime.log(msg);
-      }
+  let tokenPersistedToConfig = Boolean(cfg.gateway?.auth?.token?.trim());
+  if (requiresPersistentTokenAuth && token && !tokenPersistedToConfig) {
+    const persisted = await persistGatewayTokenToConfig({ token, json, warnings });
+    tokenPersistedToConfig = persisted.tokenPersisted;
+    cfg = persisted.config;
+    if (cfg.gateway?.auth?.token?.trim()) {
+      token = cfg.gateway.auth.token;
     }
   }
 
   const { programArguments, workingDirectory, environment } = await buildGatewayInstallPlan({
     env: process.env,
     port,
-    token,
+    token: tokenPersistedToConfig ? undefined : token,
     runtime: runtimeRaw,
     warn: (message) => {
       if (json) {

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -72,6 +72,26 @@ describe("runServiceRestart token drift", () => {
     expect(payload.warnings?.[0]).toContain("gateway install --force");
   });
 
+  it("does not warn when the service relies on config auth instead of an embedded token", async () => {
+    service.readCommand.mockResolvedValue({
+      environment: {},
+    });
+
+    const { runServiceRestart } = await import("./lifecycle-core.js");
+
+    await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+      checkTokenDrift: true,
+    });
+
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as { warnings?: string[] };
+    expect(payload.warnings).toBeUndefined();
+  });
+
   it("skips drift warning when disabled", async () => {
     const { runServiceRestart } = await import("./lifecycle-core.js");
 

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -83,6 +83,23 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(true);
   });
 
+  it("does not flag gateway token mismatch when service token is omitted", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "linux",
+      expectedGatewayToken: "new-token",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
+    ).toBe(false);
+  });
+
   it("does not flag gateway token mismatch when service token matches config token", async () => {
     const audit = await auditGatewayServiceConfig({
       env: { HOME: "/tmp" },
@@ -127,8 +144,7 @@ describe("checkTokenDrift", () => {
 
   it("detects drift when config has token but service has no token", () => {
     const result = checkTokenDrift({ serviceToken: undefined, configToken: "new-token" });
-    expect(result).not.toBeNull();
-    expect(result?.code).toBe(SERVICE_AUDIT_CODES.gatewayTokenDrift);
+    expect(result).toBeNull();
   });
 
   it("returns null when service has token but config does not", () => {

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -212,7 +212,7 @@ function auditGatewayToken(
     return;
   }
   const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN?.trim();
-  if (serviceToken === expectedToken) {
+  if (!serviceToken || serviceToken === expectedToken) {
     return;
   }
   issues.push({
@@ -376,8 +376,9 @@ export function checkTokenDrift(params: {
     return null;
   }
 
-  // Drift: config has token, service has different or no token
-  if (configToken && serviceToken !== configToken) {
+  // Drift: config has token and service still embeds a different token.
+  // A missing service token is acceptable because the daemon can read auth from config.
+  if (configToken && serviceToken && serviceToken !== configToken) {
     return {
       code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
       message:

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -12,6 +12,7 @@ import { getCustomProviderApiKey, resolveEnvApiKey } from "../agents/model-auth.
 import { normalizeProviderId } from "../agents/model-selection.js";
 import { loadConfig } from "../config/config.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import { resolveSecretEnvValue } from "../utils/secret-env.js";
 import type { UsageProviderId } from "./provider-usage.types.js";
 
 export type ProviderAuth = {
@@ -37,7 +38,7 @@ function parseGoogleToken(apiKey: string): { token: string } | null {
 
 function resolveZaiApiKey(): string | undefined {
   const envDirect =
-    normalizeSecretInput(process.env.ZAI_API_KEY) || normalizeSecretInput(process.env.Z_AI_API_KEY);
+    resolveSecretEnvValue("ZAI_API_KEY")?.value || resolveSecretEnvValue("Z_AI_API_KEY")?.value;
   if (envDirect) {
     return envDirect;
   }

--- a/src/utils/secret-env.ts
+++ b/src/utils/secret-env.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import { normalizeOptionalSecretInput } from "./normalize-secret-input.js";
+
+export type SecretEnvValue = {
+  value: string;
+  source: "env" | "file";
+  envVar: string;
+};
+
+export function resolveSecretEnvValue(
+  envVar: string,
+  env: NodeJS.ProcessEnv = process.env,
+): SecretEnvValue | null {
+  const direct = normalizeOptionalSecretInput(env[envVar]);
+  if (direct) {
+    return { value: direct, source: "env", envVar };
+  }
+
+  const fileVar = `${envVar}_FILE`;
+  const filePath = normalizeOptionalSecretInput(env[fileVar]);
+  if (!filePath) {
+    return null;
+  }
+
+  try {
+    const fromFile = normalizeOptionalSecretInput(fs.readFileSync(filePath, "utf-8"));
+    if (!fromFile) {
+      return null;
+    }
+    return { value: fromFile, source: "file", envVar: fileVar };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- support file-backed provider auth env vars via `*_FILE`
- persist gateway tokens into config for daemon installs instead of embedding them in service env
- update daemon drift/audit tests for config-backed gateway auth

## Testing
- corepack pnpm exec vitest run src/agents/live-auth-keys.test.ts
- corepack pnpm exec vitest run --config vitest.e2e.config.ts src/agents/model-auth.e2e.test.ts
- corepack pnpm exec vitest run src/cli/daemon-cli/install.test.ts
- corepack pnpm exec vitest run src/cli/daemon-cli/lifecycle-core.test.ts src/daemon/service-audit.test.ts