### PR TITLE
fix(gateway): strip inbound metadata from TUI session titles and prefer external displayName

### DIFF
--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -12,6 +12,7 @@ import {
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
+import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { extractToolCallNames, hasToolCall } from "../utils/transcript-tools.js";
 import { stripEnvelope } from "./chat-sanitize.js";
@@ -366,7 +367,8 @@ export function readSessionTitleFieldsFromTranscript(
 
 function extractTextFromContent(content: TranscriptMessage["content"]): string | null {
   if (typeof content === "string") {
-    const normalized = stripInlineDirectiveTagsForDisplay(content).text.trim();
+    const stripped = stripInboundMetadata(content);
+    const normalized = stripInlineDirectiveTagsForDisplay(stripped).text.trim();
     return normalized || null;
   }
   if (!Array.isArray(content)) {
@@ -377,7 +379,8 @@ function extractTextFromContent(content: TranscriptMessage["content"]): string |
       continue;
     }
     if (part.type === "text" || part.type === "output_text" || part.type === "input_text") {
-      const normalized = stripInlineDirectiveTagsForDisplay(part.text).text.trim();
+      const stripped = stripInboundMetadata(part.text);
+      const normalized = stripInlineDirectiveTagsForDisplay(stripped).text.trim();
       if (normalized) {
         return normalized;
       }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -594,6 +594,18 @@ describe("deriveSessionTitle", () => {
     } as SessionEntry;
     expect(deriveSessionTitle(entry)).toBe("Actual Subject");
   });
+
+  test("prefers external displayName over entry.displayName", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      displayName: "Entry Display Name",
+      subject: "Group Chat",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, undefined, "External Display Name")).toBe(
+      "External Display Name",
+    );
+  });
 });
 
 describe("listSessionsFromStore search", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -150,9 +150,15 @@ function truncateTitle(text: string, maxLen: number): string {
 export function deriveSessionTitle(
   entry: SessionEntry | undefined,
   firstUserMessage?: string | null,
+  displayName?: string | null,
 ): string | undefined {
   if (!entry) {
     return undefined;
+  }
+
+  // Prefer external displayName (from outer session record) over entry.displayName
+  if (displayName?.trim()) {
+    return displayName.trim();
   }
 
   if (entry.displayName?.trim()) {
@@ -878,7 +884,7 @@ export function listSessionsFromStore(params: {
           agentId,
         );
         if (includeDerivedTitles) {
-          derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
+          derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage, rest.displayName);
         }
         if (includeLastMessage && fields.lastMessagePreview) {
           lastMessagePreview = fields.lastMessagePreview;


### PR DESCRIPTION
Fixes #39722

## Summary

Fixes two bugs in TUI session title derivation:

1. Bug 1: extractTextFromContent did not strip inbound metadata blocks before extracting the first user message, causing session titles to show untrusted metadata instead of actual message content.

2. Bug 2: deriveSessionTitle only checked entry.displayName but the actual displayName value is on the outer session record, not on entry, causing the guard to never fire and falling through to the first user message.

## Changes

- Added stripInboundMetadata import to session-utils.fs.ts
- Modified extractTextFromContent to strip inbound metadata blocks before extracting text
- Updated deriveSessionTitle to accept an optional displayName parameter (external displayName from outer session record)
- Modified listSessionsFromStore to pass rest.displayName to deriveSessionTitle
- Added test case to verify external displayName takes precedence over entry.displayName

## Testing

- All existing tests pass
- New test case verifies external displayName priority
- Linting passes