### PR TITLE
fix(podman): add SELinux relabels for rootless bind mounts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,23 +183,23 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "abb0380989460de3f211d60628b439de7ebcd482",
+        "hashed_secret": "7afea670e53d801f1f881c99c40aa177e3395bfa",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "c0baa9660a8d3b11874c63a535d8369f4a8fa8fa",
         "is_verified": false,
-        "line_number": 722
+        "line_number": 723
       }
     ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
@@ -9795,63 +9795,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1611
+        "line_number": 1612
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1628
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1812
+        "line_number": 1813
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1985
+        "line_number": 1986
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2041
+        "line_number": 2042
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2274
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2401
+        "line_number": 2402
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2654
+        "line_number": 2655
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2656
+        "line_number": 2657
       }
     ],
     "docs/gateway/configuration.md": [
@@ -9945,7 +9945,7 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2489
+        "line_number": 2490
       }
     ],
     "docs/install/macos-vm.md": [
@@ -10033,14 +10033,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T05:05:36Z"
+  "generated_at": "2026-03-08T06:54:06Z"
 }

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -70,11 +70,30 @@ fi
 CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$EFFECTIVE_HOME/.openclaw}"
 ENV_FILE="${OPENCLAW_PODMAN_ENV:-$CONFIG_DIR/.env}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$CONFIG_DIR/workspace}"
+
+resolve_bind_mount_options() {
+  if [[ -n "${OPENCLAW_BIND_MOUNT_OPTIONS:-}" ]]; then
+    printf '%s' "$OPENCLAW_BIND_MOUNT_OPTIONS"
+    return 0
+  fi
+  if command -v getenforce >/dev/null 2>&1; then
+    case "$(getenforce 2>/dev/null || true)" in
+      Enforcing|Permissive)
+        printf '%s' ':rw,Z'
+        return 0
+        ;;
+    esac
+  fi
+  printf '%s' ':rw'
+}
 CONTAINER_NAME="${OPENCLAW_PODMAN_CONTAINER:-openclaw}"
 OPENCLAW_IMAGE="${OPENCLAW_PODMAN_IMAGE:-openclaw:local}"
 PODMAN_PULL="${OPENCLAW_PODMAN_PULL:-never}"
 HOST_GATEWAY_PORT="${OPENCLAW_PODMAN_GATEWAY_HOST_PORT:-${OPENCLAW_GATEWAY_PORT:-18789}}"
 HOST_BRIDGE_PORT="${OPENCLAW_PODMAN_BRIDGE_HOST_PORT:-${OPENCLAW_BRIDGE_PORT:-18790}}"
+BIND_MOUNT_OPTIONS="$(resolve_bind_mount_options)"
+CONFIG_MOUNT="$CONFIG_DIR:/home/node/.openclaw$BIND_MOUNT_OPTIONS"
+WORKSPACE_MOUNT="$WORKSPACE_DIR:/home/node/.openclaw/workspace$BIND_MOUNT_OPTIONS"
 
 # Safe cwd for podman (openclaw is nologin; avoid inherited cwd from sudo)
 cd "$EFFECTIVE_HOME" 2>/dev/null || cd /tmp 2>/dev/null || true
@@ -189,8 +208,8 @@ if [[ "$RUN_SETUP" == true ]]; then
     "${USERNS_ARGS[@]}" "${RUN_USER_ARGS[@]}" \
     -e HOME=/home/node -e TERM=xterm-256color -e BROWSER=echo \
     -e OPENCLAW_GATEWAY_TOKEN="$OPENCLAW_GATEWAY_TOKEN" \
-    -v "$CONFIG_DIR:/home/node/.openclaw:rw" \
-    -v "$WORKSPACE_DIR:/home/node/.openclaw/workspace:rw" \
+    -v "$CONFIG_MOUNT" \
+    -v "$WORKSPACE_MOUNT" \
     "${ENV_FILE_ARGS[@]}" \
     "$OPENCLAW_IMAGE" \
     node dist/index.js onboard "$@"
@@ -203,8 +222,8 @@ podman run --pull="$PODMAN_PULL" -d --replace \
   -e HOME=/home/node -e TERM=xterm-256color \
   -e OPENCLAW_GATEWAY_TOKEN="$OPENCLAW_GATEWAY_TOKEN" \
   "${ENV_FILE_ARGS[@]}" \
-  -v "$CONFIG_DIR:/home/node/.openclaw:rw" \
-  -v "$WORKSPACE_DIR:/home/node/.openclaw/workspace:rw" \
+  -v "$CONFIG_MOUNT" \
+  -v "$WORKSPACE_MOUNT" \
   -p "${HOST_GATEWAY_PORT}:18789" \
   -p "${HOST_BRIDGE_PORT}:18790" \
   "$OPENCLAW_IMAGE" \

--- a/test/scripts/run-openclaw-podman.test.ts
+++ b/test/scripts/run-openclaw-podman.test.ts
@@ -53,6 +53,10 @@ function findMounts(args: string[]): string[] {
   return mounts;
 }
 
+function expectMountSuffix(mounts: string[], suffix: string): void {
+  expect(mounts.some((mount) => mount.endsWith(suffix))).toBe(true);
+}
+
 describe("scripts/run-openclaw-podman.sh", () => {
   beforeAll(async () => {
     fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-run-podman-"));
@@ -107,18 +111,14 @@ printf '%s\n' "$@" > "$FAKE_PODMAN_LOG"
 
   it("uses rw bind mounts when SELinux is disabled", async () => {
     const mounts = findMounts(await runScript({ FAKE_GETENFORCE: "Disabled" }));
-    expect(mounts).toContain(`${fakeHomeDir}/.openclaw:/home/node/.openclaw:rw`);
-    expect(mounts).toContain(
-      `${fakeHomeDir}/.openclaw/workspace:/home/node/.openclaw/workspace:rw`,
-    );
+    expectMountSuffix(mounts, `:/home/node/.openclaw:rw`);
+    expectMountSuffix(mounts, `:/home/node/.openclaw/workspace:rw`);
   });
 
   it("adds Z relabels when SELinux is enforcing", async () => {
     const mounts = findMounts(await runScript({ FAKE_GETENFORCE: "Enforcing" }));
-    expect(mounts).toContain(`${fakeHomeDir}/.openclaw:/home/node/.openclaw:rw,Z`);
-    expect(mounts).toContain(
-      `${fakeHomeDir}/.openclaw/workspace:/home/node/.openclaw/workspace:rw,Z`,
-    );
+    expectMountSuffix(mounts, `:/home/node/.openclaw:rw,Z`);
+    expectMountSuffix(mounts, `:/home/node/.openclaw/workspace:rw,Z`);
   });
 
   it("honors explicit bind mount option overrides", async () => {
@@ -128,9 +128,7 @@ printf '%s\n' "$@" > "$FAKE_PODMAN_LOG"
         OPENCLAW_BIND_MOUNT_OPTIONS: ":ro,z",
       }),
     );
-    expect(mounts).toContain(`${fakeHomeDir}/.openclaw:/home/node/.openclaw:ro,z`);
-    expect(mounts).toContain(
-      `${fakeHomeDir}/.openclaw/workspace:/home/node/.openclaw/workspace:ro,z`,
-    );
+    expectMountSuffix(mounts, `:/home/node/.openclaw:ro,z`);
+    expectMountSuffix(mounts, `:/home/node/.openclaw/workspace:ro,z`);
   });
 });

--- a/test/scripts/run-openclaw-podman.test.ts
+++ b/test/scripts/run-openclaw-podman.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SCRIPT = path.join(process.cwd(), "scripts", "run-openclaw-podman.sh");
+const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
+const BASH_ARGS = process.platform === "win32" ? [SCRIPT] : ["--noprofile", "--norc", SCRIPT];
+const BASE_PATH = process.env.PATH ?? "/usr/bin:/bin";
+const BASE_LANG = process.env.LANG ?? "C";
+let fixtureRoot = "";
+let fakeBinDir = "";
+let fakeHomeDir = "";
+let fakePodmanLog = "";
+
+async function writeExecutable(filePath: string, body: string): Promise<void> {
+  await writeFile(filePath, body, "utf8");
+  chmodSync(filePath, 0o755);
+}
+
+async function runScript(extraEnv: Record<string, string> = {}): Promise<string[]> {
+  await writeFile(fakePodmanLog, "", "utf8");
+  const env = {
+    HOME: fakeHomeDir,
+    PATH: `${fakeBinDir}${path.delimiter}${BASE_PATH}`,
+    LANG: BASE_LANG,
+    OPENCLAW_PODMAN_USER: "testuser",
+    OPENCLAW_GATEWAY_TOKEN: "test-token",
+    FAKE_TEST_HOME: fakeHomeDir,
+    FAKE_PODMAN_LOG: fakePodmanLog,
+    ...extraEnv,
+  };
+  execFileSync(BASH_BIN, BASH_ARGS, {
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return (await readFile(fakePodmanLog, "utf8"))
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function findMounts(args: string[]): string[] {
+  const mounts: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "-v" && args[i + 1]) {
+      mounts.push(args[i + 1]);
+    }
+  }
+  return mounts;
+}
+
+describe("scripts/run-openclaw-podman.sh", () => {
+  beforeAll(async () => {
+    fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-run-podman-"));
+    fakeBinDir = path.join(fixtureRoot, "bin");
+    fakeHomeDir = path.join(fixtureRoot, "home");
+    fakePodmanLog = path.join(fixtureRoot, "podman.log");
+    await mkdir(fakeBinDir, { recursive: true });
+    await mkdir(fakeHomeDir, { recursive: true });
+
+    await writeExecutable(
+      path.join(fakeBinDir, "getent"),
+      `#!/usr/bin/env bash
+if [[ "$1" == "passwd" && "$2" == "testuser" ]]; then
+  printf 'testuser:x:1234:1234::%s:/usr/sbin/nologin\n' "$FAKE_TEST_HOME"
+  exit 0
+fi
+exit 2
+`,
+    );
+    await writeExecutable(
+      path.join(fakeBinDir, "id"),
+      `#!/usr/bin/env bash
+if [[ "$1" == "-u" && "$2" == "testuser" ]]; then
+  echo 1234
+  exit 0
+fi
+exec /usr/bin/id "$@"
+`,
+    );
+    await writeExecutable(
+      path.join(fakeBinDir, "getenforce"),
+      `#!/usr/bin/env bash
+printf '%s\n' "\${FAKE_GETENFORCE:-Disabled}"
+`,
+    );
+    await writeExecutable(
+      path.join(fakeBinDir, "podman"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+: "\${FAKE_PODMAN_LOG:?}"
+printf '%s\n' "$@" > "$FAKE_PODMAN_LOG"
+`,
+    );
+  });
+
+  afterAll(async () => {
+    if (!fixtureRoot) {
+      return;
+    }
+    await rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("uses rw bind mounts when SELinux is disabled", async () => {
+    const mounts = findMounts(await runScript({ FAKE_GETENFORCE: "Disabled" }));
+    expect(mounts).toContain(`${fakeHomeDir}/.openclaw:/home/node/.openclaw:rw`);
+    expect(mounts).toContain(
+      `${fakeHomeDir}/.openclaw/workspace:/home/node/.openclaw/workspace:rw`,
+    );
+  });
+
+  it("adds Z relabels when SELinux is enforcing", async () => {
+    const mounts = findMounts(await runScript({ FAKE_GETENFORCE: "Enforcing" }));
+    expect(mounts).toContain(`${fakeHomeDir}/.openclaw:/home/node/.openclaw:rw,Z`);
+    expect(mounts).toContain(
+      `${fakeHomeDir}/.openclaw/workspace:/home/node/.openclaw/workspace:rw,Z`,
+    );
+  });
+
+  it("honors explicit bind mount option overrides", async () => {
+    const mounts = findMounts(
+      await runScript({
+        FAKE_GETENFORCE: "Enforcing",
+        OPENCLAW_BIND_MOUNT_OPTIONS: ":ro,z",
+      }),
+    );
+    expect(mounts).toContain(`${fakeHomeDir}/.openclaw:/home/node/.openclaw:ro,z`);
+    expect(mounts).toContain(
+      `${fakeHomeDir}/.openclaw/workspace:/home/node/.openclaw/workspace:ro,z`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- auto-detect SELinux via `getenforce` and add `:rw,Z` to Podman bind mounts when needed
- honor `OPENCLAW_BIND_MOUNT_OPTIONS` overrides for callers that need custom mount flags
- cover the mount selection logic with a focused script test

Closes #39448.

## Validation
- `bash -n scripts/run-openclaw-podman.sh`
- `pnpm test -- test/scripts/run-openclaw-podman.test.ts`
