### PR TITLE
fix: suppress doctor stdout for ACP commands

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -208,6 +208,19 @@ describe("registerPreActionHooks", () => {
     });
   });
 
+  it("suppresses doctor stdout for acp commands even without --json", async () => {
+    await runPreAction({
+      parseArgv: ["acp", "client"],
+      processArgv: ["node", "openclaw", "acp", "client"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["acp", "client"],
+      suppressDoctorStdout: true,
+    });
+  });
+
   it("bypasses config guard for config validate", async () => {
     await runPreAction({
       parseArgv: ["config", "validate"],

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -88,6 +88,11 @@ function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
 }
 
 function isJsonOutputMode(commandPath: string[], argv: string[]): boolean {
+  // ACP commands must keep stdout machine-parseable (NDJSON over stdio).
+  // Suppress doctor note boxes even without --json to avoid protocol pollution.
+  if (commandPath[0] === "acp") {
+    return true;
+  }
   if (!hasFlag(argv, "--json")) {
     return false;
   }


### PR DESCRIPTION
## Summary
- suppress doctor note output for all `openclaw acp ...` command paths during pre-action config guard
- keep ACP stdio output machine-parseable (NDJSON) even when doctor warnings are present
- add a preaction unit test to lock the ACP suppression behavior

## Testing
- attempted: `pnpm vitest run src/cli/program/preaction.test.ts` (pnpm not available in this environment)
- attempted: `bunx vitest run src/cli/program/preaction.test.ts` (failed in this environment: missing `vite/module-runner`)

Fixes #39789
