### PR TITLE
fix: tighten sandbox base64 heuristic to reduce false positives

### DIFF
--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeEnvVars } from "./sanitize-env-vars.js";
+import { sanitizeEnvVars, validateEnvVarValue } from "./sanitize-env-vars.js";
 
 describe("sanitizeEnvVars", () => {
   it("keeps normal env vars and blocks obvious credentials", () => {
@@ -40,6 +40,44 @@ describe("sanitizeEnvVars", () => {
     expect(result.allowed).toEqual({ USER: "alice", SAFE_TEXT: base64Like });
     expect(result.blocked).toContain("NULL");
     expect(result.warnings).toContain("SAFE_TEXT: Value looks like base64-encoded credential data");
+  });
+
+  it("does not flag long alphanumeric strings without base64 characteristics", () => {
+    // A long hex string (e.g. SHA-256 hash repeated) — no +, /, or = so not base64
+    const longHex = "a]b]c".replace(/]/g, "").padEnd(80, "0").repeat(1).slice(0, 80);
+    const longAlphanumeric = "a]".replace(/]/g, "").padStart(1, "a").repeat(80).slice(0, 80);
+    expect(validateEnvVarValue(longHex)).toBeUndefined();
+    expect(validateEnvVarValue(longAlphanumeric)).toBeUndefined();
+
+    // 83 chars — not divisible by 4, even with base64 chars
+    const oddLength = "YWFh".repeat(20) + "YWF";
+    expect(oddLength.length).toBe(83);
+    expect(validateEnvVarValue(oddLength)).toBeUndefined();
+
+    // Long alphanumeric path or identifier (no +/=/): should not warn
+    const longPath = "abcdefghijklmnopqrstuvwxyz0123456789".repeat(3).slice(0, 80);
+    expect(validateEnvVarValue(longPath)).toBeUndefined();
+  });
+
+  it("flags actual base64-encoded credential data", () => {
+    // Valid base64: length 88 (divisible by 4), proper padding, contains +/=
+    const realBase64 =
+      "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==";
+    expect(realBase64.length % 4).toBe(0);
+    expect(validateEnvVarValue(realBase64)).toBe("Value looks like base64-encoded credential data");
+
+    // Valid base64 with + and / characters
+    const base64WithSpecials = "ABCD+/EF".repeat(10);
+    expect(base64WithSpecials.length).toBe(80);
+    expect(validateEnvVarValue(base64WithSpecials)).toBe(
+      "Value looks like base64-encoded credential data",
+    );
+
+    // Valid base64 with single = padding, length 84
+    const singlePad = "YWFhYWFh".repeat(10) + "YWE=";
+    expect(singlePad.length).toBe(84);
+    expect(singlePad.length % 4).toBe(0);
+    expect(validateEnvVarValue(singlePad)).toBe("Value looks like base64-encoded credential data");
   });
 
   it("supports strict mode with explicit allowlist", () => {

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -51,7 +51,8 @@ function looksLikeBase64Credential(value: string): boolean {
   if (value.length < 80 || value.length % 4 !== 0) {
     return false;
   }
-  // Must contain at least one of +, /, or = to distinguish from plain alphanumeric strings
+  // Must contain at least one of +, /, or = to distinguish from plain alphanumeric strings.
+  // Accepts ~7.7% false-negative rate: valid base64 using only [A-Za-z0-9] bypasses detection.
   if (!/[+/=]/.test(value)) {
     return false;
   }

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -42,6 +42,22 @@ export type EnvSanitizationOptions = {
   customAllowedPatterns?: ReadonlyArray<RegExp>;
 };
 
+/**
+ * Checks whether a value looks like base64-encoded credential data.
+ * Requires valid base64 structure: charset [A-Za-z0-9+/], length divisible
+ * by 4, and at most 2 trailing '=' padding characters.
+ */
+function looksLikeBase64Credential(value: string): boolean {
+  if (value.length < 80 || value.length % 4 !== 0) {
+    return false;
+  }
+  // Must contain at least one of +, /, or = to distinguish from plain alphanumeric strings
+  if (!/[+/=]/.test(value)) {
+    return false;
+  }
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+}
+
 export function validateEnvVarValue(value: string): string | undefined {
   if (value.includes("\0")) {
     return "Contains null bytes";
@@ -49,7 +65,7 @@ export function validateEnvVarValue(value: string): string | undefined {
   if (value.length > 32768) {
     return "Value exceeds maximum length";
   }
-  if (/^[A-Za-z0-9+/=]{80,}$/.test(value)) {
+  if (looksLikeBase64Credential(value)) {
     return "Value looks like base64-encoded credential data";
   }
   return undefined;


### PR DESCRIPTION
## Summary
- Tightened base64 detection regex to require valid base64 structure (length % 4 === 0, proper padding)
- Added requirement for at least one base64-specific character (+, /, or =) to avoid flagging plain alphanumeric strings
- Reduces false positives on legitimate long env var values

## Test plan
- [x] Added tests for false-positive cases (long hex/alphanumeric strings, odd-length strings)
- [x] Added tests for true-positive cases (real base64 with padding, base64 with +/ chars)
- [x] Existing tests still pass
- [x] pnpm check passes

Fixes #39680

🤖 AI-assisted