### PR TITLE
fix(cron): normalize moonshot kimi anthropic tool schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - ACP/stop reason mapping: resolve gateway chat `state: "error"` completions as ACP `end_turn` instead of `refusal` so transient backend failures are not surfaced as deliberate refusals. (#41187) thanks @pejmanjohn.
 - ACP/setSessionMode: propagate gateway `sessions.patch` failures back to ACP clients so rejected mode changes no longer return silent success. (#41185) thanks @pejmanjohn.
 - Agents/embedded logs: add structured, sanitized lifecycle and failover observation events so overload and provider failures are easier to tail and filter. (#41336) thanks @altaywtf.
+- Cron/Moonshot Kimi tools: normalize `anthropic-messages` tool payloads for Moonshot `kimi-*` and `k2*` models so isolated cron runs stop failing schema validation on OpenAI-style tool wrappers. Fixes #39359. (#39493) Thanks @SergioChan.
 - iOS/gateway foreground recovery: reconnect immediately on foreground return after stale background sockets are torn down, so the app no longer stays disconnected until a later wake path happens. (#41384) Thanks @mbelinky.
 - Cron/subagent followup: do not misclassify empty or `NO_REPLY` cron responses as interim acknowledgements that need a rerun, so deliberately silent cron jobs are no longer retried. (#41383) thanks @jackal092927.
 - Auth/cooldowns: reset expired auth-profile cooldown error counters before computing the next backoff so stale on-disk counters do not re-escalate into long cooldown loops after expiry. (#41028) thanks @zerone0x.

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -823,6 +823,48 @@ describe("applyExtraParamsToAgent", () => {
     ]);
   });
 
+  it("normalizes moonshot k2 anthropic tools to OpenAI function format", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tools: [
+          {
+            name: "read",
+            description: "Read file",
+            input_schema: { type: "object", properties: { path: { type: "string" } } },
+          },
+        ],
+      };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "moonshot", "k2-0711", undefined, "low");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "moonshot",
+      id: "k2-0711",
+      baseUrl: "https://api.moonshot.ai/v1",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read file",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ]);
+  });
+
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -781,6 +781,48 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
   });
 
+  it("normalizes moonshot kimi anthropic tools to OpenAI function format", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tools: [
+          {
+            name: "read",
+            description: "Read file",
+            input_schema: { type: "object", properties: { path: { type: "string" } } },
+          },
+        ],
+      };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "low");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "moonshot",
+      id: "kimi-k2.5",
+      baseUrl: "https://api.moonshot.ai/v1",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read file",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ]);
+  });
+
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -53,9 +53,20 @@ function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
   return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
 }
 
+function isMoonshotKimiAnthropicModel(model: { provider?: unknown; id?: unknown }): boolean {
+  const provider = typeof model.provider === "string" ? model.provider.trim().toLowerCase() : "";
+  if (provider !== "moonshot") {
+    return false;
+  }
+
+  const modelId = typeof model.id === "string" ? model.id.trim().toLowerCase() : "";
+  return modelId.startsWith("kimi-") || modelId.startsWith("k2");
+}
+
 function requiresAnthropicToolPayloadCompatibilityForModel(model: {
   api?: unknown;
   provider?: unknown;
+  id?: unknown;
   compat?: unknown;
 }): boolean {
   if (model.api !== "anthropic-messages") {
@@ -66,6 +77,10 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
     typeof model.provider === "string" &&
     requiresOpenAiCompatibleAnthropicToolPayload(model.provider)
   ) {
+    return true;
+  }
+
+  if (isMoonshotKimiAnthropicModel(model)) {
     return true;
   }
 
@@ -81,9 +96,13 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
 
 function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
   provider?: unknown;
+  id?: unknown;
   compat?: unknown;
 }): boolean {
   if (typeof model.provider === "string" && usesOpenAiFunctionAnthropicToolSchema(model.provider)) {
+    return true;
+  }
+  if (isMoonshotKimiAnthropicModel(model)) {
     return true;
   }
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
@@ -97,12 +116,16 @@ function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
 
 function usesOpenAiStringModeAnthropicToolChoiceForModel(model: {
   provider?: unknown;
+  id?: unknown;
   compat?: unknown;
 }): boolean {
   if (
     typeof model.provider === "string" &&
     usesOpenAiStringModeAnthropicToolChoice(model.provider)
   ) {
+    return true;
+  }
+  if (isMoonshotKimiAnthropicModel(model)) {
     return true;
   }
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {


### PR DESCRIPTION
## Summary
- normalize Anthropics-style tools payloads into OpenAI `type: "function"` schema for Moonshot Kimi runs (`moonshot` provider + `anthropic-messages` API + `kimi-*`/`k2*` model IDs)
- keep existing behavior for explicit `kimi-coding` provider and `api.kimi.com/coding` endpoints
- add regression coverage for Moonshot Kimi payload normalization in isolated run path

## Testing
- `pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts`

## Related
Fixes #39359