### PR TITLE
fix(agents): resolve gateway token from env for agent tool calls

### DIFF
--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -61,6 +61,24 @@ describe("gateway tool defaults", () => {
     );
   });
 
+  it("falls back to OPENCLAW_GATEWAY_TOKEN when no explicit token or URL override is given", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-fallback-token";
+    const opts = resolveGatewayOptions({});
+    expect(opts.token).toBe("env-fallback-token");
+  });
+
+  it("falls back to CLAWDBOT_GATEWAY_TOKEN (legacy) when OPENCLAW_GATEWAY_TOKEN is unset", () => {
+    process.env.CLAWDBOT_GATEWAY_TOKEN = "legacy-fallback-token";
+    const opts = resolveGatewayOptions({});
+    expect(opts.token).toBe("legacy-fallback-token");
+  });
+
+  it("prefers explicit gatewayToken over env fallback", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    const opts = resolveGatewayOptions({ gatewayToken: "explicit-token" });
+    expect(opts.token).toBe("explicit-token");
+  });
+
   it("uses OPENCLAW_GATEWAY_TOKEN for allowlisted local overrides", () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
     const opts = resolveGatewayOptions({ gatewayUrl: "ws://127.0.0.1:18789" });

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -1,6 +1,10 @@
 import { loadConfig, resolveGatewayPort } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
-import { resolveGatewayCredentialsFromConfig, trimToUndefined } from "../../gateway/credentials.js";
+import {
+  readGatewayTokenEnv,
+  resolveGatewayCredentialsFromConfig,
+  trimToUndefined,
+} from "../../gateway/credentials.js";
 import { resolveLeastPrivilegeOperatorScopesForMethod } from "../../gateway/method-scopes.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { readStringParam } from "./common.js";
@@ -129,7 +133,7 @@ export function resolveGatewayOptions(opts?: GatewayCallOptions) {
         target: validatedOverride.target,
         explicitToken,
       })
-    : explicitToken;
+    : (explicitToken ?? readGatewayTokenEnv());
   const timeoutMs =
     typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? Math.max(1, Math.floor(opts.timeoutMs))


### PR DESCRIPTION
## Summary

When `gateway.auth.mode` is `"token"` and agent tools (`sessions_spawn`, `cron`, `sessions_list`, etc.) are invoked from non-webchat channels (e.g. Telegram), the call fails with `device-required` after a 10-second timeout.

**Root cause:** `resolveGatewayOptions()` only reads `opts.gatewayToken` (the explicit parameter) when there is no URL override. It does not fall back to `OPENCLAW_GATEWAY_TOKEN` / `CLAWDBOT_GATEWAY_TOKEN` from the environment, unlike the CLI/WebChat path which uses `resolveGatewayCredentials()`.

**Fix:** Add `?? readGatewayTokenEnv()` as a fallback when no explicit token and no URL override are provided.

## Changes

- **`src/agents/tools/gateway.ts`** — import `readGatewayTokenEnv` and use it as fallback in `resolveGatewayOptions()`
- **`src/agents/tools/gateway.test.ts`** — 3 new tests: env fallback, legacy env fallback, explicit token takes precedence over env

## Testing

All 15 tests pass in `gateway.test.ts`.

Closes #35039