### PR TITLE
fix(auth): accept newer Anthropic setup-token prefixes

### DIFF
--- a/src/agents/anthropic.setup-token.live.test.ts
+++ b/src/agents/anthropic.setup-token.live.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { type Api, completeSimple, type Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
-  ANTHROPIC_SETUP_TOKEN_PREFIX,
+  hasAllowedAnthropicSetupTokenPrefix,
   validateAnthropicSetupToken,
 } from "../commands/auth-token.js";
 import { loadConfig } from "../config/config.js";
@@ -37,7 +37,7 @@ type TokenSource = {
 };
 
 function isSetupToken(value: string): boolean {
-  return value.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX);
+  return hasAllowedAnthropicSetupTokenPrefix(value);
 }
 
 function listSetupTokenProfiles(store: {

--- a/src/commands/auth-token.test.ts
+++ b/src/commands/auth-token.test.ts
@@ -12,8 +12,22 @@ describe("validateAnthropicSetupToken", () => {
     expect(validateAnthropicSetupToken(token)).toBeUndefined();
   });
 
+  it("accepts bb-prefixed setup tokens", () => {
+    const token = `bb${"x".repeat(80)}`;
+    expect(validateAnthropicSetupToken(token)).toBeUndefined();
+  });
+
+  it("rejects too-short setup tokens", () => {
+    const token = "sk-ant-oat01-short";
+    expect(validateAnthropicSetupToken(token)).toBe(
+      "Token looks too short; paste the full setup-token",
+    );
+  });
+
   it("rejects non-anthropic tokens", () => {
     const token = `sk-proj-${"x".repeat(120)}`;
-    expect(validateAnthropicSetupToken(token)).toBe("Expected token starting with sk-ant-");
+    expect(validateAnthropicSetupToken(token)).toBe(
+      "Expected token starting with one of: sk-ant-, bb",
+    );
   });
 });

--- a/src/commands/auth-token.test.ts
+++ b/src/commands/auth-token.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { validateAnthropicSetupToken } from "./auth-token.js";
+
+describe("validateAnthropicSetupToken", () => {
+  it("accepts legacy oat01 setup tokens", () => {
+    const token = `sk-ant-oat01-${"x".repeat(80)}`;
+    expect(validateAnthropicSetupToken(token)).toBeUndefined();
+  });
+
+  it("accepts newer anthropic setup token prefixes", () => {
+    const token = `sk-ant-api02-${"x".repeat(80)}`;
+    expect(validateAnthropicSetupToken(token)).toBeUndefined();
+  });
+
+  it("rejects non-anthropic tokens", () => {
+    const token = `sk-proj-${"x".repeat(120)}`;
+    expect(validateAnthropicSetupToken(token)).toBe("Expected token starting with sk-ant-");
+  });
+});

--- a/src/commands/auth-token.ts
+++ b/src/commands/auth-token.ts
@@ -1,7 +1,7 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 
 export const ANTHROPIC_SETUP_TOKEN_PREFIX = "sk-ant-oat01-";
-export const ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIX = "sk-ant-";
+export const ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIXES = ["sk-ant-", "bb"] as const;
 export const ANTHROPIC_SETUP_TOKEN_MIN_LENGTH = 80;
 export const DEFAULT_TOKEN_PROFILE_NAME = "default";
 
@@ -24,13 +24,18 @@ export function buildTokenProfileId(params: { provider: string; name: string }):
   return `${provider}:${name}`;
 }
 
+export function hasAllowedAnthropicSetupTokenPrefix(raw: string): boolean {
+  const trimmed = raw.trim();
+  return ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
 export function validateAnthropicSetupToken(raw: string): string | undefined {
   const trimmed = raw.trim();
   if (!trimmed) {
     return "Required";
   }
-  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIX)) {
-    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIX}`;
+  if (!hasAllowedAnthropicSetupTokenPrefix(trimmed)) {
+    return `Expected token starting with one of: ${ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIXES.join(", ")}`;
   }
   if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
     return "Token looks too short; paste the full setup-token";

--- a/src/commands/auth-token.ts
+++ b/src/commands/auth-token.ts
@@ -1,6 +1,7 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 
 export const ANTHROPIC_SETUP_TOKEN_PREFIX = "sk-ant-oat01-";
+export const ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIX = "sk-ant-";
 export const ANTHROPIC_SETUP_TOKEN_MIN_LENGTH = 80;
 export const DEFAULT_TOKEN_PROFILE_NAME = "default";
 
@@ -28,8 +29,8 @@ export function validateAnthropicSetupToken(raw: string): string | undefined {
   if (!trimmed) {
     return "Required";
   }
-  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX)) {
-    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIX}`;
+  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIX)) {
+    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_ALLOWED_PREFIX}`;
   }
   if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
     return "Token looks too short; paste the full setup-token";


### PR DESCRIPTION
## Summary
- relax Anthropic setup-token prefix validation from exact `sk-ant-oat01-` to generic `sk-ant-`
- keep minimum-length guard so obviously incomplete tokens are still rejected
- add focused tests covering legacy prefix, newer prefix variants, and non-Anthropic rejection

## Testing
- pnpm vitest run src/commands/auth-token.test.ts

## Related
Fixes #39423