### PR TITLE
fix(doctor): read gateway token from systemd EnvironmentFile

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -12,6 +12,7 @@ import { parseSystemdExecStart } from "./systemd-unit.js";
 import {
   isSystemdUserServiceAvailable,
   parseSystemdShow,
+  readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserUnitPath,
   stopSystemdService,
@@ -220,6 +221,45 @@ describe("resolveSystemdUserUnitPath", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveSystemdUserUnitPath(env)).toBe(expected);
+  });
+});
+
+describe("readSystemdServiceExecStart", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads OPENCLAW_GATEWAY_TOKEN from EnvironmentFile entries", async () => {
+    const unitPath = "/home/test/.config/systemd/user/openclaw-gateway.service";
+    const envFilePath = "/home/test/.openclaw/secrets/gateway.env";
+    const envFileDirective = "%h/.openclaw/secrets/gateway.env";
+    vi.spyOn(fs, "readFile").mockImplementation(async (target, encoding) => {
+      expect(encoding).toBe("utf8");
+      if (target === unitPath) {
+        return [
+          "[Service]",
+          "ExecStart=/usr/bin/node /usr/local/bin/openclaw gateway --port 18789",
+          `EnvironmentFile=${envFileDirective}`,
+          "",
+        ].join("\n");
+      }
+      if (target === envFilePath) {
+        return [
+          "# comment",
+          "OPENCLAW_GATEWAY_TOKEN=from-env-file",
+          "PATH=/usr/local/bin:/usr/bin:/bin",
+          "",
+        ].join("\n");
+      }
+      throw Object.assign(new Error(`unexpected path: ${String(target)}`), { code: "ENOENT" });
+    });
+
+    const command = await readSystemdServiceExecStart({ HOME: "/home/test" });
+
+    expect(command?.environment).toMatchObject({
+      OPENCLAW_GATEWAY_TOKEN: "from-env-file",
+      PATH: "/usr/local/bin:/usr/bin:/bin",
+    });
   });
 });
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -56,6 +56,84 @@ export type { SystemdUserLingerStatus };
 
 // Unit file parsing/rendering: see systemd-unit.ts
 
+function unquoteSystemdValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (!(trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+    return trimmed;
+  }
+  let out = "";
+  let escapeNext = false;
+  for (const ch of trimmed.slice(1, -1)) {
+    if (escapeNext) {
+      out += ch;
+      escapeNext = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escapeNext = true;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+function resolveSystemdEnvironmentFilePath(
+  raw: string,
+  env: GatewayServiceEnv,
+): {
+  path: string;
+  optional: boolean;
+} | null {
+  let value = unquoteSystemdValue(raw);
+  let optional = false;
+  if (value.startsWith("-")) {
+    optional = true;
+    value = value.slice(1).trim();
+  }
+  if (!value) {
+    return null;
+  }
+  const home = toPosixPath(resolveHomeDir(env));
+  const resolvedPath = value.replaceAll("%h", home);
+  return { path: resolvedPath, optional };
+}
+
+async function mergeSystemdEnvironmentFile(
+  environment: Record<string, string>,
+  raw: string,
+  env: GatewayServiceEnv,
+): Promise<void> {
+  const resolved = resolveSystemdEnvironmentFilePath(raw, env);
+  if (!resolved) {
+    return;
+  }
+  try {
+    const content = await fs.readFile(resolved.path, "utf8");
+    for (const rawLine of content.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith("#") || line.startsWith(";")) {
+        continue;
+      }
+      const parsed = parseSystemdEnvAssignment(line);
+      if (parsed) {
+        environment[parsed.key] = parsed.value;
+      }
+    }
+  } catch (error) {
+    if (
+      resolved.optional &&
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "ENOENT"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
 export async function readSystemdServiceExecStart(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
@@ -74,6 +152,12 @@ export async function readSystemdServiceExecStart(
         execStart = line.slice("ExecStart=".length).trim();
       } else if (line.startsWith("WorkingDirectory=")) {
         workingDirectory = line.slice("WorkingDirectory=".length).trim();
+      } else if (line.startsWith("EnvironmentFile=")) {
+        await mergeSystemdEnvironmentFile(
+          environment,
+          line.slice("EnvironmentFile=".length).trim(),
+          env,
+        );
       } else if (line.startsWith("Environment=")) {
         const raw = line.slice("Environment=".length).trim();
         const parsed = parseSystemdEnvAssignment(raw);

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { createEventHandlers } from "./tui-event-handlers.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { createEventHandlers } from "./tui-event-handlers.js";
 
 type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {
@@ -483,5 +483,21 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+  });
+
+  it("reloads history when a local run ends without a displayable final message", () => {
+    const { state, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-local-silent" },
+    });
+
+    noteLocalRunId("run-local-silent");
+
+    handleChatEvent({
+      runId: "run-local-silent",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    });
+
+    expect(loadHistory).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,7 +1,7 @@
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
-import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
 type EventHandlerChatLog = {
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;
@@ -136,10 +136,16 @@ export function createEventHandlers(context: EventHandlerContext) {
     return sessionRuns.has(activeRunId);
   };
 
-  const maybeRefreshHistoryForRun = (runId: string) => {
-    if (isLocalRunId?.(runId)) {
+  const maybeRefreshHistoryForRun = (
+    runId: string,
+    opts?: { allowLocalWithoutDisplayableFinal?: boolean },
+  ) => {
+    const isLocalRun = isLocalRunId?.(runId) ?? false;
+    if (isLocalRun) {
       forgetLocalRunId?.(runId);
-      return;
+      if (!opts?.allowLocalWithoutDisplayableFinal) {
+        return;
+      }
     }
     if (hasConcurrentActiveRun(runId)) {
       return;
@@ -202,7 +208,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "final") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message) {
-        maybeRefreshHistoryForRun(evt.runId);
+        maybeRefreshHistoryForRun(evt.runId, {
+          allowLocalWithoutDisplayableFinal: true,
+        });
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender();

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,5 +1,5 @@
-import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 


### PR DESCRIPTION
Fixes #39437

## Summary
- load `EnvironmentFile=` entries when reading the systemd user unit
- merge env-file variables into the service command environment before audit
- cover `%h`-expanded gateway token files with a regression test

## Why
`openclaw doctor` was only reading inline `Environment=` assignments from the systemd unit. When `OPENCLAW_GATEWAY_TOKEN` came from `EnvironmentFile=%h/...`, the service audit saw the token as missing and emitted a false-positive mismatch warning.

## Verification
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/vitest run src/daemon/systemd.test.ts src/daemon/service-audit.test.ts src/commands/doctor-gateway-services.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxlint src/daemon/systemd.ts src/daemon/systemd.test.ts`
