### PR TITLE
fix(feishu): restore @larksuiteoapi/node-sdk in root dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -340,6 +340,7 @@
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "@line/bot-sdk": "^10.6.0",
     "@lydell/node-pty": "1.2.0-beta.3",
     "@mariozechner/pi-agent-core": "0.55.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@homebridge/ciao':
         specifier: ^1.3.5
         version: 1.3.5
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.59.0
+        version: 1.59.0
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0


### PR DESCRIPTION
## Summary

- Problem: The bundled Feishu extension crashes on `npm install -g openclaw` with `Error: Cannot find module '@larksuiteoapi/node-sdk'` since v2026.3.7.
- Why it matters: All Feishu/Lark onboarding and existing Feishu integrations are broken for npm users — three independent reporters confirmed.
- What changed: Re-added `@larksuiteoapi/node-sdk` to root `package.json` so the bundled extension can resolve it through the root `node_modules` tree.
- What did NOT change (scope boundary): No code changes in the Feishu extension itself, no version bump, no changes to the plugin loader or build pipeline.

### Root cause

Commit `e1503349c` ("scope extension runtime deps to plugin manifests") removed `@larksuiteoapi/node-sdk` from root `package.json`. The intent was to have each extension declare its own deps. However, bundled extensions shipped inside the npm package resolve modules via the **root** `node_modules` tree — `.gitignore` excludes `**/node_modules/`, so extension-level `node_modules/` is never published.

Other bundled channel deps (`@discordjs/voice`, `@slack/bolt`, `@slack/web-api`) remain in root for the same reason.

| Extension | External dep | In root `package.json`? |
|-----------|-------------|------------------------|
| Discord | `@discordjs/voice` | ✅ Yes |
| Slack | `@slack/bolt` | ✅ Yes |
| Feishu | `@larksuiteoapi/node-sdk` | ❌ **Missing** (this PR fixes it) |

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #39733

## User-visible / Behavior Changes

Feishu/Lark channel loads successfully again after `npm install -g openclaw`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps
1. `npm install -g openclaw@latest`
2. Run `openclaw` → choose Feishu channel during onboarding
3. Observe plugin load succeeds (previously: `Cannot find module '@larksuiteoapi/node-sdk'`)

### Expected
- Feishu extension loads and prompts for App ID / Secret

### Actual (before fix)
- `[plugins] feishu failed to load: Error: Cannot find module '@larksuiteoapi/node-sdk'`

## Evidence

- [x] Module resolution verified: `require.resolve('@larksuiteoapi/node-sdk', { paths: ['extensions/feishu/src'] })` succeeds
- [x] All 35 Feishu test files pass (348 tests)

## Human Verification (required)

- Verified scenarios: module resolves from extension path; all Feishu tests pass
- Edge cases checked: alphabetical ordering in `package.json` correct; lockfile updated cleanly
- What you did **not** verify: actual global npm install on a clean machine (no access to one)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove the `@larksuiteoapi/node-sdk` line from root `package.json`
- Files/config to restore: `package.json`, `pnpm-lock.yaml`
- Known bad symptoms reviewers should watch for: dependency version conflict between root and `extensions/feishu/package.json` (currently both `^1.59.0`)

## Risks and Mitigations

- Risk: This re-adds a dep that was intentionally scoped to the extension manifest in `e1503349c`.
  - Mitigation: The root entry is necessary until the build/publish pipeline installs extension-level `node_modules` before `npm pack`. This matches how Discord and Slack deps are handled today.
