### PR TITLE
Fix Control UI device auth token signing

### DIFF
--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -148,7 +148,7 @@ describe("GatewayBrowserClient", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps shared auth token separate from cached device token", async () => {
+  it("signs with the shared auth token when one is provided", async () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",
       token: "shared-auth-token",
@@ -167,14 +167,39 @@ describe("GatewayBrowserClient", () => {
     const connectFrame = JSON.parse(ws.sent.at(-1) ?? "{}") as {
       id?: string;
       method?: string;
-      params?: { auth?: { token?: string } };
+      params?: { auth?: { token?: string; deviceToken?: string } };
     };
     expect(connectFrame.id).toBe("req-1");
     expect(connectFrame.method).toBe("connect");
     expect(connectFrame.params?.auth?.token).toBe("shared-auth-token");
+    expect(connectFrame.params?.auth?.deviceToken).toBeUndefined();
     expect(signDevicePayloadMock).toHaveBeenCalledWith("private-key", expect.any(String));
     const signedPayload = signDevicePayloadMock.mock.calls[0]?.[1];
-    expect(signedPayload).toContain("|stored-device-token|nonce-1");
-    expect(signedPayload).not.toContain("shared-auth-token");
+    expect(signedPayload).toContain("|shared-auth-token|nonce-1|test-platform|");
+    expect(signedPayload).not.toContain("stored-device-token");
+  });
+
+  it("falls back to the cached device token when no shared token is provided", async () => {
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+    ws.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "nonce-1" },
+    });
+    await Promise.resolve();
+
+    const connectFrame = JSON.parse(ws.sent.at(-1) ?? "{}") as {
+      params?: { auth?: { token?: string; deviceToken?: string } };
+    };
+    expect(connectFrame.params?.auth?.token).toBe("stored-device-token");
+    expect(connectFrame.params?.auth?.deviceToken).toBe("stored-device-token");
+    const signedPayload = signDevicePayloadMock.mock.calls[0]?.[1];
+    expect(signedPayload).toContain("|stored-device-token|nonce-1|test-platform|");
   });
 });

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -1,4 +1,4 @@
-import { buildDeviceAuthPayload } from "../../../src/gateway/device-auth.js";
+import { buildDeviceAuthPayloadV3 } from "../../../src/gateway/device-auth.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -102,10 +102,12 @@ type Pending = {
 export type GatewayBrowserClientOptions = {
   url: string;
   token?: string;
+  deviceToken?: string;
   password?: string;
   clientName?: GatewayClientName;
   clientVersion?: string;
   platform?: string;
+  deviceFamily?: string;
   mode?: GatewayClientMode;
   instanceId?: string;
   onHello?: (hello: GatewayHelloOk) => void;
@@ -205,22 +207,29 @@ export class GatewayBrowserClient {
     const role = "operator";
     let deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null = null;
     let canFallbackToShared = false;
-    let authToken = this.opts.token;
+    const explicitGatewayToken = this.opts.token?.trim() || undefined;
+    const explicitDeviceToken = this.opts.deviceToken?.trim() || undefined;
+    const authPassword = this.opts.password?.trim() || undefined;
     let deviceToken: string | undefined;
 
     if (isSecureContext) {
       deviceIdentity = await loadOrCreateDeviceIdentity();
-      deviceToken = loadDeviceAuthToken({
+      const storedToken = loadDeviceAuthToken({
         deviceId: deviceIdentity.deviceId,
         role,
       })?.token;
+      deviceToken =
+        explicitDeviceToken ??
+        (!(explicitGatewayToken || authPassword) ? (storedToken ?? undefined) : undefined);
       canFallbackToShared = Boolean(deviceToken && this.opts.token);
     }
+    const authToken = explicitGatewayToken ?? deviceToken;
     const auth =
-      authToken || this.opts.password
+      authToken || authPassword || deviceToken
         ? {
             token: authToken,
-            password: this.opts.password,
+            deviceToken,
+            password: authPassword,
           }
         : undefined;
 
@@ -237,15 +246,18 @@ export class GatewayBrowserClient {
     if (isSecureContext && deviceIdentity) {
       const signedAtMs = Date.now();
       const nonce = this.connectNonce ?? "";
-      const payload = buildDeviceAuthPayload({
+      const platform = this.opts.platform ?? navigator.platform ?? "web";
+      const payload = buildDeviceAuthPayloadV3({
         deviceId: deviceIdentity.deviceId,
         clientId: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
         clientMode: this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT,
         role,
         scopes,
         signedAtMs,
-        token: deviceToken ?? null,
+        token: authToken ?? null,
         nonce,
+        platform,
+        deviceFamily: this.opts.deviceFamily,
       });
       const signature = await signDevicePayload(deviceIdentity.privateKey, payload);
       device = {
@@ -263,6 +275,7 @@ export class GatewayBrowserClient {
         id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
         version: this.opts.clientVersion ?? "control-ui",
         platform: this.opts.platform ?? navigator.platform ?? "web",
+        deviceFamily: this.opts.deviceFamily,
         mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT,
         instanceId: this.opts.instanceId,
       },


### PR DESCRIPTION
## Summary

Fix the Control UI browser client so device auth signs the same effective token that is sent in the `connect` auth payload.

## What changed

- align browser token resolution with the canonical gateway client
- include `auth.deviceToken` on the device-token fallback path
- sign with the effective auth token instead of a stale cached token
- use the v3 device-auth payload in the browser client
- add regression coverage for shared-token and cached-device-token behavior

## Verification

- `pnpm ui:build`
- reproduced browser connection success after the fix

Closes #39417
