### PR TITLE
config: Support setting userTimezone per agent

### DIFF
--- a/docs/automation/troubleshooting.md
+++ b/docs/automation/troubleshooting.md
@@ -98,13 +98,14 @@ Common signatures:
 openclaw config get agents.defaults.heartbeat.activeHours
 openclaw config get agents.defaults.heartbeat.activeHours.timezone
 openclaw config get agents.defaults.userTimezone || echo "agents.defaults.userTimezone not set"
+openclaw config get agents.list
 openclaw cron list
 openclaw logs --follow
 ```
 
 Quick rules:
 
-- `Config path not found: agents.defaults.userTimezone` means the key is unset; heartbeat falls back to host timezone (or `activeHours.timezone` if set).
+- `Config path not found: agents.defaults.userTimezone` means the default key is unset; heartbeat still uses `agents.list[].userTimezone` for the active agent when present, otherwise falls back to host timezone (or `activeHours.timezone` if set).
 - Cron without `--tz` uses gateway host timezone.
 - Heartbeat `activeHours` uses configured timezone resolution (`user`, `local`, or explicit IANA tz).
 - ISO timestamps without timezone are treated as UTC for cron `at` schedules.

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -98,6 +98,7 @@ includes a timestamp line.
 Configure with:
 
 - `agents.defaults.userTimezone`
+- `agents.list[].userTimezone` to override the default for a specific agent
 - `agents.defaults.timeFormat` (`auto` | `12` | `24`)
 
 See [Date & Time](/date-time) for full behavior details.

--- a/docs/concepts/timezone.md
+++ b/docs/concepts/timezone.md
@@ -35,7 +35,7 @@ You can override this with:
 ```
 
 - `envelopeTimezone: "utc"` uses UTC.
-- `envelopeTimezone: "user"` uses `agents.defaults.userTimezone` (falls back to host timezone).
+- `envelopeTimezone: "user"` uses the active agent's `agents.list[].userTimezone` when set, otherwise `agents.defaults.userTimezone`, then falls back to the host timezone.
 - Use an explicit IANA timezone (e.g., `"Europe/Vienna"`) for a fixed offset.
 - `envelopeTimestamp: "off"` removes absolute timestamps from envelope headers.
 - `envelopeElapsed: "off"` removes elapsed time suffixes (the `+2m` style).
@@ -72,12 +72,16 @@ Raw provider fields are preserved.
 
 ## User timezone for the system prompt
 
-Set `agents.defaults.userTimezone` to tell the model the user's local time zone. If it is
-unset, OpenClaw resolves the **host timezone at runtime** (no config write).
+Set `agents.defaults.userTimezone` to tell the model the default user-local time zone. You can
+override it per agent with `agents.list[].userTimezone`. If neither is set, OpenClaw resolves the
+**host timezone at runtime** (no config write).
 
 ```json5
 {
-  agents: { defaults: { userTimezone: "America/Chicago" } },
+  agents: {
+    defaults: { userTimezone: "America/Chicago" },
+    list: [{ id: "work", userTimezone: "Europe/London" }],
+  },
 }
 ```
 

--- a/docs/date-time.md
+++ b/docs/date-time.md
@@ -37,7 +37,7 @@ You can override this behavior:
 
 - `envelopeTimezone: "utc"` uses UTC.
 - `envelopeTimezone: "local"` uses the host timezone.
-- `envelopeTimezone: "user"` uses `agents.defaults.userTimezone` (falls back to host timezone).
+- `envelopeTimezone: "user"` uses the active agent's `agents.list[].userTimezone` when set, otherwise `agents.defaults.userTimezone`, then falls back to the host timezone.
 - Use an explicit IANA timezone (e.g., `"America/Chicago"`) for a fixed zone.
 - `envelopeTimestamp: "off"` removes absolute timestamps from envelope headers.
 - `envelopeElapsed: "off"` removes elapsed time suffixes (the `+2m` style).
@@ -97,8 +97,29 @@ System: [2026-01-12 12:19:17 PST] Model switched.
 }
 ```
 
-- `userTimezone` sets the **user-local timezone** for prompt context.
+- `agents.defaults.userTimezone` sets the default **user-local timezone** for prompt context.
+- `agents.list[].userTimezone` overrides that default for a specific agent.
 - `timeFormat` controls **12h/24h display** in the prompt. `auto` follows OS prefs.
+
+### Per-agent override example
+
+```json5
+{
+  agents: {
+    defaults: {
+      userTimezone: "America/Chicago",
+    },
+    list: [
+      {
+        id: "work",
+        userTimezone: "Europe/London",
+      },
+    ],
+  },
+}
+```
+
+In that config, the default agent uses `America/Chicago`, while the `work` agent uses `Europe/London` for prompt context, `session_status`, heartbeat `"user"` windows, and envelope/system-event timestamps when `envelopeTimezone: "user"` is selected.
 
 ## Time format detection (auto)
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -838,7 +838,8 @@ Higher values preserve more visual detail.
 
 ### `agents.defaults.userTimezone`
 
-Timezone for system prompt context (not message timestamps). Falls back to host timezone.
+Default timezone for system prompt context and other user-time features. Per-agent override:
+`agents.list[].userTimezone`. Falls back to host timezone when neither is set.
 
 ```json5
 {
@@ -1409,6 +1410,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `id`: stable agent id (required).
 - `default`: when multiple are set, first wins (warning logged). If none set, first list entry is default.
 - `model`: string form overrides `primary` only; object form `{ primary, fallbacks }` overrides both (`[]` disables global fallbacks). Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
+- `userTimezone`: optional IANA timezone override for this agent. Used before `agents.defaults.userTimezone` for prompt context, `session_status`, heartbeat `"user"` active-hours resolution, and `"user"` envelope/system-event timestamps.
 - `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.
 - `thinkingDefault`: optional per-agent default thinking level (`off | minimal | low | medium | high | xhigh | adaptive`). Overrides `agents.defaults.thinkingDefault` for this agent when no per-message or session override is set.
 - `reasoningDefault`: optional per-agent default reasoning visibility (`on | off | stream`). Applies when no per-message or session reasoning override is set.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -233,7 +233,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery.
 - `suppressToolErrorWarnings`: when true, suppresses tool error warning payloads during heartbeat runs.
 - `activeHours`: restricts heartbeat runs to a time window. Object with `start` (HH:MM, inclusive; use `00:00` for start-of-day), `end` (HH:MM exclusive; `24:00` allowed for end-of-day), and optional `timezone`.
-  - Omitted or `"user"`: uses your `agents.defaults.userTimezone` if set, otherwise falls back to the host system timezone.
+  - Omitted or `"user"`: uses the active agent's `agents.list[].userTimezone` if set, otherwise `agents.defaults.userTimezone`, then falls back to the host system timezone.
   - `"local"`: always uses the host system timezone.
   - Any IANA identifier (e.g. `America/New_York`): used directly; if invalid, falls back to the `"user"` behavior above.
   - `start` and `end` must not be equal for an active window; equal values are treated as zero-width (always outside the window).

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -347,7 +347,7 @@ async function dispatchDiscordComponentEvent(params: {
     allowNameMatching,
   });
   const storePath = resolveStorePath(ctx.cfg.session?.store, { agentId });
-  const envelopeOptions = resolveEnvelopeFormatOptions(ctx.cfg);
+  const envelopeOptions = resolveEnvelopeFormatOptions(ctx.cfg, { agentId });
   const previousTimestamp = readSessionUpdatedAt({
     storePath,
     sessionKey,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -236,7 +236,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: route.agentId,
   });
-  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
+  const envelopeOptions = resolveEnvelopeFormatOptions(cfg, { agentId: route.agentId });
   const previousTimestamp = readSessionUpdatedAt({
     storePath,
     sessionKey: route.sessionKey,

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -396,7 +396,9 @@ export function buildIMessageInboundContext(params: {
   imessageTo: string;
   inboundHistory?: Array<{ sender: string; body: string; timestamp?: number }>;
 } {
-  const envelopeOptions = params.envelopeOptions ?? resolveEnvelopeFormatOptions(params.cfg);
+  const envelopeOptions =
+    params.envelopeOptions ??
+    resolveEnvelopeFormatOptions(params.cfg, { agentId: params.decision.route.agentId });
   const { decision } = params;
   const chatId = decision.chatId;
   const chatTarget =

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -135,7 +135,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const storePath = resolveStorePath(deps.cfg.session?.store, {
       agentId: route.agentId,
     });
-    const envelopeOptions = resolveEnvelopeFormatOptions(deps.cfg);
+    const envelopeOptions = resolveEnvelopeFormatOptions(deps.cfg, { agentId: route.agentId });
     const previousTimestamp = readSessionUpdatedAt({
       storePath,
       sessionKey: route.sessionKey,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -601,7 +601,7 @@ export async function prepareSlackMessage(params: {
   const storePath = resolveStorePath(ctx.cfg.session?.store, {
     agentId: route.agentId,
   });
-  const envelopeOptions = resolveEnvelopeFormatOptions(ctx.cfg);
+  const envelopeOptions = resolveEnvelopeFormatOptions(ctx.cfg, { agentId: route.agentId });
   const previousTimestamp = readSessionUpdatedAt({
     storePath,
     sessionKey,

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -131,7 +131,7 @@ export async function buildTelegramInboundContextPayload(params: {
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: route.agentId,
   });
-  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
+  const envelopeOptions = resolveEnvelopeFormatOptions(cfg, { agentId: route.agentId });
   const previousTimestamp = readSessionUpdatedAt({
     storePath,
     sessionKey: route.sessionKey,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
   resolveAgentExplicitModelPrimary,
+  resolveAgentUserTimezone,
   resolveFallbackAgentId,
   resolveEffectiveModelFallbacks,
   resolveAgentModelFallbacksOverride,
@@ -21,6 +22,40 @@ import {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+});
+
+describe("resolveAgentUserTimezone", () => {
+  it("uses the per-agent override when configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+        list: [{ id: "work", userTimezone: "America/Los_Angeles" }],
+      },
+    };
+
+    expect(resolveAgentUserTimezone(cfg, "work")).toBe("America/Los_Angeles");
+  });
+
+  it("falls back to the default agent timezone", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+        list: [{ id: "work" }],
+      },
+    };
+
+    expect(resolveAgentUserTimezone(cfg, "work")).toBe("America/New_York");
+  });
+
+  it("falls back to the system timezone when nothing is configured", () => {
+    const hostTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone?.trim() || "UTC";
+
+    expect(resolveAgentUserTimezone({}, "work")).toBe(hostTimezone);
+  });
 });
 
 describe("resolveAgentConfig", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -11,6 +11,7 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
+import { resolveUserTimezone } from "./date-time.js";
 import { normalizeSkillFilter } from "./skills/filter.js";
 import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 const log = createSubsystemLogger("agent-scope");
@@ -148,6 +149,11 @@ export function resolveAgentConfig(
     sandbox: entry.sandbox,
     tools: entry.tools,
   };
+}
+
+export function resolveAgentUserTimezone(cfg: OpenClawConfig, agentId?: string): string {
+  const overrides = agentId ? resolveAgentEntry(cfg, agentId)?.userTimezone : undefined;
+  return resolveUserTimezone(overrides ?? cfg.agents?.defaults?.userTimezone);
 }
 
 export function resolveAgentSkillsFilter(

--- a/src/agents/current-time.test.ts
+++ b/src/agents/current-time.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolveCronStyleNow } from "./current-time.js";
+
+describe("resolveCronStyleNow", () => {
+  it("uses the per-agent userTimezone override when configured", () => {
+    const result = resolveCronStyleNow(
+      {
+        agents: {
+          defaults: {
+            userTimezone: "America/New_York",
+            timeFormat: "12",
+          },
+          list: [
+            {
+              id: "work",
+              userTimezone: "America/Los_Angeles",
+            },
+          ],
+        },
+      },
+      Date.UTC(2026, 2, 3, 17, 0, 0),
+      "work",
+    );
+
+    expect(result.userTimezone).toBe("America/Los_Angeles");
+    expect(result.timeLine).toContain("Current time: Tuesday, March 3rd, 2026 — 9:00 AM");
+    expect(result.timeLine).toContain("(America/Los_Angeles)");
+  });
+
+  it("falls back to agents.defaults.userTimezone when no per-agent override exists", () => {
+    const result = resolveCronStyleNow(
+      {
+        agents: {
+          defaults: {
+            userTimezone: "America/New_York",
+            timeFormat: "12",
+          },
+          list: [
+            {
+              id: "work",
+            },
+          ],
+        },
+      },
+      Date.UTC(2026, 2, 3, 17, 0, 0),
+      "work",
+    );
+
+    expect(result.userTimezone).toBe("America/New_York");
+    expect(result.timeLine).toContain("Current time: Tuesday, March 3rd, 2026 — 12:00 PM");
+    expect(result.timeLine).toContain("(America/New_York)");
+  });
+});

--- a/src/agents/current-time.ts
+++ b/src/agents/current-time.ts
@@ -1,9 +1,6 @@
-import {
-  type TimeFormatPreference,
-  formatUserTime,
-  resolveUserTimeFormat,
-  resolveUserTimezone,
-} from "./date-time.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentUserTimezone } from "./agent-scope.js";
+import { formatUserTime, resolveUserTimeFormat } from "./date-time.js";
 
 export type CronStyleNow = {
   userTimezone: string;
@@ -11,17 +8,12 @@ export type CronStyleNow = {
   timeLine: string;
 };
 
-type TimeConfigLike = {
-  agents?: {
-    defaults?: {
-      userTimezone?: string;
-      timeFormat?: TimeFormatPreference;
-    };
-  };
-};
-
-export function resolveCronStyleNow(cfg: TimeConfigLike, nowMs: number): CronStyleNow {
-  const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+export function resolveCronStyleNow(
+  cfg: OpenClawConfig,
+  nowMs: number,
+  agentId?: string,
+): CronStyleNow {
+  const userTimezone = resolveAgentUserTimezone(cfg, agentId);
   const userTimeFormat = resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat);
   const formattedTime =
     formatUserTime(new Date(nowMs), userTimezone, userTimeFormat) ?? new Date(nowMs).toISOString();
@@ -30,11 +22,16 @@ export function resolveCronStyleNow(cfg: TimeConfigLike, nowMs: number): CronSty
   return { userTimezone, formattedTime, timeLine };
 }
 
-export function appendCronStyleCurrentTimeLine(text: string, cfg: TimeConfigLike, nowMs: number) {
+export function appendCronStyleCurrentTimeLine(
+  text: string,
+  cfg: OpenClawConfig,
+  nowMs: number,
+  agentId?: string,
+) {
   const base = text.trimEnd();
   if (!base || base.includes("Current time:")) {
     return base;
   }
-  const { timeLine } = resolveCronStyleNow(cfg, nowMs);
+  const { timeLine } = resolveCronStyleNow(cfg, nowMs, agentId);
   return `${base}\n${timeLine}`;
 }

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -1,18 +1,18 @@
 import { execFileSync } from "node:child_process";
+import { resolveTimezone } from "../infra/format-time/format-datetime.ts";
 
 export type TimeFormatPreference = "auto" | "12" | "24";
 export type ResolvedTimeFormat = "12" | "24";
 
 let cachedTimeFormat: ResolvedTimeFormat | undefined;
 
+/** Normalize a configured IANA timezone string, or fall back to the host timezone. */
 export function resolveUserTimezone(configured?: string): string {
   const trimmed = configured?.trim();
   if (trimmed) {
-    try {
-      new Intl.DateTimeFormat("en-US", { timeZone: trimmed }).format(new Date());
-      return trimmed;
-    } catch {
-      // ignore invalid timezone
+    const resolved = resolveTimezone(trimmed);
+    if (resolved) {
+      return resolved;
     }
   }
   const host = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -190,6 +190,45 @@ describe("session_status tool", () => {
     expect(details.statusText).not.toContain("OAuth/token status");
   });
 
+  it("uses the per-agent userTimezone override in the status time line", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-16T15:00:00.000Z"));
+      mockConfig = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-5" },
+            models: {},
+            userTimezone: "America/New_York",
+            timeFormat: "12",
+          },
+          list: [{ id: "support", userTimezone: "America/Los_Angeles" }],
+        },
+        tools: {
+          agentToAgent: { enabled: false },
+        },
+      };
+      resetSessionStore({
+        main: {
+          sessionId: "s1",
+          updatedAt: 10,
+        },
+      });
+
+      const tool = getSessionStatusTool("agent:support:main");
+
+      const result = await tool.execute("call-timezone", { sessionKey: "main" });
+      const details = result.details as { ok?: boolean; statusText?: string };
+      expect(details.ok).toBe(true);
+      expect(details.statusText).toContain(
+        "🕒 Time: Monday, February 16th, 2026 — 7:00 AM (America/Los_Angeles)",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("errors for unknown session keys", async () => {
     resetSessionStore({
       main: { sessionId: "s1", updatedAt: 10 },

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -34,7 +34,11 @@ import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
-import { resolveAgentUserTimezone, resolveSessionAgentIds } from "../agent-scope.js";
+import {
+  resolveAgentUserTimezone,
+  resolveSessionAgentId,
+  resolveSessionAgentIds,
+} from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -34,7 +34,7 @@ import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
-import { resolveSessionAgentId, resolveSessionAgentIds } from "../agent-scope.js";
+import { resolveAgentUserTimezone, resolveSessionAgentIds } from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
@@ -44,7 +44,7 @@ import {
 } from "../compaction-real-conversation.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { ensureCustomApiRegistered } from "../custom-api-registry.js";
-import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
+import { formatUserTime, resolveUserTimeFormat } from "../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
 import { resolveMemorySearchConfig } from "../memory-search.js";
@@ -933,7 +933,11 @@ export async function compactEmbeddedPiSessionDirect(
     };
     const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
     const reasoningTagHint = isReasoningTagProvider(provider);
-    const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
+    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: params.sessionKey,
+      config: params.config,
+    });
+    const userTimezone = resolveAgentUserTimezone(params.config ?? {}, sessionAgentId);
     const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
     const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
     const isDefaultAgent = sessionAgentId === defaultAgentId;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -937,10 +937,6 @@ export async function compactEmbeddedPiSessionDirect(
     };
     const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
     const reasoningTagHint = isReasoningTagProvider(provider);
-    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
-      sessionKey: params.sessionKey,
-      config: params.config,
-    });
     const userTimezone = resolveAgentUserTimezone(params.config ?? {}, sessionAgentId);
     const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
     const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);

--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -102,3 +102,64 @@ describe("buildSystemPromptParams repo root", () => {
     expect(runtimeInfo.repoRoot).toBeUndefined();
   });
 });
+
+describe("buildSystemPromptParams user timezone", () => {
+  it("uses the per-agent userTimezone override when configured", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+        list: [
+          {
+            id: "work",
+            userTimezone: "America/Los_Angeles",
+          },
+        ],
+      },
+    };
+
+    const { userTimezone } = buildSystemPromptParams({
+      config,
+      agentId: "work",
+      runtime: {
+        host: "host",
+        os: "os",
+        arch: "arch",
+        node: "node",
+        model: "model",
+      },
+    });
+
+    expect(userTimezone).toBe("America/Los_Angeles");
+  });
+
+  it("falls back to agents.defaults.userTimezone when no per-agent override exists", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+        list: [
+          {
+            id: "work",
+          },
+        ],
+      },
+    };
+
+    const { userTimezone } = buildSystemPromptParams({
+      config,
+      agentId: "work",
+      runtime: {
+        host: "host",
+        os: "os",
+        arch: "arch",
+        node: "node",
+        model: "model",
+      },
+    });
+
+    expect(userTimezone).toBe("America/New_York");
+  });
+});

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -2,12 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { findGitRoot } from "../infra/git-root.js";
-import {
-  formatUserTime,
-  resolveUserTimeFormat,
-  resolveUserTimezone,
-  type ResolvedTimeFormat,
-} from "./date-time.js";
+import { resolveAgentUserTimezone } from "./agent-scope.js";
+import { formatUserTime, resolveUserTimeFormat, type ResolvedTimeFormat } from "./date-time.js";
 
 export type RuntimeInfoInput = {
   agentId?: string;
@@ -44,7 +40,7 @@ export function buildSystemPromptParams(params: {
     workspaceDir: params.workspaceDir,
     cwd: params.cwd,
   });
-  const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
+  const userTimezone = resolveAgentUserTimezone(params.config ?? {}, params.agentId);
   const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
   const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
   return {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -24,8 +24,8 @@ import {
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
-import { resolveAgentDir } from "../agent-scope.js";
-import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
+import { resolveAgentDir, resolveAgentUserTimezone } from "../agent-scope.js";
+import { formatUserTime, resolveUserTimeFormat } from "../date-time.js";
 import { resolveModelAuthLabel } from "../model-auth-label.js";
 import { loadModelCatalog } from "../model-catalog.js";
 import {
@@ -464,7 +464,7 @@ export function createSessionStatusTool(opts?: {
         resolved.entry.queueDebounceMs ?? resolved.entry.queueCap ?? resolved.entry.queueDrop,
       );
 
-      const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+      const userTimezone = resolveAgentUserTimezone(cfg, agentId);
       const userTimeFormat = resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat);
       const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
       const timeLine = userTime

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -1,3 +1,4 @@
+import { resolveAgentUserTimezone } from "../agents/agent-scope.js";
 import { resolveUserTimezone } from "../agents/date-time.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import { resolveSenderLabel, type SenderLabelParams } from "../channels/sender-label.js";
@@ -62,13 +63,16 @@ function sanitizeEnvelopeHeaderPart(value: string): string {
     .trim();
 }
 
-export function resolveEnvelopeFormatOptions(cfg?: OpenClawConfig): EnvelopeFormatOptions {
+export function resolveEnvelopeFormatOptions(
+  cfg?: OpenClawConfig,
+  opts?: { agentId?: string },
+): EnvelopeFormatOptions {
   const defaults = cfg?.agents?.defaults;
   return {
     timezone: defaults?.envelopeTimezone,
     includeTimestamp: defaults?.envelopeTimestamp !== "off",
     includeElapsed: defaults?.envelopeElapsed !== "off",
-    userTimezone: defaults?.userTimezone,
+    userTimezone: resolveAgentUserTimezone(cfg ?? {}, opts?.agentId),
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -466,9 +466,13 @@ export async function runMemoryFlushIfNeeded(params: {
   }
   let memoryCompactionCompleted = false;
   const memoryFlushNowMs = Date.now();
+  const agentIdForFlush = params.sessionKey
+    ? resolveAgentIdFromSessionKey(params.sessionKey)
+    : undefined;
   const memoryFlushWritePath = resolveMemoryFlushRelativePathForRun({
     cfg: params.cfg,
     nowMs: memoryFlushNowMs,
+    agentId: agentIdForFlush,
   });
   const flushSystemPrompt = [
     params.followupRun.run.extraSystemPrompt,
@@ -502,9 +506,7 @@ export async function runMemoryFlushIfNeeded(params: {
             prompt: memoryFlushSettings.prompt,
             cfg: params.cfg,
             nowMs: memoryFlushNowMs,
-            agentId: params.sessionKey
-              ? resolveAgentIdFromSessionKey(params.sessionKey)
-              : undefined,
+            agentId: agentIdForFlush,
           }),
           extraSystemPrompt: flushSystemPrompt,
           bootstrapPromptWarningSignaturesSeen,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -502,6 +502,9 @@ export async function runMemoryFlushIfNeeded(params: {
             prompt: memoryFlushSettings.prompt,
             cfg: params.cfg,
             nowMs: memoryFlushNowMs,
+            agentId: params.sessionKey
+              ? resolveAgentIdFromSessionKey(params.sessionKey)
+              : undefined,
           }),
           extraSystemPrompt: flushSystemPrompt,
           bootstrapPromptWarningSignaturesSeen,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -8,6 +8,7 @@ import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import type { TemplateContext } from "../templating.js";
+import * as postCompactionContext from "./post-compaction-context.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
 
@@ -838,6 +839,105 @@ describe("runReplyAgent auto-compaction token update", () => {
     const queuedSystemEvents = peekSystemEvents(sessionKey);
     expect(queuedSystemEvents.some((event) => event.includes("Post-Compaction Audit"))).toBe(false);
     expect(queuedSystemEvents.some((event) => event.includes("WORKFLOW_AUTO.md"))).toBe(false);
+  });
+
+  it("uses the config-resolved default agent timezone for legacy main post-compaction context", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-post-compact-default-agent-"));
+    const workspaceDir = path.join(tmp, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const sessionFile = path.join(tmp, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ type: "message", message: { role: "assistant", content: [] } })}\n`,
+      "utf-8",
+    );
+
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10_000,
+      compactionCount: 0,
+    };
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+    const readPostCompactionContextSpy = vi
+      .spyOn(postCompactionContext, "readPostCompactionContext")
+      .mockResolvedValue(null);
+    runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+      params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      params.onAgentEvent?.({ stream: "compaction", data: { phase: "end", willRetry: false } });
+      return {
+        payloads: [{ text: "done" }],
+        meta: {
+          agentMeta: {
+            usage: { input: 11_000, output: 500, total: 11_500 },
+            lastCallUsage: { input: 10_500, output: 500, total: 11_000 },
+            compactionCount: 1,
+          },
+        },
+      };
+    });
+
+    const config = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+          timeFormat: "12",
+          compaction: { memoryFlush: { enabled: false } },
+        },
+        list: [{ id: "work", default: true, userTimezone: "America/Los_Angeles" }],
+      },
+    };
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+      config,
+      sessionFile,
+      workspaceDir,
+    });
+
+    const previousCwd = process.cwd();
+    process.chdir(workspaceDir);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-03T14:00:00.000Z"));
+      await runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        isStreaming: false,
+        typing,
+        sessionCtx,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        storePath,
+        defaultModel: "anthropic/claude-opus-4-5",
+        agentCfgContextTokens: 200_000,
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      });
+      expect(readPostCompactionContextSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        config,
+        undefined,
+        "work",
+      );
+    } finally {
+      vi.useRealTimers();
+      process.chdir(previousCwd);
+      readPostCompactionContextSpy.mockRestore();
+    }
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -736,7 +736,12 @@ export async function runReplyAgent(params: {
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
         const workspaceDir = process.cwd();
-        readPostCompactionContext(workspaceDir, cfg)
+        readPostCompactionContext(
+          workspaceDir,
+          cfg,
+          undefined,
+          sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined,
+        )
           .then((contextContent) => {
             if (contextContent) {
               enqueueSystemEvent(contextContent, { sessionKey });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
@@ -6,7 +7,6 @@ import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import {
-  resolveAgentIdFromSessionKey,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionTranscriptPath,
@@ -324,7 +324,7 @@ export async function runReplyAgent(params: {
       fallbackNoticeActiveModel: undefined,
       fallbackNoticeReason: undefined,
     };
-    const agentId = resolveAgentIdFromSessionKey(sessionKey);
+    const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
     const nextSessionFile = resolveSessionTranscriptPath(
       nextSessionId,
       agentId,
@@ -740,7 +740,7 @@ export async function runReplyAgent(params: {
           workspaceDir,
           cfg,
           undefined,
-          resolveAgentIdFromSessionKey(sessionKey),
+          resolveSessionAgentId({ sessionKey, config: cfg }),
         )
           .then((contextContent) => {
             if (contextContent) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -740,7 +740,7 @@ export async function runReplyAgent(params: {
           workspaceDir,
           cfg,
           undefined,
-          sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined,
+          resolveAgentIdFromSessionKey(sessionKey),
         )
           .then((contextContent) => {
             if (contextContent) {

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -49,6 +49,29 @@ describe("resolveMemoryFlushPromptForRun", () => {
     expect(relativePath).toBe("memory/2026-02-16.md");
   });
 
+  it("uses the per-agent userTimezone override for the canonical memory path", () => {
+    const relativePath = resolveMemoryFlushRelativePathForRun({
+      cfg: {
+        agents: {
+          defaults: {
+            userTimezone: "America/New_York",
+            timeFormat: "12",
+          },
+          list: [
+            {
+              id: "work",
+              userTimezone: "America/Los_Angeles",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      nowMs: Date.UTC(2026, 1, 16, 15, 0, 0),
+      agentId: "work",
+    });
+
+    expect(relativePath).toBe("memory/2026-02-16.md");
+  });
+
   it("uses the per-agent userTimezone override when configured", () => {
     const prompt = resolveMemoryFlushPromptForRun({
       prompt: "Store durable notes in memory/YYYY-MM-DD.md",

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -48,6 +48,33 @@ describe("resolveMemoryFlushPromptForRun", () => {
 
     expect(relativePath).toBe("memory/2026-02-16.md");
   });
+
+  it("uses the per-agent userTimezone override when configured", () => {
+    const prompt = resolveMemoryFlushPromptForRun({
+      prompt: "Store durable notes in memory/YYYY-MM-DD.md",
+      cfg: {
+        agents: {
+          defaults: {
+            userTimezone: "America/New_York",
+            timeFormat: "12",
+          },
+          list: [
+            {
+              id: "work",
+              userTimezone: "America/Los_Angeles",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      nowMs: Date.UTC(2026, 1, 16, 15, 0, 0),
+      agentId: "work",
+    });
+
+    expect(prompt).toContain("memory/2026-02-16.md");
+    expect(prompt).toContain(
+      "Current time: Monday, February 16th, 2026 — 7:00 AM (America/Los_Angeles) / 2026-02-16 15:00 UTC",
+    );
+  });
 });
 
 describe("DEFAULT_MEMORY_FLUSH_PROMPT", () => {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -60,9 +60,10 @@ function formatDateStampInTimezone(nowMs: number, timezone: string): string {
 export function resolveMemoryFlushRelativePathForRun(params: {
   cfg?: OpenClawConfig;
   nowMs?: number;
+  agentId?: string;
 }): string {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
-  const { userTimezone } = resolveCronStyleNow(params.cfg ?? {}, nowMs);
+  const { userTimezone } = resolveCronStyleNow(params.cfg ?? {}, nowMs, params.agentId);
   const dateStamp = formatDateStampInTimezone(nowMs, userTimezone);
   return `memory/${dateStamp}.md`;
 }

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -71,15 +71,11 @@ export function resolveMemoryFlushPromptForRun(params: {
   prompt: string;
   cfg?: OpenClawConfig;
   nowMs?: number;
+  agentId?: string;
 }): string {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
-  const { timeLine } = resolveCronStyleNow(params.cfg ?? {}, nowMs);
-  const dateStamp = resolveMemoryFlushRelativePathForRun({
-    cfg: params.cfg,
-    nowMs,
-  })
-    .replace(/^memory\//, "")
-    .replace(/\.md$/, "");
+  const { userTimezone, timeLine } = resolveCronStyleNow(params.cfg ?? {}, nowMs, params.agentId);
+  const dateStamp = formatDateStampInTimezone(nowMs, userTimezone);
   const withDate = params.prompt.replaceAll("YYYY-MM-DD", dateStamp).trimEnd();
   if (!withDate) {
     return timeLine;

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -250,6 +250,28 @@ Read WORKFLOW.md on startup.
     expect(result).toContain("Current time:");
   });
 
+  it("uses the per-agent userTimezone override when configured", async () => {
+    const content = `## Session Startup
+
+Read memory/YYYY-MM-DD.md on startup.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const cfg = {
+      agents: {
+        defaults: { userTimezone: "America/New_York", timeFormat: "12" },
+        list: [{ id: "work", userTimezone: "America/Los_Angeles" }],
+      },
+    } as OpenClawConfig;
+    const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
+    const result = await readPostCompactionContext(tmpDir, cfg, nowMs, "work");
+
+    expect(result).not.toBeNull();
+    expect(result).toContain("memory/2026-03-03.md");
+    expect(result).toContain(
+      "Current time: Tuesday, March 3rd, 2026 — 6:00 AM (America/Los_Angeles) / 2026-03-03 14:00 UTC",
+    );
+  });
+
   // -------------------------------------------------------------------------
   // postCompactionSections config
   // -------------------------------------------------------------------------

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
+import { resolveAgentUserTimezone } from "../../agents/agent-scope.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
-import { resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 
@@ -64,6 +64,7 @@ export async function readPostCompactionContext(
   workspaceDir: string,
   cfg?: OpenClawConfig,
   nowMs?: number,
+  agentId?: string,
 ): Promise<string | null> {
   const agentsPath = path.join(workspaceDir, "AGENTS.md");
 
@@ -118,11 +119,11 @@ export async function readPostCompactionContext(
     const displayNames = foundSectionNames.length > 0 ? foundSectionNames : sectionNames;
 
     const resolvedNowMs = nowMs ?? Date.now();
-    const timezone = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+    const timezone = resolveAgentUserTimezone(cfg ?? {}, agentId);
     const dateStamp = formatDateStamp(resolvedNowMs, timezone);
     // Always append the real runtime timestamp — AGENTS.md content may itself contain
     // "Current time:" as user-authored text, so we must not gate on that substring.
-    const { timeLine } = resolveCronStyleNow(cfg ?? {}, resolvedNowMs);
+    const { timeLine } = resolveCronStyleNow(cfg ?? {}, resolvedNowMs, agentId);
 
     const combined = sections.join("\n\n").replaceAll("YYYY-MM-DD", dateStamp);
     const safeContent =

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAgentUserTimezone } from "../../agents/agent-scope.js";
+import { resolveAgentUserTimezone, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
 import { ensureSkillsWatcher, getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -19,7 +19,6 @@ import {
 } from "../../infra/format-time/format-datetime.ts";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 
 /** Drain queued system events, format as `System:` lines, return the block (or undefined). */
 export async function drainFormattedSystemEvents(params: {
@@ -94,7 +93,7 @@ export async function drainFormattedSystemEvents(params: {
 
   const systemLines: string[] = [];
   const queued = drainSystemEventEntries(params.sessionKey);
-  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg });
   systemLines.push(
     ...queued
       .map((event) => {

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveUserTimezone } from "../../agents/date-time.js";
+import { resolveAgentUserTimezone } from "../../agents/agent-scope.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
 import { ensureSkillsWatcher, getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -52,7 +52,7 @@ export async function drainFormattedSystemEvents(params: {
     return trimmed;
   };
 
-  const resolveSystemEventTimezone = (cfg: OpenClawConfig) => {
+  const resolveSystemEventTimezone = (cfg: OpenClawConfig, agentId?: string) => {
     const raw = cfg.agents?.defaults?.envelopeTimezone?.trim();
     if (!raw) {
       return { mode: "local" as const };
@@ -67,19 +67,19 @@ export async function drainFormattedSystemEvents(params: {
     if (lowered === "user") {
       return {
         mode: "iana" as const,
-        timeZone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
+        timeZone: resolveAgentUserTimezone(cfg, agentId),
       };
     }
     const explicit = resolveTimezone(raw);
     return explicit ? { mode: "iana" as const, timeZone: explicit } : { mode: "local" as const };
   };
 
-  const formatSystemEventTimestamp = (ts: number, cfg: OpenClawConfig) => {
+  const formatSystemEventTimestamp = (ts: number, cfg: OpenClawConfig, agentId?: string) => {
     const date = new Date(ts);
     if (Number.isNaN(date.getTime())) {
       return "unknown-time";
     }
-    const zone = resolveSystemEventTimezone(cfg);
+    const zone = resolveSystemEventTimezone(cfg, agentId);
     if (zone.mode === "utc") {
       return formatUtcTimestamp(date, { displaySeconds: true });
     }
@@ -94,6 +94,7 @@ export async function drainFormattedSystemEvents(params: {
 
   const systemLines: string[] = [];
   const queued = drainSystemEventEntries(params.sessionKey);
+  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
   systemLines.push(
     ...queued
       .map((event) => {
@@ -101,7 +102,7 @@ export async function drainFormattedSystemEvents(params: {
         if (!compacted) {
           return null;
         }
-        return `[${formatSystemEventTimestamp(event.ts, params.cfg)}] ${compacted}`;
+        return `[${formatSystemEventTimestamp(event.ts, params.cfg, agentId)}] ${compacted}`;
       })
       .filter((v): v is string => Boolean(v)),
   );

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -333,7 +333,7 @@ function resolveCompactionSessionFile(params: {
   storePath?: string;
   newSessionId: string;
 }): string {
-  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey });
   const pathOpts = resolveSessionFilePathOptions({
     agentId,
     storePath: params.storePath,

--- a/src/channels/session-envelope.ts
+++ b/src/channels/session-envelope.ts
@@ -12,7 +12,7 @@ export function resolveInboundSessionEnvelopeContext(params: {
   });
   return {
     storePath,
-    envelopeOptions: resolveEnvelopeFormatOptions(params.cfg),
+    envelopeOptions: resolveEnvelopeFormatOptions(params.cfg, { agentId: params.agentId }),
     previousTimestamp: readSessionUpdatedAt({
       storePath,
       sessionKey: params.sessionKey,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -3420,6 +3420,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                 fastModeDefault: {
                   type: "boolean",
                 },
+                userTimezone: {
+                  type: "string",
+                },
                 skills: {
                   type: "array",
                   items: {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -71,6 +71,8 @@ export type AgentConfig = {
   reasoningDefault?: "on" | "off" | "stream";
   /** Optional per-agent default for fast mode. */
   fastModeDefault?: boolean;
+  /** Optional IANA timezone for this agent's user context. */
+  userTimezone?: string;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
   memorySearch?: MemorySearchConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -11,6 +11,7 @@ import {
   BlockStreamingCoalesceSchema,
   CliBackendSchema,
   HumanDelaySchema,
+  IanaTimezoneSchema,
   TypingModeSchema,
 } from "./zod-schema.core.js";
 
@@ -44,7 +45,7 @@ export const AgentDefaultsSchema = z
     bootstrapPromptTruncationWarning: z
       .union([z.literal("off"), z.literal("once"), z.literal("always")])
       .optional(),
-    userTimezone: z.string().optional(),
+    userTimezone: IanaTimezoneSchema.optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),
     envelopeTimestamp: z.union([z.literal("on"), z.literal("off")]).optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -5,6 +5,7 @@ import { AgentModelSchema } from "./zod-schema.agent-model.js";
 import {
   GroupChatSchema,
   HumanDelaySchema,
+  IanaTimezoneSchema,
   IdentitySchema,
   SecretInputSchema,
   ToolsLinksSchema,
@@ -773,6 +774,7 @@ export const AgentEntrySchema = z
       .optional(),
     reasoningDefault: z.enum(["on", "off", "stream"]).optional(),
     fastModeDefault: z.boolean().optional(),
+    userTimezone: IanaTimezoneSchema.optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { z } from "zod";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
+import { resolveTimezone } from "../infra/format-time/format-datetime.ts";
 import {
   formatExecSecretRefIdValidationMessage,
   isValidExecSecretRefId,
@@ -15,6 +16,10 @@ const ENV_SECRET_REF_ID_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
 const SECRET_PROVIDER_ALIAS_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
+
+export const IanaTimezoneSchema = z
+  .string()
+  .refine((value) => resolveTimezone(value.trim()) !== undefined, "Expected valid IANA timezone.");
 
 function isAbsolutePath(value: string): boolean {
   return (

--- a/src/config/zod-schema.timezone.test.ts
+++ b/src/config/zod-schema.timezone.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
+import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
+
+describe("timezone schemas", () => {
+  it("accepts omitted optional userTimezone values", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        timeFormat: "24",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      AgentEntrySchema.parse({
+        id: "work",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts valid IANA userTimezone values", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        userTimezone: "America/Chicago",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      AgentEntrySchema.parse({
+        id: "work",
+        userTimezone: "America/Los_Angeles",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects invalid IANA userTimezone values", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        userTimezone: "Mars/Olympus",
+      }),
+    ).toThrow();
+    expect(() =>
+      AgentEntrySchema.parse({
+        id: "work",
+        userTimezone: "not-a-timezone",
+      }),
+    ).toThrow();
+  });
+});

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -54,6 +54,7 @@ vi.mock("../../agents/agent-scope.js", async (importOriginal) => {
     resolveAgentConfig: resolveAgentConfigMock,
     resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
     resolveAgentModelFallbacksOverride: resolveAgentModelFallbacksOverrideMock,
+    resolveAgentUserTimezone: vi.fn().mockReturnValue("UTC"),
     resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
     resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
     resolveAgentSkillsFilter: resolveAgentSkillsFilterMock,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -336,7 +336,7 @@ export async function runCronIsolatedAgentTurn(params: {
     deliveryContract,
   });
 
-  const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
+  const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now, agentId);
   const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();
 
   // SECURITY: Wrap external hook content with security boundaries to prevent prompt injection

--- a/src/gateway/server-methods/agent-timestamp.ts
+++ b/src/gateway/server-methods/agent-timestamp.ts
@@ -1,4 +1,4 @@
-import { resolveUserTimezone } from "../../agents/date-time.js";
+import { resolveAgentUserTimezone } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 
@@ -73,8 +73,11 @@ export function injectTimestamp(message: string, opts?: TimestampInjectionOption
 /**
  * Build TimestampInjectionOptions from an OpenClawConfig.
  */
-export function timestampOptsFromConfig(cfg: OpenClawConfig): TimestampInjectionOptions {
+export function timestampOptsFromConfig(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): TimestampInjectionOptions {
   return {
-    timezone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
+    timezone: resolveAgentUserTimezone(cfg, agentId),
   };
 }

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -31,7 +31,8 @@ vi.mock("../../config/sessions.js", async () => {
   return {
     ...actual,
     updateSessionStore: mocks.updateSessionStore,
-    resolveAgentIdFromSessionKey: () => "main",
+    resolveAgentIdFromSessionKey: (sessionKey: string | undefined) =>
+      typeof sessionKey === "string" && sessionKey.startsWith("agent:work:") ? "work" : "main",
     resolveExplicitAgentSessionKey: () => undefined,
     resolveAgentMainSessionKey: ({
       cfg,
@@ -58,7 +59,11 @@ vi.mock("../../config/config.js", async () => {
 });
 
 vi.mock("../../agents/agent-scope.js", () => ({
-  listAgentIds: () => ["main"],
+  listAgentIds: () => ["main", "work"],
+  resolveSessionAgentId: (params: { sessionKey?: string }) =>
+    typeof params?.sessionKey === "string" && params.sessionKey.startsWith("agent:work:")
+      ? "work"
+      : "main",
 }));
 
 vi.mock("../../infra/agent-events.js", () => ({
@@ -566,6 +571,53 @@ describe("gateway agent handler", () => {
 
     const callArgs = mocks.agentCommand.mock.calls[0][0];
     expect(callArgs.message).toBe("[Wed 2026-01-28 20:30 EST] Is it the weekend?");
+
+    resetTimeConfig();
+  });
+
+  it("uses the session agent timezone when agentId is omitted", async () => {
+    setupNewYorkTimeConfig("2026-01-29T01:30:00.000Z");
+    mocks.loadConfigReturn = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+        list: [
+          {
+            id: "work",
+            userTimezone: "America/Los_Angeles",
+          },
+        ],
+      },
+    };
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: mocks.loadConfigReturn,
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "existing-session-id",
+        updatedAt: Date.now(),
+      },
+      canonicalKey: "agent:work:main",
+    });
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "What time is it?",
+        sessionKey: "agent:work:main",
+        idempotencyKey: "test-timestamp-session-agent",
+      },
+      { reqId: "ts-session-agent" },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+
+    const callArgs = mocks.agentCommand.mock.calls[0][0];
+    expect(callArgs.message).toBe("[Wed 2026-01-28 17:30 PST] What time is it?");
 
     resetTimeConfig();
   });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -420,7 +420,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     // formatting in a separate code path — they never reach this handler.
     // See: https://github.com/moltbot/moltbot/issues/3658
     if (!skipTimestampInjection) {
-      message = injectTimestamp(message, timestampOptsFromConfig(cfg));
+      message = injectTimestamp(message, timestampOptsFromConfig(cfg, request.agentId));
     }
 
     if (requestedSessionKey) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { listAgentIds } from "../../agents/agent-scope.js";
+import { listAgentIds, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import {
   normalizeSpawnedRunMetadata,
@@ -420,7 +420,11 @@ export const agentHandlers: GatewayRequestHandlers = {
     // formatting in a separate code path — they never reach this handler.
     // See: https://github.com/moltbot/moltbot/issues/3658
     if (!skipTimestampInjection) {
-      message = injectTimestamp(message, timestampOptsFromConfig(cfg, request.agentId));
+      const resolvedAgentId = resolveSessionAgentId({
+        sessionKey: requestedSessionKey,
+        config: cfg,
+      });
+      message = injectTimestamp(message, timestampOptsFromConfig(cfg, resolvedAgentId));
     }
 
     if (requestedSessionKey) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1408,10 +1408,17 @@ export const chatHandlers: GatewayRequestHandlers = {
         mainKey: cfg.session?.mainKey,
         sessionKey,
       });
+      const agentId = resolveSessionAgentId({
+        sessionKey,
+        config: cfg,
+      });
       // Inject timestamp so agents know the current date/time.
       // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
       // See: https://github.com/moltbot/moltbot/issues/3658
-      const stampedMessage = injectTimestamp(messageForAgent, timestampOptsFromConfig(cfg));
+      const stampedMessage = injectTimestamp(
+        messageForAgent,
+        timestampOptsFromConfig(cfg, agentId),
+      );
 
       const ctx: MsgContext = {
         Body: messageForAgent,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1444,10 +1444,6 @@ export const chatHandlers: GatewayRequestHandlers = {
         GatewayClientScopes: client?.connect?.scopes,
       };
 
-      const agentId = resolveSessionAgentId({
-        sessionKey,
-        config: cfg,
-      });
       const { onModelSelected, ...replyPipeline } = createChannelReplyPipeline({
         cfg,
         agentId,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -240,6 +240,35 @@ describe("timestampOptsFromConfig", () => {
   ])("$name", ({ cfg, expected }) => {
     expect(timestampOptsFromConfig(cfg).timezone).toBe(expected);
   });
+
+  it("uses the per-agent userTimezone override when configured", () => {
+    const opts = timestampOptsFromConfig(
+      {
+        agents: {
+          defaults: {
+            userTimezone: "America/Chicago",
+          },
+          list: [
+            {
+              id: "work",
+              userTimezone: "America/Los_Angeles",
+            },
+          ],
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      } as any,
+      "work",
+    );
+
+    expect(opts.timezone).toBe("America/Los_Angeles");
+  });
+
+  it("falls back gracefully with empty config", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const opts = timestampOptsFromConfig({} as any);
+
+    expect(opts.timezone).toBeDefined();
+  });
 });
 
 describe("normalizeRpcAttachmentsToChatAttachments", () => {

--- a/src/infra/heartbeat-active-hours.test.ts
+++ b/src/infra/heartbeat-active-hours.test.ts
@@ -59,6 +59,28 @@ describe("isWithinActiveHours", () => {
     expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 23, 59, 0))).toBe(true);
   });
 
+  it("uses the per-agent userTimezone override for user-scoped windows", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          userTimezone: "UTC",
+        },
+        list: [
+          {
+            id: "work",
+            userTimezone: "America/Los_Angeles",
+          },
+        ],
+      },
+    };
+    const heartbeat = heartbeatWindow("08:00", "10:00", "user");
+
+    expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 16, 30, 0), "work")).toBe(true);
+    expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 18, 30, 0), "work")).toBe(
+      false,
+    );
+  });
+
   it("supports overnight ranges", () => {
     const cfg = cfgWithUserTimezone("UTC");
     const heartbeat = heartbeatWindow("22:00", "06:00", "UTC");

--- a/src/infra/heartbeat-active-hours.ts
+++ b/src/infra/heartbeat-active-hours.ts
@@ -1,26 +1,22 @@
-import { resolveUserTimezone } from "../agents/date-time.js";
+import { resolveAgentUserTimezone } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import { resolveTimezone } from "./format-time/format-datetime.ts";
 
 type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
 
 const ACTIVE_HOURS_TIME_PATTERN = /^(?:([01]\d|2[0-3]):([0-5]\d)|24:00)$/;
 
-function resolveActiveHoursTimezone(cfg: OpenClawConfig, raw?: string): string {
+function resolveActiveHoursTimezone(cfg: OpenClawConfig, raw?: string, agentId?: string): string {
   const trimmed = raw?.trim();
   if (!trimmed || trimmed === "user") {
-    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+    return resolveAgentUserTimezone(cfg, agentId);
   }
   if (trimmed === "local") {
     const host = Intl.DateTimeFormat().resolvedOptions().timeZone;
     return host?.trim() || "UTC";
   }
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: trimmed }).format(new Date());
-    return trimmed;
-  } catch {
-    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
-  }
+  return resolveTimezone(trimmed) ?? resolveAgentUserTimezone(cfg, agentId);
 }
 
 function parseActiveHoursTime(opts: { allow24: boolean }, raw?: string): number | null {
@@ -71,6 +67,7 @@ export function isWithinActiveHours(
   cfg: OpenClawConfig,
   heartbeat?: HeartbeatConfig,
   nowMs?: number,
+  agentId?: string,
 ): boolean {
   const active = heartbeat?.activeHours;
   if (!active) {
@@ -86,7 +83,7 @@ export function isWithinActiveHours(
     return false;
   }
 
-  const timeZone = resolveActiveHoursTimezone(cfg, active.timezone);
+  const timeZone = resolveActiveHoursTimezone(cfg, active.timezone, agentId);
   const currentMin = resolveMinutesInTimeZone(nowMs ?? Date.now(), timeZone);
   if (currentMin === null) {
     return true;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -547,7 +547,7 @@ export async function runHeartbeatOnce(opts: {
   }
 
   const startedAt = opts.deps?.nowMs?.() ?? Date.now();
-  if (!isWithinActiveHours(cfg, heartbeat, startedAt)) {
+  if (!isWithinActiveHours(cfg, heartbeat, startedAt, agentId)) {
     return { status: "skipped", reason: "quiet-hours" };
   }
 

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-updates.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { formatZonedTimestamp } from "./format-time/format-datetime.ts";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
 import {
   drainSystemEventEntries,
@@ -182,6 +183,41 @@ describe("system events (session routing)", () => {
     });
     expect(result).toContain("Node: Mac Studio");
     expect(result).not.toContain("last input");
+  });
+
+  it("uses the per-agent userTimezone override for user envelope timestamps", async () => {
+    const key = "agent:work:main";
+    const cfg = {
+      agents: {
+        defaults: {
+          envelopeTimezone: "user",
+          userTimezone: "America/New_York",
+        },
+        list: [{ id: "work", userTimezone: "America/Los_Angeles" }],
+      },
+    } as OpenClawConfig;
+    const timestamp = new Date("2026-01-12T20:19:17Z");
+    const expectedTimestamp = formatZonedTimestamp(timestamp, {
+      timeZone: "America/Los_Angeles",
+      displaySeconds: true,
+    });
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(timestamp);
+      enqueueSystemEvent("Model switched.", { sessionKey: key });
+
+      const result = await drainFormattedSystemEvents({
+        cfg,
+        sessionKey: key,
+        isMainSession: false,
+        isNewSession: false,
+      });
+
+      expect(expectedTimestamp).toBeDefined();
+      expect(result).toContain(`System: [${expectedTimestamp}] Model switched.`);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -219,6 +219,41 @@ describe("system events (session routing)", () => {
       vi.useRealTimers();
     }
   });
+
+  it("uses the config-resolved default agent timezone for legacy main session keys", async () => {
+    const key = "main";
+    const cfg = {
+      agents: {
+        defaults: {
+          envelopeTimezone: "user",
+          userTimezone: "America/New_York",
+        },
+        list: [{ id: "work", default: true, userTimezone: "America/Los_Angeles" }],
+      },
+    } as OpenClawConfig;
+    const timestamp = new Date("2026-01-12T20:19:17Z");
+    const expectedTimestamp = formatZonedTimestamp(timestamp, {
+      timeZone: "America/Los_Angeles",
+      displaySeconds: true,
+    });
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(timestamp);
+      enqueueSystemEvent("Model switched.", { sessionKey: key });
+
+      const result = await drainFormattedSystemEvents({
+        cfg,
+        sessionKey: key,
+        isMainSession: true,
+        isNewSession: false,
+      });
+
+      expect(expectedTimestamp).toBeDefined();
+      expect(result).toContain(`System: [${expectedTimestamp}] Model switched.`);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("isCronSystemEvent", () => {

--- a/src/plugin-sdk/inbound-envelope.ts
+++ b/src/plugin-sdk/inbound-envelope.ts
@@ -31,13 +31,15 @@ export function createInboundEnvelopeBuilder<TConfig, TEnvelope>(params: {
   sessionStore?: string;
   resolveStorePath: (store: string | undefined, opts: { agentId: string }) => string;
   readSessionUpdatedAt: (params: { storePath: string; sessionKey: string }) => number | undefined;
-  resolveEnvelopeFormatOptions: (cfg: TConfig) => TEnvelope;
+  resolveEnvelopeFormatOptions: (cfg: TConfig, opts?: { agentId?: string }) => TEnvelope;
   formatAgentEnvelope: (params: InboundEnvelopeFormatParams<TEnvelope>) => string;
 }) {
   const storePath = params.resolveStorePath(params.sessionStore, {
     agentId: params.route.agentId,
   });
-  const envelopeOptions = params.resolveEnvelopeFormatOptions(params.cfg);
+  const envelopeOptions = params.resolveEnvelopeFormatOptions(params.cfg, {
+    agentId: params.route.agentId,
+  });
   return (input: { channel: string; from: string; body: string; timestamp?: number }) => {
     const previousTimestamp = params.readSessionUpdatedAt({
       storePath,
@@ -70,7 +72,7 @@ export function resolveInboundRouteEnvelopeBuilder<
   sessionStore?: string;
   resolveStorePath: (store: string | undefined, opts: { agentId: string }) => string;
   readSessionUpdatedAt: (params: { storePath: string; sessionKey: string }) => number | undefined;
-  resolveEnvelopeFormatOptions: (cfg: TConfig) => TEnvelope;
+  resolveEnvelopeFormatOptions: (cfg: TConfig, opts?: { agentId?: string }) => TEnvelope;
   formatAgentEnvelope: (params: InboundEnvelopeFormatParams<TEnvelope>) => string;
 }): {
   route: TRoute;
@@ -108,7 +110,7 @@ type InboundRouteEnvelopeRuntime<
     readSessionUpdatedAt: (params: { storePath: string; sessionKey: string }) => number | undefined;
   };
   reply: {
-    resolveEnvelopeFormatOptions: (cfg: TConfig) => TEnvelope;
+    resolveEnvelopeFormatOptions: (cfg: TConfig, opts?: { agentId?: string }) => TEnvelope;
     formatAgentEnvelope: (params: InboundEnvelopeFormatParams<TEnvelope>) => string;
   };
 };


### PR DESCRIPTION
## Summary

- Problem: OpenClaw only supported a single global `agents.defaults.userTimezone`, so multi-agent setups could not give different agents correct local time context.
- Why it matters: Agent-local time affects system prompt time context, heartbeat active-hours, session status, envelope timestamps, system event timestamps, and time-based helper prompts like memory flush/post-compaction context.
- What changed: Added `agents.list[].userTimezone`, introduced shared agent-aware timezone resolution, threaded `agentId` through the relevant call sites, validated configured IANA timezones in schema, and added tests/docs for the new behavior.
- What did NOT change (scope boundary): This does not change `timeFormat` per agent, host timezone fallback behavior, or explicit non-`user` timezone settings such as fixed IANA/UTC/local envelope config.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39579 

## User-visible / Behavior Changes

- New optional config: `agents.list[].userTimezone`.
- When set, the active agent's `userTimezone` now overrides `agents.defaults.userTimezone`.
- This per-agent timezone is now used for:
  - system prompt time context
  - `session_status` time line
  - heartbeat `activeHours.timezone: "user"`
  - `"user"` envelope timestamps
  - `"user"` system-event timestamps
  - cron-style current-time injection used by memory flush and post-compaction context
- If no per-agent value is set, behavior remains: `agents.defaults.userTimezone` then host timezone fallback.
- Config validation now rejects invalid IANA timezone strings for both default and per-agent `userTimezone`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: podman
- Model/provider: N/A
- Integration/channel (if any): gateway + multi-agent config; verified via user testing
- Relevant config (redacted):
  ```json5
  {
    agents: {
      defaults: {
        userTimezone: "America/New_York",
        envelopeTimezone: "user",
      },
      list: [
        {
          id: "work",
          userTimezone: "America/Los_Angeles",
        },
      ],
    },
  }
  ```

### Steps

1. Configure `agents.defaults.userTimezone` and a different `agents.list[].userTimezone` for a non-default agent.
2. Run flows using that agent, including session status, prompt/time injection paths, and any envelope/system-event path using `"user"` timezone.
3. Observe the active agent uses its own timezone instead of the global default.

### Expected

- The active agent consistently uses its own `userTimezone` override everywhere `"user"` timezone semantics are intended.

### Actual

- Before this change, the default/global timezone was used even for non-default agents.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Multi-agent config with different default/per-agent timezones
  - User-visible behavior manually tested as a user
  - Full local validation: `pnpm build && pnpm check && pnpm test`
- Edge cases checked:
  - Agent without override falls back to `agents.defaults.userTimezone`
  - No configured timezone falls back to host timezone
  - Invalid configured timezones are rejected by schema validation
  - Envelope/system-event `"user"` timezone paths receive the active `agentId`
- What you did **not** verify:
  - Every external channel manually end-to-end in a live environment

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:
  - Optional only: add `agents.list[].userTimezone` where agent-specific timezone behavior is desired.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove per-agent `userTimezone` entries and rely on `agents.defaults.userTimezone` or revert this PR.
- Files/config to restore:
  - Agent timezone config in `agents.list[]`
- Known bad symptoms reviewers should watch for:
  - Non-default agents showing the default timezone in prompts, envelopes, heartbeat windows, or status output
  - `"user"` timezone behavior not varying by agent

## Risks and Mitigations

- Risk: A call site using `"user"` timezone semantics could miss passing `agentId` and silently fall back to the default timezone.
  - Mitigation: Updated the shared helpers/call sites across gateway, envelope, heartbeat, memory flush, post-compaction context, and system events; added targeted tests.
- Risk: Rejecting invalid timezone strings at schema level could break previously accepted but incorrect configs.
  - Mitigation: This is intentional fail-fast validation; docs and tests cover the accepted IANA-only behavior.

## AI Assistance

This PR was AI-assisted using GPT-5.4 and Gemini 3.1 Pro.