### PR TITLE
fix(feishu): report connection/event activity for health monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: publish connection, event, and validated transport activity timestamps into gateway channel health without counting startup probes or rejected webhook requests as activity. (#39489) Thanks @CyberWenShiFu.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1251,6 +1251,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             runtime: ctx.runtime,
             abortSignal: ctx.abortSignal,
             accountId: ctx.accountId,
+            statusSink: (patch) => ctx.setStatus({ accountId: ctx.accountId, ...patch }),
           });
         },
       },

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -168,6 +168,7 @@ type RegisterEventHandlersContext = {
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
+  recordTransportActivityWithEvents?: boolean;
   statusSink?: FeishuStatusSink;
 };
 
@@ -252,7 +253,7 @@ function registerEventHandlers(
     statusSink?.({
       connected: true,
       lastEventAt: now,
-      lastTransportActivityAt: now,
+      ...(context.recordTransportActivityWithEvents ? { lastTransportActivityAt: now } : {}),
       lastError: null,
     });
   };
@@ -475,6 +476,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       runtime,
       chatHistories,
       fireAndForget: params.fireAndForget ?? true,
+      recordTransportActivityWithEvents: connectionMode === "websocket",
       statusSink,
     });
 

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -19,6 +19,7 @@ import {
 import { applyBotIdentityState, startBotIdentityRecovery } from "./monitor.bot-identity.js";
 import { createFeishuBotMenuHandler } from "./monitor.bot-menu-handler.js";
 import { createFeishuDriveCommentNoticeHandler } from "./monitor.comment-notice-handler.js";
+import type { FeishuStatusSink } from "./monitor.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
@@ -167,6 +168,7 @@ type RegisterEventHandlersContext = {
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
+  statusSink?: FeishuStatusSink;
 };
 
 function parseFeishuBotAddedEventPayload(value: unknown): FeishuBotAddedEvent | null {
@@ -242,9 +244,18 @@ function registerEventHandlers(
   eventDispatcher: Lark.EventDispatcher,
   context: RegisterEventHandlersContext,
 ): void {
-  const { cfg, accountId, runtime, chatHistories, fireAndForget } = context;
+  const { cfg, accountId, runtime, chatHistories, fireAndForget, statusSink } = context;
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
+  const markEventReceived = () => {
+    const now = Date.now();
+    statusSink?.({
+      connected: true,
+      lastEventAt: now,
+      lastTransportActivityAt: now,
+      lastError: null,
+    });
+  };
   const runFeishuHandler = async (params: { task: () => Promise<void>; errorMessage: string }) => {
     if (fireAndForget) {
       void params.task().catch((err) => {
@@ -275,6 +286,7 @@ function registerEventHandlers(
       getBotOpenId: (id) => botOpenIds.get(id),
       getBotName: (id) => botNames.get(id),
       resolveSequentialKey: getFeishuSequentialKey,
+      onEventReceived: markEventReceived,
     }),
     "im.message.message_read_v1": async () => {
       // Ignore read receipts
@@ -285,6 +297,7 @@ function registerEventHandlers(
         if (!event) {
           return;
         }
+        markEventReceived();
         log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
@@ -296,6 +309,7 @@ function registerEventHandlers(
         if (!chatId) {
           return;
         }
+        markEventReceived();
         log(`feishu[${accountId}]: bot removed from chat ${chatId}`);
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
@@ -312,6 +326,7 @@ function registerEventHandlers(
         errorMessage: `feishu[${accountId}]: error handling reaction event`,
         task: async () => {
           const event = data as FeishuReactionCreatedEvent;
+          markEventReceived();
           const myBotId = botOpenIds.get(accountId);
           const syntheticEvent = await resolveReactionSyntheticEvent({
             cfg,
@@ -341,6 +356,7 @@ function registerEventHandlers(
         errorMessage: `feishu[${accountId}]: error handling reaction removal event`,
         task: async () => {
           const event = data as FeishuReactionDeletedEvent;
+          markEventReceived();
           const myBotId = botOpenIds.get(accountId);
           const syntheticEvent = await resolveReactionSyntheticEvent({
             cfg,
@@ -380,6 +396,7 @@ function registerEventHandlers(
           error(`feishu[${accountId}]: ignoring malformed card action payload`);
           return;
         }
+        markEventReceived();
         const promise = handleFeishuCardAction({
           cfg,
           event,
@@ -412,10 +429,11 @@ export type MonitorSingleAccountParams = {
   abortSignal?: AbortSignal;
   botOpenIdSource?: BotOpenIdSource;
   fireAndForget?: boolean;
+  statusSink?: FeishuStatusSink;
 };
 
 export async function monitorSingleAccount(params: MonitorSingleAccountParams): Promise<void> {
-  const { cfg, account, runtime, abortSignal } = params;
+  const { cfg, account, runtime, abortSignal, statusSink } = params;
   const { accountId } = account;
   const log = runtime?.log ?? console.log;
 
@@ -432,6 +450,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   }
 
   const connectionMode = account.config.connectionMode ?? "websocket";
+  statusSink?.({ mode: connectionMode, connected: false });
   if (connectionMode === "webhook" && !account.verificationToken?.trim()) {
     throw new Error(`Feishu account "${accountId}" webhook mode requires verificationToken`);
   }
@@ -456,12 +475,27 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       runtime,
       chatHistories,
       fireAndForget: params.fireAndForget ?? true,
+      statusSink,
     });
 
     if (connectionMode === "webhook") {
-      return await monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher });
+      return await monitorWebhook({
+        account,
+        accountId,
+        runtime,
+        abortSignal,
+        eventDispatcher,
+        statusSink,
+      });
     }
-    return await monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
+    return await monitorWebSocket({
+      account,
+      accountId,
+      runtime,
+      abortSignal,
+      eventDispatcher,
+      statusSink,
+    });
   } finally {
     threadBindingManager?.stop();
   }

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -56,6 +56,7 @@ type FeishuMessageReceiveHandlerContext = {
     botOpenId?: string;
     botName?: string;
   }) => string;
+  onEventReceived?: () => void;
 };
 
 function normalizeFeishuChatType(value: unknown): FeishuChatType | undefined {
@@ -173,6 +174,7 @@ export function createFeishuMessageReceiveHandler({
   getBotName = () => undefined,
   resolveSequentialKey = ({ accountId, event }) =>
     `feishu:${accountId}:${event.message.chat_id?.trim() || "unknown"}`,
+  onEventReceived,
 }: FeishuMessageReceiveHandlerContext): (data: unknown) => Promise<void> {
   const inboundDebounceMs = core.channel.debounce.resolveInboundDebounceMs({
     cfg,
@@ -319,6 +321,7 @@ export function createFeishuMessageReceiveHandler({
       log(`feishu[${accountId}]: dropping duplicate event for message ${messageId}`);
       return;
     }
+    onEventReceived?.();
     const processMessage = async () => {
       await inboundDebouncer.enqueue(event);
     };

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -13,6 +13,7 @@ import {
   resolveReactionSyntheticEvent,
   type FeishuReactionCreatedEvent,
 } from "./monitor.account.js";
+import type { FeishuStatusSink } from "./monitor.js";
 import { setFeishuRuntime } from "./runtime.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -166,6 +167,8 @@ function createTextEvent(params: {
 async function setupDebounceMonitor(params?: {
   botOpenId?: string;
   botName?: string;
+  account?: ResolvedFeishuAccount;
+  statusSink?: FeishuStatusSink;
 }): Promise<(data: unknown) => Promise<void>> {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlers = registered;
@@ -174,13 +177,14 @@ async function setupDebounceMonitor(params?: {
 
   await monitorSingleAccount({
     cfg: buildDebounceConfig(),
-    account: buildDebounceAccount(),
+    account: params?.account ?? buildDebounceAccount(),
     runtime: createNonExitingRuntimeEnv(),
     botOpenIdSource: {
       kind: "prefetched",
       botOpenId: params?.botOpenId ?? "ou_bot",
       botName: params?.botName,
     },
+    statusSink: params?.statusSink,
   });
 
   const onMessage = handlers["im.message.receive_v1"];
@@ -494,6 +498,69 @@ describe("monitorSingleAccount lifecycle", () => {
       | { stop: ReturnType<typeof vi.fn> }
       | undefined;
     expect(manager?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("records websocket inbound events as both event and transport activity", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(12_345);
+      setFeishuRuntime(createFeishuMonitorRuntime());
+      const statusSink = vi.fn();
+      await setupDebounceMonitor({ statusSink });
+
+      await handlers["im.chat.member.bot.added_v1"]?.({
+        chat_id: "oc_group_1",
+        operator_id: { open_id: "ou_admin" },
+      });
+
+      expect(statusSink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connected: true,
+          lastEventAt: 12_345,
+          lastTransportActivityAt: 12_345,
+          lastError: null,
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not double-count webhook-dispatched events as transport activity", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(23_456);
+      setFeishuRuntime(createFeishuMonitorRuntime());
+      const statusSink = vi.fn();
+      await setupDebounceMonitor({
+        account: {
+          ...buildDebounceAccount(),
+          encryptKey: "encrypt_key",
+          verificationToken: "verify_token",
+          config: {
+            ...buildDebounceAccount().config,
+            connectionMode: "webhook",
+          },
+        },
+        statusSink,
+      });
+
+      await handlers["im.chat.member.bot.added_v1"]?.({
+        chat_id: "oc_group_1",
+        operator_id: { open_id: "ou_admin" },
+      });
+
+      const eventPatch = statusSink.mock.calls
+        .map(([patch]) => patch as Record<string, unknown>)
+        .find((patch) => patch.lastEventAt === 23_456);
+      expect(eventPatch).toEqual({
+        connected: true,
+        lastEventAt: 23_456,
+        lastError: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -10,6 +10,7 @@ import {
   readWebhookBodyOrReject,
   safeEqualSecret,
 } from "./monitor-transport-runtime-api.js";
+import type { FeishuStatusSink } from "./monitor.js";
 import {
   botNames,
   botOpenIds,
@@ -28,6 +29,7 @@ export type MonitorTransportParams = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   eventDispatcher: Lark.EventDispatcher;
+  statusSink?: FeishuStatusSink;
 };
 
 const FEISHU_WS_RECONNECT_INITIAL_DELAY_MS = 1_000;
@@ -166,6 +168,7 @@ export async function monitorWebSocket({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -182,18 +185,29 @@ export async function monitorWebSocket({
       wsClient = await createFeishuWSClient(account);
       if (abortSignal?.aborted) {
         cleanupFeishuWsClient({ accountId, wsClient, error });
+        statusSink?.({ connected: false });
         break;
       }
       wsClients.set(accountId, wsClient);
       await wsClient.start({ eventDispatcher });
       attempt = 0;
+      const now = Date.now();
+      statusSink?.({
+        connected: true,
+        mode: "websocket",
+        lastConnectedAt: now,
+        lastTransportActivityAt: now,
+        lastError: null,
+      });
       log(`feishu[${accountId}]: WebSocket client started`);
       await waitForFeishuWsAbort(abortSignal);
       log(`feishu[${accountId}]: abort signal received, stopping`);
       cleanupFeishuWsClient({ accountId, wsClient, error });
+      statusSink?.({ connected: false });
       return;
     } catch (err) {
       cleanupFeishuWsClient({ accountId, wsClient, error });
+      statusSink?.({ connected: false, lastError: formatFeishuWsErrorForLog(err) });
       if (abortSignal?.aborted) {
         break;
       }
@@ -217,6 +231,7 @@ export async function monitorWebhook({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -295,6 +310,13 @@ export async function monitorWebhook({
           respondText(res, 400, "Invalid JSON");
           return;
         }
+        const receivedAt = Date.now();
+        statusSink?.({
+          connected: true,
+          mode: "webhook",
+          lastTransportActivityAt: receivedAt,
+          lastError: null,
+        });
 
         const { isChallenge, challenge } = Lark.generateChallenge(payload, {
           encryptKey,
@@ -305,6 +327,7 @@ export async function monitorWebhook({
           res.end(JSON.stringify(challenge));
           return;
         }
+        statusSink?.({ lastEventAt: receivedAt });
 
         const value = await eventDispatcher.invoke(buildFeishuWebhookEnvelope(req, payload), {
           needCheck: false,
@@ -333,6 +356,7 @@ export async function monitorWebhook({
       httpServers.delete(accountId);
       botOpenIds.delete(accountId);
       botNames.delete(accountId);
+      statusSink?.({ connected: false });
     };
 
     const handleAbort = () => {
@@ -350,10 +374,19 @@ export async function monitorWebhook({
     abortSignal?.addEventListener("abort", handleAbort, { once: true });
 
     server.listen(port, host, () => {
+      const now = Date.now();
+      statusSink?.({
+        connected: true,
+        mode: "webhook",
+        lastConnectedAt: now,
+        lastTransportActivityAt: now,
+        lastError: null,
+      });
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
     });
 
     server.on("error", (err) => {
+      statusSink?.({ connected: false, lastError: String(err) });
       error(`feishu[${accountId}]: Webhook server error: ${err}`);
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -196,7 +196,6 @@ export async function monitorWebSocket({
         connected: true,
         mode: "websocket",
         lastConnectedAt: now,
-        lastTransportActivityAt: now,
         lastError: null,
       });
       log(`feishu[${accountId}]: WebSocket client started`);
@@ -379,7 +378,6 @@ export async function monitorWebhook({
         connected: true,
         mode: "webhook",
         lastConnectedAt: now,
-        lastTransportActivityAt: now,
         lastError: null,
       });
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -8,11 +8,21 @@ import {
   stopFeishuMonitorState,
 } from "./monitor.state.js";
 
+export type FeishuStatusSink = (patch: {
+  connected?: boolean;
+  lastConnectedAt?: number | null;
+  lastEventAt?: number | null;
+  lastTransportActivityAt?: number | null;
+  mode?: string;
+  lastError?: string | null;
+}) => void;
+
 export type MonitorFeishuOpts = {
   config?: ClawdbotConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   accountId?: string;
+  statusSink?: FeishuStatusSink;
 };
 
 let monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined;
@@ -50,6 +60,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
       account,
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
+      statusSink: opts.statusSink,
     });
   }
 
@@ -88,6 +99,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
         botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+        statusSink: opts.statusSink,
       }),
     );
   }

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -1,3 +1,4 @@
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { listEnabledFeishuAccounts, resolveFeishuRuntimeAccount } from "./accounts.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
@@ -8,14 +9,8 @@ import {
   stopFeishuMonitorState,
 } from "./monitor.state.js";
 
-export type FeishuStatusSink = (patch: {
-  connected?: boolean;
-  lastConnectedAt?: number | null;
-  lastEventAt?: number | null;
-  lastTransportActivityAt?: number | null;
-  mode?: string;
-  lastError?: string | null;
-}) => void;
+export type FeishuStatusPatch = Omit<ChannelAccountSnapshot, "accountId">;
+export type FeishuStatusSink = (patch: FeishuStatusPatch) => void;
 
 export type MonitorFeishuOpts = {
   config?: ClawdbotConfig;

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -217,6 +217,82 @@ describe("Feishu webhook signed-request e2e", () => {
     );
   });
 
+  it("reports webhook transport activity only after signed payload validation", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    const statusSink = vi.fn();
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "status-activity",
+        path: "/hook-e2e-status-activity",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+        statusSink,
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const activityPatches = () =>
+          statusSink.mock.calls
+            .map(([patch]) => patch as Record<string, unknown>)
+            .filter((patch) => typeof patch.lastTransportActivityAt === "number");
+
+        expect(activityPatches()).toHaveLength(0);
+
+        const unsignedResponse = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ type: "url_verification", challenge: "challenge-token" }),
+        });
+        expect(unsignedResponse.status).toBe(401);
+        expect(activityPatches()).toHaveLength(0);
+
+        const rawInvalidBody = "{not-json";
+        const invalidJsonResponse = await fetch(url, {
+          method: "POST",
+          headers: signFeishuPayload({ encryptKey: "encrypt_key", rawBody: rawInvalidBody }),
+          body: rawInvalidBody,
+        });
+        expect(invalidJsonResponse.status).toBe(400);
+        expect(activityPatches()).toHaveLength(0);
+
+        const eventPatchCountBeforeChallenge = statusSink.mock.calls.filter(
+          ([patch]) => typeof (patch as Record<string, unknown>).lastEventAt === "number",
+        ).length;
+        const challengeResponse = await postSignedPayload(url, {
+          type: "url_verification",
+          challenge: "challenge-token",
+        });
+        expect(challengeResponse.status).toBe(200);
+        expect(activityPatches()).toEqual([
+          expect.objectContaining({
+            connected: true,
+            mode: "webhook",
+            lastTransportActivityAt: expect.any(Number),
+            lastError: null,
+          }),
+        ]);
+        expect(
+          statusSink.mock.calls.filter(
+            ([patch]) => typeof (patch as Record<string, unknown>).lastEventAt === "number",
+          ),
+        ).toHaveLength(eventPatchCountBeforeChallenge);
+
+        const eventResponse = await postSignedPayload(url, {
+          schema: "2.0",
+          header: { event_type: "unknown.event" },
+          event: {},
+        });
+        expect(eventResponse.status).toBe(200);
+        expect(activityPatches()).toHaveLength(2);
+        expect(
+          statusSink.mock.calls.some(
+            ([patch]) => typeof (patch as Record<string, unknown>).lastEventAt === "number",
+          ),
+        ).toBe(true);
+      },
+    );
+  });
+
   it("accepts signed non-challenge events and reaches the dispatcher", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
 

--- a/extensions/feishu/src/monitor.webhook.test-helpers.ts
+++ b/extensions/feishu/src/monitor.webhook.test-helpers.ts
@@ -2,7 +2,7 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
-import type { monitorFeishuProvider } from "./monitor.js";
+import type { FeishuStatusSink, monitorFeishuProvider } from "./monitor.js";
 
 const WEBHOOK_READY_MAX_ATTEMPTS = 200;
 const WEBHOOK_READY_RETRY_DELAY_MS = 50;
@@ -69,6 +69,7 @@ export async function withRunningWebhookMonitor(
     path: string;
     verificationToken: string;
     encryptKey: string;
+    statusSink?: FeishuStatusSink;
   },
   monitor: typeof monitorFeishuProvider,
   run: (url: string) => Promise<void>,
@@ -91,6 +92,7 @@ export async function withRunningWebhookMonitor(
       runtime,
       abortSignal: abortController.signal,
       accountId: params.accountId,
+      statusSink: params.statusSink,
     });
 
     const url = `http://127.0.0.1:${port}${params.path}`;


### PR DESCRIPTION
## Summary

Implement Feishu channel health-signal reporting so gateway health monitoring can observe runtime activity correctly:

- add a status sink path from Feishu channel startup into monitor runtime updates
- report lifecycle connectivity (`connected`) and mode (`websocket`/`webhook`)
- report `lastEventAt` on inbound Feishu events
- clear connectivity on shutdown/error paths

This improves health monitor observability for Feishu channels and reduces false unhealthy restarts caused by missing runtime activity signals.

## Changes

- `extensions/feishu/src/channel.ts`
  - pass `statusSink` into `monitorFeishuProvider` (`ctx.setStatus` patch sink)
- `extensions/feishu/src/monitor.ts`
  - plumb `statusSink` through monitor options to single-account monitors
- `extensions/feishu/src/monitor.account.ts`
  - accept `statusSink`
  - mark inbound events as activity (`lastEventAt`) and connected
  - initialize mode/connected status for account monitor lifecycle
- `extensions/feishu/src/monitor.transport.ts`
  - accept `statusSink`
  - websocket/webhook start/abort/error paths update connectivity/error status
  - webhook request ingress updates `lastEventAt`

## Issue

Fixes #39488

## Test note

I could not run the full local extension test suite in this environment because `pnpm` is unavailable in the host shell. Please rely on CI for full validation.
