### PR TITLE
fix(agents): strip unsupported schema keywords for Moonshot/Kimi models

### DIFF
--- a/src/agents/pi-tools.schema.moonshot.test.ts
+++ b/src/agents/pi-tools.schema.moonshot.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+/**
+ * Moonshot/Kimi models reject JSON Schema validation keywords (minLength,
+ * maxLength, minimum, maximum, minItems, maxItems) in tool definitions.
+ * These tests verify that the schema cleaning pipeline strips them when
+ * the provider is Moonshot — matching the behaviour already in place for xAI.
+ */
+describe("normalizeToolParameters — Moonshot provider", () => {
+  const toolWithConstraints = {
+    name: "web_search",
+    label: "Web Search",
+    description: "Search the web",
+    execute: async () => ({ content: [], details: {} }),
+    parameters: {
+      type: "object" as const,
+      properties: {
+        query: { type: "string", minLength: 1, maxLength: 500 },
+        count: { type: "number", minimum: 1, maximum: 10 },
+        tags: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 5 },
+      },
+      required: ["query"],
+    },
+  } as AnyAgentTool;
+
+  it("strips validation keywords for direct moonshot provider", () => {
+    const result = normalizeToolParameters(toolWithConstraints, {
+      modelProvider: "moonshot",
+      modelId: "moonshot-v1-128k",
+    });
+    const props = (result.parameters as Record<string, unknown>).properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    // string constraints stripped
+    expect(props.query).not.toHaveProperty("minLength");
+    expect(props.query).not.toHaveProperty("maxLength");
+    expect(props.query).toHaveProperty("type", "string");
+    // number constraints stripped
+    expect(props.count).not.toHaveProperty("minimum");
+    expect(props.count).not.toHaveProperty("maximum");
+    // array constraints stripped
+    expect(props.tags).not.toHaveProperty("minItems");
+    expect(props.tags).not.toHaveProperty("maxItems");
+  });
+
+  it("strips validation keywords for openrouter with moonshotai/ model", () => {
+    const result = normalizeToolParameters(toolWithConstraints, {
+      modelProvider: "openrouter",
+      modelId: "moonshotai/Kimi-K2.5",
+    });
+    const props = (result.parameters as Record<string, unknown>).properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.query).not.toHaveProperty("minLength");
+    expect(props.count).not.toHaveProperty("minimum");
+    expect(props.tags).not.toHaveProperty("minItems");
+  });
+
+  it("strips validation keywords for together with kimi model", () => {
+    const result = normalizeToolParameters(toolWithConstraints, {
+      modelProvider: "together",
+      modelId: "moonshotai/Kimi-K2-Instruct-0905",
+    });
+    const props = (result.parameters as Record<string, unknown>).properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.query).not.toHaveProperty("maxLength");
+    expect(props.count).not.toHaveProperty("maximum");
+    expect(props.tags).not.toHaveProperty("maxItems");
+  });
+
+  it("preserves validation keywords for non-moonshot providers", () => {
+    const result = normalizeToolParameters(toolWithConstraints, {
+      modelProvider: "openai",
+      modelId: "gpt-4o",
+    });
+    const props = (result.parameters as Record<string, unknown>).properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.query).toHaveProperty("minLength", 1);
+    expect(props.query).toHaveProperty("maxLength", 500);
+    expect(props.count).toHaveProperty("minimum", 1);
+    expect(props.count).toHaveProperty("maximum", 10);
+    expect(props.tags).toHaveProperty("minItems", 1);
+    expect(props.tags).toHaveProperty("maxItems", 5);
+  });
+
+  it("preserves non-constraint schema properties", () => {
+    const result = normalizeToolParameters(toolWithConstraints, {
+      modelProvider: "moonshot",
+    });
+    const params = result.parameters as Record<string, unknown>;
+    expect(params).toHaveProperty("type", "object");
+    expect(params).toHaveProperty("required");
+    const props = params.properties as Record<string, Record<string, unknown>>;
+    expect(props.query).toHaveProperty("type", "string");
+    expect(props.count).toHaveProperty("type", "number");
+    expect(props.tags).toHaveProperty("type", "array");
+    expect(props.tags).toHaveProperty("items");
+  });
+});

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -1,6 +1,11 @@
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { cleanSchemaForGemini } from "./schema/clean-for-gemini.js";
-import { isXaiProvider, stripXaiUnsupportedKeywords } from "./schema/clean-for-xai.js";
+import {
+  isMoonshotProvider,
+  isXaiProvider,
+  stripMoonshotUnsupportedKeywords,
+  stripXaiUnsupportedKeywords,
+} from "./schema/clean-for-xai.js";
 
 function extractEnumValues(schema: unknown): unknown[] | undefined {
   if (!schema || typeof schema !== "object") {
@@ -89,10 +94,14 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const isXai = isXaiProvider(options?.modelProvider, options?.modelId);
+  const isMoonshot = isMoonshotProvider(options?.modelProvider, options?.modelId);
 
   function applyProviderCleaning(s: unknown): unknown {
     if (isGeminiProvider && !isAnthropicProvider) {
       return cleanSchemaForGemini(s);
+    }
+    if (isMoonshot) {
+      return stripMoonshotUnsupportedKeywords(s);
     }
     if (isXai) {
       return stripXaiUnsupportedKeywords(s);

--- a/src/agents/schema/clean-for-xai.test.ts
+++ b/src/agents/schema/clean-for-xai.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isXaiProvider, stripXaiUnsupportedKeywords } from "./clean-for-xai.js";
+import { isMoonshotProvider, isXaiProvider, stripXaiUnsupportedKeywords } from "./clean-for-xai.js";
 
 describe("isXaiProvider", () => {
   it("matches direct xai provider", () => {
@@ -151,5 +151,42 @@ describe("stripXaiUnsupportedKeywords", () => {
     expect(stripXaiUnsupportedKeywords(null)).toBeNull();
     expect(stripXaiUnsupportedKeywords("string")).toBe("string");
     expect(stripXaiUnsupportedKeywords(42)).toBe(42);
+  });
+});
+
+describe("isMoonshotProvider", () => {
+  it("matches direct moonshot provider", () => {
+    expect(isMoonshotProvider("moonshot")).toBe(true);
+  });
+
+  it("matches case-insensitively on provider id", () => {
+    expect(isMoonshotProvider("Moonshot")).toBe(true);
+    expect(isMoonshotProvider("MOONSHOT")).toBe(true);
+  });
+
+  it("matches openrouter with moonshotai/ model prefix", () => {
+    expect(isMoonshotProvider("openrouter", "moonshotai/Kimi-K2.5")).toBe(true);
+  });
+
+  it("matches together with moonshotai/ model prefix", () => {
+    expect(isMoonshotProvider("together", "moonshotai/Kimi-K2-Instruct-0905")).toBe(true);
+  });
+
+  it("matches openrouter with kimi in model id", () => {
+    expect(isMoonshotProvider("openrouter", "kimi-k2.5")).toBe(true);
+  });
+
+  it("does not match openrouter with non-moonshot model", () => {
+    expect(isMoonshotProvider("openrouter", "openai/gpt-4o")).toBe(false);
+  });
+
+  it("does not match unrelated providers", () => {
+    expect(isMoonshotProvider("openai")).toBe(false);
+    expect(isMoonshotProvider("anthropic")).toBe(false);
+    expect(isMoonshotProvider("google")).toBe(false);
+  });
+
+  it("handles undefined provider", () => {
+    expect(isMoonshotProvider(undefined)).toBe(false);
   });
 });

--- a/src/agents/schema/clean-for-xai.ts
+++ b/src/agents/schema/clean-for-xai.ts
@@ -10,37 +10,72 @@ export const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
   "maxContains",
 ]);
 
-export function stripXaiUnsupportedKeywords(schema: unknown): unknown {
+// Moonshot/Kimi rejects numeric constraints in addition to the string/array
+// constraints that xAI rejects.
+export const MOONSHOT_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
+  ...XAI_UNSUPPORTED_SCHEMA_KEYWORDS,
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+]);
+
+export function stripUnsupportedSchemaKeywords(schema: unknown, keywords: Set<string>): unknown {
   if (!schema || typeof schema !== "object") {
     return schema;
   }
   if (Array.isArray(schema)) {
-    return schema.map(stripXaiUnsupportedKeywords);
+    return schema.map((item) => stripUnsupportedSchemaKeywords(item, keywords));
   }
   const obj = schema as Record<string, unknown>;
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
-    if (XAI_UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
+    if (keywords.has(key)) {
       continue;
     }
     if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
       cleaned[key] = Object.fromEntries(
         Object.entries(value as Record<string, unknown>).map(([k, v]) => [
           k,
-          stripXaiUnsupportedKeywords(v),
+          stripUnsupportedSchemaKeywords(v, keywords),
         ]),
       );
     } else if (key === "items" && value && typeof value === "object") {
       cleaned[key] = Array.isArray(value)
-        ? value.map(stripXaiUnsupportedKeywords)
-        : stripXaiUnsupportedKeywords(value);
+        ? value.map((item) => stripUnsupportedSchemaKeywords(item, keywords))
+        : stripUnsupportedSchemaKeywords(value, keywords);
     } else if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
-      cleaned[key] = value.map(stripXaiUnsupportedKeywords);
+      cleaned[key] = value.map((item) => stripUnsupportedSchemaKeywords(item, keywords));
     } else {
       cleaned[key] = value;
     }
   }
   return cleaned;
+}
+
+export function stripXaiUnsupportedKeywords(schema: unknown): unknown {
+  return stripUnsupportedSchemaKeywords(schema, XAI_UNSUPPORTED_SCHEMA_KEYWORDS);
+}
+
+export function stripMoonshotUnsupportedKeywords(schema: unknown): unknown {
+  return stripUnsupportedSchemaKeywords(schema, MOONSHOT_UNSUPPORTED_SCHEMA_KEYWORDS);
+}
+
+export function isMoonshotProvider(modelProvider?: string, modelId?: string): boolean {
+  const provider = modelProvider?.toLowerCase() ?? "";
+  if (provider === "moonshot") {
+    return true;
+  }
+  const lowerModelId = modelId?.toLowerCase() ?? "";
+  // OpenRouter / Together proxy to Moonshot/Kimi models
+  if (
+    (provider === "openrouter" || provider === "together") &&
+    (lowerModelId.startsWith("moonshotai/") || lowerModelId.includes("kimi"))
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export function isXaiProvider(modelProvider?: string, modelId?: string): boolean {

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -56,13 +56,24 @@ describe("resolveTranscriptPolicy", () => {
 
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {
     const policy = resolveTranscriptPolicy({
-      provider: "moonshot",
-      modelId: "kimi-k2.5",
+      provider: "deepseek",
+      modelId: "deepseek-chat",
       modelApi: "openai-completions",
     });
     expect(policy.applyGoogleTurnOrdering).toBe(true);
     expect(policy.validateGeminiTurns).toBe(true);
     expect(policy.validateAnthropicTurns).toBe(true);
+  });
+
+  it("excludes moonshot from strict OpenAI-compatible turn validation", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      modelApi: "openai-completions",
+    });
+    expect(policy.applyGoogleTurnOrdering).toBe(false);
+    expect(policy.validateGeminiTurns).toBe(false);
+    expect(policy.validateAnthropicTurns).toBe(false);
   });
 
   it("enables Anthropic-compatible policies for Bedrock provider", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -38,7 +38,7 @@ const OPENAI_MODEL_APIS = new Set([
   "openai-codex-responses",
 ]);
 const OPENAI_PROVIDERS = new Set(["openai", "openai-codex"]);
-const OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS = new Set(["openrouter", "opencode"]);
+const OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS = new Set(["openrouter", "opencode", "moonshot"]);
 
 function isOpenAiApi(modelApi?: string | null): boolean {
   if (!modelApi) {


### PR DESCRIPTION
## Summary

Moonshot/Kimi tool calls broke silently after two changes:

1. **`fe94e83f6`** made schema cleaning provider-aware — Moonshot was left without any cleaning, but its API rejects validation keywords (`minLength`, `minimum`, etc.)
2. **`9757d2bb6` / `f304ca09b`** applied strict OpenAI-compatible turn validation to all `openai-completions` providers — Moonshot got `validateAnthropicTurns` (strips tool-use blocks), `validateGeminiTurns`, and `applyGoogleTurnOrdering`, breaking tool-call continuity

## Fixes

### 1. Schema cleaning
- Add `isMoonshotProvider()` — detects direct `moonshot`, OpenRouter/Together proxied `moonshotai/` and `kimi` models
- Add `MOONSHOT_UNSUPPORTED_SCHEMA_KEYWORDS` — extends xAI's set with numeric constraints (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`)
- Refactor into reusable `stripUnsupportedSchemaKeywords(schema, keywords)`

### 2. Transcript policy
- Add `"moonshot"` to `OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS` so Moonshot is no longer subjected to Gemini/Anthropic turn validation

## Files changed

| File | Change |
|---|---|
| `src/agents/schema/clean-for-xai.ts` | `isMoonshotProvider()`, keyword set, refactored strip helper |
| `src/agents/pi-tools.schema.ts` | Apply Moonshot cleaning in `applyProviderCleaning()` |
| `src/agents/transcript-policy.ts` | Exclude moonshot from strict compat validation |
| `src/agents/schema/clean-for-xai.test.ts` | 8 tests for `isMoonshotProvider()` |
| `src/agents/pi-tools.schema.moonshot.test.ts` | 5 integration tests for schema pipeline |
| `src/agents/transcript-policy.test.ts` | 1 test for moonshot exclusion |

## Testing

All 46 tests pass across 3 test files.

Closes #39603