### PR TITLE
fix(feishu): respect configured localRoots for outbound media paths

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -160,6 +160,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         textChunkLimit: { type: "integer", minimum: 1 },
         chunkMode: { type: "string", enum: ["length", "newline"] },
         mediaMaxMb: { type: "number", minimum: 0 },
+        localRoots: {
+          oneOf: [
+            { type: "string", enum: ["any"] },
+            { type: "array", items: { type: "string" } },
+          ],
+        },
         renderMode: { type: "string", enum: ["auto", "raw", "card"] },
         accounts: {
           type: "object",
@@ -177,6 +183,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               webhookHost: { type: "string" },
               webhookPath: { type: "string" },
               webhookPort: { type: "integer", minimum: 1 },
+              localRoots: {
+                oneOf: [
+                  { type: "string", enum: ["any"] },
+                  { type: "array", items: { type: "string" } },
+                ],
+              },
             },
           },
         },

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -165,6 +165,7 @@ const FeishuSharedConfigShape = {
   chunkMode: z.enum(["length", "newline"]).optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema,
   mediaMaxMb: z.number().positive().optional(),
+  localRoots: z.union([z.literal("any"), z.array(z.string())]).optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -288,6 +288,36 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
+  it("uses channels.feishu.localRoots='any' when explicit mediaLocalRoots are absent", async () => {
+    loadWebMediaMock.mockResolvedValue({
+      buffer: Buffer.from("local-file"),
+      fileName: "doc.pdf",
+      kind: "document",
+      contentType: "application/pdf",
+    });
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      configured: true,
+      accountId: "main",
+      config: { localRoots: "any" },
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+    });
+
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaUrl: "/Users/demo/file.pdf",
+    });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith(
+      "/Users/demo/file.pdf",
+      expect.objectContaining({
+        localRoots: "any",
+      }),
+    );
+  });
+
   it("fails closed when media URL fetch is blocked", async () => {
     loadWebMediaMock.mockRejectedValueOnce(
       new Error("Blocked: resolves to private/internal IP address"),

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -454,10 +454,18 @@ export async function sendMediaFeishu(params: {
     buffer = mediaBuffer;
     name = fileName ?? "file";
   } else if (mediaUrl) {
+    const configuredLocalRoots = account.config?.localRoots;
+    const effectiveLocalRoots = mediaLocalRoots?.length
+      ? mediaLocalRoots
+      : configuredLocalRoots === "any"
+        ? "any"
+        : configuredLocalRoots?.length
+          ? configuredLocalRoots
+          : undefined;
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
-      localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
+      localRoots: effectiveLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw message send --channel feishu --media <local path>` can fail with `LocalMediaAccessError: path-not-allowed` even when users configure `channels.feishu.localRoots`.
- Why it matters: Feishu users cannot use documented per-channel local media allowlists/bypass behavior for legitimate local attachments.
- What changed: Added `localRoots` to Feishu config schema (`"any"` or `string[]`) and wired outbound media loading to fall back to `account.config.localRoots` when runtime `mediaLocalRoots` is absent.
- What did NOT change (scope boundary): No change to default security roots, no cross-channel behavior changes, and no bypass when agent-scoped roots are explicitly provided.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39506
- Related #27884

## User-visible / Behavior Changes

- Feishu now honors `channels.feishu.localRoots` (including `"any"`) for outbound local media when explicit runtime `mediaLocalRoots` are not provided.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: channel-configured `localRoots` can widen local media read scope for Feishu outbound attachments.
  - Mitigation: behavior is explicit opt-in, schema constrained to `"any"`/`string[]`, and existing default root restrictions remain unchanged when `localRoots` is unset.

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu outbound media
- Relevant config (redacted): `channels.feishu.localRoots: "any"`

### Steps

1. Configure Feishu with `channels.feishu.localRoots: "any"`.
2. Run outbound media send with a local path outside default roots.
3. Observe `loadWebMedia` receives `localRoots: "any"` and proceeds through media upload flow.

### Expected

- Configured Feishu local roots are respected for outbound local media path validation.

### Actual

- Added fallback to account/channel config roots, including `"any"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `mediaLocalRoots` explicit array still forwarded unchanged.
  - `account.config.localRoots = "any"` is used when `mediaLocalRoots` is absent.
- Edge cases checked:
  - Existing default behavior remains when neither explicit roots nor config roots are set.
- What you did **not** verify:
  - End-to-end live Feishu delivery against real tenant credentials.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Optional
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `channels.feishu.localRoots` from config, or revert this PR commit.
- Files/config to restore:
  - `extensions/feishu/src/media.ts`
  - `extensions/feishu/src/config-schema.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected acceptance/rejection of local media paths in Feishu sends.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Misconfigured `localRoots` may be broader than intended.
  - Mitigation: keep roots narrow by default; use `"any"` only when explicitly desired.
