### PR TITLE
fix: preserve entity IDs wrapped in punctuation from word-wrap splitting

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -249,6 +249,20 @@ describe("sanitizeRenderableText", () => {
     expect(sanitized).toBe(input);
   });
 
+  it("preserves entity IDs with dots and underscores wrapped in backticks", () => {
+    const input = "`binary_sensor.sense_energy_monitor_power`";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
+  it("preserves bare entity IDs with dots and underscores", () => {
+    const input = "binary_sensor.sense_energy_monitor_power";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
   it("preserves long credential-like mixed alnum tokens for copy safety", () => {
     const input = "e3b19c3b87bcf364b23eebb2c276e96ec478956ba1d84c93"; // pragma: allowlist secret
     const sanitized = sanitizeRenderableText(input);

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -78,7 +78,7 @@ function isCopySensitiveToken(token: string): boolean {
   if (token.includes("/") || token.includes("\\")) {
     return true;
   }
-  if (token.includes("_") && FILE_LIKE_RE.test(token)) {
+  if (candidate.includes("_") && FILE_LIKE_RE.test(candidate)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

- Fix entity IDs (e.g. `binary_sensor.sense_energy_monitor_power`) being split with inserted spaces when rendered in chat output
- Root cause: `isCopySensitiveToken()` in `src/tui/tui-formatters.ts` tested the raw token (including surrounding backticks/quotes) against `FILE_LIKE_RE`, which rejects non-alphanumeric characters like backticks
- Fix: use the punctuation-stripped `candidate` instead of `token` for the underscore + `FILE_LIKE_RE` check, consistent with how the credential-like token check already works

Fixes #39505

## Test plan

- [x] Added test: entity ID wrapped in backticks is preserved
- [x] Added test: bare entity ID is preserved
- [x] All 28 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)