### PR TITLE
fix(podman): avoid inherited cwd during podman load

### DIFF
--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -265,9 +265,7 @@ chmod 700 "$TMP_STAGE_DIR"
 trap 'rm -rf "$TMP_STAGE_DIR"' EXIT
 podman save openclaw:local -o "$TMP_IMAGE"
 chmod 600 "$TMP_IMAGE"
-# Stream the image into the target user's podman load so private temp directories
-# do not need to be traversable by $OPENCLAW_USER.
-cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load
+(cd "$TMP_IMAGE_DIR" && cat "$TMP_IMAGE" | run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load)
 rm -rf "$TMP_STAGE_DIR"
 trap - EXIT
 


### PR DESCRIPTION
## Summary
- run `podman load` from the shared temp base instead of inheriting the caller cwd
- avoid `cannot chdir` failures when `setup-podman.sh` is launched from a private checkout path

Closes #39434.

## Root cause
`run_as_user ... podman load` inherited the invoking shell cwd. If the script was started from a directory the target user could not traverse, Podman failed before reading the streamed image.

## Validation
- `bash -n setup-podman.sh`
- local smoke with fake `sudo`/`podman` from a private cwd, confirming `podman load` now runs with `PWD=/var/tmp` instead of the private checkout path
