### PR TITLE
fix: remove redundant root strip-ansi dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,7 +378,6 @@
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.5",
     "sqlite-vec": "0.1.7-alpha.2",
-    "strip-ansi": "^7.2.0",
     "tar": "7.5.10",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
       sqlite-vec:
         specifier: 0.1.7-alpha.2
         version: 0.1.7-alpha.2
-      strip-ansi:
-        specifier: ^7.2.0
-        version: 7.2.0
       tar:
         specifier: 7.5.10
         version: 7.5.10


### PR DESCRIPTION
## Summary

- remove the redundant root `strip-ansi` dependency now that `#38999` uses pnpm `packageExtensions`
- keep `strip-ansi` scoped to `@mariozechner/pi-coding-agent` via the pnpm-native injection
- shrink the root importer and lockfile back to the minimal state

## Linked Issue/PR

- Follow-up to #38999

## Verification

- [x] `pnpm install --ignore-scripts`
- [x] `node -e "import('@mariozechner/pi-coding-agent')..."`
- [x] `pnpm openclaw --help`
- [x] `pnpm why strip-ansi` confirms it remains transitive rather than a root dependency
