### PR TITLE
fix(session-store): display token usage even when only promptTokens is available

### DIFF
--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -79,26 +79,36 @@ export async function updateSessionStoreAfterAgentRun(params: {
   if (result.meta.systemPromptReport) {
     next.systemPromptReport = result.meta.systemPromptReport;
   }
+
+  // Always try to derive totalTokens, even if usage is incomplete.
+  // Some providers (e.g., Kimi) only return promptTokens without structured usage.
+  const totalTokens = deriveSessionTotalTokens({
+    usage,
+    contextTokens,
+    promptTokens,
+  });
+
   if (hasNonzeroUsage(usage)) {
     const input = usage.input ?? 0;
     const output = usage.output ?? 0;
-    const totalTokens = deriveSessionTotalTokens({
-      usage,
-      contextTokens,
-      promptTokens,
-    });
     next.inputTokens = input;
     next.outputTokens = output;
-    if (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0) {
-      next.totalTokens = totalTokens;
-      next.totalTokensFresh = true;
-    } else {
-      next.totalTokens = undefined;
-      next.totalTokensFresh = false;
-    }
     next.cacheRead = usage.cacheRead ?? 0;
     next.cacheWrite = usage.cacheWrite ?? 0;
   }
+
+  // Update totalTokens when valid token data is available,
+  // so promptTokens-only responses (e.g., Kimi) still display context usage.
+  // If no token data is available (e.g., aborted runs), preserve the previous value.
+  if (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0) {
+    next.totalTokens = totalTokens;
+    next.totalTokensFresh = true;
+  } else if (hasNonzeroUsage(usage) || (typeof promptTokens === "number" && Number.isFinite(promptTokens))) {
+    // If we have usage/promptTokens data but totalTokens is still invalid, mark as stale
+    next.totalTokens = undefined;
+    next.totalTokensFresh = false;
+  }
+  // Otherwise: no token data at all (aborted/failed run) — preserve previous totalTokens
   if (compactionsThisRun > 0) {
     next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;
   }


### PR DESCRIPTION
# Issue #39620 Root Cause Analysis & Fix

## Problem
Token usage displays as "unknown" in `openclaw status` and `openclaw sessions` after upgrading to 2026.3.7.

## Root Cause

### What Changed in 2026.3.7
The embedded Pi runner now produces **additional usage metadata fields**:
- `promptTokens` (from providers like Kimi that don't return structured `usage.input/output`)
- `lastCallUsage` (latest API call usage snapshot)

### The Bug
**Location**: `src/commands/agent/session-store.ts` lines 79-97

**Old Code**:
```typescript
if (hasNonzeroUsage(usage)) {
  const totalTokens = deriveSessionTotalTokens({ usage, contextTokens, promptTokens });
  next.totalTokens = totalTokens;
  // ... update other usage fields
}
```

**Problem**:
1. `hasNonzeroUsage(usage)` checks if `usage.input`, `usage.output`, `usage.cacheRead`, `usage.cacheWrite`, or `usage.total` are non-zero
2. When Kimi returns **only `promptTokens`** (no structured `usage` object), `hasNonzeroUsage(usage)` returns `false`
3. The entire token update block is **skipped**
4. `next.totalTokens` remains `undefined`
5. Display shows "unknown/256k (?%)"

### Why This Affects Kimi Specifically
Kimi (moonshot/kimi-k2.5) returns usage data in a different format:
- **Kimi**: Returns `promptTokens` directly, but `usage.input`/`usage.output` may be undefined
- **OpenAI-style**: Returns structured `usage: { input, output, total }`

## Solution

### Fix Strategy
**Decouple `totalTokens` calculation from `hasNonzeroUsage` check:**

1. **Always calculate `totalTokens`** (before checking `hasNonzeroUsage`)
2. `deriveSessionTotalTokens` already handles `promptTokens`-only cases gracefully
3. Update `totalTokens` **regardless** of whether `usage` is complete
4. Only update `inputTokens`/`outputTokens`/`cacheRead`/`cacheWrite` when `hasNonzeroUsage(usage)` is true

### Implementation
```typescript
// Always try to derive totalTokens, even if usage is incomplete
const totalTokens = deriveSessionTotalTokens({
  usage,
  contextTokens,
  promptTokens,  // ← This is the key! Works even when usage is incomplete
});

if (hasNonzeroUsage(usage)) {
  // Only update detailed usage fields when available
  next.inputTokens = usage.input ?? 0;
  next.outputTokens = usage.output ?? 0;
  next.cacheRead = usage.cacheRead ?? 0;
  next.cacheWrite = usage.cacheWrite ?? 0;
}

// Update totalTokens regardless (handles promptTokens-only cases)
if (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0) {
  next.totalTokens = totalTokens;
  next.totalTokensFresh = true;
} else {
  next.totalTokens = undefined;
  next.totalTokensFresh = false;
}
```

## Impact

### Before Fix
- **Kimi users**: Token usage shows "unknown" even though `promptTokens` is available
- **OpenAI-style**: Works fine (has structured `usage`)

### After Fix
- **Kimi users**: Token usage displays correctly using `promptTokens`
- **OpenAI-style**: Still works (backward compatible)
- **All providers**: `totalTokens` updated when ANY valid token data is available

## Testing

### Manual Verification
1. Use Kimi model (moonshot/kimi-k2.5)
2. Send a message
3. Run `openclaw status` or `openclaw sessions`
4. **Before**: Shows "unknown/256k (?%)"
5. **After**: Shows actual token usage (e.g., "83k/256k (32%)")

### Regression Protection
- Existing behavior for OpenAI-style providers: **Unchanged**
- Only fixes the `promptTokens`-only case that was broken in 2026.3.7

## Related

- **Changelog (2026.3.7)**: "... usage payloads, so session history/status no longer regress to unknown token utilization for otherwise successful runs."
  - The fix was **partially implemented** (added `promptTokens` support in runner)
  - But the **CLI session store write-back** wasn't updated to handle `promptTokens`-only cases
  - This PR completes the fix

- **User Report**: Issue #39620 by Alex Feng
- **Provider**: moonshot/kimi-k2.5
- **Working Version**: 2026.3.2
- **Broken Version**: 2026.3.7

## Files Modified
- `src/commands/agent/session-store.ts`: Decouple `totalTokens` calculation from `hasNonzeroUsage` guard
