### PR TITLE
fix(ui): include deviceToken in browser client auth object (#39667)

### DIFF
--- a/src/gateway/browser-client-auth.test.ts
+++ b/src/gateway/browser-client-auth.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Unit tests for the browser client auth object construction logic.
+ *
+ * These tests verify that the browser client (GatewayBrowserClient) constructs
+ * the `auth` object in the same way as the Node.js client (GatewayClient),
+ * specifically ensuring the `deviceToken` field is included when available.
+ *
+ * The logic under test is extracted from `sendConnect()` in `gateway.ts`.
+ */
+
+/**
+ * Mirrors the auth object construction logic from `GatewayBrowserClient.sendConnect()`.
+ * This is extracted to enable unit testing without requiring a full WebSocket setup.
+ */
+function buildBrowserConnectAuth(params: {
+  explicitGatewayToken: string | undefined;
+  password: string | undefined;
+  storedDeviceToken: string | undefined;
+}):
+  | { token: string | undefined; deviceToken: string | undefined; password: string | undefined }
+  | undefined {
+  const explicitGatewayToken = params.explicitGatewayToken?.trim() || undefined;
+  let authToken = explicitGatewayToken;
+  // Mirror the deviceToken suppression logic from gateway.ts lines 218-220:
+  // deviceToken is only used when no explicit shared token/password is provided.
+  const deviceToken = !(explicitGatewayToken || params.password?.trim())
+    ? (params.storedDeviceToken ?? undefined)
+    : undefined;
+  authToken = explicitGatewayToken ?? deviceToken;
+  // Fixed auth construction: includes deviceToken field (aligned with Node.js client)
+  const auth =
+    authToken || params.password || deviceToken
+      ? {
+          token: authToken,
+          deviceToken: deviceToken,
+          password: params.password,
+        }
+      : undefined;
+  return auth;
+}
+
+/**
+ * Mirrors the auth object construction logic from `GatewayClient.sendConnect()`
+ * in `src/gateway/client.ts` (the Node.js reference implementation).
+ */
+function buildNodeConnectAuth(params: {
+  explicitGatewayToken: string | undefined;
+  explicitDeviceToken: string | undefined;
+  password: string | undefined;
+  storedDeviceToken: string | undefined;
+}):
+  | { token: string | undefined; deviceToken: string | undefined; password: string | undefined }
+  | undefined {
+  const explicitGatewayToken = params.explicitGatewayToken?.trim() || undefined;
+  const explicitDeviceToken = params.explicitDeviceToken?.trim() || undefined;
+  const resolvedDeviceToken =
+    explicitDeviceToken ??
+    (!(explicitGatewayToken || params.password?.trim())
+      ? (params.storedDeviceToken ?? undefined)
+      : undefined);
+  const authToken = explicitGatewayToken ?? resolvedDeviceToken;
+  const authPassword = params.password?.trim() || undefined;
+  const auth =
+    authToken || authPassword || resolvedDeviceToken
+      ? {
+          token: authToken,
+          deviceToken: resolvedDeviceToken,
+          password: authPassword,
+        }
+      : undefined;
+  return auth;
+}
+
+describe("browser client auth object construction", () => {
+  describe("shared token only (no cached device token)", () => {
+    it("includes deviceToken as undefined in auth object", () => {
+      const auth = buildBrowserConnectAuth({
+        explicitGatewayToken: "shared-secret-123",
+        password: undefined,
+        storedDeviceToken: undefined,
+      });
+      expect(auth).toEqual({
+        token: "shared-secret-123",
+        deviceToken: undefined,
+        password: undefined,
+      });
+    });
+
+    it("matches Node.js client behavior", () => {
+      const browserAuth = buildBrowserConnectAuth({
+        explicitGatewayToken: "shared-secret-123",
+        password: undefined,
+        storedDeviceToken: undefined,
+      });
+      const nodeAuth = buildNodeConnectAuth({
+        explicitGatewayToken: "shared-secret-123",
+        explicitDeviceToken: undefined,
+        password: undefined,
+        storedDeviceToken: undefined,
+      });
+      expect(browserAuth).toEqual(nodeAuth);
+    });
+  });
+
+  describe("device token only (no shared token)", () => {
+    it("uses stored device token as both auth.token and auth.deviceToken", () => {
+      const auth = buildBrowserConnectAuth({
+        explicitGatewayToken: undefined,
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      expect(auth).toEqual({
+        token: "device-jwt-abc",
+        deviceToken: "device-jwt-abc",
+        password: undefined,
+      });
+    });
+
+    it("matches Node.js client behavior", () => {
+      const browserAuth = buildBrowserConnectAuth({
+        explicitGatewayToken: undefined,
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      const nodeAuth = buildNodeConnectAuth({
+        explicitGatewayToken: undefined,
+        explicitDeviceToken: undefined,
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      expect(browserAuth).toEqual(nodeAuth);
+    });
+  });
+
+  describe("shared token + cached device token", () => {
+    it("suppresses deviceToken when shared token is present", () => {
+      const auth = buildBrowserConnectAuth({
+        explicitGatewayToken: "shared-secret-123",
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      // When explicitGatewayToken is present, deviceToken is suppressed (set to undefined)
+      expect(auth).toEqual({
+        token: "shared-secret-123",
+        deviceToken: undefined,
+        password: undefined,
+      });
+    });
+
+    it("matches Node.js client behavior", () => {
+      const browserAuth = buildBrowserConnectAuth({
+        explicitGatewayToken: "shared-secret-123",
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      const nodeAuth = buildNodeConnectAuth({
+        explicitGatewayToken: "shared-secret-123",
+        explicitDeviceToken: undefined,
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      expect(browserAuth).toEqual(nodeAuth);
+    });
+  });
+
+  describe("password only", () => {
+    it("suppresses deviceToken when password is present", () => {
+      const auth = buildBrowserConnectAuth({
+        explicitGatewayToken: undefined,
+        password: "my-password",
+        storedDeviceToken: "device-jwt-abc",
+      });
+      expect(auth).toEqual({
+        token: undefined,
+        deviceToken: undefined,
+        password: "my-password",
+      });
+    });
+  });
+
+  describe("no credentials at all", () => {
+    it("returns undefined when no auth is available", () => {
+      const auth = buildBrowserConnectAuth({
+        explicitGatewayToken: undefined,
+        password: undefined,
+        storedDeviceToken: undefined,
+      });
+      expect(auth).toBeUndefined();
+    });
+
+    it("matches Node.js client behavior", () => {
+      const browserAuth = buildBrowserConnectAuth({
+        explicitGatewayToken: undefined,
+        password: undefined,
+        storedDeviceToken: undefined,
+      });
+      const nodeAuth = buildNodeConnectAuth({
+        explicitGatewayToken: undefined,
+        explicitDeviceToken: undefined,
+        password: undefined,
+        storedDeviceToken: undefined,
+      });
+      expect(browserAuth).toEqual(nodeAuth);
+    });
+  });
+
+  describe("auth.deviceToken field presence", () => {
+    it("always includes deviceToken key in auth object (even when undefined)", () => {
+      const auth = buildBrowserConnectAuth({
+        explicitGatewayToken: "shared-secret-123",
+        password: undefined,
+        storedDeviceToken: undefined,
+      });
+      expect(auth).toBeDefined();
+      expect("deviceToken" in auth!).toBe(true);
+    });
+  });
+});

--- a/src/gateway/browser-client-auth.test.ts
+++ b/src/gateway/browser-client-auth.test.ts
@@ -206,15 +206,45 @@ describe("browser client auth object construction", () => {
     });
   });
 
-  describe("auth.deviceToken field presence", () => {
-    it("always includes deviceToken key in auth object (even when undefined)", () => {
+  describe("serialized auth over the wire", () => {
+    it("preserves deviceToken in JSON when device token is the only credential", () => {
+      const auth = buildBrowserConnectAuth({
+        explicitGatewayToken: undefined,
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      // Validate the serialized frame that is actually sent via JSON.stringify,
+      // since undefined values are dropped during serialization.
+      const wire = JSON.parse(JSON.stringify(auth));
+      expect(wire).toHaveProperty("deviceToken", "device-jwt-abc");
+    });
+
+    it("serialized auth matches between browser and Node.js clients", () => {
+      const browserAuth = buildBrowserConnectAuth({
+        explicitGatewayToken: undefined,
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      const nodeAuth = buildNodeConnectAuth({
+        explicitGatewayToken: undefined,
+        explicitDeviceToken: undefined,
+        password: undefined,
+        storedDeviceToken: "device-jwt-abc",
+      });
+      expect(JSON.parse(JSON.stringify(browserAuth))).toEqual(JSON.parse(JSON.stringify(nodeAuth)));
+    });
+
+    it("omits deviceToken from wire when suppressed by shared token", () => {
       const auth = buildBrowserConnectAuth({
         explicitGatewayToken: "shared-secret-123",
         password: undefined,
-        storedDeviceToken: undefined,
+        storedDeviceToken: "device-jwt-abc",
       });
-      expect(auth).toBeDefined();
-      expect("deviceToken" in auth!).toBe(true);
+      // When deviceToken is undefined, JSON.stringify drops it — this is expected
+      // and matches the Node.js client behavior.
+      const wire = JSON.parse(JSON.stringify(auth));
+      expect(wire).not.toHaveProperty("deviceToken");
+      expect(wire).toHaveProperty("token", "shared-secret-123");
     });
   });
 });

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -222,9 +222,10 @@ export class GatewayBrowserClient {
     }
     authToken = explicitGatewayToken ?? deviceToken;
     const auth =
-      authToken || this.opts.password
+      authToken || this.opts.password || deviceToken
         ? {
             token: authToken,
+            deviceToken: deviceToken,
             password: this.opts.password,
           }
         : undefined;


### PR DESCRIPTION
### Summary

**Problem:**
The Control UI browser client (`ui/src/ui/gateway.ts`) was omitting the `deviceToken` field when constructing the `auth` object during connection handshakes. This created an inconsistency with the Node.js client (`src/gateway/client.ts`) and caused the server's `resolveDeviceTokenCandidate()` to incorrectly fall back to treating the shared gateway token as a device token candidate, leading to "device signature invalid" or "device identity required" errors in certain authentication scenarios.

**Why:**
The browser client's auth object construction logic was missing the `deviceToken` property assignment, even though the variable was correctly resolved and the protocol schema (`ConnectParamsSchema`) supports it.

**What changed:**
- Updated `ui/src/ui/gateway.ts` to include the `deviceToken` field in the `auth` object, aligning it with the Node.js client implementation.
- Added comprehensive unit tests in `src/gateway/browser-client-auth.test.ts` to verify the browser client's auth object construction logic matches the Node.js client across all credential combinations.

**What did NOT change:**
- The server-side signature verification and token resolution logic remains untouched.
- The cryptographic signing process in the browser client remains unchanged.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Linked Issue

Fixes #39667

### Testing

- [x] Added unit tests for browser client auth object construction (`src/gateway/browser-client-auth.test.ts`)
- [x] Verified existing `device-auth.test.ts` passes
- [x] Verified existing `server.auth.browser-hardening.test.ts` passes
- [x] Ran end-to-end simulation verifying payload consistency between client signing and server reconstruction
