### PR TITLE
fix(agents): allow /agent reads in ro sandbox guards

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -358,19 +358,8 @@ function mapContainerPathToWorkspaceRoot(params: {
   filePath: string;
   root: string;
   containerWorkdir?: string;
+  agentWorkspaceMount?: string;
 }): string {
-  const containerWorkdir = params.containerWorkdir?.trim();
-  if (!containerWorkdir) {
-    return params.filePath;
-  }
-  const normalizedWorkdir = containerWorkdir.replace(/\\/g, "/").replace(/\/+$/, "");
-  if (!normalizedWorkdir.startsWith("/")) {
-    return params.filePath;
-  }
-  if (!normalizedWorkdir) {
-    return params.filePath;
-  }
-
   let candidate = params.filePath.startsWith("@") ? params.filePath.slice(1) : params.filePath;
   if (/^file:\/\//i.test(candidate)) {
     try {
@@ -392,18 +381,58 @@ function mapContainerPathToWorkspaceRoot(params: {
   }
 
   const normalizedCandidate = candidate.replace(/\\/g, "/");
-  if (normalizedCandidate === normalizedWorkdir) {
-    return path.resolve(params.root);
+  const containerPath = remapContainerPathToHostRoot({
+    candidate: normalizedCandidate,
+    containerRoot: params.containerWorkdir,
+    hostRoot: params.root,
+  });
+  if (containerPath) {
+    return containerPath;
   }
-  const prefix = `${normalizedWorkdir}/`;
-  if (!normalizedCandidate.startsWith(prefix)) {
-    return candidate;
+  const agentWorkspacePath = remapContainerPathToHostRoot({
+    candidate: normalizedCandidate,
+    containerRoot: params.agentWorkspaceMount,
+    hostRoot: params.root,
+  });
+  if (agentWorkspacePath) {
+    return agentWorkspacePath;
   }
-  const relative = normalizedCandidate.slice(prefix.length);
+  return candidate;
+}
+
+function remapContainerPathToHostRoot(params: {
+  candidate: string;
+  containerRoot?: string;
+  hostRoot: string;
+}): string | undefined {
+  const containerRoot = normalizeContainerRoot(params.containerRoot);
+  if (!containerRoot) {
+    return undefined;
+  }
+  if (params.candidate === containerRoot) {
+    return path.resolve(params.hostRoot);
+  }
+  const prefix = `${containerRoot}/`;
+  if (!params.candidate.startsWith(prefix)) {
+    return undefined;
+  }
+  const relative = params.candidate.slice(prefix.length);
   if (!relative) {
-    return path.resolve(params.root);
+    return path.resolve(params.hostRoot);
   }
-  return path.resolve(params.root, ...relative.split("/").filter(Boolean));
+  return path.resolve(params.hostRoot, ...relative.split("/").filter(Boolean));
+}
+
+function normalizeContainerRoot(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!normalized || !normalized.startsWith("/")) {
+    return undefined;
+  }
+  return normalized;
 }
 
 export function wrapToolWorkspaceRootGuardWithOptions(
@@ -411,6 +440,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
   root: string,
   options?: {
     containerWorkdir?: string;
+    agentWorkspaceMount?: string;
   },
 ): AnyAgentTool {
   return {
@@ -426,6 +456,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
           filePath,
           root,
           containerWorkdir: options?.containerWorkdir,
+          agentWorkspaceMount: options?.agentWorkspaceMount,
         });
         await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
       }

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -76,6 +76,22 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
     });
   });
 
+  it("maps explicit /agent workspace mount paths to the host workspace root", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+      agentWorkspaceMount: "/agent",
+    });
+
+    await wrapped.execute("tc-agent-mount", { path: "/agent/docs/readme.md" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(root, "docs", "readme.md"),
+      cwd: root,
+      root,
+    });
+  });
+
   it("normalizes @-prefixed absolute paths before guard checks", async () => {
     const { tool } = createToolHarness();
     const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
@@ -101,6 +117,21 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
 
     expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
       filePath: "/workspace-two/secret.txt",
+      cwd: root,
+      root,
+    });
+  });
+
+  it("does not remap /agent paths when no agent workspace mount is configured", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+    });
+
+    await wrapped.execute("tc-agent-unmapped", { path: "/agent/docs/readme.md" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: "/agent/docs/readme.md",
       cwd: root,
       root,
     });

--- a/src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts
+++ b/src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts
@@ -58,6 +58,29 @@ describe("tools.fs.workspaceOnly", () => {
     });
   });
 
+  it("allows the official /agent mount in read-only sandbox mode when workspaceOnly is enabled", async () => {
+    await withUnsafeMountedSandboxHarness(
+      async ({ sandboxRoot, agentRoot, sandbox }) => {
+        await fs.writeFile(path.join(agentRoot, "secret.txt"), "shh", "utf8");
+
+        const cfg = { tools: { fs: { workspaceOnly: true } } } as unknown as OpenClawConfig;
+        const tools = createOpenClawCodingTools({
+          sandbox,
+          workspaceDir: sandboxRoot,
+          config: cfg,
+        });
+        const readTool = tools.find((tool) => tool.name === "read") as ToolWithExecute | undefined;
+        if (!readTool) {
+          throw new Error("read tool missing");
+        }
+
+        const readResult = await readTool.execute("t-ro-read", { path: "/agent/secret.txt" });
+        expect(getTextContent(readResult as Parameters<typeof getTextContent>[0])).toContain("shh");
+      },
+      { workspaceAccess: "ro" },
+    );
+  });
+
   it("rejects sandbox mounts outside the workspace root when enabled", async () => {
     await withUnsafeMountedSandboxHarness(async ({ sandboxRoot, agentRoot, sandbox }) => {
       await fs.writeFile(path.join(agentRoot, "secret.txt"), "shh", "utf8");

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -43,6 +43,7 @@ import {
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
 import { isXaiProvider } from "./schema/clean-for-xai.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
@@ -360,6 +361,8 @@ export function createOpenClawCodingTools(options?: {
           workspaceOnly
             ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
                 containerWorkdir: sandbox.containerWorkdir,
+                agentWorkspaceMount:
+                  sandbox.workspaceAccess === "ro" ? SANDBOX_AGENT_WORKSPACE_MOUNT : undefined,
               })
             : sandboxed,
         ];
@@ -452,6 +455,8 @@ export function createOpenClawCodingTools(options?: {
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
+                    agentWorkspaceMount:
+                      sandbox.workspaceAccess === "ro" ? SANDBOX_AGENT_WORKSPACE_MOUNT : undefined,
                   },
                 )
               : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
@@ -461,6 +466,8 @@ export function createOpenClawCodingTools(options?: {
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
+                    agentWorkspaceMount:
+                      sandbox.workspaceAccess === "ro" ? SANDBOX_AGENT_WORKSPACE_MOUNT : undefined,
                   },
                 )
               : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -455,8 +455,6 @@ export function createOpenClawCodingTools(options?: {
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
-                    agentWorkspaceMount:
-                      sandbox.workspaceAccess === "ro" ? SANDBOX_AGENT_WORKSPACE_MOUNT : undefined,
                   },
                 )
               : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
@@ -466,8 +464,6 @@ export function createOpenClawCodingTools(options?: {
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
-                    agentWorkspaceMount:
-                      sandbox.workspaceAccess === "ro" ? SANDBOX_AGENT_WORKSPACE_MOUNT : undefined,
                   },
                 )
               : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),

--- a/src/agents/test-helpers/unsafe-mounted-sandbox.ts
+++ b/src/agents/test-helpers/unsafe-mounted-sandbox.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { SandboxContext } from "../sandbox.js";
+import type { SandboxContext, SandboxWorkspaceAccess } from "../sandbox.js";
 import type { SandboxFsBridge, SandboxResolvedPath } from "../sandbox/fs-bridge.js";
 import { createSandboxFsBridgeFromResolver } from "./host-sandbox-fs-bridge.js";
 import { createPiToolsSandboxContext } from "./pi-tools-sandbox-context.js";
@@ -50,6 +50,7 @@ export function createUnsafeMountedSandbox(params: {
   sandboxRoot: string;
   agentRoot: string;
   workspaceContainerRoot?: string;
+  workspaceAccess?: SandboxWorkspaceAccess;
 }): SandboxContext {
   const bridge = createUnsafeMountedBridge({
     root: params.sandboxRoot,
@@ -59,7 +60,7 @@ export function createUnsafeMountedSandbox(params: {
   return createPiToolsSandboxContext({
     workspaceDir: params.sandboxRoot,
     agentWorkspaceDir: params.agentRoot,
-    workspaceAccess: "rw",
+    workspaceAccess: params.workspaceAccess ?? "rw",
     fsBridge: bridge,
     tools: { allow: [], deny: [] },
   });
@@ -67,13 +68,18 @@ export function createUnsafeMountedSandbox(params: {
 
 export async function withUnsafeMountedSandboxHarness(
   run: (ctx: { sandboxRoot: string; agentRoot: string; sandbox: SandboxContext }) => Promise<void>,
+  options?: { workspaceAccess?: SandboxWorkspaceAccess },
 ) {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sbx-mounts-"));
   const sandboxRoot = path.join(stateDir, "sandbox");
   const agentRoot = path.join(stateDir, "agent");
   await fs.mkdir(sandboxRoot, { recursive: true });
   await fs.mkdir(agentRoot, { recursive: true });
-  const sandbox = createUnsafeMountedSandbox({ sandboxRoot, agentRoot });
+  const sandbox = createUnsafeMountedSandbox({
+    sandboxRoot,
+    agentRoot,
+    workspaceAccess: options?.workspaceAccess,
+  });
   try {
     await run({ sandboxRoot, agentRoot, sandbox });
   } finally {


### PR DESCRIPTION
## Summary

Fixes #39497.

When `tools.fs.workspaceOnly` is enabled for sandboxed embedded runs, the workspace-root guard only remaps container paths under `containerWorkdir` (usually `/workspace`). In `workspaceAccess: "ro"` mode, the read-only agent workspace is mounted at `/agent`, so valid read calls like `read /agent/...` were still treated as escaping the sandbox root and rejected before the sandbox FS bridge could resolve them.

## Changes

- extend `wrapToolWorkspaceRootGuardWithOptions` to accept an explicit `agentWorkspaceMount`
- only enable `/agent` remapping when the sandbox is actually running with `workspaceAccess: "ro"`
- keep `/agent` unmapped in other modes so the existing workspace-only protection for arbitrary mounts stays intact
- add regression coverage for both the direct guard mapping and the `createOpenClawCodingTools` wiring

## Why this shape

A previous attempt at this fix (`#39525`) was directionally right but missed forwarding the new option through `wrapToolWorkspaceRootGuardWithOptions`, and it defaulted `/agent` remapping on unconditionally. This version keeps the mapping opt-in and wires it through all affected call sites.

## Verification

- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/vitest run src/agents/pi-tools.read.workspace-root-guard.test.ts src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxlint src/agents/pi-tools.read.ts src/agents/pi-tools.ts src/agents/pi-tools.read.workspace-root-guard.test.ts src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts src/agents/test-helpers/unsafe-mounted-sandbox.ts`
