### PR TITLE
fix: expose native GPT-5.4 context window on openai-codex provider

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -165,6 +165,9 @@ describe("loadModelCatalog", () => {
         name: "gpt-5.4",
       }),
     );
+    // GPT-5.4 on codex should get its native 1.05M context, not the template's 272k
+    const codexGpt54 = result.find((e) => e.provider === "openai-codex" && e.id === "gpt-5.4");
+    expect(codexGpt54?.contextWindow).toBe(1_050_000);
   });
 
   it("merges configured models for opted-in non-pi-native providers", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -39,12 +39,14 @@ const OPENAI_GPT54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
+const OPENAI_GPT54_CONTEXT_TOKENS = 1_050_000;
 const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["kilocode"]);
 
 type SyntheticCatalogFallback = {
   provider: string;
   id: string;
   templateIds: readonly string[];
+  patch?: Partial<ModelCatalogEntry>;
 };
 
 const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
@@ -62,6 +64,7 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: CODEX_PROVIDER,
     id: OPENAI_CODEX_GPT54_MODEL_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
+    patch: { contextWindow: OPENAI_GPT54_CONTEXT_TOKENS },
   },
   {
     provider: CODEX_PROVIDER,
@@ -92,6 +95,7 @@ function applySyntheticCatalogFallbacks(models: ModelCatalogEntry[]): void {
       ...template,
       id: fallback.id,
       name: fallback.id,
+      ...fallback.patch,
     });
   }
 }

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -355,7 +355,7 @@ describe("resolveForwardCompatModel", () => {
     expect(model?.maxTokens).toBe(128_000);
   });
 
-  it("resolves openai-codex gpt-5.4 via codex template fallback", () => {
+  it("resolves openai-codex gpt-5.4 via codex template fallback with native context window", () => {
     const registry = createRegistry({
       "openai-codex/gpt-5.2-codex": createOpenAICodexTemplateModel("gpt-5.2-codex"),
     });
@@ -363,7 +363,8 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    // GPT-5.4 gets its native 1.05M context window, not the template's 272k
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
   });
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -123,9 +123,17 @@ function resolveOpenAICodexForwardCompatModel(
 
   let templateIds: readonly string[];
   let eligibleProviders: Set<string>;
+  // GPT-5.4 on the Codex path supports the same native 1.05M context window as the
+  // direct OpenAI provider. Apply the correct capability patch so users see the full
+  // context window instead of inheriting the smaller template value.
+  let patch: Partial<Model<Api>> | undefined;
   if (lower === OPENAI_CODEX_GPT_54_MODEL_ID) {
     templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT54_ELIGIBLE_PROVIDERS;
+    patch = {
+      contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS,
+      maxTokens: OPENAI_GPT_54_MAX_TOKENS,
+    };
   } else if (lower === OPENAI_CODEX_GPT_53_MODEL_ID) {
     templateIds = OPENAI_CODEX_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT53_ELIGIBLE_PROVIDERS;
@@ -146,6 +154,7 @@ function resolveOpenAICodexForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...patch,
     } as Model<Api>);
   }
 
@@ -158,8 +167,8 @@ function resolveOpenAICodexForwardCompatModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow: patch?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+    maxTokens: patch?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -58,6 +58,32 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
+  it("applies native 1.05M context window for openai-codex/gpt-5.4 via template", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model?.contextWindow).toBe(1_050_000);
+    expect(result.model?.maxTokens).toBe(128_000);
+  });
+
+  it("applies native 1.05M context window for openai-codex/gpt-5.4 without template", () => {
+    // No template mocked — exercises the hard-coded fallback path
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model?.contextWindow).toBe(1_050_000);
+    expect(result.model?.maxTokens).toBe(128_000);
+  });
+
+  it("preserves template context window for openai-codex/gpt-5.3-codex", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model?.contextWindow).toBe(272_000);
+    expect(result.model?.maxTokens).toBe(128_000);
+  });
+
   it("keeps unknown-model errors for non-forward-compat IDs", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -36,13 +36,16 @@ export function mockOpenAICodexTemplateModel(): void {
 export function buildOpenAICodexForwardCompatExpectation(
   id: string = "gpt-5.3-codex",
 ): Partial<typeof OPENAI_CODEX_TEMPLATE_MODEL> & { provider: string; id: string } {
+  // GPT-5.4 gets patched to its native 1.05M context window; other codex models
+  // inherit the template's context window.
+  const isGpt54 = id.toLowerCase() === "gpt-5.4";
   return {
     provider: "openai-codex",
     id,
     api: "openai-codex-responses",
     baseUrl: "https://chatgpt.com/backend-api",
     reasoning: true,
-    contextWindow: 272000,
+    contextWindow: isGpt54 ? 1_050_000 : 272000,
     maxTokens: 128000,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #39782

When using `openai-codex/gpt-5.4`, the context window was incorrectly reported as 200k (or 272k when cloned from a template) instead of the model's native 1.05M token context window.

**Root cause:** `resolveOpenAICodexForwardCompatModel` in `model-forward-compat.ts` had two issues:

1. **Template clone path:** Cloned from `gpt-5.3-codex`/`gpt-5.2-codex` template without overriding context window, inheriting the template's smaller value (272k)
2. **Fallback path:** Used `DEFAULT_CONTEXT_TOKENS` (200k) for both `contextWindow` and `maxTokens` when no template was available

The direct OpenAI path (`openai/gpt-5.4`) already correctly used `OPENAI_GPT_54_CONTEXT_TOKENS = 1,050,000`, but the Codex path did not.

## Changes

- **`model-forward-compat.ts`:** Apply `contextWindow: 1_050_000` and `maxTokens: 128_000` patch when resolving `gpt-5.4` on the `openai-codex` provider (both template and fallback paths). Other codex models (e.g. `gpt-5.3-codex`) retain their template values.
- **`model-catalog.ts`:** Add `patch: { contextWindow: 1_050_000 }` to the synthetic catalog fallback for `openai-codex/gpt-5.4`, so the model catalog also reports the correct context window.
- **Tests:** Updated and added tests in `model-compat.test.ts`, `model-forward-compat.test.ts`, `model.test-harness.ts`, and `model-catalog.test.ts` to verify the 1.05M context window for codex/gpt-5.4 in all code paths.

## Test plan

- [x] `pnpm test -- src/agents/pi-embedded-runner/model.forward-compat.test.ts` — 13 tests pass (3 new)
- [x] `pnpm test -- src/agents/model-compat.test.ts` — 32 tests pass
- [x] `pnpm test -- src/agents/model-catalog.test.ts` — 7 tests pass
- [x] `pnpm check` — lint/format/typecheck all green