### PR TITLE
fix(routing): map discord account IDs to matching agents

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -392,6 +392,44 @@ describe("resolveAgentRoute", () => {
     expect(route.accountId).toBe("biz");
   });
 
+  test("discord accountId auto-matches agentId when no binding exists", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: "~/main" },
+          { id: "agenta", workspace: "~/agenta" },
+        ],
+      },
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "agentA",
+      peer: { kind: "direct", id: "u-1" },
+    });
+    expect(route.agentId).toBe("agenta");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
+  test("discord auto-match does not override default account", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: "~/main" },
+          { id: "default", workspace: "~/default-agent" },
+        ],
+      },
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "direct", id: "u-1" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("default");
+  });
+
   test("defaultAgentId is used when no binding matches", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -165,6 +165,25 @@ export function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): 
   return lookup.fallbackDefaultAgentId;
 }
 
+function resolveImplicitAccountAgentId(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  accountId: string;
+}): string | null {
+  // Keep scope narrow: this fallback is currently expected for Discord multi-account routing.
+  if (params.channel !== "discord") {
+    return null;
+  }
+  if (!params.accountId || params.accountId === DEFAULT_ACCOUNT_ID) {
+    return null;
+  }
+  const candidate = pickFirstExistingAgentId(params.cfg, params.accountId);
+  if (normalizeAgentId(candidate) !== normalizeAgentId(params.accountId)) {
+    return null;
+  }
+  return candidate;
+}
+
 type NormalizedPeerConstraint =
   | { state: "none" }
   | { state: "invalid" }
@@ -798,6 +817,18 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       }
       return choose(matched.binding.agentId, tier.matchedBy);
     }
+  }
+
+  const implicitAccountAgentId = resolveImplicitAccountAgentId({
+    cfg: input.cfg,
+    channel,
+    accountId,
+  });
+  if (implicitAccountAgentId) {
+    if (shouldLogDebug) {
+      logDebug(`[routing] match: matchedBy=binding.account agentId=${implicitAccountAgentId}`);
+    }
+    return choose(implicitAccountAgentId, "binding.account");
   }
 
   return choose(resolveDefaultAgentId(input.cfg), "default");


### PR DESCRIPTION
## Summary
- add Discord-only fallback routing: when no binding matches, map `accountId` to an agent with the same ID
- keep fallback disabled for the `default` account id to avoid surprising overrides
- add regression tests for positive auto-match and default-account guard

## Why
In multi-account Discord setups, account names are commonly aligned with agent IDs. Without explicit bindings, traffic incorrectly fell back to the default agent, which could bypass intended per-agent permission boundaries.

## Behavior
When `channel=discord` and no explicit binding matches:
- if `accountId` matches an existing agent id (case-insensitive), route to that agent
- if `accountId=default`, keep existing default-agent behavior

## Test evidence
- `pnpm vitest run --config vitest.unit.config.ts src/routing/resolve-route.test.ts`
  - Passed: 1 file, 43 tests

Fixes #39428
