### PR TITLE
fix(ui): implement reactive chat updates for messages and agent events

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -131,9 +131,6 @@ async function sendChatMessageNow(
   if (ok && opts?.refreshSessions && runId) {
     host.refreshSessionsAfterChat.add(runId);
   }
-  if (ok) {
-  void refreshChat(host as any);
-  }
   return ok;
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -131,6 +131,9 @@ async function sendChatMessageNow(
   if (ok && opts?.refreshSessions && runId) {
     host.refreshSessionsAfterChat.add(runId);
   }
+  if (ok && typeof (host as any).refreshChat === 'function') {
+    void (host as any).refreshChat(host);
+  }
   return ok;
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -131,8 +131,8 @@ async function sendChatMessageNow(
   if (ok && opts?.refreshSessions && runId) {
     host.refreshSessionsAfterChat.add(runId);
   }
-  if (ok && typeof (host as any).refreshChat === 'function') {
-    void (host as any).refreshChat(host);
+  if (ok) {
+  void refreshChat(host as any);
   }
   return ok;
 }

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -407,7 +407,9 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   if (payload.stream === "chat" || payload.stream === "message") {
-   void refreshChat(host as any);
+    if (payload.data?.sessionId === (host as any).activeSessionId {
+      void refreshChat(host as any);
+    }
    return;
   }
 
@@ -475,8 +477,4 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   entry.message = buildToolStreamMessage(entry);
   trimToolStream(host);
   scheduleToolStreamSync(host, phase === "result");
-
-  if (phase === "result") {
-    void refreshChat(host as any);
-  }
 }

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -405,7 +405,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
-  if (payload.stream !== "tool") {
+  if (payload.stream !== "tool" && payload.stream !== "chat" && payload.stream !== "message") {
     return;
   }
 
@@ -469,4 +469,8 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   entry.message = buildToolStreamMessage(entry);
   trimToolStream(host);
   scheduleToolStreamSync(host, phase === "result");
+
+  if (typeof (host as any).refreshChat === 'function') {
+    void (host as any).refreshChat(host);
+  }
 }

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -1,4 +1,5 @@
 import { truncateText } from "./format.ts";
+import { refreshChat } from "./app-chat";
 
 const TOOL_STREAM_LIMIT = 50;
 const TOOL_STREAM_THROTTLE_MS = 80;
@@ -405,7 +406,12 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
-  if (payload.stream !== "tool" && payload.stream !== "chat" && payload.stream !== "message") {
+  if (payload.stream === "chat" || payload.stream === "message") {
+   void refreshChat(host as any);
+   return;
+  }
+
+  if (payload.stream !== "tool") {
     return;
   }
 
@@ -470,7 +476,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   trimToolStream(host);
   scheduleToolStreamSync(host, phase === "result");
 
-  if (typeof (host as any).refreshChat === 'function') {
-    void (host as any).refreshChat(host);
+  if (phase === "result") {
+    void refreshChat(host as any);
   }
 }

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -406,11 +406,11 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
-  if (payload.stream === "chat" || payload.stream === "message") {
-    if (payload.data?.sessionId === (host as any).activeSessionId {
+  if (payload.stream === "assistant") {
+    if (payload.data?.sessionId === (host as any).activeSessionId) {
       void refreshChat(host as any);
     }
-   return;
+    return;
   }
 
   if (payload.stream !== "tool") {


### PR DESCRIPTION
This PR fixes the issue where the Webchat UI requires a manual page refresh to see new messages (Issue #39744).

**Changes:**
- `app-chat.ts`: Added a `refreshChat()` trigger immediately after a successful `sendChatMessageNow` dispatch. This ensures the user's message appears in the UI without delay.
- `app-tool-stream.ts`: Modified the event filter to allow `chat` and `message` streams (previously restricted to `tool` only).
- `app-tool-stream.ts`: Added a reactive `refreshChat()` call within` handleAgentEvent` to ensure AI responses are rendered in real-time as they arrive via the gateway.

Tested on WSL2 environment with local loopback gateway.