### PR TITLE
fix(agents): normalize 429/RESOURCE_EXHAUSTED into failover errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Signal/config validation: add `channels.signal.groups` schema support so per-group `requireMention`, `tools`, and `toolsBySender` overrides no longer get rejected during config validation. (#27199) Thanks @unisone.
 - Config/discovery: accept `discovery.wideArea.domain` in strict config validation so unicast DNS-SD gateway configs no longer fail with an unrecognized-key error. (#35615) Thanks @ingyukoh.
 - Telegram/media errors: redact Telegram file URLs before building media fetch errors so failed inbound downloads do not leak bot tokens into logs. Thanks @space08.
+- Agents/failover: normalize abort-wrapped `429 RESOURCE_EXHAUSTED` provider failures before abort short-circuiting so wrapped Google/Vertex rate limits continue across configured fallback models, including the embedded runner prompt-error path. (#39820) Thanks @lupuletic.
 
 ## 2026.3.12
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -364,6 +364,23 @@ describe("failover-error", () => {
     expect(isTimeoutError(err)).toBe(true);
   });
 
+  it("classifies abort-wrapped RESOURCE_EXHAUSTED as rate_limit", () => {
+    const err = Object.assign(new Error("request aborted"), {
+      name: "AbortError",
+      cause: {
+        error: {
+          code: 429,
+          message: GEMINI_RESOURCE_EXHAUSTED_MESSAGE,
+          status: "RESOURCE_EXHAUSTED",
+        },
+      },
+    });
+
+    expect(resolveFailoverReasonFromError(err)).toBe("rate_limit");
+    expect(coerceToFailoverError(err)?.reason).toBe("rate_limit");
+    expect(coerceToFailoverError(err)?.status).toBe(429);
+  });
+
   it("coerces failover-worthy errors into FailoverError with metadata", () => {
     const err = coerceToFailoverError("credit balance too low", {
       provider: "anthropic",

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -238,16 +238,18 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   ) {
     return "timeout";
   }
-  if (isTimeoutError(err)) {
-    return "timeout";
-  }
-  // Walk into error cause chain (e.g. AbortError wrapping a rate-limit cause)
+  // Walk into error cause chain *before* timeout heuristics so that a specific
+  // cause (e.g. RESOURCE_EXHAUSTED wrapped in AbortError) overrides a parent
+  // message-based "timeout" guess from isTimeoutError.
   const cause = getErrorCause(err);
   if (cause && cause !== err) {
     const causeReason = resolveFailoverReasonFromError(cause);
     if (causeReason) {
       return causeReason;
     }
+  }
+  if (isTimeoutError(err)) {
+    return "timeout";
   }
   if (!message) {
     return null;

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -72,9 +72,16 @@ function getStatusCode(err: unknown): number | undefined {
   if (!err || typeof err !== "object") {
     return undefined;
   }
+  // Dig into nested `err.error` shapes (e.g. Google Vertex abort wrappers)
+  const nestedError =
+    "error" in err && err.error && typeof err.error === "object"
+      ? (err.error as { status?: unknown; code?: unknown })
+      : undefined;
   const candidate =
     (err as { status?: unknown; statusCode?: unknown }).status ??
-    (err as { statusCode?: unknown }).statusCode;
+    (err as { statusCode?: unknown }).statusCode ??
+    nestedError?.code ??
+    nestedError?.status;
   if (typeof candidate === "number") {
     return candidate;
   }
@@ -88,7 +95,11 @@ function getErrorCode(err: unknown): string | undefined {
   if (!err || typeof err !== "object") {
     return undefined;
   }
-  const candidate = (err as { code?: unknown }).code;
+  const nestedError =
+    "error" in err && err.error && typeof err.error === "object"
+      ? (err.error as { code?: unknown; status?: unknown })
+      : undefined;
+  const candidate = (err as { code?: unknown }).code ?? nestedError?.status ?? nestedError?.code;
   if (typeof candidate !== "string") {
     return undefined;
   }
@@ -114,8 +125,51 @@ function getErrorMessage(err: unknown): string {
     if (typeof message === "string") {
       return message;
     }
+    // Extract message from nested `err.error.message` (e.g. Google Vertex wrappers)
+    const nestedMessage =
+      "error" in err &&
+      err.error &&
+      typeof err.error === "object" &&
+      typeof (err.error as { message?: unknown }).message === "string"
+        ? ((err.error as { message: string }).message ?? "")
+        : "";
+    if (nestedMessage) {
+      return nestedMessage;
+    }
   }
   return "";
+}
+
+function getErrorCause(err: unknown): unknown {
+  if (!err || typeof err !== "object" || !("cause" in err)) {
+    return undefined;
+  }
+  return (err as { cause?: unknown }).cause;
+}
+
+/** Classify rate-limit / overloaded from symbolic error codes like RESOURCE_EXHAUSTED. */
+function classifyFailoverReasonFromSymbolicCode(raw: string | undefined): FailoverReason | null {
+  const normalized = raw?.trim().toUpperCase();
+  if (!normalized) {
+    return null;
+  }
+  switch (normalized) {
+    case "RESOURCE_EXHAUSTED":
+    case "RATE_LIMIT":
+    case "RATE_LIMITED":
+    case "RATE_LIMIT_EXCEEDED":
+    case "TOO_MANY_REQUESTS":
+    case "THROTTLED":
+    case "THROTTLING":
+    case "THROTTLINGEXCEPTION":
+    case "THROTTLING_EXCEPTION":
+      return "rate_limit";
+    case "OVERLOADED":
+    case "OVERLOADED_ERROR":
+      return "overloaded";
+    default:
+      return null;
+  }
 }
 
 function hasTimeoutHint(err: unknown): boolean {
@@ -160,6 +214,12 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
     return statusReason;
   }
 
+  // Check symbolic error codes (e.g. RESOURCE_EXHAUSTED from Google APIs)
+  const symbolicCodeReason = classifyFailoverReasonFromSymbolicCode(getErrorCode(err));
+  if (symbolicCodeReason) {
+    return symbolicCodeReason;
+  }
+
   const code = (getErrorCode(err) ?? "").toUpperCase();
   if (
     [
@@ -180,6 +240,14 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
   if (isTimeoutError(err)) {
     return "timeout";
+  }
+  // Walk into error cause chain (e.g. AbortError wrapping a rate-limit cause)
+  const cause = getErrorCause(err);
+  if (cause && cause !== err) {
+    const causeReason = resolveFailoverReasonFromError(cause);
+    if (causeReason) {
+      return causeReason;
+    }
   }
   if (!message) {
     return null;

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -68,20 +68,36 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
   }
 }
 
-function getStatusCode(err: unknown): number | undefined {
+function findErrorProperty<T>(
+  err: unknown,
+  reader: (candidate: unknown) => T | undefined,
+  seen: Set<object> = new Set(),
+): T | undefined {
+  const direct = reader(err);
+  if (direct !== undefined) {
+    return direct;
+  }
   if (!err || typeof err !== "object") {
     return undefined;
   }
-  // Dig into nested `err.error` shapes (e.g. Google Vertex abort wrappers)
-  const nestedError =
-    "error" in err && err.error && typeof err.error === "object"
-      ? (err.error as { status?: unknown; code?: unknown })
-      : undefined;
+  if (seen.has(err)) {
+    return undefined;
+  }
+  seen.add(err);
+  const candidate = err as { error?: unknown; cause?: unknown };
+  return (
+    findErrorProperty(candidate.error, reader, seen) ??
+    findErrorProperty(candidate.cause, reader, seen)
+  );
+}
+
+function readDirectStatusCode(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
   const candidate =
     (err as { status?: unknown; statusCode?: unknown }).status ??
-    (err as { statusCode?: unknown }).statusCode ??
-    nestedError?.code ??
-    nestedError?.status;
+    (err as { statusCode?: unknown }).statusCode;
   if (typeof candidate === "number") {
     return candidate;
   }
@@ -91,53 +107,55 @@ function getStatusCode(err: unknown): number | undefined {
   return undefined;
 }
 
-function getErrorCode(err: unknown): string | undefined {
+function getStatusCode(err: unknown): number | undefined {
+  return findErrorProperty(err, readDirectStatusCode);
+}
+
+function readDirectErrorCode(err: unknown): string | undefined {
   if (!err || typeof err !== "object") {
     return undefined;
   }
-  const nestedError =
-    "error" in err && err.error && typeof err.error === "object"
-      ? (err.error as { code?: unknown; status?: unknown })
-      : undefined;
-  const candidate = (err as { code?: unknown }).code ?? nestedError?.status ?? nestedError?.code;
-  if (typeof candidate !== "string") {
+  const directCode = (err as { code?: unknown }).code;
+  if (typeof directCode === "string") {
+    const trimmed = directCode.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  const status = (err as { status?: unknown }).status;
+  if (typeof status !== "string" || /^\d+$/.test(status)) {
     return undefined;
   }
-  const trimmed = candidate.trim();
+  const trimmed = status.trim();
   return trimmed ? trimmed : undefined;
 }
 
-function getErrorMessage(err: unknown): string {
+function getErrorCode(err: unknown): string | undefined {
+  return findErrorProperty(err, readDirectErrorCode);
+}
+
+function readDirectErrorMessage(err: unknown): string | undefined {
   if (err instanceof Error) {
-    return err.message;
+    return err.message || undefined;
   }
   if (typeof err === "string") {
-    return err;
+    return err || undefined;
   }
   if (typeof err === "number" || typeof err === "boolean" || typeof err === "bigint") {
     return String(err);
   }
   if (typeof err === "symbol") {
-    return err.description ?? "";
+    return err.description ?? undefined;
   }
   if (err && typeof err === "object") {
     const message = (err as { message?: unknown }).message;
     if (typeof message === "string") {
-      return message;
-    }
-    // Extract message from nested `err.error.message` (e.g. Google Vertex wrappers)
-    const nestedMessage =
-      "error" in err &&
-      err.error &&
-      typeof err.error === "object" &&
-      typeof (err.error as { message?: unknown }).message === "string"
-        ? ((err.error as { message: string }).message ?? "")
-        : "";
-    if (nestedMessage) {
-      return nestedMessage;
+      return message || undefined;
     }
   }
-  return "";
+  return undefined;
+}
+
+function getErrorMessage(err: unknown): string {
+  return findErrorProperty(err, readDirectErrorMessage) ?? "";
 }
 
 function getErrorCause(err: unknown): unknown {

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -2,8 +2,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { registerLogTransport, resetLogger, setLoggerOverride } from "../logging/logger.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
+import { registerLogTransport, resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
 // Mock auth-profiles module — must be before importing model-fallback
@@ -395,14 +395,6 @@ describe("runWithModelFallback – probe logic", () => {
     // All three candidates must be attempted — the abort must not short-circuit
     expect(run).toHaveBeenCalledTimes(3);
 
-    // Verify the primary error is classified as rate_limit, not timeout — the
-    // cause chain (RESOURCE_EXHAUSTED) must override the parent AbortError message.
-    try {
-      await runWithModelFallback({ cfg, provider: "google", model: "gemini-3-flash-preview", run });
-    } catch (err) {
-      expect(String(err)).toContain("(rate_limit)");
-      expect(String(err)).not.toMatch(/gemini.*\(timeout\)/);
-    }
     expect(run).toHaveBeenNthCalledWith(1, "google", "gemini-3-flash-preview", {
       allowTransientCooldownProbe: true,
     });

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -331,6 +331,76 @@ describe("runWithModelFallback – probe logic", () => {
     });
   });
 
+  it("keeps walking remaining fallbacks after an abort-wrapped RESOURCE_EXHAUSTED probe failure", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "google/gemini-3-flash-preview",
+            fallbacks: ["anthropic/claude-haiku-3-5", "deepseek/deepseek-chat"],
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
+
+    mockedResolveAuthProfileOrder.mockImplementation(({ provider }: { provider: string }) => {
+      if (provider === "google") {
+        return ["google-profile-1"];
+      }
+      if (provider === "anthropic") {
+        return ["anthropic-profile-1"];
+      }
+      if (provider === "deepseek") {
+        return ["deepseek-profile-1"];
+      }
+      return [];
+    });
+    mockedIsProfileInCooldown.mockImplementation((_store, profileId: string) =>
+      profileId.startsWith("google"),
+    );
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 30 * 1000);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("rate_limit");
+
+    // Simulate Google Vertex abort-wrapped RESOURCE_EXHAUSTED (the shape that was
+    // previously swallowed by shouldRethrowAbort before the fallback loop could continue)
+    const primaryAbort = Object.assign(new Error("request aborted"), {
+      name: "AbortError",
+      cause: {
+        error: {
+          code: 429,
+          message: "Resource has been exhausted (e.g. check quota).",
+          status: "RESOURCE_EXHAUSTED",
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(primaryAbort)
+      .mockRejectedValueOnce(
+        Object.assign(new Error("fallback still rate limited"), { status: 429 }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("final fallback still rate limited"), { status: 429 }),
+      );
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "google",
+        model: "gemini-3-flash-preview",
+        run,
+      }),
+    ).rejects.toThrow(/All models failed \(3\)/);
+
+    // All three candidates must be attempted — the abort must not short-circuit
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(run).toHaveBeenNthCalledWith(1, "google", "gemini-3-flash-preview", {
+      allowTransientCooldownProbe: true,
+    });
+    expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5");
+    expect(run).toHaveBeenNthCalledWith(3, "deepseek", "deepseek-chat");
+  });
+
   it("throttles probe when called within 30s interval", async () => {
     const cfg = makeCfg();
     // Cooldown just about to expire (within probe margin)

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -2,8 +2,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import type { AuthProfileStore } from "./auth-profiles.js";
 import { registerLogTransport, resetLogger, setLoggerOverride } from "../logging/logger.js";
+import type { AuthProfileStore } from "./auth-profiles.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
 // Mock auth-profiles module — must be before importing model-fallback

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -394,6 +394,15 @@ describe("runWithModelFallback – probe logic", () => {
 
     // All three candidates must be attempted — the abort must not short-circuit
     expect(run).toHaveBeenCalledTimes(3);
+
+    // Verify the primary error is classified as rate_limit, not timeout — the
+    // cause chain (RESOURCE_EXHAUSTED) must override the parent AbortError message.
+    try {
+      await runWithModelFallback({ cfg, provider: "google", model: "gemini-3-flash-preview", run });
+    } catch (err) {
+      expect(String(err)).toContain("(rate_limit)");
+      expect(String(err)).not.toMatch(/gemini.*\(timeout\)/);
+    }
     expect(run).toHaveBeenNthCalledWith(1, "google", "gemini-3-flash-preview", {
       allowTransientCooldownProbe: true,
     });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -140,10 +140,16 @@ async function runFallbackCandidate<T>(params: {
       result,
     };
   } catch (err) {
-    if (shouldRethrowAbort(err)) {
+    // Normalize abort-wrapped rate-limit errors (e.g. Google Vertex RESOURCE_EXHAUSTED)
+    // so they become FailoverErrors and continue the fallback loop instead of aborting.
+    const normalizedFailover = coerceToFailoverError(err, {
+      provider: params.provider,
+      model: params.model,
+    });
+    if (shouldRethrowAbort(err) && !normalizedFailover) {
       throw err;
     }
-    return { ok: false, error: err };
+    return { ok: false, error: normalizedFailover ?? err };
   }
 }
 

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
@@ -209,9 +209,20 @@ vi.mock("../defaults.js", () => ({
   DEFAULT_PROVIDER: "anthropic",
 }));
 
+export const mockedCoerceToFailoverError = vi.fn();
+export const mockedDescribeFailoverError = vi.fn((err: unknown) => ({
+  message: err instanceof Error ? err.message : String(err),
+  reason: undefined,
+  status: undefined,
+  code: undefined,
+}));
+export const mockedResolveFailoverStatus = vi.fn();
+
 vi.mock("../failover-error.js", () => ({
   FailoverError: class extends Error {},
-  resolveFailoverStatus: vi.fn(),
+  coerceToFailoverError: mockedCoerceToFailoverError,
+  describeFailoverError: mockedDescribeFailoverError,
+  resolveFailoverStatus: mockedResolveFailoverStatus,
 }));
 
 vi.mock("./lanes.js", () => ({

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
@@ -209,7 +209,6 @@ vi.mock("../defaults.js", () => ({
   DEFAULT_PROVIDER: "anthropic",
 }));
 
-export const mockedCoerceToFailoverError = vi.fn();
 type MockFailoverErrorDescription = {
   message: string;
   reason: string | undefined;
@@ -217,7 +216,15 @@ type MockFailoverErrorDescription = {
   code: string | undefined;
 };
 
-export const mockedDescribeFailoverError = vi.fn(
+type MockCoerceToFailoverError = (
+  err: unknown,
+  params?: { provider?: string; model?: string; profileId?: string },
+) => unknown;
+type MockDescribeFailoverError = (err: unknown) => MockFailoverErrorDescription;
+type MockResolveFailoverStatus = (reason: string) => number | undefined;
+
+export const mockedCoerceToFailoverError = vi.fn<MockCoerceToFailoverError>();
+export const mockedDescribeFailoverError = vi.fn<MockDescribeFailoverError>(
   (err: unknown): MockFailoverErrorDescription => ({
     message: err instanceof Error ? err.message : String(err),
     reason: undefined,
@@ -225,7 +232,7 @@ export const mockedDescribeFailoverError = vi.fn(
     code: undefined,
   }),
 );
-export const mockedResolveFailoverStatus = vi.fn();
+export const mockedResolveFailoverStatus = vi.fn<MockResolveFailoverStatus>();
 
 vi.mock("../failover-error.js", () => ({
   FailoverError: class extends Error {},

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
@@ -210,12 +210,21 @@ vi.mock("../defaults.js", () => ({
 }));
 
 export const mockedCoerceToFailoverError = vi.fn();
-export const mockedDescribeFailoverError = vi.fn((err: unknown) => ({
-  message: err instanceof Error ? err.message : String(err),
-  reason: undefined,
-  status: undefined,
-  code: undefined,
-}));
+type MockFailoverErrorDescription = {
+  message: string;
+  reason: string | undefined;
+  status: number | undefined;
+  code: string | undefined;
+};
+
+export const mockedDescribeFailoverError = vi.fn(
+  (err: unknown): MockFailoverErrorDescription => ({
+    message: err instanceof Error ? err.message : String(err),
+    reason: undefined,
+    status: undefined,
+    code: undefined,
+  }),
+);
 export const mockedResolveFailoverStatus = vi.fn();
 
 vi.mock("../failover-error.js", () => ({

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -301,7 +301,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     await expect(
       runEmbeddedPiAgent({
         ...overflowBaseRunParams,
-        cfg: {
+        config: {
           agents: {
             defaults: {
               model: {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -9,7 +9,12 @@ import {
   mockOverflowRetrySuccess,
   queueOverflowAttemptWithOversizedToolOutput,
 } from "./run.overflow-compaction.fixture.js";
-import { mockedGlobalHookRunner } from "./run.overflow-compaction.mocks.shared.js";
+import {
+  mockedCoerceToFailoverError,
+  mockedDescribeFailoverError,
+  mockedGlobalHookRunner,
+  mockedResolveFailoverStatus,
+} from "./run.overflow-compaction.mocks.shared.js";
 import {
   mockedContextEngine,
   mockedCompactDirect,
@@ -25,6 +30,9 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     vi.clearAllMocks();
     mockedRunEmbeddedAttempt.mockReset();
     mockedCompactDirect.mockReset();
+    mockedCoerceToFailoverError.mockReset();
+    mockedDescribeFailoverError.mockReset();
+    mockedResolveFailoverStatus.mockReset();
     mockedSessionLikelyHasOversizedToolResults.mockReset();
     mockedTruncateOversizedToolResultsInSession.mockReset();
     mockedGlobalHookRunner.runBeforeAgentStart.mockReset();
@@ -36,6 +44,13 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       compacted: false,
       reason: "nothing to compact",
     });
+    mockedCoerceToFailoverError.mockReturnValue(null);
+    mockedDescribeFailoverError.mockImplementation((err: unknown) => ({
+      message: err instanceof Error ? err.message : String(err),
+      reason: undefined,
+      status: undefined,
+      code: undefined,
+    }));
     mockedSessionLikelyHasOversizedToolResults.mockReturnValue(false);
     mockedTruncateOversizedToolResultsInSession.mockResolvedValue({
       truncated: false,
@@ -254,5 +269,58 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(mockedCompactDirect).not.toHaveBeenCalled();
     expect(result.meta.error?.kind).toBe("retry_limit");
     expect(result.payloads?.[0]?.isError).toBe(true);
+  });
+
+  it("normalizes abort-wrapped prompt errors before handing off to model fallback", async () => {
+    const promptError = Object.assign(new Error("request aborted"), {
+      name: "AbortError",
+      cause: {
+        error: {
+          code: 429,
+          message: "Resource has been exhausted (e.g. check quota).",
+          status: "RESOURCE_EXHAUSTED",
+        },
+      },
+    });
+    const normalized = Object.assign(new Error("Resource has been exhausted (e.g. check quota)."), {
+      name: "FailoverError",
+      reason: "rate_limit",
+      status: 429,
+    });
+
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError }));
+    mockedCoerceToFailoverError.mockReturnValueOnce(normalized);
+    mockedDescribeFailoverError.mockImplementation((err: unknown) => ({
+      message: err instanceof Error ? err.message : String(err),
+      reason: err === normalized ? "rate_limit" : undefined,
+      status: err === normalized ? 429 : undefined,
+      code: undefined,
+    }));
+    mockedResolveFailoverStatus.mockReturnValueOnce(429);
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                fallbacks: ["openai/gpt-5.2"],
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toBe(normalized);
+
+    expect(mockedCoerceToFailoverError).toHaveBeenCalledWith(
+      promptError,
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "test-model",
+        profileId: "test-profile",
+      }),
+    );
+    expect(mockedResolveFailoverStatus).toHaveBeenCalledWith("rate_limit");
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -28,7 +28,12 @@ import {
   resolveContextWindowInfo,
 } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
-import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
+import {
+  coerceToFailoverError,
+  describeFailoverError,
+  FailoverError,
+  resolveFailoverStatus,
+} from "../failover-error.js";
 import {
   applyLocalNoAuthHeaderOverride,
   ensureAuthProfileStore,
@@ -1217,7 +1222,17 @@ export async function runEmbeddedPiAgent(
           }
 
           if (promptError && !aborted) {
-            const errorText = describeUnknownError(promptError);
+            // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
+            // FailoverError so rate-limit classification works even for nested shapes.
+            const normalizedPromptFailover = coerceToFailoverError(promptError, {
+              provider: activeErrorContext.provider,
+              model: activeErrorContext.model,
+              profileId: lastProfileId,
+            });
+            const promptErrorDetails = normalizedPromptFailover
+              ? describeFailoverError(normalizedPromptFailover)
+              : describeFailoverError(promptError);
+            const errorText = promptErrorDetails.message || describeUnknownError(promptError);
             if (await maybeRefreshCopilotForAuthError(errorText, copilotAuthRetry)) {
               authRetryPending = true;
               continue;
@@ -1281,14 +1296,16 @@ export async function runEmbeddedPiAgent(
                 },
               };
             }
-            const promptFailoverReason = classifyFailoverReason(errorText);
+            const promptFailoverReason =
+              promptErrorDetails.reason ?? classifyFailoverReason(errorText);
             const promptProfileFailureReason =
               resolveAuthProfileFailureReason(promptFailoverReason);
             await maybeMarkAuthProfileFailure({
               profileId: lastProfileId,
               reason: promptProfileFailureReason,
             });
-            const promptFailoverFailure = isFailoverErrorMessage(errorText);
+            const promptFailoverFailure =
+              promptFailoverReason !== null || isFailoverErrorMessage(errorText);
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
             const logPromptFailoverDecision = createFailoverDecisionLogger({
@@ -1330,13 +1347,16 @@ export async function runEmbeddedPiAgent(
               const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
               logPromptFailoverDecision("fallback_model", { status });
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              throw new FailoverError(errorText, {
-                reason: promptFailoverReason ?? "unknown",
-                provider,
-                model: modelId,
-                profileId: lastProfileId,
-                status,
-              });
+              throw (
+                normalizedPromptFailover ??
+                new FailoverError(errorText, {
+                  reason: promptFailoverReason ?? "unknown",
+                  provider,
+                  model: modelId,
+                  profileId: lastProfileId,
+                  status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
+                })
+              );
             }
             if (promptFailoverFailure || promptFailoverReason) {
               logPromptFailoverDecision("surface_error");


### PR DESCRIPTION
## Summary
- Fixes model fallback not triggering on 429 rate limit errors when the provider wraps them in abort-style error shapes (e.g. Google Vertex `AbortError { cause: { error: { code: 429, status: "RESOURCE_EXHAUSTED" } } }`)
- Adds nested error extraction (`err.error.code`, `err.error.status`, `err.error.message`) and symbolic code classification (`RESOURCE_EXHAUSTED` → `rate_limit`) to `failover-error.ts`
- Adds cause-chain traversal so abort-wrapped rate limits are recognized before `shouldRethrowAbort` short-circuits the fallback loop
- Updates `pi-embedded-runner/run.ts` to use `coerceToFailoverError` for consistent error normalization before failover classification

## Change Type
Bug fix

## Linked Issue
Closes #11972

## Security Impact
None — error classification only, no auth/data changes.

## Test Plan
- [x] Added regression test: abort-wrapped RESOURCE_EXHAUSTED probe failure walks all 3 fallback candidates
- [x] All 17 probe tests pass
- [x] `pnpm check` (format + lint + types) passes
- [x] Pre-existing unrelated test failure in `model-fallback.test.ts` (ANSI sanitization) is environment-dependent and not caused by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted contribution*