### PR TITLE
fix(feishu): make replyInThread "disabled" fully suppress thread replies

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1670,7 +1670,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
-  it("forces thread replies when inbound message contains thread_id", async () => {
+  it("suppresses thread replies when replyInThread is disabled even if inbound message contains thread_id", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -1703,8 +1703,8 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
-        replyInThread: true,
-        threadReply: true,
+        replyInThread: false,
+        threadReply: false,
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -249,10 +249,12 @@ function resolveFeishuGroupSession(params: {
 
   const normalizedThreadId = threadId?.trim();
   const normalizedRootId = rootId?.trim();
-  const threadReply = Boolean(normalizedThreadId || normalizedRootId);
-  const replyInThread =
-    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
-    threadReply;
+  const configReplyInThread =
+    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
+  // Only treat incoming thread context as a thread reply when the config enables it;
+  // otherwise "disabled" would still follow threads on quote-reply messages.
+  const threadReply = configReplyInThread && Boolean(normalizedThreadId || normalizedRootId);
+  const replyInThread = configReplyInThread;
 
   const legacyTopicSessionMode =
     groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -251,10 +251,6 @@ function resolveFeishuGroupSession(params: {
   const normalizedRootId = rootId?.trim();
   const configReplyInThread =
     (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-  // Only treat incoming thread context as a thread reply when the config enables it;
-  // otherwise "disabled" would still follow threads on quote-reply messages.
-  const threadReply = configReplyInThread && Boolean(normalizedThreadId || normalizedRootId);
-  const replyInThread = configReplyInThread;
 
   const legacyTopicSessionMode =
     groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
@@ -262,6 +258,16 @@ function resolveFeishuGroupSession(params: {
     groupConfig?.groupSessionScope ??
     feishuCfg?.groupSessionScope ??
     (legacyTopicSessionMode === "enabled" ? "group_topic" : "group");
+
+  const isTopicScope =
+    groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender";
+  // Preserve thread context when config enables it OR when the group uses a
+  // topic-based session scope (topic sessions inherently need thread anchoring).
+  // When replyInThread is "disabled" in a non-topic group, incoming thread_id /
+  // root_id are ignored so quote-reply messages don't silently create threads.
+  const threadReply =
+    (configReplyInThread || isTopicScope) && Boolean(normalizedThreadId || normalizedRootId);
+  const replyInThread = configReplyInThread;
 
   // Keep topic session keys stable across the "first turn creates thread" flow:
   // first turn may only have message_id, while the next turn carries root_id/thread_id.


### PR DESCRIPTION
## Summary

- **Problem:** When `replyInThread` is set to `"disabled"`, the bot still creates thread-style replies if the user sends a message using Feishu's "reply to" (quote-reply) feature. This happens because the presence of `threadId` or `rootId` in the incoming message unconditionally sets `threadReply = true` and overrides the `replyInThread` config value.
- **Why it matters:** Users who configure `replyInThread: "disabled"` expect all bot replies to appear as independent messages in the group chat, regardless of how the user initiated the conversation. The current behavior breaks this expectation for quote-reply messages.
- **What changed:** Made `threadReply` and `replyInThread` in `resolveFeishuGroupSession` conditional on the config value. When `replyInThread` is `"disabled"`, both `threadReply` and `replyInThread` are always `false`, even when the incoming message has `threadId`/`rootId`.
- **What did NOT change (scope boundary):** When `replyInThread` is `"enabled"`, behavior is identical to before — thread context from incoming messages is preserved and the bot replies in-thread. Topic-mode groups and `replyTargetMessageId` logic (from #33789) are unaffected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #32980
- Related #33789

## User-visible / Behavior Changes

- When `replyInThread: "disabled"` (the default), bot replies are always sent as independent messages, even when the user uses Feishu's quote-reply feature. Previously, quote-reply messages would cause the bot to create thread-style replies despite the disabled config.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Integration/channel: Feishu
- Relevant config: `channels.feishu.replyInThread: "disabled"` (default)

### Steps

1. Configure a Feishu group with `replyInThread: "disabled"` (or use the default)
2. Send a regular @bot message → bot replies as independent message ✓
3. Use Feishu's "reply to" (quote-reply) on a previous message, @bot in the reply

### Expected

- Bot reply appears as an independent message in the group chat (not in a thread)

### Actual (before fix)

- Bot reply appears as a thread reply under the quoted message

## Evidence

- [x] Tested in production Feishu group with `replyInThread: "disabled"` — quote-reply messages now produce independent bot replies

## Human Verification (required)

- Verified scenarios: Regular @bot message, quote-reply @bot message, both with `replyInThread: "disabled"`
- Edge cases checked: `replyInThread: "enabled"` still works correctly (thread behavior preserved)
- What you did **not** verify: `group_topic` / `group_topic_sender` session modes (no topic-mode group available for testing, but code path is unaffected by this change)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `replyInThread: "enabled"` to restore old behavior, or revert this commit
- Files/config to restore: `extensions/feishu/src/bot.ts`
- Known bad symptoms reviewers should watch for: Bot replies not appearing in expected thread location when `replyInThread: "enabled"`

## Risks and Mitigations

- Risk: Users who relied on the implicit "follow thread when user replies in-thread" behavior with `replyInThread: "disabled"` will see a behavior change
  - Mitigation: This is the intended semantic — "disabled" should mean "never use threads". Users who want thread-following can set `replyInThread: "enabled"`.