### PR TITLE
feat(tui): infer workspace agent when launching TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- TUI: infer the active agent from the current workspace when launched inside a configured agent workspace, while preserving explicit `agent:` session targets. (#39591) thanks @arceus77-7.
+
 ### Fixes
 
 - macOS app/chat UI: route browser proxy through the local node browser service, preserve plain-text paste semantics, strip completed assistant trace/debug wrapper noise from transcripts, refresh permission state after returning from System Settings, and tolerate malformed cron rows in the macOS tab. (#39516) Thanks @Imhermes1.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -17,6 +17,7 @@ Related:
 Notes:
 
 - `tui` resolves configured gateway auth SecretRefs for token/password auth when possible (`env`/`file`/`exec` providers).
+- When launched from inside a configured agent workspace directory, TUI auto-selects that agent for the session key default (unless `--session` is explicitly `agent:<id>:...`).
 
 ## Examples
 
@@ -24,4 +25,6 @@ Notes:
 openclaw tui
 openclaw tui --url ws://127.0.0.1:18789 --token <token>
 openclaw tui --session main --deliver
+# when run inside an agent workspace, infers that agent automatically
+openclaw tui --session bugfix
 ```

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -461,6 +463,39 @@ describe("resolveAgentIdByWorkspacePath", () => {
     expect(
       resolveAgentIdByWorkspacePath(cfg, `/tmp/openclaw-agent-scope-${Date.now()}-unrelated`),
     ).toBeUndefined();
+  });
+
+  it("matches workspace paths through symlink aliases", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-scope-"));
+    const realWorkspaceRoot = path.join(tempRoot, "real-root");
+    const realOpsWorkspace = path.join(realWorkspaceRoot, "projects", "ops");
+    const aliasWorkspaceRoot = path.join(tempRoot, "alias-root");
+    try {
+      fs.mkdirSync(path.join(realOpsWorkspace, "src"), { recursive: true });
+      fs.symlinkSync(
+        realWorkspaceRoot,
+        aliasWorkspaceRoot,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: realWorkspaceRoot },
+            { id: "ops", workspace: realOpsWorkspace },
+          ],
+        },
+      };
+
+      expect(
+        resolveAgentIdByWorkspacePath(cfg, path.join(aliasWorkspaceRoot, "projects", "ops")),
+      ).toBe("ops");
+      expect(
+        resolveAgentIdByWorkspacePath(cfg, path.join(aliasWorkspaceRoot, "projects", "ops", "src")),
+      ).toBe("ops");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -433,45 +433,53 @@ describe("resolveAgentConfig", () => {
 
 describe("resolveAgentIdByWorkspacePath", () => {
   it("returns the most specific workspace match for a directory", () => {
+    const workspaceRoot = `/tmp/openclaw-agent-scope-${Date.now()}-root`;
+    const opsWorkspace = `${workspaceRoot}/projects/ops`;
     const cfg: OpenClawConfig = {
       agents: {
         list: [
-          { id: "main", workspace: "/tmp/openclaw" },
-          { id: "ops", workspace: "/tmp/openclaw/projects/ops" },
+          { id: "main", workspace: workspaceRoot },
+          { id: "ops", workspace: opsWorkspace },
         ],
       },
     };
 
-    expect(resolveAgentIdByWorkspacePath(cfg, "/tmp/openclaw/projects/ops/src")).toBe("ops");
+    expect(resolveAgentIdByWorkspacePath(cfg, `${opsWorkspace}/src`)).toBe("ops");
   });
 
   it("returns undefined when directory has no matching workspace", () => {
+    const workspaceRoot = `/tmp/openclaw-agent-scope-${Date.now()}-root`;
     const cfg: OpenClawConfig = {
       agents: {
         list: [
-          { id: "main", workspace: "/tmp/openclaw" },
-          { id: "ops", workspace: "/tmp/openclaw-ops" },
+          { id: "main", workspace: workspaceRoot },
+          { id: "ops", workspace: `${workspaceRoot}-ops` },
         ],
       },
     };
 
-    expect(resolveAgentIdByWorkspacePath(cfg, "/var/tmp/unrelated")).toBeUndefined();
+    expect(
+      resolveAgentIdByWorkspacePath(cfg, `/tmp/openclaw-agent-scope-${Date.now()}-unrelated`),
+    ).toBeUndefined();
   });
 });
 
 describe("resolveAgentIdsByWorkspacePath", () => {
   it("returns matching workspaces ordered by specificity", () => {
+    const workspaceRoot = `/tmp/openclaw-agent-scope-${Date.now()}-root`;
+    const opsWorkspace = `${workspaceRoot}/projects/ops`;
+    const opsDevWorkspace = `${opsWorkspace}/dev`;
     const cfg: OpenClawConfig = {
       agents: {
         list: [
-          { id: "main", workspace: "/tmp/openclaw" },
-          { id: "ops", workspace: "/tmp/openclaw/projects/ops" },
-          { id: "ops-dev", workspace: "/tmp/openclaw/projects/ops/dev" },
+          { id: "main", workspace: workspaceRoot },
+          { id: "ops", workspace: opsWorkspace },
+          { id: "ops-dev", workspace: opsDevWorkspace },
         ],
       },
     };
 
-    expect(resolveAgentIdsByWorkspacePath(cfg, "/tmp/openclaw/projects/ops/dev/pkg")).toEqual([
+    expect(resolveAgentIdsByWorkspacePath(cfg, `${opsDevWorkspace}/pkg`)).toEqual([
       "ops-dev",
       "ops",
       "main",

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -429,7 +429,9 @@ describe("resolveAgentConfig", () => {
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
     expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
   });
+});
 
+describe("resolveAgentIdByWorkspacePath", () => {
   it("returns the most specific workspace match for a directory", () => {
     const cfg: OpenClawConfig = {
       agents: {
@@ -455,7 +457,9 @@ describe("resolveAgentConfig", () => {
 
     expect(resolveAgentIdByWorkspacePath(cfg, "/var/tmp/unrelated")).toBeUndefined();
   });
+});
 
+describe("resolveAgentIdsByWorkspacePath", () => {
   it("returns matching workspaces ordered by specificity", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -13,6 +13,8 @@ import {
   resolveAgentModelPrimary,
   resolveRunModelFallbacksOverride,
   resolveAgentWorkspaceDir,
+  resolveAgentIdByWorkspacePath,
+  resolveAgentIdsByWorkspacePath,
 } from "./agent-scope.js";
 
 afterEach(() => {
@@ -426,5 +428,49 @@ describe("resolveAgentConfig", () => {
 
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
     expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
+  });
+
+  it("returns the most specific workspace match for a directory", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: "/tmp/openclaw" },
+          { id: "ops", workspace: "/tmp/openclaw/projects/ops" },
+        ],
+      },
+    };
+
+    expect(resolveAgentIdByWorkspacePath(cfg, "/tmp/openclaw/projects/ops/src")).toBe("ops");
+  });
+
+  it("returns undefined when directory has no matching workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: "/tmp/openclaw" },
+          { id: "ops", workspace: "/tmp/openclaw-ops" },
+        ],
+      },
+    };
+
+    expect(resolveAgentIdByWorkspacePath(cfg, "/var/tmp/unrelated")).toBeUndefined();
+  });
+
+  it("returns matching workspaces ordered by specificity", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: "/tmp/openclaw" },
+          { id: "ops", workspace: "/tmp/openclaw/projects/ops" },
+          { id: "ops-dev", workspace: "/tmp/openclaw/projects/ops/dev" },
+        ],
+      },
+    };
+
+    expect(resolveAgentIdsByWorkspacePath(cfg, "/tmp/openclaw/projects/ops/dev/pkg")).toEqual([
+      "ops-dev",
+      "ops",
+      "main",
+    ]);
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
@@ -271,8 +272,16 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
 }
 
 function normalizePathForComparison(input: string): string {
-  const normalized = path.resolve(stripNullBytes(resolveUserPath(input)));
-  if (process.platform === "win32" || process.platform === "darwin") {
+  const resolved = path.resolve(stripNullBytes(resolveUserPath(input)));
+  let normalized = resolved;
+  // Prefer realpath when available to normalize aliases/symlinks (for example /tmp -> /private/tmp)
+  // and canonical path case without forcing case-folding on case-sensitive macOS volumes.
+  try {
+    normalized = fs.realpathSync.native(resolved);
+  } catch {
+    // Keep lexical path for non-existent directories.
+  }
+  if (process.platform === "win32") {
     return normalized.toLowerCase();
   }
   return normalized;

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -272,7 +272,7 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
 
 function normalizePathForComparison(input: string): string {
   const normalized = path.resolve(stripNullBytes(resolveUserPath(input)));
-  if (process.platform === "win32") {
+  if (process.platform === "win32" || process.platform === "darwin") {
     return normalized.toLowerCase();
   }
   return normalized;

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -270,6 +270,54 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));
 }
 
+function normalizePathForComparison(input: string): string {
+  const normalized = path.resolve(stripNullBytes(resolveUserPath(input)));
+  if (process.platform === "win32") {
+    return normalized.toLowerCase();
+  }
+  return normalized;
+}
+
+function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const relative = path.relative(rootPath, candidatePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function resolveAgentIdsByWorkspacePath(
+  cfg: OpenClawConfig,
+  workspacePath: string,
+): string[] {
+  const normalizedWorkspacePath = normalizePathForComparison(workspacePath);
+  const ids = listAgentIds(cfg);
+  const matches: Array<{ id: string; workspaceDir: string; order: number }> = [];
+
+  for (let index = 0; index < ids.length; index += 1) {
+    const id = ids[index];
+    const workspaceDir = normalizePathForComparison(resolveAgentWorkspaceDir(cfg, id));
+    if (!isPathWithinRoot(normalizedWorkspacePath, workspaceDir)) {
+      continue;
+    }
+    matches.push({ id, workspaceDir, order: index });
+  }
+
+  matches.sort((left, right) => {
+    const workspaceLengthDelta = right.workspaceDir.length - left.workspaceDir.length;
+    if (workspaceLengthDelta !== 0) {
+      return workspaceLengthDelta;
+    }
+    return left.order - right.order;
+  });
+
+  return matches.map((entry) => entry.id);
+}
+
+export function resolveAgentIdByWorkspacePath(
+  cfg: OpenClawConfig,
+  workspacePath: string,
+): string | undefined {
+  return resolveAgentIdsByWorkspacePath(cfg, workspacePath)[0];
+}
+
 export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.agentDir?.trim();

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import { getSlashCommands, parseCommand } from "./commands.js";
 import {
   createBackspaceDeduper,
@@ -6,6 +7,7 @@ import {
   resolveCtrlCAction,
   resolveFinalAssistantText,
   resolveGatewayDisconnectState,
+  resolveInitialTuiAgentId,
   resolveTuiSessionKey,
   stopTuiSafely,
 } from "./tui.js";
@@ -104,6 +106,50 @@ describe("resolveTuiSessionKey", () => {
         sessionMainKey: "agent:main:main",
       }),
     ).toBe("agent:main:test1");
+  });
+});
+
+describe("resolveInitialTuiAgentId", () => {
+  const cfg: OpenClawConfig = {
+    agents: {
+      list: [
+        { id: "main", workspace: "/tmp/openclaw" },
+        { id: "ops", workspace: "/tmp/openclaw/projects/ops" },
+      ],
+    },
+  };
+
+  it("infers agent from cwd when session is not agent-prefixed", () => {
+    expect(
+      resolveInitialTuiAgentId({
+        cfg,
+        fallbackAgentId: "main",
+        initialSessionInput: "",
+        cwd: "/tmp/openclaw/projects/ops/src",
+      }),
+    ).toBe("ops");
+  });
+
+  it("keeps explicit agent prefix from --session", () => {
+    expect(
+      resolveInitialTuiAgentId({
+        cfg,
+        fallbackAgentId: "main",
+        initialSessionInput: "agent:main:incident",
+        cwd: "/tmp/openclaw/projects/ops/src",
+      }),
+    ).toBe("main");
+  });
+
+  it("falls back when cwd has no matching workspace", () => {
+    expect(
+      resolveInitialTuiAgentId({
+        cfg,
+        fallbackAgentId: "main",
+        initialSessionInput: "",
+        cwd: "/var/tmp/unrelated",
+      }),
+    ).toBe("main");
   });
 });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -329,6 +329,7 @@ export async function runTui(opts: TuiOptions) {
     cfg: config,
     fallbackAgentId: agentDefaultId,
     initialSessionInput,
+    cwd: process.cwd(),
   });
   let agents: AgentSummary[] = [];
   const agentNames = new Map<string, string>();

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -8,8 +8,8 @@ import {
   Text,
   TUI,
 } from "@mariozechner/pi-tui";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { loadConfig } from "../config/config.js";
+import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import {
   buildAgentMainSessionKey,
   normalizeAgentId,
@@ -208,6 +208,28 @@ export function resolveTuiSessionKey(params: {
   return `agent:${params.currentAgentId}:${trimmed.toLowerCase()}`;
 }
 
+export function resolveInitialTuiAgentId(params: {
+  cfg: OpenClawConfig;
+  fallbackAgentId: string;
+  initialSessionInput?: string;
+  cwd?: string;
+}) {
+  const parsed = parseAgentSessionKey((params.initialSessionInput ?? "").trim());
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+
+  const inferredFromWorkspace = resolveAgentIdByWorkspacePath(
+    params.cfg,
+    params.cwd ?? process.cwd(),
+  );
+  if (inferredFromWorkspace) {
+    return inferredFromWorkspace;
+  }
+
+  return normalizeAgentId(params.fallbackAgentId);
+}
+
 export function resolveGatewayDisconnectState(reason?: string): {
   connectionStatus: string;
   activityStatus: string;
@@ -303,7 +325,11 @@ export async function runTui(opts: TuiOptions) {
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
   let sessionMainKey = normalizeMainKey(config.session?.mainKey);
   let agentDefaultId = resolveDefaultAgentId(config);
-  let currentAgentId = agentDefaultId;
+  let currentAgentId = resolveInitialTuiAgentId({
+    cfg: config,
+    fallbackAgentId: agentDefaultId,
+    initialSessionInput,
+  });
   let agents: AgentSummary[] = [];
   const agentNames = new Map<string, string>();
   let currentSessionKey = "";


### PR DESCRIPTION
## Summary
When `openclaw tui` is started from inside an agent workspace directory, TUI now infers that agent and uses it for default session routing.

This makes local workspace workflows feel automatic:
- run TUI inside `workspace-ops` → default session routes to `ops`
- run TUI inside `workspace-main` → default session routes to `main`

## Behavior
- New resolver in agent scope:
  - `resolveAgentIdsByWorkspacePath(cfg, workspacePath)`
  - `resolveAgentIdByWorkspacePath(cfg, workspacePath)`
- Matching rule: pick the **most specific workspace path** (longest prefix match).
- Explicit session target still wins:
  - `--session agent:<id>:...` keeps that explicit agent.
- If no workspace matches, behavior is unchanged (fallback to default agent).

## Code changes
- `src/agents/agent-scope.ts`
  - added workspace-path → agent resolution helpers
- `src/tui/tui.ts`
  - added `resolveInitialTuiAgentId(...)`
  - wired startup agent selection to infer from CWD when session is not agent-prefixed
- `docs/cli/tui.md`
  - documented workspace-based auto-selection behavior

## Tests
Added/updated tests for:
- specific vs broad workspace matching
- no-match behavior
- ordered match list by specificity
- TUI startup inference behavior
- explicit `agent:` session override behavior

Executed:
- `npx vitest run src/agents/agent-scope.test.ts src/tui/tui.test.ts src/cli/program.smoke.test.ts`
