### PR TITLE
feat: add configurable silence timeout

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9809,49 +9809,49 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1813
+        "line_number": 1815
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1986
+        "line_number": 1988
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2042
+        "line_number": 2044
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2274
+        "line_number": 2276
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2402
+        "line_number": 2404
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2655
+        "line_number": 2657
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2657
+        "line_number": 2659
       }
     ],
     "docs/gateway/configuration.md": [
@@ -10198,21 +10198,21 @@
         "filename": "docs/tools/web.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 179
+        "line_number": 202
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "674397e2c0c2faaa85961c708d2a96a7cc7af217",
         "is_verified": false,
-        "line_number": 277
+        "line_number": 303
       }
     ],
     "docs/tts.md": [
@@ -11583,7 +11583,7 @@
         "filename": "src/agents/pi-embedded-runner/model.ts",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 272
+        "line_number": 267
       }
     ],
     "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts": [
@@ -11680,7 +11680,7 @@
         "filename": "src/agents/tools/web-search.ts",
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 266
       }
     ],
     "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
@@ -12335,14 +12335,14 @@
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 649
+        "line_number": 651
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 680
+        "line_number": 684
       }
     ],
     "src/config/schema.irc.ts": [
@@ -12388,7 +12388,7 @@
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "2eda7cd978f39eebec3bf03e4410a40e14167fff",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 325
       }
     ],
     "src/config/slack-http-config.test.ts": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T13:52:40Z"
+  "generated_at": "2026-03-08T14:28:30Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - TUI: infer the active agent from the current workspace when launched inside a configured agent workspace, while preserving explicit `agent:` session targets. (#39591) thanks @arceus77-7.
 - Tools/Brave web search: add opt-in `tools.web.search.brave.mode: "llm-context"` so `web_search` can call Brave's LLM Context endpoint and return extracted grounding snippets with source metadata, plus config/docs/test coverage. (#33383) Thanks @thirumaleshp.
+- Talk mode: add top-level `talk.silenceTimeoutMs` config so Talk waits a configurable amount of silence before auto-sending the current transcript, while keeping each platform's existing default pause window when unset. (#39607) Thanks @danodoesdesign. Fixes #17147.
 
 ### Fixes
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -107,7 +107,9 @@ class TalkModeManager(
     }
 
     internal fun resolvedSilenceTimeoutMs(talk: JsonObject?): Long {
-      val timeout = talk?.get("silenceTimeoutMs").asDoubleOrNull() ?: return defaultSilenceTimeoutMs
+      val primitive = talk?.get("silenceTimeoutMs") as? JsonPrimitive ?: return defaultSilenceTimeoutMs
+      if (primitive.isString) return defaultSilenceTimeoutMs
+      val timeout = primitive.content.toDoubleOrNull() ?: return defaultSilenceTimeoutMs
       if (timeout <= 0 || timeout % 1.0 != 0.0 || timeout > Long.MAX_VALUE.toDouble()) {
         return defaultSilenceTimeoutMs
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -59,8 +59,8 @@ class TalkModeManager(
     private const val tag = "TalkMode"
     private const val defaultModelIdFallback = "eleven_v3"
     private const val defaultOutputFormatFallback = "pcm_24000"
-private const val defaultTalkProvider = "elevenlabs"
-    private const val silenceWindowMs = 500L
+    private const val defaultTalkProvider = "elevenlabs"
+    private const val defaultSilenceTimeoutMs = 700L
     private const val listenWatchdogMs = 12_000L
     private const val chatFinalWaitWithSubscribeMs = 45_000L
     private const val chatFinalWaitWithoutSubscribeMs = 6_000L
@@ -105,6 +105,14 @@ private const val defaultTalkProvider = "elevenlabs"
         normalizedPayload = false,
       )
     }
+
+    internal fun resolvedSilenceTimeoutMs(talk: JsonObject?): Long {
+      val timeout = talk?.get("silenceTimeoutMs").asDoubleOrNull() ?: return defaultSilenceTimeoutMs
+      if (timeout <= 0 || timeout % 1.0 != 0.0 || timeout > Long.MAX_VALUE.toDouble()) {
+        return defaultSilenceTimeoutMs
+      }
+      return timeout.toLong()
+    }
   }
 
   private val mainHandler = Handler(Looper.getMainLooper())
@@ -134,7 +142,7 @@ private const val defaultTalkProvider = "elevenlabs"
   private var listeningMode = false
 
   private var silenceJob: Job? = null
-  private val silenceWindowMs = 700L
+  private var silenceWindowMs = defaultSilenceTimeoutMs
   private var lastTranscript: String = ""
   private var lastHeardAtMs: Long? = null
   private var lastSpokenText: String? = null
@@ -1411,6 +1419,7 @@ private const val defaultTalkProvider = "elevenlabs"
         activeConfig?.get("outputFormat")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
       val key = activeConfig?.get("apiKey")?.asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
       val interrupt = talk?.get("interruptOnSpeech")?.asBooleanOrNull()
+      val silenceTimeoutMs = resolvedSilenceTimeoutMs(talk)
 
       if (!isCanonicalMainSessionKey(mainSessionKey)) {
         mainSessionKey = mainKey
@@ -1427,7 +1436,11 @@ private const val defaultTalkProvider = "elevenlabs"
       if (!modelOverrideActive) currentModelId = defaultModelId
       defaultOutputFormat = outputFormat ?: defaultOutputFormatFallback
       apiKey = key ?: envKey?.takeIf { it.isNotEmpty() }
-      Log.d(tag, "reloadConfig apiKey=${if (apiKey != null) "set" else "null"} voiceId=$defaultVoiceId")
+      silenceWindowMs = silenceTimeoutMs
+      Log.d(
+        tag,
+        "reloadConfig apiKey=${if (apiKey != null) "set" else "null"} voiceId=$defaultVoiceId silenceTimeoutMs=$silenceTimeoutMs",
+      )
       if (interrupt != null) interruptOnSpeech = interrupt
       activeProviderIsElevenLabs = activeProvider == defaultTalkProvider
       if (!activeProviderIsElevenLabs) {
@@ -1441,6 +1454,7 @@ private const val defaultTalkProvider = "elevenlabs"
       }
       configLoaded = true
     } catch (_: Throwable) {
+      silenceWindowMs = defaultSilenceTimeoutMs
       defaultVoiceId = envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() }
       defaultModelId = defaultModelIdFallback
       if (!modelOverrideActive) currentModelId = defaultModelId

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
@@ -54,4 +54,23 @@ class TalkModeConfigParsingTest {
     assertEquals("voice-legacy", selection?.config?.get("voiceId")?.jsonPrimitive?.content)
     assertEquals("legacy-key", selection?.config?.get("apiKey")?.jsonPrimitive?.content)
   }
+
+  @Test
+  fun readsConfiguredSilenceTimeoutMs() {
+    val talk = buildJsonObject { put("silenceTimeoutMs", 1500) }
+
+    assertEquals(1500L, TalkModeManager.resolvedSilenceTimeoutMs(talk))
+  }
+
+  @Test
+  fun defaultsSilenceTimeoutMsWhenMissing() {
+    assertEquals(700L, TalkModeManager.resolvedSilenceTimeoutMs(null))
+  }
+
+  @Test
+  fun defaultsSilenceTimeoutMsWhenInvalid() {
+    val talk = buildJsonObject { put("silenceTimeoutMs", 0) }
+
+    assertEquals(700L, TalkModeManager.resolvedSilenceTimeoutMs(talk))
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
@@ -73,4 +73,11 @@ class TalkModeConfigParsingTest {
 
     assertEquals(700L, TalkModeManager.resolvedSilenceTimeoutMs(talk))
   }
+
+  @Test
+  fun defaultsSilenceTimeoutMsWhenString() {
+    val talk = buildJsonObject { put("silenceTimeoutMs", "1500") }
+
+    assertEquals(700L, TalkModeManager.resolvedSilenceTimeoutMs(talk))
+  }
 }

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -98,7 +98,7 @@ final class TalkModeManager: NSObject {
 
     private var gateway: GatewayNodeSession?
     private var gatewayConnected = false
-    private var silenceWindow: TimeInterval = TimeInterval(Self.defaultSilenceTimeoutMs) / 1000
+    private var silenceWindow: TimeInterval = TimeInterval(TalkModeManager.defaultSilenceTimeoutMs) / 1000
     private var lastAudioActivity: Date?
     private var noiseFloorSamples: [Double] = []
     private var noiseFloor: Double?
@@ -2010,6 +2010,9 @@ extension TalkModeManager {
             where timeout > 0 && timeout.rounded(.towardZero) == timeout && timeout <= Double(Int.max):
             return Int(timeout)
         case let timeout as NSNumber:
+            if CFGetTypeID(timeout) == CFBooleanGetTypeID() {
+                return Self.defaultSilenceTimeoutMs
+            }
             let value = timeout.doubleValue
             if value > 0 && value.rounded(.towardZero) == value && value <= Double(Int.max) {
                 return Int(value)

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -34,6 +34,7 @@ final class TalkModeManager: NSObject {
     private typealias SpeechRequest = SFSpeechAudioBufferRecognitionRequest
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
+    private static let defaultSilenceTimeoutMs = 900
     private static let redactedConfigSentinel = "__OPENCLAW_REDACTED__"
     var isEnabled: Bool = false
     var isListening: Bool = false
@@ -97,7 +98,7 @@ final class TalkModeManager: NSObject {
 
     private var gateway: GatewayNodeSession?
     private var gatewayConnected = false
-    private let silenceWindow: TimeInterval = 0.9
+    private var silenceWindow: TimeInterval = TimeInterval(Self.defaultSilenceTimeoutMs) / 1000
     private var lastAudioActivity: Date?
     private var noiseFloorSamples: [Double] = []
     private var noiseFloor: Double?
@@ -2001,6 +2002,24 @@ extension TalkModeManager {
             config: normalizedProviders[providerID] ?? [:])
     }
 
+    static func resolvedSilenceTimeoutMs(_ talk: [String: Any]?) -> Int {
+        switch talk?["silenceTimeoutMs"] {
+        case let timeout as Int where timeout > 0:
+            return timeout
+        case let timeout as Double
+            where timeout > 0 && timeout.rounded(.towardZero) == timeout && timeout <= Double(Int.max):
+            return Int(timeout)
+        case let timeout as NSNumber:
+            let value = timeout.doubleValue
+            if value > 0 && value.rounded(.towardZero) == value && value <= Double(Int.max) {
+                return Int(value)
+            }
+            return Self.defaultSilenceTimeoutMs
+        default:
+            return Self.defaultSilenceTimeoutMs
+        }
+    }
+
     func reloadConfig() async {
         guard let gateway else { return }
         self.pcmFormatUnavailable = false
@@ -2020,6 +2039,7 @@ extension TalkModeManager {
             }
             let activeProvider = selection?.provider ?? Self.defaultTalkProvider
             let activeConfig = selection?.config
+            let silenceTimeoutMs = Self.resolvedSilenceTimeoutMs(talk)
             self.defaultVoiceId = (activeConfig?["voiceId"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if let aliases = activeConfig?["voiceAliases"] as? [String: Any] {
@@ -2067,8 +2087,9 @@ extension TalkModeManager {
             if let interrupt = talk?["interruptOnSpeech"] as? Bool {
                 self.interruptOnSpeech = interrupt
             }
+            self.silenceWindow = TimeInterval(silenceTimeoutMs) / 1000
             if selection != nil {
-                GatewayDiagnostics.log("talk config provider=\(activeProvider)")
+                GatewayDiagnostics.log("talk config provider=\(activeProvider) silenceTimeoutMs=\(silenceTimeoutMs)")
             }
         } catch {
             self.defaultModelId = Self.defaultModelIdFallback
@@ -2079,6 +2100,7 @@ extension TalkModeManager {
             self.gatewayTalkDefaultModelId = nil
             self.gatewayTalkApiKeyConfigured = false
             self.gatewayTalkConfigLoaded = false
+            self.silenceWindow = TimeInterval(Self.defaultSilenceTimeoutMs) / 1000
         }
     }
 

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -47,4 +47,24 @@ import Testing
             userInfo: [NSLocalizedDescriptionKey: "queue enqueue failed"])
         #expect(TalkModeManager._test_isPCMFormatRejectedByAPI(error) == false)
     }
+
+    @Test func readsConfiguredSilenceTimeoutMs() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": 1500,
+        ]
+
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 1500)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenMissing() {
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(nil) == 900)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": 0,
+        ]
+
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 900)
+    }
 }

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -67,4 +67,12 @@ import Testing
 
         #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 900)
     }
+
+    @Test func defaultsSilenceTimeoutMsWhenBool() {
+        let talk: [String: Any] = [
+            "silenceTimeoutMs": true,
+        ]
+
+        #expect(TalkModeManager.resolvedSilenceTimeoutMs(talk) == 900)
+    }
 }

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -12,6 +12,7 @@ actor TalkModeRuntime {
     private let ttsLogger = Logger(subsystem: "ai.openclaw", category: "talk.tts")
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
+    private static let defaultSilenceTimeoutMs = 700
 
     private final class RMSMeter: @unchecked Sendable {
         private let lock = NSLock()
@@ -66,7 +67,7 @@ actor TalkModeRuntime {
     private var fallbackVoiceId: String?
     private var lastPlaybackWasPCM: Bool = false
 
-    private let silenceWindow: TimeInterval = 0.7
+    private var silenceWindow: TimeInterval = TimeInterval(TalkModeRuntime.defaultSilenceTimeoutMs) / 1000
     private let minSpeechRMS: Double = 1e-3
     private let speechBoostFactor: Double = 6.0
 
@@ -783,6 +784,7 @@ extension TalkModeRuntime {
         }
         self.defaultOutputFormat = cfg.outputFormat
         self.interruptOnSpeech = cfg.interruptOnSpeech
+        self.silenceWindow = TimeInterval(cfg.silenceTimeoutMs) / 1000
         self.apiKey = cfg.apiKey
         let hasApiKey = (cfg.apiKey?.isEmpty == false)
         let voiceLabel = (cfg.voiceId?.isEmpty == false) ? cfg.voiceId! : "none"
@@ -792,7 +794,8 @@ extension TalkModeRuntime {
                 "talk config voiceId=\(voiceLabel, privacy: .public) " +
                     "modelId=\(modelLabel, privacy: .public) " +
                     "apiKey=\(hasApiKey, privacy: .public) " +
-                    "interrupt=\(cfg.interruptOnSpeech, privacy: .public)")
+                    "interrupt=\(cfg.interruptOnSpeech, privacy: .public) " +
+                    "silenceTimeoutMs=\(cfg.silenceTimeoutMs, privacy: .public)")
     }
 
     private struct TalkRuntimeConfig {
@@ -801,6 +804,7 @@ extension TalkModeRuntime {
         let modelId: String?
         let outputFormat: String?
         let interruptOnSpeech: Bool
+        let silenceTimeoutMs: Int
         let apiKey: String?
     }
 
@@ -880,6 +884,21 @@ extension TalkModeRuntime {
             normalizedPayload: false)
     }
 
+    static func resolvedSilenceTimeoutMs(_ talk: [String: AnyCodable]?) -> Int {
+        if let timeout = talk?["silenceTimeoutMs"]?.intValue, timeout > 0 {
+            return timeout
+        }
+        if
+            let timeout = talk?["silenceTimeoutMs"]?.doubleValue,
+            timeout > 0,
+            timeout.rounded(.towardZero) == timeout,
+            timeout <= Double(Int.max)
+        {
+            return Int(timeout)
+        }
+        return Self.defaultSilenceTimeoutMs
+    }
+
     private func fetchTalkConfig() async -> TalkRuntimeConfig {
         let env = ProcessInfo.processInfo.environment
         let envVoice = env["ELEVENLABS_VOICE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -895,6 +914,7 @@ extension TalkModeRuntime {
             let selection = Self.selectTalkProviderConfig(talk)
             let activeProvider = selection?.provider ?? Self.defaultTalkProvider
             let activeConfig = selection?.config
+            let silenceTimeoutMs = Self.resolvedSilenceTimeoutMs(talk)
             let ui = snap.config?["ui"]?.dictionaryValue
             let rawSeam = ui?["seamColor"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             await MainActor.run {
@@ -939,6 +959,7 @@ extension TalkModeRuntime {
                 modelId: resolvedModel,
                 outputFormat: outputFormat,
                 interruptOnSpeech: interrupt ?? true,
+                silenceTimeoutMs: silenceTimeoutMs,
                 apiKey: resolvedApiKey)
         } catch {
             let resolvedVoice =
@@ -951,6 +972,7 @@ extension TalkModeRuntime {
                 modelId: Self.defaultModelIdFallback,
                 outputFormat: nil,
                 interruptOnSpeech: true,
+                silenceTimeoutMs: Self.defaultSilenceTimeoutMs,
                 apiKey: resolvedApiKey)
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/TalkModeConfigParsingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkModeConfigParsingTests.swift
@@ -32,4 +32,24 @@ struct TalkModeConfigParsingTests {
         #expect(selection?.config["voiceId"]?.stringValue == "voice-legacy")
         #expect(selection?.config["apiKey"]?.stringValue == "legacy-key")
     }
+
+    @Test func readsConfiguredSilenceTimeoutMs() {
+        let talk: [String: AnyCodable] = [
+            "silenceTimeoutMs": AnyCodable(1500),
+        ]
+
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == 1500)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenMissing() {
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(nil) == 700)
+    }
+
+    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
+        let talk: [String: AnyCodable] = [
+            "silenceTimeoutMs": AnyCodable(0),
+        ]
+
+        #expect(TalkModeRuntime.resolvedSilenceTimeoutMs(talk) == 700)
+    }
 }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1659,6 +1659,7 @@ Defaults for Talk mode (macOS/iOS/Android).
     modelId: "eleven_v3",
     outputFormat: "mp3_44100_128",
     apiKey: "elevenlabs_api_key",
+    silenceTimeoutMs: 1500,
     interruptOnSpeech: true,
   },
 }
@@ -1668,6 +1669,7 @@ Defaults for Talk mode (macOS/iOS/Android).
 - `apiKey` and `providers.*.apiKey` accept plaintext strings or SecretRef objects.
 - `ELEVENLABS_API_KEY` fallback applies only when no Talk API key is configured.
 - `voiceAliases` lets Talk directives use friendly names.
+- `silenceTimeoutMs` controls how long Talk mode waits after user silence before it sends the transcript. Unset keeps the platform default pause window (`700` ms on macOS and Android, `900` ms on iOS).
 
 ---
 

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -56,6 +56,7 @@ Supported keys:
     modelId: "eleven_v3",
     outputFormat: "mp3_44100_128",
     apiKey: "elevenlabs_api_key",
+    silenceTimeoutMs: 1500,
     interruptOnSpeech: true,
   },
 }
@@ -64,6 +65,7 @@ Supported keys:
 Defaults:
 
 - `interruptOnSpeech`: true
+- `silenceTimeoutMs`: when unset, Talk keeps the platform default pause window before sending the transcript (`700` ms on macOS and Android, `900` ms on iOS)
 - `voiceId`: falls back to `ELEVENLABS_VOICE_ID` / `SAG_VOICE_ID` (or first ElevenLabs voice when API key is available)
 - `modelId`: defaults to `eleven_v3` when unset
 - `apiKey`: falls back to `ELEVENLABS_API_KEY` (or gateway shell profile if available)

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -305,6 +305,7 @@ const TARGET_KEYS = [
   "talk.modelId",
   "talk.outputFormat",
   "talk.interruptOnSpeech",
+  "talk.silenceTimeoutMs",
   "meta",
   "env",
   "env.shellEnv",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -163,6 +163,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Use this legacy ElevenLabs API key for Talk mode only during migration, and keep secrets in env-backed storage. Prefer talk.providers.elevenlabs.apiKey (fallback: ELEVENLABS_API_KEY).",
   "talk.interruptOnSpeech":
     "If true (default), stop assistant speech when the user starts speaking in Talk mode. Keep enabled for conversational turn-taking.",
+  "talk.silenceTimeoutMs":
+    "Milliseconds of user silence before Talk mode finalizes and sends the current transcript. Leave unset to keep the platform default pause window (700 ms on macOS and Android, 900 ms on iOS).",
   acp: "ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.",
   "acp.enabled":
     "Global ACP feature gate. Keep disabled unless ACP runtime + policy are configured.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -651,6 +651,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "talk.modelId": "Talk Model ID",
   "talk.outputFormat": "Talk Output Format",
   "talk.interruptOnSpeech": "Talk Interrupt on Speech",
+  "talk.silenceTimeoutMs": "Talk Silence Timeout (ms)",
   messages: "Messages",
   "messages.messagePrefix": "Inbound Message Prefix",
   "messages.responsePrefix": "Outbound Response Prefix",

--- a/src/config/talk.normalize.test.ts
+++ b/src/config/talk.normalize.test.ts
@@ -32,6 +32,7 @@ describe("talk normalization", () => {
       outputFormat: "pcm_44100",
       apiKey: "secret-key", // pragma: allowlist secret
       interruptOnSpeech: false,
+      silenceTimeoutMs: 1500,
     });
 
     expect(normalized).toEqual({
@@ -51,6 +52,7 @@ describe("talk normalization", () => {
       outputFormat: "pcm_44100",
       apiKey: "secret-key", // pragma: allowlist secret
       interruptOnSpeech: false,
+      silenceTimeoutMs: 1500,
     });
   });
 

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -47,6 +47,13 @@ function normalizeTalkSecretInput(value: unknown): TalkProviderConfig["apiKey"] 
   return coerceSecretRef(value) ?? undefined;
 }
 
+function normalizeSilenceTimeoutMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
+}
+
 function normalizeTalkProviderConfig(value: unknown): TalkProviderConfig | undefined {
   if (!isPlainObject(value)) {
     return undefined;
@@ -124,6 +131,10 @@ function normalizedLegacyTalkFields(source: Record<string, unknown>): Partial<Ta
   const apiKey = normalizeTalkSecretInput(source.apiKey);
   if (apiKey !== undefined) {
     legacy.apiKey = apiKey;
+  }
+  const silenceTimeoutMs = normalizeSilenceTimeoutMs(source.silenceTimeoutMs);
+  if (silenceTimeoutMs !== undefined) {
+    legacy.silenceTimeoutMs = silenceTimeoutMs;
   }
   return legacy;
 }
@@ -266,6 +277,9 @@ export function buildTalkConfigResponse(value: unknown): TalkConfig | undefined 
   const payload: TalkConfig = {};
   if (typeof normalized.interruptOnSpeech === "boolean") {
     payload.interruptOnSpeech = normalized.interruptOnSpeech;
+  }
+  if (typeof normalized.silenceTimeoutMs === "number") {
+    payload.silenceTimeoutMs = normalized.silenceTimeoutMs;
   }
   if (normalized.providers && Object.keys(normalized.providers).length > 0) {
     payload.providers = normalized.providers;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -70,6 +70,8 @@ export type TalkConfig = {
   providers?: Record<string, TalkProviderConfig>;
   /** Stop speaking when user starts talking (default: true). */
   interruptOnSpeech?: boolean;
+  /** Milliseconds of user silence before Talk mode sends the transcript after a pause. */
+  silenceTimeoutMs?: number;
 
   /**
    * Legacy ElevenLabs compatibility fields.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -595,6 +595,7 @@ export const OpenClawSchema = z
         outputFormat: z.string().optional(),
         apiKey: SecretInputSchema.optional().register(sensitive),
         interruptOnSpeech: z.boolean().optional(),
+        silenceTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -42,6 +42,7 @@ export const TalkConfigResultSchema = Type.Object(
               outputFormat: Type.Optional(Type.String()),
               apiKey: Type.Optional(Type.String()),
               interruptOnSpeech: Type.Optional(Type.Boolean()),
+              silenceTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
             },
             { additionalProperties: false },
           ),

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -56,7 +56,11 @@ async function connectOperator(ws: GatewaySocket, scopes: string[]) {
   });
 }
 
-async function writeTalkConfig(config: { apiKey?: string; voiceId?: string }) {
+async function writeTalkConfig(config: {
+  apiKey?: string;
+  voiceId?: string;
+  silenceTimeoutMs?: number;
+}) {
   const { writeConfigFile } = await import("../config/config.js");
   await writeConfigFile({ talk: config });
 }
@@ -68,6 +72,7 @@ describe("gateway talk.config", () => {
       talk: {
         voiceId: "voice-123",
         apiKey: "secret-key-abc", // pragma: allowlist secret
+        silenceTimeoutMs: 1500,
       },
       session: {
         mainKey: "main-test",
@@ -88,6 +93,7 @@ describe("gateway talk.config", () => {
             };
             apiKey?: string;
             voiceId?: string;
+            silenceTimeoutMs?: number;
           };
         };
       }>(ws, "talk.config", {});
@@ -99,6 +105,7 @@ describe("gateway talk.config", () => {
       );
       expect(res.payload?.config?.talk?.voiceId).toBe("voice-123");
       expect(res.payload?.config?.talk?.apiKey).toBe("__OPENCLAW_REDACTED__");
+      expect(res.payload?.config?.talk?.silenceTimeoutMs).toBe(1500);
     });
   });
 


### PR DESCRIPTION
## Summary

Forgive me, this is my first OSS contribution! I hope it is valuable.
Written 99% with codex via 5.4 

- Problem: Talk mode for the apps has hard-coded, reasonably aggressive talking cadence timeouts before sending the transcript onwards. For example on macOS it's set to 0.7s.
- Why it matters: This doesn't allow for much room for variability in speech patterns or customisation to user preference. In various experiences IRL, I've found people have gotten cut off prior to completing their thought.
- What changed: This feature adds a new talk mode config to modify this hard-coded value, keeping defaults but letting someone customise the millisecond timing. It then makes the required changes to surface that on the 3 major platforms that do/will support talk mode, macOS, iOS and Android.
- What did NOT change (scope boundary): Nothing has changed in system design our foundational, only variables and whatnot required to support replacing a hard coded value with a dynamic, configurable one.

## Change Type (select all)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [X] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [X] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes:
-- https://github.com/openclaw/openclaw/issues/17147
- Related:
-- https://github.com/openclaw/openclaw/issues/4314 (Similar but different output intention)

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
- New config line under Talk category for timeout milliseconds
- Stays at default values unless user changes them
- User can change the values to higher or lower ms counts
- Lower ms counts will result in talk mode ending turn and sending on transcript quicker after shorter waits
- Higher ms counts will result in talk mode ending turn and sending on transcript later after longer waits

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS Tahoe 
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): N/A
- Relevant config (redacted): talk.silenceTimeoutMs: ####

### Steps

1. Visit dashboard config page
2. Change and save value for Talk > Silence timeout. Set value to 10000 ms
3. Start talk mode on macOS via app and speak

### Expected

- Observe significantly longer silence wait times before talk mode sends transcript onwards

### Actual

- Have observed this

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [X] Screenshot/recording 
- [ ] Perf numbers (if relevant)

Unsure how to provide behavioural evidence for this sorry :S

<img width="879" height="736" alt="image" src="https://github.com/user-attachments/assets/9c47f23a-25f7-4169-9596-a8485bf7c880" />

<img width="744" height="166" alt="image" src="https://github.com/user-attachments/assets/c05fdf38-6e95-4e91-b5b8-3b44bf83466a" />


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Talk mode on macOS
- Edge cases checked: None, unsure what they would be
- What you did **not** verify: Android or iOS use cases

## Compatibility / Migration

- Backward compatible? (`No, assumedly because config change`)
- Config/env changes? (`Yes`)
- Migration needed? (`Unsure`)
- If yes, exact upgrade steps: I wouldn't expect so

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert to parent commit in all instances of runtime changes
- Files/config to restore: All listed in commits
- Known bad symptoms reviewers should watch for: /

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
