### PR TITLE
fix(ui): add loading indicator to Debug Snapshots card (#39777)

### DIFF
--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -44,9 +44,14 @@ export function renderDebug(props: DebugProps) {
             ${props.loading ? "Refreshing…" : "Refresh"}
           </button>
         </div>
-        <div class="stack" style="margin-top: 12px;">
-          <div>
-            <div class="muted">Status</div>
+          <div class="stack" style="margin-top: 12px;">
+            ${
+              props.loading
+                ? html`<div class="callout" style="margin-top: 8px;">Loading snapshot data...</div>`
+                : !props.status && !props.health && !props.heartbeat
+                  ? html`<div class="callout warn" style="margin-top: 8px;">Not connected to gateway. Refresh will be available when connected.</div>`
+                  : nothing
+            }
             ${
               securitySummary
                 ? html`<div class="callout ${securityTone}" style="margin-top: 8px;">

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -44,7 +44,9 @@ export function renderDebug(props: DebugProps) {
             ${props.loading ? "Refreshing…" : "Refresh"}
           </button>
         </div>
-          <div class="stack" style="margin-top: 12px;">
+         <div class="stack" style="margin-top: 12px;">
+           <div>
+             <div class="muted">Status</div>
             ${
               props.loading
                 ? html`<div class="callout" style="margin-top: 8px;">Loading snapshot data...</div>`

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -45,15 +45,15 @@ export function renderDebug(props: DebugProps) {
           </button>
         </div>
          <div class="stack" style="margin-top: 12px;">
+          ${
+            props.loading
+              ? html`<div class="callout" style="margin-top: 8px;">Loading snapshot data...</div>`
+              : !props.status && !props.health && !props.heartbeat
+                ? html`<div class="callout warn" style="margin-top: 8px;">Not connected to gateway. Refresh will be available when connected.</div>`
+                : nothing
+            }
            <div>
              <div class="muted">Status</div>
-            ${
-              props.loading
-                ? html`<div class="callout" style="margin-top: 8px;">Loading snapshot data...</div>`
-                : !props.status && !props.health && !props.heartbeat
-                  ? html`<div class="callout warn" style="margin-top: 8px;">Not connected to gateway. Refresh will be available when connected.</div>`
-                  : nothing
-            }
             ${
               securitySummary
                 ? html`<div class="callout ${securityTone}" style="margin-top: 8px;">


### PR DESCRIPTION
Found this while testing the Debug tab — clicking Refresh does nothing visible when disconnected, and there's no loading indicator while data is loading.

The issue is that `loadDebug()` silently returns when not connected, and the view only shows "Refreshing..." on the button text without any indicator in the card body.

This PR adds:
1. A "Loading snapshot data..." callout while the refresh is in progress
2. A "Not connected to gateway" warning when disconnected and no data available

## Changes
- Added conditional rendering for loading state in the Snapshots card body
- Added warning callout when not connected

## Testing
- Manual testing shows loading indicator during refresh
- Warning appears when opened before connecting to gateway

---

Fixes #39777