### PR TITLE
feat(tui): update token count after each LLM attempt during runs

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -941,7 +941,6 @@ export async function runEmbeddedPiAgent(
           const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
-
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.
           lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -5,7 +5,6 @@ import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
 } from "../../context-engine/index.js";
-import { emitAgentEvent } from "../../infra/agent-events.js";
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -942,24 +941,6 @@ export async function runEmbeddedPiAgent(
           const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
-
-          // Emit a live usage event so the TUI footer updates after each LLM attempt.
-          const usageForEvent = lastAssistantUsage ?? attempt.attemptUsage;
-          const promptTokensForEvent = derivePromptTokens({
-            input: usageForEvent?.input,
-            cacheRead: usageForEvent?.cacheRead,
-            cacheWrite: usageForEvent?.cacheWrite,
-          });
-          emitAgentEvent({
-            runId: params.runId,
-            stream: "usage",
-            data: {
-              totalTokens: promptTokensForEvent ?? 0,
-              contextTokens: ctxInfo.tokens,
-              inputTokens: usageAccumulator.input,
-              outputTokens: usageAccumulator.output,
-            },
-          });
 
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -943,14 +943,14 @@ export async function runEmbeddedPiAgent(
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
 
-          // Emit a live usage event so the TUI footer updates in real time.
-          const usageForEvent = lastAssistantUsage ?? attemptUsage;
+          // Emit a live usage event so the TUI footer updates after each LLM attempt.
+          const usageForEvent = lastAssistantUsage ?? attempt.attemptUsage;
           const promptTokensForEvent = derivePromptTokens({
             input: usageForEvent?.input,
             cacheRead: usageForEvent?.cacheRead,
             cacheWrite: usageForEvent?.cacheWrite,
           });
-          if (typeof promptTokensForEvent === "number" && promptTokensForEvent > 0) {
+          if (typeof promptTokensForEvent === "number") {
             emitAgentEvent({
               runId: params.runId,
               stream: "usage",

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -950,18 +950,16 @@ export async function runEmbeddedPiAgent(
             cacheRead: usageForEvent?.cacheRead,
             cacheWrite: usageForEvent?.cacheWrite,
           });
-          if (typeof promptTokensForEvent === "number") {
-            emitAgentEvent({
-              runId: params.runId,
-              stream: "usage",
-              data: {
-                totalTokens: promptTokensForEvent,
-                contextTokens: ctxInfo.tokens,
-                inputTokens: usageAccumulator.input,
-                outputTokens: usageAccumulator.output,
-              },
-            });
-          }
+          emitAgentEvent({
+            runId: params.runId,
+            stream: "usage",
+            data: {
+              totalTokens: promptTokensForEvent ?? 0,
+              contextTokens: ctxInfo.tokens,
+              inputTokens: usageAccumulator.input,
+              outputTokens: usageAccumulator.output,
+            },
+          });
 
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -5,6 +5,7 @@ import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
 } from "../../context-engine/index.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -941,6 +942,27 @@ export async function runEmbeddedPiAgent(
           const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
+
+          // Emit a live usage event so the TUI footer updates in real time.
+          const usageForEvent = lastAssistantUsage ?? attemptUsage;
+          const promptTokensForEvent = derivePromptTokens({
+            input: usageForEvent?.input,
+            cacheRead: usageForEvent?.cacheRead,
+            cacheWrite: usageForEvent?.cacheWrite,
+          });
+          if (typeof promptTokensForEvent === "number" && promptTokensForEvent > 0) {
+            emitAgentEvent({
+              runId: params.runId,
+              stream: "usage",
+              data: {
+                totalTokens: promptTokensForEvent,
+                contextTokens: ctxInfo.tokens,
+                inputTokens: usageAccumulator.input,
+                outputTokens: usageAccumulator.output,
+              },
+            });
+          }
+
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.
           lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -282,6 +282,20 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       usage.total ??
       (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
     usageTotals.total += usageTotal;
+
+    // Emit a live usage event so the TUI footer updates after each LLM response.
+    // This must fire before agent_end / lifecycle "end" so the TUI receives it
+    // while the run is still active.
+    const promptTokens = (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "usage",
+      data: {
+        totalTokens: promptTokens,
+        inputTokens: usageTotals.input,
+        outputTokens: usageTotals.output,
+      },
+    });
   };
   const getUsageTotals = () => {
     const hasUsage =

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -287,7 +287,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // This must fire before agent_end / lifecycle "end" so the TUI receives it
     // while the run is still active.
     const derivedPrompt = (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
-    const promptTokens = derivedPrompt || (usage.total ?? 0);
+    // Only use prompt-derived tokens for totalTokens (context window size).
+    // usage.total includes output tokens, which would inflate the display.
+    const promptTokens = derivedPrompt > 0 ? derivedPrompt : undefined;
     emitAgentEvent({
       runId: params.runId,
       stream: "usage",

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -286,7 +286,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Emit a live usage event so the TUI footer updates after each LLM response.
     // This must fire before agent_end / lifecycle "end" so the TUI receives it
     // while the run is still active.
-    const promptTokens = (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+    const derivedPrompt = (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+    const promptTokens = derivedPrompt || (usage.total ?? 0);
     emitAgentEvent({
       runId: params.runId,
       stream: "usage",

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -294,7 +294,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       runId: params.runId,
       stream: "usage",
       data: {
+        // Prompt tokens for this single LLM call — used as a context-window-size proxy.
         totalTokens: promptTokens,
+        // Cumulative run totals for billing/display purposes.
         inputTokens: usageTotals.input,
         outputTokens: usageTotals.output,
       },

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,6 +1,12 @@
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 
-export type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error" | (string & {});
+export type AgentEventStream =
+  | "lifecycle"
+  | "tool"
+  | "assistant"
+  | "error"
+  | "usage"
+  | (string & {});
 
 export type AgentEventPayload = {
   runId: string;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -320,7 +320,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     if (evt.stream === "usage") {
-      if (onUsageUpdate && (isActiveRun || finalizedRuns.has(evt.runId))) {
+      if (isActiveRun && onUsageUpdate) {
         onUsageUpdate(evt.data ?? {});
         tui.requestRender();
       }

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -103,6 +103,19 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
   };
 
+  // Schedule a follow-up refresh after the live-usage freshness guard
+  // expires so authoritative persisted data replaces live values.
+  const scheduleDelayedRefresh = () => {
+    if (Date.now() - state.liveUsageUpdatedAt < 5_000) {
+      const sessionKey = state.currentSessionKey;
+      setTimeout(() => {
+        if (state.currentSessionKey === sessionKey) {
+          void refreshSessionInfo?.();
+        }
+      }, 6_000);
+    }
+  };
+
   const finalizeRun = (params: {
     runId: string;
     wasActiveRun: boolean;
@@ -114,15 +127,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
-    // Schedule a follow-up refresh after the live-usage freshness guard
-    // expires so authoritative persisted data replaces live values.
-    if (params.wasActiveRun && Date.now() - state.liveUsageUpdatedAt < 5_000) {
-      const sessionKey = state.currentSessionKey;
-      setTimeout(() => {
-        if (state.currentSessionKey === sessionKey) {
-          void refreshSessionInfo?.();
-        }
-      }, 6_000);
+    if (params.wasActiveRun) {
+      scheduleDelayedRefresh();
     }
   };
 
@@ -138,15 +144,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
-    // Schedule a follow-up refresh after the live-usage freshness guard
-    // expires so authoritative persisted data replaces live values.
-    if (params.wasActiveRun && Date.now() - state.liveUsageUpdatedAt < 5_000) {
-      const sessionKey = state.currentSessionKey;
-      setTimeout(() => {
-        if (state.currentSessionKey === sessionKey) {
-          void refreshSessionInfo?.();
-        }
-      }, 6_000);
+    if (params.wasActiveRun) {
+      scheduleDelayedRefresh();
     }
   };
 

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -116,8 +116,13 @@ export function createEventHandlers(context: EventHandlerContext) {
     void refreshSessionInfo?.();
     // Schedule a follow-up refresh after the live-usage freshness guard
     // expires so authoritative persisted data replaces live values.
-    if (params.wasActiveRun && state.liveUsageUpdatedAt > 0) {
-      setTimeout(() => void refreshSessionInfo?.(), 6_000);
+    if (params.wasActiveRun && Date.now() - state.liveUsageUpdatedAt < 5_000) {
+      const sessionKey = state.currentSessionKey;
+      setTimeout(() => {
+        if (state.currentSessionKey === sessionKey) {
+          void refreshSessionInfo?.();
+        }
+      }, 6_000);
     }
   };
 
@@ -135,8 +140,13 @@ export function createEventHandlers(context: EventHandlerContext) {
     void refreshSessionInfo?.();
     // Schedule a follow-up refresh after the live-usage freshness guard
     // expires so authoritative persisted data replaces live values.
-    if (params.wasActiveRun && state.liveUsageUpdatedAt > 0) {
-      setTimeout(() => void refreshSessionInfo?.(), 6_000);
+    if (params.wasActiveRun && Date.now() - state.liveUsageUpdatedAt < 5_000) {
+      const sessionKey = state.currentSessionKey;
+      setTimeout(() => {
+        if (state.currentSessionKey === sessionKey) {
+          void refreshSessionInfo?.();
+        }
+      }, 6_000);
     }
   };
 

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -30,6 +30,7 @@ type EventHandlerContext = {
   isLocalRunId?: (runId: string) => boolean;
   forgetLocalRunId?: (runId: string) => void;
   clearLocalRunIds?: () => void;
+  onUsageUpdate?: (data: Record<string, unknown>) => void;
 };
 
 export function createEventHandlers(context: EventHandlerContext) {
@@ -43,6 +44,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     isLocalRunId,
     forgetLocalRunId,
     clearLocalRunIds,
+    onUsageUpdate,
   } = context;
   const finalizedRuns = new Map<string, number>();
   const sessionRuns = new Map<string, number>();
@@ -315,6 +317,13 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
       }
       tui.requestRender();
+      return;
+    }
+    if (evt.stream === "usage") {
+      if (onUsageUpdate) {
+        onUsageUpdate(evt.data ?? {});
+        tui.requestRender();
+      }
       return;
     }
     if (evt.stream === "lifecycle") {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -320,7 +320,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     if (evt.stream === "usage") {
-      if (onUsageUpdate) {
+      if (onUsageUpdate && (isActiveRun || finalizedRuns.has(evt.runId))) {
         onUsageUpdate(evt.data ?? {});
         tui.requestRender();
       }

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -114,6 +114,11 @@ export function createEventHandlers(context: EventHandlerContext) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
+    // Schedule a follow-up refresh after the live-usage freshness guard
+    // expires so authoritative persisted data replaces live values.
+    if (params.wasActiveRun && state.liveUsageUpdatedAt > 0) {
+      setTimeout(() => void refreshSessionInfo?.(), 6_000);
+    }
   };
 
   const terminateRun = (params: {
@@ -128,6 +133,11 @@ export function createEventHandlers(context: EventHandlerContext) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
+    // Schedule a follow-up refresh after the live-usage freshness guard
+    // expires so authoritative persisted data replaces live values.
+    if (params.wasActiveRun && state.liveUsageUpdatedAt > 0) {
+      setTimeout(() => void refreshSessionInfo?.(), 6_000);
+    }
   };
 
   const hasConcurrentActiveRun = (runId: string) => {

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -3,6 +3,7 @@ import {
   extractContentFromMessage,
   extractTextFromMessage,
   extractThinkingFromMessage,
+  formatTokens,
   isCommandMessage,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
@@ -282,5 +283,34 @@ describe("sanitizeRenderableText", () => {
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toBe(input);
+  });
+});
+
+describe("formatTokens", () => {
+  it("returns 'tokens 0' when both total and context are null", () => {
+    expect(formatTokens(null, null)).toBe("tokens 0");
+  });
+
+  it("returns 'tokens 0' when both total and context are undefined", () => {
+    expect(formatTokens(undefined, undefined)).toBe("tokens 0");
+  });
+
+  it("returns 'tokens 0' when called with no arguments", () => {
+    expect(formatTokens()).toBe("tokens 0");
+  });
+
+  it("shows total with 0 fallback when total is null but context is provided", () => {
+    const result = formatTokens(null, 200000);
+    expect(result).toBe("tokens 0/200k");
+  });
+
+  it("formats both total and context with percentage", () => {
+    const result = formatTokens(50000, 200000);
+    expect(result).toBe("tokens 50k/200k (25%)");
+  });
+
+  it("shows total without context when context is null", () => {
+    const result = formatTokens(50000, null);
+    expect(result).toBe("tokens 50k");
   });
 });

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -347,9 +347,9 @@ export function isCommandMessage(message: unknown): boolean {
 
 export function formatTokens(total?: number | null, context?: number | null) {
   if (total == null && context == null) {
-    return "tokens ?";
+    return "tokens 0";
   }
-  const totalLabel = total == null ? "?" : formatTokenCount(total);
+  const totalLabel = total == null ? "0" : formatTokenCount(total);
   if (context == null) {
     return `tokens ${totalLabel}`;
   }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -174,14 +174,19 @@ export function createSessionActions(context: SessionActionContext) {
     if (entry?.responseUsage !== undefined) {
       next.responseUsage = entry.responseUsage;
     }
-    if (entry?.inputTokens !== undefined) {
-      next.inputTokens = entry.inputTokens;
-    }
-    if (entry?.outputTokens !== undefined) {
-      next.outputTokens = entry.outputTokens;
-    }
-    if (entry?.totalTokens !== undefined) {
-      next.totalTokens = entry.totalTokens;
+    // Skip overwriting token data when a live usage event was received recently,
+    // since the server may not have persisted the latest usage yet.
+    const hasRecentLiveUsage = Date.now() - state.liveUsageUpdatedAt < 5_000;
+    if (!hasRecentLiveUsage) {
+      if (entry?.inputTokens !== undefined) {
+        next.inputTokens = entry.inputTokens;
+      }
+      if (entry?.outputTokens !== undefined) {
+        next.outputTokens = entry.outputTokens;
+      }
+      if (entry?.totalTokens !== undefined) {
+        next.totalTokens = entry.totalTokens;
+      }
     }
     if (entry?.contextTokens !== undefined || defaults?.contextTokens !== undefined) {
       next.contextTokens =

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -362,6 +362,7 @@ export function createSessionActions(context: SessionActionContext) {
     state.currentSessionKey = nextKey;
     state.activeChatRunId = null;
     state.currentSessionId = null;
+    state.liveUsageUpdatedAt = 0;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness
     // so refresh data for the newly selected session isn't rejected as stale.
     state.sessionInfo.updatedAt = null;

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -97,6 +97,7 @@ export type TuiStateAccess = {
   activeChatRunId: string | null;
   historyLoaded: boolean;
   sessionInfo: SessionInfo;
+  readonly liveUsageUpdatedAt: number;
   initialSessionApplied: boolean;
   isConnected: boolean;
   autoMessageSent: boolean;

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -97,7 +97,7 @@ export type TuiStateAccess = {
   activeChatRunId: string | null;
   historyLoaded: boolean;
   sessionInfo: SessionInfo;
-  readonly liveUsageUpdatedAt: number;
+  liveUsageUpdatedAt: number;
   initialSessionApplied: boolean;
   isConnected: boolean;
   autoMessageSent: boolean;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -423,6 +423,9 @@ export async function runTui(opts: TuiOptions) {
     get liveUsageUpdatedAt() {
       return liveUsageUpdatedAt;
     },
+    set liveUsageUpdatedAt(value) {
+      liveUsageUpdatedAt = value;
+    },
     get initialSessionApplied() {
       return initialSessionApplied;
     },

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -407,6 +407,9 @@ export async function runTui(opts: TuiOptions) {
     },
     set activeChatRunId(value) {
       activeChatRunId = value;
+      if (value) {
+        liveUsageUpdatedAt = 0;
+      }
     },
     get historyLoaded() {
       return historyLoaded;
@@ -840,8 +843,8 @@ export async function runTui(opts: TuiOptions) {
       }
       if (updated) {
         liveUsageUpdatedAt = Date.now();
+        updateFooter();
       }
-      updateFooter();
     },
   });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -349,6 +349,7 @@ export async function runTui(opts: TuiOptions) {
   const autoMessage = opts.message?.trim();
   let autoMessageSent = false;
   let sessionInfo: SessionInfo = {};
+  let liveUsageUpdatedAt = 0;
   let lastCtrlCAt = 0;
   let exitRequested = false;
   let activityStatus = "idle";
@@ -418,6 +419,9 @@ export async function runTui(opts: TuiOptions) {
     },
     set sessionInfo(value) {
       sessionInfo = value;
+    },
+    get liveUsageUpdatedAt() {
+      return liveUsageUpdatedAt;
     },
     get initialSessionApplied() {
       return initialSessionApplied;
@@ -826,6 +830,7 @@ export async function runTui(opts: TuiOptions) {
       if (typeof data.outputTokens === "number") {
         sessionInfo.outputTokens = data.outputTokens;
       }
+      liveUsageUpdatedAt = Date.now();
       updateFooter();
     },
   });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -813,6 +813,21 @@ export async function runTui(opts: TuiOptions) {
     isLocalRunId,
     forgetLocalRunId,
     clearLocalRunIds,
+    onUsageUpdate: (data) => {
+      if (typeof data.totalTokens === "number") {
+        sessionInfo.totalTokens = data.totalTokens;
+      }
+      if (typeof data.contextTokens === "number") {
+        sessionInfo.contextTokens = data.contextTokens;
+      }
+      if (typeof data.inputTokens === "number") {
+        sessionInfo.inputTokens = data.inputTokens;
+      }
+      if (typeof data.outputTokens === "number") {
+        sessionInfo.outputTokens = data.outputTokens;
+      }
+      updateFooter();
+    },
   });
 
   const requestExit = () => {
@@ -921,24 +936,6 @@ export async function runTui(opts: TuiOptions) {
       handleChatEvent(evt.payload);
     }
     if (evt.event === "agent") {
-      const payload = evt.payload as Record<string, unknown> | undefined;
-      if (payload?.stream === "usage") {
-        const data = (payload.data ?? {}) as Record<string, unknown>;
-        if (typeof data.totalTokens === "number") {
-          sessionInfo.totalTokens = data.totalTokens;
-        }
-        if (typeof data.contextTokens === "number") {
-          sessionInfo.contextTokens = data.contextTokens;
-        }
-        if (typeof data.inputTokens === "number") {
-          sessionInfo.inputTokens = data.inputTokens;
-        }
-        if (typeof data.outputTokens === "number") {
-          sessionInfo.outputTokens = data.outputTokens;
-        }
-        updateFooter();
-        tui.requestRender();
-      }
       handleAgentEvent(evt.payload);
     }
   };

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -821,19 +821,26 @@ export async function runTui(opts: TuiOptions) {
     forgetLocalRunId,
     clearLocalRunIds,
     onUsageUpdate: (data) => {
+      let updated = false;
       if (typeof data.totalTokens === "number") {
         sessionInfo.totalTokens = data.totalTokens;
+        updated = true;
       }
       if (typeof data.contextTokens === "number") {
         sessionInfo.contextTokens = data.contextTokens;
+        updated = true;
       }
       if (typeof data.inputTokens === "number") {
         sessionInfo.inputTokens = data.inputTokens;
+        updated = true;
       }
       if (typeof data.outputTokens === "number") {
         sessionInfo.outputTokens = data.outputTokens;
+        updated = true;
       }
-      liveUsageUpdatedAt = Date.now();
+      if (updated) {
+        liveUsageUpdatedAt = Date.now();
+      }
       updateFooter();
     },
   });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -921,6 +921,24 @@ export async function runTui(opts: TuiOptions) {
       handleChatEvent(evt.payload);
     }
     if (evt.event === "agent") {
+      const payload = evt.payload as Record<string, unknown> | undefined;
+      if (payload?.stream === "usage") {
+        const data = (payload.data ?? {}) as Record<string, unknown>;
+        if (typeof data.totalTokens === "number") {
+          sessionInfo.totalTokens = data.totalTokens;
+        }
+        if (typeof data.contextTokens === "number") {
+          sessionInfo.contextTokens = data.contextTokens;
+        }
+        if (typeof data.inputTokens === "number") {
+          sessionInfo.inputTokens = data.inputTokens;
+        }
+        if (typeof data.outputTokens === "number") {
+          sessionInfo.outputTokens = data.outputTokens;
+        }
+        updateFooter();
+        tui.requestRender();
+      }
       handleAgentEvent(evt.payload);
     }
   };


### PR DESCRIPTION
## Summary
- Emit a `usage` agent event from `recordAssistantUsage` in `pi-embedded-subscribe.ts` after each LLM response, so the TUI footer token count updates once each response completes (before run finalization)
- Gate the TUI usage handler on `isActiveRun` to prevent concurrent/background runs from corrupting the footer
- Prevent `refreshSessionInfo` from overwriting live token data with stale server values for 5s after a usage event
- Display `tokens 0` instead of `tokens ?` for null token counts in the TUI footer

## Test plan
- [x] Token count updates in the TUI footer after each LLM response
- [x] Token count updates on every message (no alternation)
- [x] Fresh sessions show `tokens 0` instead of `tokens ?`
- [x] `formatTokens` unit tests pass (6 new tests)