### PR TITLE
docs: clarify GPT OAuth multi-account rotation

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -46,7 +46,8 @@ If you authenticate multiple GPT OAuth profiles for the same provider (for examp
 OpenClaw can rotate between them when one profile is rate-limited or out of
 credits/quota.
 
-You can make the order explicit:
+You can make the order explicit in your **gateway config** (for example
+`~/.openclaw/gateway/config.json` or `~/.openclaw/gateway/config.yaml`):
 
 ```json
 {
@@ -64,6 +65,8 @@ Behavior at runtime:
 - On failover-worthy errors (`429`, rate limit, quota/billing exhaustion), it
   marks the current profile unavailable and retries with the next eligible
   profile.
+- If you **user-pin** a specific profile (for example `/model …@openai-codex:work@example.com`),
+  OpenClaw does **not** rotate to another profile; it will proceed to **model fallback** instead.
 - If no eligible profile remains, model fallback rules apply.
 
 Use `/model status` to inspect active candidates and the next auth profile.

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -39,6 +39,38 @@ OAuth logins create distinct profiles so multiple accounts can coexist.
 
 Profiles live in `~/.openclaw/agents/<agentId>/agent/auth-profiles.json` under `profiles`.
 
+### Example: rotating multiple GPT OAuth accounts
+
+If you authenticate multiple GPT OAuth profiles for the same provider (for example
+`openai-codex:work@example.com` and `openai-codex:personal@example.com`),
+OpenClaw can rotate between them when one profile is rate-limited or out of
+credits/quota.
+
+You can make the order explicit:
+
+```json
+{
+  "auth": {
+    "order": {
+      "openai-codex": [
+        "openai-codex:work@example.com",
+        "openai-codex:personal@example.com"
+      ]
+    }
+  }
+}
+```
+
+Behavior at runtime:
+
+- OpenClaw keeps a session-pinned profile for normal requests.
+- On failover-worthy errors (`429`, rate limit, quota/billing exhaustion), it
+  marks the current profile unavailable and retries with the next eligible
+  profile.
+- If no eligible profile remains, model fallback rules apply.
+
+Use `/model status` to inspect active candidates and the next auth profile.
+
 ## Rotation order
 
 When a provider has multiple profiles, OpenClaw chooses an order like this:

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -52,10 +52,7 @@ You can make the order explicit:
 {
   "auth": {
     "order": {
-      "openai-codex": [
-        "openai-codex:work@example.com",
-        "openai-codex:personal@example.com"
-      ]
+      "openai-codex": ["openai-codex:work@example.com", "openai-codex:personal@example.com"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a concrete `openai-codex` multi-account OAuth example to model failover docs
- document how `auth.order` can explicitly prioritize multiple GPT OAuth profiles
- clarify runtime behavior when a profile hits rate-limit/quota and when model fallback takes over
- point users to `/model status` to inspect candidate and next profile

## Why
Users commonly ask whether GPT OAuth credentials can be rotated across multiple accounts when one account is rate-limited or out of quota. The runtime already supports profile rotation, but the docs lacked an explicit GPT-focused example.

## Testing
- docs-only change