### PR TITLE
Gateway: fix Control UI method guard blocking plugin webhook POST requests

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -275,11 +275,12 @@ export function handleControlUiHttpRequest(
   if (!urlRaw) {
     return false;
   }
+
+  // Pass non-GET/HEAD requests through so downstream handlers (plugin HTTP
+  // routes/handlers, webhooks, etc.) are not blocked by the Control UI SPA
+  // fallback.  The SPA only serves static assets and never handles POST.
   if (req.method !== "GET" && req.method !== "HEAD") {
-    res.statusCode = 405;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end("Method Not Allowed");
-    return true;
+    return false;
   }
 
   const url = new URL(urlRaw, "http://localhost");


### PR DESCRIPTION
## Summary

- `handleControlUiHttpRequest` rejects all non-GET/HEAD requests with 405 **before** checking whether the URL path belongs to the Control UI. Because this handler runs before plugin HTTP routes/handlers in the gateway request chain (`server-http.ts`), every POST request — including plugin webhooks registered via `registerHttpHandler` or `registerHttpRoute` (e.g. `/dchat`) — is intercepted and never reaches the plugin handler.
- Changed the early method guard from returning 405 to `return false`, letting non-GET/HEAD requests fall through to downstream handlers. The Control UI is a static SPA that only serves GET/HEAD requests and has no reason to claim POST.

## Test plan

- [x] `control-ui.http.test.ts` — 14 tests passed
- [x] `gateway-misc.test.ts` — 21 tests passed
- [x] `server.plugin-http-auth.test.ts` — 14 tests passed
- [x] `control-ui-csp.test.ts` — 2 tests passed
- [ ] Manual: restart gateway, verify `POST /dchat` no longer returns 405

🤖 Generated with [Qoder][https://qoder.com]