### PR TITLE
Telegram: add wildcard topic defaults

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -185,7 +185,7 @@
         "filename": "appcast.xml",
         "hashed_secret": "abb0380989460de3f211d60628b439de7ebcd482",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 365
       },
       {
         "type": "Base64 High Entropy String",
@@ -9945,7 +9945,7 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2489
+        "line_number": 2490
       }
     ],
     "docs/install/macos-vm.md": [
@@ -10033,14 +10033,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T07:23:24Z"
+  "generated_at": "2026-03-08T07:28:20Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9795,63 +9795,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1611
+        "line_number": 1612
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1628
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1812
+        "line_number": 1813
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1985
+        "line_number": 1986
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2041
+        "line_number": 2042
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2274
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2401
+        "line_number": 2402
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2654
+        "line_number": 2655
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2656
+        "line_number": 2657
       }
     ],
     "docs/gateway/configuration.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T05:05:36Z"
+  "generated_at": "2026-03-08T07:23:24Z"
 }

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -449,6 +449,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     Topic inheritance: topic entries inherit group settings unless overridden (`requireMention`, `allowFrom`, `skills`, `systemPrompt`, `enabled`, `groupPolicy`).
     `agentId` is topic-only and does not inherit from group defaults.
 
+    You can also set `channels.telegram.groups.<chatId>.topics."*"` as the default config for every topic/thread in that Telegram group. Exact topic IDs still win over `"*"`.
+
     **Per-topic agent routing**: Each topic can route to a different agent by setting `agentId` in the topic config. This gives each topic its own isolated workspace, memory, and session. Example:
 
     ```json5
@@ -857,6 +859,7 @@ Primary reference:
   - `channels.telegram.groups.<id>.requireMention`: mention gating default.
   - `channels.telegram.groups.<id>.skills`: skill filter (omit = all skills, empty = none).
   - `channels.telegram.groups.<id>.allowFrom`: per-group sender allowlist override.
+  - `channels.telegram.groups.<id>.topics."*"`: default per-topic/thread settings for that group; exact topic IDs override it.
   - `channels.telegram.groups.<id>.systemPrompt`: extra system prompt for the group.
   - `channels.telegram.groups.<id>.enabled`: disable the group when `false`.
   - `channels.telegram.groups.<id>.topics.<threadId>.*`: per-topic overrides (group fields + topic-only `agentId`).

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -207,7 +207,7 @@ export type TelegramGroupConfig = {
   toolsBySender?: GroupToolPolicyBySenderConfig;
   /** If specified, only load these skills for this group (when no topic). Omit = all skills; empty = no skills. */
   skills?: string[];
-  /** Per-topic configuration (key is message_thread_id as string) */
+  /** Per-topic configuration (key is message_thread_id as string, or "*" for topic defaults) */
   topics?: Record<string, TelegramTopicConfig>;
   /** If false, disable the bot for this group (and its topics). */
   enabled?: boolean;
@@ -227,7 +227,7 @@ export type TelegramDirectConfig = {
   toolsBySender?: GroupToolPolicyBySenderConfig;
   /** If specified, only load these skills for this DM (when no topic). Omit = all skills; empty = no skills. */
   skills?: string[];
-  /** Per-topic configuration for DM topics (key is message_thread_id as string) */
+  /** Per-topic configuration for DM topics (key is message_thread_id as string, or "*" for topic defaults) */
   topics?: Record<string, TelegramTopicConfig>;
   /** If false, disable the bot for this DM (and its topics). */
   enabled?: boolean;

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1049,6 +1049,142 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(0);
   });
 
+  it("uses topics.* as the default config for forum topics in a group", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groups: {
+            "-1001234567890": {
+              requireMention: false,
+              allowFrom: ["999999999"],
+              topics: {
+                "*": { allowFrom: ["123456789"] },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum Group",
+          is_forum: true,
+        },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+        message_thread_id: 77,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers exact topic config over topics.* fallback", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groups: {
+            "-1001234567890": {
+              allowFrom: ["999999999"],
+              topics: {
+                "*": { allowFrom: ["123456789"] },
+                "77": { allowFrom: ["555555555"] },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum Group",
+          is_forum: true,
+        },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+        message_thread_id: 77,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("uses topics.* agentId as the default route for unmatched forum topics", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    loadConfig.mockReturnValue({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "zu" }],
+      },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: {
+            "-1001234567890": {
+              requireMention: false,
+              topics: {
+                "*": { agentId: "zu" },
+              },
+            },
+          },
+        },
+      },
+      messages: { groupChat: { mentionPatterns: [] } },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum Group",
+          is_forum: true,
+        },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+        message_thread_id: 77,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toContain("agent:zu:");
+    expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toContain(
+      "telegram:group:-1001234567890:topic:77",
+    );
+  });
+
   it("allows group messages for per-group groupPolicy open override (global groupPolicy allowlist)", async () => {
     onSpy.mockClear();
     replySpy.mockClear();
@@ -1243,6 +1379,7 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).toHaveBeenCalledWith(
       12345,
       "You are not authorized to use this command.",
+      {},
     );
   });
 

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -22,6 +22,7 @@ import {
   resolveChannelGroupRequireMention,
 } from "../config/group-policy.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
+import type { TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
 import { formatUncaughtError } from "../infra/errors.js";
 import { getChildLogger } from "../logging.js";
@@ -311,10 +312,8 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     const direct = telegramCfg.direct;
     const chatIdStr = String(chatId);
     const isDm = !chatIdStr.startsWith("-");
-    const resolveTopicConfig = <
-      TConfig extends { topics?: Record<string, { [key: string]: unknown }> | undefined },
-    >(
-      scopedConfig: TConfig | undefined,
+    const resolveTopicConfig = (
+      scopedConfig: { topics?: Record<string, TelegramTopicConfig> } | undefined,
       threadId?: number,
     ) =>
       threadId != null

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -311,12 +311,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     const direct = telegramCfg.direct;
     const chatIdStr = String(chatId);
     const isDm = !chatIdStr.startsWith("-");
+    const resolveTopicConfig = <
+      TConfig extends { topics?: Record<string, { [key: string]: unknown }> | undefined },
+    >(
+      scopedConfig: TConfig | undefined,
+      threadId?: number,
+    ) =>
+      threadId != null
+        ? (scopedConfig?.topics?.[String(threadId)] ?? scopedConfig?.topics?.["*"])
+        : undefined;
 
     if (isDm) {
       const directConfig = direct?.[chatIdStr] ?? direct?.["*"];
       if (directConfig) {
-        const topicConfig =
-          messageThreadId != null ? directConfig.topics?.[String(messageThreadId)] : undefined;
+        const topicConfig = resolveTopicConfig(directConfig, messageThreadId);
         return { groupConfig: directConfig, topicConfig };
       }
       // DMs without direct config: don't fall through to groups lookup
@@ -327,8 +335,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       return { groupConfig: undefined, topicConfig: undefined };
     }
     const groupConfig = groups[chatIdStr] ?? groups["*"];
-    const topicConfig =
-      messageThreadId != null ? groupConfig?.topics?.[String(messageThreadId)] : undefined;
+    const topicConfig = resolveTopicConfig(groupConfig, messageThreadId);
     return { groupConfig, topicConfig };
   };
 


### PR DESCRIPTION
## Summary
- add `topics."*"` fallback support for Telegram group and DM topic config resolution
- cover wildcard topic defaults and exact-topic override behavior in Telegram bot tests
- document `topics."*"` as the per-group default topic/thread config

## Testing
- `pnpm vitest run src/telegram/bot.test.ts src/config/config.telegram-topic-agentid.test.ts`
