### PR TITLE
fix: add shell:true for browser spawn on Windows

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -276,6 +276,7 @@ export async function launchOpenClawChrome(
 
     return spawn(exe.path, args, {
       stdio: "pipe",
+      shell: process.platform === "win32",
       env: {
         ...process.env,
         // Reduce accidental sharing with the user's env.


### PR DESCRIPTION
Fixes #39522

- Set shell: true when spawning Chrome on Windows (process.platform === 'win32')
- This allows Windows to properly resolve .cmd/.bat wrappers and PATH-based executables
- Fixes 'spawn UNKNOWN' error when running 'openclaw browser start' on Windows 11