### PR TITLE
fix(gateway): Limit k2p5 OpenAI tool for cron only

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -732,7 +732,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
   });
 
-  it("normalizes kimi-coding anthropic tools to OpenAI function format", () => {
+  it("preserves anthropic tool schema for interactive kimi-coding endpoints", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -777,6 +777,83 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.tools).toEqual([
       {
+        name: "read",
+        description: "Read file",
+        input_schema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "exec",
+          description: "Run command",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+    expect(payloads[0]?.tool_choice).toEqual({
+      type: "function",
+      function: { name: "read" },
+    });
+  });
+
+  it("normalizes kimi-coding anthropic tools to OpenAI function format for cron runs", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tools: [
+          {
+            name: "read",
+            description: "Read file",
+            input_schema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+          {
+            type: "function",
+            function: {
+              name: "exec",
+              description: "Run command",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+        tool_choice: { type: "tool", name: "read" },
+      };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "kimi-coding",
+      "k2p5",
+      undefined,
+      "low",
+      undefined,
+      "cron",
+    );
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "kimi-coding",
+      id: "k2p5",
+      baseUrl: "https://api.kimi.com/coding/",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tools).toEqual([
+      {
         type: "function",
         function: {
           name: "read",
@@ -801,40 +878,6 @@ describe("applyExtraParamsToAgent", () => {
       type: "function",
       function: { name: "read" },
     });
-  });
-
-  it("normalizes anthropic tool_choice modes for kimi-coding endpoints", () => {
-    const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = {
-        tools: [
-          {
-            name: "read",
-            description: "Read file",
-            input_schema: { type: "object", properties: {} },
-          },
-        ],
-        tool_choice: { type: "auto" },
-      };
-      options?.onPayload?.(payload);
-      payloads.push(payload);
-      return {} as ReturnType<StreamFn>;
-    };
-    const agent = { streamFn: baseStreamFn };
-
-    applyExtraParamsToAgent(agent, undefined, "kimi-coding", "k2p5", undefined, "low");
-
-    const model = {
-      api: "anthropic-messages",
-      provider: "kimi-coding",
-      id: "k2p5",
-      baseUrl: "https://api.kimi.com/coding/",
-    } as Model<"anthropic-messages">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {});
-
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.tool_choice).toBe("auto");
   });
 
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -881,8 +881,10 @@ function normalizeKimiCodingToolChoice(toolChoice: unknown): unknown {
 }
 
 /**
- * Kimi Coding's anthropic-messages endpoint expects OpenAI-style tool payloads
- * (`tools[].function`) even when messages use Anthropic request framing.
+ * Cron's isolated Kimi Coding runs still hit an endpoint variant that rejects
+ * Anthropic tool schema and requires OpenAI-style `tools[].function`.
+ * Keep this compat scoped to cron so interactive sessions stay on Anthropic
+ * framing and avoid the literal `<function_calls>` regression.
  */
 function createKimiCodingAnthropicToolSchemaWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
@@ -1189,6 +1191,7 @@ export function applyExtraParamsToAgent(
   extraParamsOverride?: Record<string, unknown>,
   thinkingLevel?: ThinkLevel,
   agentId?: string,
+  trigger?: string,
 ): void {
   const resolvedExtraParams = resolveExtraParams({
     cfg,
@@ -1245,7 +1248,9 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createMoonshotThinkingWrapper(agent.streamFn, moonshotThinkingType);
   }
 
-  agent.streamFn = createKimiCodingAnthropicToolSchemaWrapper(agent.streamFn);
+  if (trigger === "cron") {
+    agent.streamFn = createKimiCodingAnthropicToolSchemaWrapper(agent.streamFn);
+  }
 
   if (provider === "openrouter") {
     log.debug(`applying OpenRouter app attribution headers for ${provider}/${modelId}`);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1282,6 +1282,7 @@ export async function runEmbeddedAttempt(
         params.streamParams,
         params.thinkLevel,
         sessionAgentId,
+        params.trigger,
       );
 
       if (cacheTrace) {


### PR DESCRIPTION
## Summary

Code change is prepared by Codex GPT 5.4.

- Problem: Can not calling tool in main.
- Why it matters: Not usable anymore for any kimi-for-code/k2p5 user
- What changed: scope tool schema compat to cron runs only
- What did NOT change (scope boundary): cron job in #37038

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39839
- Related #37038

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: None because above is all No

## Repro + Verification

### Environment

- OS: MacOS
- Runtime/container: Node 24
- Model/provider: kimi-for-code/k2p5
- Integration/channel (if any): kimiclaw
- Relevant config (redacted):

### Steps

1. Open main dialog
2. Type `/new`

### Expected

- Get Agent in your own soul and memory.

### Actual

- Return pure text without tool call.

```txt
read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-03-06.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-03-05.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/MEMORY.md"})
```

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Using at kimi.com, kimiclaw web UI
- Edge cases checked: Always happen, no edge case.
- What you did **not** verify: I verified.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: No need.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: ship a new release
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

`None`
