### PR TITLE
fix(matrix): cap room info cache to prevent unbounded memory growth

### DIFF
--- a/extensions/matrix/src/matrix/monitor/room-info.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.ts
@@ -6,6 +6,8 @@ export type MatrixRoomInfo = {
   altAliases: string[];
 };
 
+const MAX_ROOM_INFO_CACHE_SIZE = 2048;
+
 export function createMatrixRoomInfoResolver(client: MatrixClient) {
   const roomInfoCache = new Map<string, MatrixRoomInfo>();
 
@@ -34,6 +36,12 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
     }
     const info = { name, canonicalAlias, altAliases };
     roomInfoCache.set(roomId, info);
+    if (roomInfoCache.size > MAX_ROOM_INFO_CACHE_SIZE) {
+      const oldest = roomInfoCache.keys().next().value;
+      if (oldest !== undefined) {
+        roomInfoCache.delete(oldest);
+      }
+    }
     return info;
   };
 


### PR DESCRIPTION
## Summary
- The `roomInfoCache` Map in `createMatrixRoomInfoResolver()` grows without limit as new rooms are encountered
- On busy Matrix servers with thousands of rooms, this causes unbounded memory growth over the process lifetime
- Cap at 2048 entries with FIFO eviction, consistent with the existing `directRoomCache` pattern in `targets.ts` (line 20-31)

## Test plan
- [x] All 108 matrix tests pass
- [x] Formatting clean (`oxfmt`)
- [x] Eviction pattern matches existing `directRoomCache` (same file structure, same Map-based FIFO)