### PR TITLE
agents: notify chat sessions on empty bg success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/background exec: notify reply-capable chat sessions when background commands finish successfully with no output by default, while preserving explicit opt-out and keeping non-chat provider labels silent. (#39726) Thanks @Sapientropic.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4089,7 +4089,6 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded runner: carry provider-observed overflow token counts into compaction so overflow retries and diagnostics use the rejected live prompt size instead of only transcript estimates. (#40357) thanks @rabsef-bicrym.
 - Agents/compaction transcript updates: emit a transcript-update event immediately after successful embedded compaction so downstream listeners observe the post-compact transcript without waiting for a later write. (#25558) thanks @rodrigouroz.
 - Agents/sessions_spawn: use the target agent workspace for cross-agent spawned runs instead of inheriting the caller workspace, so child sessions load the correct workspace-scoped instructions and persona files. (#40176) Thanks @moshehbenavraham.
-- Agents/background exec chat notifications: treat chat delivery background exec completions as notify-on-empty-success by default so `exit 0` tasks without stdout/stderr stop looking like "started, then silence" on chat surfaces. (#39726) Thanks @Sapientropic.
 
 ## 2026.3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4088,6 +4088,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded runner: carry provider-observed overflow token counts into compaction so overflow retries and diagnostics use the rejected live prompt size instead of only transcript estimates. (#40357) thanks @rabsef-bicrym.
 - Agents/compaction transcript updates: emit a transcript-update event immediately after successful embedded compaction so downstream listeners observe the post-compact transcript without waiting for a later write. (#25558) thanks @rodrigouroz.
 - Agents/sessions_spawn: use the target agent workspace for cross-agent spawned runs instead of inheriting the caller workspace, so child sessions load the correct workspace-scoped instructions and persona files. (#40176) Thanks @moshehbenavraham.
+- Agents/background exec chat notifications: treat chat delivery background exec completions as notify-on-empty-success by default so `exit 0` tasks without stdout/stderr stop looking like "started, then silence" on chat surfaces. (#39726) Thanks @Sapientropic.
 
 ## 2026.3.7
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -23,6 +23,7 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
+import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
@@ -1427,7 +1428,11 @@ export function createExecTool(
   });
   const notifyOnExitEmptySuccess =
     defaults?.notifyOnExitEmptySuccess ??
-    Boolean(notifyDeliveryContext?.channel && notifyDeliveryContext.to);
+    Boolean(
+      notifyDeliveryContext?.channel &&
+      notifyDeliveryContext.to &&
+      isDeliverableMessageChannel(notifyDeliveryContext.channel),
+    );
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
   // Derive agentId only when sessionKey is an agent session key.
   const parsedAgentSession = parseAgentSessionKey(defaults?.sessionKey);

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1418,7 +1418,6 @@ export function createExecTool(
     );
   }
   const notifyOnExit = defaults?.notifyOnExit !== false;
-  const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
   const notifySessionKey = normalizeOptionalString(defaults?.sessionKey);
   const notifyDeliveryContext = normalizeDeliveryContext({
     channel: defaults?.messageProvider,
@@ -1426,6 +1425,9 @@ export function createExecTool(
     accountId: defaults?.accountId,
     threadId: defaults?.currentThreadTs,
   });
+  const notifyOnExitEmptySuccess =
+    defaults?.notifyOnExitEmptySuccess ??
+    Boolean(notifyDeliveryContext?.channel && notifyDeliveryContext.to);
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
   // Derive agentId only when sessionKey is an agent session key.
   const parsedAgentSession = parseAgentSessionKey(defaults?.sessionKey);

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -22,8 +22,8 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
-import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import { normalizeDeliveryContext, type DeliveryContext } from "../utils/delivery-context.js";
+import { isGatewayMessageChannel } from "../utils/message-channel.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
@@ -93,6 +93,14 @@ function buildExecForegroundResult(params: {
     aggregated: params.outcome.aggregated,
     cwd: params.cwd,
   });
+}
+
+function shouldNotifyOnExitEmptySuccessByDefault(deliveryContext?: DeliveryContext): boolean {
+  return Boolean(
+    deliveryContext?.channel &&
+    deliveryContext.to &&
+    isGatewayMessageChannel(deliveryContext.channel),
+  );
 }
 
 const PREFLIGHT_ENV_OPTIONS_WITH_VALUES = new Set([
@@ -1428,11 +1436,7 @@ export function createExecTool(
   });
   const notifyOnExitEmptySuccess =
     defaults?.notifyOnExitEmptySuccess ??
-    Boolean(
-      notifyDeliveryContext?.channel &&
-      notifyDeliveryContext.to &&
-      isDeliverableMessageChannel(notifyDeliveryContext.channel),
-    );
+    shouldNotifyOnExitEmptySuccessByDefault(notifyDeliveryContext);
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
   // Derive agentId only when sessionKey is an agent session key.
   const parsedAgentSession = parseAgentSessionKey(defaults?.sessionKey);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -454,12 +454,30 @@ type DisallowedElevationCase = LabeledCase & {
   expectedOutputIncludes?: string;
 };
 type NotifyNoopCase = LabeledCase & {
-  notifyOnExitEmptySuccess: boolean;
+  notifyOnExitEmptySuccess?: boolean;
+  overrides?: Partial<ExecToolConfig>;
+  shouldEmitEvent: boolean;
 };
 const NOOP_NOTIFY_CASES: NotifyNoopCase[] = [
-  withLabel("default behavior skips no-op completion events", { notifyOnExitEmptySuccess: false }),
+  withLabel("default behavior skips no-op completion events", {
+    shouldEmitEvent: false,
+  }),
   withLabel("explicitly enabling no-op completion emits completion events", {
     notifyOnExitEmptySuccess: true,
+    shouldEmitEvent: true,
+  }),
+  withLabel("chat delivery contexts emit no-op completion events by default", {
+    overrides: { messageProvider: "discord", currentChannelId: "channel-1" },
+    shouldEmitEvent: true,
+  }),
+  withLabel("provider labels without a delivery target skip no-op completion events", {
+    overrides: { messageProvider: "discord" },
+    shouldEmitEvent: false,
+  }),
+  withLabel("explicitly disabling no-op completion overrides chat delivery defaults", {
+    notifyOnExitEmptySuccess: false,
+    overrides: { messageProvider: "discord", currentChannelId: "channel-1" },
+    shouldEmitEvent: false,
   }),
 ];
 const DISALLOWED_ELEVATION_CASES: DisallowedElevationCase[] = [
@@ -507,12 +525,8 @@ const LONG_LOG_EXPECTATION_CASES: LongLogExpectationCase[] = [
     mustNotContain: ["showing last 200"],
   }),
 ];
-const expectNotifyNoopEvents = (
-  events: string[],
-  notifyOnExitEmptySuccess: boolean,
-  label: string,
-) => {
-  if (!notifyOnExitEmptySuccess) {
+const expectNotifyNoopEvents = (events: string[], shouldEmitEvent: boolean, label: string) => {
+  if (!shouldEmitEvent) {
     expect(events, label).toEqual([]);
     return;
   }
@@ -610,15 +624,21 @@ const runLongLogExpectationCase = async ({
   expectTextContainsValues(snapshot.text, mustContain, true);
   expectTextContainsValues(snapshot.text, mustNotContain, false);
 };
-const runNotifyNoopCase = async ({ label, notifyOnExitEmptySuccess }: NotifyNoopCase) => {
-  const tool = createNotifyOnExitExecTool(
-    notifyOnExitEmptySuccess ? { notifyOnExitEmptySuccess: true } : {},
-  );
+const runNotifyNoopCase = async ({
+  label,
+  notifyOnExitEmptySuccess,
+  overrides,
+  shouldEmitEvent,
+}: NotifyNoopCase) => {
+  const tool = createNotifyOnExitExecTool({
+    ...overrides,
+    ...(typeof notifyOnExitEmptySuccess === "boolean" ? { notifyOnExitEmptySuccess } : {}),
+  });
 
   const { status } = await runBackgroundCommandToCompletion(tool, COMMAND_NOOP);
   expect(status).toBe(PROCESS_STATUS_COMPLETED);
   const events = peekSystemEvents(DEFAULT_NOTIFY_SESSION_KEY);
-  expectNotifyNoopEvents(events, notifyOnExitEmptySuccess, label);
+  expectNotifyNoopEvents(events, shouldEmitEvent, label);
 };
 
 describe("tool descriptions", () => {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -474,6 +474,10 @@ const NOOP_NOTIFY_CASES: NotifyNoopCase[] = [
     overrides: { messageProvider: "discord" },
     shouldEmitEvent: false,
   }),
+  withLabel("generic provider labels do not opt into no-op completion events", {
+    overrides: { messageProvider: "openai", currentChannelId: "channel-1" },
+    shouldEmitEvent: false,
+  }),
   withLabel("explicitly disabling no-op completion overrides chat delivery defaults", {
     notifyOnExitEmptySuccess: false,
     overrides: { messageProvider: "discord", currentChannelId: "channel-1" },

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -470,12 +470,20 @@ const NOOP_NOTIFY_CASES: NotifyNoopCase[] = [
     overrides: { messageProvider: "discord", currentChannelId: "channel-1" },
     shouldEmitEvent: true,
   }),
+  withLabel("internal webchat contexts emit no-op completion events by default", {
+    overrides: { messageProvider: "webchat", currentChannelId: "webchat:thread-1" },
+    shouldEmitEvent: true,
+  }),
   withLabel("provider labels without a delivery target skip no-op completion events", {
     overrides: { messageProvider: "discord" },
     shouldEmitEvent: false,
   }),
   withLabel("generic provider labels do not opt into no-op completion events", {
     overrides: { messageProvider: "openai", currentChannelId: "channel-1" },
+    shouldEmitEvent: false,
+  }),
+  withLabel("internal non-chat provider labels do not opt into no-op completion events", {
+    overrides: { messageProvider: "heartbeat", currentChannelId: "channel-1" },
     shouldEmitEvent: false,
   }),
   withLabel("explicitly disabling no-op completion overrides chat delivery defaults", {


### PR DESCRIPTION
## Summary
- default `notifyOnExitEmptySuccess` to true when the exec tool is created for a chat context
- keep the existing silent empty-success behavior for non-chat contexts unless it is explicitly enabled
- add regression coverage for default non-chat, explicit opt-in, and chat-context default notification
- add a changelog note

## Why
Background `exec` on chat surfaces already has enough session context to send an exit notification back to the originating conversation. The remaining gap is the common `exit 0` + empty stdout/stderr case, which currently looks like "started, then silence" even though the task finished successfully.

This is the narrower chat-surface piece of #18237. It does not change polling behavior or broader background execution policy.

## Testing
- `npx pnpm exec vitest run src/agents/bash-tools.test.ts`
- `npx pnpm exec oxlint src/agents/bash-tools.exec.ts src/agents/bash-tools.test.ts`
