### PR TITLE
fix(setup-podman): cd to TMPDIR before podman load to avoid cwd permission error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Docs/browser: add a layered WSL2 + Windows remote Chrome CDP troubleshooting guide, including Control UI origin pitfalls and extension-relay bind-address guidance. (#39407) Thanks @Owlock.
 - Context engine registry/bundled builds: share the registry state through a `globalThis` singleton so duplicated bundled module copies can resolve engines registered by each other at runtime, with regression coverage for duplicate-module imports. (#40115) thanks @jalehman.
 - macOS/Tailscale gateway discovery: keep Tailscale Serve probing alive when other remote gateways are already discovered, prefer direct transport for resolved `.ts.net` and Tailscale Serve gateways, and set `TERM=dumb` for GUI-launched Tailscale CLI discovery. (#40167) thanks @ngutman.
+- Podman/setup: fix `cannot chdir: Permission denied` in `run_as_user` when `setup-podman.sh` is invoked from a directory the target user cannot access, by wrapping user-switch calls in a subshell that cd's to `/tmp` with `/` fallback. (#39435) Thanks @langdon and @jlcbk.
 
 ## 2026.3.7
 

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -267,7 +267,8 @@ podman save openclaw:local -o "$TMP_IMAGE"
 chmod 600 "$TMP_IMAGE"
 # Stream the image into the target user's podman load so private temp directories
 # do not need to be traversable by $OPENCLAW_USER.
-cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load
+# cd to /tmp so podman load (running as openclaw) doesn't inherit a cwd it can't access.
+(cd "${TMPDIR:-/tmp}" && cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load)
 rm -rf "$TMP_STAGE_DIR"
 trap - EXIT
 

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -80,12 +80,17 @@ run_root() {
 }
 
 run_as_user() {
+  # When switching users, the caller's cwd may be inaccessible to the target
+  # user (e.g. a private home dir). Wrap in a subshell that cd's to a
+  # world-traversable directory so sudo/runuser don't fail with "cannot chdir".
+  # TODO: replace with fully rootless podman build to eliminate the need for
+  # user-switching entirely.
   local user="$1"
   shift
   if command -v sudo >/dev/null 2>&1; then
-    sudo -u "$user" "$@"
+    ( cd /tmp 2>/dev/null || cd /; sudo -u "$user" "$@" )
   elif is_root && command -v runuser >/dev/null 2>&1; then
-    runuser -u "$user" -- "$@"
+    ( cd /tmp 2>/dev/null || cd /; runuser -u "$user" -- "$@" )
   else
     echo "Need sudo (or root+runuser) to run commands as $user." >&2
     exit 1
@@ -267,8 +272,7 @@ podman save openclaw:local -o "$TMP_IMAGE"
 chmod 600 "$TMP_IMAGE"
 # Stream the image into the target user's podman load so private temp directories
 # do not need to be traversable by $OPENCLAW_USER.
-# cd to /tmp so podman load (running as openclaw) doesn't inherit a cwd it can't access.
-(cd "${TMPDIR:-/tmp}" && cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load)
+cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load
 rm -rf "$TMP_STAGE_DIR"
 trap - EXIT
 


### PR DESCRIPTION
Fixes #39434

## Summary

- `setup-podman.sh` fails during `podman load` with `cannot chdir: Permission denied` when invoked from a directory the `openclaw` user cannot access (typical for home directory repo checkouts)
- `run_as_user` calls `sudo -u openclaw`, which inherits the caller's cwd; Podman then fails when it tries to verify that cwd
- Fix: wrap the `podman load` pipeline in a subshell that first `cd`s to `${TMPDIR:-/tmp}` (world-accessible); `$TMP_IMAGE` is always absolute so `cat` is unaffected

## Test plan

- [x] Reproduced the failure on Fedora 43 with `sudo ./setup-podman.sh --quadlet` from a private home directory checkout
- [x] Confirmed fix resolves the error and setup completes successfully end-to-end
- [x] `src/docker-setup.test.ts` — 9/9 tests pass

## AI-assisted

This fix was identified and written with Claude Code. The root cause, fix, and test were reviewed and understood before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)