### PR TITLE
fix(security): reject hostname ws:// targets in allowPrivateWs mode

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -450,7 +450,7 @@ describe("isSecureWebSocketUrl", () => {
     }
   });
 
-  it("allows private ws:// only when opt-in is enabled", () => {
+  it("allows private ws:// IP literals only when opt-in is enabled", () => {
     const allowedWhenOptedIn = [
       "ws://10.0.0.5:18789",
       "http://10.0.0.5:18789",
@@ -460,11 +460,23 @@ describe("isSecureWebSocketUrl", () => {
       "ws://169.254.10.20:18789",
       "ws://[fc00::1]:18789",
       "ws://[fe80::1]:18789",
-      "ws://gateway.private.example:18789",
     ];
 
     for (const input of allowedWhenOptedIn) {
       expect(isSecureWebSocketUrl(input, { allowPrivateWs: true }), input).toBe(true);
+    }
+  });
+
+  it("rejects ws:// hostnames even when allowPrivateWs is enabled (#37177)", () => {
+    const hostnameWsUrls = [
+      "ws://gateway.private.example:18789",
+      "ws://openclaw-gateway.ai:18789",
+      "ws://my-server.local:18789",
+      "ws://internal.corp.net:18789",
+    ];
+
+    for (const input of hostnameWsUrls) {
+      expect(isSecureWebSocketUrl(input, { allowPrivateWs: true }), input).toBe(false);
     }
   });
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -440,17 +440,14 @@ export function isSecureWebSocketUrl(
     return true;
   }
   // Optional break-glass for trusted private-network overlays.
+  // Only allow private/loopback IP literals — hostnames are rejected because
+  // DNS resolution is not available in this synchronous validator and
+  // allowing arbitrary hostnames would effectively disable TLS enforcement
+  // for any non-IP target (see #37177).
   if (opts?.allowPrivateWs) {
     if (isPrivateOrLoopbackHost(parsed.hostname)) {
       return true;
     }
-    // Hostnames may resolve to private networks (for example in VPN/Tailnet DNS),
-    // but resolution is not available in this synchronous validator.
-    const hostForIpCheck =
-      parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
-        ? parsed.hostname.slice(1, -1)
-        : parsed.hostname;
-    return net.isIP(hostForIpCheck) === 0;
   }
   return false;
 }


### PR DESCRIPTION
## Problem

When `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` is enabled, `isSecureWebSocketUrl()` accepts **any** `ws://` hostname — not just private/loopback targets.

The root cause is in `src/gateway/net.ts`: the `allowPrivateWs` branch falls through to `net.isIP(hostForIpCheck) === 0`, which returns `true` for any hostname (since `net.isIP()` returns `0` for non-IP strings). This means `ws://evil-public-server.com:18789` would pass validation, effectively disabling TLS enforcement for all hostname-based targets.

**Security impact:** MITM and plaintext credential/conversation exposure when a user can influence the gateway remote URL or DNS resolution.

## Fix

- Remove the hostname pass-through fallback (the `net.isIP() === 0` check)
- Restrict `allowPrivateWs` mode to **private/loopback IP literals only**, which aligns with the original intent of the break-glass flag
- `localhost` continues to work because `isPrivateOrLoopbackHost()` already handles it via the `parseHostForAddressChecks` localhost special case

The fix is minimal (5 lines removed, 4 comment lines added) to keep the security surface change small and auditable.

## Testing

- Updated existing test: removed `ws://gateway.private.example:18789` from the allowed-with-opt-in list (it was asserting the **buggy** behavior)
- Added new dedicated test: `rejects ws:// hostnames even when allowPrivateWs is enabled (#37177)` covering private-looking hostnames, `.local`, and `.corp.net` domains
- Existing regression tests for private IP literals, public IP rejection, and non-unicast IPv6 remain unchanged

```
pnpm test src/gateway/net.test.ts
```

## Why the previous attempt (#37883) was closed

PR #37883 attempted a similar fix but was closed without merge. This PR takes the same core approach (reject hostnames, allow only IP literals) but:
1. Preserves the existing `isPrivateOrLoopbackHost()` call which already handles `localhost`
2. Adds comprehensive test coverage for the hostname rejection case
3. Keeps the diff minimal (2 files, ~27 lines changed)

Fixes #37177