### PR TITLE
fix(slack): allow unsigned url_verification challenge in HTTP mode

### DIFF
--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { parse as parseQueryString } from "node:querystring";
 import SlackBolt from "@slack/bolt";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
@@ -21,7 +22,7 @@ import { normalizeResolvedSecretInputString } from "../../config/types.secrets.j
 import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-patches.js";
 import { warn } from "../../globals.js";
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
-import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
+import { installRequestBodyLimitGuard, readRequestBodyWithLimit } from "../../infra/http-body.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
@@ -219,6 +220,33 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             return;
           }
           try {
+            // Slack url_verification challenge requests don't include signatures
+            // We need to handle them before the HTTPReceiver's signature verification
+            const rawBody = await readRequestBodyWithLimit(req, {
+              maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
+              timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
+            });
+            const contentType = req.headers["content-type"] || "";
+            
+            let body: { [key: string]: unknown } | unknown;
+            if (contentType.includes("application/x-www-form-urlencoded")) {
+              body = parseQueryString(rawBody);
+            } else {
+              try {
+                body = JSON.parse(rawBody);
+              } catch {
+                body = {};
+              }
+            }
+            
+            // Handle url_verification challenge (no signature)
+            if (body?.type === "url_verification") {
+              res.writeHead(200, { "content-type": "application/json" });
+              res.end(JSON.stringify({ challenge: body.challenge }));
+              return;
+            }
+            
+            // Delegate to HTTPReceiver for all other requests
             await Promise.resolve(receiver.requestListener(req, res));
           } catch (err) {
             if (!guard.isTripped()) {

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -191,6 +191,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       ? new HTTPReceiver({
           signingSecret: signingSecret ?? "",
           endpoints: slackWebhookPath,
+          signatureVerification: false,
         })
       : null;
   const clientOptions = resolveSlackWebClientOptions();
@@ -220,14 +221,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             return;
           }
           try {
-            // Slack url_verification challenge requests don't include signatures
-            // We need to handle them before the HTTPReceiver's signature verification
+            // Read and cache the request body
             const rawBody = await readRequestBodyWithLimit(req, {
               maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
               timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
             });
-            const contentType = req.headers["content-type"] || "";
             
+            // Parse body to check for url_verification
+            const contentType = req.headers["content-type"] || "";
             let body: { [key: string]: unknown } | unknown;
             if (contentType.includes("application/x-www-form-urlencoded")) {
               body = parseQueryString(rawBody);
@@ -239,14 +240,33 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
               }
             }
             
-            // Handle url_verification challenge (no signature)
-            if (body?.type === "url_verification") {
+            // Handle url_verification challenge (no signature required)
+            if (body && typeof body === "object" && "type" in body && body.type === "url_verification") {
               res.writeHead(200, { "content-type": "application/json" });
-              res.end(JSON.stringify({ challenge: body.challenge }));
+              res.end(JSON.stringify({ challenge: (body as { challenge: string }).challenge }));
               return;
             }
             
-            // Delegate to HTTPReceiver for all other requests
+            // For other requests, verify signature manually (HTTPReceiver expects unsigned body)
+            const { signature, timestamp } = extractSlackSignatureHeaders(req);
+            if (signature && timestamp !== undefined && signingSecret) {
+              const isValid = verifySlackSignature({
+                signingSecret,
+                body: rawBody,
+                signature,
+                timestamp,
+              });
+              if (!isValid) {
+                res.writeHead(401);
+                res.end("Invalid signature");
+                return;
+              }
+            }
+            
+            // Manually create buffered request with cached body for HTTPReceiver
+            (req as { rawBody: Buffer }).rawBody = Buffer.from(rawBody);
+            
+            // Delegate to HTTPReceiver (signature verification is disabled)
             await Promise.resolve(receiver.requestListener(req, res));
           } catch (err) {
             if (!guard.isTripped()) {

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -23,6 +23,7 @@ import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-
 import { warn } from "../../globals.js";
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
 import { installRequestBodyLimitGuard, readRequestBodyWithLimit } from "../../infra/http-body.js";
+import { extractSlackSignatureHeaders, verifySlackSignature } from "./slack-signature.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
@@ -248,19 +249,27 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             }
             
             // For other requests, verify signature manually (HTTPReceiver expects unsigned body)
+            // url_verification is already handled above; all other requests MUST have valid signatures
             const { signature, timestamp } = extractSlackSignatureHeaders(req);
-            if (signature && timestamp !== undefined && signingSecret) {
-              const isValid = verifySlackSignature({
-                signingSecret,
-                body: rawBody,
-                signature,
-                timestamp,
-              });
-              if (!isValid) {
-                res.writeHead(401);
-                res.end("Invalid signature");
-                return;
-              }
+            
+            // Reject requests without signature headers (except url_verification which was handled above)
+            if (!signature || timestamp === undefined) {
+              res.writeHead(401);
+              res.end("Missing signature");
+              return;
+            }
+            
+            // Verify signature
+            const isValid = verifySlackSignature({
+              signingSecret,
+              body: rawBody,
+              signature,
+              timestamp,
+            });
+            if (!isValid) {
+              res.writeHead(401);
+              res.end("Invalid signature");
+              return;
             }
             
             // Manually create buffered request with cached body for HTTPReceiver

--- a/src/slack/monitor/slack-signature.ts
+++ b/src/slack/monitor/slack-signature.ts
@@ -1,0 +1,53 @@
+import crypto from "node:crypto";
+import type { IncomingMessage } from "node:http";
+
+/**
+ * Verify Slack request signature (HMAC-SHA256)
+ * Based on: https://api.slack.com/authentication/verifying-requests-from-slack
+ */
+export function verifySlackSignature(params: {
+  signingSecret: string;
+  body: string;
+  signature: string;
+  timestamp: number;
+}): boolean {
+  const { signingSecret, body, signature, timestamp } = params;
+
+  // Check timestamp is within 5 minutes
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > 5 * 60) {
+    return false;
+  }
+
+  // Compute HMAC-SHA256
+  const hmac = crypto.createHmac("sha256", signingSecret);
+  const baseString = `${timestamp}:${body}`;
+  hmac.update(baseString);
+  const computedSignature = `v0=${hmac.digest("hex")}`;
+
+  // Compare signatures using constant-time comparison
+  return crypto.timingSafeEqual(
+    Buffer.from(computedSignature),
+    Buffer.from(signature),
+  );
+}
+
+/**
+ * Extract signature and timestamp from request headers
+ */
+export function extractSlackSignatureHeaders(req: IncomingMessage): {
+  signature?: string;
+  timestamp?: number;
+} {
+  const signature = Array.isArray(req.headers["x-slack-signature"])
+    ? req.headers["x-slack-signature"][0]
+    : req.headers["x-slack-signature"];
+
+  const timestampHeader = Array.isArray(req.headers["x-slack-request-timestamp"])
+    ? req.headers["x-slack-request-timestamp"][0]
+    : req.headers["x-slack-request-timestamp"];
+
+  const timestamp = timestampHeader ? Number.parseInt(timestampHeader, 10) : undefined;
+
+  return { signature, timestamp };
+}

--- a/src/slack/monitor/slack-signature.ts
+++ b/src/slack/monitor/slack-signature.ts
@@ -21,15 +21,20 @@ export function verifySlackSignature(params: {
 
   // Compute HMAC-SHA256
   const hmac = crypto.createHmac("sha256", signingSecret);
-  const baseString = `${timestamp}:${body}`;
+  const baseString = `v0:${timestamp}:${body}`;
   hmac.update(baseString);
   const computedSignature = `v0=${hmac.digest("hex")}`;
 
   // Compare signatures using constant-time comparison
-  return crypto.timingSafeEqual(
-    Buffer.from(computedSignature),
-    Buffer.from(signature),
-  );
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(computedSignature),
+      Buffer.from(signature),
+    );
+  } catch {
+    // timingSafeEqual throws RangeError if buffer lengths differ
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
Slack's initial url_verification challenge requests don't include X-Slack-Signature headers, causing HTTPReceiver to reject them with 401 errors. This made HTTP mode impossible to use.

**V2 Fix - Proper body handling:**

This version properly handles the request body without consuming it:
1. Creates a custom Slack signature verification module (slack-signature.ts)
2. Disables HTTPReceiver's automatic signature verification
3. Reads and caches the request body once
4. Checks for url_verification and responds immediately if found
5. Manually verifies signatures for all other requests
6. Injects the cached body into the request for HTTPReceiver

This approach avoids the stream consumption bug from V1 that would break all other Slack events in HTTP mode.

Fixes #39432