### PR TITLE
fix: correct agentId extraction in agent_end hook

### DIFF
--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -120,7 +120,7 @@ export async function emitResetCommandHooks(params: {
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {
-            agentId: params.sessionKey?.split(":")[0] ?? "main",
+            agentId: params.sessionKey?.split(":")[1] ?? "main",
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Summary
Fixes #39521

The `agent_end` hook was using `split(":")[0]` on session keys like `agent:<agentId>:main`, which always returned `"agent"` instead of the actual agent ID. Changed to `split(":")[1]`.

## Changes
- Fixed split index in `src/auto-reply/reply/commands-core.ts` from `[0]` to `[1]` so the correct agent ID is extracted from the session key

---
Generated by Orbit