### PR TITLE
Fix double JSON-serialization of vLLM content blocks

### DIFF
--- a/src/shared/chat-content.test.ts
+++ b/src/shared/chat-content.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { extractTextFromChatContent } from "./chat-content.js";
+
+describe("extractTextFromChatContent", () => {
+  it("returns text from a plain string", () => {
+    expect(extractTextFromChatContent("hello world")).toBe("hello world");
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractTextFromChatContent("")).toBeNull();
+  });
+
+  it("returns null for non-string non-array", () => {
+    expect(extractTextFromChatContent(42)).toBeNull();
+    expect(extractTextFromChatContent(null)).toBeNull();
+    expect(extractTextFromChatContent(undefined)).toBeNull();
+  });
+
+  it("extracts text from an array of content blocks", () => {
+    const content = [
+      { type: "text", text: "hello" },
+      { type: "text", text: "world" },
+    ];
+    expect(extractTextFromChatContent(content)).toBe("hello world");
+  });
+
+  it("skips non-text blocks", () => {
+    const content = [
+      { type: "image", url: "http://example.com/img.png" },
+      { type: "text", text: "hello" },
+    ];
+    expect(extractTextFromChatContent(content)).toBe("hello");
+  });
+
+  it("extracts text from a JSON-stringified array of content blocks", () => {
+    const blocks = [
+      { type: "text", text: "hello" },
+      { type: "text", text: "world" },
+    ];
+    const content = JSON.stringify(blocks);
+    expect(extractTextFromChatContent(content)).toBe("hello world");
+  });
+
+  it("returns plain text for a string that starts with [ but is not valid JSON", () => {
+    expect(extractTextFromChatContent("[not valid json")).toBe("[not valid json");
+  });
+
+  it("returns plain text for a JSON array that does not contain content blocks", () => {
+    const content = JSON.stringify([1, 2, 3]);
+    expect(extractTextFromChatContent(content)).toBe("[1,2,3]");
+  });
+
+  it("returns plain text for a JSON array of objects without type/text", () => {
+    const content = JSON.stringify([{ foo: "bar" }]);
+    expect(extractTextFromChatContent(content)).toBe('[{"foo":"bar"}]');
+  });
+
+  it("applies sanitizeText to JSON-stringified content blocks", () => {
+    const blocks = [{ type: "text", text: "hello <b>world</b>" }];
+    const content = JSON.stringify(blocks);
+    const result = extractTextFromChatContent(content, {
+      sanitizeText: (t) => t.replace(/<[^>]+>/g, ""),
+    });
+    expect(result).toBe("hello world");
+  });
+
+  it("applies joinWith to JSON-stringified content blocks", () => {
+    const blocks = [
+      { type: "text", text: "hello" },
+      { type: "text", text: "world" },
+    ];
+    const content = JSON.stringify(blocks);
+    // Default normalizeText collapses whitespace; use identity to preserve the join separator.
+    expect(extractTextFromChatContent(content, { joinWith: "\n", normalizeText: (t) => t })).toBe(
+      "hello\nworld",
+    );
+  });
+});

--- a/src/shared/chat-content.test.ts
+++ b/src/shared/chat-content.test.ts
@@ -55,6 +55,15 @@ describe("extractTextFromChatContent", () => {
     expect(extractTextFromChatContent(content)).toBe('[{"foo":"bar"}]');
   });
 
+  it("extracts text from a JSON-stringified mixed-content array (text + image blocks)", () => {
+    const blocks = [
+      { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+      { type: "text", text: "hello" },
+    ];
+    const content = JSON.stringify(blocks);
+    expect(extractTextFromChatContent(content)).toBe("hello");
+  });
+
   it("applies sanitizeText to JSON-stringified content blocks", () => {
     const blocks = [{ type: "text", text: "hello <b>world</b>" }];
     const content = JSON.stringify(blocks);

--- a/src/shared/chat-content.ts
+++ b/src/shared/chat-content.ts
@@ -19,7 +19,7 @@ export function extractTextFromChatContent(
           Array.isArray(parsed) &&
           parsed.length > 0 &&
           parsed.every(
-            (item) => item && typeof item === "object" && "type" in item && "text" in item,
+            (item) => item && typeof item === "object" && "type" in item,
           )
         ) {
           return extractTextFromChatContent(parsed, opts);

--- a/src/shared/chat-content.ts
+++ b/src/shared/chat-content.ts
@@ -10,6 +10,25 @@ export function extractTextFromChatContent(
   const joinWith = opts?.joinWith ?? " ";
 
   if (typeof content === "string") {
+    // Detect JSON-stringified arrays of content blocks (e.g. from vLLM openai-completions).
+    // Without this guard the string would be returned as-is and later double-serialized.
+    if (content.startsWith("[") && content.endsWith("]")) {
+      try {
+        const parsed: unknown = JSON.parse(content);
+        if (
+          Array.isArray(parsed) &&
+          parsed.length > 0 &&
+          parsed.every(
+            (item) => item && typeof item === "object" && "type" in item && "text" in item,
+          )
+        ) {
+          return extractTextFromChatContent(parsed, opts);
+        }
+      } catch {
+        // Not valid JSON – fall through and treat as plain text.
+      }
+    }
+
     const value = opts?.sanitizeText ? opts.sanitizeText(content) : content;
     const normalized = normalize(value);
     return normalized ? normalized : null;


### PR DESCRIPTION
## Summary
- When `extractTextFromChatContent` receives a string that is a JSON-stringified array of content blocks (e.g. from vLLM openai-completions), it now detects and parses those blocks instead of returning the raw JSON string. This prevents downstream `JSON.stringify` from double-serializing the content.
- Added comprehensive tests for `extractTextFromChatContent` covering plain strings, arrays, JSON-stringified arrays, and edge cases.

Closes #38543

## Test plan
- [x] New unit tests in `src/shared/chat-content.test.ts` (11 tests passing)
- [ ] Verify vLLM openai-completions responses render correctly without nested JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)