### PR TITLE
fix(transcript-policy): don't preserve thinking signatures for kimi-coding (#39798)

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -122,6 +122,15 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.preserveSignatures).toBe(false);
   });
 
+  it("does not preserve signatures for kimi-coding provider (#39798)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "kimi-coding",
+      modelId: "k2p5",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
+
   it("enables turn-ordering and assistant-merge for strict OpenAI-compatible providers (#38962)", () => {
     const policy = resolveTranscriptPolicy({
       provider: "vllm",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -123,7 +123,8 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: isAnthropic,
+    // kimi-coding uses anthropic-messages API but cannot handle re-sent thinkingSignature blobs (#39798)
+    preserveSignatures: isAnthropic && provider !== "kimi-coding",
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -39,6 +39,8 @@ const OPENAI_MODEL_APIS = new Set([
 ]);
 const OPENAI_PROVIDERS = new Set(["openai", "openai-codex"]);
 const OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS = new Set(["openrouter", "opencode"]);
+// Providers that use anthropic-messages API but cannot handle re-sent thinkingSignature blobs (#39798)
+const ANTHROPIC_API_SIGNATURE_EXCLUDED_PROVIDERS = new Set(["kimi-coding"]);
 
 function isOpenAiApi(modelApi?: string | null): boolean {
   if (!modelApi) {
@@ -123,8 +125,7 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    // kimi-coding uses anthropic-messages API but cannot handle re-sent thinkingSignature blobs (#39798)
-    preserveSignatures: isAnthropic && provider !== "kimi-coding",
+    preserveSignatures: isAnthropic && !ANTHROPIC_API_SIGNATURE_EXCLUDED_PROVIDERS.has(provider),
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Summary

- **Problem:** Since v2026.3.7, `kimi-coding` (which uses `modelApi: "anthropic-messages"`) received its own `thinkingSignature` blobs back as context on turn 2+, causing JSON parse crashes and session termination.
- **Why it matters:** Every multi-turn `kimi-coding` / k2p5 session crashes on turn 2 with `Unexpected non-whitespace character after JSON at position N`.
- **What changed:** `preserveSignatures` is now `isAnthropic && provider !== "kimi-coding"` — kimi-coding is excluded from signature preservation despite using the Anthropic messages API.
- **What did NOT change:** All other Anthropic, Bedrock, and compatible providers are unaffected. No behaviour change for any provider except `kimi-coding`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #39798

## User-visible / Behavior Changes

`kimi-coding` / k2p5 multi-turn sessions no longer crash on turn 2. Thinking blocks from prior turns are stripped before being re-sent, matching the pre-v2026.3.7 behaviour.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker, Ubuntu-based)
- Model/provider: kimi-coding / k2p5, modelApi: anthropic-messages

### Steps

1. Configure a model with `provider: kimi-coding`, `model: k2p5`
2. Run any agent session requiring more than one LLM turn (e.g. a task that calls a tool and continues)
3. Before fix: crash on turn 2 — `Unexpected non-whitespace character after JSON at position N`
4. After fix: session continues normally across turns

### Expected

Session continues across multiple turns.

### Actual (before fix)

Session crashes on turn 2 with a JSON parse error originating from re-sent `thinkingSignature` blobs.

## Evidence

- [x] Failing test/log before + passing after

15 tests pass in `src/agents/transcript-policy.test.ts`, including the new regression test for kimi-coding (`does not preserve signatures for kimi-coding provider (#39798)`).

## Human Verification (required)

- Verified scenarios: `resolveTranscriptPolicy({ provider: "kimi-coding", modelApi: "anthropic-messages" })` returns `preserveSignatures: false`
- Edge cases checked: All other Anthropic/Bedrock providers still return `preserveSignatures: true`; Google/OpenAI/Mistral unaffected
- What you did not verify: live end-to-end session with real kimi API credentials

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single-line change in `src/agents/transcript-policy.ts` (remove `&& provider !== "kimi-coding"`)
- Files/config to restore: `src/agents/transcript-policy.ts` only