### PR TITLE
discord: include accountId in no-mention auto-reply logs

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -688,6 +688,8 @@ export async function preflightDiscordMessage(
       logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
       logger.info(
         {
+          accountId: params.accountId,
+          guildId: params.data.guild_id,
           channelId: messageChannelId,
           reason: "no-mention",
         },


### PR DESCRIPTION
## What
Include `accountId` (and `guildId`) in the `discord-auto-reply` log line emitted when a guild message is dropped due to mention gating (`reason: "no-mention"`).

## Why
When multiple Discord accounts/providers are configured (e.g. `default` + another bot account), the current log message is ambiguous:

```json
{ "channelId": "...", "reason": "no-mention" }
```

This can look like a config bug (e.g. `requireMention: false` seemingly not taking effect), while in reality it may be a different account/provider instance performing the drop.

Adding `accountId` makes field diagnosis significantly easier.

## Tests
- `vitest run src/discord/monitor/message-handler.preflight.test.ts`
