### PR TITLE
fix(nostr): validate account ID format in profile HTTP handler

### DIFF
--- a/extensions/nostr/src/nostr-profile-http.test.ts
+++ b/extensions/nostr/src/nostr-profile-http.test.ts
@@ -10,6 +10,7 @@ import {
   createNostrProfileHttpHandler,
   getNostrProfileRateLimitStateSizeForTest,
   isNostrProfileRateLimitedForTest,
+  parseAccountIdFromPath,
   type NostrProfileHttpContext,
 } from "./nostr-profile-http.js";
 
@@ -509,6 +510,32 @@ describe("nostr-profile-http", () => {
       expect(res._getStatusCode()).toBe(404);
       const data = JSON.parse(res._getData());
       expect(data.error).toContain("not found");
+    });
+  });
+
+  describe("parseAccountIdFromPath", () => {
+    it("extracts a valid account id", () => {
+      expect(parseAccountIdFromPath("/api/channels/nostr/default/profile")).toBe("default");
+    });
+
+    it("accepts alphanumeric ids with dashes and underscores", () => {
+      expect(parseAccountIdFromPath("/api/channels/nostr/my-bot_1/profile")).toBe("my-bot_1");
+    });
+
+    it("returns null for non-matching paths", () => {
+      expect(parseAccountIdFromPath("/api/channels/telegram/default/profile")).toBeNull();
+    });
+
+    it("rejects path traversal sequences", () => {
+      expect(parseAccountIdFromPath("/api/channels/nostr/../admin/profile")).toBeNull();
+    });
+
+    it("rejects percent-encoded characters", () => {
+      expect(parseAccountIdFromPath("/api/channels/nostr/%2e%2e/profile")).toBeNull();
+    });
+
+    it("rejects account ids with special characters", () => {
+      expect(parseAccountIdFromPath("/api/channels/nostr/acc<script>/profile")).toBeNull();
     });
   });
 });

--- a/extensions/nostr/src/nostr-profile-http.ts
+++ b/extensions/nostr/src/nostr-profile-http.ts
@@ -182,10 +182,15 @@ async function readJsonBody(
   throw new Error(result.code === "INVALID_JSON" ? "Invalid JSON" : result.error);
 }
 
-function parseAccountIdFromPath(pathname: string): string | null {
+/** @internal Exported for testing. */
+export function parseAccountIdFromPath(pathname: string): string | null {
   // Match: /api/channels/nostr/:accountId/profile
   const match = pathname.match(/^\/api\/channels\/nostr\/([^/]+)\/profile/);
-  return match?.[1] ?? null;
+  const accountId = match?.[1] ?? null;
+  if (accountId && !/^[a-zA-Z0-9_-]+$/.test(accountId)) {
+    return null;
+  }
+  return accountId;
 }
 
 function isLoopbackRemoteAddress(remoteAddress: string | undefined): boolean {


### PR DESCRIPTION
## Summary
- Restrict `parseAccountIdFromPath()` to accept only alphanumeric characters, dashes, and underscores
- Previously the regex `[^/]+` allowed path traversal sequences (`..`), percent-encoded bytes (`%2e`), and special characters (`<script>`) in the account ID parameter
- Add 6 targeted tests for the validation logic

## Test plan
- [x] All 294 existing nostr tests pass
- [x] New tests verify rejection of `..`, `%2e%2e`, `<script>`, and other invalid account IDs
- [x] Valid account IDs (`default`, `my-bot_1`) still accepted