### PR TITLE
fix(config): make models.providers.<id>.models optional to allow credential-only entries

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -183,6 +183,43 @@ describe("embedding provider remote overrides", () => {
     expect(headers.Authorization).toBe("Bearer provider-key");
   });
 
+  it("uses models.providers.openai.baseUrl when no remote.baseUrl is provided", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    mockResolvedProviderKey("provider-key");
+
+    // Use a hostname that resolves in DNS so the SSRF guard's pre-flight lookup
+    // succeeds and the stubbed fetch is reached. The important invariant is that
+    // the URL comes from models.providers.openai.baseUrl, NOT the hardcoded default.
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://example.com/v1",
+          },
+        },
+      },
+    };
+
+    const result = await createEmbeddingProvider({
+      config: cfg as never,
+      provider: "openai",
+      remote: {
+        // No remote.baseUrl — must fall through to models.providers.openai.baseUrl
+      },
+      model: "text-embedding-3-small",
+      fallback: "none",
+    });
+
+    const provider = requireProvider(result);
+    await provider.embedQuery("hello");
+
+    const { url } = readFirstFetchRequest(fetchMock);
+    // Must use the provider-configured baseUrl, not the hardcoded DEFAULT_OPENAI_BASE_URL
+    expect(url).toBe("https://example.com/v1/embeddings");
+    expect(url).not.toBe("https://api.openai.com/v1/embeddings");
+  });
+
   it("builds Gemini embeddings requests with api key header", async () => {
     const fetchMock = createGeminiFetchMock();
     vi.stubGlobal("fetch", fetchMock);

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -258,7 +258,12 @@ export const ModelProviderSchema = z
     injectNumCtxForOpenAICompat: z.boolean().optional(),
     headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
     authHeader: z.boolean().optional(),
-    models: z.array(ModelDefinitionSchema),
+    // Provider entries used solely for credential or baseUrl configuration
+    // (e.g. a custom OpenAI-compatible embedding endpoint) need not enumerate
+    // their models.  Defaulting to an empty array lets users omit the field
+    // without triggering a validation error that would cause the gateway to
+    // keep running with the stale config and silently ignore the custom baseUrl.
+    models: z.array(ModelDefinitionSchema).default([]),
   })
   .strict();
 

--- a/src/config/zod-schema.model-provider.test.ts
+++ b/src/config/zod-schema.model-provider.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+/**
+ * Regression tests for ModelProviderSchema — specifically the `models` field.
+ *
+ * Users who configure `models.providers.<id>` solely for credential/baseUrl
+ * purposes (e.g. a custom OpenAI-compatible embedding endpoint) should be able
+ * to omit the `models` array without triggering a validation error.  A failed
+ * validation causes the gateway to keep running with the stale config and
+ * silently fall back to the default provider baseUrl.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/39589
+ */
+describe("ModelProviderSchema", () => {
+  it("accepts a provider entry without a models array (defaults to [])", () => {
+    const result = OpenClawSchema.safeParse({
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.custom-provider.net/v1",
+            apiKey: "sk-test",
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.models?.providers?.["openai"]?.models).toEqual([]);
+      expect(result.data.models?.providers?.["openai"]?.baseUrl).toBe(
+        "https://api.custom-provider.net/v1",
+      );
+    }
+  });
+
+  it("accepts a provider entry with an explicit empty models array", () => {
+    const result = OpenClawSchema.safeParse({
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.custom-provider.net/v1",
+            apiKey: "sk-test",
+            models: [],
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.models?.providers?.["openai"]?.models).toEqual([]);
+    }
+  });
+
+  it("preserves baseUrl from models.providers when models field is omitted", () => {
+    // Ensures the custom baseUrl survives config validation so the embedding
+    // system can pick it up instead of falling back to the hardcoded default.
+    const result = OpenClawSchema.safeParse({
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.gptsapi.net/v1",
+            api: "openai-completions",
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.models?.providers?.["openai"]?.baseUrl).toBe("https://api.gptsapi.net/v1");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

When a user configures `models.providers.openai` with a custom `baseUrl` (e.g. an OpenAI-compatible embedding endpoint) but without a `models` array, OpenClaw's config validation rejects the entry with **`INVALID_CONFIG`**:

```json
{
  "models": {
    "providers": {
      "openai": {
        "baseUrl": "https://api.gptsapi.net/v1",
        "apiKey": "${OPENAI_API_KEY}",
        "api": "openai-completions"
      }
    }
  }
}
```

On a live gateway a failed reload is silently ignored (the gateway keeps running with the stale config). The stale config has no `models.providers.openai` entry, so `providerConfig?.baseUrl` in `resolveRemoteEmbeddingBearerClient` is `undefined`, and the embedding system falls back to the hard-coded `DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"` instead of the intended custom endpoint. The user then sees `TypeError: fetch failed` when the request reaches the wrong host.

## Root Cause

`ModelProviderSchema` in `src/config/zod-schema.core.ts` declares `models` as a **required** field:

```ts
models: z.array(ModelDefinitionSchema),  // required — fails if omitted
```

Users who configure a provider entry solely for credentials/baseUrl (no custom models) have no reason to include an empty `models: []`. Making the field required creates an unnecessary footgun.

## Fix

Change the field declaration to use `.default([])`:

```ts
models: z.array(ModelDefinitionSchema).default([]),
```

The parsed output still always contains an array (never `undefined`), so all downstream code that iterates over models remains safe. Configs that omit `models` now pass validation and the gateway picks up the custom `baseUrl` correctly.

## Tests

**`src/config/zod-schema.model-provider.test.ts`** (new file, 3 tests):
- ✅ Provider entry without `models` field passes validation and defaults to `[]`
- ✅ Provider entry with explicit `models: []` passes validation  
- ✅ `baseUrl` is preserved when `models` is omitted

**`src/memory/embeddings.test.ts`** (1 test added):
- ✅ `createEmbeddingProvider` routes to `models.providers.openai.baseUrl` when no `remote.baseUrl` override is present

Fixes #39589