### PR TITLE
docs(changelog): add #39377 failover note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - macOS app/chat UI: route browser proxy through the local node browser service, preserve plain-text paste semantics, strip completed assistant trace/debug wrapper noise from transcripts, refresh permission state after returning from System Settings, and tolerate malformed cron rows in the macOS tab. (#39516) Thanks @Imhermes1.
 - Mattermost replies: keep `root_id` pinned to the existing thread root when an agent replies inside a thread, while still using reply-target threading for top-level posts. (#27744) thanks @hnykda.
+- Agents/failover: detect Amazon Bedrock `Too many tokens per day` quota errors as rate limits across fallback, cron retry, and memory embeddings while keeping context-window `too many tokens per request` errors out of the rate-limit lane. (#39377) Thanks @gambletan.
 
 ## 2026.3.7
 


### PR DESCRIPTION
## Summary

Add the missing changelog entry for the Bedrock rate-limit fix that landed in #39377.

## Changes

- add a `2026.3.8` fix entry for the Bedrock `Too many tokens per day` failover/retry fix
- attribute the contribution to @gambletan

## Validation

- changelog-only change
