### PR TITLE
Subagents: keep orchestrators active for legacy descendant keys

### DIFF
--- a/src/agents/subagent-registry-queries.test.ts
+++ b/src/agents/subagent-registry-queries.test.ts
@@ -175,6 +175,27 @@ describe("subagent registry query regressions", () => {
     expect(countActiveRunsForSessionFromRuns(runs, "agent:main:main")).toBe(0);
   });
 
+  it("treats legacy subagent requester keys as canonical descendants", () => {
+    const parentSessionKey = "agent:main:subagent:orchestrator";
+    const runs = toRunMap([
+      makeRun({
+        runId: "run-parent-ended",
+        childSessionKey: parentSessionKey,
+        requesterSessionKey: "agent:main:main",
+        endedAt: 100,
+        cleanupCompletedAt: undefined,
+      }),
+      makeRun({
+        runId: "run-child-active",
+        childSessionKey: `${parentSessionKey}:subagent:child`,
+        requesterSessionKey: "subagent:orchestrator",
+      }),
+    ]);
+
+    expect(countPendingDescendantRunsFromRuns(runs, parentSessionKey)).toBe(1);
+    expect(countActiveRunsForSessionFromRuns(runs, "agent:main:main")).toBe(1);
+  });
+
   it("scopes direct child listings to the requester run window when requesterRunId is provided", () => {
     const requesterSessionKey = "agent:main:subagent:orchestrator";
     const runs = toRunMap([

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -1,17 +1,35 @@
 import type { DeliveryContext } from "../utils/delivery-context.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+function normalizeGraphSessionKey(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const lowered = trimmed.toLowerCase();
+  if (lowered.startsWith("agent:")) {
+    return lowered;
+  }
+  if (lowered.startsWith("subagent:")) {
+    return `agent:main:${lowered}`;
+  }
+  if (lowered.startsWith("acp:")) {
+    return `agent:main:${lowered}`;
+  }
+  return trimmed;
+}
+
 export function findRunIdsByChildSessionKeyFromRuns(
   runs: Map<string, SubagentRunRecord>,
   childSessionKey: string,
 ): string[] {
-  const key = childSessionKey.trim();
+  const key = normalizeGraphSessionKey(childSessionKey);
   if (!key) {
     return [];
   }
   const runIds: string[] = [];
   for (const [runId, entry] of runs.entries()) {
-    if (entry.childSessionKey === key) {
+    if (normalizeGraphSessionKey(entry.childSessionKey) === key) {
       runIds.push(runId);
     }
   }
@@ -25,7 +43,7 @@ export function listRunsForRequesterFromRuns(
     requesterRunId?: string;
   },
 ): SubagentRunRecord[] {
-  const key = requesterSessionKey.trim();
+  const key = normalizeGraphSessionKey(requesterSessionKey);
   if (!key) {
     return [];
   }
@@ -38,7 +56,7 @@ export function listRunsForRequesterFromRuns(
   const upperBound = requesterRunMatchesScope?.endedAt;
 
   return [...runs.values()].filter((entry) => {
-    if (entry.requesterSessionKey !== key) {
+    if (normalizeGraphSessionKey(entry.requesterSessionKey) !== key) {
       return false;
     }
     if (typeof lowerBound === "number" && entry.createdAt < lowerBound) {
@@ -55,13 +73,13 @@ function findLatestRunForChildSession(
   runs: Map<string, SubagentRunRecord>,
   childSessionKey: string,
 ): SubagentRunRecord | undefined {
-  const key = childSessionKey.trim();
+  const key = normalizeGraphSessionKey(childSessionKey);
   if (!key) {
     return undefined;
   }
   let latest: SubagentRunRecord | undefined;
   for (const entry of runs.values()) {
-    if (entry.childSessionKey !== key) {
+    if (normalizeGraphSessionKey(entry.childSessionKey) !== key) {
       continue;
     }
     if (!latest || entry.createdAt > latest.createdAt) {
@@ -106,7 +124,7 @@ export function countActiveRunsForSessionFromRuns(
   runs: Map<string, SubagentRunRecord>,
   requesterSessionKey: string,
 ): number {
-  const key = requesterSessionKey.trim();
+  const key = normalizeGraphSessionKey(requesterSessionKey);
   if (!key) {
     return 0;
   }
@@ -123,7 +141,7 @@ export function countActiveRunsForSessionFromRuns(
 
   let count = 0;
   for (const entry of runs.values()) {
-    if (entry.requesterSessionKey !== key) {
+    if (normalizeGraphSessionKey(entry.requesterSessionKey) !== key) {
       continue;
     }
     if (typeof entry.endedAt !== "number") {
@@ -142,7 +160,7 @@ function forEachDescendantRun(
   rootSessionKey: string,
   visitor: (runId: string, entry: SubagentRunRecord) => void,
 ): boolean {
-  const root = rootSessionKey.trim();
+  const root = normalizeGraphSessionKey(rootSessionKey);
   if (!root) {
     return false;
   }
@@ -154,11 +172,11 @@ function forEachDescendantRun(
       continue;
     }
     for (const [runId, entry] of runs.entries()) {
-      if (entry.requesterSessionKey !== requester) {
+      if (normalizeGraphSessionKey(entry.requesterSessionKey) !== requester) {
         continue;
       }
       visitor(runId, entry);
-      const childKey = entry.childSessionKey.trim();
+      const childKey = normalizeGraphSessionKey(entry.childSessionKey);
       if (!childKey || visited.has(childKey)) {
         continue;
       }


### PR DESCRIPTION
## Summary

- Problem: `subagents list` could label a depth-1 run-mode orchestrator as `done` when active depth-2 children existed but were linked via legacy requester keys like `subagent:...`.
- Why it matters: this makes orchestrators look completed and can trigger duplicate orchestrator spawns.
- What changed: normalized subagent/acp key shapes during subagent-registry query matching so `subagent:...` and `agent:main:subagent:...` resolve to the same graph node.
- What did NOT change (scope boundary): no spawn semantics, no lifecycle timing changes, no output format changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39619
- Related #

## User-visible / Behavior Changes

- `subagents list` now keeps run-mode orchestrators in active/waiting status when descendants are tracked with legacy `subagent:` requester keys.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A
- Integration/channel (if any): subagent registry query path used by `subagents` tool and `/subagents list`
- Relevant config (redacted): N/A

### Steps

1. Create an ended depth-1 orchestrator run under requester `agent:main:main`.
2. Create an active child run whose requester key is legacy `subagent:orchestrator`.
3. Query descendant counts / active run counts from the main requester.

### Expected

- Parent orchestrator is treated as active while child is pending.

### Actual

- Parent could be treated as done due key-shape mismatch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Added regression test covering legacy `subagent:` requester key linkage.
  - Re-ran existing subagents list regression tests for tool + command output.
- Edge cases checked:
  - Canonical `agent:` key path remains passing.
- What you did **not** verify:
  - Live multi-channel runtime reproduction on external services.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Subagents: normalize legacy requester keys for descendant status`.
- Files/config to restore:
  - `src/agents/subagent-registry-queries.ts`
  - `src/agents/subagent-registry-queries.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected descendant matching for non-subagent keys.

## Risks and Mitigations

- Risk:
  - Over-normalizing unrelated keys could mis-link run graphs.
  - Mitigation:
  - Normalization only rewrites `agent:`, `subagent:`, and `acp:` forms; other keys are unchanged.
