### PR TITLE
fix: harden macOS update restart recovery

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -206,4 +206,68 @@ describe("inspectGatewayRestart", () => {
 
     expect(snapshot.healthy).toBe(true);
   });
+
+  it("passes env with the expected wrapper to service.isLoaded", async () => {
+    const env = { OPENCLAW_PROFILE: "ziggy" } as NodeJS.ProcessEnv;
+    const service = {
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 4242 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 4242, ppid: 1, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    await inspectGatewayRestart({ service, port: 18789, env });
+
+    expect((service as { isLoaded: ReturnType<typeof vi.fn> }).isLoaded).toHaveBeenCalledWith({
+      env,
+    });
+  });
+});
+
+describe("waitForGatewayHealthyRestart", () => {
+  beforeEach(() => {
+    inspectPortUsage.mockReset();
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 4242, ppid: 1, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    classifyPortListener.mockReset();
+    classifyPortListener.mockReturnValue("gateway");
+    probeGateway.mockReset();
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  });
+
+  it("does not stop on a single transient unloaded snapshot", async () => {
+    const service = {
+      isLoaded: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
+      readRuntime: vi.fn(async () => ({ status: "running", state: "running", pid: 4242 })),
+    } as unknown as GatewayService;
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      attempts: 2,
+      delayMs: 0,
+    });
+
+    expect((service as { isLoaded: ReturnType<typeof vi.fn> }).isLoaded).toHaveBeenCalledTimes(2);
+    expect(snapshot.serviceLoaded).toBe(true);
+    expect(snapshot.healthy).toBe(true);
+  });
 });

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -19,6 +19,7 @@ export const DEFAULT_RESTART_HEALTH_ATTEMPTS = Math.ceil(
 export type GatewayRestartSnapshot = {
   runtime: GatewayServiceRuntime;
   portUsage: PortUsage;
+  serviceLoaded: boolean | null;
   healthy: boolean;
   staleGatewayPids: number[];
 };
@@ -63,6 +64,12 @@ export async function inspectGatewayRestart(params: {
 }): Promise<GatewayRestartSnapshot> {
   const env = params.env ?? process.env;
   let runtime: GatewayServiceRuntime = { status: "unknown" };
+  let serviceLoaded: boolean | null = null;
+  try {
+    serviceLoaded = await params.service.isLoaded(env);
+  } catch {
+    serviceLoaded = null;
+  }
   try {
     runtime = await params.service.readRuntime(env);
   } catch (err) {
@@ -105,8 +112,8 @@ export async function inspectGatewayRestart(params: {
       ? portUsage.listeners.some((listener) => listenerOwnedByRuntimePid({ listener, runtimePid }))
       : gatewayListeners.length > 0 ||
         (portUsage.status === "busy" && portUsage.listeners.length === 0);
-  let healthy = running && ownsPort;
-  if (!healthy && running && portUsage.status === "busy") {
+  let healthy = running && ownsPort && serviceLoaded !== false;
+  if (!healthy && serviceLoaded !== false && running && portUsage.status === "busy") {
     try {
       healthy = await confirmGatewayReachable(params.port);
     } catch {
@@ -136,6 +143,7 @@ export async function inspectGatewayRestart(params: {
   return {
     runtime,
     portUsage,
+    serviceLoaded,
     healthy,
     staleGatewayPids,
   };
@@ -161,6 +169,9 @@ export async function waitForGatewayHealthyRestart(params: {
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (snapshot.healthy) {
+      return snapshot;
+    }
+    if (snapshot.serviceLoaded === false) {
       return snapshot;
     }
     if (snapshot.staleGatewayPids.length > 0 && snapshot.runtime.status !== "running") {
@@ -191,6 +202,11 @@ export function renderRestartDiagnostics(snapshot: GatewayRestartSnapshot): stri
 
   if (runtimeSummary) {
     lines.push(`Service runtime: ${runtimeSummary}`);
+  }
+  if (snapshot.serviceLoaded === false) {
+    lines.push("Service registration: not loaded.");
+  } else if (snapshot.serviceLoaded === true) {
+    lines.push("Service registration: loaded.");
   }
 
   if (snapshot.portUsage.status === "busy") {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -15,6 +15,7 @@ export const DEFAULT_RESTART_HEALTH_DELAY_MS = 500;
 export const DEFAULT_RESTART_HEALTH_ATTEMPTS = Math.ceil(
   DEFAULT_RESTART_HEALTH_TIMEOUT_MS / DEFAULT_RESTART_HEALTH_DELAY_MS,
 );
+const UNLOADED_SNAPSHOT_THRESHOLD = 2;
 
 export type GatewayRestartSnapshot = {
   runtime: GatewayServiceRuntime;
@@ -66,7 +67,7 @@ export async function inspectGatewayRestart(params: {
   let runtime: GatewayServiceRuntime = { status: "unknown" };
   let serviceLoaded: boolean | null = null;
   try {
-    serviceLoaded = await params.service.isLoaded(env);
+    serviceLoaded = await params.service.isLoaded({ env });
   } catch {
     serviceLoaded = null;
   }
@@ -166,13 +167,19 @@ export async function waitForGatewayHealthyRestart(params: {
     env: params.env,
     includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
   });
+  let unloadedSnapshots = 0;
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (snapshot.healthy) {
       return snapshot;
     }
     if (snapshot.serviceLoaded === false) {
-      return snapshot;
+      unloadedSnapshots += 1;
+      if (unloadedSnapshots >= UNLOADED_SNAPSHOT_THRESHOLD) {
+        return snapshot;
+      }
+    } else {
+      unloadedSnapshots = 0;
     }
     if (snapshot.staleGatewayPids.length > 0 && snapshot.runtime.status !== "running") {
       return snapshot;

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -553,6 +553,20 @@ describe("update-cli", () => {
     await runRestartFallbackScenario({ daemonInstall: "ok" });
   });
 
+  it("re-registers the gateway when detached restart leaves the service unloaded", async () => {
+    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+    serviceLoaded
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await updateCommand({});
+
+    expect(runRestartScript).toHaveBeenCalled();
+    expect(runDaemonInstall).toHaveBeenCalledTimes(2);
+    expect(runDaemonRestart).toHaveBeenCalledTimes(1);
+  });
+
   it("updateCommand does not refresh service env when --no-restart is set", async () => {
     vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
     serviceLoaded.mockResolvedValue(true);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -558,9 +558,25 @@ describe("update-cli", () => {
     serviceLoaded
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(true);
 
     await updateCommand({});
+
+    expect(runRestartScript).toHaveBeenCalled();
+    expect(runDaemonInstall).toHaveBeenCalledTimes(2);
+    expect(runDaemonRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-registers the gateway in json mode when detached restart leaves the service unloaded", async () => {
+    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+    serviceLoaded
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await updateCommand({ json: true });
 
     expect(runRestartScript).toHaveBeenCalled();
     expect(runDaemonInstall).toHaveBeenCalledTimes(2);

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -97,6 +97,7 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
+      expect(content).toContain("plutil -lint");
       expect(content).toContain("launchctl bootout 'gui/501/ai.openclaw.gateway'");
       expect(content).toContain("launchctl bootstrap 'gui/501'");
       expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -97,9 +97,9 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
-      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
-      // Should fall back to bootstrap when kickstart fails (service deregistered after bootout)
+      expect(content).toContain("launchctl bootout 'gui/501/ai.openclaw.gateway'");
       expect(content).toContain("launchctl bootstrap 'gui/501'");
+      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
     });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -93,12 +93,10 @@ rm -f "$0"
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-# Try kickstart first (works when the service is still registered).
-# If it fails (e.g. after bootout), re-register via bootstrap then kickstart.
-if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
-  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
-  launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
-fi
+# Hard-reset launchd state to avoid stale runtime / unloaded-label drift.
+launchctl bootout 'gui/${uid}/${escaped}' 2>/dev/null || true
+launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null || true
+launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
 # Self-cleanup
 rm -f "$0"
 `;

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -94,9 +94,13 @@ rm -f "$0"
 # Wait briefly to ensure file locks are released after update.
 sleep 1
 # Hard-reset launchd state to avoid stale runtime / unloaded-label drift.
-launchctl bootout 'gui/${uid}/${escaped}' 2>/dev/null || true
-launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null || true
-launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
+if [ -f '${escapedPlistPath}' ] && plutil -lint '${escapedPlistPath}' >/dev/null 2>&1; then
+  launchctl bootout 'gui/${uid}/${escaped}' 2>/dev/null || true
+  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null || true
+  launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
+else
+  launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
+fi
 # Self-cleanup
 rm -f "$0"
 `;

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -565,6 +565,22 @@ async function maybeRestartService(params: {
           service,
           port: params.gatewayPort,
         });
+        if (!health.healthy && health.serviceLoaded === false) {
+          if (!params.opts.json) {
+            defaultRuntime.log(
+              theme.warn("Gateway service was left unloaded after restart. Re-registering..."),
+            );
+          }
+          await runDaemonInstall({
+            force: true,
+            json: params.opts.json || undefined,
+          });
+          await runDaemonRestart();
+          health = await waitForGatewayHealthyRestart({
+            service,
+            port: params.gatewayPort,
+          });
+        }
         if (!health.healthy && health.staleGatewayPids.length > 0) {
           if (!params.opts.json) {
             defaultRuntime.log(

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -559,7 +559,7 @@ async function maybeRestartService(params: {
         }
       }
 
-      if (!params.opts.json && restartInitiated) {
+      if (restartInitiated) {
         const service = resolveGatewayService();
         let health = await waitForGatewayHealthyRestart({
           service,
@@ -597,9 +597,9 @@ async function maybeRestartService(params: {
           });
         }
 
-        if (health.healthy) {
+        if (!params.opts.json && health.healthy) {
           defaultRuntime.log(theme.success("Daemon restart completed."));
-        } else {
+        } else if (!params.opts.json) {
           defaultRuntime.log(theme.warn("Gateway did not become healthy after restart."));
           for (const line of renderRestartDiagnostics(health)) {
             defaultRuntime.log(theme.muted(line));
@@ -610,7 +610,9 @@ async function maybeRestartService(params: {
             ),
           );
         }
-        defaultRuntime.log("");
+        if (!params.opts.json) {
+          defaultRuntime.log("");
+        }
       }
     } catch (err) {
       if (!params.opts.json) {


### PR DESCRIPTION
## Summary / What changed
- hard-reset the macOS LaunchAgent during detached update restarts with `bootout -> bootstrap -> kickstart`
- treat `service not loaded` as unhealthy in restart health checks and show it in diagnostics
- re-register and restart automatically when a detached update restart leaves the LaunchAgent unloaded
- add regression tests for the macOS restart script and the unloaded-service recovery path

## Why
This follows the repro from @smile-xuc in #39074.

On macOS, `openclaw update` can leave the gateway in a half-alive state where a process still exists, but the LaunchAgent is no longer loaded. In that state, runtime and port checks can look good enough, while the real gateway session is broken and needs manual cleanup.

## Tests
- `pnpm vitest run src/cli/update-cli/restart-helper.test.ts src/cli/update-cli.test.ts src/cli/daemon-cli/lifecycle.test.ts`

## Real-world validation
- tested on live macOS 26.3 LaunchAgent deployments since 2026-03-08
- reproduced the unloaded `ai.openclaw.gateway` state after restart on a live gateway
- verified recovery by re-registering the service and confirming the gateway listened again and resumed WhatsApp inbound handling
- AI-assisted: yes, with local validation and targeted regression tests

## Issue
Fixes #39074
