### PR TITLE
fix(reasoning-tags): fall back to tag-only removal when strict mode produces empty result

### DIFF
--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -197,6 +197,54 @@ describe("stripReasoningTagsFromText", () => {
     });
   });
 
+  describe("strict-mode empty-result fallback", () => {
+    it("falls back to tag-only removal when strict mode strips all content", () => {
+      const cases = [
+        {
+          name: "unclosed think tag wrapping entire response",
+          input: "<think>This is the full response text",
+          expected: "This is the full response text",
+        },
+        {
+          name: "closed think tags wrapping entire response",
+          input: "<think>This is the full response text</think>",
+          expected: "This is the full response text",
+        },
+        {
+          name: "thinking tag wrapping entire response",
+          input: "<thinking>Full response here</thinking>",
+          expected: "Full response here",
+        },
+        {
+          name: "unclosed thinking tag wrapping entire response",
+          input: "<thinking>Full response here",
+          expected: "Full response here",
+        },
+      ] as const;
+      for (const { name, input, expected } of cases) {
+        expect(stripReasoningTagsFromText(input, { mode: "strict" }), name).toBe(expected);
+      }
+    });
+
+    it("does not fall back when there is visible text outside tags", () => {
+      const input = "Before <think>hidden</think>";
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("Before");
+    });
+
+    it("does not fall back for whitespace-only input", () => {
+      const input = "   ";
+      // No thinking tags present, so input passes through unchanged
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("   ");
+    });
+
+    it("preserves content inside code blocks during fallback", () => {
+      const input = "<think>Use ```code``` in your response</think>";
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe(
+        "Use ```code``` in your response",
+      );
+    });
+  });
+
   describe("trim options", () => {
     it("applies configured trim strategies", () => {
       const cases = [

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -88,5 +88,17 @@ export function stripReasoningTagsFromText(
     result += cleaned.slice(lastIndex);
   }
 
-  return applyTrim(result, trimMode);
+  const trimmed = applyTrim(result, trimMode);
+
+  // When strict-mode stripping removes ALL visible text but the original had
+  // content, fall back to tag-only removal. This prevents silent response drops
+  // when models incorrectly wrap their entire response in <think> tags — a
+  // pattern observed with Gemini Flash during session startup sequences.
+  if (mode === "strict" && !trimmed && text.trim()) {
+    THINKING_TAG_RE.lastIndex = 0;
+    const tagOnly = cleaned.replace(THINKING_TAG_RE, "");
+    return applyTrim(tagOnly, trimMode);
+  }
+
+  return trimmed;
 }


### PR DESCRIPTION
## Summary

When models (e.g. Gemini Flash) incorrectly wrap their entire response in `<think>` tags — a pattern observed during session startup sequences — `stripReasoningTagsFromText` in strict mode strips ALL content, producing an empty string. This cascades through the delivery pipeline: `extractAssistantText` returns empty → payload builder produces zero payloads → the user sees "typing..." but receives no response ("No reply from agent.").

This PR adds a defensive fallback: when strict-mode stripping would produce an empty result but the original text had content, fall back to tag-only removal (stripping the `<think>`/`</think>` tags themselves while preserving the text between them).

### Affected callers (all use strict mode)
- `telegram/reasoning-lane-coordinator.ts`
- `discord/monitor/message-handler.process.ts`
- `agents/pi-embedded-utils.ts` (via `stripThinkingTagsFromText`)
- `agents/tools/message-tool.ts`
- `agents/tools/sessions-helpers.ts`

### Behavior change
| Input | Before | After |
|-------|--------|-------|
| `<think>Full response</think>` | `""` (empty) | `"Full response"` |
| `<think>Full response` (unclosed) | `""` (empty) | `"Full response"` |
| `Before <think>hidden</think>` | `"Before"` | `"Before"` (unchanged) |
| `<think>first</think>visible<think>second</think>` | `"visible"` | `"visible"` (unchanged) |

The fallback only activates when strict mode would otherwise produce an empty result — existing behavior for inputs with visible text outside tags is preserved.

## Test plan

- [x] Added test cases for the empty-result fallback (closed tags, unclosed tags, thinking variant)
- [x] Verified existing tests still pass (no regressions)
- [x] Verified fallback does NOT activate when visible text exists outside tags
- [x] All 16 reasoning-tags tests pass