### PR TITLE
fix(telegram): apply reply_to only to first stream preview to avoid 'Deleted message'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Telegram: suppress stale reply links on rotated streaming previews so cleaned-up partial messages do not leave "Deleted message" artifacts, while preserving forum thread IDs and `replyToMode: "all"` reply behavior. Fixes #39718; carries forward #39772. Thanks @widingmarcus-cyber and @ksylvan.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -419,6 +419,7 @@ export const dispatchTelegramMessage = async ({
           thread: threadSpec,
           previewTransport: useMessagePreviewTransportForDm ? "message" : "auto",
           replyToMessageId: draftReplyToMessageId,
+          replyToMode,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,
           onSupersededPreview:

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -574,6 +574,111 @@ describe("createTelegramDraftStream", () => {
     );
   });
 
+  it("applies reply_to_message_id only to the first message, not after forceNewMessage (#39718)", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      replyToMessageId: 999,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", {
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+
+    stream.forceNewMessage();
+    stream.update("After rotation");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenLastCalledWith(123, "After rotation", undefined);
+  });
+
+  it("keeps thread params when dropping reply_to_message_id after forceNewMessage", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "message",
+      replyToMessageId: 999,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", {
+      message_thread_id: 42,
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+
+    stream.forceNewMessage();
+    stream.update("After rotation");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenLastCalledWith(123, "After rotation", {
+      message_thread_id: 42,
+    });
+  });
+
+  it("does not consume reply_to_message_id before the first successful send", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockRejectedValueOnce(
+        Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }),
+      )
+      .mockResolvedValueOnce({ message_id: 42 });
+    const stream = createDraftStream(api, { replyToMessageId: 999 });
+
+    stream.update("Hello");
+    await stream.flush();
+    expect(stream.sendMayHaveLanded?.()).toBe(false);
+
+    stream.forceNewMessage();
+    stream.update("After retry");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenLastCalledWith(123, "After retry", {
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+  });
+
+  it("drops reply_to_message_id after a superseded first send lands", async () => {
+    let resolveFirstSend: ((value: { message_id: number }) => void) | undefined;
+    const firstSend = new Promise<{ message_id: number }>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+    const api = createMockDraftApi();
+    api.sendMessage.mockReturnValueOnce(firstSend).mockResolvedValueOnce({ message_id: 42 });
+    const stream = createDraftStream(api, { replyToMessageId: 999 });
+
+    stream.update("Message A");
+    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledTimes(1));
+
+    stream.forceNewMessage();
+    stream.update("Message B");
+
+    resolveFirstSend?.({ message_id: 17 });
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "Message A", {
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Message B", undefined);
+  });
+
   it("supports rendered previews with parse_mode", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -653,6 +653,34 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
+  it("restores reply_to_message_id when an in-flight first send safely fails during rotation", async () => {
+    let rejectFirstSend: ((reason: unknown) => void) | undefined;
+    const firstSend = new Promise<{ message_id: number }>((_, reject) => {
+      rejectFirstSend = reject;
+    });
+    const api = createMockDraftApi();
+    api.sendMessage.mockReturnValueOnce(firstSend).mockResolvedValueOnce({ message_id: 42 });
+    const stream = createDraftStream(api, { replyToMessageId: 999 });
+
+    stream.update("Message A");
+    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledTimes(1));
+
+    stream.forceNewMessage();
+    stream.update("Message B");
+    rejectFirstSend?.(Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }));
+    await stream.flush();
+
+    stream.forceNewMessage();
+    stream.update("Message B");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Message B", {
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+  });
+
   it("drops reply_to_message_id after a superseded first send lands", async () => {
     let resolveFirstSend: ((value: { message_id: number }) => void) | undefined;
     const firstSend = new Promise<{ message_id: number }>((resolve) => {
@@ -677,6 +705,65 @@ describe("createTelegramDraftStream", () => {
       allow_sending_without_reply: true,
     });
     expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Message B", undefined);
+  });
+
+  it("preserves reply_to_message_id after forceNewMessage when replyToMode is all", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "message",
+      replyToMessageId: 999,
+      replyToMode: "all",
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.forceNewMessage();
+    stream.update("After rotation");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "Hello", {
+      message_thread_id: 42,
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "After rotation", {
+      message_thread_id: 42,
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+  });
+
+  it("materialized draft previews consume single-use reply_to_message_id", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+      replyToMessageId: 999,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    await stream.materialize?.();
+    stream.forceNewMessage();
+    stream.update("After rotation");
+    await stream.flush();
+    await stream.materialize?.();
+
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "Hello", {
+      message_thread_id: 42,
+      reply_to_message_id: 999,
+      allow_sending_without_reply: true,
+    });
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "After rotation", {
+      message_thread_id: 42,
+    });
   });
 
   it("supports rendered previews with parse_mode", async () => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -600,7 +600,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.sendMessage).toHaveBeenLastCalledWith(123, "After rotation", undefined);
   });
 
-  it("keeps thread params when dropping reply_to_message_id after forceNewMessage", async () => {
+  it("keeps thread params when dropping reply_to_message_id after forceNewMessage (#39718)", async () => {
     const api = createMockDraftApi();
     api.sendMessage
       .mockResolvedValueOnce({ message_id: 17 })

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -198,7 +198,11 @@ export function createTelegramDraftStream(params: {
     // Only apply reply_to_message_id on the first message of the stream.
     // After forceNewMessage(), subsequent messages should not reply to avoid
     // "Deleted message" artifacts when archived previews are cleaned up (#39718).
-    const shouldIncludeReply = !hasAppliedReply && baseReplyParams?.reply_to_message_id != null;
+    const shouldIncludeReply =
+      !hasAppliedReply &&
+      baseReplyParams != null &&
+      "reply_to_message_id" in baseReplyParams &&
+      baseReplyParams.reply_to_message_id != null;
     const replyParams = shouldIncludeReply ? baseReplyParams : threadParams;
     // Mark reply as applied BEFORE the await to prevent race with forceNewMessage (#39718).
     // Even if forceNewMessage fires during this in-flight send, subsequent sends

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -198,7 +198,14 @@ export function createTelegramDraftStream(params: {
     // Only apply reply_to_message_id on the first message of the stream.
     // After forceNewMessage(), subsequent messages should not reply to avoid
     // "Deleted message" artifacts when archived previews are cleaned up (#39718).
-    const replyParams = hasAppliedReply ? threadParams : baseReplyParams;
+    const shouldIncludeReply = !hasAppliedReply && baseReplyParams?.reply_to_message_id != null;
+    const replyParams = shouldIncludeReply ? baseReplyParams : threadParams;
+    // Mark reply as applied BEFORE the await to prevent race with forceNewMessage (#39718).
+    // Even if forceNewMessage fires during this in-flight send, subsequent sends
+    // will see hasAppliedReply=true and skip the reply context.
+    if (shouldIncludeReply) {
+      hasAppliedReply = true;
+    }
     const sendParams = sendArgs.renderedParseMode
       ? {
           ...replyParams,

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -207,9 +207,19 @@ export function createTelegramDraftStream(params: {
     // Mark reply as applied BEFORE the await to prevent race with forceNewMessage (#39718).
     // Even if forceNewMessage fires during this in-flight send, subsequent sends
     // will see hasAppliedReply=true and skip the reply context.
+    const replyAppliedGeneration = shouldIncludeReply ? generation : undefined;
     if (shouldIncludeReply) {
       hasAppliedReply = true;
     }
+    const restoreReplyForSafeFailure = (err: unknown) => {
+      if (
+        shouldIncludeReply &&
+        replyAppliedGeneration === generation &&
+        (isSafeToRetrySendError(err) || isTelegramClientRejection(err))
+      ) {
+        hasAppliedReply = false;
+      }
+    };
     const sendParams = sendArgs.renderedParseMode
       ? {
           ...replyParams,
@@ -224,19 +234,25 @@ export function createTelegramDraftStream(params: {
       };
     } catch (err) {
       if (!usedThreadParams || !THREAD_NOT_FOUND_RE.test(String(err))) {
+        restoreReplyForSafeFailure(err);
         throw err;
       }
       const threadlessParams: TelegramSendMessageParams = { ...sendParams };
       delete threadlessParams.message_thread_id;
       params.warn?.(sendArgs.fallbackWarnMessage);
-      return {
-        sent: await params.api.sendMessage(
-          chatId,
-          sendArgs.renderedText,
-          Object.keys(threadlessParams).length > 0 ? threadlessParams : undefined,
-        ),
-        usedThreadParams: false,
-      };
+      try {
+        return {
+          sent: await params.api.sendMessage(
+            chatId,
+            sendArgs.renderedText,
+            Object.keys(threadlessParams).length > 0 ? threadlessParams : undefined,
+          ),
+          usedThreadParams: false,
+        };
+      } catch (retryErr) {
+        restoreReplyForSafeFailure(retryErr);
+        throw retryErr;
+      }
     }
   };
   const sendMessageTransportPreview = async ({

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -155,7 +155,8 @@ export function createTelegramDraftStream(params: {
         : params.thread?.scope === "dm";
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
-  const replyParams =
+  let hasAppliedReply = false;
+  const baseReplyParams =
     replyToMessageId != null
       ? {
           ...threadParams,
@@ -194,6 +195,10 @@ export function createTelegramDraftStream(params: {
     renderedParseMode: "HTML" | undefined;
     fallbackWarnMessage: string;
   }) => {
+    // Only apply reply_to_message_id on the first message of the stream.
+    // After forceNewMessage(), subsequent messages should not reply to avoid
+    // "Deleted message" artifacts when archived previews are cleaned up (#39718).
+    const replyParams = hasAppliedReply ? threadParams : baseReplyParams;
     const sendParams = sendArgs.renderedParseMode
       ? {
           ...replyParams,
@@ -263,6 +268,7 @@ export function createTelegramDraftStream(params: {
     const normalizedMessageId = Math.trunc(sentMessageId);
     const visibleSinceMs = Date.now();
     if (sendGeneration !== generation) {
+      hasAppliedReply = true;
       params.onSupersededPreview?.({
         messageId: normalizedMessageId,
         textSnapshot: renderedText,
@@ -273,6 +279,7 @@ export function createTelegramDraftStream(params: {
     }
     streamMessageId = normalizedMessageId;
     streamVisibleSinceMs = visibleSinceMs;
+    hasAppliedReply = true;
     return true;
   };
   const sendDraftTransportPreview = async ({
@@ -449,6 +456,7 @@ export function createTelegramDraftStream(params: {
       if (typeof sentId === "number" && Number.isFinite(sentId)) {
         streamMessageId = Math.trunc(sentId);
         streamVisibleSinceMs = Date.now();
+        hasAppliedReply = true;
         if (resolvedDraftApi != null && streamDraftId != null) {
           const clearDraftId = streamDraftId;
           const clearThreadParams =

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -3,6 +3,7 @@ import {
   createFinalizableDraftStreamControlsForState,
   takeMessageIdAfterStop,
 } from "openclaw/plugin-sdk/channel-lifecycle";
+import type { ReplyToMode } from "openclaw/plugin-sdk/config-types";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 import { isSafeToRetrySendError, isTelegramClientRejection } from "./network-errors.js";
@@ -129,6 +130,7 @@ export function createTelegramDraftStream(params: {
   thread?: TelegramThreadSpec | null;
   previewTransport?: "auto" | "message" | "draft";
   replyToMessageId?: number;
+  replyToMode?: ReplyToMode;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
@@ -155,7 +157,8 @@ export function createTelegramDraftStream(params: {
         : params.thread?.scope === "dm";
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
-  let hasAppliedReply = false;
+  const replyToMode = params.replyToMode ?? "first";
+  let hasAppliedSingleUseReply = false;
   const baseReplyParams =
     replyToMessageId != null
       ? {
@@ -195,29 +198,28 @@ export function createTelegramDraftStream(params: {
     renderedParseMode: "HTML" | undefined;
     fallbackWarnMessage: string;
   }) => {
-    // Only apply reply_to_message_id on the first message of the stream.
-    // After forceNewMessage(), subsequent messages should not reply to avoid
-    // "Deleted message" artifacts when archived previews are cleaned up (#39718).
+    // For single-use modes, only apply reply_to_message_id to the first preview
+    // send. Rotated previews otherwise point at previews that may be deleted
+    // after cleanup and expose Telegram "Deleted message" artifacts (#39718).
     const shouldIncludeReply =
-      !hasAppliedReply &&
+      (replyToMode === "all" || !hasAppliedSingleUseReply) &&
       baseReplyParams != null &&
       "reply_to_message_id" in baseReplyParams &&
       baseReplyParams.reply_to_message_id != null;
     const replyParams = shouldIncludeReply ? baseReplyParams : threadParams;
-    // Mark reply as applied BEFORE the await to prevent race with forceNewMessage (#39718).
-    // Even if forceNewMessage fires during this in-flight send, subsequent sends
-    // will see hasAppliedReply=true and skip the reply context.
-    const replyAppliedGeneration = shouldIncludeReply ? generation : undefined;
-    if (shouldIncludeReply) {
-      hasAppliedReply = true;
+    // Mark single-use replies as applied before awaiting to prevent races with
+    // forceNewMessage. Safe first-send failures restore the context below.
+    const consumedSingleUseReply = shouldIncludeReply && replyToMode !== "all";
+    if (consumedSingleUseReply) {
+      hasAppliedSingleUseReply = true;
     }
     const restoreReplyForSafeFailure = (err: unknown) => {
       if (
-        shouldIncludeReply &&
-        replyAppliedGeneration === generation &&
+        consumedSingleUseReply &&
+        typeof streamMessageId !== "number" &&
         (isSafeToRetrySendError(err) || isTelegramClientRejection(err))
       ) {
-        hasAppliedReply = false;
+        hasAppliedSingleUseReply = false;
       }
     };
     const sendParams = sendArgs.renderedParseMode
@@ -295,7 +297,6 @@ export function createTelegramDraftStream(params: {
     const normalizedMessageId = Math.trunc(sentMessageId);
     const visibleSinceMs = Date.now();
     if (sendGeneration !== generation) {
-      hasAppliedReply = true;
       params.onSupersededPreview?.({
         messageId: normalizedMessageId,
         textSnapshot: renderedText,
@@ -306,7 +307,6 @@ export function createTelegramDraftStream(params: {
     }
     streamMessageId = normalizedMessageId;
     streamVisibleSinceMs = visibleSinceMs;
-    hasAppliedReply = true;
     return true;
   };
   const sendDraftTransportPreview = async ({
@@ -483,7 +483,6 @@ export function createTelegramDraftStream(params: {
       if (typeof sentId === "number" && Number.isFinite(sentId)) {
         streamMessageId = Math.trunc(sentId);
         streamVisibleSinceMs = Date.now();
-        hasAppliedReply = true;
         if (resolvedDraftApi != null && streamDraftId != null) {
           const clearDraftId = streamDraftId;
           const clearThreadParams =


### PR DESCRIPTION
## Summary

- **Problem:** During Telegram streaming, the reply header briefly shows "Deleted message" when tool boundaries cause `forceNewMessage()` to create new preview messages.
- **Root cause:** After `forceNewMessage()`, the new preview message was also sent with `reply_to_message_id` pointing to the user's original message. When the first preview was archived and deleted, Telegram briefly showed "Deleted message" for subsequent previews that also tried to reply to the same user message.
- **Fix:** Track whether `reply_to_message_id` has been applied with `hasAppliedReply` flag. Only the first preview message gets the reply context; subsequent messages after `forceNewMessage()` are sent without a reply target.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Telegram)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39718
- Related to #32924 (which fixes reasoning lane deletions, different root cause)

## User-visible / Behavior Changes

- The first assistant streaming reply in Telegram will still quote/reply to the user's message
- Subsequent assistant messages in the same stream (e.g., after tool use) will NOT quote/reply to the user's message
- This prevents the brief "Deleted message" artifact that appeared during streaming

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Enable streaming in Telegram
2. Ask the agent a question that triggers tool use (multiple response segments)
3. **Before fix:** Brief "Deleted message" appears in reply header during streaming
4. **After fix:** First message replies to user, subsequent messages have no reply context

### Evidence

- [x] New test: `applies reply_to_message_id only to the first message, not after forceNewMessage (#39718)`
- [x] All 28 tests in `draft-stream.test.ts` pass

## Human Verification

- Verified: First message gets reply_to, subsequent messages do not
- Edge cases: Materialize still uses reply context correctly for the permanent message
- What I did not verify: Live Telegram testing (no Telegram access)

## Compatibility / Migration

- Backward compatible? Yes (slightly changed UX for multi-segment responses)
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to revert: Revert PR commit
- Known bad symptoms: Users might miss the reply context on subsequent messages (acceptable trade-off)