### PR TITLE
fix(providers): add kimi-coding User-Agent for subscription auth

### DIFF
--- a/src/agents/models-config.providers.kimi-coding.test.ts
+++ b/src/agents/models-config.providers.kimi-coding.test.ts
@@ -31,6 +31,11 @@ describe("kimi-coding implicit provider (#22409)", () => {
     expect(provider.models[0].id).toBe("k2p5");
   });
 
+  it("should include User-Agent header for subscription authentication (#30099)", () => {
+    const provider = buildKimiCodingProvider();
+    expect(provider.headers).toEqual({ "User-Agent": "claude-code/0.1.0" });
+  });
+
   it("should not include kimi-coding when no API key is configured", async () => {
     const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
     const envSnapshot = captureEnv(["KIMI_API_KEY"]);

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -308,6 +308,9 @@ export function buildKimiCodingProvider(): ProviderConfig {
   return {
     baseUrl: KIMI_CODING_BASE_URL,
     api: "anthropic-messages",
+    // Kimi Code API requires this User-Agent for subscription-tier authentication.
+    // Without it, requests are rejected or silently fall back to pay-per-use.
+    headers: { "User-Agent": "claude-code/0.1.0" },
     models: [
       {
         id: KIMI_CODING_DEFAULT_MODEL_ID,


### PR DESCRIPTION
## Root Cause

The Kimi Code API requires `User-Agent: claude-code/0.1.0` for subscription-tier authentication. Without this header, API requests are rejected or silently fall back to pay-per-use pricing, causing users with Kimi Code Plan subscriptions to experience authentication failures.

## Fix

Add the required `User-Agent` header to the built-in kimi-coding provider config in `buildKimiCodingProvider()`. The existing provider `headers` plumbing in `model.ts` already propagates provider-level headers into the resolved `Model.headers`, which pi-ai includes in outgoing HTTP requests.

## Changes

- `src/agents/models-config.providers.ts`: Add `headers: { "User-Agent": "claude-code/0.1.0" }` to kimi-coding provider config
- `src/agents/models-config.providers.kimi-coding.test.ts`: Add test verifying header is present

## Test plan

- [x] New test: `should include User-Agent header for subscription authentication (#30099)`
- [x] All 4 kimi-coding provider tests pass
- [x] All 32 model resolution tests pass (headers plumbing unaffected)

Fixes #30099