### PR TITLE
feat(feishu): add a read-only mode for group chats

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9626,7 +9626,7 @@
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 501
+        "line_number": 540
       }
     ],
     "docs/channels/irc.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T05:05:36Z"
+  "generated_at": "2026-03-08T11:42:24Z"
 }

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -235,6 +235,45 @@ If your tenant is on Lark (international), set the domain to `lark` (or a full d
 }
 ```
 
+### Read group messages without replying
+
+If you want OpenClaw to keep receiving Feishu group messages but never send replies back into groups,
+set `disableGroupReplies: true`.
+
+This is useful when you want the bot to:
+
+- read group history or live group traffic,
+- keep private chat replies enabled,
+- and enforce a program-level “groups are read-only” policy.
+
+Example:
+
+```json5
+{
+  channels: {
+    feishu: {
+      enabled: true,
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["oc_group_a", "oc_group_b"],
+      requireMention: true,
+      disableGroupReplies: true,
+      accounts: {
+        main: {
+          appId: "cli_xxx",
+          appSecret: "xxx",
+        },
+      },
+    },
+  },
+}
+```
+
+Behavior with `disableGroupReplies: true`:
+
+- inbound Feishu group messages are still accepted,
+- DM replies continue to work,
+- explicit outbound Feishu group targets such as `chat:oc_xxx` / `group:oc_xxx` are blocked.
+
 ### Quota optimization flags
 
 You can reduce Feishu API usage with two optional flags:

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2060,6 +2060,43 @@ describe("broadcast dispatch", () => {
     );
   });
 
+  it("uses noop dispatcher for broadcast active agent when disableGroupReplies is enabled", async () => {
+    const cfg: ClawdbotConfig = {
+      broadcast: { "oc-broadcast-group": ["susan", "main"] },
+      agents: { list: [{ id: "main" }, { id: "susan" }] },
+      channels: {
+        feishu: {
+          disableGroupReplies: true,
+          groups: {
+            "oc-broadcast-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as unknown as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: "msg-broadcast-no-group-replies",
+        chat_id: "oc-broadcast-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(2);
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+  });
+
   it("cross-account broadcast dedup: second account skips dispatch", async () => {
     const cfg: ClawdbotConfig = {
       broadcast: { "oc-broadcast-group": ["susan", "main"] },

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2016,6 +2016,50 @@ describe("broadcast dispatch", () => {
     );
   });
 
+  it("uses noop group dispatcher when disableGroupReplies is enabled", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          disableGroupReplies: true,
+          groups: {
+            "oc-broadcast-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: "msg-no-group-replies",
+        chat_id: "oc-broadcast-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockWithReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcher: expect.objectContaining({
+          sendToolResult: expect.any(Function),
+          sendBlockReply: expect.any(Function),
+          sendFinalReply: expect.any(Function),
+        }),
+      }),
+    );
+  });
+
   it("cross-account broadcast dedup: second account skips dispatch", async () => {
     const cfg: ClawdbotConfig = {
       broadcast: { "oc-broadcast-group": ["susan", "main"] },

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1499,20 +1499,42 @@ export async function handleFeishuMessage(params: {
         ctx.mentionedBot,
       );
 
-      const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
-        cfg,
-        agentId: route.agentId,
-        runtime: runtime as RuntimeEnv,
-        chatId: ctx.chatId,
-        replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
-        replyInThread,
-        rootId: ctx.rootId,
-        threadReply,
-        mentionTargets: ctx.mentionTargets,
-        accountId: account.accountId,
-        messageCreateTimeMs,
-      });
+      const disableGroupReplies = Boolean(isGroup && feishuCfg?.disableGroupReplies);
+      const noopDispatcher = {
+        sendToolResult: () => false,
+        sendBlockReply: () => false,
+        sendFinalReply: () => false,
+        waitForIdle: async () => {},
+        getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+        markComplete: () => {},
+      };
+
+      const { dispatcher, replyOptions, markDispatchIdle } = disableGroupReplies
+        ? {
+            dispatcher: noopDispatcher,
+            replyOptions: undefined,
+            markDispatchIdle: () => {},
+          }
+        : createFeishuReplyDispatcher({
+            cfg,
+            agentId: route.agentId,
+            runtime: runtime as RuntimeEnv,
+            chatId: ctx.chatId,
+            replyToMessageId: replyTargetMessageId,
+            skipReplyToInMessages: !isGroup,
+            replyInThread,
+            rootId: ctx.rootId,
+            threadReply,
+            mentionTargets: ctx.mentionTargets,
+            accountId: account.accountId,
+            messageCreateTimeMs,
+          });
+
+      if (disableGroupReplies) {
+        log(
+          `feishu[${account.accountId}]: group replies disabled for ${ctx.chatId}; dispatching with noop reply dispatcher`,
+        );
+      }
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
       const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1401,20 +1401,42 @@ export async function handleFeishuMessage(params: {
 
         if (agentId === activeAgentId) {
           // Active agent: real Feishu dispatcher (responds on Feishu)
-          const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
-            cfg,
-            agentId,
-            runtime: runtime as RuntimeEnv,
-            chatId: ctx.chatId,
-            replyToMessageId: replyTargetMessageId,
-            skipReplyToInMessages: !isGroup,
-            replyInThread,
-            rootId: ctx.rootId,
-            threadReply,
-            mentionTargets: ctx.mentionTargets,
-            accountId: account.accountId,
-            messageCreateTimeMs,
-          });
+          const disableGroupReplies = Boolean(isGroup && feishuCfg?.disableGroupReplies);
+          const noopDispatcher = {
+            sendToolResult: () => false,
+            sendBlockReply: () => false,
+            sendFinalReply: () => false,
+            waitForIdle: async () => {},
+            getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+            markComplete: () => {},
+          };
+
+          const { dispatcher, replyOptions, markDispatchIdle } = disableGroupReplies
+            ? {
+                dispatcher: noopDispatcher,
+                replyOptions: undefined,
+                markDispatchIdle: () => {},
+              }
+            : createFeishuReplyDispatcher({
+                cfg,
+                agentId,
+                runtime: runtime as RuntimeEnv,
+                chatId: ctx.chatId,
+                replyToMessageId: replyTargetMessageId,
+                skipReplyToInMessages: !isGroup,
+                replyInThread,
+                rootId: ctx.rootId,
+                threadReply,
+                mentionTargets: ctx.mentionTargets,
+                accountId: account.accountId,
+                messageCreateTimeMs,
+              });
+
+          if (disableGroupReplies) {
+            log(
+              `feishu[${account.accountId}]: group replies disabled for ${ctx.chatId}; broadcast active dispatch uses noop reply dispatcher`,
+            );
+          }
 
           log(
             `feishu[${account.accountId}]: broadcast active dispatch agent=${agentId} (session=${agentSessionKey})`,

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -149,6 +149,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
           items: { oneOf: [{ type: "string" }, { type: "number" }] },
         },
         requireMention: { type: "boolean" },
+        disableGroupReplies: { type: "boolean" },
         groupSessionScope: {
           type: "string",
           enum: ["group", "group_sender", "group_topic", "group_topic_sender"],

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -157,6 +157,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  disableGroupReplies: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),

--- a/extensions/feishu/src/send-target.test.ts
+++ b/extensions/feishu/src/send-target.test.ts
@@ -57,6 +57,43 @@ describe("resolveFeishuSendTarget", () => {
     expect(result.receiveIdType).toBe("user_id");
   });
 
+  it("blocks explicit group targets when disableGroupReplies is enabled", () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      config: {
+        disableGroupReplies: true,
+      },
+    });
+
+    expect(() =>
+      resolveFeishuSendTarget({
+        cfg,
+        to: "feishu:group:oc_123",
+      }),
+    ).toThrow('Feishu group replies are disabled by config for account "default"');
+  });
+
+  it("still allows dm targets when disableGroupReplies is enabled", () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      config: {
+        disableGroupReplies: true,
+      },
+    });
+
+    const result = resolveFeishuSendTarget({
+      cfg,
+      to: "feishu:user:ou_123",
+    });
+
+    expect(result.receiveId).toBe("ou_123");
+    expect(result.receiveIdType).toBe("open_id");
+  });
+
   it("throws when target account is not configured", () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "default",

--- a/extensions/feishu/src/send-target.test.ts
+++ b/extensions/feishu/src/send-target.test.ts
@@ -75,6 +75,24 @@ describe("resolveFeishuSendTarget", () => {
     ).toThrow('Feishu group replies are disabled by config for account "default"');
   });
 
+  it("blocks group targets with whitespace after provider prefix", () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      config: {
+        disableGroupReplies: true,
+      },
+    });
+
+    expect(() =>
+      resolveFeishuSendTarget({
+        cfg,
+        to: "feishu: group:oc_123",
+      }),
+    ).toThrow('Feishu group replies are disabled by config for account "default"');
+  });
+
   it("still allows dm targets when disableGroupReplies is enabled", () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "default",

--- a/extensions/feishu/src/send-target.ts
+++ b/extensions/feishu/src/send-target.ts
@@ -21,9 +21,20 @@ export function resolveFeishuSendTarget(params: {
   // Preserve explicit routing prefixes (chat/group/user/dm/open_id) when present.
   // normalizeFeishuTarget strips these prefixes, so infer type from the raw target first.
   const withoutProviderPrefix = target.replace(/^(feishu|lark):/i, "");
+  const lowered = withoutProviderPrefix.toLowerCase();
+  const receiveIdType = resolveReceiveIdType(withoutProviderPrefix);
+  const isExplicitGroupTarget =
+    lowered.startsWith("chat:") || lowered.startsWith("group:") || lowered.startsWith("channel:");
+
+  if (account.config?.disableGroupReplies && isExplicitGroupTarget && receiveIdType === "chat_id") {
+    throw new Error(
+      `Feishu group replies are disabled by config for account "${account.accountId}"`,
+    );
+  }
+
   return {
     client,
     receiveId,
-    receiveIdType: resolveReceiveIdType(withoutProviderPrefix),
+    receiveIdType,
   };
 }

--- a/extensions/feishu/src/send-target.ts
+++ b/extensions/feishu/src/send-target.ts
@@ -20,7 +20,7 @@ export function resolveFeishuSendTarget(params: {
   }
   // Preserve explicit routing prefixes (chat/group/user/dm/open_id) when present.
   // normalizeFeishuTarget strips these prefixes, so infer type from the raw target first.
-  const withoutProviderPrefix = target.replace(/^(feishu|lark):/i, "");
+  const withoutProviderPrefix = target.replace(/^(feishu|lark):/i, "").trim();
   const lowered = withoutProviderPrefix.toLowerCase();
   const receiveIdType = resolveReceiveIdType(withoutProviderPrefix);
   const isExplicitGroupTarget =


### PR DESCRIPTION
## What this changes

This PR adds a Feishu config switch for teams that want OpenClaw to **observe group chats without ever replying into them**.

New config:

- `channels.feishu.disableGroupReplies: true`

When enabled:

- Feishu **group messages are still received** and routed into the agent
- Feishu **DM replies continue to work normally**
- Feishu **group replies are blocked at the program level**
- Explicit outbound Feishu group targets such as `chat:oc_xxx` / `group:oc_xxx` are also blocked

## Why

Some deployments want the bot to:

- read group history or live group traffic
- keep private chat interactions enabled
- avoid accidental replies in groups, even if the model is prompted, mentioned, or socially engineered

This moves that behavior from a prompt-level convention to a **channel-level guardrail**.

## Implementation

- add `disableGroupReplies` to the Feishu config schema and channel config schema
- use a no-op reply dispatcher for Feishu group dispatch when the flag is enabled
- reject explicit outbound Feishu group targets when group replies are disabled
- document the config in `docs/channels/feishu.md`

## Example

```json5
{
  channels: {
    feishu: {
      enabled: true,
      groupPolicy: "allowlist",
      groupAllowFrom: ["oc_group_a", "oc_group_b"],
      requireMention: true,
      disableGroupReplies: true
    }
  }
}
```

## Testing

```bash
npx vitest run \
  extensions/feishu/src/send-target.test.ts \
  extensions/feishu/src/outbound.test.ts \
  extensions/feishu/src/bot.test.ts
```

Passed locally.

## Notes

This intentionally keeps inbound group visibility intact while making outbound group replies impossible unless the config is changed.
