### PR TITLE
docs: Clarify Main Session Cron behavior and HEARTBEAT.md integration

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -144,7 +144,7 @@ They must use `payload.kind = "systemEvent"`.
 This is the best fit when you want the normal heartbeat prompt + main-session context.
 See [Heartbeat](/gateway/heartbeat).
 
-#### HEARTBEAT.md Integration for Main Session Jobs
+##### HEARTBEAT.md Integration for Main Session Jobs
 
 **Important:** Main session cron jobs use a specialized prompt (`buildCronEventPrompt`) that does **not** include the "Read HEARTBEAT.md" instruction from the default heartbeat prompt.
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -144,6 +144,25 @@ They must use `payload.kind = "systemEvent"`.
 This is the best fit when you want the normal heartbeat prompt + main-session context.
 See [Heartbeat](/gateway/heartbeat).
 
+#### HEARTBEAT.md Integration for Main Session Jobs
+
+**Important:** Main session cron jobs use a specialized prompt (`buildCronEventPrompt`) that does **not** include the "Read HEARTBEAT.md" instruction from the default heartbeat prompt.
+
+If you want your cron events to trigger tasks defined in `HEARTBEAT.md`, add the following to your `AGENTS.md`:
+
+```markdown
+## Cron System Event Handling
+
+When you receive a cron system event (prompt contains "A scheduled reminder has been triggered"):
+1. Read `HEARTBEAT.md` to find the task configuration for this event (e.g., `daily_morning_brief`)
+2. Execute the task (e.g., send daily brief, wake-up call, etc.)
+3. Report completion to the user
+```
+
+This workaround is necessary because the cron event prompt is designed to be self-contained and does not automatically reference `HEARTBEAT.md`.
+
+**Related Issue:** [#11726](https://github.com/openclaw/openclaw/issues/11726)
+
 #### Isolated jobs (dedicated cron sessions)
 
 Isolated jobs run a dedicated agent turn in session `cron:<jobId>`.

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -214,6 +214,23 @@ Think of it like a human reviewing their journal and updating their mental model
 
 The goal: Be helpful without being annoying. Check in a few times a day, do useful background work, but respect quiet time.
 
+### Handling Cron System Events
+
+If you use Main Session Cron jobs (`--session main --system-event`), add this section to handle cron events:
+
+```markdown
+## Cron System Event Handling
+
+When your prompt contains "A scheduled reminder has been triggered":
+1. Read `HEARTBEAT.md` to find the task configuration for the event
+2. Execute the task (e.g., daily brief, wake-up call, calendar check)
+3. Report completion to the user
+
+Example event texts: `daily_morning_brief`, `calendar_sync`, `weekly_review`
+```
+
+This is necessary because cron event prompts do not include the "Read HEARTBEAT.md" instruction by default.
+
 ## Make It Yours
 
 This is a starting point. Add your own conventions, style, and rules as you figure out what works.

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -3,6 +3,11 @@ import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 // Build a dynamic prompt for cron events by embedding the actual event content.
 // This ensures the model sees the reminder text directly instead of relying on
 // "shown in the system messages above" which may not be visible in context.
+// 
+// Note: The prompt intentionally omits "Read HEARTBEAT.md" because cron events
+// are meant to be self-contained reminders. If you need HEARTBEAT.md integration,
+// configure your agent's AGENTS.md to check HEARTBEAT.md when receiving system events.
+// See: https://github.com/openclaw/openclaw/issues/11726
 export function buildCronEventPrompt(
   pendingEvents: string[],
   opts?: {


### PR DESCRIPTION
## Problem

When using Main Session Cron jobs (`--session main --system-event`), the cron event prompt does not include the "Read HEARTBEAT.md" instruction that the default heartbeat prompt contains.

This causes confusion for users who expect their HEARTBEAT.md tasks to be executed when cron events trigger.

**Related Issues:**
- #11726 - Cron jobs with sessionTarget: "main" inject systemEvent but dont trigger agent turn
- #10538 - Cron main-session jobs frequently "skipped: timeout waiting for main lane to become idle"

## Root Cause

In `/app/src/infra/heartbeat-runner.ts`, when cron events are present, the system calls `buildCronEventPrompt()` instead of the default `HEARTBEAT_PROMPT`:

```typescript
const prompt = hasExecCompletion
  ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
  : hasCronEvents
    ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })  // ← No "Read HEARTBEAT.md"
    : resolveHeartbeatPrompt(params.cfg, params.heartbeat);  // ← Contains "Read HEARTBEAT.md"
```

## Changes

1. **`/app/src/infra/heartbeat-events-filter.ts`** - Added code comment explaining the behavior and workaround
2. **`/app/docs/automation/cron-jobs.md`** - Added "HEARTBEAT.md Integration" section with workaround guidance
3. **`/app/docs/reference/templates/AGENTS.md`** - Added "Handling Cron System Events" section to template

## Workaround for Users

Until this is fixed, users can add the following to their `AGENTS.md`:

```markdown
## Cron System Event Handling

When you receive a cron system event (prompt contains "A scheduled reminder has been triggered"):
1. Read HEARTBEAT.md to find the task configuration for this event
2. Execute the task (e.g., send daily brief, wake-up call, etc.)
3. Report completion to the user
```

## Future Work

Consider adding a config option to include HEARTBEAT.md instruction in cron event prompts, or merge cron event handling with heartbeat prompt logic for consistency.