### PR TITLE
fix(agents): resolve gpt-5.4 crash when custom openai-codex config omits api

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11583,7 +11583,7 @@
         "filename": "src/agents/pi-embedded-runner/model.ts",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 267
+        "line_number": 272
       }
     ],
     "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts": [

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -638,6 +638,32 @@ describe("resolveModel", () => {
     });
   });
 
+  it("uses codex fallback when inline model omits api (#39682)", () => {
+    mockOpenAICodexTemplateModel();
+
+    // When a user lists gpt-5.4 under openai-codex models without specifying
+    // an api, the inline match must not shadow the forward-compat resolver
+    // that supplies "openai-codex-responses".
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://custom.example.com",
+            models: [{ id: "gpt-5.4" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent", cfg);
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      api: "openai-codex-responses",
+      id: "gpt-5.4",
+      provider: "openai-codex",
+    });
+  });
+
   it("includes auth hint for unknown ollama models (#17328)", () => {
     // resetMockDiscoverModels() in beforeEach already sets find → null
     const result = resolveModel("ollama", "gemma3:4b", "/tmp/agent");

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -161,7 +161,12 @@ export function resolveModelWithRegistry(params: {
     (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
   );
   if (inlineMatch) {
-    return normalizeModelCompat(inlineMatch as Model<Api>);
+    // When the inline model already carries a concrete api, use it as-is.
+    // Otherwise fall through so forward-compat resolvers can supply the
+    // correct api (e.g. "openai-codex-responses" for gpt-5.4).  #39682
+    if (inlineMatch.api) {
+      return normalizeModelCompat(inlineMatch as Model<Api>);
+    }
   }
 
   // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.


### PR DESCRIPTION
Fixes #39682

## Summary

When you configure `openai-codex` with a custom models list but don't set `api`:

```yaml
models:
  providers:
    openai-codex:
      models:
        - id: gpt-5.4
```

`buildInlineProviderModels` produces `api: undefined`, and the inline match returns it before forward-compat gets a chance to fill in `openai-codex-responses`. This crashes the agent.

The fix is small: only return the inline match early when it actually has an `api`. Otherwise let it fall through to the forward-compat path, which already handles user config (baseUrl, headers etc.) via `applyConfiguredProviderOverrides`.

## Testing

Added a regression test for the config above. Existing 43 tests unaffected.