### PR TITLE
plugins: skip npm update for private bundled plugins

### DIFF
--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -73,6 +73,70 @@ describe("bundled plugin sources", () => {
     });
   });
 
+  it("omits npmSpec for private bundled packages without explicit install.npmSpec", () => {
+    discoverOpenClawPluginsMock.mockReturnValue({
+      candidates: [
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/memory-lancedb",
+          packageName: "@openclaw/memory-lancedb",
+          packagePrivate: true,
+          packageManifest: {},
+        },
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/voice-call",
+          packageName: "@openclaw/voice-call",
+          packagePrivate: true,
+          packageManifest: { install: { npmSpec: "@openclaw/voice-call" } },
+        },
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/feishu",
+          packageName: "@openclaw/feishu",
+          packageManifest: { install: { npmSpec: "@openclaw/feishu" } },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadPluginManifestMock.mockImplementation((rootDir: string) => {
+      if (rootDir === "/app/extensions/memory-lancedb") {
+        return { ok: true, manifest: { id: "memory-lancedb" } };
+      }
+      if (rootDir === "/app/extensions/voice-call") {
+        return { ok: true, manifest: { id: "voice-call" } };
+      }
+      if (rootDir === "/app/extensions/feishu") {
+        return { ok: true, manifest: { id: "feishu" } };
+      }
+      return { ok: false, error: "not found", manifestPath: `${rootDir}/openclaw.plugin.json` };
+    });
+
+    const map = resolveBundledPluginSources({});
+
+    // Private package without explicit npmSpec should have no npmSpec
+    expect(map.get("memory-lancedb")).toEqual({
+      pluginId: "memory-lancedb",
+      localPath: "/app/extensions/memory-lancedb",
+      npmSpec: undefined,
+    });
+
+    // Private package WITH explicit install.npmSpec should keep its npmSpec
+    expect(map.get("voice-call")).toEqual({
+      pluginId: "voice-call",
+      localPath: "/app/extensions/voice-call",
+      npmSpec: "@openclaw/voice-call",
+    });
+
+    // Non-private package should use packageName as npmSpec fallback
+    expect(map.get("feishu")).toEqual({
+      pluginId: "feishu",
+      localPath: "/app/extensions/feishu",
+      npmSpec: "@openclaw/feishu",
+    });
+  });
+
   it("finds bundled source by npm spec", () => {
     discoverOpenClawPluginsMock.mockReturnValue({
       candidates: [

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -30,9 +30,14 @@ export function resolveBundledPluginSources(params: {
       continue;
     }
 
+    // Private packages are not published to npm, so only use an explicit
+    // install.npmSpec when present. Falling back to packageName for private
+    // packages would cause the updater to try to npm-install a package that
+    // does not exist (e.g. @openclaw/memory-lancedb).
+    const explicitNpmSpec = candidate.packageManifest?.install?.npmSpec?.trim();
     const npmSpec =
-      candidate.packageManifest?.install?.npmSpec?.trim() ||
-      candidate.packageName?.trim() ||
+      explicitNpmSpec ||
+      (candidate.packagePrivate ? undefined : candidate.packageName?.trim()) ||
       undefined;
 
     bundled.set(pluginId, {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -24,6 +24,7 @@ export type PluginCandidate = {
   packageName?: string;
   packageVersion?: string;
   packageDescription?: string;
+  packagePrivate?: boolean;
   packageDir?: string;
   packageManifest?: OpenClawPackageManifest;
 };
@@ -359,6 +360,7 @@ function addCandidate(params: {
     packageName: manifest?.name?.trim() || undefined,
     packageVersion: manifest?.version?.trim() || undefined,
     packageDescription: manifest?.description?.trim() || undefined,
+    packagePrivate: manifest?.private === true ? true : undefined,
     packageDir: params.packageDir,
     packageManifest: getPackageManifestMetadata(manifest ?? undefined),
   });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -170,6 +170,7 @@ export type PackageManifest = {
   name?: string;
   version?: string;
   description?: string;
+  private?: boolean;
 } & Partial<Record<ManifestKey, OpenClawPackageManifest>>;
 
 export function getPackageManifestMetadata(


### PR DESCRIPTION
## Summary

- Fix `openclaw update` on beta/stable channels trying to npm-install bundled path-loaded plugins (like `memory-lancedb`) as npm packages (e.g. `@openclaw/memory-lancedb`), which don't exist on npm
- When resolving bundled plugin sources, skip using `packageName` as the npm spec fallback when the package has `"private": true` in its `package.json`
- Plugins with an explicit `install.npmSpec` in their openclaw package manifest are unaffected

## How it works

The `resolveBundledPluginSources` function constructs an `npmSpec` for each bundled plugin by checking:
1. An explicit `install.npmSpec` in the package's openclaw manifest
2. Falling back to `packageName` from `package.json`

For `memory-lancedb`, there's no explicit `npmSpec`, so it fell back to `@openclaw/memory-lancedb` (the `name` field). But the package is `"private": true` and not published to npm, so the updater's attempt to `npm install` it fails with a "package not found" error.

The fix adds `packagePrivate` to the plugin candidate metadata and skips the `packageName` fallback when the package is private.

Fixes #39519

## Test plan

- [x] Added test in `bundled-sources.test.ts` verifying private packages without explicit `npmSpec` get `undefined`
- [x] Added test verifying private packages WITH explicit `install.npmSpec` still keep their spec
- [x] All existing tests pass (`bundled-sources`, `update`, `discovery`)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)