### PR TITLE
Telegram: relay group bot messages across accounts with loop prevention

### DIFF
--- a/src/telegram/bot-handlers.relay.test.ts
+++ b/src/telegram/bot-handlers.relay.test.ts
@@ -1,0 +1,303 @@
+import type { UserFromGetMe } from "@grammyjs/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { registerTelegramHandlers } from "./bot-handlers.js";
+import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import { buildTelegramUpdateKey, type TelegramUpdateKeyContext } from "./bot-updates.js";
+import type { TelegramContext } from "./bot/types.js";
+import {
+  clearTelegramGroupRelayState,
+  publishTelegramGroupRelay,
+  registerTelegramGroupRelayEndpoint,
+  trackTelegramRelayMessageOwner,
+} from "./group-bot-relay.js";
+
+type RelayHarness = {
+  unregisterRelay: () => void;
+  processCalls: TelegramContext[];
+  shouldSkipUpdateCalls: TelegramUpdateKeyContext[];
+  getMeMock: ReturnType<typeof vi.fn<() => Promise<UserFromGetMe>>>;
+};
+
+function createRelayHarness(params?: {
+  getMeImpl?: () => Promise<UserFromGetMe>;
+  shouldSkipUpdate?: (ctx: TelegramUpdateKeyContext) => boolean;
+}): RelayHarness {
+  const processCalls: TelegramContext[] = [];
+  const shouldSkipUpdateCalls: TelegramUpdateKeyContext[] = [];
+
+  const getMeMock = vi.fn<() => Promise<UserFromGetMe>>(
+    params?.getMeImpl ??
+      (async () =>
+        ({
+          id: 22,
+          username: "jade_bot",
+          first_name: "Jade",
+          is_bot: true,
+        }) as UserFromGetMe),
+  );
+
+  const bot = {
+    api: {
+      getMe: getMeMock,
+      sendMessage: vi.fn(async () => ({ message_id: 1 })),
+      setMessageReaction: vi.fn(async () => undefined),
+      answerCallbackQuery: vi.fn(async () => undefined),
+      editMessageText: vi.fn(async () => ({ message_id: 1 })),
+      deleteMessage: vi.fn(async () => true),
+      getFile: vi.fn(async () => ({ file_path: "media/file.jpg" })),
+    },
+    on: vi.fn(),
+  } as unknown as RegisterTelegramHandlerParams["bot"];
+
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as RegisterTelegramHandlerParams["logger"];
+
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+  } as unknown as RuntimeEnv;
+
+  const cfg = {
+    channels: {
+      telegram: {
+        dmPolicy: "open",
+        groupPolicy: "open",
+        allowFrom: ["*"],
+        groups: {
+          "*": { enabled: true, requireMention: false },
+        },
+      },
+    },
+  } as OpenClawConfig;
+
+  const telegramCfg = {
+    dmPolicy: "open",
+    groupPolicy: "open",
+    allowFrom: ["*"],
+    groups: {
+      "*": { enabled: true, requireMention: false },
+    },
+  } as TelegramAccountConfig;
+
+  const unregisterRelay = registerTelegramHandlers({
+    cfg,
+    accountId: "jade",
+    bot,
+    opts: { token: "tok" },
+    runtime,
+    mediaMaxBytes: 8 * 1024 * 1024,
+    telegramCfg,
+    allowFrom: ["*"],
+    groupAllowFrom: ["*"],
+    resolveGroupPolicy: () => "open",
+    resolveTelegramGroupConfig: () => ({
+      groupConfig: { enabled: true, requireMention: false },
+      topicConfig: undefined,
+    }),
+    shouldSkipUpdate: (ctx) => {
+      shouldSkipUpdateCalls.push(ctx);
+      return params?.shouldSkipUpdate?.(ctx) ?? false;
+    },
+    processMessage: async (ctx) => {
+      processCalls.push(ctx);
+    },
+    logger,
+  });
+
+  return {
+    unregisterRelay,
+    processCalls,
+    shouldSkipUpdateCalls,
+    getMeMock,
+  };
+}
+
+describe("telegram relay handler", () => {
+  beforeEach(() => {
+    clearTelegramGroupRelayState();
+  });
+
+  it("builds synthetic dedupe keys from chat + message id instead of synthetic update_id", async () => {
+    const harness = createRelayHarness();
+    const unregisterSource = registerTelegramGroupRelayEndpoint({
+      accountId: "knox",
+      resolveIdentity: async () => ({
+        botUserId: 11,
+        botUsername: "knox_bot",
+        botDisplayName: "Knox",
+      }),
+      handleRelay: async () => {},
+    });
+
+    trackTelegramRelayMessageOwner({ chatId: -1001, messageId: 301, accountId: "jade" });
+    trackTelegramRelayMessageOwner({ chatId: -1002, messageId: 302, accountId: "jade" });
+
+    try {
+      await publishTelegramGroupRelay({
+        sourceAccountId: "knox",
+        isGroup: true,
+        chatId: -1001,
+        messageId: 700,
+        text: "relay one",
+        replyToMessageId: 301,
+        chain: { chainId: "relay-key-1", turn: 0, humanInitiated: true },
+      });
+      await publishTelegramGroupRelay({
+        sourceAccountId: "knox",
+        isGroup: true,
+        chatId: -1002,
+        messageId: 700,
+        text: "relay two",
+        replyToMessageId: 302,
+        chain: { chainId: "relay-key-2", turn: 0, humanInitiated: true },
+      });
+    } finally {
+      unregisterSource();
+      harness.unregisterRelay();
+    }
+
+    expect(harness.processCalls).toHaveLength(2);
+    const keys = harness.shouldSkipUpdateCalls.map((ctx) => buildTelegramUpdateKey(ctx));
+    expect(keys).toEqual(["message:-1001:700", "message:-1002:700"]);
+    for (const ctx of harness.shouldSkipUpdateCalls) {
+      expect(ctx.update?.update_id).toBeUndefined();
+    }
+  });
+
+  it("retries getMe identity lookup after transient relay failures", async () => {
+    const harness = createRelayHarness({
+      getMeImpl: vi
+        .fn<() => Promise<UserFromGetMe>>()
+        .mockRejectedValueOnce(new Error("transient"))
+        .mockResolvedValue({
+          id: 22,
+          username: "jade_bot",
+          first_name: "Jade",
+          is_bot: true,
+        } as UserFromGetMe),
+    });
+    const unregisterSource = registerTelegramGroupRelayEndpoint({
+      accountId: "knox",
+      resolveIdentity: async () => ({
+        botUserId: 11,
+        botUsername: "knox_bot",
+        botDisplayName: "Knox",
+      }),
+      handleRelay: async () => {},
+    });
+
+    try {
+      await publishTelegramGroupRelay({
+        sourceAccountId: "knox",
+        isGroup: true,
+        chatId: -1001,
+        messageId: 701,
+        text: "@jade_bot first",
+        chain: { chainId: "relay-getme-1", turn: 0, humanInitiated: true },
+      });
+      await publishTelegramGroupRelay({
+        sourceAccountId: "knox",
+        isGroup: true,
+        chatId: -1001,
+        messageId: 702,
+        text: "@jade_bot second",
+        chain: { chainId: "relay-getme-2", turn: 0, humanInitiated: true },
+      });
+    } finally {
+      unregisterSource();
+      harness.unregisterRelay();
+    }
+
+    expect(harness.getMeMock).toHaveBeenCalledTimes(2);
+    expect(harness.processCalls).toHaveLength(1);
+    expect(harness.processCalls[0]?.message?.text).toBe("@jade_bot second");
+  });
+
+  it("uses a stable synthetic sender id when source identity is unavailable", async () => {
+    const harness = createRelayHarness();
+    const unregisterSource = registerTelegramGroupRelayEndpoint({
+      accountId: "knox",
+      resolveIdentity: async () => null,
+      handleRelay: async () => {},
+    });
+
+    trackTelegramRelayMessageOwner({ chatId: -1001, messageId: 303, accountId: "jade" });
+    trackTelegramRelayMessageOwner({ chatId: -1001, messageId: 304, accountId: "jade" });
+
+    try {
+      await publishTelegramGroupRelay({
+        sourceAccountId: "knox",
+        isGroup: true,
+        chatId: -1001,
+        messageId: 703,
+        text: "fallback one",
+        replyToMessageId: 303,
+        chain: { chainId: "relay-fallback-1", turn: 0, humanInitiated: true },
+      });
+      await publishTelegramGroupRelay({
+        sourceAccountId: "knox",
+        isGroup: true,
+        chatId: -1001,
+        messageId: 704,
+        text: "fallback two",
+        replyToMessageId: 304,
+        chain: { chainId: "relay-fallback-2", turn: 0, humanInitiated: true },
+      });
+    } finally {
+      unregisterSource();
+      harness.unregisterRelay();
+    }
+
+    expect(harness.processCalls).toHaveLength(2);
+    const firstSenderId = harness.processCalls[0]?.message?.from?.id;
+    const secondSenderId = harness.processCalls[1]?.message?.from?.id;
+    expect(typeof firstSenderId).toBe("number");
+    expect(firstSenderId).toBe(secondSenderId);
+    expect(firstSenderId).not.toBe(703);
+    expect(secondSenderId).not.toBe(704);
+    expect(firstSenderId != null && firstSenderId < 0).toBe(true);
+  });
+
+  it("does not mirror source text into synthetic reply_to_message text", async () => {
+    const harness = createRelayHarness();
+    const unregisterSource = registerTelegramGroupRelayEndpoint({
+      accountId: "knox",
+      resolveIdentity: async () => ({
+        botUserId: 11,
+        botUsername: "knox_bot",
+        botDisplayName: "Knox",
+      }),
+      handleRelay: async () => {},
+    });
+
+    trackTelegramRelayMessageOwner({ chatId: -1001, messageId: 345, accountId: "jade" });
+
+    try {
+      await publishTelegramGroupRelay({
+        sourceAccountId: "knox",
+        isGroup: true,
+        chatId: -1001,
+        messageId: 705,
+        text: "follow-up response",
+        replyToMessageId: 345,
+        chain: { chainId: "relay-reply-shape", turn: 0, humanInitiated: true },
+      });
+    } finally {
+      unregisterSource();
+      harness.unregisterRelay();
+    }
+
+    expect(harness.processCalls).toHaveLength(1);
+    const relayed = harness.processCalls[0]?.message;
+    expect(relayed?.text).toBe("follow-up response");
+    expect(relayed?.reply_to_message?.message_id).toBe(345);
+    expect(relayed?.reply_to_message?.text).toBeUndefined();
+  });
+});

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -111,6 +111,18 @@ function resolveInboundMediaFileId(msg: Message): string | undefined {
   );
 }
 
+function buildRelaySyntheticSenderId(accountId: string): number {
+  // Use a stable negative identifier derived from accountId when source bot identity
+  // is temporarily unavailable. This avoids treating per-chat message IDs as user IDs.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < accountId.length; i += 1) {
+    hash ^= accountId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  const unsignedHash = hash >>> 0;
+  return -1_000_000_000 - (unsignedHash % 1_000_000_000);
+}
+
 export const registerTelegramHandlers = ({
   cfg,
   accountId,
@@ -1489,18 +1501,26 @@ export const registerTelegramHandlers = ({
     }
   };
 
-  let cachedRelayBotMe: UserFromGetMe | null | undefined;
+  let cachedRelayBotMe: UserFromGetMe | undefined;
+  let relayBotMeLookupPromise: Promise<UserFromGetMe | undefined> | undefined;
   const resolveRelayBotMe = async (): Promise<UserFromGetMe | undefined> => {
     if (cachedRelayBotMe !== undefined) {
-      return cachedRelayBotMe ?? undefined;
-    }
-    try {
-      cachedRelayBotMe = await bot.api.getMe();
       return cachedRelayBotMe;
-    } catch {
-      cachedRelayBotMe = null;
-      return undefined;
     }
+    if (!relayBotMeLookupPromise) {
+      relayBotMeLookupPromise = (async () => {
+        try {
+          const me = await bot.api.getMe();
+          cachedRelayBotMe = me;
+          return me;
+        } catch {
+          return undefined;
+        } finally {
+          relayBotMeLookupPromise = undefined;
+        }
+      })();
+    }
+    return relayBotMeLookupPromise;
   };
   const unregisterGroupRelay = registerTelegramGroupRelayEndpoint({
     accountId,
@@ -1525,7 +1545,8 @@ export const registerTelegramHandlers = ({
         return;
       }
       const relayBotMe = await resolveRelayBotMe();
-      const relayFromId = relay.source.botUserId ?? relay.messageId;
+      const relayFromId =
+        relay.source.botUserId ?? buildRelaySyntheticSenderId(relay.source.accountId);
       const replyToMessage =
         relay.replyTargetsRecipient &&
         relay.replyToMessageId != null &&
@@ -1540,7 +1561,6 @@ export const registerTelegramHandlers = ({
                 first_name: relay.target.botDisplayName || relay.target.botUsername || "Bot",
                 ...(relay.target.botUsername ? { username: relay.target.botUsername } : {}),
               },
-              text: relay.text,
             }
           : undefined;
       const syntheticMessage = attachTelegramRelayMeta(
@@ -1564,7 +1584,6 @@ export const registerTelegramHandlers = ({
       );
       const syntheticDedupeContext = {
         update: {
-          update_id: relay.messageId,
           message: syntheticMessage,
         },
       } as TelegramUpdateKeyContext;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,4 +1,4 @@
-import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+import type { Message, ReactionTypeEmoji, UserFromGetMe } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   createInboundDebouncer,
@@ -61,6 +61,7 @@ import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,
 } from "./group-access.js";
+import { attachTelegramRelayMeta, registerTelegramGroupRelayEndpoint } from "./group-bot-relay.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import {
@@ -1488,6 +1489,103 @@ export const registerTelegramHandlers = ({
     }
   };
 
+  let cachedRelayBotMe: UserFromGetMe | null | undefined;
+  const resolveRelayBotMe = async (): Promise<UserFromGetMe | undefined> => {
+    if (cachedRelayBotMe !== undefined) {
+      return cachedRelayBotMe ?? undefined;
+    }
+    try {
+      cachedRelayBotMe = await bot.api.getMe();
+      return cachedRelayBotMe;
+    } catch {
+      cachedRelayBotMe = null;
+      return undefined;
+    }
+  };
+  const unregisterGroupRelay = registerTelegramGroupRelayEndpoint({
+    accountId,
+    resolveIdentity: async () => {
+      const me = await resolveRelayBotMe();
+      if (!me) {
+        return null;
+      }
+      return {
+        botUserId: me.id,
+        botUsername: me.username,
+        botDisplayName: me.first_name || me.username || `bot:${accountId}`,
+      };
+    },
+    handleRelay: async (relay) => {
+      if (!relay.text.trim()) {
+        return;
+      }
+      const relayChatId =
+        typeof relay.chatId === "number" ? relay.chatId : Number.parseInt(String(relay.chatId), 10);
+      if (!Number.isFinite(relayChatId)) {
+        return;
+      }
+      const relayBotMe = await resolveRelayBotMe();
+      const relayFromId = relay.source.botUserId ?? relay.messageId;
+      const replyToMessage =
+        relay.replyTargetsRecipient &&
+        relay.replyToMessageId != null &&
+        typeof relay.target.botUserId === "number"
+          ? {
+              message_id: relay.replyToMessageId,
+              date: Math.floor(relay.sentAtMs / 1000),
+              chat: { id: relayChatId, type: "supergroup" as const },
+              from: {
+                id: relay.target.botUserId,
+                is_bot: true as const,
+                first_name: relay.target.botDisplayName || relay.target.botUsername || "Bot",
+                ...(relay.target.botUsername ? { username: relay.target.botUsername } : {}),
+              },
+              text: relay.text,
+            }
+          : undefined;
+      const syntheticMessage = attachTelegramRelayMeta(
+        {
+          message_id: relay.messageId,
+          date: Math.floor(relay.sentAtMs / 1000),
+          chat: { id: relayChatId, type: "supergroup" as const },
+          from: {
+            id: relayFromId,
+            is_bot: true as const,
+            first_name: relay.source.botDisplayName || relay.source.botUsername || "Bot",
+            ...(relay.source.botUsername ? { username: relay.source.botUsername } : {}),
+          },
+          text: relay.text,
+          ...(relay.messageThreadId != null
+            ? { message_thread_id: Math.trunc(relay.messageThreadId) }
+            : {}),
+          ...(replyToMessage ? { reply_to_message: replyToMessage } : {}),
+        } as Message,
+        relay.relayMeta,
+      );
+      const syntheticDedupeContext = {
+        update: {
+          update_id: relay.messageId,
+          message: syntheticMessage,
+        },
+      } as TelegramUpdateKeyContext;
+      await handleInboundMessageLike({
+        ctxForDedupe: syntheticDedupeContext,
+        ctx: buildSyntheticContext({ me: relayBotMe }, syntheticMessage),
+        msg: syntheticMessage,
+        chatId: relayChatId,
+        isGroup: true,
+        isForum: relay.messageThreadId != null,
+        messageThreadId: relay.messageThreadId,
+        senderId: String(relayFromId),
+        senderUsername: relay.source.botUsername ?? "",
+        requireConfiguredGroup: false,
+        sendOversizeWarning: false,
+        oversizeLogMessage: "relayed bot media exceeds size limit",
+        errorMessage: "group relay handler failed",
+      });
+    },
+  });
+
   bot.on("message", async (ctx) => {
     const msg = ctx.message;
     if (!msg) {
@@ -1562,4 +1660,6 @@ export const registerTelegramHandlers = ({
       errorMessage: "channel_post handler failed",
     });
   });
+
+  return unregisterGroupRelay;
 };

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -31,6 +31,7 @@ import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import { renderTelegramHtmlText } from "./format.js";
+import { publishTelegramGroupRelay, readTelegramRelayMeta } from "./group-bot-relay.js";
 import {
   type ArchivedPreview,
   createLaneDeliveryStateTracker,
@@ -161,6 +162,13 @@ export const dispatchTelegramMessage = async ({
     removeAckAfterReply,
     statusReactionController,
   } = context;
+  const inboundRelayMeta = readTelegramRelayMeta(msg);
+  const relayChainId =
+    inboundRelayMeta?.chainId ??
+    `telegram:${route.accountId}:${chatId}:${msg.message_id ?? msg.date ?? Date.now()}`;
+  const relayChainTurn = inboundRelayMeta?.turn ?? 0;
+  const relayHumanInitiated = inboundRelayMeta?.humanInitiated ?? msg.from?.is_bot !== true;
+  const relayThreadId = threadSpec?.scope === "forum" ? threadSpec.id : undefined;
 
   const draftMaxChars = Math.min(textLimit, 4096);
   const tableMode = resolveMarkdownTableMode({
@@ -457,6 +465,29 @@ export const dispatchTelegramMessage = async ({
     });
     if (result.delivered) {
       deliveryState.markDelivered();
+    }
+    const deliveredMessages = result.deliveredMessages ?? [];
+    if (isGroup && deliveredMessages.length > 0) {
+      for (const deliveredMessage of deliveredMessages) {
+        try {
+          await publishTelegramGroupRelay({
+            sourceAccountId: route.accountId,
+            chatId,
+            messageId: deliveredMessage.messageId,
+            text: deliveredMessage.text,
+            replyToMessageId: deliveredMessage.replyToMessageId,
+            messageThreadId: relayThreadId,
+            isGroup,
+            chain: {
+              chainId: relayChainId,
+              turn: relayChainTurn,
+              humanInitiated: relayHumanInitiated,
+            },
+          });
+        } catch (err) {
+          logVerbose(`telegram relay publish failed: ${String(err)}`);
+        }
+      }
     }
     return result.delivered;
   };

--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -4,6 +4,7 @@ import type { MsgContext } from "../auto-reply/templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { MockFn } from "../test-utils/vitest-mock-fn.js";
+import { clearTelegramGroupRelayState } from "./group-bot-relay.js";
 
 type AnyMock = MockFn<(...args: unknown[]) => unknown>;
 type AnyAsyncMock = MockFn<(...args: unknown[]) => Promise<unknown>>;
@@ -274,6 +275,7 @@ export function makeForumGroupMessageCtx(params?: {
 
 beforeEach(() => {
   resetInboundDedupe();
+  clearTelegramGroupRelayState();
   loadConfig.mockReset();
   loadConfig.mockReturnValue(DEFAULT_TELEGRAM_TEST_CONFIG);
   loadWebMedia.mockReset();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -389,7 +389,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     opts,
   });
 
-  registerTelegramHandlers({
+  const unregisterGroupRelay = registerTelegramHandlers({
     cfg,
     accountId: account.accountId,
     bot,
@@ -408,6 +408,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
 
   const originalStop = bot.stop.bind(bot);
   bot.stop = ((...args: Parameters<typeof originalStop>) => {
+    unregisterGroupRelay?.();
     threadBindingManager?.stop();
     return originalStop(...args);
   }) as typeof bot.stop;

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -18,6 +18,7 @@ import {
   renderTelegramHtmlText,
   wrapFileReferencesInHtml,
 } from "../format.js";
+import { trackTelegramRelayMessageOwner } from "../group-bot-relay.js";
 import { buildInlineKeyboard } from "../send.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
 import {
@@ -512,12 +513,24 @@ export async function deliverReplies(params: {
   linkPreview?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
-}): Promise<{ delivered: boolean }> {
+}): Promise<{
+  delivered: boolean;
+  deliveredMessages: Array<{
+    messageId: number;
+    text: string;
+    replyToMessageId?: number;
+  }>;
+}> {
   const progress: DeliveryProgress = {
     hasReplied: false,
     hasDelivered: false,
     deliveredCount: 0,
   };
+  const deliveredMessages: Array<{
+    messageId: number;
+    text: string;
+    replyToMessageId?: number;
+  }> = [];
   const hookRunner = getGlobalHookRunner();
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
@@ -621,6 +634,20 @@ export async function deliverReplies(params: {
         runtime: params.runtime,
         firstDeliveredMessageId,
       });
+      if (typeof firstDeliveredMessageId === "number") {
+        if (params.accountId) {
+          trackTelegramRelayMessageOwner({
+            chatId: params.chatId,
+            messageId: firstDeliveredMessageId,
+            accountId: params.accountId,
+          });
+        }
+        deliveredMessages.push({
+          messageId: firstDeliveredMessageId,
+          text: contentForSentHook,
+          replyToMessageId: replyToId,
+        });
+      }
 
       if (hasMessageSentHooks) {
         const deliveredThisReply = progress.deliveredCount > deliveredCountBeforeReply;
@@ -657,5 +684,5 @@ export async function deliverReplies(params: {
     }
   }
 
-  return { delivered: progress.hasDelivered };
+  return { delivered: progress.hasDelivered, deliveredMessages };
 }

--- a/src/telegram/group-bot-relay.test.ts
+++ b/src/telegram/group-bot-relay.test.ts
@@ -1,0 +1,204 @@
+import type { Message } from "@grammyjs/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  attachTelegramRelayMeta,
+  clearTelegramGroupRelayState,
+  publishTelegramGroupRelay,
+  readTelegramRelayMeta,
+  registerTelegramGroupRelayEndpoint,
+  resolveTelegramRelayMessageOwner,
+  trackTelegramRelayMessageOwner,
+  type TelegramGroupRelayInbound,
+} from "./group-bot-relay.js";
+
+describe("telegram group bot relay", () => {
+  beforeEach(() => {
+    clearTelegramGroupRelayState();
+  });
+
+  it("relays mention-targeted group bot messages to matching account", async () => {
+    const targetDeliveries: TelegramGroupRelayInbound[] = [];
+    const unregisterSource = registerTelegramGroupRelayEndpoint({
+      accountId: "knox",
+      resolveIdentity: async () => ({
+        botUserId: 11,
+        botUsername: "knox_bot",
+        botDisplayName: "Knox",
+      }),
+      handleRelay: async () => {},
+    });
+    const unregisterTarget = registerTelegramGroupRelayEndpoint({
+      accountId: "jade",
+      resolveIdentity: async () => ({
+        botUserId: 22,
+        botUsername: "jade_bot",
+        botDisplayName: "Jade",
+      }),
+      handleRelay: async (payload) => {
+        targetDeliveries.push(payload);
+      },
+    });
+
+    await publishTelegramGroupRelay({
+      sourceAccountId: "knox",
+      isGroup: true,
+      chatId: -100123,
+      messageId: 700,
+      text: "Hey @jade_bot can you help?",
+      chain: { chainId: "c1", turn: 0, humanInitiated: true },
+    });
+
+    expect(targetDeliveries).toHaveLength(1);
+    expect(targetDeliveries[0]?.relayMeta.turn).toBe(1);
+    expect(targetDeliveries[0]?.source.accountId).toBe("knox");
+    expect(targetDeliveries[0]?.target.accountId).toBe("jade");
+    expect(resolveTelegramRelayMessageOwner(-100123, 700)).toBe("knox");
+
+    unregisterSource();
+    unregisterTarget();
+  });
+
+  it("routes by reply target ownership even without explicit mention", async () => {
+    const targetDeliveries: TelegramGroupRelayInbound[] = [];
+    registerTelegramGroupRelayEndpoint({
+      accountId: "knox",
+      resolveIdentity: async () => ({
+        botUserId: 11,
+        botUsername: "knox_bot",
+      }),
+      handleRelay: async () => {},
+    });
+    registerTelegramGroupRelayEndpoint({
+      accountId: "jade",
+      resolveIdentity: async () => ({
+        botUserId: 22,
+        botUsername: "jade_bot",
+      }),
+      handleRelay: async (payload) => {
+        targetDeliveries.push(payload);
+      },
+    });
+
+    const now = Date.now();
+    trackTelegramRelayMessageOwner({
+      chatId: -100123,
+      messageId: 345,
+      accountId: "jade",
+      recordedAtMs: now,
+    });
+
+    await publishTelegramGroupRelay({
+      sourceAccountId: "knox",
+      isGroup: true,
+      chatId: -100123,
+      messageId: 701,
+      text: "replying without mention",
+      replyToMessageId: 345,
+      chain: { chainId: "c2", turn: 0, humanInitiated: true },
+      sentAtMs: now + 500,
+    });
+
+    expect(targetDeliveries).toHaveLength(1);
+    expect(targetDeliveries[0]?.replyTargetsRecipient).toBe(true);
+    expect(targetDeliveries[0]?.replyToMessageId).toBe(345);
+  });
+
+  it("does not relay bot-originated chains that are not human-initiated", async () => {
+    const targetHandler = vi.fn(async () => {});
+    registerTelegramGroupRelayEndpoint({
+      accountId: "a",
+      resolveIdentity: async () => ({ botUsername: "a_bot" }),
+      handleRelay: async () => {},
+    });
+    registerTelegramGroupRelayEndpoint({
+      accountId: "b",
+      resolveIdentity: async () => ({ botUsername: "b_bot" }),
+      handleRelay: targetHandler,
+    });
+
+    await publishTelegramGroupRelay({
+      sourceAccountId: "a",
+      isGroup: true,
+      chatId: -1001,
+      messageId: 77,
+      text: "@b_bot ping",
+      chain: { chainId: "non-human", turn: 0, humanInitiated: false },
+    });
+
+    expect(targetHandler).not.toHaveBeenCalled();
+  });
+
+  it("caps relay turn depth and enforces cooldown per chain target", async () => {
+    const targetHandler = vi.fn(async () => {});
+    registerTelegramGroupRelayEndpoint({
+      accountId: "a",
+      resolveIdentity: async () => ({ botUsername: "a_bot" }),
+      handleRelay: async () => {},
+    });
+    registerTelegramGroupRelayEndpoint({
+      accountId: "b",
+      resolveIdentity: async () => ({ botUsername: "b_bot" }),
+      handleRelay: targetHandler,
+    });
+
+    await publishTelegramGroupRelay({
+      sourceAccountId: "a",
+      isGroup: true,
+      chatId: -1001,
+      messageId: 78,
+      text: "@b_bot first",
+      chain: { chainId: "chain-1", turn: 3, humanInitiated: true },
+      sentAtMs: 1_000,
+    });
+    expect(targetHandler).not.toHaveBeenCalled();
+
+    await publishTelegramGroupRelay({
+      sourceAccountId: "a",
+      isGroup: true,
+      chatId: -1001,
+      messageId: 79,
+      text: "@b_bot one",
+      chain: { chainId: "chain-2", turn: 0, humanInitiated: true },
+      sentAtMs: 2_000,
+    });
+    await publishTelegramGroupRelay({
+      sourceAccountId: "a",
+      isGroup: true,
+      chatId: -1001,
+      messageId: 80,
+      text: "@b_bot two",
+      chain: { chainId: "chain-2", turn: 0, humanInitiated: true },
+      sentAtMs: 2_001,
+    });
+    await publishTelegramGroupRelay({
+      sourceAccountId: "a",
+      isGroup: true,
+      chatId: -1001,
+      messageId: 81,
+      text: "@b_bot three",
+      chain: { chainId: "chain-2", turn: 0, humanInitiated: true },
+      sentAtMs: 7_100,
+    });
+
+    expect(targetHandler).toHaveBeenCalledTimes(2);
+  });
+
+  it("attaches and reads relay chain metadata from message objects", () => {
+    const message = {
+      message_id: 1,
+      date: 1736380800,
+      chat: { id: 123, type: "private" as const },
+    } as Message;
+    const attached = attachTelegramRelayMeta(message, {
+      chainId: "meta-chain",
+      turn: 2,
+      humanInitiated: true,
+    });
+    const meta = readTelegramRelayMeta(attached);
+    expect(meta).toEqual({
+      chainId: "meta-chain",
+      turn: 2,
+      humanInitiated: true,
+    });
+  });
+});

--- a/src/telegram/group-bot-relay.ts
+++ b/src/telegram/group-bot-relay.ts
@@ -1,0 +1,340 @@
+import type { Message } from "@grammyjs/types";
+
+const RELAY_MAX_TURNS = 3;
+const RELAY_COOLDOWN_MS = 5_000;
+const MESSAGE_OWNER_TTL_MS = 24 * 60 * 60 * 1000;
+const RELAY_META_SYMBOL = Symbol.for("openclaw.telegram.groupRelayMeta");
+
+export type TelegramRelayChainMeta = {
+  chainId: string;
+  turn: number;
+  humanInitiated: boolean;
+};
+
+export type TelegramRelayIdentity = {
+  botUserId?: number;
+  botUsername?: string;
+  botDisplayName?: string;
+};
+
+export type TelegramGroupRelayInbound = {
+  chatId: number | string;
+  messageId: number;
+  messageThreadId?: number;
+  text: string;
+  sentAtMs: number;
+  replyToMessageId?: number;
+  replyTargetsRecipient: boolean;
+  source: {
+    accountId: string;
+    botUserId?: number;
+    botUsername?: string;
+    botDisplayName?: string;
+  };
+  target: {
+    accountId: string;
+    botUserId?: number;
+    botUsername?: string;
+    botDisplayName?: string;
+  };
+  relayMeta: TelegramRelayChainMeta;
+};
+
+type TelegramRelayEndpoint = {
+  accountId: string;
+  resolveIdentity: () => Promise<TelegramRelayIdentity | null>;
+  handleRelay: (payload: TelegramGroupRelayInbound) => Promise<void>;
+};
+
+type PublishTelegramGroupRelayParams = {
+  sourceAccountId: string;
+  chatId: number | string;
+  messageId: number;
+  text?: string;
+  replyToMessageId?: number;
+  messageThreadId?: number;
+  isGroup: boolean;
+  sentAtMs?: number;
+  chain: TelegramRelayChainMeta;
+};
+
+type TrackTelegramRelayMessageParams = {
+  chatId: number | string;
+  messageId: number;
+  accountId: string;
+  recordedAtMs?: number;
+};
+
+type MessageOwnerEntry = {
+  accountId: string;
+  recordedAtMs: number;
+};
+
+const relayEndpoints = new Map<string, TelegramRelayEndpoint>();
+const relayMessageOwners = new Map<string, Map<number, MessageOwnerEntry>>();
+const relayCooldownByKey = new Map<string, number>();
+
+function normalizeChatKey(chatId: number | string): string {
+  return String(chatId);
+}
+
+function normalizeUsername(username?: string): string | null {
+  const value = username?.trim().replace(/^@+/, "").toLowerCase();
+  return value ? value : null;
+}
+
+function isFiniteMessageId(messageId: number): boolean {
+  return Number.isFinite(messageId) && messageId > 0;
+}
+
+function cleanupMessageOwners(map: Map<number, MessageOwnerEntry>, nowMs: number): void {
+  for (const [messageId, owner] of map) {
+    if (!isFiniteMessageId(messageId) || nowMs - owner.recordedAtMs > MESSAGE_OWNER_TTL_MS) {
+      map.delete(messageId);
+    }
+  }
+}
+
+function cleanupCooldownEntries(nowMs: number): void {
+  for (const [key, lastRelayMs] of relayCooldownByKey) {
+    if (nowMs - lastRelayMs > RELAY_COOLDOWN_MS * 10) {
+      relayCooldownByKey.delete(key);
+    }
+  }
+}
+
+function isTelegramMentionWordChar(char: string | undefined): boolean {
+  if (!char) {
+    return false;
+  }
+  return /[a-z0-9_]/i.test(char);
+}
+
+function textMentionsBot(text: string, username: string): boolean {
+  if (!text) {
+    return false;
+  }
+  const normalizedUsername = normalizeUsername(username);
+  if (!normalizedUsername) {
+    return false;
+  }
+  const haystack = text.toLowerCase();
+  const mention = `@${normalizedUsername}`;
+  let startIndex = 0;
+  while (startIndex < haystack.length) {
+    const idx = haystack.indexOf(mention, startIndex);
+    if (idx === -1) {
+      return false;
+    }
+    const prev = idx > 0 ? haystack[idx - 1] : undefined;
+    const next = haystack[idx + mention.length];
+    if (!isTelegramMentionWordChar(prev) && !isTelegramMentionWordChar(next)) {
+      return true;
+    }
+    startIndex = idx + 1;
+  }
+  return false;
+}
+
+async function resolveRelayIdentity(
+  accountId: string,
+  cache: Map<string, TelegramRelayIdentity | null>,
+): Promise<TelegramRelayIdentity | null> {
+  if (cache.has(accountId)) {
+    return cache.get(accountId) ?? null;
+  }
+  const endpoint = relayEndpoints.get(accountId);
+  if (!endpoint) {
+    cache.set(accountId, null);
+    return null;
+  }
+  try {
+    const identity = await endpoint.resolveIdentity();
+    cache.set(accountId, identity);
+    return identity;
+  } catch {
+    cache.set(accountId, null);
+    return null;
+  }
+}
+
+function shouldRelayWithCooldown(params: {
+  chainId: string;
+  chatId: number | string;
+  sourceAccountId: string;
+  targetAccountId: string;
+  nowMs: number;
+}): boolean {
+  const key = `${params.chainId}:${normalizeChatKey(params.chatId)}:${params.sourceAccountId}:${params.targetAccountId}`;
+  const previous = relayCooldownByKey.get(key);
+  if (previous != null && params.nowMs - previous < RELAY_COOLDOWN_MS) {
+    return false;
+  }
+  relayCooldownByKey.set(key, params.nowMs);
+  if (relayCooldownByKey.size > 2048) {
+    cleanupCooldownEntries(params.nowMs);
+  }
+  return true;
+}
+
+function isValidRelayMeta(meta: unknown): meta is TelegramRelayChainMeta {
+  if (!meta || typeof meta !== "object") {
+    return false;
+  }
+  const typed = meta as TelegramRelayChainMeta;
+  return (
+    typeof typed.chainId === "string" &&
+    typed.chainId.trim().length > 0 &&
+    Number.isFinite(typed.turn) &&
+    typed.turn >= 0 &&
+    typeof typed.humanInitiated === "boolean"
+  );
+}
+
+export function registerTelegramGroupRelayEndpoint(endpoint: TelegramRelayEndpoint): () => void {
+  relayEndpoints.set(endpoint.accountId, endpoint);
+  return () => {
+    const current = relayEndpoints.get(endpoint.accountId);
+    if (current === endpoint) {
+      relayEndpoints.delete(endpoint.accountId);
+    }
+  };
+}
+
+export function trackTelegramRelayMessageOwner(params: TrackTelegramRelayMessageParams): void {
+  if (!isFiniteMessageId(params.messageId)) {
+    return;
+  }
+  const nowMs = params.recordedAtMs ?? Date.now();
+  const chatKey = normalizeChatKey(params.chatId);
+  let chatOwners = relayMessageOwners.get(chatKey);
+  if (!chatOwners) {
+    chatOwners = new Map();
+    relayMessageOwners.set(chatKey, chatOwners);
+  }
+  chatOwners.set(params.messageId, {
+    accountId: params.accountId,
+    recordedAtMs: nowMs,
+  });
+  if (chatOwners.size > 512) {
+    cleanupMessageOwners(chatOwners, nowMs);
+  }
+}
+
+export function resolveTelegramRelayMessageOwner(
+  chatId: number | string,
+  messageId: number,
+): string | undefined {
+  if (!isFiniteMessageId(messageId)) {
+    return undefined;
+  }
+  const chatOwners = relayMessageOwners.get(normalizeChatKey(chatId));
+  if (!chatOwners) {
+    return undefined;
+  }
+  cleanupMessageOwners(chatOwners, Date.now());
+  return chatOwners.get(messageId)?.accountId;
+}
+
+export function attachTelegramRelayMeta(
+  message: Message,
+  relayMeta: TelegramRelayChainMeta,
+): Message {
+  (message as Message & { [RELAY_META_SYMBOL]?: TelegramRelayChainMeta })[RELAY_META_SYMBOL] =
+    relayMeta;
+  return message;
+}
+
+export function readTelegramRelayMeta(message: Message): TelegramRelayChainMeta | undefined {
+  const relayMeta = (message as Message & { [RELAY_META_SYMBOL]?: TelegramRelayChainMeta })[
+    RELAY_META_SYMBOL
+  ];
+  return isValidRelayMeta(relayMeta) ? relayMeta : undefined;
+}
+
+export async function publishTelegramGroupRelay(
+  params: PublishTelegramGroupRelayParams,
+): Promise<void> {
+  const sentAtMs = params.sentAtMs ?? Date.now();
+  trackTelegramRelayMessageOwner({
+    chatId: params.chatId,
+    messageId: params.messageId,
+    accountId: params.sourceAccountId,
+    recordedAtMs: sentAtMs,
+  });
+
+  if (!params.isGroup) {
+    return;
+  }
+  if (!params.chain.humanInitiated) {
+    return;
+  }
+  const nextTurn = params.chain.turn + 1;
+  if (nextTurn > RELAY_MAX_TURNS) {
+    return;
+  }
+
+  const text = params.text?.trim() ?? "";
+  const identityCache = new Map<string, TelegramRelayIdentity | null>();
+  const sourceIdentity = await resolveRelayIdentity(params.sourceAccountId, identityCache);
+
+  for (const endpoint of relayEndpoints.values()) {
+    if (endpoint.accountId === params.sourceAccountId) {
+      continue;
+    }
+
+    const targetIdentity = await resolveRelayIdentity(endpoint.accountId, identityCache);
+    const mentionedTarget = textMentionsBot(text, targetIdentity?.botUsername ?? "");
+    const replyTargetsRecipient =
+      params.replyToMessageId != null &&
+      resolveTelegramRelayMessageOwner(params.chatId, params.replyToMessageId) ===
+        endpoint.accountId;
+    if (!mentionedTarget && !replyTargetsRecipient) {
+      continue;
+    }
+    if (
+      !shouldRelayWithCooldown({
+        chainId: params.chain.chainId,
+        chatId: params.chatId,
+        sourceAccountId: params.sourceAccountId,
+        targetAccountId: endpoint.accountId,
+        nowMs: sentAtMs,
+      })
+    ) {
+      continue;
+    }
+
+    await endpoint.handleRelay({
+      chatId: params.chatId,
+      messageId: params.messageId,
+      messageThreadId: params.messageThreadId,
+      text,
+      sentAtMs,
+      replyToMessageId: params.replyToMessageId,
+      replyTargetsRecipient,
+      source: {
+        accountId: params.sourceAccountId,
+        botUserId: sourceIdentity?.botUserId,
+        botUsername: sourceIdentity?.botUsername,
+        botDisplayName: sourceIdentity?.botDisplayName,
+      },
+      target: {
+        accountId: endpoint.accountId,
+        botUserId: targetIdentity?.botUserId,
+        botUsername: targetIdentity?.botUsername,
+        botDisplayName: targetIdentity?.botDisplayName,
+      },
+      relayMeta: {
+        chainId: params.chain.chainId,
+        turn: nextTurn,
+        humanInitiated: params.chain.humanInitiated,
+      },
+    });
+  }
+}
+
+export function clearTelegramGroupRelayState(): void {
+  relayEndpoints.clear();
+  relayMessageOwners.clear();
+  relayCooldownByKey.clear();
+}

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -27,6 +27,7 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
+import { trackTelegramRelayMessageOwner } from "./group-bot-relay.js";
 import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
@@ -727,6 +728,11 @@ export async function sendMessageTelegram(
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
     recordSentMessage(chatId, mediaMessageId);
+    trackTelegramRelayMessageOwner({
+      chatId,
+      messageId: mediaMessageId,
+      accountId: account.accountId,
+    });
     recordChannelActivity({
       channel: "telegram",
       accountId: account.accountId,
@@ -747,6 +753,11 @@ export async function sendMessageTelegram(
       // Return the text message ID as the "main" message (it's the actual content).
       const textMessageId = resolveTelegramMessageIdOrThrow(textRes, "text follow-up send");
       recordSentMessage(chatId, textMessageId);
+      trackTelegramRelayMessageOwner({
+        chatId,
+        messageId: textMessageId,
+        accountId: account.accountId,
+      });
       return {
         messageId: String(textMessageId),
         chatId: resolvedChatId,
@@ -769,6 +780,11 @@ export async function sendMessageTelegram(
   const res = await sendTelegramText(text, textParams, opts.plainText);
   const messageId = resolveTelegramMessageIdOrThrow(res, "text send");
   recordSentMessage(chatId, messageId);
+  trackTelegramRelayMessageOwner({
+    chatId,
+    messageId,
+    accountId: account.accountId,
+  });
   recordChannelActivity({
     channel: "telegram",
     accountId: account.accountId,
@@ -1053,6 +1069,11 @@ export async function sendStickerTelegram(
   const messageId = resolveTelegramMessageIdOrThrow(result, "sticker send");
   const resolvedChatId = String(result?.chat?.id ?? chatId);
   recordSentMessage(chatId, messageId);
+  trackTelegramRelayMessageOwner({
+    chatId,
+    messageId,
+    accountId: account.accountId,
+  });
   recordChannelActivity({
     channel: "telegram",
     accountId: account.accountId,
@@ -1160,6 +1181,11 @@ export async function sendPollTelegram(
   const resolvedChatId = String(result?.chat?.id ?? chatId);
   const pollId = result?.poll?.id;
   recordSentMessage(chatId, messageId);
+  trackTelegramRelayMessageOwner({
+    chatId,
+    messageId,
+    accountId: account.accountId,
+  });
 
   recordChannelActivity({
     channel: "telegram",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram bots in the same group cannot receive each other’s messages, so multi-agent group conversations break.
- Why it matters: families/teams running multiple OpenClaw Telegram bot accounts cannot have bot-to-bot visible collaboration in one group thread.
- What changed: added an OpenClaw-layer Telegram group relay that internally forwards outbound bot messages to other local Telegram bot accounts when targeted by mention/reply, then re-injects them through normal inbound processing.
- What did NOT change (scope boundary): no cross-channel behavior change, no Telegram API polling/webhook protocol changes, and no new user-facing config surface in this patch.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39402
- Related #39386

## User-visible / Behavior Changes

- In Telegram groups, when bot account A sends a message that @mentions bot account B (or replies to a message owned by B), OpenClaw now internally relays that message to B as an inbound event.
- Relayed events continue through existing route/auth/mention processing, so responses still appear on the same Telegram group surface for humans and bots.
- Loop prevention guards added in relay flow:
  - human-initiated chain required
  - max bot-to-bot turn depth = 3
  - per-chain per-target cooldown = 5s

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): multi-account `channels.telegram.accounts.*`

### Steps

1. Configure two Telegram bot accounts in OpenClaw, both in the same Telegram group.
2. Send a group message that triggers bot A to post text mentioning bot B (or replying to B’s message).
3. Confirm OpenClaw internally relays A’s outbound to B and B processes/responds in the same group.

### Expected

- Targeted bot receives/processes peer-bot message, with bounded relay depth and cooldown protection.

### Actual

- Implemented and covered by new relay unit tests and Telegram dispatch tests.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands:

- `pnpm exec oxfmt --check src/telegram/group-bot-relay.ts src/telegram/group-bot-relay.test.ts src/telegram/bot-handlers.ts src/telegram/bot-message-dispatch.ts src/telegram/bot.create-telegram-bot.test-harness.ts src/telegram/bot.ts src/telegram/bot/delivery.replies.ts src/telegram/send.ts` (pass)
- `pnpm test src/telegram/group-bot-relay.test.ts src/telegram/bot-message-dispatch.test.ts` (pass: 64 tests)
- `pnpm test src/telegram/bot.create-telegram-bot.test.ts -t "dedupes duplicate updates for callback_query, message, and channel_post"` (pass)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - mention-target relay routing between account endpoints
  - reply-target ownership routing (no explicit mention required)
  - relay chain metadata propagation and turn incrementing
  - cooldown + max-turn guards in relay path
- Edge cases checked:
  - non-human-initiated chains do not relay
  - relay registry state reset in Telegram bot harness tests to avoid cross-test leakage
- What you did **not** verify:
  - live Telegram multi-bot behavior against real Bot API accounts (local test env only)

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/telegram/group-bot-relay.ts`
  - `src/telegram/bot-handlers.ts`
  - `src/telegram/bot-message-dispatch.ts`
  - `src/telegram/bot/delivery.replies.ts`
  - `src/telegram/send.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected bot-to-bot relay in groups that should be mention/reply gated
  - repeated chained bot replies beyond expected depth/cooldown

## Risks and Mitigations

- Risk: relay state is process-local, so behavior only applies among accounts running in the same gateway process.
  - Mitigation: scoped intentionally to the issue use-case (multi-agent bots on one gateway), with clear bounded relay guards.
- Risk: synthetic relayed inbound messages could bypass mention detection if not guarded.
  - Mitigation: relay dispatch itself enforces mention-or-reply targeting per recipient and retains normal inbound policy checks.
