### PR TITLE
fix(agents): prevent kimi-coding crash from re-sent thinking signatures

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -133,6 +133,16 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.validateAnthropicTurns).toBe(true);
   });
 
+  it("does not preserve signatures for kimi-coding using anthropic-messages API (#39798)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "kimi-coding",
+      modelId: "k2p5",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+    expect(policy.dropThinkingBlocks).toBe(true);
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -94,12 +94,22 @@ export function resolveTranscriptPolicy(params: {
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
   const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
+  const isKimiCoding = provider === "kimi-coding";
   const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+
+  // Some providers use `anthropic-messages` modelApi but cannot handle re-sent
+  // thinking block signatures. For these, we must detect native Anthropic
+  // providers (anthropic, amazon-bedrock) rather than relying on isAnthropic
+  // which also matches third-party API-compatible providers like kimi-coding.
+  const isNativeAnthropic =
+    isAnthropic && (provider === "anthropic" || provider === "amazon-bedrock");
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
+  // kimi-coding uses anthropic-messages API but cannot parse re-sent thinking
+  // signatures, causing JSON parse crashes on turn 2+ (#39798).
   // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = isCopilotClaude;
+  const dropThinkingBlocks = isCopilotClaude || isKimiCoding;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
@@ -123,7 +133,7 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: isAnthropic,
+    preserveSignatures: isNativeAnthropic,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Problem

`kimi-coding/k2p5` crashes on every multi-turn session since v2026.3.7 with:

```
Unexpected non-whitespace character after JSON at position N
```

The crash occurs on turn 2 when the assistant's prior `thinkingSignature` blobs are re-sent in context. kimi-coding uses `modelApi: "anthropic-messages"` but cannot handle these signatures, unlike native Anthropic/Bedrock providers.

Fixes #39798

## Root Cause

In `src/agents/transcript-policy.ts`, `preserveSignatures` was set to `isAnthropic`, which is `true` for any provider using `anthropic-messages` API — including third-party providers like `kimi-coding` that can't actually handle re-sent signatures.

```diff
- preserveSignatures: isAnthropic,
+ preserveSignatures: isNativeAnthropic,
```

## Solution

1. **Narrow `preserveSignatures`** to only native Anthropic providers (`anthropic`, `amazon-bedrock`), not all providers using the Anthropic messages API
2. **Add `kimi-coding` to `dropThinkingBlocks`** alongside `github-copilot`, so thinking blocks are stripped before re-sending context
3. **Add test coverage** for the kimi-coding transcript policy

## Changes

- `src/agents/transcript-policy.ts`: Introduce `isNativeAnthropic` and `isKimiCoding` flags
- `src/agents/transcript-policy.test.ts`: Add test verifying kimi-coding gets `preserveSignatures: false` and `dropThinkingBlocks: true`

## Testing

```
pnpm exec vitest run src/agents/transcript-policy.test.ts
# 15 tests passed
```