### PR TITLE
Gateway: prevent duplicate webchat assistant transcript entries

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { GATEWAY_CLIENT_CAPS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
@@ -16,6 +16,8 @@ const mockState = vi.hoisted(() => ({
   finalText: "[[reply_to_current]]",
   triggerAgentRunStart: false,
   agentRunId: "run-agent-1",
+  persistAssistantBeforeFinal: false,
+  persistedAssistantText: "",
   sessionEntry: {} as Record<string, unknown>,
   lastDispatchCtx: undefined as MsgContext | undefined,
 }));
@@ -67,6 +69,16 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       if (mockState.triggerAgentRunStart) {
         params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
       }
+      if (mockState.persistAssistantBeforeFinal) {
+        const sessionManager = SessionManager.open(mockState.transcriptPath);
+        sessionManager.appendMessage({
+          role: "assistant",
+          content: [{ type: "text", text: mockState.persistedAssistantText }],
+          timestamp: Date.now(),
+          stopReason: "stop",
+          usage: { input: 0, output: 0, totalTokens: 0 },
+        });
+      }
       params.dispatcher.sendFinalReply({ text: mockState.finalText });
       params.dispatcher.markComplete();
       await params.dispatcher.waitForIdle();
@@ -93,6 +105,27 @@ function createTranscriptFixture(prefix: string) {
     "utf-8",
   );
   mockState.transcriptPath = transcriptPath;
+}
+
+function readTranscriptAssistantMessages(transcriptPath: string): Array<Record<string, unknown>> {
+  const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/).filter(Boolean);
+  return lines
+    .map((line) => {
+      try {
+        return JSON.parse(line) as { message?: unknown };
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is { message: Record<string, unknown> } => {
+      return (
+        Boolean(entry) &&
+        Boolean(entry?.message) &&
+        typeof entry?.message === "object" &&
+        (entry.message as { role?: unknown }).role === "assistant"
+      );
+    })
+    .map((entry) => entry.message);
 }
 
 function extractFirstTextBlock(payload: unknown): string | undefined {
@@ -210,6 +243,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.mainSessionKey = "main";
     mockState.triggerAgentRunStart = false;
     mockState.agentRunId = "run-agent-1";
+    mockState.persistAssistantBeforeFinal = false;
+    mockState.persistedAssistantText = "";
     mockState.sessionEntry = {};
     mockState.lastDispatchCtx = undefined;
   });
@@ -325,6 +360,25 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       }),
     );
     expect(extractFirstTextBlock(payload)).toBe("");
+  });
+
+  it("chat.send avoids duplicate transcript append when a matching assistant message was already persisted", async () => {
+    createTranscriptFixture("openclaw-chat-send-dedup-existing-assistant-");
+    mockState.finalText = "Perfect - right there in Starred, one click away.";
+    mockState.persistAssistantBeforeFinal = true;
+    mockState.persistedAssistantText = `\n\n${mockState.finalText}`;
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-existing-assistant",
+    });
+
+    const assistantMessages = readTranscriptAssistantMessages(mockState.transcriptPath);
+    expect(assistantMessages).toHaveLength(1);
+    expect(extractFirstTextBlock(payload)?.trim()).toBe(mockState.finalText);
   });
 
   it("rejects oversized chat.send session keys before dispatch", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -561,6 +561,75 @@ function appendAssistantTranscriptMessage(params: {
   });
 }
 
+function extractAssistantMessageText(message: Record<string, unknown>): string | null {
+  if (typeof message.text === "string" && message.text.trim()) {
+    return message.text;
+  }
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  if (!Array.isArray(message.content)) {
+    return null;
+  }
+
+  const textBlocks = message.content
+    .map((block) => {
+      if (!block || typeof block !== "object") {
+        return null;
+      }
+      const typed = block as { type?: unknown; text?: unknown };
+      return typed.type === "text" && typeof typed.text === "string" ? typed.text : null;
+    })
+    .filter((value): value is string => typeof value === "string");
+
+  if (textBlocks.length === 0) {
+    return null;
+  }
+  return textBlocks.join("\n");
+}
+
+function findRecentMatchingAssistantTranscriptMessage(params: {
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  expectedText: string;
+  minTimestampMs: number;
+}): Record<string, unknown> | undefined {
+  const normalizedExpectedText = params.expectedText.trim();
+  if (!normalizedExpectedText) {
+    return undefined;
+  }
+
+  const messages = readSessionMessages(params.sessionId, params.storePath, params.sessionFile);
+  for (let idx = messages.length - 1; idx >= 0; idx -= 1) {
+    const current = messages[idx];
+    if (!current || typeof current !== "object") {
+      continue;
+    }
+    const message = current as Record<string, unknown>;
+    if (message.role !== "assistant") {
+      continue;
+    }
+
+    const timestampRaw = message.timestamp;
+    const timestamp =
+      typeof timestampRaw === "number" && Number.isFinite(timestampRaw) ? timestampRaw : undefined;
+    if (typeof timestamp === "number" && timestamp < params.minTimestampMs) {
+      return undefined;
+    }
+
+    const text = extractAssistantMessageText(message);
+    if (!text) {
+      return undefined;
+    }
+    if (text.trim() === normalizedExpectedText) {
+      return message;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
 function collectSessionAbortPartials(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatRunBuffers: Map<string, string>;
@@ -1089,30 +1158,41 @@ export const chatHandlers: GatewayRequestHandlers = {
               const { storePath: latestStorePath, entry: latestEntry } =
                 loadSessionEntry(sessionKey);
               const sessionId = latestEntry?.sessionId ?? entry?.sessionId ?? clientRunId;
-              const appended = appendAssistantTranscriptMessage({
-                message: combinedReply,
+              const existingMessage = findRecentMatchingAssistantTranscriptMessage({
                 sessionId,
                 storePath: latestStorePath,
                 sessionFile: latestEntry?.sessionFile,
-                agentId,
-                createIfMissing: true,
+                expectedText: combinedReply,
+                minTimestampMs: now,
               });
-              if (appended.ok) {
-                message = appended.message;
+              if (existingMessage) {
+                message = existingMessage;
               } else {
-                context.logGateway.warn(
-                  `webchat transcript append failed: ${appended.error ?? "unknown error"}`,
-                );
-                const now = Date.now();
-                message = {
-                  role: "assistant",
-                  content: [{ type: "text", text: combinedReply }],
-                  timestamp: now,
-                  // Keep this compatible with Pi stopReason enums even though this message isn't
-                  // persisted to the transcript due to the append failure.
-                  stopReason: "stop",
-                  usage: { input: 0, output: 0, totalTokens: 0 },
-                };
+                const appended = appendAssistantTranscriptMessage({
+                  message: combinedReply,
+                  sessionId,
+                  storePath: latestStorePath,
+                  sessionFile: latestEntry?.sessionFile,
+                  agentId,
+                  createIfMissing: true,
+                });
+                if (appended.ok) {
+                  message = appended.message;
+                } else {
+                  context.logGateway.warn(
+                    `webchat transcript append failed: ${appended.error ?? "unknown error"}`,
+                  );
+                  const now = Date.now();
+                  message = {
+                    role: "assistant",
+                    content: [{ type: "text", text: combinedReply }],
+                    timestamp: now,
+                    // Keep this compatible with Pi stopReason enums even though this message isn't
+                    // persisted to the transcript due to the append failure.
+                    stopReason: "stop",
+                    usage: { input: 0, output: 0, totalTokens: 0 },
+                  };
+                }
               }
             }
             broadcastChatFinal({


### PR DESCRIPTION
## Summary

- Problem: `chat.send` fallback persistence in Control UI could append a second assistant transcript message when the same assistant turn was already persisted upstream.
- Why it matters: session JSONL gets duplicate assistant entries, polluting context and showing double messages in webchat.
- What changed: before fallback append, `chat.send` now checks the latest recent assistant transcript message for a text match and reuses it instead of appending again.
- What did NOT change (scope boundary): no changes to non-webchat channel delivery paths, transcript format, or session compaction behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39469
- Related #

## User-visible / Behavior Changes

- Control UI `chat.send` no longer records duplicate assistant transcript entries for turns where assistant output was already persisted.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local dev macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: mocked in unit tests
- Integration/channel (if any): gateway Control UI (`chat.send`)
- Relevant config (redacted): default test harness config

### Steps

1. Simulate `chat.send` non-streaming flow where no agent lifecycle start event is observed.
2. Persist assistant transcript output upstream before `chat.send` fallback append executes.
3. Complete dispatch final payload and inspect transcript assistant entries.

### Expected

- Exactly one assistant transcript message for the turn.

### Actual

- Verified: one assistant transcript message after fix (regression test).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Added regression test covering pre-persisted assistant + `chat.send` fallback path.
  - Confirmed gateway chat suites pass locally.
- Edge cases checked:
  - Existing non-streaming command path still broadcasts final payload.
- What you did **not** verify:
  - Live end-to-end against an actual Control UI browser session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `17354028d`.
- Files/config to restore:
  - `src/gateway/server-methods/chat.ts`
  - `src/gateway/server-methods/chat.directive-tags.test.ts`
- Known bad symptoms reviewers should watch for:
  - Missing assistant transcript persistence for non-agent chat replies.

## Risks and Mitigations

- Risk:
  - False-positive dedupe if fallback text exactly matches a recent assistant message.
- Mitigation:
  - Matching is limited to the latest assistant message and requires recency (`timestamp >= turn start`), reducing accidental skips.

## Validation Commands

- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts` (pass: 19 tests)
- `pnpm test src/gateway/server.chat.gateway-server-chat.test.ts` (pass: 10 tests)
