### PR TITLE
fix(feishu): detect bot mention in reply messages and prevent unwanted thread routing

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -22,6 +22,28 @@ function makeEvent(
   };
 }
 
+function makeReplyEvent(
+  chatType: "p2p" | "group" | "private",
+  mentions: Array<{ key: string; name: string; id: { open_id?: string } }> | undefined,
+  text: string,
+  parentId: string,
+) {
+  return {
+    sender: {
+      sender_id: { user_id: "u1", open_id: "ou_sender" },
+    },
+    message: {
+      message_id: "msg_1",
+      chat_id: "oc_chat1",
+      chat_type: chatType,
+      message_type: "text",
+      content: JSON.stringify({ text }),
+      mentions,
+      parent_id: parentId,
+    },
+  };
+}
+
 function makePostEvent(content: unknown) {
   return {
     sender: { sender_id: { user_id: "u1", open_id: "ou_sender" } },
@@ -189,5 +211,66 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     });
     const ctx = parseFeishuMessageEvent(event as any, "ou_bot_123");
     expect(ctx.content).toBe("[Forwarded message: sc_abc123]");
+  });
+
+  it("returns mentionedBot=true for reply with orphaned mention key (bot dropped from mentions)", () => {
+    const event = makeReplyEvent(
+      "group",
+      [{ key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } }],
+      "@_user_1 @_user_2 hello",
+      "om_parent_msg_id",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("returns mentionedBot=true for reply with empty mentions but mention keys in text", () => {
+    const event = makeReplyEvent("group", [], "@_user_1 hello", "om_parent_msg_id");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("returns mentionedBot=false for reply with no orphaned mention keys", () => {
+    const event = makeReplyEvent(
+      "group",
+      [{ key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } }],
+      "@_user_1 hello",
+      "om_parent_msg_id",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=false for non-reply message with no mentions", () => {
+    const event = makeEvent("group", [], "hello");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("clears rootId when bot is mentioned in a reply message", () => {
+    const event = makeReplyEvent(
+      "group",
+      [{ key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } }],
+      "@_user_1 hello",
+      "om_parent_msg_id",
+    );
+    (event.message as any).root_id = "om_root_msg_id";
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+    expect(ctx.rootId).toBeUndefined();
+    expect(ctx.parentId).toBe("om_parent_msg_id");
+  });
+
+  it("preserves rootId when bot is NOT mentioned in a reply message", () => {
+    const event = makeReplyEvent(
+      "group",
+      [{ key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } }],
+      "@_user_1 hello",
+      "om_parent_msg_id",
+    );
+    (event.message as any).root_id = "om_root_msg_id";
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+    expect(ctx.rootId).toBe("om_root_msg_id");
   });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -467,6 +467,14 @@ function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boole
   // Reply messages: Feishu may omit the bot from the mentions array while
   // keeping the @_user_N / @_bot_N placeholder in the text content.  Detect
   // orphaned mention keys as a signal that a mention was dropped.
+  //
+  // Trade-off: this heuristic cannot tell *which* user the orphaned key
+  // belongs to.  In practice the false-positive risk is negligible because:
+  //   1. If the bot IS in the mentions array, we already returned true above.
+  //   2. We only reach here when at least one @_user_N key has no matching
+  //      entry — Feishu almost exclusively drops bot mentions in replies.
+  //   3. A false positive (bot responds once extra) is far less harmful than
+  //      a false negative (bot silently ignores a real @-mention).
   if (event.message.parent_id && event.message.message_type === "text") {
     try {
       const parsed = JSON.parse(rawContent);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -457,14 +457,26 @@ function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boole
   const rawContent = event.message.content ?? "";
   if (rawContent.includes("@_all")) return true;
   const mentions = event.message.mentions ?? [];
-  if (mentions.length > 0) {
-    // Rely on Feishu mention IDs; display names can vary by alias/context.
-    return mentions.some((m) => m.id.open_id === botOpenId);
-  }
+  // Check structured mentions array for bot open_id
+  if (mentions.some((m) => m.id.open_id === botOpenId)) return true;
   // Post (rich text) messages may have empty message.mentions when they contain docs/paste
   if (event.message.message_type === "post") {
     const { mentionedOpenIds } = parsePostContent(event.message.content);
-    return mentionedOpenIds.some((id) => id === botOpenId);
+    if (mentionedOpenIds.some((id) => id === botOpenId)) return true;
+  }
+  // Reply messages: Feishu may omit the bot from the mentions array while
+  // keeping the @_user_N / @_bot_N placeholder in the text content.  Detect
+  // orphaned mention keys as a signal that a mention was dropped.
+  if (event.message.parent_id && event.message.message_type === "text") {
+    try {
+      const parsed = JSON.parse(rawContent);
+      const text = typeof parsed.text === "string" ? parsed.text : "";
+      const knownKeys = new Set(mentions.map((m) => m.key));
+      const keysInText = text.match(/@_[a-z]+_\d+/g) ?? [];
+      if (keysInText.some((key) => !knownKeys.has(key))) return true;
+    } catch {
+      // malformed content — ignore
+    }
   }
   return false;
 }
@@ -796,7 +808,11 @@ export function parseFeishuMessageEvent(
     chatType: event.message.chat_type,
     mentionedBot,
     hasAnyMention,
-    rootId: event.message.root_id || undefined,
+    // When the bot is explicitly @-mentioned in a reply message, reply in the
+    // main chat instead of entering the topic thread.  The user's intent is to
+    // address the bot, not to continue the thread they replied to.
+    rootId:
+      mentionedBot && event.message.parent_id ? undefined : event.message.root_id || undefined,
     parentId: event.message.parent_id || undefined,
     threadId: event.message.thread_id || undefined,
     content,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -481,7 +481,7 @@ function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boole
       const text = typeof parsed.text === "string" ? parsed.text : "";
       const knownKeys = new Set(mentions.map((m) => m.key));
       const keysInText = text.match(/@_[a-z]+_\d+/g) ?? [];
-      if (keysInText.some((key) => !knownKeys.has(key))) return true;
+      if (keysInText.some((key: string) => !knownKeys.has(key))) return true;
     } catch {
       // malformed content — ignore
     }


### PR DESCRIPTION
## Summary

- Fix `checkBotMentioned()` to detect bot @-mention in reply messages where Feishu drops the bot from the `mentions` array but keeps the `@_user_N` placeholder in the text
- Clear `rootId` when bot is explicitly @-mentioned in a reply, so the bot replies in the main chat instead of creating a topic thread
- Add 6 test cases covering orphaned mention key detection and rootId clearing behavior

Fixes #39568

## Test plan

- [x] Verified on production Feishu group: bot correctly responds to reply+@mention
- [x] Verified bot replies in main chat instead of creating topic thread
- [x] Unit tests pass for orphaned mention key detection
- [x] Unit tests pass for rootId clearing logic
- [ ] `pnpm test` passes