### PR TITLE
fix(nostr): clear relay publish timers to prevent leaks and unhandled rejections

### DIFF
--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -111,9 +111,13 @@ export async function importProfileFromRelays(
     const events: Array<{ event: Event; relay: string }> = [];
 
     // Create timeout promise
+    let overallTimer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<void>((resolve) => {
-      setTimeout(resolve, timeoutMs);
+      overallTimer = setTimeout(resolve, timeoutMs);
     });
+
+    // Track per-relay cleanup timers so they can be cleared early
+    const subTimers: ReturnType<typeof setTimeout>[] = [];
 
     // Create subscription promise
     const subscriptionPromise = new Promise<void>((resolve) => {
@@ -151,14 +155,22 @@ export async function importProfileFromRelays(
         );
 
         // Clean up subscription after timeout
-        setTimeout(() => {
+        const subTimer = setTimeout(() => {
           sub.close();
         }, timeoutMs);
+        subTimers.push(subTimer);
       }
     });
 
     // Wait for either all relays to respond or timeout
-    await Promise.race([subscriptionPromise, timeoutPromise]);
+    try {
+      await Promise.race([subscriptionPromise, timeoutPromise]);
+    } finally {
+      clearTimeout(overallTimer);
+      for (const t of subTimers) {
+        clearTimeout(t);
+      }
+    }
 
     // No events found
     if (events.length === 0) {

--- a/extensions/nostr/src/nostr-profile.ts
+++ b/extensions/nostr/src/nostr-profile.ts
@@ -177,9 +177,10 @@ export async function publishProfileEvent(
 
   // Publish to each relay in parallel with timeout
   const publishPromises = relays.map(async (relay) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("timeout")), RELAY_PUBLISH_TIMEOUT_MS);
+        timer = setTimeout(() => reject(new Error("timeout")), RELAY_PUBLISH_TIMEOUT_MS);
       });
 
       // oxlint-disable-next-line typescript/no-floating-promises
@@ -189,6 +190,8 @@ export async function publishProfileEvent(
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       failures.push({ relay, error: errorMessage });
+    } finally {
+      clearTimeout(timer);
     }
   });
 


### PR DESCRIPTION
## Summary

- `publishProfileEvent()` uses `Promise.race` with a `setTimeout`-based timeout per relay. When `pool.publish()` resolves first, the pending timer fires later and **rejects a promise nobody is listening to**, causing an `unhandledRejection` event in strict Node.js environments.
- `importProfileFromRelays()` creates both an overall timeout timer and per-relay subscription cleanup timers that **continue running** even when all relays respond before the deadline.

This stores timer handles and clears them in `finally` blocks so timers are always cleaned up regardless of which side wins the race.

## Changes

- **`nostr-profile.ts`**: Track `setTimeout` handle per relay, `clearTimeout` in `finally`
- **`nostr-profile-import.ts`**: Track overall + per-relay timers, clear all in `finally`

## Test plan

- [x] All 288 existing Nostr extension tests pass (`npx vitest run extensions/nostr/src/`)
- [x] No functional behavior change — only timer cleanup added