### PR TITLE
config-cli: add --no-redact flag to config get tokens

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -318,7 +318,9 @@ Common signatures:
 
 ```bash
 openclaw config get gateway.bind
-openclaw config get gateway.auth.token
+# use --no-redact if you need to see the actual token instead of
+# the default redacted sentinel
+openclaw config get gateway.auth.token [--no-redact]
 openclaw gateway status
 openclaw logs --follow
 ```

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -349,7 +349,8 @@ The wizard opens your browser with a clean (non-tokenized) dashboard URL right a
 
 - Open `http://127.0.0.1:18789/`.
 - If it asks for auth, paste the token from `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`) into Control UI settings.
-- Retrieve it from the gateway host: `openclaw config get gateway.auth.token` (or generate one: `openclaw doctor --generate-gateway-token`).
+- Retrieve it from the gateway host:
+  `openclaw config get gateway.auth.token --no-redact` (or generate one: `openclaw doctor --generate-gateway-token`).
 
 **Not on localhost:**
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -349,8 +349,7 @@ The wizard opens your browser with a clean (non-tokenized) dashboard URL right a
 
 - Open `http://127.0.0.1:18789/`.
 - If it asks for auth, paste the token from `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`) into Control UI settings.
-- Retrieve it from the gateway host:
-  `openclaw config get gateway.auth.token --no-redact` (or generate one: `openclaw doctor --generate-gateway-token`).
+- Retrieve it from the gateway host: `openclaw config get gateway.auth.token --no-redact` (or generate one: `openclaw doctor --generate-gateway-token`).
 
 **Not on localhost:**
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -243,13 +243,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand([
-        "config",
-        "get",
-        "gateway.auth.token",
-        "--no-redact",
-        "--json",
-      ]);
+      await runConfigCommand(["config", "get", "gateway.auth.token", "--no-redact", "--json"]);
 
       const output = mockLog.mock.calls.at(0)?.[0];
       expect(output).toBe(JSON.stringify("super-secret-token", null, 2));

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -203,7 +203,7 @@ describe("config cli", () => {
   });
 
   describe("config get", () => {
-    it("redacts sensitive values", async () => {
+    it("redacts sensitive values by default", async () => {
       const resolved: OpenClawConfig = {
         gateway: {
           auth: {
@@ -216,6 +216,43 @@ describe("config cli", () => {
       await runConfigCommand(["config", "get", "gateway.auth.token"]);
 
       expect(mockLog).toHaveBeenCalledWith("__OPENCLAW_REDACTED__");
+    });
+
+    it("returns the real value when --no-redact is specified", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          auth: {
+            token: "super-secret-token",
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "get", "gateway.auth.token", "--no-redact"]);
+
+      expect(mockLog).toHaveBeenCalledWith("super-secret-token");
+    });
+
+    it("works with --json alongside --no-redact", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          auth: {
+            token: "super-secret-token",
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "get",
+        "gateway.auth.token",
+        "--no-redact",
+        "--json",
+      ]);
+
+      const output = mockLog.mock.calls.at(0)?.[0];
+      expect(output).toBe(JSON.stringify("super-secret-token", null, 2));
     });
   });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -276,7 +276,12 @@ function ensureValidOllamaProviderForApiKeySet(
   });
 }
 
-export async function runConfigGet(opts: { path: string; json?: boolean; noRedact?: boolean; runtime?: RuntimeEnv }) {
+export async function runConfigGet(opts: {
+  path: string;
+  json?: boolean;
+  noRedact?: boolean;
+  runtime?: RuntimeEnv;
+}) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const parsedPath = parseRequiredPath(opts.path);
@@ -423,17 +428,10 @@ export function registerConfigCli(program: Command) {
     .description("Get a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
     .option("--json", "Output JSON", false)
-    .option(
-      "--no-redact",
-      "Do not redact sensitive values (use with caution, may expose secrets)",
-      false,
-    )
+    .option("--no-redact", "Show sensitive values in plaintext instead of redacting them")
     .action(async (path: string, opts) => {
-      await runConfigGet({
-        path,
-        json: Boolean(opts.json),
-        noRedact: Boolean(opts.noRedact),
-      });
+      // Commander maps --no-redact to opts.redact = false
+      await runConfigGet({ path, json: Boolean(opts.json), noRedact: opts.redact === false });
     });
 
   cmd

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -276,13 +276,17 @@ function ensureValidOllamaProviderForApiKeySet(
   });
 }
 
-export async function runConfigGet(opts: { path: string; json?: boolean; runtime?: RuntimeEnv }) {
+export async function runConfigGet(opts: { path: string; json?: boolean; noRedact?: boolean; runtime?: RuntimeEnv }) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const parsedPath = parseRequiredPath(opts.path);
     const snapshot = await loadValidConfig(runtime);
-    const redacted = redactConfigObject(snapshot.config);
-    const res = getAtPath(redacted, parsedPath);
+    // By default we redact sensitive values so they do not leak to terminal
+    // history or logs.  Callers can request the raw value with
+    // `--no-redact` for debugging purposes (the value may still be
+    // redacted elsewhere, e.g. when writing snapshots).
+    const configToQuery = opts.noRedact ? snapshot.config : redactConfigObject(snapshot.config);
+    const res = getAtPath(configToQuery, parsedPath);
     if (!res.found) {
       runtime.error(danger(`Config path not found: ${opts.path}`));
       runtime.exit(1);
@@ -419,8 +423,17 @@ export function registerConfigCli(program: Command) {
     .description("Get a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
     .option("--json", "Output JSON", false)
+    .option(
+      "--no-redact",
+      "Do not redact sensitive values (use with caution, may expose secrets)",
+      false,
+    )
     .action(async (path: string, opts) => {
-      await runConfigGet({ path, json: Boolean(opts.json) });
+      await runConfigGet({
+        path,
+        json: Boolean(opts.json),
+        noRedact: Boolean(opts.noRedact),
+      });
     });
 
   cmd

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -91,7 +91,7 @@ describe("program routes", () => {
         "--json",
       ]),
     ).resolves.toBe(true);
-    expect(runConfigGetMock).toHaveBeenCalledWith({ path: "update.channel", json: true });
+    expect(runConfigGetMock).toHaveBeenCalledWith({ path: "update.channel", json: true, noRedact: false });
   });
 
   it("passes config unset path correctly when root option values precede command", async () => {
@@ -116,7 +116,7 @@ describe("program routes", () => {
         "--json",
       ]),
     ).resolves.toBe(true);
-    expect(runConfigGetMock).toHaveBeenCalledWith({ path: "update.channel", json: true });
+    expect(runConfigGetMock).toHaveBeenCalledWith({ path: "update.channel", json: true, noRedact: false });
   });
 
   it("passes config unset path when root value options appear after subcommand", async () => {

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -91,7 +91,11 @@ describe("program routes", () => {
         "--json",
       ]),
     ).resolves.toBe(true);
-    expect(runConfigGetMock).toHaveBeenCalledWith({ path: "update.channel", json: true, noRedact: false });
+    expect(runConfigGetMock).toHaveBeenCalledWith({
+      path: "update.channel",
+      json: true,
+      noRedact: false,
+    });
   });
 
   it("passes config unset path correctly when root option values precede command", async () => {
@@ -116,7 +120,11 @@ describe("program routes", () => {
         "--json",
       ]),
     ).resolves.toBe(true);
-    expect(runConfigGetMock).toHaveBeenCalledWith({ path: "update.channel", json: true, noRedact: false });
+    expect(runConfigGetMock).toHaveBeenCalledWith({
+      path: "update.channel",
+      json: true,
+      noRedact: false,
+    });
   });
 
   it("passes config unset path when root value options appear after subcommand", async () => {

--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -139,7 +139,7 @@ const routeConfigGet: RouteSpec = {
   run: async (argv) => {
     const positionals = getCommandPositionalsWithRootOptions(argv, {
       commandPath: ["config", "get"],
-      booleanFlags: ["--json"],
+      booleanFlags: ["--json", "--no-redact"],
     });
     if (!positionals || positionals.length !== 1) {
       return false;
@@ -149,8 +149,9 @@ const routeConfigGet: RouteSpec = {
       return false;
     }
     const json = hasFlag(argv, "--json");
+    const noRedact = hasFlag(argv, "--no-redact");
     const { runConfigGet } = await import("../config-cli.js");
-    await runConfigGet({ path: pathArg, json });
+    await runConfigGet({ path: pathArg, json, noRedact });
     return true;
   },
 };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** `openclaw config get` redacts every sensitive value (e.g. `gateway.auth.token`) by
  default, which is good for safety but makes it impossible to retrieve the real
  value from the CLI without editing the config file.
- **Why it matters:** users/developers often need the actual token for tooling,
  scripts, debugging, or dashboard auth; the current behaviour forces them to
  read the config file or regenerate a token.
- **What changed:** added a `--no-redact` boolean option to `config get` (CLI,
  fast‑routing and tests updated), plus docs/FAQ/troubleshooting entries.
  The option bypasses `redactConfigObject()` so callers receive the raw value.
- **What did NOT change (scope boundary):** redaction still happens by default
  and for all other commands; web UI and server-side redaction are unaffected.

<img width="936" height="251" alt="Screenshot 2026-03-07 at 7 38 04 PM" src="https://github.com/user-attachments/assets/1c9cb17a-6f61-4584-babe-cd2ba92afc0a" />

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Docs
- [ ] Refactor
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none filed)
- Related # (none)

## User-visible / Behavior Changes

- `openclaw config get` now accepts `--no-redact`; without it the output is
  still `__OPENCLAW_REDACTED__`.
- Documentation and FAQ updated to show the full command.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes` – opt‑in bypass of redaction)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Exposing secret values is intentionally opt‑in; users must explicitly pass
    `--no-redact`. CLI logs/tests still treat redacted output as default, so
    accidental leaks are unlikely.

## Repro + Verification

### Environment

- OS: any (tests run on CI container)
- Runtime/container: Node 22+
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): `gateway.auth.token` set to dummy value

### Steps

1. Set a gateway token in config.
2. Run `openclaw config get gateway.auth.token` → see `__OPENCLAW_REDACTED__`.
3. Run `openclaw config get gateway.auth.token --no-redact` → see real token.

### Expected

- step 2 prints sentinel
- step 3 prints token string

### Actual

- behavior matches expected.

## Evidence

- New unit tests cover both redacted default and `--no-redact` (normal and
  `--json` variants).
- Documentation snippets updated.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - CLI output with/without `--no-redact`.
  - Routing layer correctly parsed the new flag.
  - Docs render correctly locally.
- Edge cases checked:
  - `--json` combined with `--no-redact`.
  - Unrelated `config get` paths unaffected.
- What you did **not** verify:
  - behavior on macOS GUI (not applicable).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert the commit or simply stop using `--no-redact`; default behavior is
    unchanged.
- Files/config to restore:
  - none
- Known bad symptoms reviewers should watch for:
  - flag not parsed (CLI error), or redaction bypassed unintentionally.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users might accidentally run `config get … --no-redact` in shared
  terminals and leak secrets.
  - Mitigation: it’s opt‑in and documented; default output remains safe.
