### PR TITLE
fix(gateway): normalize auth values before ws connect

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,23 +183,23 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "abb0380989460de3f211d60628b439de7ebcd482",
+        "hashed_secret": "7afea670e53d801f1f881c99c40aa177e3395bfa",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "c0baa9660a8d3b11874c63a535d8369f4a8fa8fa",
         "is_verified": false,
-        "line_number": 722
+        "line_number": 723
       }
     ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
@@ -9795,63 +9795,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1611
+        "line_number": 1612
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1628
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1812
+        "line_number": 1813
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1985
+        "line_number": 1986
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2041
+        "line_number": 2042
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2274
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2401
+        "line_number": 2402
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2654
+        "line_number": 2655
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2656
+        "line_number": 2657
       }
     ],
     "docs/gateway/configuration.md": [
@@ -9945,7 +9945,7 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2489
+        "line_number": 2490
       }
     ],
     "docs/install/macos-vm.md": [
@@ -10033,14 +10033,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [
@@ -12470,35 +12470,35 @@
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
         "is_verified": false,
-        "line_number": 607
+        "line_number": 623
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
         "is_verified": false,
-        "line_number": 611
+        "line_number": 627
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 683
+        "line_number": 699
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "e493f561d90c6638c1f51c5a8a069c3b129b79ed",
         "is_verified": false,
-        "line_number": 690
+        "line_number": 706
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "bddc29032de580fb53b3a9a0357dd409086db800",
         "is_verified": false,
-        "line_number": 704
+        "line_number": 720
       }
     ],
     "src/gateway/client.e2e.test.ts": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T05:05:36Z"
+  "generated_at": "2026-03-08T07:07:40Z"
 }

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -215,6 +215,22 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.password).toBeUndefined();
   });
 
+  it("normalizes non-Latin1 gateway env tokens before connecting", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "remote", bind: "loopback", remote: {} },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+    process.env.OPENCLAW_GATEWAY_URL = "wss://gateway-in-container.internal:9443/ws";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "│env-token";
+
+    await callGateway({
+      method: "health",
+    });
+
+    expect(lastClientOptions?.token).toBe("env-token");
+  });
+
   it("uses env URL override credentials without resolving local password SecretRefs", async () => {
     loadConfig.mockReturnValue({
       gateway: {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -21,6 +21,7 @@ import { GatewayClient } from "./client.js";
 import {
   GatewaySecretRefUnavailableError,
   resolveGatewayCredentialsFromConfig,
+  trimCredentialToUndefined,
   trimToUndefined,
   type GatewayCredentialMode,
   type GatewayCredentialPrecedence,
@@ -87,12 +88,8 @@ export type ExplicitGatewayAuth = {
 };
 
 export function resolveExplicitGatewayAuth(opts?: ExplicitGatewayAuth): ExplicitGatewayAuth {
-  const token =
-    typeof opts?.token === "string" && opts.token.trim().length > 0 ? opts.token.trim() : undefined;
-  const password =
-    typeof opts?.password === "string" && opts.password.trim().length > 0
-      ? opts.password.trim()
-      : undefined;
+  const token = trimCredentialToUndefined(opts?.token);
+  const password = trimCredentialToUndefined(opts?.password);
   return { token, password };
 }
 

--- a/src/gateway/credentials.test.ts
+++ b/src/gateway/credentials.test.ts
@@ -523,4 +523,19 @@ describe("resolveGatewayCredentialsFromValues", () => {
     });
     expect(resolved).toEqual({ token: "real-token-value", password: "real-password" }); // pragma: allowlist secret
   });
+
+  it("normalizes non-Latin1 gateway credentials before precedence checks", () => {
+    const resolved = resolveGatewayCredentialsFromValues({
+      configToken: "  \u2502config-token\n",
+      configPassword: "\u2502config-password", // pragma: allowlist secret
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "\u2502env-token",
+        OPENCLAW_GATEWAY_PASSWORD: "\u2502env-password", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+    });
+    expect(resolved).toEqual({
+      token: "env-token",
+      password: "env-password", // pragma: allowlist secret
+    });
+  });
 });

--- a/src/gateway/credentials.ts
+++ b/src/gateway/credentials.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { containsEnvVarReference } from "../config/env-substitution.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 
 export type ExplicitGatewayAuth = {
   token?: string;
@@ -65,11 +66,14 @@ export function trimToUndefined(value: unknown): string | undefined {
  * also be rejected, but this is an extremely unlikely edge case.
  */
 export function trimCredentialToUndefined(value: unknown): string | undefined {
-  const trimmed = trimToUndefined(value);
-  if (trimmed && containsEnvVarReference(trimmed)) {
+  const normalized = normalizeSecretInput(value);
+  if (!normalized) {
     return undefined;
   }
-  return trimmed;
+  if (containsEnvVarReference(normalized)) {
+    return undefined;
+  }
+  return normalized;
 }
 
 function firstDefined(values: Array<string | undefined>): string | undefined {
@@ -89,28 +93,28 @@ export function readGatewayTokenEnv(
   env: NodeJS.ProcessEnv = process.env,
   includeLegacyEnv = true,
 ): string | undefined {
-  const primary = trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
+  const primary = trimCredentialToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
   if (primary) {
     return primary;
   }
   if (!includeLegacyEnv) {
     return undefined;
   }
-  return trimToUndefined(env.CLAWDBOT_GATEWAY_TOKEN);
+  return trimCredentialToUndefined(env.CLAWDBOT_GATEWAY_TOKEN);
 }
 
 export function readGatewayPasswordEnv(
   env: NodeJS.ProcessEnv = process.env,
   includeLegacyEnv = true,
 ): string | undefined {
-  const primary = trimToUndefined(env.OPENCLAW_GATEWAY_PASSWORD);
+  const primary = trimCredentialToUndefined(env.OPENCLAW_GATEWAY_PASSWORD);
   if (primary) {
     return primary;
   }
   if (!includeLegacyEnv) {
     return undefined;
   }
-  return trimToUndefined(env.CLAWDBOT_GATEWAY_PASSWORD);
+  return trimCredentialToUndefined(env.CLAWDBOT_GATEWAY_PASSWORD);
 }
 
 export function hasGatewayTokenEnvCandidate(
@@ -173,8 +177,8 @@ export function resolveGatewayCredentialsFromConfig(params: {
 }): ResolvedGatewayCredentials {
   const env = params.env ?? process.env;
   const includeLegacyEnv = params.includeLegacyEnv ?? true;
-  const explicitToken = trimToUndefined(params.explicitAuth?.token);
-  const explicitPassword = trimToUndefined(params.explicitAuth?.password);
+  const explicitToken = trimCredentialToUndefined(params.explicitAuth?.token);
+  const explicitPassword = trimCredentialToUndefined(params.explicitAuth?.password);
   if (explicitToken || explicitPassword) {
     return { token: explicitToken, password: explicitPassword };
   }
@@ -216,12 +220,16 @@ export function resolveGatewayCredentialsFromConfig(params: {
     value: remote?.password,
     defaults,
   }).ref;
-  const remoteToken = remoteTokenRef ? undefined : trimToUndefined(remote?.token);
-  const remotePassword = remotePasswordRef ? undefined : trimToUndefined(remote?.password);
-  const localToken = localTokenRef ? undefined : trimToUndefined(params.cfg.gateway?.auth?.token);
+  const remoteToken = remoteTokenRef ? undefined : trimCredentialToUndefined(remote?.token);
+  const remotePassword = remotePasswordRef
+    ? undefined
+    : trimCredentialToUndefined(remote?.password);
+  const localToken = localTokenRef
+    ? undefined
+    : trimCredentialToUndefined(params.cfg.gateway?.auth?.token);
   const localPassword = localPasswordRef
     ? undefined
-    : trimToUndefined(params.cfg.gateway?.auth?.password);
+    : trimCredentialToUndefined(params.cfg.gateway?.auth?.password);
 
   const localTokenPrecedence =
     params.localTokenPrecedence ??


### PR DESCRIPTION
## Summary
- normalize explicit, env, and config-backed gateway token/password values before they reach the websocket client
- add regression coverage for non-Latin1 auth values like `U+2502` so malformed copy/paste input no longer trips ByteString conversion

Closes #39426.

## Why
The gateway auth path still trimmed token/password values but did not run the same secret normalization that already protects provider API keys. That left non-Latin1 paste artifacts able to reach the websocket client and trigger ByteString errors.

## Validation
- `pnpm test -- src/gateway/credentials.test.ts src/gateway/call.test.ts`
