### PR TITLE
fix(memory): truncate local embedding input to model context size

### DIFF
--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -412,10 +412,14 @@ describe("local embedding normalization", () => {
     vector: number[],
     resolveModelFile: (modelPath: string, modelDirectory?: string) => Promise<string> = async () =>
       "/fake/model.gguf",
+    modelOverrides?: { trainContextSize?: number },
   ): void {
     importNodeLlamaCppMock.mockResolvedValue({
       getLlama: async () => ({
         loadModel: vi.fn().mockResolvedValue({
+          trainContextSize: modelOverrides?.trainContextSize ?? 8192,
+          tokenize: (text: string) => Array.from(text, (_, i) => i),
+          detokenize: (tokens: number[]) => tokens.map(() => "x").join(""),
           createEmbeddingContext: vi.fn().mockResolvedValue({
             getEmbeddingFor: vi.fn().mockResolvedValue({
               vector: new Float32Array(vector),
@@ -473,6 +477,47 @@ describe("local embedding normalization", () => {
     expect(embedding.every((value) => Number.isFinite(value))).toBe(true);
   });
 
+  it("truncates input to model context size for BERT-class models", async () => {
+    const getEmbeddingForSpy = vi.fn().mockResolvedValue({
+      vector: new Float32Array([1, 0, 0, 0]),
+    });
+
+    importNodeLlamaCppMock.mockResolvedValue({
+      getLlama: async () => ({
+        loadModel: vi.fn().mockResolvedValue({
+          trainContextSize: 512,
+          tokenize: (text: string) => Array.from(text, (_, i) => i),
+          detokenize: (tokens: number[]) => tokens.map(() => "x").join(""),
+          createEmbeddingContext: vi.fn().mockResolvedValue({
+            getEmbeddingFor: getEmbeddingForSpy,
+          }),
+        }),
+      }),
+      resolveModelFile: async () => "/fake/bge-small.gguf",
+      LlamaLogLevel: { error: 0 },
+    });
+
+    const result = await createLocalProviderForTest();
+    const provider = requireProvider(result);
+
+    // Text with 1000 characters exceeds 512-token context
+    await provider.embedQuery("a".repeat(1000));
+    const passedText = getEmbeddingForSpy.mock.calls[0]?.[0] as string;
+    expect(passedText.length).toBeLessThanOrEqual(512);
+  });
+
+  it("exposes trainContextSize as maxInputTokens after init", async () => {
+    mockSingleLocalEmbeddingVector([1, 0, 0, 0], undefined, { trainContextSize: 512 });
+
+    const result = await createLocalProviderForTest();
+    const provider = requireProvider(result);
+
+    // Before first call, maxInputTokens may not be set yet
+    await provider.embedQuery("hello");
+    // After init, maxInputTokens should reflect the model's context size
+    expect(provider.maxInputTokens).toBe(512);
+  });
+
   it("normalizes batch embeddings to magnitude ~1.0", async () => {
     const unnormalizedVectors = [
       [2.35, 3.45, 0.63, 4.3],
@@ -483,6 +528,9 @@ describe("local embedding normalization", () => {
     importNodeLlamaCppMock.mockResolvedValue({
       getLlama: async () => ({
         loadModel: vi.fn().mockResolvedValue({
+          trainContextSize: 8192,
+          tokenize: (text: string) => Array.from(text, (_, i) => i),
+          detokenize: (tokens: number[]) => tokens.map(() => "x").join(""),
           createEmbeddingContext: vi.fn().mockResolvedValue({
             getEmbeddingFor: vi
               .fn()
@@ -543,6 +591,9 @@ describe("local embedding ensureContext concurrency", () => {
               await new Promise((r) => setTimeout(r, params.initializationDelayMs));
             }
             return {
+              trainContextSize: 8192,
+              tokenize: (text: string) => Array.from(text, (_, i) => i),
+              detokenize: (tokens: number[]) => tokens.map(() => "x").join(""),
               createEmbeddingContext: async () => {
                 createContextSpy();
                 return {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -14,6 +14,15 @@ import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./emb
 import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
 import { importNodeLlamaCpp } from "./node-llama.js";
 
+// node-llama-cpp LlamaModel exposes tokenizer and context size methods at
+// runtime, but tsgo's type resolution does not surface them from the
+// published declarations.  Define a minimal interface for the subset we use.
+type LlamaModelWithTokenizer = LlamaModel & {
+  trainContextSize: number;
+  tokenize(text: string): unknown[];
+  detokenize(tokens: unknown[]): string;
+};
+
 function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
   const sanitized = vec.map((value) => (Number.isFinite(value) ? value : 0));
   const magnitude = Math.sqrt(sanitized.reduce((sum, value) => sum + value * value, 0));
@@ -110,7 +119,7 @@ async function createLocalEmbeddingProvider(
   const { getLlama, resolveModelFile, LlamaLogLevel } = await importNodeLlamaCpp();
 
   let llama: Llama | null = null;
-  let embeddingModel: LlamaModel | null = null;
+  let embeddingModel: LlamaModelWithTokenizer | null = null;
   let embeddingContext: LlamaEmbeddingContext | null = null;
   let initPromise: Promise<LlamaEmbeddingContext> | null = null;
 
@@ -167,7 +176,9 @@ async function createLocalEmbeddingProvider(
         }
         if (!embeddingModel) {
           const resolved = await resolveModelFile(modelPath, modelCacheDir || undefined);
-          embeddingModel = await llama.loadModel({ modelPath: resolved });
+          embeddingModel = (await llama.loadModel({
+            modelPath: resolved,
+          })) as LlamaModelWithTokenizer;
         }
         if (!embeddingContext) {
           embeddingContext = await embeddingModel.createEmbeddingContext();

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -114,6 +114,45 @@ async function createLocalEmbeddingProvider(
   let embeddingContext: LlamaEmbeddingContext | null = null;
   let initPromise: Promise<LlamaEmbeddingContext> | null = null;
 
+  // Truncate text to fit the model's context window using its native tokenizer.
+  // This is a safety net for models with small context sizes (e.g. BERT 512 tokens)
+  // where the upstream byte-based chunk splitting may still produce inputs that
+  // exceed the token limit.
+  const truncateToContextSize = (text: string): string => {
+    if (!embeddingModel) {
+      return text;
+    }
+    const contextSize = embeddingModel.trainContextSize;
+    if (!contextSize || contextSize <= 0) {
+      return text;
+    }
+    const tokens = embeddingModel.tokenize(text);
+    if (tokens.length <= contextSize) {
+      return text;
+    }
+    return embeddingModel.detokenize(tokens.slice(0, contextSize));
+  };
+
+  const provider: EmbeddingProvider = {
+    id: "local",
+    model: modelPath,
+    embedQuery: async (text) => {
+      const ctx = await ensureContext();
+      const embedding = await ctx.getEmbeddingFor(truncateToContextSize(text));
+      return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
+    },
+    embedBatch: async (texts) => {
+      const ctx = await ensureContext();
+      const embeddings = await Promise.all(
+        texts.map(async (text) => {
+          const embedding = await ctx.getEmbeddingFor(truncateToContextSize(text));
+          return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
+        }),
+      );
+      return embeddings;
+    },
+  };
+
   const ensureContext = async (): Promise<LlamaEmbeddingContext> => {
     if (embeddingContext) {
       return embeddingContext;
@@ -133,6 +172,12 @@ async function createLocalEmbeddingProvider(
         if (!embeddingContext) {
           embeddingContext = await embeddingModel.createEmbeddingContext();
         }
+        // Expose model's actual context size so upstream chunk splitting
+        // can use token-accurate limits instead of the byte-based fallback.
+        const trainCtx = embeddingModel.trainContextSize;
+        if (typeof trainCtx === "number" && trainCtx > 0) {
+          provider.maxInputTokens = trainCtx;
+        }
         return embeddingContext;
       } catch (err) {
         initPromise = null;
@@ -142,25 +187,7 @@ async function createLocalEmbeddingProvider(
     return initPromise;
   };
 
-  return {
-    id: "local",
-    model: modelPath,
-    embedQuery: async (text) => {
-      const ctx = await ensureContext();
-      const embedding = await ctx.getEmbeddingFor(text);
-      return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
-    },
-    embedBatch: async (texts) => {
-      const ctx = await ensureContext();
-      const embeddings = await Promise.all(
-        texts.map(async (text) => {
-          const embedding = await ctx.getEmbeddingFor(text);
-          return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
-        }),
-      );
-      return embeddings;
-    },
-  };
+  return provider;
 }
 
 export async function createEmbeddingProvider(


### PR DESCRIPTION
## Summary

- Problem: Local embedding provider with BERT-class models (e.g. `bge-small-zh-v1.5`, 512-token context) fails with "Input is longer than the context size" error during `openclaw memory index`, even with small files
- Why it matters: Memory indexing is completely broken for users with BERT embedding models, which are popular for non-English (especially Chinese) use cases
- What changed: After loading the local model, expose its `trainContextSize` as `maxInputTokens` for accurate upstream chunk splitting, and add a tokenizer-based truncation safety net inside `embedQuery`/`embedBatch`
- What did NOT change (scope boundary): No changes to remote embedding providers, chunk splitting algorithm, or memory indexing pipeline. The upstream `enforceEmbeddingMaxInputTokens` byte-based splitting continues to run as a coarse first pass

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #39592

## User-visible / Behavior Changes

Local embedding models with small context windows (e.g. BERT 512 tokens) now work correctly instead of crashing. No config changes needed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: local embedding with `bge-small-zh-v1.5-q4_k_m.gguf` (BERT, 512-token context)

### Steps

1. Configure local embedding provider with a BERT GGUF model (512-token context)
2. Run `openclaw memory index --force`
3. Observe error: "Input is longer than the context size"

### Expected

- Memory indexing completes successfully; text is automatically truncated to fit the model's context window

### Actual (before fix)

- `Memory index failed (main): Input is longer than the context size`

## Root Cause

The upstream chunk splitter uses UTF-8 byte length as a conservative proxy for token count, with a 2048-byte fallback for local providers. For BERT models with 512-token context:

| Script | Bytes per char | Chars in 2048 bytes | Tokens (approx) | Model limit |
|--------|---------------|--------------------|-----------------| ------------|
| Latin (ASCII) | 1 | 2048 | ≤2048 | 512 |
| Chinese (CJK) | 3 | ~682 | ~682 | 512 |

Even with the byte-based cap, 2048 bytes of text can produce 682+ tokens for Chinese text, exceeding the 512-token limit.

## Fix (two-layer approach)

1. **`maxInputTokens` propagation**: After model init, set `provider.maxInputTokens = embeddingModel.trainContextSize` so subsequent upstream chunk splits use the model's actual token limit instead of the 2048-byte fallback
2. **Tokenizer-based truncation safety net**: Inside `embedQuery`/`embedBatch`, tokenize the input and truncate to `trainContextSize` tokens before calling `getEmbeddingFor()`. This catches edge cases where pre-chunking still produces oversized inputs (e.g., the first batch before `maxInputTokens` is set)

## Evidence

- [x] Failing test/log before + passing after
- New test: `truncates input to model context size for BERT-class models` — mocks a 512-token model and verifies input is truncated
- New test: `exposes trainContextSize as maxInputTokens after init` — verifies the provider advertises the correct limit after first use

## Human Verification (required)

- Verified scenarios: All 25 embedding tests pass (including 2 new tests for truncation and maxInputTokens propagation), plus 4 chunk-limits tests
- Edge cases checked: Zero/negative trainContextSize, model not yet loaded (pre-init), text already within limit
- What you did **not** verify: End-to-end test with a real BERT GGUF model (requires the model file)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; the 2048-byte fallback resumes
- Files/config to restore: `src/memory/embeddings.ts`
- Known bad symptoms reviewers should watch for: If truncation is too aggressive, embeddings may lose tail content — but this is strictly better than crashing

## Risks and Mitigations

- Risk: Truncation discards tail content for very long chunks
  - Mitigation: The upstream `enforceEmbeddingMaxInputTokens` already splits chunks; truncation is a last-resort safety net that only activates when pre-split chunks still exceed the model's token limit. Some content loss is always preferable to a hard crash