### PR TITLE
Fix profile API key normalization for agent auth

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -348,6 +348,24 @@ describe("getApiKeyForModel", () => {
     });
   });
 
+  it("sanitizes non-Latin1 characters from auth profile API keys", async () => {
+    const resolved = await resolveApiKeyForProvider({
+      provider: "anthropic",
+      store: {
+        version: 1,
+        profiles: {
+          "anthropic:default": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "\u2502sk-ant-test-key",
+          },
+        },
+      },
+    });
+    expect(resolved.apiKey).toBe("sk-ant-test-key");
+    expect(resolved.source).toBe("profile:anthropic:default");
+  });
+
   it("resolveEnvApiKey('huggingface') returns HUGGINGFACE_HUB_TOKEN when set", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -179,12 +179,13 @@ export async function resolveApiKeyForProvider(params: {
       profileId,
       agentDir: params.agentDir,
     });
-    if (!resolved) {
+    const sanitizedApiKey = normalizeOptionalSecretInput(resolved?.apiKey);
+    if (!resolved || !sanitizedApiKey) {
       throw new Error(`No credentials found for profile "${profileId}".`);
     }
     const mode = store.profiles[profileId]?.type;
     return {
-      apiKey: resolved.apiKey,
+      apiKey: sanitizedApiKey,
       profileId,
       source: `profile:${profileId}`,
       mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
@@ -210,10 +211,11 @@ export async function resolveApiKeyForProvider(params: {
         profileId: candidate,
         agentDir: params.agentDir,
       });
-      if (resolved) {
+      const sanitizedApiKey = normalizeOptionalSecretInput(resolved?.apiKey);
+      if (resolved && sanitizedApiKey) {
         const mode = store.profiles[candidate]?.type;
         return {
-          apiKey: resolved.apiKey,
+          apiKey: sanitizedApiKey,
           profileId: candidate,
           source: `profile:${candidate}`,
           mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw agent --agent main --message "hello"` could fail with a ByteString error when an auth-profile key contained pasted Unicode box-drawing characters (for example U+2502 `│`).
- Why it matters: the agent command fails before sending a model request, producing a low-level runtime error instead of a normal auth error/path.
- What changed: normalized profile-resolved API keys in `resolveApiKeyForProvider` before returning them, including explicit `--profile` and ordered profile fallback paths.
- What did NOT change (scope boundary): no provider/model selection logic changes, no gateway protocol changes, and no non-profile credential source changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39426
- Related #

## User-visible / Behavior Changes

- `openclaw agent ...` no longer surfaces a ByteString crash when a stored auth-profile key contains non-Latin1 paste artifacts; the key is sanitized before runtime use.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: key normalization could alter malformed stored secrets.
  - Mitigation: normalization is already used for env/config secret paths and now aligns profile behavior to prevent invalid header ByteString failures.

## Repro + Verification

### Environment

- OS: macOS (issue report), local validation on dev workspace
- Runtime/container: Node.js 22.x, pnpm
- Model/provider: profile credential resolution path
- Integration/channel (if any): CLI `agent`
- Relevant config (redacted): auth profile store with an API key containing leading U+2502

### Steps

1. Configure an auth profile with a key containing `│` (U+2502) at the start.
2. Resolve provider auth via agent credential path.
3. Run agent command.

### Expected

- Key is sanitized before runtime use; no ByteString conversion crash.

### Actual

- Before fix: invalid key chars could reach runtime header construction and fail with ByteString conversion error.
- After fix: sanitized key is returned from profile path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran targeted test including new regression for U+2502 profile key sanitization.
- Edge cases checked:
  - Explicit profile path and profile-order path both normalize before return.
- What you did **not** verify:
  - End-to-end local model invocation with a real provider key in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Agent: sanitize profile API keys before runtime use`.
- Files/config to restore:
  - `src/agents/model-auth.ts`
  - `src/agents/model-auth.profiles.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected "No credentials found for profile ..." if a profile key normalizes to empty.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: malformed legacy profile keys now normalize earlier and may expose missing-credential errors.
  - Mitigation: this is safer than request-time ByteString crashes and matches existing env/config normalization behavior.

## Validation Commands

- `pnpm test src/agents/model-auth.profiles.test.ts`
  - Result: passed (`1` file, `19` tests).
