### PR TITLE
fix: resolve runtime import error for parse-finite-number in extensions

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -1,4 +1,4 @@
-import { parseFiniteNumber } from "../../../src/infra/parse-finite-number.js";
+import { parseFiniteNumber } from "./parse-finite-number.js";
 import { extractHandleFromChatGuid, normalizeBlueBubblesHandle } from "./targets.js";
 import type { BlueBubblesAttachment } from "./types.js";
 

--- a/extensions/bluebubbles/src/parse-finite-number.ts
+++ b/extensions/bluebubbles/src/parse-finite-number.ts
@@ -1,0 +1,42 @@
+function normalizeNumericString(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function parseFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+export function parseStrictInteger(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? value : undefined;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = normalizeNumericString(value);
+  if (!normalized || !/^[+-]?\d+$/.test(normalized)) {
+    return undefined;
+  }
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+export function parseStrictPositiveInteger(value: unknown): number | undefined {
+  const parsed = parseStrictInteger(value);
+  return parsed !== undefined && parsed > 0 ? parsed : undefined;
+}
+
+export function parseStrictNonNegativeInteger(value: unknown): number | undefined {
+  const parsed = parseStrictInteger(value);
+  return parsed !== undefined && parsed >= 0 ? parsed : undefined;
+}

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -30,7 +30,7 @@ import {
   listSkillCommandsForAgents,
   type HistoryEntry,
 } from "openclaw/plugin-sdk/mattermost";
-import { parseStrictPositiveInteger } from "../../../../src/infra/parse-finite-number.js";
+import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/extensions/mattermost/src/mattermost/parse-finite-number.ts
+++ b/extensions/mattermost/src/mattermost/parse-finite-number.ts
@@ -1,0 +1,42 @@
+function normalizeNumericString(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function parseFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+export function parseStrictInteger(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? value : undefined;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = normalizeNumericString(value);
+  if (!normalized || !/^[+-]?\d+$/.test(normalized)) {
+    return undefined;
+  }
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+export function parseStrictPositiveInteger(value: unknown): number | undefined {
+  const parsed = parseStrictInteger(value);
+  return parsed !== undefined && parsed > 0 ? parsed : undefined;
+}
+
+export function parseStrictNonNegativeInteger(value: unknown): number | undefined {
+  const parsed = parseStrictInteger(value);
+  return parsed !== undefined && parsed >= 0 ? parsed : undefined;
+}


### PR DESCRIPTION
## Summary

BlueBubbles and Mattermost plugins import from `../../../src/infra/parse-finite-number.js` which is not bundled in the npm package, causing runtime errors.

### Bug Report
- Fixes #39627

## Changes

- Add local copy of `parse-finite-number.ts` in BlueBubbles extension
- Add local copy of `parse-finite-number.ts` in Mattermost extension  
- Update imports to use relative local paths

## Files Changed

- `extensions/bluebubbles/src/parse-finite-number.ts` (new)
- `extensions/bluebubbles/src/monitor-normalize.ts` (updated import)
- `extensions/mattermost/src/mattermost/parse-finite-number.ts` (new)
- `extensions/mattermost/src/mattermost/monitor.ts` (updated import)

## Testing

Built locally with `pnpm build` - no errors.

---

*AI-assisted PR (lightly tested)*
