### PR TITLE
fix(gateway): seed Control UI origins for CLI --bind override

### DIFF
--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -45,13 +45,17 @@ export function buildDefaultControlUiAllowedOrigins(params: {
 
 export function ensureControlUiAllowedOriginsForNonLoopbackBind(
   config: OpenClawConfig,
-  opts?: { defaultPort?: number; requireControlUiEnabled?: boolean },
+  opts?: {
+    defaultPort?: number;
+    requireControlUiEnabled?: boolean;
+    bindOverride?: GatewayNonLoopbackBindMode;
+  },
 ): {
   config: OpenClawConfig;
   seededOrigins: string[] | null;
   bind: GatewayNonLoopbackBindMode | null;
 } {
-  const bind = config.gateway?.bind;
+  const bind = opts?.bindOverride ?? config.gateway?.bind;
   if (!isGatewayNonLoopbackBindMode(bind)) {
     return { config, seededOrigins: null, bind: null };
   }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -18,6 +18,7 @@ import {
   readConfigFileSnapshot,
   writeConfigFile,
 } from "../config/config.js";
+import { isGatewayNonLoopbackBindMode } from "../config/gateway-control-ui-origins.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
@@ -460,6 +461,8 @@ export async function startGatewayServer(
     config: cfgAtStart,
     writeConfig: writeConfigFile,
     log,
+    bindOverride: isGatewayNonLoopbackBindMode(opts.bind) ? opts.bind : undefined,
+    defaultPort: port,
   });
 
   initSubagentRegistry();

--- a/src/gateway/startup-control-ui-origins.ts
+++ b/src/gateway/startup-control-ui-origins.ts
@@ -8,8 +8,13 @@ export async function maybeSeedControlUiAllowedOriginsAtStartup(params: {
   config: OpenClawConfig;
   writeConfig: (config: OpenClawConfig) => Promise<void>;
   log: { info: (msg: string) => void; warn: (msg: string) => void };
+  bindOverride?: GatewayNonLoopbackBindMode;
+  defaultPort?: number;
 }): Promise<OpenClawConfig> {
-  const seeded = ensureControlUiAllowedOriginsForNonLoopbackBind(params.config);
+  const seeded = ensureControlUiAllowedOriginsForNonLoopbackBind(params.config, {
+    bindOverride: params.bindOverride,
+    defaultPort: params.defaultPort,
+  });
   if (!seeded.seededOrigins || !seeded.bind) {
     return params.config;
   }


### PR DESCRIPTION
## Summary

Fixes #39228 - Docker gateway crash-loops when `--bind lan` is passed via CLI but `gateway.bind` is not set in config file.

## Root Cause

The startup function only checks `config.gateway?.bind` from the config file, ignoring CLI `--bind` override. When Docker passes `--bind lan` via CLI without setting it in config, required `allowedOrigins` are not seeded.

## Fix

Thread the CLI `--bind` override through to the origin seeding function:

**Modified files:**
- `src/config/gateway-control-ui-origins.ts` - Add `bindOverride` parameter
- `src/gateway/startup-control-ui-origins.ts` - Pass `bindOverride` through
- `src/gateway/server.impl.ts` - Pass filtered `opts.bind` at call site

## Test plan

- [x] Type check passes
- [x] Gateway tests pass  
- [x] Code formatting verified

## Related

Follow-up to #29385 which added startup seeding but only for config-file bind modes.