### PR TITLE
fix(discord): poll for initial connected state instead of point-in-time check

### DIFF
--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -45,6 +45,18 @@ export async function runDiscordGatewayLifecycle(params: {
   let lifecycleStopping = false;
   let forceStopHandler: ((err: unknown) => void) | undefined;
   let queuedForceStopError: unknown;
+  let initialPollId: ReturnType<typeof setInterval> | undefined;
+  let initialTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  const clearInitialPoll = () => {
+    if (initialPollId) {
+      clearInterval(initialPollId);
+      initialPollId = undefined;
+    }
+    if (initialTimeoutId) {
+      clearTimeout(initialTimeoutId);
+      initialTimeoutId = undefined;
+    }
+  };
 
   const pushStatus = (patch: Parameters<DiscordMonitorStatusSink>[0]) => {
     params.statusSink?.(patch);
@@ -242,18 +254,36 @@ export async function runDiscordGatewayLifecycle(params: {
   };
   gatewayEmitter?.on("debug", onGatewayDebug);
 
-  // If the gateway is already connected when the lifecycle starts (the
-  // "WebSocket connection opened" debug event was emitted before we
-  // registered the listener above), push the initial connected status now.
-  // Guard against lifecycleStopping: if the abortSignal was already aborted,
-  // onAbort() ran synchronously above and pushed connected: false — don't
-  // contradict it with a spurious connected: true.
-  if (gateway?.isConnected && !lifecycleStopping) {
-    const at = Date.now();
-    pushStatus({
-      ...createConnectedChannelStatusPatch(at),
-      lastDisconnect: null,
-    });
+  // The gateway may already be mid-READY handshake when the lifecycle starts
+  // (the "WebSocket connection opened" debug event fired before we registered
+  // the listener above). A single point-in-time check on `isConnected` can
+  // miss this — Carbon flips the flag only after the full READY/RESUMED
+  // exchange. Poll briefly so we don't leave the channel marked "stuck".
+  if (!lifecycleStopping) {
+    if (gateway?.isConnected) {
+      const at = Date.now();
+      pushStatus({
+        ...createConnectedChannelStatusPatch(at),
+        lastDisconnect: null,
+      });
+    } else {
+      const INITIAL_POLL_MS = 250;
+      const INITIAL_POLL_TIMEOUT_MS = 10_000;
+      initialPollId = setInterval(() => {
+        if (!gateway?.isConnected) {
+          return;
+        }
+        const at = Date.now();
+        pushStatus({
+          ...createConnectedChannelStatusPatch(at),
+          lastDisconnect: null,
+        });
+        clearInitialPoll();
+      }, INITIAL_POLL_MS);
+      initialTimeoutId = setTimeout(() => {
+        clearInitialPoll();
+      }, INITIAL_POLL_TIMEOUT_MS);
+    }
   }
 
   let sawDisallowedIntents = false;
@@ -329,6 +359,7 @@ export async function runDiscordGatewayLifecycle(params: {
     stopGatewayLogging();
     reconnectStallWatchdog.stop();
     clearHelloWatch();
+    clearInitialPoll();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
     params.abortSignal?.removeEventListener("abort", onAbort);
     if (params.voiceManager) {


### PR DESCRIPTION
## Summary

When the Discord gateway lifecycle starts, the READY handshake may already be in flight. The previous point-in-time `isConnected` check could miss this transient state, leaving the channel marked as "stuck" and triggering unnecessary restarts by the health monitor.

This replaces the single check with a brief 250ms poll (up to 10s) that catches the connected transition reliably.

### Changes

- Add `initialPollId` / `initialTimeoutId` / `clearInitialPoll()` at function scope alongside existing timer variables
- Replace the point-in-time `if (gateway?.isConnected)` check with an interval that polls until connected or times out
- Clean up timers in the `finally` block to prevent leaks

### Why polling?

Carbon's `GatewayPlugin` sets `isConnected = true` only after the full READY/RESUMED exchange completes. If the lifecycle function starts while that exchange is in progress, the flag is still `false` at the instant of the check. The health monitor then sees no `connected: true` status update and marks the channel as "stuck" after the configured threshold, triggering a restart.

Polling for up to 10 seconds covers the handshake window without introducing a hard dependency on Carbon internals.

## Test plan

- [x] `pnpm build` passes
- [x] Tested on live gateway — no false "stuck" restarts observed over multiple hours
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: King <king@boundedagency.ai>