### PR TITLE
Sandbox: fix Dockerized browser bridge and tab creation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12335,14 +12335,14 @@
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 651
+        "line_number": 655
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 684
+        "line_number": 688
       }
     ],
     "src/config/schema.irc.ts": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T14:28:30Z"
+  "generated_at": "2026-03-08T16:32:20Z"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       # - /var/run/docker.sock:/var/run/docker.sock
     # group_add:
     #   - "${DOCKER_GID:-999}"
+    extra_hosts:
+      # Let a Dockerized gateway reach sandbox browser ports published on the Docker host.
+      - "host.docker.internal:host-gateway"
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -29,6 +29,7 @@ function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxConte
     browserAllowHostControl: true,
     browser: {
       bridgeUrl: "http://localhost:9222",
+      advertisedBridgeUrl: "http://host.docker.internal:9222",
       noVncUrl: "http://localhost:6080",
       containerName: "openclaw-sbx-browser-test",
     },
@@ -50,7 +51,7 @@ describe("buildEmbeddedSandboxInfo", () => {
       containerWorkspaceDir: "/workspace",
       workspaceAccess: "none",
       agentWorkspaceMount: undefined,
-      browserBridgeUrl: "http://localhost:9222",
+      browserBridgeUrl: "http://host.docker.internal:9222",
       browserNoVncUrl: "http://localhost:6080",
       hostBrowserAllowed: true,
     });

--- a/src/agents/pi-embedded-runner/sandbox-info.ts
+++ b/src/agents/pi-embedded-runner/sandbox-info.ts
@@ -16,7 +16,8 @@ export function buildEmbeddedSandboxInfo(
     containerWorkspaceDir: sandbox.containerWorkdir,
     workspaceAccess: sandbox.workspaceAccess,
     agentWorkspaceMount: sandbox.workspaceAccess === "ro" ? "/agent" : undefined,
-    browserBridgeUrl: sandbox.browser?.bridgeUrl,
+    // Embedded sandbox consumers need the container-reachable bridge URL when it differs.
+    browserBridgeUrl: sandbox.browser?.advertisedBridgeUrl ?? sandbox.browser?.bridgeUrl,
     browserNoVncUrl: sandbox.browser?.noVncUrl,
     hostBrowserAllowed: sandbox.browserAllowHostControl,
     ...(elevatedAllowed

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -157,7 +157,8 @@ describe("ensureSandboxBrowser create args", () => {
       entry.startsWith("OPENCLAW_BROWSER_NOVNC_PASSWORD="),
     );
     expect(passwordEntry).toMatch(/^OPENCLAW_BROWSER_NOVNC_PASSWORD=[A-Za-z0-9]{8}$/);
-    expect(result?.bridgeUrl).toBe("http://host.docker.internal:19000");
+    expect(result?.bridgeUrl).toBe("http://127.0.0.1:19000");
+    expect(result?.advertisedBridgeUrl).toBe("http://host.docker.internal:19000");
     expect(result?.noVncUrl).toMatch(/^http:\/\/127\.0\.0\.1:19000\/sandbox\/novnc\?token=/);
     expect(result?.noVncUrl).not.toContain("password=");
     expect(bridgeMocks.startBrowserBridgeServer).toHaveBeenCalledWith(

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
-import { ensureSandboxBrowser } from "./browser.js";
+import {
+  applySandboxBridgeAccessToDockerConfig,
+  ensureSandboxBrowser,
+  resolveSandboxBridgeAccess,
+} from "./browser.js";
 import { resetNoVncObserverTokensForTests } from "./novnc-auth.js";
 import { collectDockerFlagValues, findDockerArgsCall } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
@@ -124,6 +128,7 @@ describe("ensureSandboxBrowser create args", () => {
       server: {} as never,
       port: 19000,
       baseUrl: "http://127.0.0.1:19000",
+      advertisedBaseUrl: "http://host.docker.internal:19000",
       state: {
         server: null,
         port: 19000,
@@ -152,8 +157,16 @@ describe("ensureSandboxBrowser create args", () => {
       entry.startsWith("OPENCLAW_BROWSER_NOVNC_PASSWORD="),
     );
     expect(passwordEntry).toMatch(/^OPENCLAW_BROWSER_NOVNC_PASSWORD=[A-Za-z0-9]{8}$/);
+    expect(result?.bridgeUrl).toBe("http://host.docker.internal:19000");
     expect(result?.noVncUrl).toMatch(/^http:\/\/127\.0\.0\.1:19000\/sandbox\/novnc\?token=/);
     expect(result?.noVncUrl).not.toContain("password=");
+    expect(bridgeMocks.startBrowserBridgeServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: "0.0.0.0",
+        advertisedHost: "host.docker.internal",
+        allowNonLoopbackHost: true,
+      }),
+    );
   });
 
   it("does not inject noVNC password env when noVNC is disabled", async () => {
@@ -205,5 +218,39 @@ describe("ensureSandboxBrowser create args", () => {
     expect(createArgs).toBeDefined();
     expect(createArgs).toContain("/tmp/workspace:/workspace");
     expect(createArgs).not.toContain("/tmp/workspace:/workspace:ro");
+  });
+
+  it("adds host-gateway alias for linux sandbox containers", () => {
+    const resolved = applySandboxBridgeAccessToDockerConfig({
+      cfg: buildConfig(false),
+      platform: "linux",
+    });
+
+    expect(resolved.docker.extraHosts).toContain("host.docker.internal:host-gateway");
+  });
+
+  it("does not duplicate host-gateway alias when already configured", () => {
+    const cfg = buildConfig(false);
+    cfg.docker.extraHosts = ["host.docker.internal:host-gateway"];
+
+    const resolved = applySandboxBridgeAccessToDockerConfig({
+      cfg,
+      platform: "linux",
+    });
+
+    expect(resolved.docker.extraHosts).toEqual(["host.docker.internal:host-gateway"]);
+  });
+
+  it("honors explicit bridgeHost override", () => {
+    const access = resolveSandboxBridgeAccess({
+      browserHost: "gateway.internal",
+      dockerExtraHosts: [],
+      platform: "linux",
+    });
+
+    expect(access).toEqual({
+      listenHost: "0.0.0.0",
+      advertisedHost: "gateway.internal",
+    });
   });
 });

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -3,6 +3,7 @@ import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import {
   applySandboxBridgeAccessToDockerConfig,
   ensureSandboxBrowser,
+  resolveSandboxBrowserCdpTarget,
   isDockerizedSandboxGatewayRuntime,
   resolveSandboxBrowserCdpHost,
   resolveSandboxBridgeAccess,
@@ -263,10 +264,36 @@ describe("ensureSandboxBrowser create args", () => {
     );
   });
 
+  it("uses the mapped CDP port for non-Dockerized gateway runtimes", async () => {
+    await expect(
+      resolveSandboxBrowserCdpTarget({
+        dockerizedGatewayRuntime: false,
+        mappedCdpPort: 49100,
+        internalCdpPort: 9222,
+      }),
+    ).resolves.toEqual({
+      host: "127.0.0.1",
+      port: 49100,
+    });
+  });
+
   it("falls back to the Docker host alias when no direct gateway network path is available", async () => {
     await expect(resolveSandboxBrowserCdpHost({ dockerizedGatewayRuntime: true })).resolves.toBe(
       "host.docker.internal",
     );
+  });
+
+  it("falls back to the mapped CDP port when only the Docker host alias is available", async () => {
+    await expect(
+      resolveSandboxBrowserCdpTarget({
+        dockerizedGatewayRuntime: true,
+        mappedCdpPort: 49100,
+        internalCdpPort: 9222,
+      }),
+    ).resolves.toEqual({
+      host: "host.docker.internal",
+      port: 49100,
+    });
   });
 
   it("detects Dockerized gateway runtime only when both dockerenv and docker.sock exist", () => {
@@ -299,6 +326,11 @@ describe("ensureSandboxBrowser create args", () => {
         resolved: expect.objectContaining({
           cdpHost: "gateway-host.internal",
           cdpIsLoopback: false,
+          profiles: {
+            openclaw: expect.objectContaining({
+              cdpPort: 49100,
+            }),
+          },
         }),
       }),
     );
@@ -359,6 +391,17 @@ describe("ensureSandboxBrowser create args", () => {
           dockerizedGatewayRuntime: true,
         }),
       ).resolves.toBe("172.18.0.3");
+      await expect(
+        resolveSandboxBrowserCdpTarget({
+          containerName: "sandbox-browser",
+          dockerizedGatewayRuntime: true,
+          mappedCdpPort: 49100,
+          internalCdpPort: 9222,
+        }),
+      ).resolves.toEqual({
+        host: "172.18.0.3",
+        port: 9222,
+      });
       expect(dockerMocks.execDocker).toHaveBeenCalledWith(
         ["network", "connect", "--alias", "sandbox-browser", "openclaw_default", "sandbox-browser"],
         { allowFailure: true },

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -3,6 +3,8 @@ import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import {
   applySandboxBridgeAccessToDockerConfig,
   ensureSandboxBrowser,
+  isDockerizedSandboxGatewayRuntime,
+  resolveSandboxBrowserCdpHost,
   resolveSandboxBridgeAccess,
 } from "./browser.js";
 import { resetNoVncObserverTokensForTests } from "./novnc-auth.js";
@@ -253,5 +255,116 @@ describe("ensureSandboxBrowser create args", () => {
       listenHost: "0.0.0.0",
       advertisedHost: "gateway.internal",
     });
+  });
+
+  it("defaults sandbox browser CDP host to loopback outside Dockerized gateway runtimes", async () => {
+    await expect(resolveSandboxBrowserCdpHost({ dockerizedGatewayRuntime: false })).resolves.toBe(
+      "127.0.0.1",
+    );
+  });
+
+  it("falls back to the Docker host alias when no direct gateway network path is available", async () => {
+    await expect(resolveSandboxBrowserCdpHost({ dockerizedGatewayRuntime: true })).resolves.toBe(
+      "host.docker.internal",
+    );
+  });
+
+  it("detects Dockerized gateway runtime only when both dockerenv and docker.sock exist", () => {
+    const paths = new Set(["/.dockerenv", "/var/run/docker.sock"]);
+    expect(
+      isDockerizedSandboxGatewayRuntime({
+        existsSync: (path) => paths.has(path),
+      }),
+    ).toBe(true);
+    expect(
+      isDockerizedSandboxGatewayRuntime({
+        existsSync: (path) => path === "/.dockerenv",
+      }),
+    ).toBe(false);
+  });
+
+  it("passes an explicit sandbox browser cdpHost into the bridge config", async () => {
+    const cfg = buildConfig(false);
+    cfg.browser.cdpHost = "gateway-host.internal";
+
+    await ensureSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    expect(bridgeMocks.startBrowserBridgeServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolved: expect.objectContaining({
+          cdpHost: "gateway-host.internal",
+          cdpIsLoopback: false,
+        }),
+      }),
+    );
+  });
+
+  it("uses the browser container IP on the shared gateway network for Dockerized runtimes", async () => {
+    const originalHostname = process.env.HOSTNAME;
+    try {
+      process.env.HOSTNAME = "gateway-container";
+      let browserInspectCount = 0;
+      dockerMocks.execDocker.mockImplementation(async (args: string[]) => {
+        if (args[0] === "inspect" && args[1] === "gateway-container") {
+          return {
+            stdout: JSON.stringify([
+              {
+                NetworkSettings: {
+                  Networks: {
+                    openclaw_default: { IPAddress: "172.18.0.2" },
+                  },
+                },
+              },
+            ]),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (args[0] === "inspect" && args[1] === "sandbox-browser") {
+          browserInspectCount += 1;
+          return {
+            stdout: JSON.stringify([
+              {
+                NetworkSettings: {
+                  Networks:
+                    browserInspectCount === 1
+                      ? {}
+                      : {
+                          openclaw_default: { IPAddress: "172.18.0.3" },
+                        },
+                },
+              },
+            ]),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (args[0] === "network" && args[1] === "connect") {
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args[0] === "image" && args[1] === "inspect") {
+          return { stdout: "[]", stderr: "", code: 0 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      });
+
+      await expect(
+        resolveSandboxBrowserCdpHost({
+          containerName: "sandbox-browser",
+          dockerizedGatewayRuntime: true,
+        }),
+      ).resolves.toBe("172.18.0.3");
+      expect(dockerMocks.execDocker).toHaveBeenCalledWith(
+        ["network", "connect", "--alias", "sandbox-browser", "openclaw_default", "sandbox-browser"],
+        { allowFailure: true },
+      );
+    } finally {
+      process.env.HOSTNAME = originalHostname;
+    }
   });
 });

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -37,6 +37,74 @@ import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
 
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
+const SANDBOX_BRIDGE_CONTAINER_HOST = "host.docker.internal";
+const SANDBOX_BRIDGE_HOST_GATEWAY = `${SANDBOX_BRIDGE_CONTAINER_HOST}:host-gateway`;
+
+type SandboxBridgeAccess = {
+  listenHost: string;
+  advertisedHost: string;
+  requiredExtraHost?: string;
+};
+
+function uniqueExtraHosts(extraHosts: string[] | undefined, entry: string): string[] {
+  const merged = [...(extraHosts ?? [])];
+  if (!merged.includes(entry)) {
+    merged.push(entry);
+  }
+  return merged;
+}
+
+export function resolveSandboxBridgeAccess(params: {
+  browserHost?: string;
+  dockerExtraHosts?: string[];
+  platform?: NodeJS.Platform;
+}): SandboxBridgeAccess {
+  const configuredHost = params.browserHost?.trim();
+  if (configuredHost) {
+    return {
+      listenHost: "0.0.0.0",
+      advertisedHost: configuredHost,
+    };
+  }
+  if (params.platform === "linux") {
+    const hasHostGatewayAlias = (params.dockerExtraHosts ?? []).some(
+      (entry) => entry.trim() === SANDBOX_BRIDGE_HOST_GATEWAY,
+    );
+    return {
+      listenHost: "0.0.0.0",
+      advertisedHost: SANDBOX_BRIDGE_CONTAINER_HOST,
+      requiredExtraHost: hasHostGatewayAlias ? undefined : SANDBOX_BRIDGE_HOST_GATEWAY,
+    };
+  }
+  return {
+    listenHost: "0.0.0.0",
+    advertisedHost: SANDBOX_BRIDGE_CONTAINER_HOST,
+  };
+}
+
+export function applySandboxBridgeAccessToDockerConfig(params: {
+  cfg: SandboxConfig;
+  platform?: NodeJS.Platform;
+}): SandboxConfig {
+  if (!params.cfg.browser.enabled) {
+    return params.cfg;
+  }
+  const access = resolveSandboxBridgeAccess({
+    browserHost: params.cfg.browser.bridgeHost,
+    dockerExtraHosts: params.cfg.docker.extraHosts,
+    platform: params.platform ?? process.platform,
+  });
+  if (!access.requiredExtraHost) {
+    return params.cfg;
+  }
+  return {
+    ...params.cfg,
+    docker: {
+      ...params.cfg.docker,
+      extraHosts: uniqueExtraHosts(params.cfg.docker.extraHosts, access.requiredExtraHost),
+    },
+  };
+}
 
 async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
@@ -329,6 +397,12 @@ export async function ensureSandboxBrowser(params: {
       return bridge;
     }
 
+    const bridgeAccess = resolveSandboxBridgeAccess({
+      browserHost: params.cfg.browser.bridgeHost,
+      dockerExtraHosts: params.cfg.docker.extraHosts,
+      platform: process.platform,
+    });
+
     const onEnsureAttachTarget = params.cfg.browser.autoStart
       ? async () => {
           const state = await dockerContainerState(containerName);
@@ -354,6 +428,9 @@ export async function ensureSandboxBrowser(params: {
         headless: params.cfg.browser.headless,
         evaluateEnabled: params.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED,
       }),
+      host: bridgeAccess.listenHost,
+      advertisedHost: bridgeAccess.advertisedHost,
+      allowNonLoopbackHost: bridgeAccess.listenHost !== "127.0.0.1",
       authToken: desiredAuthToken,
       authPassword: desiredAuthPassword,
       onEnsureAttachTarget,
@@ -394,7 +471,7 @@ export async function ensureSandboxBrowser(params: {
       : undefined;
 
   return {
-    bridgeUrl: resolvedBridge.baseUrl,
+    bridgeUrl: resolvedBridge.advertisedBaseUrl,
     noVncUrl,
     containerName,
   };

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -471,7 +471,12 @@ export async function ensureSandboxBrowser(params: {
       : undefined;
 
   return {
-    bridgeUrl: resolvedBridge.advertisedBaseUrl,
+    // Keep the host-local bridge URL for host-side browser tool calls so loopback auth still applies.
+    bridgeUrl: resolvedBridge.baseUrl,
+    advertisedBridgeUrl:
+      resolvedBridge.advertisedBaseUrl === resolvedBridge.baseUrl
+        ? undefined
+        : resolvedBridge.advertisedBaseUrl,
     noVncUrl,
     containerName,
   };

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -151,6 +151,11 @@ export function isDockerizedSandboxGatewayRuntime(params?: {
   return existsSync(DOCKER_ENV_MARKER) && existsSync(DOCKER_SOCKET_PATH);
 }
 
+type ResolvedSandboxBrowserCdpTarget = {
+  host: string;
+  port: number;
+};
+
 async function inspectDockerNetworks(containerName: string): Promise<DockerNetworkMap> {
   const result = await execDocker(["inspect", containerName], { allowFailure: true });
   if (result.code !== 0) {
@@ -245,6 +250,48 @@ export async function resolveSandboxBrowserCdpHost(params: {
     }
   }
   return SANDBOX_BRIDGE_CONTAINER_HOST;
+}
+
+export async function resolveSandboxBrowserCdpTarget(params: {
+  containerName?: string;
+  cdpHost?: string;
+  dockerizedGatewayRuntime?: boolean;
+  mappedCdpPort: number;
+  internalCdpPort: number;
+}): Promise<ResolvedSandboxBrowserCdpTarget> {
+  const configuredHost = params.cdpHost?.trim();
+  if (configuredHost) {
+    return {
+      host: configuredHost,
+      port: params.mappedCdpPort,
+    };
+  }
+  if (!params.dockerizedGatewayRuntime) {
+    return {
+      host: "127.0.0.1",
+      port: params.mappedCdpPort,
+    };
+  }
+  if (params.containerName) {
+    const gatewayNetwork = await resolveDockerizedGatewayNetworkName();
+    if (gatewayNetwork) {
+      const networkIp = await ensureContainerNetworkIp({
+        containerName: params.containerName,
+        network: gatewayNetwork,
+        alias: params.containerName,
+      });
+      if (networkIp) {
+        return {
+          host: networkIp,
+          port: params.internalCdpPort,
+        };
+      }
+    }
+  }
+  return {
+    host: SANDBOX_BRIDGE_CONTAINER_HOST,
+    port: params.mappedCdpPort,
+  };
 }
 
 function buildSandboxBrowserResolvedConfig(params: {
@@ -463,10 +510,12 @@ export async function ensureSandboxBrowser(params: {
   if (!mappedCdp) {
     throw new Error(`Failed to resolve CDP port mapping for ${containerName}.`);
   }
-  const sandboxCdpHost = await resolveSandboxBrowserCdpHost({
+  const sandboxCdpTarget = await resolveSandboxBrowserCdpTarget({
     containerName,
     cdpHost: params.cfg.browser.cdpHost,
     dockerizedGatewayRuntime: isDockerizedSandboxGatewayRuntime(),
+    mappedCdpPort: mappedCdp,
+    internalCdpPort: params.cfg.browser.cdpPort,
   });
 
   const mappedNoVnc = noVncEnabled
@@ -498,8 +547,8 @@ export async function ensureSandboxBrowser(params: {
   const shouldReuse =
     existing &&
     existing.containerName === containerName &&
-    existingProfile?.cdpPort === mappedCdp &&
-    existing.bridge.state.resolved.cdpHost === sandboxCdpHost;
+    existingProfile?.cdpPort === sandboxCdpTarget.port &&
+    existing.bridge.state.resolved.cdpHost === sandboxCdpTarget.host;
   const authMatches =
     !existing ||
     (existing.authToken === desiredAuthToken && existing.authPassword === desiredAuthPassword);
@@ -537,13 +586,13 @@ export async function ensureSandboxBrowser(params: {
             await execDocker(["start", containerName]);
           }
           const ok = await waitForSandboxCdp({
-            cdpHost: sandboxCdpHost,
-            cdpPort: mappedCdp,
+            cdpHost: sandboxCdpTarget.host,
+            cdpPort: sandboxCdpTarget.port,
             timeoutMs: params.cfg.browser.autoStartTimeoutMs,
           });
           if (!ok) {
             throw new Error(
-              `Sandbox browser CDP did not become reachable on ${sandboxCdpHost}:${mappedCdp} within ${params.cfg.browser.autoStartTimeoutMs}ms.`,
+              `Sandbox browser CDP did not become reachable on ${sandboxCdpTarget.host}:${sandboxCdpTarget.port} within ${params.cfg.browser.autoStartTimeoutMs}ms.`,
             );
           }
         }
@@ -552,8 +601,8 @@ export async function ensureSandboxBrowser(params: {
     return await startBrowserBridgeServer({
       resolved: buildSandboxBrowserResolvedConfig({
         controlPort: 0,
-        cdpHost: sandboxCdpHost,
-        cdpPort: mappedCdp,
+        cdpHost: sandboxCdpTarget.host,
+        cdpPort: sandboxCdpTarget.port,
         headless: params.cfg.browser.headless,
         evaluateEnabled: params.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED,
       }),

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "../../browser/bridge-server.js";
 import { type ResolvedBrowserConfig, resolveProfile } from "../../browser/config.js";
 import {
@@ -7,6 +8,7 @@ import {
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "../../browser/constants.js";
 import { deriveDefaultBrowserCdpPortRange } from "../../config/port-defaults.js";
+import { isLoopbackHost } from "../../gateway/net.js";
 import { defaultRuntime } from "../../runtime.js";
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import { computeSandboxBrowserConfigHash } from "./config-hash.js";
@@ -39,12 +41,21 @@ const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
 const SANDBOX_BRIDGE_CONTAINER_HOST = "host.docker.internal";
 const SANDBOX_BRIDGE_HOST_GATEWAY = `${SANDBOX_BRIDGE_CONTAINER_HOST}:host-gateway`;
+const DOCKER_ENV_MARKER = "/.dockerenv";
+const DOCKER_SOCKET_PATH = "/var/run/docker.sock";
 
 type SandboxBridgeAccess = {
   listenHost: string;
   advertisedHost: string;
   requiredExtraHost?: string;
 };
+
+type DockerNetworkMap = Record<
+  string,
+  {
+    IPAddress?: string;
+  }
+>;
 
 function uniqueExtraHosts(extraHosts: string[] | undefined, entry: string): string[] {
   const merged = [...(extraHosts ?? [])];
@@ -106,9 +117,13 @@ export function applySandboxBridgeAccessToDockerConfig(params: {
   };
 }
 
-async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
+async function waitForSandboxCdp(params: {
+  cdpHost: string;
+  cdpPort: number;
+  timeoutMs: number;
+}): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
-  const url = `http://127.0.0.1:${params.cdpPort}/json/version`;
+  const url = `http://${params.cdpHost}:${params.cdpPort}/json/version`;
   while (Date.now() < deadline) {
     try {
       const ctrl = new AbortController();
@@ -129,13 +144,117 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
   return false;
 }
 
+export function isDockerizedSandboxGatewayRuntime(params?: {
+  existsSync?: (path: string) => boolean;
+}): boolean {
+  const existsSync = params?.existsSync ?? fs.existsSync;
+  return existsSync(DOCKER_ENV_MARKER) && existsSync(DOCKER_SOCKET_PATH);
+}
+
+async function inspectDockerNetworks(containerName: string): Promise<DockerNetworkMap> {
+  const result = await execDocker(["inspect", containerName], { allowFailure: true });
+  if (result.code !== 0) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(result.stdout) as Array<{
+      NetworkSettings?: { Networks?: DockerNetworkMap };
+    }>;
+    return parsed[0]?.NetworkSettings?.Networks ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function pickDockerGatewayNetworkName(networks: DockerNetworkMap): string | null {
+  for (const name of Object.keys(networks)) {
+    const normalized = name.trim().toLowerCase();
+    if (!normalized || normalized === "host" || normalized === "none") {
+      continue;
+    }
+    return name;
+  }
+  return null;
+}
+
+async function resolveDockerizedGatewayNetworkName(): Promise<string | null> {
+  const gatewayContainerName = process.env.HOSTNAME?.trim();
+  if (!gatewayContainerName) {
+    return null;
+  }
+  return pickDockerGatewayNetworkName(await inspectDockerNetworks(gatewayContainerName));
+}
+
+async function ensureContainerNetworkIp(params: {
+  containerName: string;
+  network: string;
+  alias?: string;
+}): Promise<string | null> {
+  const currentNetworks = await inspectDockerNetworks(params.containerName);
+  const existingIp = currentNetworks[params.network]?.IPAddress?.trim();
+  if (existingIp) {
+    return existingIp;
+  }
+
+  const connectArgs = ["network", "connect"];
+  const alias = params.alias?.trim();
+  if (alias) {
+    connectArgs.push("--alias", alias);
+  }
+  connectArgs.push(params.network, params.containerName);
+  const connectResult = await execDocker(connectArgs, { allowFailure: true });
+  if (connectResult.code !== 0) {
+    const detail = [connectResult.stderr.trim(), connectResult.stdout.trim()]
+      .filter(Boolean)
+      .join(" ");
+    if (!/already exists|already connected/i.test(detail)) {
+      throw new Error(
+        `Failed to connect sandbox browser ${params.containerName} to Docker network ${params.network}: ${detail || `exit ${connectResult.code}`}`,
+      );
+    }
+  }
+
+  const updatedNetworks = await inspectDockerNetworks(params.containerName);
+  const updatedIp = updatedNetworks[params.network]?.IPAddress?.trim();
+  return updatedIp || null;
+}
+
+export async function resolveSandboxBrowserCdpHost(params: {
+  containerName?: string;
+  cdpHost?: string;
+  dockerizedGatewayRuntime?: boolean;
+}): Promise<string> {
+  const configuredHost = params.cdpHost?.trim();
+  if (configuredHost) {
+    return configuredHost;
+  }
+  if (!params.dockerizedGatewayRuntime) {
+    return "127.0.0.1";
+  }
+  if (params.containerName) {
+    const gatewayNetwork = await resolveDockerizedGatewayNetworkName();
+    if (gatewayNetwork) {
+      const networkIp = await ensureContainerNetworkIp({
+        containerName: params.containerName,
+        network: gatewayNetwork,
+        alias: params.containerName,
+      });
+      if (networkIp) {
+        return networkIp;
+      }
+    }
+  }
+  return SANDBOX_BRIDGE_CONTAINER_HOST;
+}
+
 function buildSandboxBrowserResolvedConfig(params: {
   controlPort: number;
+  cdpHost: string;
   cdpPort: number;
   headless: boolean;
   evaluateEnabled: boolean;
 }): ResolvedBrowserConfig {
-  const cdpHost = "127.0.0.1";
+  const cdpHost = params.cdpHost;
   const cdpPortRange = deriveDefaultBrowserCdpPortRange(params.controlPort);
   return {
     enabled: true,
@@ -143,7 +262,7 @@ function buildSandboxBrowserResolvedConfig(params: {
     controlPort: params.controlPort,
     cdpProtocol: "http",
     cdpHost,
-    cdpIsLoopback: true,
+    cdpIsLoopback: isLoopbackHost(cdpHost),
     cdpPortRangeStart: cdpPortRange.start,
     cdpPortRangeEnd: cdpPortRange.end,
     remoteCdpTimeoutMs: 1500,
@@ -344,6 +463,11 @@ export async function ensureSandboxBrowser(params: {
   if (!mappedCdp) {
     throw new Error(`Failed to resolve CDP port mapping for ${containerName}.`);
   }
+  const sandboxCdpHost = await resolveSandboxBrowserCdpHost({
+    containerName,
+    cdpHost: params.cfg.browser.cdpHost,
+    dockerizedGatewayRuntime: isDockerizedSandboxGatewayRuntime(),
+  });
 
   const mappedNoVnc = noVncEnabled
     ? await readDockerPort(containerName, params.cfg.browser.noVncPort)
@@ -372,7 +496,10 @@ export async function ensureSandboxBrowser(params: {
   }
 
   const shouldReuse =
-    existing && existing.containerName === containerName && existingProfile?.cdpPort === mappedCdp;
+    existing &&
+    existing.containerName === containerName &&
+    existingProfile?.cdpPort === mappedCdp &&
+    existing.bridge.state.resolved.cdpHost === sandboxCdpHost;
   const authMatches =
     !existing ||
     (existing.authToken === desiredAuthToken && existing.authPassword === desiredAuthPassword);
@@ -410,12 +537,13 @@ export async function ensureSandboxBrowser(params: {
             await execDocker(["start", containerName]);
           }
           const ok = await waitForSandboxCdp({
+            cdpHost: sandboxCdpHost,
             cdpPort: mappedCdp,
             timeoutMs: params.cfg.browser.autoStartTimeoutMs,
           });
           if (!ok) {
             throw new Error(
-              `Sandbox browser CDP did not become reachable on 127.0.0.1:${mappedCdp} within ${params.cfg.browser.autoStartTimeoutMs}ms.`,
+              `Sandbox browser CDP did not become reachable on ${sandboxCdpHost}:${mappedCdp} within ${params.cfg.browser.autoStartTimeoutMs}ms.`,
             );
           }
         }
@@ -424,6 +552,7 @@ export async function ensureSandboxBrowser(params: {
     return await startBrowserBridgeServer({
       resolved: buildSandboxBrowserResolvedConfig({
         controlPort: 0,
+        cdpHost: sandboxCdpHost,
         cdpPort: mappedCdp,
         headless: params.cfg.browser.headless,
         evaluateEnabled: params.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED,

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -137,6 +137,7 @@ export function resolveSandboxBrowserConfig(params: {
       globalBrowser?.containerPrefix ??
       DEFAULT_SANDBOX_BROWSER_PREFIX,
     network: agentBrowser?.network ?? globalBrowser?.network ?? DEFAULT_SANDBOX_BROWSER_NETWORK,
+    bridgeHost: agentBrowser?.bridgeHost ?? globalBrowser?.bridgeHost,
     cdpPort: agentBrowser?.cdpPort ?? globalBrowser?.cdpPort ?? DEFAULT_SANDBOX_BROWSER_CDP_PORT,
     cdpSourceRange: agentBrowser?.cdpSourceRange ?? globalBrowser?.cdpSourceRange,
     vncPort: agentBrowser?.vncPort ?? globalBrowser?.vncPort ?? DEFAULT_SANDBOX_BROWSER_VNC_PORT,

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -138,6 +138,7 @@ export function resolveSandboxBrowserConfig(params: {
       DEFAULT_SANDBOX_BROWSER_PREFIX,
     network: agentBrowser?.network ?? globalBrowser?.network ?? DEFAULT_SANDBOX_BROWSER_NETWORK,
     bridgeHost: agentBrowser?.bridgeHost ?? globalBrowser?.bridgeHost,
+    cdpHost: agentBrowser?.cdpHost ?? globalBrowser?.cdpHost,
     cdpPort: agentBrowser?.cdpPort ?? globalBrowser?.cdpPort ?? DEFAULT_SANDBOX_BROWSER_CDP_PORT,
     cdpSourceRange: agentBrowser?.cdpSourceRange ?? globalBrowser?.cdpSourceRange,
     vncPort: agentBrowser?.vncPort ?? globalBrowser?.vncPort ?? DEFAULT_SANDBOX_BROWSER_VNC_PORT,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -7,7 +7,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { resolveUserPath } from "../../utils.js";
 import { syncSkillsToWorkspace } from "../skills.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "../workspace.js";
-import { ensureSandboxBrowser } from "./browser.js";
+import { applySandboxBridgeAccessToDockerConfig, ensureSandboxBrowser } from "./browser.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
 import { ensureSandboxContainer } from "./docker.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
@@ -129,7 +129,9 @@ export async function resolveSandboxContext(params: {
     docker: cfg.docker,
     workspaceDir,
   });
-  const resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
+  const resolvedCfg = applySandboxBridgeAccessToDockerConfig({
+    cfg: docker === cfg.docker ? cfg : { ...cfg, docker },
+  });
 
   const containerName = await ensureSandboxContainer({
     sessionKey: rawSessionKey,

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -65,7 +65,10 @@ export type SandboxConfig = {
 };
 
 export type SandboxBrowserContext = {
+  // Host-side tools still talk to the local bridge URL so loopback auth keeps working.
   bridgeUrl: string;
+  // Sandboxed agents/containers need a separately advertised, container-reachable URL.
+  advertisedBridgeUrl?: string;
   noVncUrl?: string;
   containerName: string;
 };

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -33,6 +33,7 @@ export type SandboxBrowserConfig = {
   image: string;
   containerPrefix: string;
   network: string;
+  bridgeHost?: string;
   cdpPort: number;
   cdpSourceRange?: string;
   vncPort: number;

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -34,6 +34,7 @@ export type SandboxBrowserConfig = {
   containerPrefix: string;
   network: string;
   bridgeHost?: string;
+  cdpHost?: string;
   cdpPort: number;
   cdpSourceRange?: string;
   vncPort: number;

--- a/src/browser/bridge-server.auth.test.ts
+++ b/src/browser/bridge-server.auth.test.ts
@@ -82,6 +82,20 @@ describe("startBrowserBridgeServer auth", () => {
     ).rejects.toThrow(/requires auth/i);
   });
 
+  it("allows sandbox bridge servers to bind non-loopback when explicitly enabled", async () => {
+    const bridge = await startBrowserBridgeServer({
+      resolved: buildResolvedConfig(),
+      host: "0.0.0.0",
+      advertisedHost: "host.docker.internal",
+      allowNonLoopbackHost: true,
+      authToken: "secret-token",
+    });
+    servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
+
+    expect(bridge.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(bridge.advertisedBaseUrl).toMatch(/^http:\/\/host\.docker\.internal:\d+$/);
+  });
+
   it("serves noVNC bootstrap html without leaking password in Location header", async () => {
     const bridge = await startBrowserBridgeServer({
       resolved: buildResolvedConfig(),

--- a/src/browser/bridge-server.auth.test.ts
+++ b/src/browser/bridge-server.auth.test.ts
@@ -96,6 +96,17 @@ describe("startBrowserBridgeServer auth", () => {
     expect(bridge.advertisedBaseUrl).toMatch(/^http:\/\/host\.docker\.internal:\d+$/);
   });
 
+  it("requires advertisedHost when non-loopback bind is enabled", async () => {
+    await expect(
+      startBrowserBridgeServer({
+        resolved: buildResolvedConfig(),
+        host: "0.0.0.0",
+        allowNonLoopbackHost: true,
+        authToken: "secret-token",
+      }),
+    ).rejects.toThrow(/advertisedHost is required/i);
+  });
+
   it("serves noVNC bootstrap html without leaking password in Location header", async () => {
     const bridge = await startBrowserBridgeServer({
       resolved: buildResolvedConfig(),

--- a/src/browser/bridge-server.ts
+++ b/src/browser/bridge-server.ts
@@ -69,12 +69,15 @@ export async function startBrowserBridgeServer(params: {
   resolveSandboxNoVncToken?: (token: string) => ResolvedNoVncObserver | null;
 }): Promise<BrowserBridge> {
   const host = params.host ?? "127.0.0.1";
-  if (!params.allowNonLoopbackHost && !isLoopbackHost(host)) {
+  const isLoopback = isLoopbackHost(host);
+  if (!params.allowNonLoopbackHost && !isLoopback) {
     throw new Error(`bridge server must bind to loopback host (got ${host})`);
   }
   const port = params.port ?? 0;
-  const advertisedHost =
-    params.advertisedHost?.trim() || (isLoopbackHost(host) ? host : "127.0.0.1");
+  const advertisedHost = params.advertisedHost?.trim() || (isLoopback ? host : undefined);
+  if (!advertisedHost) {
+    throw new Error("advertisedHost is required when binding to a non-loopback host");
+  }
 
   const app = express();
   installBrowserCommonMiddleware(app);
@@ -132,7 +135,7 @@ export async function startBrowserBridgeServer(params: {
 
   setBridgeAuthForPort(resolvedPort, { token: authToken, password: authPassword });
 
-  const baseUrl = `http://${isLoopbackHost(host) ? host : "127.0.0.1"}:${resolvedPort}`;
+  const baseUrl = `http://${isLoopback ? host : "127.0.0.1"}:${resolvedPort}`;
   const advertisedBaseUrl = `http://${advertisedHost}:${resolvedPort}`;
   return { server, port: resolvedPort, baseUrl, advertisedBaseUrl, state };
 }

--- a/src/browser/bridge-server.ts
+++ b/src/browser/bridge-server.ts
@@ -20,6 +20,7 @@ export type BrowserBridge = {
   server: Server;
   port: number;
   baseUrl: string;
+  advertisedBaseUrl: string;
   state: BrowserServerState;
 };
 
@@ -59,17 +60,21 @@ function buildNoVncBootstrapHtml(params: ResolvedNoVncObserver): string {
 export async function startBrowserBridgeServer(params: {
   resolved: ResolvedBrowserConfig;
   host?: string;
+  advertisedHost?: string;
   port?: number;
   authToken?: string;
   authPassword?: string;
+  allowNonLoopbackHost?: boolean;
   onEnsureAttachTarget?: (profile: ProfileContext["profile"]) => Promise<void>;
   resolveSandboxNoVncToken?: (token: string) => ResolvedNoVncObserver | null;
 }): Promise<BrowserBridge> {
   const host = params.host ?? "127.0.0.1";
-  if (!isLoopbackHost(host)) {
+  if (!params.allowNonLoopbackHost && !isLoopbackHost(host)) {
     throw new Error(`bridge server must bind to loopback host (got ${host})`);
   }
   const port = params.port ?? 0;
+  const advertisedHost =
+    params.advertisedHost?.trim() || (isLoopbackHost(host) ? host : "127.0.0.1");
 
   const app = express();
   installBrowserCommonMiddleware(app);
@@ -127,8 +132,9 @@ export async function startBrowserBridgeServer(params: {
 
   setBridgeAuthForPort(resolvedPort, { token: authToken, password: authPassword });
 
-  const baseUrl = `http://${host}:${resolvedPort}`;
-  return { server, port: resolvedPort, baseUrl, state };
+  const baseUrl = `http://${isLoopbackHost(host) ? host : "127.0.0.1"}:${resolvedPort}`;
+  const advertisedBaseUrl = `http://${advertisedHost}:${resolvedPort}`;
+  return { server, port: resolvedPort, baseUrl, advertisedBaseUrl, state };
 }
 
 export async function stopBrowserBridgeServer(server: Server): Promise<void> {

--- a/src/browser/server-context.remote-profile-tab-ops.suite.ts
+++ b/src/browser/server-context.remote-profile-tab-ops.suite.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "./server-context.chrome-test-harness.js";
+import * as cdpModule from "./cdp.js";
 import * as chromeModule from "./chrome.js";
 import * as pwAiModule from "./pw-ai-module.js";
 import { createBrowserRouteContext } from "./server-context.js";
@@ -97,6 +98,43 @@ describe("browser server-context remote profile tab operations", () => {
       targetId: "T1",
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses CDP tab creation for attachOnly remote profiles", async () => {
+    const listPagesViaPlaywright = vi.fn(async () => [
+      { targetId: "T2", title: "Tab 2", url: "about:blank", type: "page" },
+    ]);
+    const createPageViaPlaywright = vi.fn(async () => ({
+      targetId: "UNEXPECTED",
+      title: "",
+      url: "about:blank",
+      type: "page",
+    }));
+    const createTargetViaCdp = vi
+      .spyOn(cdpModule, "createTargetViaCdp")
+      .mockResolvedValue({ targetId: "T2" });
+
+    vi.spyOn(pwAiModule, "getPwAiModule").mockResolvedValue({
+      listPagesViaPlaywright,
+      createPageViaPlaywright,
+    } as unknown as Awaited<ReturnType<typeof pwAiModule.getPwAiModule>>);
+
+    const { state } = createRemoteRouteHarness();
+    state.resolved.profiles.remote = {
+      ...state.resolved.profiles.remote,
+      attachOnly: true,
+    };
+    const remote = createBrowserRouteContext({ getState: () => state }).forProfile("remote");
+
+    const opened = await remote.openTab("about:blank");
+    expect(opened.targetId).toBe("T2");
+    expect(state.profiles.get("remote")?.lastTargetId).toBe("T2");
+    expect(createTargetViaCdp).toHaveBeenCalledWith({
+      cdpUrl: "https://browserless.example/chrome?token=abc",
+      url: "about:blank",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+    expect(createPageViaPlaywright).not.toHaveBeenCalled();
   });
 
   it("prefers lastTargetId for remote profiles when targetId is omitted", async () => {

--- a/src/browser/server-context.tab-ops.ts
+++ b/src/browser/server-context.tab-ops.ts
@@ -130,9 +130,10 @@ export function createProfileTabOps({
   const openTab = async (url: string): Promise<BrowserTab> => {
     const ssrfPolicyOpts = withBrowserNavigationPolicy(state().resolved.ssrfPolicy);
 
-    // For remote profiles, use Playwright's persistent connection to create tabs
-    // This ensures the tab persists beyond a single request.
-    if (!profile.cdpIsLoopback) {
+    // Most remote profiles need Playwright's persistent connection so new tabs survive
+    // beyond a single HTTP request. Attach-only remotes already expose a stable target
+    // set, so prefer raw CDP there and avoid Playwright's newPage() path.
+    if (!profile.cdpIsLoopback && !profile.attachOnly) {
       const mod = await getPwAiModule({ mode: "strict" });
       const createPageViaPlaywright = (mod as Partial<PwAiModule> | null)?.createPageViaPlaywright;
       if (typeof createPageViaPlaywright === "function") {

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -276,6 +276,33 @@ describe("sandbox browser binds config", () => {
     expect(resolved.network).toBe("openclaw-sandbox-browser-agent");
   });
 
+  it("prefers agent bridgeHost over global browser bridgeHost", () => {
+    const resolved = resolveSandboxBrowserConfig({
+      scope: "agent",
+      globalBrowser: { bridgeHost: "global-host.internal" },
+      agentBrowser: { bridgeHost: "agent-host.internal" },
+    });
+    expect(resolved.bridgeHost).toBe("agent-host.internal");
+  });
+
+  it("accepts sandbox.browser.bridgeHost in config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            browser: {
+              bridgeHost: "gateway.internal",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.browser?.bridgeHost).toBe("gateway.internal");
+    }
+  });
+
   it("merges cdpSourceRange with agent override", () => {
     const resolved = resolveSandboxBrowserConfig({
       scope: "agent",

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -303,6 +303,33 @@ describe("sandbox browser binds config", () => {
     }
   });
 
+  it("prefers agent cdpHost over global browser cdpHost", () => {
+    const resolved = resolveSandboxBrowserConfig({
+      scope: "agent",
+      globalBrowser: { cdpHost: "global-cdp.internal" },
+      agentBrowser: { cdpHost: "agent-cdp.internal" },
+    });
+    expect(resolved.cdpHost).toBe("agent-cdp.internal");
+  });
+
+  it("accepts sandbox.browser.cdpHost in config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            browser: {
+              cdpHost: "gateway-cdp.internal",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.browser?.cdpHost).toBe("gateway-cdp.internal");
+    }
+  });
+
   it("merges cdpSourceRange with agent override", () => {
     const resolved = resolveSandboxBrowserConfig({
       scope: "agent",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -364,6 +364,10 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.sandbox.browser.network":
     "Docker network for sandbox browser containers (default: openclaw-sandbox-browser). Avoid bridge if you need stricter isolation.",
   "agents.list[].sandbox.browser.network": "Per-agent override for sandbox browser Docker network.",
+  "agents.defaults.sandbox.browser.bridgeHost":
+    "Optional hostname or IP that sandbox containers should use to reach the host-side browser bridge. Leave unset to use the Docker host alias automatically.",
+  "agents.list[].sandbox.browser.bridgeHost":
+    "Per-agent override for the sandbox browser bridge hostname advertised into sandbox containers.",
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "DANGEROUS break-glass override that allows sandbox Docker network mode container:<id>. This joins another container namespace and weakens sandbox isolation.",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -368,6 +368,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional hostname or IP that sandbox containers should use to reach the host-side browser bridge. Leave unset to use the Docker host alias automatically.",
   "agents.list[].sandbox.browser.bridgeHost":
     "Per-agent override for the sandbox browser bridge hostname advertised into sandbox containers.",
+  "agents.defaults.sandbox.browser.cdpHost":
+    "Optional hostname or IP that the gateway process should use to reach the sandbox browser CDP via Docker-published ports. Leave unset to use loopback on host gateways and the Docker host alias automatically for Dockerized gateways.",
+  "agents.list[].sandbox.browser.cdpHost":
+    "Per-agent override for the hostname or IP that the gateway process should use for sandbox browser CDP access.",
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "DANGEROUS break-glass override that allows sandbox Docker network mode container:<id>. This joins another container namespace and weakens sandbox isolation.",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -472,6 +472,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.list.*.heartbeat.directPolicy": "Heartbeat Direct Policy",
   "agents.defaults.heartbeat.suppressToolErrorWarnings": "Heartbeat Suppress Tool Error Warnings",
   "agents.defaults.sandbox.browser.network": "Sandbox Browser Network",
+  "agents.defaults.sandbox.browser.bridgeHost": "Sandbox Browser Bridge Host",
   "agents.defaults.sandbox.browser.cdpSourceRange": "Sandbox Browser CDP Source Port Range",
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Sandbox Docker Allow Container Namespace Join",
@@ -810,6 +811,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.list[].heartbeat.suppressToolErrorWarnings":
     "Agent Heartbeat Suppress Tool Error Warnings",
   "agents.list[].sandbox.browser.network": "Agent Sandbox Browser Network",
+  "agents.list[].sandbox.browser.bridgeHost": "Agent Sandbox Browser Bridge Host",
   "agents.list[].sandbox.browser.cdpSourceRange": "Agent Sandbox Browser CDP Source Port Range",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Agent Sandbox Docker Allow Container Namespace Join",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -473,6 +473,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.heartbeat.suppressToolErrorWarnings": "Heartbeat Suppress Tool Error Warnings",
   "agents.defaults.sandbox.browser.network": "Sandbox Browser Network",
   "agents.defaults.sandbox.browser.bridgeHost": "Sandbox Browser Bridge Host",
+  "agents.defaults.sandbox.browser.cdpHost": "Sandbox Browser CDP Host",
   "agents.defaults.sandbox.browser.cdpSourceRange": "Sandbox Browser CDP Source Port Range",
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Sandbox Docker Allow Container Namespace Join",
@@ -812,6 +813,7 @@ export const FIELD_LABELS: Record<string, string> = {
     "Agent Heartbeat Suppress Tool Error Warnings",
   "agents.list[].sandbox.browser.network": "Agent Sandbox Browser Network",
   "agents.list[].sandbox.browser.bridgeHost": "Agent Sandbox Browser Bridge Host",
+  "agents.list[].sandbox.browser.cdpHost": "Agent Sandbox Browser CDP Host",
   "agents.list[].sandbox.browser.cdpSourceRange": "Agent Sandbox Browser CDP Source Port Range",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Agent Sandbox Docker Allow Container Namespace Join",

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -65,6 +65,8 @@ export type SandboxBrowserSettings = {
   containerPrefix?: string;
   /** Docker network for sandbox browser containers (default: openclaw-sandbox-browser). */
   network?: string;
+  /** Hostname or IP that sandbox containers should use to reach the host-side browser bridge. */
+  bridgeHost?: string;
   cdpPort?: number;
   /** Optional CIDR allowlist for CDP ingress at the container edge (for example: 172.21.0.1/32). */
   cdpSourceRange?: string;

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -67,6 +67,12 @@ export type SandboxBrowserSettings = {
   network?: string;
   /** Hostname or IP that sandbox containers should use to reach the host-side browser bridge. */
   bridgeHost?: string;
+  /**
+   * Hostname or IP that the gateway process should use to reach the sandbox browser CDP
+   * via the published Docker port. Leave unset to use loopback on bare-metal gateways and
+   * the Docker host alias automatically for Dockerized gateways.
+   */
+  cdpHost?: string;
   cdpPort?: number;
   /** Optional CIDR allowlist for CDP ingress at the container edge (for example: 172.21.0.1/32). */
   cdpSourceRange?: string;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -209,6 +209,7 @@ export const SandboxBrowserSchema = z
     image: z.string().optional(),
     containerPrefix: z.string().optional(),
     network: z.string().optional(),
+    bridgeHost: z.string().optional(),
     cdpPort: z.number().int().positive().optional(),
     cdpSourceRange: z.string().optional(),
     vncPort: z.number().int().positive().optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -210,6 +210,7 @@ export const SandboxBrowserSchema = z
     containerPrefix: z.string().optional(),
     network: z.string().optional(),
     bridgeHost: z.string().optional(),
+    cdpHost: z.string().optional(),
     cdpPort: z.number().int().positive().optional(),
     cdpSourceRange: z.string().optional(),
     vncPort: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

- split the sandbox browser bridge into a host-local URL and a separately advertised container-reachable URL so sandboxed agents stop inheriting an unreachable `127.0.0.1`
- when the gateway runs in Docker, resolve sandbox browser CDP using a reachable host/port pair instead of assuming the host-published loopback path is reachable from the sandboxed flow
- keep attach-only remote sandbox browser profiles on the raw CDP tab-open path instead of the Playwright `newPage()` path that was timing out for sandbox browser `open` requests

Fixes #8273

## Testing

- `pnpm vitest run src/agents/sandbox/browser.create.test.ts src/browser/server-context.remote-tab-ops.test.ts src/browser/server-context.tab-selection-state.test.ts`
- `pnpm build`
- rebuilt `openclaw:local`, recreated the gateway + sandbox browser, and verified from a normal chat session that `browser status` works, `browser open about:blank` works, and opening `https://example.com` returns the title `Example Domain`
