### PR TITLE
fix(podman): avoid sudo -u failing from private cwd

### DIFF
--- a/scripts/test/setup-podman.safe-cwd.test.sh
+++ b/scripts/test/setup-podman.safe-cwd.test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal regression test for setup-podman.sh run_as_user safe cwd.
+# We don't invoke sudo/runuser here; we just ensure the script contains
+# the safe-cwd wrapper so callers in private directories don't fail.
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+file="$root/setup-podman.sh"
+
+# Expect the safe_cwd variable and a subshell wrapper around sudo/runuser.
+grep -q 'local safe_cwd=' "$file"
+grep -q '( cd "$safe_cwd"' "$file"
+
+echo "ok"

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -80,12 +80,23 @@ run_root() {
 }
 
 run_as_user() {
+  # When switching users, the current working directory may become unreadable
+  # to the target user (e.g. caller runs this script from a private dir like
+  # chmod 700). `sudo -u` (and runuser) will fail before executing the command
+  # with: "cannot chdir".
+  #
+  # Force a safe cwd so rootless podman operations (and any other call sites)
+  # don't inherit an inaccessible directory.
   local user="$1"
   shift
+  local safe_cwd="${TMPDIR:-/tmp}"
+  if [[ -z "$safe_cwd" || ! -d "$safe_cwd" || ! -x "$safe_cwd" ]]; then
+    safe_cwd="/tmp"
+  fi
   if command -v sudo >/dev/null 2>&1; then
-    sudo -u "$user" "$@"
+    ( cd "$safe_cwd" 2>/dev/null || cd / 2>/dev/null || true; sudo -u "$user" "$@" )
   elif is_root && command -v runuser >/dev/null 2>&1; then
-    runuser -u "$user" -- "$@"
+    ( cd "$safe_cwd" 2>/dev/null || cd / 2>/dev/null || true; runuser -u "$user" -- "$@" )
   else
     echo "Need sudo (or root+runuser) to run commands as $user." >&2
     exit 1


### PR DESCRIPTION
### What
Ensure `setup-podman.sh` can run `sudo -u` / `runuser -u` even when the caller's current working directory is not accessible to the target user.

### Why
If the script is invoked from a private directory (e.g. `chmod 700`), `sudo -u` / `runuser` can fail before executing the command with a `cannot chdir` error.

### How
Wrap the user-switch execution in a subshell that `cd`s to a safe, executable directory (`$TMPDIR` or `/tmp`, with fallback to `/`).

### Testing
- `bash scripts/test/setup-podman.safe-cwd.test.sh`