### PR TITLE
fix(config): add missing params field to AgentEntrySchema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -738,6 +738,7 @@ export const AgentEntrySchema = z
       })
       .strict()
       .optional(),
+    params: z.record(z.string(), z.unknown()).optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,


### PR DESCRIPTION
## Summary

- Add missing params field to AgentEntrySchema in the Zod validation schema
- The AgentConfig TypeScript type defines params for per-agent stream parameters but the Zod schema was missing this field
- Since AgentEntrySchema uses .strict(), any config with params would fail validation

## Test plan

- [ ] Configure params on an agent entry, verify config validates
- [ ] Verify existing configs without params continue to work