### PR TITLE
feat(feishu): expose non-bot @mentions in inbound conversation metadata

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1327,6 +1327,17 @@ export async function handleFeishuMessage(params: {
         ReplyToBody: quotedContent ?? undefined,
         Timestamp: Date.now(),
         WasMentioned: wasMentioned,
+        // Expose all non-bot mentions so agents can detect when another bot/user was @mentioned.
+        // This allows agents to stay silent when a different bot (e.g. @Arbiter) was addressed.
+        Mentions:
+          (event.message.mentions ?? [])
+            .filter((m) => m.id.open_id && m.id.open_id !== botOpenId)
+            .map((m) => ({ id: m.id.open_id!, name: m.name }))
+            .length > 0
+            ? (event.message.mentions ?? [])
+                .filter((m) => m.id.open_id && m.id.open_id !== botOpenId)
+                .map((m) => ({ id: m.id.open_id!, name: m.name }))
+            : undefined,
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -116,6 +116,10 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     is_forum: ctx.IsForum === true ? true : undefined,
     is_group_chat: !isDirect ? true : undefined,
     was_mentioned: ctx.WasMentioned === true ? true : undefined,
+    mentions:
+      Array.isArray(ctx.Mentions) && ctx.Mentions.length > 0
+        ? ctx.Mentions.map((m) => ({ id: m.id, name: m.name }))
+        : undefined,
     has_reply_context: ctx.ReplyToBody ? true : undefined,
     has_forwarded_context: ctx.ForwardedFrom ? true : undefined,
     has_thread_starter: safeTrim(ctx.ThreadStarterBody) ? true : undefined,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -130,6 +130,12 @@ export type MsgContext = {
   /** Provider surface label (e.g. discord, slack). Prefer this over `Provider` when available. */
   Surface?: string;
   WasMentioned?: boolean;
+  /**
+   * List of non-bot users/bots mentioned in the message (excluding the bot itself).
+   * Each entry has `{ id: string; name: string }`.
+   * Populated by channel plugins (e.g. Feishu) where structured mention data is available.
+   */
+  Mentions?: Array<{ id: string; name: string }>;
   CommandAuthorized?: boolean;
   CommandSource?: "text" | "native";
   CommandTargetSessionKey?: string;


### PR DESCRIPTION
## Problem

In a Feishu group chat with multiple bots (e.g. `龙虾小子` + `Arbiter`), when a user types `@Arbiter hello`, the `@Arbiter` is a Feishu rich-text mention element — **not plain text**. The receiving bot only sees the stripped message body (`hello`), with no signal that a *different* bot was addressed.

Result: both bots respond, even though only one was addressed.

## Root Cause

The Feishu plugin already has full mention data in `event.message.mentions`, and `normalizeMentions()` converts mention keys to `<at user_id="...">` tags in the message body. However, this normalized form still doesn't give the agent a clean, structured list of *who* was mentioned. The agent needs to pattern-match against raw HTML tags in an untrusted string — fragile and easy to miss.

## Fix

Surface the structured mention list directly in the **trusted inbound conversation-info metadata block** that agents already read.

**Three small changes:**

1. `extensions/feishu/src/bot.ts` — collect all non-self mentions from `event.message.mentions` and pass them as `Mentions` in the template context.
2. `src/auto-reply/templating.ts` — add `Mentions?: Array<{ id: string; name: string }>` to `TemplateContext`.
3. `src/auto-reply/reply/inbound-meta.ts` — include `mentions` in the conversation-info user-role block when present.

## Result

When a user sends `@Arbiter hello` in a group, the receiving bot now sees:

```json
{
  "message_id": "...",
  "is_group_chat": true,
  "mentions": [{"id": "ou_arbiter_openid", "name": "Arbiter"}]
}
```

The agent can compare `mentions[*].name` (or `id`) against its known sibling bots and emit `NO_REPLY` immediately — no regex on message body required.

## Notes

- Only non-self mentions are included (the bot's own mention is already captured by `was_mentioned`).
- The field is omitted entirely when there are no non-self mentions (zero overhead for typical messages).
- No breaking changes; existing agents that don't use `mentions` are unaffected.

---

*Discovered while running two bots (龙虾小子 + Arbiter) in the same Feishu group. Both would respond to `@Arbiter` messages because the mention wasn't detectable from the agent's perspective.*