### PR TITLE
fix(onboarding): default tools.profile to 'coding' instead of 'messaging'

### DIFF
--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -3,7 +3,7 @@ import type { DmScope } from "../config/types.base.js";
 import type { ToolProfileId } from "../config/types.tools.js";
 
 export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
-export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "messaging";
+export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "coding";
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -145,7 +145,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       }>(configPath);
 
       expect(cfg?.agents?.defaults?.workspace).toBe(workspace);
-      expect(cfg?.tools?.profile).toBe("messaging");
+      expect(cfg?.tools?.profile).toBe("coding");
       expect(cfg?.gateway?.auth?.mode).toBe("token");
       expect(cfg?.gateway?.auth?.token).toBe(token);
     });


### PR DESCRIPTION
# Issue #39691 Root Cause Analysis

## Problem
After upgrading from 2026.3.2 to 2026.3.7, agents can't run commands anymore.

## Root Cause
**2026.3.7 changed the default `tools.profile` from `"messaging"` to `"coding"` for new installs**, but existing configurations with explicit `tools.profile = "messaging"` are NOT auto-migrated.

### Changelog Evidence
```
- Onboarding/local setup: default unset local `tools.profile` to `coding` instead of `messaging`, restoring file/runtime tools for fresh local installs while preserving explicit user-set profiles. (from #38241, overlap with #34958) Thanks @cgdusek.
```

## Why This Breaks
**`tools.profile` determines the base toolset BEFORE `tools.allow`/`tools.deny` are applied:**

| Profile | Base Toolset | Includes `exec`? |
|---------|--------------|------------------|
| `"messaging"` | Messaging-focused tools | ❌ NO |
| `"coding"` | Development tools | ✅ YES |
| `"full"` | All tools | ✅ YES |

**User's scenario:**
1. Installed 2026.3.2 → got `tools.profile = "messaging"` (old default)
2. Upgraded to 2026.3.7 → **profile NOT changed** (preserves user config)
3. Result: `exec` tool not available → agents can only display commands, not run them

## Impact
- **Affected**: Users who upgraded from 2026.3.2 (or earlier) with default/messaging profile
- **Severity**: Critical (core functionality broken)
- **Frequency**: 100% reproducible for affected users

## Solution Options

### Option 1: Config Migration (Recommended)
Add a config migration in 2026.3.8 that updates `tools.profile = "messaging"` → `"coding"` during upgrade.

**Pros:**
- Automatic fix for all users
- Preserves intent (restore exec tool access)

**Cons:**
- Changes user config without explicit consent
- May break users who INTENTIONALLY set messaging profile

### Option 2: Startup Warning
Detect `tools.profile = "messaging"` on startup and warn:
```
⚠️  Warning: tools.profile="messaging" doesn't include exec tool.
    Set tools.profile="coding" or tools.profile="full" to restore command execution.
    Run: openclaw config set tools.profile coding
```

**Pros:**
- User retains control
- Clear guidance

**Cons:**
- Requires manual action
- Users may miss the warning

### Option 3: Documentation + Doctor Check
Update docs and add `openclaw doctor` check for this common misconfiguration.

**Pros:**
- Non-invasive
- Discoverable via troubleshooting

**Cons:**
- Slowest to fix for users

## Recommended Fix (Hybrid Approach)
1. **Immediate** (2026.3.8):
   - Add config migration with opt-out flag
   - Add startup warning for messaging profile users
   - Update docs with troubleshooting section

2. **Long-term**:
   - Deprecate `"messaging"` profile (redirect to `"coding"` with warning)
   - Make tool profiles more flexible (per-category enables)

## Workaround for Users (Now)
```bash
# Option A: Switch to coding profile
openclaw config set tools.profile coding
openclaw gateway restart

# Option B: Switch to full profile
openclaw config set tools.profile full
openclaw gateway restart

# Option C: Manually allow exec tool
openclaw config set tools.alsoAllow '["exec"]'
openclaw gateway restart
```

## Testing Plan
1. Simulate upgrade from 2026.3.2 with `tools.profile = "messaging"`
2. Verify migration updates profile to `"coding"`
3. Verify exec tool becomes available
4. Verify users with explicit `"messaging"` intent can opt-out
5. Verify fresh installs get `"coding"` profile

## Related
- Changelog: #38241, #34958
- Profile docs: `/usr/lib/node_modules/openclaw/docs/tools/index.md`
