### PR TITLE
fix: correct agent_end hook agentId extraction (split index)

### DIFF
--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -120,7 +120,7 @@ export async function emitResetCommandHooks(params: {
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {
-            agentId: params.sessionKey?.split(":")[0] ?? "main",
+            agentId: params.sessionKey?.split(":")[1] ?? "main",
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Summary
Fixes #39521

The `agent_end` hook passes the wrong `agentId` because session keys are formatted as `agent:<agentId>:main`, but the code uses `split(":")[0]` which returns the literal string `"agent"` instead of the actual agent ID. Changed to `split(":")[1]`.

## Changes
- Fix off-by-one in `split(":")` index in `src/auto-reply/reply/commands-core.ts`

---
Generated by Orbit 🛸