### PR TITLE
Feature: support github-copilot gpt-5.3-codex and gpt-5.4

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -140,6 +140,22 @@ describe("loadModelCatalog", () => {
         contextWindow: 272000,
         input: ["text", "image"],
       },
+      {
+        id: "gpt-5.2",
+        provider: "github-copilot",
+        name: "GPT-5.2",
+        reasoning: true,
+        contextWindow: 128000,
+        input: ["text", "image"],
+      },
+      {
+        id: "gpt-5.2-codex",
+        provider: "github-copilot",
+        name: "GPT-5.2 Codex",
+        reasoning: true,
+        contextWindow: 266000,
+        input: ["text", "image"],
+      },
     ]);
 
     const result = await loadModelCatalog({ config: {} as OpenClawConfig });
@@ -161,6 +177,20 @@ describe("loadModelCatalog", () => {
     expect(result).toContainEqual(
       expect.objectContaining({
         provider: "openai-codex",
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+      }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "github-copilot",
+        id: "gpt-5.3-codex",
+        name: "gpt-5.3-codex",
+      }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "github-copilot",
         id: "gpt-5.4",
         name: "gpt-5.4",
       }),

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -33,6 +33,7 @@ const defaultImportPiSdk = () => import("./pi-model-discovery.js");
 let importPiSdk = defaultImportPiSdk;
 
 const CODEX_PROVIDER = "openai-codex";
+const GITHUB_COPILOT_PROVIDER = "github-copilot";
 const OPENAI_PROVIDER = "openai";
 const OPENAI_GPT54_MODEL_ID = "gpt-5.4";
 const OPENAI_GPT54_PRO_MODEL_ID = "gpt-5.4-pro";
@@ -62,6 +63,16 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: CODEX_PROVIDER,
     id: OPENAI_CODEX_GPT54_MODEL_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
+  },
+  {
+    provider: GITHUB_COPILOT_PROVIDER,
+    id: OPENAI_CODEX_GPT53_MODEL_ID,
+    templateIds: ["gpt-5.2-codex"],
+  },
+  {
+    provider: GITHUB_COPILOT_PROVIDER,
+    id: OPENAI_GPT54_MODEL_ID,
+    templateIds: ["gpt-5.2"],
   },
   {
     provider: CODEX_PROVIDER,

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -72,6 +72,21 @@ function createOpenAICodexTemplateModel(id: string): Model<Api> {
   } as Model<Api>;
 }
 
+function createGitHubCopilotTemplateModel(id: string): Model<Api> {
+  return {
+    id,
+    name: id,
+    provider: "github-copilot",
+    api: "openai-responses",
+    baseUrl: "https://api.individual.githubcopilot.com",
+    input: ["text", "image"],
+    reasoning: true,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+  } as Model<Api>;
+}
+
 function createRegistry(models: Record<string, Model<Api>>): ModelRegistry {
   return {
     find(provider: string, modelId: string) {
@@ -364,6 +379,18 @@ describe("resolveForwardCompatModel", () => {
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
     expect(model?.contextWindow).toBe(272_000);
+    expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves github-copilot gpt-5.4 via gpt-5.2 template fallback", () => {
+    const registry = createRegistry({
+      "github-copilot/gpt-5.2": createGitHubCopilotTemplateModel("gpt-5.2"),
+    });
+    const model = resolveForwardCompatModel("github-copilot", "gpt-5.4", registry);
+    expectResolvedForwardCompat(model, { provider: "github-copilot", id: "gpt-5.4" });
+    expect(model?.api).toBe("openai-responses");
+    expect(model?.baseUrl).toBe("https://api.individual.githubcopilot.com");
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
   });
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -6,6 +6,7 @@ import { normalizeProviderId } from "./model-selection.js";
 
 const OPENAI_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
+const GITHUB_COPILOT_PROVIDER = "github-copilot";
 const OPENAI_GPT_54_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
@@ -77,6 +78,50 @@ function resolveOpenAIGpt54ForwardCompatModel(
       api: "openai-responses",
       provider: normalizedProvider,
       baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS,
+      maxTokens: OPENAI_GPT_54_MAX_TOKENS,
+    } as Model<Api>)
+  );
+}
+
+function resolveGitHubCopilotForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== GITHUB_COPILOT_PROVIDER) {
+    return undefined;
+  }
+
+  const trimmedModelId = modelId.trim();
+  if (trimmedModelId.toLowerCase() !== OPENAI_GPT_54_MODEL_ID) {
+    return undefined;
+  }
+
+  return (
+    cloneFirstTemplateModel({
+      normalizedProvider,
+      trimmedModelId,
+      templateIds: [...OPENAI_GPT_54_TEMPLATE_MODEL_IDS],
+      modelRegistry,
+      patch: {
+        api: "openai-responses",
+        provider: normalizedProvider,
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS,
+        maxTokens: OPENAI_GPT_54_MAX_TOKENS,
+      },
+    }) ??
+    normalizeModelCompat({
+      id: trimmedModelId,
+      name: trimmedModelId,
+      api: "openai-responses",
+      provider: normalizedProvider,
       reasoning: true,
       input: ["text", "image"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -322,6 +367,7 @@ export function resolveForwardCompatModel(
 ): Model<Api> | undefined {
   return (
     resolveOpenAIGpt54ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveGitHubCopilotForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveOpenAICodexForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??

--- a/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
@@ -239,7 +239,7 @@ describe("directive behavior", () => {
 
       const unsupportedModelTexts = await runThinkingDirective(home, "openai/gpt-4.1-mini");
       expect(unsupportedModelTexts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.4, openai/gpt-5.4-pro, openai/gpt-5.2, openai-codex/gpt-5.4, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.4, openai/gpt-5.4-pro, openai/gpt-5.2, openai-codex/gpt-5.4, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.4, github-copilot/gpt-5.3-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
       );
       expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
     });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -58,7 +58,9 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
   });
 
-  it("includes xhigh for github-copilot gpt-5.2 refs", () => {
+  it("includes xhigh for github-copilot gpt-5.x refs", () => {
+    expect(listThinkingLevels("github-copilot", "gpt-5.4")).toContain("xhigh");
+    expect(listThinkingLevels("github-copilot", "gpt-5.3-codex")).toContain("xhigh");
     expect(listThinkingLevels("github-copilot", "gpt-5.2")).toContain("xhigh");
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -30,6 +30,8 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
+  "github-copilot/gpt-5.4",
+  "github-copilot/gpt-5.3-codex",
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
 ] as const;


### PR DESCRIPTION
## Summary

- Problem: GitHub Copilot users cannot see/select `github-copilot/gpt-5.3-codex` and `github-copilot/gpt-5.4` from OpenClaw model discovery/catalog.
- Why it matters: new Copilot GPT-5.x releases are unavailable in `models list` and model selection paths.
- What changed:
  - Added synthetic catalog fallbacks for `github-copilot/gpt-5.3-codex` (from `gpt-5.2-codex`) and `github-copilot/gpt-5.4` (from `gpt-5.2`).
  - Added forward-compat model resolution for `github-copilot/gpt-5.4` so runtime model resolution works even when upstream catalog lags.
  - Extended xhigh thinking allowlist/tests to include Copilot `gpt-5.3-codex` and `gpt-5.4`.
- What did NOT change (scope boundary): no provider auth/token flow changes, no docs/config schema changes, no unrelated model/provider updates.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39459
- Related #N/A

## User-visible / Behavior Changes

- `openclaw models list --provider github-copilot` can now surface `github-copilot/gpt-5.3-codex` and `github-copilot/gpt-5.4` via synthetic forward-compat entries when template models are present.
- `github-copilot/gpt-5.4` is now forward-compatible in runtime model resolution paths.
- `/thinking xhigh` support matrix now includes `github-copilot/gpt-5.3-codex` and `github-copilot/gpt-5.4`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: github-copilot
- Integration/channel (if any): n/a
- Relevant config (redacted): default test harness configs

### Steps

1. Run targeted tests for model catalog + forward-compat + thinking allowlist.
2. Run directive behavior test file that contains xhigh support-matrix assertion.

### Expected

- Targeted suites pass for changed model support behavior.

### Actual

- Pass:
  - `pnpm test src/agents/model-catalog.test.ts src/agents/model-compat.test.ts src/auto-reply/thinking.test.ts`
- Known harness failure (pre-existing, unrelated to this change's logic):
  - `pnpm test src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts`
  - Fails at test setup with `TypeError: vi.mocked(...).mockReset is not a function` in `reply.directive.directive-behavior.e2e-harness.ts`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Synthetic catalog now includes Copilot `gpt-5.3-codex` and `gpt-5.4` when templates exist.
  - Forward-compat resolver returns Copilot `gpt-5.4` from `gpt-5.2` template.
  - xhigh allowlist includes new Copilot GPT-5.x IDs.
- Edge cases checked:
  - Existing OpenAI/OpenAI-Codex fallback expectations still pass.
- What you did **not** verify:
  - Live Copilot API calls with real account credentials.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `0fa838fdf`.
- Files/config to restore:
  - `src/agents/model-catalog.ts`
  - `src/agents/model-forward-compat.ts`
  - `src/auto-reply/thinking.ts`
- Known bad symptoms reviewers should watch for:
  - Missing Copilot `gpt-5.3-codex`/`gpt-5.4` in catalog output.
  - `Unknown model` for `github-copilot/gpt-5.4` despite Copilot provider being configured.

## Risks and Mitigations

- Risk: synthetic entries could diverge from upstream metadata.
  - Mitigation: clone existing provider template models and only patch id/name; behavior tracks known-good Copilot templates.
