### PR TITLE
fix(plugins): suppress duplicate-id warning when user plugin shadows bundled

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -162,19 +162,10 @@ describe("loadPluginManifestRegistry", () => {
     writeManifest(dirA, manifest);
     writeManifest(dirB, manifest);
 
-    // The loader's first-seen-wins order means bundled always takes priority over
-    // global. The warning should explain this and tell the user how to override it.
+    // Typical discovery order: bundled first, global second. Bundled wins (first-seen).
     const candidates: PluginCandidate[] = [
-      createPluginCandidate({
-        idHint: "feishu",
-        rootDir: dirA,
-        origin: "bundled",
-      }),
-      createPluginCandidate({
-        idHint: "feishu",
-        rootDir: dirB,
-        origin: "global",
-      }),
+      createPluginCandidate({ idHint: "feishu", rootDir: dirA, origin: "bundled" }),
+      createPluginCandidate({ idHint: "feishu", rootDir: dirB, origin: "global" }),
     ];
 
     const registry = loadRegistry(candidates);
@@ -182,6 +173,25 @@ describe("loadPluginManifestRegistry", () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]?.message).toContain("bundled copy takes priority");
     expect(warnings[0]?.message).toContain("plugins.load.paths");
+  });
+
+  it("emits actionable warning with correct winner when global is discovered before bundled", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    // Reversed order: global first, bundled second. Global wins (first-seen) —
+    // the user's installed version is already active, so no warning is needed.
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({ idHint: "feishu", rootDir: dirA, origin: "global" }),
+      createPluginCandidate({ idHint: "feishu", rootDir: dirB, origin: "bundled" }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    const warnings = registry.diagnostics.filter((d) => d.level === "warn");
+    expect(warnings).toHaveLength(0);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -175,7 +175,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(warnings[0]?.message).toContain("plugins.load.paths");
   });
 
-  it("emits actionable warning with correct winner when global is discovered before bundled", () => {
+  it("suppresses all warnings when the higher-precedence global plugin is discovered before bundled", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "feishu", configSchema: { type: "object" } };

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -130,18 +130,20 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("emits duplicate warning for truly distinct plugins with same id and same origin tier", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
     writeManifest(dirA, manifest);
     writeManifest(dirB, manifest);
 
+    // Two distinct directories with the same origin tier (global + global) —
+    // this is a genuine conflict the user needs to know about.
     const candidates: PluginCandidate[] = [
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirA,
-        origin: "bundled",
+        origin: "global",
       }),
       createPluginCandidate({
         idHint: "test-plugin",
@@ -151,6 +153,30 @@ describe("loadPluginManifestRegistry", () => {
     ];
 
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+  });
+
+  it("suppresses duplicate warning when higher-precedence plugin shadows bundled plugin", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    // global (rank 2) overriding bundled (rank 3) — expected from `openclaw configure` installs.
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -155,14 +155,15 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
   });
 
-  it("suppresses duplicate warning when higher-precedence plugin shadows bundled plugin", () => {
+  it("emits actionable warning when bundled plugin shadows user-installed global plugin", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "feishu", configSchema: { type: "object" } };
     writeManifest(dirA, manifest);
     writeManifest(dirB, manifest);
 
-    // global (rank 2) overriding bundled (rank 3) — expected from `openclaw configure` installs.
+    // The loader's first-seen-wins order means bundled always takes priority over
+    // global. The warning should explain this and tell the user how to override it.
     const candidates: PluginCandidate[] = [
       createPluginCandidate({
         idHint: "feishu",
@@ -176,7 +177,11 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ];
 
-    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+    const registry = loadRegistry(candidates);
+    const warnings = registry.diagnostics.filter((d) => d.level === "warn");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain("bundled copy takes priority");
+    expect(warnings[0]?.message).toContain("plugins.load.paths");
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -173,6 +173,9 @@ describe("loadPluginManifestRegistry", () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]?.message).toContain("bundled copy takes priority");
     expect(warnings[0]?.message).toContain("plugins.load.paths");
+    // Both records are retained in the manifest registry — deduplication is the
+    // loader's responsibility (loader.ts first-seen-wins on discovery.candidates).
+    expect(registry.plugins).toHaveLength(2);
   });
 
   it("suppresses all warnings when the higher-precedence global plugin is discovered before bundled", () => {
@@ -192,6 +195,8 @@ describe("loadPluginManifestRegistry", () => {
     const registry = loadRegistry(candidates);
     const warnings = registry.diagnostics.filter((d) => d.level === "warn");
     expect(warnings).toHaveLength(0);
+    // Both records retained — deduplication is the loader's responsibility.
+    expect(registry.plugins).toHaveLength(2);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -231,10 +231,10 @@ export function loadPluginManifestRegistry(params: {
       }
       const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
       const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
-      const isBundledUserConflict =
-        existing.candidate.origin === "bundled" && candidate.origin !== "bundled";
-      if (isBundledUserConflict) {
-        // Bundled won (first-seen): user's install (global/workspace/config) is inactive.
+      const isBundledGlobalConflict =
+        existing.candidate.origin === "bundled" && candidate.origin === "global";
+      if (isBundledGlobalConflict) {
+        // Bundled won (first-seen): user's global install is inactive.
         // Emit a targeted message with a remediation hint.
         diagnostics.push({
           level: "warn",

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -229,13 +229,23 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      // Only warn when both candidates share the same precedence tier.
-      // When origins differ (e.g. a global plugin shadowing a bundled one),
-      // the higher-precedence copy is intentionally overriding the lower-
-      // precedence one — this is expected from `openclaw configure` installs.
-      const sameTier =
-        PLUGIN_ORIGIN_RANK[candidate.origin] === PLUGIN_ORIGIN_RANK[existing.candidate.origin];
-      if (sameTier) {
+      // For a bundled-vs-global conflict the loader's first-seen-wins order means
+      // the bundled copy always takes priority over a user-installed global plugin.
+      // Emit a targeted, actionable message so the user knows their installed copy
+      // is inactive and how to fix it — rather than the generic "may be overridden" text.
+      const isBundledGlobalConflict =
+        (candidate.origin === "global" && existing.candidate.origin === "bundled") ||
+        (candidate.origin === "bundled" && existing.candidate.origin === "global");
+      if (isBundledGlobalConflict) {
+        const globalSource =
+          candidate.origin === "global" ? candidate.source : existing.candidate.source;
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: globalSource,
+          message: `plugin '${manifest.id}' is installed in the extensions directory but the bundled copy takes priority; add it to plugins.load.paths in your config to use your installed version (${globalSource})`,
+        });
+      } else {
         diagnostics.push({
           level: "warn",
           pluginId: manifest.id,

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -231,10 +231,10 @@ export function loadPluginManifestRegistry(params: {
       }
       const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
       const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
-      const isBundledGlobalConflict =
-        existing.candidate.origin === "bundled" && candidate.origin === "global";
-      if (isBundledGlobalConflict) {
-        // Bundled won (first-seen): user's global install is inactive.
+      const isBundledUserConflict =
+        existing.candidate.origin === "bundled" && candidate.origin !== "bundled";
+      if (isBundledUserConflict) {
+        // Bundled won (first-seen): user's install (global/workspace/config) is inactive.
         // Emit a targeted message with a remediation hint.
         diagnostics.push({
           level: "warn",

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -252,6 +252,9 @@ export function loadPluginManifestRegistry(params: {
         });
       }
       // else: candidate has lower precedence than existing — intentional override, no warning.
+      // Always update seenIds so subsequent candidates compare against the most recent
+      // entry, not the stale first-seen one (avoids broken diagnostics in 3-way conflicts).
+      seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -229,23 +229,18 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      // For a bundled-vs-global conflict the loader's first-seen-wins order means
-      // the bundled copy always takes priority over a user-installed global plugin.
-      // Emit a targeted, actionable message so the user knows their installed copy
-      // is inactive and how to fix it — rather than the generic "may be overridden" text.
-      const isBundledGlobalConflict =
-        (candidate.origin === "global" && existing.candidate.origin === "bundled") ||
-        (candidate.origin === "bundled" && existing.candidate.origin === "global");
-      if (isBundledGlobalConflict) {
-        const globalSource =
-          candidate.origin === "global" ? candidate.source : existing.candidate.source;
+      // For a bundled-vs-global conflict, use first-seen (existing) to determine
+      // the actual winner. Only warn when bundled won — the user's global install
+      // is inactive and needs an actionable hint. When global won, the user's
+      // install is already active so no warning is needed.
+      if (existing.candidate.origin === "bundled" && candidate.origin === "global") {
         diagnostics.push({
           level: "warn",
           pluginId: manifest.id,
-          source: globalSource,
-          message: `plugin '${manifest.id}' is installed in the extensions directory but the bundled copy takes priority; add it to plugins.load.paths in your config to use your installed version (${globalSource})`,
+          source: candidate.source,
+          message: `plugin '${manifest.id}' is installed in the extensions directory but the bundled copy takes priority; add it to plugins.load.paths in your config to use your installed version (${candidate.source})`,
         });
-      } else {
+      } else if (existing.candidate.origin !== "global" || candidate.origin !== "bundled") {
         diagnostics.push({
           level: "warn",
           pluginId: manifest.id,

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -229,12 +229,20 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+      // Only warn when both candidates share the same precedence tier.
+      // When origins differ (e.g. a global plugin shadowing a bundled one),
+      // the higher-precedence copy is intentionally overriding the lower-
+      // precedence one — this is expected from `openclaw configure` installs.
+      const sameTier =
+        PLUGIN_ORIGIN_RANK[candidate.origin] === PLUGIN_ORIGIN_RANK[existing.candidate.origin];
+      if (sameTier) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        });
+      }
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -229,18 +229,21 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      // For a bundled-vs-global conflict, use first-seen (existing) to determine
-      // the actual winner. Only warn when bundled won — the user's global install
-      // is inactive and needs an actionable hint. When global won, the user's
-      // install is already active so no warning is needed.
-      if (existing.candidate.origin === "bundled" && candidate.origin === "global") {
+      const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
+      const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
+      const isBundledGlobalConflict =
+        existing.candidate.origin === "bundled" && candidate.origin === "global";
+      if (isBundledGlobalConflict) {
+        // Bundled won (first-seen): user's global install is inactive.
+        // Emit a targeted message with a remediation hint.
         diagnostics.push({
           level: "warn",
           pluginId: manifest.id,
           source: candidate.source,
           message: `plugin '${manifest.id}' is installed in the extensions directory but the bundled copy takes priority; add it to plugins.load.paths in your config to use your installed version (${candidate.source})`,
         });
-      } else if (existing.candidate.origin !== "global" || candidate.origin !== "bundled") {
+      } else if (candidateRank <= existingRank) {
+        // Candidate has equal or higher precedence — genuine conflict worth surfacing.
         diagnostics.push({
           level: "warn",
           pluginId: manifest.id,
@@ -248,6 +251,7 @@ export function loadPluginManifestRegistry(params: {
           message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
         });
       }
+      // else: candidate has lower precedence than existing — intentional override, no warning.
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }


### PR DESCRIPTION
## Problem

When a plugin is bundled with the OpenClaw npm package (e.g. `extensions/feishu`) and the user also installs the same plugin via `openclaw configure` into `~/.openclaw/extensions/`, OpenClaw emits a confusing `duplicate plugin id detected; later plugin may be overridden` warning — cryptic, no context, no action path. Fixes #38437.

## Root Cause

`src/plugins/manifest-registry.ts` unconditionally pushed the generic duplicate warning for any two candidates sharing a plugin ID but residing in different directories. It had no special handling for intentional overrides.

The loader's first-seen-wins order (`loader.ts:632-647`) combined with discovery order (bundled before global, `discovery.ts:680-701`) means the bundled copy always takes priority when both are present — but the warning gave the user no indication of this, nor any way to fix it.

## Fix

Use `PLUGIN_ORIGIN_RANK` to determine whether a conflict is worth surfacing:

- **`bundled` existing + `global` candidate** (the reported scenario): emit a targeted actionable warning naming the bundled copy as the winner and directing the user to `plugins.load.paths` to override
- **`candidateRank <= existingRank`** (equal or higher precedence conflict): emit the generic `duplicate plugin id detected` warning — genuine conflict worth surfacing
- **`candidateRank > existingRank`** (candidate has lower precedence): intentional override, no warning
```diff
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+      const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
+      const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
+      const isBundledGlobalConflict =
+        existing.candidate.origin === "bundled" && candidate.origin === "global";
+      if (isBundledGlobalConflict) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `plugin '${manifest.id}' is installed in the extensions directory but the bundled copy takes priority; add it to plugins.load.paths in your config to use your installed version (${candidate.source})`,
+        });
+      } else if (candidateRank <= existingRank) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        });
+      }
+      // else: candidate has lower precedence — intentional override, no warning.
```

## Testing

- Updated `"emits duplicate warning for truly distinct plugins with same id and same origin tier"` — uses `global`+`global` to confirm same-tier warnings still fire
- Added `"emits actionable warning when bundled plugin shadows user-installed global plugin"` — normal discovery order (bundled first), asserts message contains `"bundled copy takes priority"` and `"plugins.load.paths"`
- Added `"suppresses all warnings when the higher-precedence global plugin is discovered before bundled"` — reversed order (global first, user's install wins), asserts 0 warnings
- All 9 tests pass

---

*AI-assisted (Claude) · Regression tests added · Fix reviewed and understood*