### PR TITLE
test(memory): assert sqlite busy_timeout is set on open

### DIFF
--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -201,6 +201,17 @@ describe("memory index", () => {
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
+
+    // Regression guard: busy_timeout is per-connection; ensure we set it on open.
+    const pragmaRows = (
+      manager as unknown as { db: { prepare: (sql: string) => { all: () => unknown[] } } }
+    ).db
+      .prepare("PRAGMA busy_timeout")
+      .all();
+    const first = pragmaRows[0] as Record<string, unknown> | undefined;
+    const busyTimeout = first ? Number(Object.values(first)[0]) : NaN;
+    expect(busyTimeout).toBe(5000);
+
     expect(embedBatchCalls).toBeGreaterThan(0);
     const results = await manager.search("alpha");
     expect(results.length).toBeGreaterThan(0);


### PR DESCRIPTION
Summary
- Adds a regression test to ensure `PRAGMA busy_timeout` is set on every SQLite connection open.
- `busy_timeout` is per-connection and resets to 0 on restart; without setting it on open, concurrent processes can fail immediately with `SQLITE_BUSY`.

What did NOT change
- No runtime behavior change (test-only).
- No changes to existing default timeout values.

Tests (local)
- `pnpm test src/memory/index.test.ts`

AI-assisted: yes.