### PR TITLE
Feature: add opt-in WhatsApp outbound any E.164 flag

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -144,6 +144,16 @@ OpenClaw recommends running WhatsApp on a separate number when possible. (The ch
 
     `allowFrom` accepts E.164-style numbers (normalized internally).
 
+    Outbound direct sends use `allowFrom` by default. To allow outbound delivery to any valid E.164 (without `allowFrom` membership checks), set:
+
+    - `channels.whatsapp.allowOutboundToAnyE164: true`
+    - optional per-account override: `channels.whatsapp.accounts.<id>.allowOutboundToAnyE164`
+
+    Risk warning:
+
+    - only enable this in trusted self-hosted setups
+    - any script/app that can run `openclaw message send --channel whatsapp` can send to arbitrary numbers from that WhatsApp account
+
     Multi-account override: `channels.whatsapp.accounts.<id>.dmPolicy` (and `allowFrom`) take precedence over channel-level defaults for that account.
 
     Runtime behavior details:
@@ -431,7 +441,7 @@ Primary reference:
 
 High-signal WhatsApp fields:
 
-- access: `dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`, `groups`
+- access: `dmPolicy`, `allowFrom`, `allowOutboundToAnyE164`, `groupPolicy`, `groupAllowFrom`, `groups`
 - delivery: `textChunkLimit`, `chunkMode`, `mediaMaxMb`, `sendReadReceipts`, `ackReaction`
 - multi-account: `accounts.<id>.enabled`, `accounts.<id>.authDir`, account-level overrides
 - operations: `configWrites`, `debounceMs`, `web.enabled`, `web.heartbeatSeconds`, `web.reconnect.*`

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -99,6 +99,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
     whatsapp: {
       dmPolicy: "pairing", // pairing | allowlist | open | disabled
       allowFrom: ["+15555550123", "+447700900123"],
+      allowOutboundToAnyE164: false,
       textChunkLimit: 4000,
       chunkMode: "length", // length | newline
       mediaMaxMb: 50,
@@ -145,7 +146,8 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Outbound commands default to account `default` if present; otherwise the first configured account id (sorted).
 - Optional `channels.whatsapp.defaultAccount` overrides that fallback default account selection when it matches a configured account id.
 - Legacy single-account Baileys auth dir is migrated by `openclaw doctor` into `whatsapp/default`.
-- Per-account overrides: `channels.whatsapp.accounts.<id>.sendReadReceipts`, `channels.whatsapp.accounts.<id>.dmPolicy`, `channels.whatsapp.accounts.<id>.allowFrom`.
+- Per-account overrides: `channels.whatsapp.accounts.<id>.sendReadReceipts`, `channels.whatsapp.accounts.<id>.dmPolicy`, `channels.whatsapp.accounts.<id>.allowFrom`, `channels.whatsapp.accounts.<id>.allowOutboundToAnyE164`.
+- Outbound direct-target safety: by default, direct outbound targets must match `allowFrom` (or `*`/empty allowlist behavior). Set `allowOutboundToAnyE164: true` only for trusted self-hosted deployments where broad outbound sending risk is acceptable.
 
 </Accordion>
 

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -1,5 +1,6 @@
 import { chunkText } from "../../../auto-reply/chunk.js";
 import { shouldLogVerbose } from "../../../globals.js";
+import { resolveWhatsAppAccount } from "../../../web/accounts.js";
 import { sendPollWhatsApp } from "../../../web/outbound.js";
 import { resolveWhatsAppOutboundTarget } from "../../../whatsapp/resolve-outbound-target.js";
 import type { ChannelOutboundAdapter } from "../types.js";
@@ -11,8 +12,18 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   chunkerMode: "text",
   textChunkLimit: 4000,
   pollMaxOptions: 12,
-  resolveTarget: ({ to, allowFrom, mode }) =>
-    resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  resolveTarget: ({ cfg, to, allowFrom, mode, accountId }) =>
+    resolveWhatsAppOutboundTarget({
+      to,
+      allowFrom,
+      mode,
+      allowOutboundToAnyE164: cfg
+        ? resolveWhatsAppAccount({
+            cfg,
+            accountId: accountId ?? undefined,
+          }).allowOutboundToAnyE164
+        : undefined,
+    }),
   sendPayload: async (ctx) =>
     await sendTextMediaPayload({ channel: "whatsapp", ctx, adapter: whatsappOutbound }),
   sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {

--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -181,6 +181,75 @@ describe("whatsappOutbound.resolveTarget", () => {
       to: "120363401234567890@g.us",
     });
   });
+
+  it("allows direct target outside allowFrom when channel enables allowOutboundToAnyE164", () => {
+    const result = whatsappOutbound.resolveTarget?.({
+      to: "+15550000000",
+      allowFrom: ["+15551234567"],
+      mode: "explicit",
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowOutboundToAnyE164: true,
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      to: "+15550000000",
+    });
+  });
+
+  it("honors per-account allowOutboundToAnyE164 override", () => {
+    const result = whatsappOutbound.resolveTarget?.({
+      to: "+15550000000",
+      allowFrom: ["+15551234567"],
+      mode: "explicit",
+      accountId: "work",
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowOutboundToAnyE164: false,
+            accounts: {
+              work: {
+                allowOutboundToAnyE164: true,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      to: "+15550000000",
+    });
+  });
+
+  it("honors explicit per-account false override when channel flag is true", () => {
+    const result = whatsappOutbound.resolveTarget?.({
+      to: "+15550000000",
+      allowFrom: ["+15551234567"],
+      mode: "explicit",
+      accountId: "work",
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowOutboundToAnyE164: true,
+            accounts: {
+              work: {
+                allowOutboundToAnyE164: false,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expectWhatsAppTargetResolutionError(result);
+  });
 });
 
 describe("normalizeSignalAccountInput", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1476,6 +1476,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow ACP spawns with thread=true to auto-bind Telegram current conversations when supported.",
   "channels.whatsapp.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
+  "channels.whatsapp.allowOutboundToAnyE164":
+    "Danger zone for self-hosted setups: when true, outbound WhatsApp direct sends can target any valid E.164 instead of being restricted to allowFrom.",
   "channels.whatsapp.selfChatMode": "Same-phone setup (bot uses your personal WhatsApp number).",
   "channels.whatsapp.debounceMs":
     "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -44,6 +44,8 @@ type WhatsAppSharedConfig = {
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /** Danger zone: allow outbound direct sends to any valid E.164, bypassing allowFrom membership checks. */
+  allowOutboundToAnyE164?: boolean;
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */
   defaultTo?: string;
   /** Optional allowlist for WhatsApp group senders (E.164). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -42,6 +42,7 @@ const WhatsAppSharedSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
+  allowOutboundToAnyE164: z.boolean().optional(),
   defaultTo: z.string().optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -19,6 +19,7 @@ export type ResolvedWhatsAppAccount = {
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
   allowFrom?: string[];
+  allowOutboundToAnyE164?: boolean;
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
@@ -137,6 +138,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
+    allowOutboundToAnyE164: accountCfg?.allowOutboundToAnyE164 ?? rootCfg?.allowOutboundToAnyE164,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,
     textChunkLimit: accountCfg?.textChunkLimit ?? rootCfg?.textChunkLimit,

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -198,6 +198,29 @@ describe("resolveWhatsAppOutboundTarget", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
       expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "broadcast" });
     });
+
+    it("allows outbound direct targets outside allowList when allowOutboundToAnyE164=true", () => {
+      mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
+      expectResolutionOk(
+        {
+          to: PRIMARY_TARGET,
+          allowFrom: [SECONDARY_TARGET],
+          allowOutboundToAnyE164: true,
+          mode: "broadcast",
+        },
+        PRIMARY_TARGET,
+      );
+    });
+
+    it("continues enforcing allowList when allowOutboundToAnyE164 is false", () => {
+      mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
+      expectResolutionError({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        allowOutboundToAnyE164: false,
+        mode: "broadcast",
+      });
+    });
   });
 
   describe("whitespace handling", () => {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -8,6 +8,7 @@ export type WhatsAppOutboundTargetResolution =
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
+  allowOutboundToAnyE164?: boolean;
   mode: string | null | undefined;
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
@@ -29,6 +30,9 @@ export function resolveWhatsAppOutboundTarget(params: {
       };
     }
     if (isWhatsAppGroupJid(normalizedTo)) {
+      return { ok: true, to: normalizedTo };
+    }
+    if (params.allowOutboundToAnyE164 === true) {
       return { ok: true, to: normalizedTo };
     }
     // Enforce allowFrom for all direct-message send modes (including explicit).


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp outbound direct sends were blocked unless the target was in `channels.whatsapp.allowFrom` (unless wildcard/empty allowlist), so self-hosted reminder flows could not send to other valid E.164 targets.
- Why it matters: this prevented legitimate SaaS-style self-hosted reminder scenarios where outbound recipients are dynamic.
- What changed: added a default-off config flag `channels.whatsapp.allowOutboundToAnyE164` (plus per-account override) that allows outbound direct sends to any valid E.164 while preserving existing default behavior.
- What did NOT change (scope boundary): inbound DM/group access policy behavior (`dmPolicy`, `allowFrom`, `groupPolicy`, pairing) is unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39563
- Related #N/A

## User-visible / Behavior Changes

- New optional config: `channels.whatsapp.allowOutboundToAnyE164` (default unset/false).
- New optional per-account override: `channels.whatsapp.accounts.<id>.allowOutboundToAnyE164`.
- When enabled, outbound direct WhatsApp targets are validated as valid E.164 and are no longer required to be in `allowFrom`.
- Group JID handling remains unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: enabling the new flag allows any process/script with `openclaw message send --channel whatsapp` access to send to arbitrary valid E.164 targets from that account.
  - Mitigation: feature is explicit opt-in and default remains restrictive; docs now label this as a trusted self-hosted danger-zone setting.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): `channels.whatsapp.allowOutboundToAnyE164` / `channels.whatsapp.accounts.<id>.allowOutboundToAnyE164`

### Steps

1. Configure WhatsApp with a strict `allowFrom` list and attempt outbound direct send to a valid E.164 not in allowlist.
2. Enable `channels.whatsapp.allowOutboundToAnyE164: true` (or account override) and retry the same send.
3. Run focused resolver/plugin tests and type checks.

### Expected

- Default behavior keeps existing restrictions.
- With the flag enabled, outbound direct send resolves for valid E.164 even when not allowlisted.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands and outcomes:

- `pnpm test -- src/whatsapp/resolve-outbound-target.test.ts src/channels/plugins/plugins-channel.test.ts`
  - First run failed because dependencies were not installed (`vitest not found`).
  - After install, rerun passed: 2 files, 47 tests.
- `pnpm tsgo`
  - Passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - default behavior still rejects non-allowlisted direct targets.
  - flag-enabled behavior allows valid non-allowlisted direct targets.
  - per-account override true/false precedence over channel-level setting.
- Edge cases checked:
  - group JID targets remain allowed as before.
  - invalid targets still fail normalization.
- What you did **not** verify:
  - live WhatsApp network delivery with real credentials/devices.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Set `channels.whatsapp.allowOutboundToAnyE164` (and any account override) to `false`/unset.
- Files/config to restore:
  - `channels.whatsapp.allowOutboundToAnyE164`
  - `channels.whatsapp.accounts.<id>.allowOutboundToAnyE164`
- Known bad symptoms reviewers should watch for:
  - unexpected outbound sends to non-allowlisted E.164 targets when the flag is enabled.

## Risks and Mitigations

- Risk:
  - Operators may enable broad outbound routing without understanding blast radius.
- Mitigation:
  - Default is unchanged (off), and docs explicitly frame this as trusted self-hosted danger-zone behavior.
