### PR TITLE
fix(darwin): remove self-kickstart from launchd gateway restart; rely on KeepAlive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -725,6 +725,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/macOS restart: remove self-issued `launchctl kickstart -k` from launchd supervised restart path to prevent race with launchd's async bootout state machine that permanently unloads the LaunchAgent. With `ThrottleInterval=1` (current default), `exit(0)` + `KeepAlive=true` restarts the service within ~1s without the race condition. (#39760) Landed from contributor PR #39763 by @daymade. Thanks @daymade.
 - Exec/system.run env sanitization: block dangerous override-only env pivots such as `GIT_SSH_COMMAND`, editor/pager hooks, and `GIT_CONFIG_` / `NPM_CONFIG_` override prefixes so allowlisted tools cannot smuggle helper command execution through subprocess environment overrides. Thanks @tdjackey and @SnailSploit for reporting.
 - Network/fetch guard redirect auth stripping: switch cross-origin redirect handling in `fetchWithSsrFGuard` from a narrow sensitive-header denylist to a safe-header allowlist so custom auth headers like `X-Api-Key` and `Private-Token` no longer leak on origin changes. Thanks @Rickidevs for reporting.
 - Security/Sandbox media reads: eliminate sandbox media TOCTOU symlink-retarget escapes by enforcing root-scoped boundary-safe reads at attachment/image load time and consolidating shared safe-read helpers across sandbox media callsites. This ships in the next npm release. Thanks @tdjackey for reporting.

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -54,8 +54,6 @@ function expectLaunchdSupervisedWithoutKickstart(params?: { launchJobLabel?: str
   process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
   const result = restartGatewayProcessWithFreshPid();
   expect(result.mode).toBe("supervised");
-  // launchd path no longer calls triggerOpenClawRestart — it relies on
-  // KeepAlive=true to restart the service after the caller exits.
   expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
   expect(spawnMock).not.toHaveBeenCalled();
 }
@@ -74,7 +72,6 @@ describe("restartGatewayProcessWithFreshPid", () => {
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
-    // launchd relies on KeepAlive=true — no kickstart call needed.
     expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -46,16 +46,17 @@ function clearSupervisorHints() {
   }
 }
 
-function expectLaunchdKickstartSupervised(params?: { launchJobLabel?: string }) {
+function expectLaunchdSupervisedWithoutKickstart(params?: { launchJobLabel?: string }) {
   setPlatform("darwin");
   if (params?.launchJobLabel) {
     process.env.LAUNCH_JOB_LABEL = params.launchJobLabel;
   }
   process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-  triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
   const result = restartGatewayProcessWithFreshPid();
   expect(result.mode).toBe("supervised");
-  expect(triggerOpenClawRestartMock).toHaveBeenCalledOnce();
+  // launchd path no longer calls triggerOpenClawRestart — it relies on
+  // KeepAlive=true to restart the service after the caller exits.
+  expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
   expect(spawnMock).not.toHaveBeenCalled();
 }
 
@@ -67,35 +68,19 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("returns supervised when launchd hints are present on macOS", () => {
+  it("returns supervised when launchd hints are present on macOS (no kickstart)", () => {
     clearSupervisorHints();
     setPlatform("darwin");
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
-    triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
-    expect(triggerOpenClawRestartMock).toHaveBeenCalledOnce();
+    // launchd relies on KeepAlive=true — no kickstart call needed.
+    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("runs launchd kickstart helper on macOS when launchd label is set", () => {
-    expectLaunchdKickstartSupervised({ launchJobLabel: "ai.openclaw.gateway" });
-  });
-
-  it("returns failed when launchd kickstart helper fails", () => {
-    setPlatform("darwin");
-    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    triggerOpenClawRestartMock.mockReturnValue({
-      ok: false,
-      method: "launchctl",
-      detail: "spawn failed",
-    });
-
-    const result = restartGatewayProcessWithFreshPid();
-
-    expect(result.mode).toBe("failed");
-    expect(result.detail).toContain("spawn failed");
+  it("returns supervised on macOS when launchd label is set (no kickstart)", () => {
+    expectLaunchdSupervisedWithoutKickstart({ launchJobLabel: "ai.openclaw.gateway" });
   });
 
   it("does not schedule kickstart on non-darwin platforms", () => {
@@ -133,7 +118,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when OPENCLAW_LAUNCHD_LABEL is set (stock launchd plist)", () => {
     clearSupervisorHints();
-    expectLaunchdKickstartSupervised();
+    expectLaunchdSupervisedWithoutKickstart();
   });
 
   it("returns supervised when OPENCLAW_SYSTEMD_UNIT is set", () => {

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -80,6 +80,22 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expectLaunchdSupervisedWithoutKickstart({ launchJobLabel: "ai.openclaw.gateway" });
   });
 
+  it("launchd supervisor never returns failed regardless of triggerOpenClawRestart outcome", () => {
+    clearSupervisorHints();
+    setPlatform("darwin");
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    // Even if triggerOpenClawRestart *would* fail, launchd path must not call it.
+    triggerOpenClawRestartMock.mockReturnValue({
+      ok: false,
+      method: "launchctl",
+      detail: "Bootstrap failed: 5: Input/output error",
+    });
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result.mode).toBe("supervised");
+    expect(result.mode).not.toBe("failed");
+    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+  });
+
   it("does not schedule kickstart on non-darwin platforms", () => {
     setPlatform("linux");
     process.env.INVOCATION_ID = "abc123";

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -31,10 +31,8 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
   const supervisor = detectRespawnSupervisor(process.env);
   if (supervisor) {
     // launchd: exit(0) is sufficient — KeepAlive=true restarts the service.
-    // Calling `kickstart -k` from within the service itself races with
-    // launchd's async bootout state machine: the spawnSync timeout kills the
-    // launchctl child, but launchd continues the bootout and eventually
-    // SIGKILLs this process, leaving the LaunchAgent permanently unloaded.
+    // Self-issued `kickstart -k` races with launchd's bootout state machine
+    // and can leave the LaunchAgent permanently unloaded.
     // See: https://github.com/openclaw/openclaw/issues/39760
     if (supervisor === "schtasks") {
       const restart = triggerOpenClawRestart();

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -30,7 +30,13 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
   }
   const supervisor = detectRespawnSupervisor(process.env);
   if (supervisor) {
-    if (supervisor === "launchd" || supervisor === "schtasks") {
+    // launchd: exit(0) is sufficient — KeepAlive=true restarts the service.
+    // Calling `kickstart -k` from within the service itself races with
+    // launchd's async bootout state machine: the spawnSync timeout kills the
+    // launchctl child, but launchd continues the bootout and eventually
+    // SIGKILLs this process, leaving the LaunchAgent permanently unloaded.
+    // See: https://github.com/openclaw/openclaw/issues/39760
+    if (supervisor === "schtasks") {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {
         return {


### PR DESCRIPTION
## Summary

Fixes gateway crash on macOS when config changes trigger restart (plugin install, settings update). The bug permanently unloads the LaunchAgent, requiring manual `launchctl load` to recover.

**Root cause**: `launchctl kickstart -k` called from within the service races with launchd's async bootout state machine. The 2s spawnSync timeout expires before launchd completes SIGTERM→SIGKILL escalation (~20s), causing bootstrap to fail with EIO. The fallback in-process restart succeeds briefly but gets SIGKILL'd by the pending bootout, leaving the service permanently unloaded.

**Fix**: On darwin/launchd, skip `triggerOpenClawRestart()` entirely. Rely on `exitProcess(0)` + `KeepAlive=true` (already set in plist template) to restart within ~1s. With `ThrottleInterval=1` (current default), this is now fast enough.

**Why this is safe now**: PR #29078 introduced `kickstart -k` to bypass a 60s `ThrottleInterval` delay from #27650. Since then, `ThrottleInterval` was reduced to 1s, making the kickstart workaround unnecessary. This fix removes the workaround and relies on the supervisor's native restart mechanism.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue

Closes #39760

## User-visible Changes

Gateway restart on macOS after config changes now completes reliably within ~1-2 seconds instead of permanently killing the service.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro

1. Install gateway as LaunchAgent: `openclaw gateway install`
2. Ask bot to install a plugin: "install @mem9/mem9"
3. Plugin writes to `openclaw.json` → reload triggers SIGUSR1 restart

**Expected**: Gateway restarts cleanly within ~1-2s.
**Actual (before fix)**: Gateway dies permanently. `launchctl list ai.openclaw.gateway` returns "Could not find service".

See #39760 for detailed system logs and failure timeline.

## Tests

```
✓ process-respawn.test.ts (13 tests including new regression test)
✓ run-loop.test.ts (8 tests)
✓ restart.test.ts (5 tests)
```

New test: `launchd supervisor never returns failed regardless of triggerOpenClawRestart outcome` — ensures launchd path always returns `{mode: "supervised"}` and never falls back to in-process restart.

## Compatibility

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks

- Risk: `KeepAlive` not set in custom plist
  - Mitigation: `KeepAlive=true` always set by `openclaw gateway install`; `gateway doctor` flags missing KeepAlive. Non-default plists out of scope.
