### PR TITLE
fix(gateway): silently auto-approve local role-upgrade pairing requests

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.silent-pairing.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.silent-pairing.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { shouldAllowSilentLocalPairing } from "./message-handler.js";
+
+const base = {
+  isLocalClient: true,
+  hasBrowserOriginHeader: false,
+  isControlUi: false,
+  isWebchat: false,
+} as const;
+
+describe("shouldAllowSilentLocalPairing", () => {
+  test("allows not-paired for local client", () => {
+    expect(shouldAllowSilentLocalPairing({ ...base, reason: "not-paired" })).toBe(true);
+  });
+
+  test("allows scope-upgrade for local client", () => {
+    expect(shouldAllowSilentLocalPairing({ ...base, reason: "scope-upgrade" })).toBe(true);
+  });
+
+  test("allows role-upgrade for local client", () => {
+    expect(shouldAllowSilentLocalPairing({ ...base, reason: "role-upgrade" })).toBe(true);
+  });
+
+  test("rejects metadata-upgrade for local client", () => {
+    expect(shouldAllowSilentLocalPairing({ ...base, reason: "metadata-upgrade" })).toBe(false);
+  });
+
+  test("rejects all reasons for non-local client", () => {
+    const remote = { ...base, isLocalClient: false };
+    expect(shouldAllowSilentLocalPairing({ ...remote, reason: "not-paired" })).toBe(false);
+    expect(shouldAllowSilentLocalPairing({ ...remote, reason: "scope-upgrade" })).toBe(false);
+    expect(shouldAllowSilentLocalPairing({ ...remote, reason: "role-upgrade" })).toBe(false);
+    expect(shouldAllowSilentLocalPairing({ ...remote, reason: "metadata-upgrade" })).toBe(false);
+  });
+
+  test("rejects non-control-ui browser origin even for local client", () => {
+    const browser = { ...base, hasBrowserOriginHeader: true };
+    expect(shouldAllowSilentLocalPairing({ ...browser, reason: "not-paired" })).toBe(false);
+    expect(shouldAllowSilentLocalPairing({ ...browser, reason: "role-upgrade" })).toBe(false);
+  });
+
+  test("allows control-ui browser origin for local client", () => {
+    const controlUi = { ...base, hasBrowserOriginHeader: true, isControlUi: true };
+    expect(shouldAllowSilentLocalPairing({ ...controlUi, reason: "not-paired" })).toBe(true);
+    expect(shouldAllowSilentLocalPairing({ ...controlUi, reason: "role-upgrade" })).toBe(true);
+  });
+
+  test("allows webchat browser origin for local client", () => {
+    const webchat = { ...base, hasBrowserOriginHeader: true, isWebchat: true };
+    expect(shouldAllowSilentLocalPairing({ ...webchat, reason: "not-paired" })).toBe(true);
+    expect(shouldAllowSilentLocalPairing({ ...webchat, reason: "role-upgrade" })).toBe(true);
+  });
+});

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -126,7 +126,7 @@ function resolveHandshakeBrowserSecurityContext(params: {
   };
 }
 
-function shouldAllowSilentLocalPairing(params: {
+export function shouldAllowSilentLocalPairing(params: {
   isLocalClient: boolean;
   hasBrowserOriginHeader: boolean;
   isControlUi: boolean;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -136,7 +136,9 @@ function shouldAllowSilentLocalPairing(params: {
   return (
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade")
+    (params.reason === "not-paired" ||
+      params.reason === "scope-upgrade" ||
+      params.reason === "role-upgrade")
   );
 }
 


### PR DESCRIPTION
## Summary

- Problem: After a gateway restart, the macOS app (connecting as `role: "node"`) hits a `role-upgrade` pairing requirement that is not auto-approved for local clients, causing a connect → `code=1008 reason=pairing required` → disconnect loop every 10 seconds
- Why it matters: The macOS app becomes unusable after every gateway restart. Manual `openclaw devices approve` is required but the Mac app UI has no approval mechanism
- What changed: Added `role-upgrade` to `shouldAllowSilentLocalPairing()` so local clients get the same silent approval treatment already given to `scope-upgrade`
- What did NOT change (scope boundary): `metadata-upgrade` remains excluded (requires explicit approval for platform/deviceFamily pinning). Remote client behavior is unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

- Local macOS app connections auto-approve `role-upgrade` after gateway restart (no manual `openclaw devices approve` needed)
- `metadata-upgrade` still requires manual approval

## Security Impact (required)

- New permissions/capabilities? `Yes` — local client role-upgrade is now silently approved
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  - Risk is confined to the local boundary. The `isLocalClient` check (loopback address only) and `hasBrowserOriginHeader`/`isControlUi`/`isWebchat` guards are preserved. Remote clients are unaffected. This matches the existing `scope-upgrade` treatment — both are "access upgrade" operations that are safe to auto-approve for local clients

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): openclaw-macos
- Relevant config (redacted): default gateway auth config

### Steps

1. Pair a device with `operator` role
2. Restart the gateway
3. macOS app reconnects with `role: "node"`

### Expected

- `role-upgrade` is silently approved for local client; connection succeeds

### Actual

- Before fix: 10-second connect/disconnect loop with `code=1008 reason=pairing required`
- After fix: Connection established without loop

## Evidence

- [x] Trace/log snippets — gateway logs confirmed pairing loop resolved after patch

## Human Verification (required)

- Verified scenarios: macOS app reconnection after gateway restart; role-upgrade silently approved
- Edge cases checked: `metadata-upgrade` remains excluded from silent approval
- What you did **not** verify: Remote client role-upgrade (confirmed unaffected via code path — `isLocalClient` guard)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/gateway/server/ws-connection/message-handler.ts`
- Known bad symptoms reviewers should watch for: unexpected silent approval of role-upgrade from non-local clients (not possible given `isLocalClient` guard)

## Risks and Mitigations

- Risk: Local processes get role-upgrade auto-approved where they previously required manual approval
  - Mitigation: `isLocalClient` + browser-origin guards maintained; matches existing `scope-upgrade` policy