### PR TITLE
fix(agents): detect codex sandbox-denied runs that exit 0 as failures

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -44,6 +44,7 @@ export type AuthProfileFailureReason =
   | "billing"
   | "timeout"
   | "model_not_found"
+  | "sandbox_denied"
   | "session_expired"
   | "unknown";
 

--- a/src/agents/cli-runner.sandbox-denied.test.ts
+++ b/src/agents/cli-runner.sandbox-denied.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { detectSandboxDenied, parseCliJsonl } from "./cli-runner/helpers.js";
+
+const CODEX_BACKEND = {
+  command: "codex",
+  args: ["exec", "--json"],
+  output: "jsonl" as const,
+  input: "arg" as const,
+  sessionIdFields: ["thread_id"],
+};
+
+describe("detectSandboxDenied", () => {
+  it("detects top-level error string mentioning sandbox policy", () => {
+    const records = [{ error: "sandbox policy: write denied for /tmp/TEST_RO.md" }];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
+
+  it("detects nested error.message mentioning sandbox denied", () => {
+    const records = [{ error: { message: "Operation sandbox denied: cannot write file" } }];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
+
+  it("detects item type error with sandbox text", () => {
+    const records = [
+      {
+        item: {
+          type: "error",
+          text: "The file could not be written because the sandbox policy blocks writes in read-only mode.",
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
+
+  it("detects tool-call output reporting sandbox denial", () => {
+    const records = [
+      {
+        item: {
+          type: "tool_call_output",
+          text: "sandbox policy: write to /workspace/TEST_RO.md denied",
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
+
+  it("detects command action with sandbox blocked status", () => {
+    const records = [
+      {
+        item: {
+          type: "command_execution",
+          text: "write denied by sandbox read-only filesystem",
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
+
+  it("detects item with sandbox denied status field", () => {
+    const records = [{ item: { type: "action", status: "sandbox_denied", text: "write file" } }];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
+
+  it("does not flag normal message text that merely discusses sandboxing", () => {
+    const records = [
+      {
+        item: {
+          type: "message",
+          text: "I would normally write a file here, but let me explain how sandbox policies work in Codex.",
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(false);
+  });
+
+  it("does not flag empty records", () => {
+    expect(detectSandboxDenied([])).toBe(false);
+  });
+
+  it("does not flag normal successful output", () => {
+    const records = [
+      {
+        item: {
+          type: "message",
+          text: "I've created the file TEST_RO.md with the content 'hello'.",
+        },
+      },
+      { usage: { input: 100, output: 50 } },
+    ];
+    expect(detectSandboxDenied(records)).toBe(false);
+  });
+});
+
+describe("parseCliJsonl sandbox detection", () => {
+  it("sets sandboxDenied when JSONL contains sandbox error item", () => {
+    const jsonl = [
+      JSON.stringify({ thread_id: "abc123" }),
+      JSON.stringify({
+        item: {
+          type: "error",
+          text: "sandbox policy: write denied for /workspace/TEST_RO.md",
+        },
+      }),
+      JSON.stringify({
+        item: {
+          type: "message",
+          text: "I was unable to write the file due to sandbox restrictions.",
+        },
+      }),
+    ].join("\n");
+
+    const result = parseCliJsonl(jsonl, CODEX_BACKEND);
+    expect(result).not.toBeNull();
+    expect(result!.sandboxDenied).toBe(true);
+    expect(result!.sessionId).toBe("abc123");
+  });
+
+  it("does not set sandboxDenied for normal output", () => {
+    const jsonl = [
+      JSON.stringify({ thread_id: "abc123" }),
+      JSON.stringify({
+        item: { type: "message", text: "I've created the file successfully." },
+      }),
+    ].join("\n");
+
+    const result = parseCliJsonl(jsonl, CODEX_BACKEND);
+    expect(result).not.toBeNull();
+    expect(result!.sandboxDenied).toBeUndefined();
+  });
+});

--- a/src/agents/cli-runner.sandbox-denied.test.ts
+++ b/src/agents/cli-runner.sandbox-denied.test.ts
@@ -115,6 +115,25 @@ describe("parseCliJsonl sandbox detection", () => {
     expect(result!.sessionId).toBe("abc123");
   });
 
+  it("detects sandboxDenied even when JSONL has no message-typed items (text-less denial)", () => {
+    const jsonl = [
+      JSON.stringify({ thread_id: "def456" }),
+      JSON.stringify({
+        item: {
+          type: "tool_call_output",
+          text: "sandbox policy: write to /workspace/TEST_RO.md denied",
+        },
+      }),
+      JSON.stringify({ usage: { input_tokens: 80, output_tokens: 20 } }),
+    ].join("\n");
+
+    const result = parseCliJsonl(jsonl, CODEX_BACKEND);
+    expect(result).not.toBeNull();
+    expect(result!.sandboxDenied).toBe(true);
+    expect(result!.text).toBe("");
+    expect(result!.sessionId).toBe("def456");
+  });
+
   it("does not set sandboxDenied for normal output", () => {
     const jsonl = [
       JSON.stringify({ thread_id: "abc123" }),

--- a/src/agents/cli-runner.sandbox-denied.test.ts
+++ b/src/agents/cli-runner.sandbox-denied.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { detectSandboxDenied, parseCliJsonl } from "./cli-runner/helpers.js";
+import {
+  detectSandboxDenied,
+  detectSandboxDeniedInText,
+  parseCliJsonl,
+} from "./cli-runner/helpers.js";
 
 const CODEX_BACKEND = {
   command: "codex",
@@ -89,6 +93,45 @@ describe("detectSandboxDenied", () => {
     ];
     expect(detectSandboxDenied(records)).toBe(false);
   });
+
+  it("does not flag long tool output that coincidentally mentions sandbox denial", () => {
+    const longLog = `${"x".repeat(600)} sandbox policy: write denied for /tmp/file ${"y".repeat(200)}`;
+    const records = [
+      {
+        item: {
+          type: "tool_call_output",
+          text: longLog,
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(false);
+  });
+
+  it("flags long tool output with error status even when text is long", () => {
+    const longLog = `${"x".repeat(600)} sandbox policy: write denied for /tmp/file`;
+    const records = [
+      {
+        item: {
+          type: "tool_call_output",
+          text: longLog,
+          status: "error",
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
+
+  it("flags short tool output with sandbox denial", () => {
+    const records = [
+      {
+        item: {
+          type: "tool_call_output",
+          text: "sandbox policy: write to /workspace/file denied",
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(true);
+  });
 });
 
 describe("parseCliJsonl sandbox detection", () => {
@@ -145,5 +188,25 @@ describe("parseCliJsonl sandbox detection", () => {
     const result = parseCliJsonl(jsonl, CODEX_BACKEND);
     expect(result).not.toBeNull();
     expect(result!.sandboxDenied).toBeUndefined();
+  });
+});
+
+describe("detectSandboxDeniedInText", () => {
+  it("detects sandbox denial in raw text output", () => {
+    expect(
+      detectSandboxDeniedInText("sandbox policy: write denied for /workspace/TEST_RO.md"),
+    ).toBe(true);
+  });
+
+  it("detects sandbox denied phrasing", () => {
+    expect(detectSandboxDeniedInText("The operation was sandbox denied")).toBe(true);
+  });
+
+  it("does not flag normal text output", () => {
+    expect(detectSandboxDeniedInText("I've created the file successfully.")).toBe(false);
+  });
+
+  it("does not flag empty text", () => {
+    expect(detectSandboxDeniedInText("")).toBe(false);
   });
 });

--- a/src/agents/cli-runner.sandbox-denied.test.ts
+++ b/src/agents/cli-runner.sandbox-denied.test.ts
@@ -229,4 +229,8 @@ describe("detectSandboxDeniedInText", () => {
   it("does not flag empty text", () => {
     expect(detectSandboxDeniedInText("")).toBe(false);
   });
+
+  it("detects multi-word path sandbox policy denial", () => {
+    expect(detectSandboxDeniedInText("sandbox policy: write to /workspace/file denied")).toBe(true);
+  });
 });

--- a/src/agents/cli-runner.sandbox-denied.test.ts
+++ b/src/agents/cli-runner.sandbox-denied.test.ts
@@ -36,24 +36,26 @@ describe("detectSandboxDenied", () => {
     expect(detectSandboxDenied(records)).toBe(true);
   });
 
-  it("detects tool-call output reporting sandbox denial", () => {
+  it("detects tool-call output reporting sandbox denial with error signal", () => {
     const records = [
       {
         item: {
           type: "tool_call_output",
           text: "sandbox policy: write to /workspace/TEST_RO.md denied",
+          status: "failed",
         },
       },
     ];
     expect(detectSandboxDenied(records)).toBe(true);
   });
 
-  it("detects command action with sandbox blocked status", () => {
+  it("detects command action with sandbox blocked status and non-zero exit", () => {
     const records = [
       {
         item: {
           type: "command_execution",
           text: "write denied by sandbox read-only filesystem",
+          exit_code: 1,
         },
       },
     ];
@@ -121,12 +123,25 @@ describe("detectSandboxDenied", () => {
     expect(detectSandboxDenied(records)).toBe(true);
   });
 
-  it("flags short tool output with sandbox denial", () => {
+  it("does not flag short tool output without error signal", () => {
     const records = [
       {
         item: {
           type: "tool_call_output",
           text: "sandbox policy: write to /workspace/file denied",
+        },
+      },
+    ];
+    expect(detectSandboxDenied(records)).toBe(false);
+  });
+
+  it("flags short tool output with error status", () => {
+    const records = [
+      {
+        item: {
+          type: "tool_call_output",
+          text: "sandbox policy: write to /workspace/file denied",
+          status: "error",
         },
       },
     ];
@@ -165,6 +180,7 @@ describe("parseCliJsonl sandbox detection", () => {
         item: {
           type: "tool_call_output",
           text: "sandbox policy: write to /workspace/TEST_RO.md denied",
+          status: "error",
         },
       }),
       JSON.stringify({ usage: { input_tokens: 80, output_tokens: 20 } }),
@@ -198,8 +214,12 @@ describe("detectSandboxDeniedInText", () => {
     ).toBe(true);
   });
 
-  it("detects sandbox denied phrasing", () => {
-    expect(detectSandboxDeniedInText("The operation was sandbox denied")).toBe(true);
+  it("does not flag vague sandbox mentions in discussion text", () => {
+    expect(detectSandboxDeniedInText("The operation was sandbox denied")).toBe(false);
+  });
+
+  it("detects write denied by sandbox in text", () => {
+    expect(detectSandboxDeniedInText("write denied by sandbox read-only filesystem")).toBe(true);
   });
 
   it("does not flag normal text output", () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -23,6 +23,7 @@ import {
   buildCliSupervisorScopeKey,
   buildCliArgs,
   buildSystemPrompt,
+  detectSandboxDeniedInText,
   enqueueCliRun,
   normalizeCliModel,
   parseCliJson,
@@ -385,6 +386,17 @@ export async function runCliAgent(params: {
         const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
 
         if (outputMode === "text") {
+          if (detectSandboxDeniedInText(stdout)) {
+            throw new FailoverError(
+              "Codex sandbox denied the requested operation (exit 0 with sandbox policy violation in text output)",
+              {
+                reason: "sandbox_denied",
+                provider: params.provider,
+                model: modelId,
+                status: resolveFailoverStatus("sandbox_denied"),
+              },
+            );
+          }
           return { text: stdout, sessionId: undefined };
         }
         if (outputMode === "jsonl") {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -389,6 +389,17 @@ export async function runCliAgent(params: {
         }
         if (outputMode === "jsonl") {
           const parsed = parseCliJsonl(stdout, backend);
+          if (parsed?.sandboxDenied) {
+            throw new FailoverError(
+              "Codex sandbox denied the requested operation (exit 0 with sandbox policy violation in output)",
+              {
+                reason: "sandbox_denied",
+                provider: params.provider,
+                model: modelId,
+                status: resolveFailoverStatus("sandbox_denied"),
+              },
+            );
+          }
           return parsed ?? { text: stdout };
         }
 

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -36,6 +36,7 @@ export type CliOutput = {
   text: string;
   sessionId?: string;
   usage?: CliUsage;
+  sandboxDenied?: boolean;
 };
 
 export function buildSystemPrompt(params: {
@@ -201,6 +202,66 @@ export function parseCliJson(raw: string, backend: CliBackendConfig): CliOutput 
   return { text: text.trim(), sessionId, usage };
 }
 
+const SANDBOX_DENIED_RE =
+  /sandbox.policy|sandbox.denied|sandbox.*read.only|read.only.*sandbox|write.*denied.*sandbox|sandbox.*blocked|permission denied.*sandbox/i;
+
+/**
+ * Detect sandbox-denied signals in parsed JSONL items.
+ *
+ * Codex may exit 0 even when a sandbox policy prevented the requested
+ * operation.  The failure is only visible inside the JSONL event stream
+ * (e.g. an item with type "error" or a tool-call result describing the
+ * denial).  We scan structured fields first so that an agent merely
+ * *discussing* sandboxing in its message text does not trigger a false
+ * positive.
+ */
+export function detectSandboxDenied(records: Record<string, unknown>[]): boolean {
+  for (const rec of records) {
+    // Check top-level error fields.
+    if (typeof rec.error === "string" && SANDBOX_DENIED_RE.test(rec.error)) {
+      return true;
+    }
+    if (
+      isRecord(rec.error) &&
+      typeof rec.error.message === "string" &&
+      SANDBOX_DENIED_RE.test(rec.error.message)
+    ) {
+      return true;
+    }
+
+    const item = isRecord(rec.item) ? rec.item : null;
+    if (!item) {
+      continue;
+    }
+
+    const itemType = typeof item.type === "string" ? item.type.toLowerCase() : "";
+
+    // Items explicitly typed as errors that mention sandbox denial.
+    if (
+      itemType === "error" &&
+      typeof item.text === "string" &&
+      SANDBOX_DENIED_RE.test(item.text)
+    ) {
+      return true;
+    }
+
+    // Tool-call outputs that report sandbox denial (e.g. shell or file tools).
+    if (
+      (itemType.includes("tool") || itemType.includes("command") || itemType.includes("action")) &&
+      typeof item.text === "string" &&
+      SANDBOX_DENIED_RE.test(item.text)
+    ) {
+      return true;
+    }
+
+    // Status field on items (some Codex versions surface "denied" status).
+    if (typeof item.status === "string" && SANDBOX_DENIED_RE.test(item.status)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput | null {
   const lines = raw
     .split(/\r?\n/g)
@@ -212,6 +273,7 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
   const texts: string[] = [];
+  const records: Record<string, unknown>[] = [];
   for (const line of lines) {
     let parsed: unknown;
     try {
@@ -222,6 +284,7 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
     if (!isRecord(parsed)) {
       continue;
     }
+    records.push(parsed);
     if (!sessionId) {
       sessionId = pickSessionId(parsed, backend);
     }
@@ -243,7 +306,8 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
   if (!text) {
     return null;
   }
-  return { text, sessionId, usage };
+  const sandboxDenied = detectSandboxDenied(records);
+  return { text, sessionId, usage, ...(sandboxDenied ? { sandboxDenied } : {}) };
 }
 
 export function resolveSystemPromptUsage(params: {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -302,11 +302,16 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
       }
     }
   }
+  const sandboxDenied = detectSandboxDenied(records);
   const text = texts.join("\n").trim();
   if (!text) {
+    // Even without extractable message text, surface sandbox denial so the
+    // caller can throw instead of treating the run as a silent success.
+    if (sandboxDenied) {
+      return { text: "", sessionId, usage, sandboxDenied };
+    }
     return null;
   }
-  const sandboxDenied = detectSandboxDenied(records);
   return { text, sessionId, usage, ...(sandboxDenied ? { sandboxDenied } : {}) };
 }
 

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -206,6 +206,19 @@ const SANDBOX_DENIED_RE =
   /sandbox.policy|sandbox.denied|sandbox.*read.only|read.only.*sandbox|write.*denied.*sandbox|sandbox.*blocked|permission denied.*sandbox/i;
 
 /**
+ * Detect sandbox-denied signals in raw text output (used for resume text-mode).
+ *
+ * This is intentionally coarser than `detectSandboxDenied` since text output
+ * lacks structured item types.  We scan the entire output for the same denial
+ * patterns.  False positives are possible but acceptable because a resumed
+ * Codex session that mentions sandbox denial in its raw output very likely
+ * experienced an actual denial.
+ */
+export function detectSandboxDeniedInText(text: string): boolean {
+  return SANDBOX_DENIED_RE.test(text);
+}
+
+/**
  * Detect sandbox-denied signals in parsed JSONL items.
  *
  * Codex may exit 0 even when a sandbox policy prevented the requested
@@ -246,12 +259,24 @@ export function detectSandboxDenied(records: Record<string, unknown>[]): boolean
     }
 
     // Tool-call outputs that report sandbox denial (e.g. shell or file tools).
+    // Only match when the item also carries an error/failure signal or when the
+    // text is short enough to be a denial message (not a long log dump that
+    // coincidentally contains denial keywords).
     if (
       (itemType.includes("tool") || itemType.includes("command") || itemType.includes("action")) &&
       typeof item.text === "string" &&
       SANDBOX_DENIED_RE.test(item.text)
     ) {
-      return true;
+      const hasErrorSignal =
+        item.status === "error" ||
+        item.status === "failed" ||
+        item.status === "denied" ||
+        (typeof item.exit_code === "number" && item.exit_code !== 0);
+      // Short tool output (<500 chars) with denial keywords is almost certainly
+      // a real denial, not a coincidental match in a long log.
+      if (hasErrorSignal || item.text.length < 500) {
+        return true;
+      }
     }
 
     // Status field on items (some Codex versions surface "denied" status).

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -206,16 +206,22 @@ const SANDBOX_DENIED_RE =
   /sandbox.policy|sandbox.denied|sandbox.*read.only|read.only.*sandbox|write.*denied.*sandbox|sandbox.*blocked|permission denied.*sandbox/i;
 
 /**
+ * Stricter regex for text-mode sandbox detection.  Requires patterns that look
+ * like actual error messages (e.g. "sandbox policy: write denied") rather than
+ * discussion of sandbox concepts.  This avoids false positives when resumed
+ * Codex output merely discusses sandbox behavior.
+ */
+const SANDBOX_DENIED_TEXT_RE =
+  /sandbox policy:\s*\S+ denied|permission denied.*sandbox|write.*denied.*sandbox|read.only.*sandbox/i;
+
+/**
  * Detect sandbox-denied signals in raw text output (used for resume text-mode).
  *
- * This is intentionally coarser than `detectSandboxDenied` since text output
- * lacks structured item types.  We scan the entire output for the same denial
- * patterns.  False positives are possible but acceptable because a resumed
- * Codex session that mentions sandbox denial in its raw output very likely
- * experienced an actual denial.
+ * Uses a stricter regex than the structured JSONL detector to avoid false
+ * positives from agents discussing sandbox concepts in their output.
  */
 export function detectSandboxDeniedInText(text: string): boolean {
-  return SANDBOX_DENIED_RE.test(text);
+  return SANDBOX_DENIED_TEXT_RE.test(text);
 }
 
 /**
@@ -272,9 +278,7 @@ export function detectSandboxDenied(records: Record<string, unknown>[]): boolean
         item.status === "failed" ||
         item.status === "denied" ||
         (typeof item.exit_code === "number" && item.exit_code !== 0);
-      // Short tool output (<500 chars) with denial keywords is almost certainly
-      // a real denial, not a coincidental match in a long log.
-      if (hasErrorSignal || item.text.length < 500) {
+      if (hasErrorSignal) {
         return true;
       }
     }

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -212,7 +212,7 @@ const SANDBOX_DENIED_RE =
  * Codex output merely discusses sandbox behavior.
  */
 const SANDBOX_DENIED_TEXT_RE =
-  /sandbox policy:\s*\S+ denied|permission denied.*sandbox|write.*denied.*sandbox|read.only.*sandbox/i;
+  /sandbox policy:\s*.+? denied|permission denied.*sandbox|write.*denied.*sandbox|read.only.*sandbox/i;
 
 /**
  * Detect sandbox-denied signals in raw text output (used for resume text-mode).

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -61,6 +61,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 400;
     case "model_not_found":
       return 404;
+    case "sandbox_denied":
+      return 403;
     case "session_expired":
       return 410; // Gone - session no longer exists
     default:

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -9,5 +9,6 @@ export type FailoverReason =
   | "billing"
   | "timeout"
   | "model_not_found"
+  | "sandbox_denied"
   | "session_expired"
   | "unknown";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -762,7 +762,11 @@ export async function runEmbeddedPiAgent(
       ): AuthProfileFailureReason | null => {
         // Timeouts are transport/model-path failures, not auth health signals,
         // so they should not persist auth-profile failure state.
-        if (!failoverReason || failoverReason === "timeout") {
+        if (
+          !failoverReason ||
+          failoverReason === "timeout" ||
+          failoverReason === "sandbox_denied"
+        ) {
           return null;
         }
         return failoverReason;


### PR DESCRIPTION
## Summary

Closes #39317.

Codex may exit 0 even when a sandbox policy prevented the requested file write. OpenClaw only checked `exitCode === 0` and treated these runs as successful, passing the agent's internal failure reasoning as normal output. This causes subagent orchestration to record work as completed when nothing actually happened.

**Changes:**

- Add `detectSandboxDenied()` to scan structured JSONL records for sandbox denial signals (error items, tool-call outputs, status fields) without false-positiving on agents that merely *discuss* sandboxing
- Wire into `parseCliJsonl()` to set `sandboxDenied` flag on `CliOutput`
- CLI runner throws `FailoverError` with reason `"sandbox_denied"` when exit-0 JSONL contains sandbox denial
- Add `"sandbox_denied"` to `FailoverReason` and `AuthProfileFailureReason` types
- Exclude `sandbox_denied` from auth profile failure tracking (local config issue, not an auth health signal)
- Map `sandbox_denied` to HTTP 403 in `resolveFailoverStatus`

## Design decisions

- **Structured field detection over keyword matching**: `detectSandboxDenied()` scans `item.type === "error"`, tool/command/action item types, `item.status`, and top-level `error` fields. It does NOT scan `item.type === "message"` text, preventing false positives when agents discuss sandbox concepts.
- **Auth profile exclusion**: Sandbox denial is a local configuration issue, not a provider auth health signal. Excluded alongside `"timeout"` in `resolveAuthProfileFailureReason()`.

## Testing

- 11 new regression tests in `cli-runner.sandbox-denied.test.ts`:
  - `detectSandboxDenied`: top-level error string, nested error.message, error-typed items, tool-call outputs, command actions, status fields, and three false-positive prevention cases
  - `parseCliJsonl` integration: sandbox error + exit 0 sets flag, normal output does not

## Files changed

| File | Change |
|------|--------|
| `src/agents/cli-runner/helpers.ts` | Add `detectSandboxDenied()`, `sandboxDenied` flag on `CliOutput` |
| `src/agents/cli-runner.ts` | Check `sandboxDenied` after exit-0 JSONL parse, throw `FailoverError` |
| `src/agents/failover-error.ts` | Map `sandbox_denied` to 403 |
| `src/agents/pi-embedded-helpers/types.ts` | Add `"sandbox_denied"` to `FailoverReason` |
| `src/agents/auth-profiles/types.ts` | Add `"sandbox_denied"` to `AuthProfileFailureReason` |
| `src/agents/pi-embedded-runner/run.ts` | Exclude `sandbox_denied` from auth profile failure state |
| `src/agents/cli-runner.sandbox-denied.test.ts` | 11 regression tests |

## Post-Deploy Monitoring & Validation

- **What to monitor**: grep gateway logs for `sandbox_denied` failover reason after deploying
- **Expected healthy behavior**: Codex runs with sandbox denials now surface as failures instead of silent false-success
- **Failure signal**: existing Codex runs that previously "succeeded" now throw FailoverError. This is the correct behavior but operators should verify sandbox config (`--sandbox workspace-write` vs `read-only`) if they see unexpected failures