### PR TITLE
fix(slack): stamp Slack DM inbound contexts with Slack origin/targe...

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -593,6 +593,44 @@ describe("gateway agent handler", () => {
     resetTimeConfig();
   });
 
+  it("routes reply to Slack when main session has Slack DM last route", async () => {
+    mockMainSessionEntry({
+      lastChannel: "slack",
+      lastTo: "user:U42",
+      lastAccountId: "default",
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": buildExistingMainStoreEntry({
+          lastChannel: "slack",
+          lastTo: "user:U42",
+          lastAccountId: "default",
+        }),
+      };
+      return await updater(store);
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "follow-up from main session",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-slack-dm-route",
+      },
+      { reqId: "slack-dm-route-1" },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+    };
+    expect(callArgs.channel).toBe("slack");
+  });
+
   it("rejects malformed agent session keys early in agent handler", async () => {
     mocks.agentCommand.mockClear();
     const respond = await invokeAgent(

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -570,6 +570,44 @@ describe("slack prepareSlackMessage inbound contract", () => {
     // MessageThreadId should be set for the reply
     expect(prepared!.ctxPayload.MessageThreadId).toBe("500.000");
   });
+
+  it("stamps OriginatingChannel: slack and OriginatingTo on DM inbound context", async () => {
+    const message = createSlackMessage({ channel: "D123", user: "U42", ts: "2.000" });
+    const prepared = await prepareWithDefaultCtx(message);
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.OriginatingChannel).toBe("slack");
+    expect(prepared!.ctxPayload.OriginatingTo).toBe("user:U42");
+  });
+
+  it("persists Slack DM delivery route to main session so later replies default to Slack", async () => {
+    const { storePath } = makeTmpStorePath();
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        session: { store: storePath },
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createSlackMessage({ channel: "D123", user: "U42", ts: "1.000" }),
+    );
+    expect(prepared).toBeTruthy();
+
+    // updateLastRoute is awaited inside prepareSlackMessage, so the store is
+    // written by the time the function returns.
+    const store = JSON.parse(fs.readFileSync(storePath, "utf8")) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const mainEntry = store["agent:main:main"];
+    expect(mainEntry?.lastChannel).toBe("slack");
+    expect(mainEntry?.lastTo).toBe("user:U42");
+  });
 });
 
 describe("prepareSlackMessage sender prefix", () => {


### PR DESCRIPTION
Slack DM turns are not carrying/persisting Slack origin routing metadata into the shared main session, so embedded/main replies default back to webchat instead of Slack.

Closes #7663

Changes:
- Update Slack DM message preparation to always set `OriginatingChannel: "slack"` and `OriginatingTo` to the DM target used for replies.
- Ensure DM inbound handling updates the main session delivery context/last route with the Slack account, target, and thread metadata before dispatch.
- Add a regression test for Slack DM preparation that verifies the finalized context and main-session route persistence.
- Add or extend a gateway/main-session delivery test to confirm a subsequent embedded/main reply resolves to Slack rather than staying on webchat.

Testing:
- pnpm build && pnpm check && pnpm test
- Run targeted Slack monitor and gateway delivery tests, especially `src/slack/monitor/message-handler/prepare.test.ts` and `src/gateway/server-methods/agent.test.ts`, and verify a Slack DM inbound turn followed by a main-session reply resolves outbound delivery to the original Slack DM target.

---
AI-assisted (Claude + Codex committee consensus, fully tested).