### PR TITLE
fix(cli): suppress spinner on dumb terminals

### DIFF
--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -1,4 +1,36 @@
 import { describe, expect, it, vi } from "vitest";
+import { withEnv } from "../test-utils/env.ts";
+
+const mocks = vi.hoisted(() => {
+  const spinnerStart = vi.fn();
+  const spinnerStop = vi.fn();
+  const spinnerMessage = vi.fn();
+  const spinnerFactory = vi.fn(() => ({
+    start: spinnerStart,
+    stop: spinnerStop,
+    message: spinnerMessage,
+  }));
+  const supportsOscProgress = vi.fn(() => false);
+  const createOscProgressController = vi.fn();
+  return {
+    spinnerStart,
+    spinnerStop,
+    spinnerMessage,
+    spinnerFactory,
+    supportsOscProgress,
+    createOscProgressController,
+  };
+});
+
+vi.mock("@clack/prompts", () => ({
+  spinner: mocks.spinnerFactory,
+}));
+
+vi.mock("osc-progress", () => ({
+  supportsOscProgress: mocks.supportsOscProgress,
+  createOscProgressController: mocks.createOscProgressController,
+}));
+
 import { createCliProgress } from "./progress.js";
 
 describe("cli progress", () => {
@@ -42,5 +74,24 @@ describe("cli progress", () => {
     progress.done();
 
     expect(write).not.toHaveBeenCalled();
+  });
+
+  it("suppresses spinner output when TERM=dumb", () => {
+    withEnv({ TERM: "dumb" }, () => {
+      const write = vi.fn();
+      const stream = {
+        isTTY: true,
+        write,
+      } as unknown as NodeJS.WriteStream;
+
+      const progress = createCliProgress({
+        label: "Waiting for agent reply...",
+        stream,
+      });
+      progress.done();
+
+      expect(mocks.spinnerFactory).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -50,15 +50,18 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
 
   const stream = options.stream ?? process.stderr;
   const isTty = stream.isTTY;
-  const allowLog = !isTty && options.fallback === "log";
-  if (!isTty && !allowLog) {
+  const term = process.env.TERM?.trim().toLowerCase() ?? "";
+  const isDumbTerm = term === "dumb";
+  const allowLog = (!isTty || isDumbTerm) && options.fallback === "log";
+  if ((!isTty || isDumbTerm) && !allowLog) {
     return noopReporter;
   }
 
   const delayMs = typeof options.delayMs === "number" ? options.delayMs : DEFAULT_DELAY_MS;
-  const canOsc = isTty && supportsOscProgress(process.env, isTty);
-  const allowSpinner = isTty && (options.fallback === undefined || options.fallback === "spinner");
-  const allowLine = isTty && options.fallback === "line";
+  const canOsc = isTty && !isDumbTerm && supportsOscProgress(process.env, isTty);
+  const allowSpinner =
+    isTty && !isDumbTerm && (options.fallback === undefined || options.fallback === "spinner");
+  const allowLine = isTty && !isDumbTerm && options.fallback === "line";
 
   let started = false;
   let label = options.label;


### PR DESCRIPTION
Fixes #39426.

## Summary
- treat `TERM=dumb` as a non-rich terminal for CLI progress output
- skip spinner/OSC progress in that mode so local agent runs stay plain-text safe
- add a regression test for dumb-terminal progress creation

## Testing
- AI-assisted: yes
- Testing: lightly tested
- `pnpm test src/cli/progress.test.ts`
