### PR TITLE
fix(ui): keep chat session dropdown entries after refresh

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,23 +183,23 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "abb0380989460de3f211d60628b439de7ebcd482",
+        "hashed_secret": "7afea670e53d801f1f881c99c40aa177e3395bfa",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "c0baa9660a8d3b11874c63a535d8369f4a8fa8fa",
         "is_verified": false,
-        "line_number": 722
+        "line_number": 723
       }
     ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
@@ -9795,63 +9795,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1611
+        "line_number": 1612
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1628
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1812
+        "line_number": 1813
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1985
+        "line_number": 1986
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2041
+        "line_number": 2042
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2274
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2401
+        "line_number": 2402
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2654
+        "line_number": 2655
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2656
+        "line_number": 2657
       }
     ],
     "docs/gateway/configuration.md": [
@@ -9945,7 +9945,7 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2489
+        "line_number": 2490
       }
     ],
     "docs/install/macos-vm.md": [
@@ -10033,14 +10033,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T05:05:36Z"
+  "generated_at": "2026-03-08T06:54:06Z"
 }

--- a/test/ui-chat-refresh.test.ts
+++ b/test/ui-chat-refresh.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: {
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+    clear: () => undefined,
+  },
+  configurable: true,
+});
+
+const loadChatHistoryMock = vi.fn(async () => undefined);
+const loadSessionsMock = vi.fn(async () => undefined);
+const scheduleChatScrollMock = vi.fn();
+
+vi.mock("../ui/src/ui/controllers/chat.ts", () => ({
+  abortChatRun: vi.fn(),
+  loadChatHistory: (...args: unknown[]) => loadChatHistoryMock(...args),
+  sendChatMessage: vi.fn(),
+}));
+
+vi.mock("../ui/src/ui/controllers/sessions.ts", () => ({
+  loadSessions: (...args: unknown[]) => loadSessionsMock(...args),
+}));
+
+vi.mock("../ui/src/ui/app-scroll.ts", () => ({
+  scheduleChatScroll: (...args: unknown[]) => scheduleChatScrollMock(...args),
+}));
+
+const { refreshChat } = await import("../ui/src/ui/app-chat.ts");
+
+describe("refreshChat", () => {
+  beforeEach(() => {
+    loadChatHistoryMock.mockClear();
+    loadSessionsMock.mockClear();
+    scheduleChatScrollMock.mockClear();
+  });
+
+  it("reloads the chat session list without activeMinutes filtering", async () => {
+    const host = {
+      connected: false,
+      chatMessage: "",
+      chatAttachments: [],
+      chatQueue: [],
+      chatRunId: null,
+      chatSending: false,
+      sessionKey: "agent:main:main",
+      basePath: "",
+      hello: null,
+      chatAvatarUrl: "stale-avatar",
+      refreshSessionsAfterChat: new Set<string>(),
+    };
+
+    await refreshChat(host, { scheduleScroll: false });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+    expect(loadSessionsMock).toHaveBeenCalledWith(host);
+    expect(scheduleChatScrollMock).not.toHaveBeenCalled();
+    expect(host.chatAvatarUrl).toBeNull();
+  });
+});

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -205,9 +205,7 @@ export async function handleSendChat(
 export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: boolean }) {
   await Promise.all([
     loadChatHistory(host as unknown as OpenClawApp),
-    loadSessions(host as unknown as OpenClawApp, {
-      activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
-    }),
+    loadSessions(host as unknown as OpenClawApp),
     refreshChatAvatar(host),
   ]);
   if (opts?.scheduleScroll !== false) {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -3,7 +3,7 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "../../../src/gateway/events.js";
 import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
-import { CHAT_SESSIONS_ACTIVE_MINUTES, flushChatQueueForEvent } from "./app-chat.ts";
+import { flushChatQueueForEvent } from "./app-chat.ts";
 import type { EventLogEntry } from "./app-events.ts";
 import {
   applySettings,
@@ -293,9 +293,7 @@ function handleTerminalChatEvent(
   if (runId && host.refreshSessionsAfterChat.has(runId)) {
     host.refreshSessionsAfterChat.delete(runId);
     if (state === "final") {
-      void loadSessions(host as unknown as OpenClawApp, {
-        activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
-      });
+      void loadSessions(host as unknown as OpenClawApp);
     }
   }
   // Reload history when tools were used so the persisted tool results


### PR DESCRIPTION
## Summary
- stop filtering chat-tab session refreshes to only the last 120 active minutes
- keep the session dropdown populated from the full session list after page refreshes and post-chat refreshes
- add a focused regression test for `refreshChat`

Closes #39450.

## Why
The chat tab refreshed `sessions.list` with `activeMinutes=120`. After switching away from `main:local`, a page refresh could reload only the recent subset, so the dropdown no longer contained the older session even though it still existed on the backend.

## Validation
- `pnpm test -- test/ui-chat-refresh.test.ts`
