### PR TITLE
fix(matrix): use main plugin-sdk export for KeyedAsyncQueue import

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 


### PR DESCRIPTION
## Problem

Matrix plugin fails to load in Docker because `send-queue.ts` imports from the sub-path `openclaw/plugin-sdk/keyed-async-queue`, which does not exist after the Docker build.

Fixes #33266

## Solution

Use the main `openclaw/plugin-sdk` export instead of the sub-path import. `KeyedAsyncQueue` is already re-exported from the main entry point.

## Changes

- `extensions/matrix/src/matrix/send-queue.ts`: Change import from `openclaw/plugin-sdk/keyed-async-queue` → `openclaw/plugin-sdk`

One-line fix. No behavior change for non-Docker environments.