### PR TITLE
fix(hooks): extract correct agentId from session key in before_reset hook

### DIFF
--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,9 +1,14 @@
 import fs from "node:fs/promises";
+import type {
+  CommandHandler,
+  CommandHandlerResult,
+  HandleCommandsParams,
+} from "./commands-types.js";
 import { resetAcpSessionInPlace } from "../../acp/persistent-bindings.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { isAcpSessionKey } from "../../routing/session-key.js";
+import { isAcpSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAcpCommand } from "./commands-acp.js";
@@ -34,11 +39,6 @@ import {
 } from "./commands-session.js";
 import { handleSubagentsCommand } from "./commands-subagents.js";
 import { handleTtsCommands } from "./commands-tts.js";
-import type {
-  CommandHandler,
-  CommandHandlerResult,
-  HandleCommandsParams,
-} from "./commands-types.js";
 import { routeReply } from "./route-reply.js";
 
 let HANDLERS: CommandHandler[] | null = null;
@@ -120,7 +120,7 @@ export async function emitResetCommandHooks(params: {
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {
-            agentId: params.sessionKey?.split(":")[0] ?? "main",
+            agentId: parseAgentSessionKey(params.sessionKey)?.agentId ?? "main",
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Summary
- Fixed incorrect agent ID extraction in the `before_reset` hook in `commands-core.ts`
- `sessionKey.split(":")[0]` was returning the literal string `"agent"` (the key prefix) instead of the actual agent ID, since session keys follow the format `agent:<agentId>:<rest>`
- Replaced with `parseAgentSessionKey()` which correctly extracts the agent ID from index `[1]`, consistent with the rest of the codebase

Fixes #39521

## Test plan
- [x] Verified `oxlint` passes on the changed file
- [x] Verified `parseAgentSessionKey` is the canonical utility used throughout the codebase for session key parsing
- [x] Ran existing session-key routing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)