### PR TITLE
gateway: fix global Control UI 404s for symlinked wrappers and pnpm hardlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - TUI/theme: detect light terminal backgrounds via `COLORFGBG` and pick a WCAG AA-compliant light palette, with `OPENCLAW_THEME=light|dark` override for terminals without auto-detection. (#38636) Thanks @ademczuk and @vincentkoc.
 - Agents/context-engine plugins: bootstrap runtime plugins once at embedded-run, compaction, and subagent boundaries so plugin-provided context engines and hooks load from the active workspace before runtime resolution. (#40232)
 - Config/runtime snapshots: keep secrets-runtime-resolved config and auth-profile snapshots intact after config writes so follow-up reads still see file-backed secret values while picking up the persisted config update. (#37313) thanks @bbblending.
+- Gateway/Control UI: resolve bundled dashboard assets through symlinked global wrappers and auto-detected package roots, while keeping configured and custom roots on the strict hardlink boundary. (#39856) Thanks @LarytheLord.
 
 ## 2026.3.7
 

--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -1,5 +1,8 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/bluebubbles";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { z } from "zod";
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
 

--- a/extensions/bluebubbles/src/runtime.ts
+++ b/extensions/bluebubbles/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 
 const runtimeStore = createPluginRuntimeStore<PluginRuntime>("BlueBubbles runtime not initialized");
 type LegacyRuntimeLogShape = { log?: (message: string) => void };

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -1,8 +1,8 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,
   collectOpenGroupPolicyConfiguredRouteWarnings,
+  createScopedChannelConfigBase,
   createScopedAccountConfigAccessors,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/discord";
 
 const { setRuntime: setDiscordRuntime, getRuntime: getDiscordRuntime } =

--- a/extensions/feishu/src/runtime.ts
+++ b/extensions/feishu/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/feishu";
 
 const { setRuntime: setFeishuRuntime, getRuntime: getFeishuRuntime } =

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -1,8 +1,8 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
 import {
   buildAccountScopedDmSecurityPolicy,
   buildOpenGroupPolicyConfigureRouteAllowlistWarning,
   collectAllowlistProviderGroupPolicyWarnings,
+  createScopedChannelConfigBase,
   createScopedAccountConfigAccessors,
   formatNormalizedAllowFromEntries,
 } from "openclaw/plugin-sdk/compat";

--- a/extensions/googlechat/src/runtime.ts
+++ b/extensions/googlechat/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/googlechat";
 
 const { setRuntime: setGoogleChatRuntime, getRuntime: getGoogleChatRuntime } =

--- a/extensions/imessage/src/runtime.ts
+++ b/extensions/imessage/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/imessage";
 
 const { setRuntime: setIMessageRuntime, getRuntime: getIMessageRuntime } =

--- a/extensions/irc/src/runtime.ts
+++ b/extensions/irc/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/irc";
 
 const { setRuntime: setIrcRuntime, getRuntime: getIrcRuntime } =

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/line";
 
 const { setRuntime: setLineRuntime, getRuntime: getLineRuntime } =

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
 
 const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/mattermost";
 
 const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/msteams";
 
 const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =

--- a/extensions/nextcloud-talk/src/runtime.ts
+++ b/extensions/nextcloud-talk/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nextcloud-talk";
 
 const { setRuntime: setNextcloudTalkRuntime, getRuntime: getNextcloudTalkRuntime } =

--- a/extensions/nostr/src/runtime.ts
+++ b/extensions/nostr/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nostr";
 
 const { setRuntime: setNostrRuntime, getRuntime: getNostrRuntime } =

--- a/extensions/signal/src/runtime.ts
+++ b/extensions/signal/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/signal";
 
 const { setRuntime: setSignalRuntime, getRuntime: getSignalRuntime } =

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -1,8 +1,8 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,
   collectOpenGroupPolicyConfiguredRouteWarnings,
+  createScopedChannelConfigBase,
   createScopedAccountConfigAccessors,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";

--- a/extensions/slack/src/runtime.ts
+++ b/extensions/slack/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/slack";
 
 const { setRuntime: setSlackRuntime, getRuntime: getSlackRuntime } =

--- a/extensions/synology-chat/src/runtime.ts
+++ b/extensions/synology-chat/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/synology-chat";
 
 const { setRuntime: setSynologyRuntime, getRuntime: getSynologyRuntime } =

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1,8 +1,8 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
 import {
   collectAllowlistProviderGroupPolicyWarnings,
   buildAccountScopedDmSecurityPolicy,
   collectOpenGroupPolicyRouteAllowlistWarnings,
+  createScopedChannelConfigBase,
   createScopedAccountConfigAccessors,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/telegram";
 
 const { setRuntime: setTelegramRuntime, getRuntime: getTelegramRuntime } =

--- a/extensions/tlon/src/runtime.ts
+++ b/extensions/tlon/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/tlon";
 
 const { setRuntime: setTlonRuntime, getRuntime: getTlonRuntime } =

--- a/extensions/twitch/src/runtime.ts
+++ b/extensions/twitch/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/twitch";
 
 const { setRuntime: setTwitchRuntime, getRuntime: getTwitchRuntime } =

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/whatsapp";
 
 const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =

--- a/extensions/zalo/src/config-schema.ts
+++ b/extensions/zalo/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { MarkdownConfigSchema } from "openclaw/plugin-sdk/zalo";
 import { z } from "zod";
 import { buildSecretInputSchema } from "./secret-input.js";

--- a/extensions/zalo/src/runtime.ts
+++ b/extensions/zalo/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalo";
 
 const { setRuntime: setZaloRuntime, getRuntime: getZaloRuntime } =

--- a/extensions/zalouser/src/config-schema.ts
+++ b/extensions/zalouser/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/zalouser";
 import { z } from "zod";
 

--- a/extensions/zalouser/src/runtime.ts
+++ b/extensions/zalouser/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalouser";
 
 const { setRuntime: setZalouserRuntime, getRuntime: getZalouserRuntime } =

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/gateway/control-ui.auto-root.http.test.ts
+++ b/src/gateway/control-ui.auto-root.http.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import type { IncomingMessage } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { resolveControlUiRootSyncMock, isPackageProvenControlUiRootSyncMock } = vi.hoisted(() => ({
+  resolveControlUiRootSyncMock: vi.fn(),
+  isPackageProvenControlUiRootSyncMock: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../infra/control-ui-assets.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/control-ui-assets.js")>();
+  return {
+    ...actual,
+    resolveControlUiRootSync: resolveControlUiRootSyncMock,
+    isPackageProvenControlUiRootSync: isPackageProvenControlUiRootSyncMock,
+  };
+});
+
+const { handleControlUiHttpRequest } = await import("./control-ui.js");
+const { makeMockHttpResponse } = await import("./test-http-response.js");
+
+async function withControlUiRoot<T>(fn: (tmp: string) => Promise<T>) {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-auto-root-"));
+  try {
+    await fs.writeFile(path.join(tmp, "index.html"), "<html>fallback</html>\n");
+    return await fn(tmp);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  resolveControlUiRootSyncMock.mockReset();
+  isPackageProvenControlUiRootSyncMock.mockReset();
+  isPackageProvenControlUiRootSyncMock.mockReturnValue(true);
+});
+
+describe("handleControlUiHttpRequest auto-detected root", () => {
+  it("serves hardlinked asset files for bundled auto-detected roots", async () => {
+    await withControlUiRoot(async (tmp) => {
+      const assetsDir = path.join(tmp, "assets");
+      await fs.mkdir(assetsDir, { recursive: true });
+      await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+      await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+      resolveControlUiRootSyncMock.mockReturnValue(tmp);
+
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/assets/app.hl.js", method: "GET" } as IncomingMessage,
+        res,
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("console.log('hi');");
+    });
+  });
+
+  it("serves hardlinked SPA fallback index.html for bundled auto-detected roots", async () => {
+    await withControlUiRoot(async (tmp) => {
+      const sourceIndex = path.join(tmp, "index.source.html");
+      const indexPath = path.join(tmp, "index.html");
+      await fs.writeFile(sourceIndex, "<html>fallback-hardlink</html>\n");
+      await fs.rm(indexPath);
+      await fs.link(sourceIndex, indexPath);
+      resolveControlUiRootSyncMock.mockReturnValue(tmp);
+
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/dashboard", method: "GET" } as IncomingMessage,
+        res,
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("<html>fallback-hardlink</html>\n");
+    });
+  });
+
+  it("rejects hardlinked assets for non-package-proven auto-detected roots", async () => {
+    isPackageProvenControlUiRootSyncMock.mockReturnValue(false);
+    await withControlUiRoot(async (tmp) => {
+      const assetsDir = path.join(tmp, "assets");
+      await fs.mkdir(assetsDir, { recursive: true });
+      await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+      await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+      resolveControlUiRootSyncMock.mockReturnValue(tmp);
+
+      const { res } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/assets/app.hl.js", method: "GET" } as IncomingMessage,
+        res,
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -101,6 +101,36 @@ describe("handleControlUiHttpRequest", () => {
     }
   }
 
+  async function withOpenClawPackageControlUiRoot<T>(params: {
+    hardlinkIndex?: boolean;
+    fn: (rootPath: string) => Promise<T>;
+  }) {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-package-root-"));
+    try {
+      const packageRoot = path.join(tmp, "node_modules", "openclaw");
+      const uiRoot = path.join(packageRoot, "dist", "control-ui");
+      await fs.mkdir(uiRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({ name: "openclaw" }),
+      );
+
+      if (params.hardlinkIndex) {
+        const storeDir = path.join(tmp, "store");
+        await fs.mkdir(storeDir, { recursive: true });
+        const storeIndex = path.join(storeDir, "index.html");
+        await fs.writeFile(storeIndex, "<html>hardlinked-package-ui</html>\n");
+        await fs.link(storeIndex, path.join(uiRoot, "index.html"));
+      } else {
+        await fs.writeFile(path.join(uiRoot, "index.html"), "<html>package-ui</html>\n");
+      }
+
+      return await params.fn(uiRoot);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  }
+
   it("sets security headers for Control UI responses", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
@@ -322,6 +352,45 @@ describe("handleControlUiHttpRequest", () => {
         } finally {
           await fs.rm(outsideDir, { recursive: true, force: true });
         }
+      },
+    });
+  });
+
+  it("rejects hardlinked index.html for non-package control-ui roots", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-index-hardlink-"));
+        try {
+          const outsideIndex = path.join(outsideDir, "index.html");
+          await fs.writeFile(outsideIndex, "<html>outside-hardlink</html>\n");
+          await fs.rm(path.join(tmp, "index.html"));
+          await fs.link(outsideIndex, path.join(tmp, "index.html"));
+
+          const { res, end, handled } = runControlUiRequest({
+            url: "/",
+            method: "GET",
+            rootPath: tmp,
+          });
+          expectNotFoundResponse({ handled, res, end });
+        } finally {
+          await fs.rm(outsideDir, { recursive: true, force: true });
+        }
+      },
+    });
+  });
+
+  it("allows hardlinked index.html for OpenClaw package control-ui roots", async () => {
+    await withOpenClawPackageControlUiRoot({
+      hardlinkIndex: true,
+      fn: async (rootPath) => {
+        const { res, end, handled } = runControlUiRequest({
+          url: "/",
+          method: "GET",
+          rootPath,
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toContain("hardlinked-package-ui");
       },
     });
   });

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -45,6 +45,7 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    rootKind?: "resolved" | "bundled";
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = handleControlUiHttpRequest(
@@ -52,7 +53,7 @@ describe("handleControlUiHttpRequest", () => {
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
-        root: { kind: "resolved", path: params.rootPath },
+        root: { kind: params.rootKind ?? "resolved", path: params.rootPath },
       },
     );
     return { res, end, handled };
@@ -96,36 +97,6 @@ describe("handleControlUiHttpRequest", () => {
       await fs.mkdir(sibling, { recursive: true });
       await fs.writeFile(path.join(root, "index.html"), "<html>ok</html>\n");
       return await params.fn({ root, sibling });
-    } finally {
-      await fs.rm(tmp, { recursive: true, force: true });
-    }
-  }
-
-  async function withOpenClawPackageControlUiRoot<T>(params: {
-    hardlinkIndex?: boolean;
-    fn: (rootPath: string) => Promise<T>;
-  }) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-package-root-"));
-    try {
-      const packageRoot = path.join(tmp, "node_modules", "openclaw");
-      const uiRoot = path.join(packageRoot, "dist", "control-ui");
-      await fs.mkdir(uiRoot, { recursive: true });
-      await fs.writeFile(
-        path.join(packageRoot, "package.json"),
-        JSON.stringify({ name: "openclaw" }),
-      );
-
-      if (params.hardlinkIndex) {
-        const storeDir = path.join(tmp, "store");
-        await fs.mkdir(storeDir, { recursive: true });
-        const storeIndex = path.join(storeDir, "index.html");
-        await fs.writeFile(storeIndex, "<html>hardlinked-package-ui</html>\n");
-        await fs.link(storeIndex, path.join(uiRoot, "index.html"));
-      } else {
-        await fs.writeFile(path.join(uiRoot, "index.html"), "<html>package-ui</html>\n");
-      }
-
-      return await params.fn(uiRoot);
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }
@@ -379,18 +350,45 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("allows hardlinked index.html for OpenClaw package control-ui roots", async () => {
-    await withOpenClawPackageControlUiRoot({
-      hardlinkIndex: true,
-      fn: async (rootPath) => {
+  it("rejects hardlinked asset files for custom/resolved roots (security boundary)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const assetsDir = path.join(tmp, "assets");
+        await fs.mkdir(assetsDir, { recursive: true });
+        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+
         const { res, end, handled } = runControlUiRequest({
-          url: "/",
+          url: "/assets/app.hl.js",
           method: "GET",
-          rootPath,
+          rootPath: tmp,
         });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(404);
+        expect(end).toHaveBeenCalledWith("Not Found");
+      },
+    });
+  });
+
+  it("serves hardlinked asset files for bundled roots (pnpm global install)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const assetsDir = path.join(tmp, "assets");
+        await fs.mkdir(assetsDir, { recursive: true });
+        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/assets/app.hl.js",
+          method: "GET",
+          rootPath: tmp,
+          rootKind: "bundled",
+        });
+
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
-        expect(String(end.mock.calls[0]?.[0] ?? "")).toContain("hardlinked-package-ui");
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("console.log('hi');");
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -3,7 +3,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
-import { resolveControlUiRootSync } from "../infra/control-ui-assets.js";
+import {
+  isPackageProvenControlUiRootSync,
+  resolveControlUiRootSync,
+} from "../infra/control-ui-assets.js";
 import { isWithinDir } from "../infra/path-safety.js";
 import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
@@ -39,6 +42,7 @@ export type ControlUiRequestOptions = {
 };
 
 export type ControlUiRootState =
+  | { kind: "bundled"; path: string }
   | { kind: "resolved"; path: string }
   | { kind: "invalid"; path: string }
   | { kind: "missing" };
@@ -256,7 +260,7 @@ function resolveSafeAvatarFile(filePath: string): { path: string; fd: number } |
 function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
-  opts?: { allowHardlinks?: boolean },
+  rejectHardlinks: boolean,
 ): { path: string; fd: number } | null {
   const opened = openBoundaryFileSync({
     absolutePath: filePath,
@@ -264,7 +268,7 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
-    rejectHardlinks: opts?.allowHardlinks ? false : undefined,
+    rejectHardlinks,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {
@@ -290,28 +294,6 @@ function isSafeRelativePath(relPath: string) {
     return false;
   }
   return true;
-}
-
-function readPackageNameFromDir(dir: string): string | null {
-  try {
-    const raw = fs.readFileSync(path.join(dir, "package.json"), "utf8");
-    const parsed = JSON.parse(raw) as { name?: unknown };
-    return typeof parsed.name === "string" ? parsed.name : null;
-  } catch {
-    return null;
-  }
-}
-
-function shouldAllowControlUiHardlinks(rootReal: string): boolean {
-  const normalizedRoot = path.resolve(rootReal);
-  const controlUiDirName = path.basename(normalizedRoot);
-  const distDir = path.dirname(normalizedRoot);
-  const distDirName = path.basename(distDir);
-  if (controlUiDirName !== "control-ui" || distDirName !== "dist") {
-    return false;
-  }
-  const packageRoot = path.dirname(distDir);
-  return readPackageNameFromDir(packageRoot) === "openclaw";
 }
 
 export function handleControlUiHttpRequest(
@@ -391,7 +373,7 @@ export function handleControlUiHttpRequest(
   }
 
   const root =
-    rootState?.kind === "resolved"
+    rootState?.kind === "resolved" || rootState?.kind === "bundled"
       ? rootState.path
       : resolveControlUiRootSync({
           moduleUrl: import.meta.url,
@@ -417,7 +399,6 @@ export function handleControlUiHttpRequest(
     respondControlUiAssetsUnavailable(res);
     return true;
   }
-  const allowHardlinks = shouldAllowControlUiHardlinks(rootReal);
 
   const uiPath =
     basePath && pathname.startsWith(`${basePath}/`) ? pathname.slice(basePath.length) : pathname;
@@ -444,7 +425,16 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const safeFile = resolveSafeControlUiFile(rootReal, filePath, { allowHardlinks });
+  const isBundledRoot =
+    rootState?.kind === "bundled" ||
+    (rootState === undefined &&
+      isPackageProvenControlUiRootSync(root, {
+        moduleUrl: import.meta.url,
+        argv1: process.argv[1],
+        cwd: process.cwd(),
+      }));
+  const rejectHardlinks = !isBundledRoot;
+  const safeFile = resolveSafeControlUiFile(rootReal, filePath, rejectHardlinks);
   if (safeFile) {
     try {
       if (respondHeadForFile(req, res, safeFile.path)) {
@@ -473,7 +463,7 @@ export function handleControlUiHttpRequest(
 
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, { allowHardlinks });
+  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, rejectHardlinks);
   if (safeIndex) {
     try {
       if (respondHeadForFile(req, res, safeIndex.path)) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -256,6 +256,7 @@ function resolveSafeAvatarFile(filePath: string): { path: string; fd: number } |
 function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
+  opts?: { allowHardlinks?: boolean },
 ): { path: string; fd: number } | null {
   const opened = openBoundaryFileSync({
     absolutePath: filePath,
@@ -263,6 +264,7 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    rejectHardlinks: opts?.allowHardlinks ? false : undefined,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {
@@ -288,6 +290,28 @@ function isSafeRelativePath(relPath: string) {
     return false;
   }
   return true;
+}
+
+function readPackageNameFromDir(dir: string): string | null {
+  try {
+    const raw = fs.readFileSync(path.join(dir, "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === "string" ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function shouldAllowControlUiHardlinks(rootReal: string): boolean {
+  const normalizedRoot = path.resolve(rootReal);
+  const controlUiDirName = path.basename(normalizedRoot);
+  const distDir = path.dirname(normalizedRoot);
+  const distDirName = path.basename(distDir);
+  if (controlUiDirName !== "control-ui" || distDirName !== "dist") {
+    return false;
+  }
+  const packageRoot = path.dirname(distDir);
+  return readPackageNameFromDir(packageRoot) === "openclaw";
 }
 
 export function handleControlUiHttpRequest(
@@ -393,6 +417,7 @@ export function handleControlUiHttpRequest(
     respondControlUiAssetsUnavailable(res);
     return true;
   }
+  const allowHardlinks = shouldAllowControlUiHardlinks(rootReal);
 
   const uiPath =
     basePath && pathname.startsWith(`${basePath}/`) ? pathname.slice(basePath.length) : pathname;
@@ -419,7 +444,7 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const safeFile = resolveSafeControlUiFile(rootReal, filePath);
+  const safeFile = resolveSafeControlUiFile(rootReal, filePath, { allowHardlinks });
   if (safeFile) {
     try {
       if (respondHeadForFile(req, res, safeFile.path)) {
@@ -448,7 +473,7 @@ export function handleControlUiHttpRequest(
 
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath);
+  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, { allowHardlinks });
   if (safeIndex) {
     try {
       if (respondHeadForFile(req, res, safeIndex.path)) {

--- a/src/gateway/server.control-ui-root.test.ts
+++ b/src/gateway/server.control-ui-root.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { installGatewayTestHooks, testState, withGatewayServer } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+async function withGlobalControlUiHardlinkFixture<T>(run: (rootPath: string) => Promise<T>) {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-ui-hardlink-"));
+  try {
+    const packageRoot = path.join(tmp, "pnpm-global", "5", "node_modules", "openclaw");
+    const controlUiRoot = path.join(packageRoot, "dist", "control-ui");
+    await fs.mkdir(controlUiRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw" }),
+    );
+
+    const storeDir = path.join(tmp, "pnpm-store", "files");
+    await fs.mkdir(storeDir, { recursive: true });
+    const storeIndex = path.join(storeDir, "index.html");
+    await fs.writeFile(storeIndex, "<html><body>pnpm-hardlink-ui</body></html>\n");
+    await fs.link(storeIndex, path.join(controlUiRoot, "index.html"));
+
+    return await run(controlUiRoot);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+}
+
+describe("gateway.controlUi.root", () => {
+  test("serves GET / when configured root points at global OpenClaw package control-ui", async () => {
+    await withGlobalControlUiHardlinkFixture(async (rootPath) => {
+      testState.gatewayControlUi = { root: rootPath };
+      await withGatewayServer(
+        async ({ port }) => {
+          const res = await fetch(`http://127.0.0.1:${port}/`);
+          expect(res.status).toBe(200);
+          const body = await res.text();
+          expect(body).toContain("pnpm-hardlink-ui");
+        },
+        { serverOptions: { controlUiEnabled: true } },
+      );
+    });
+  });
+});

--- a/src/gateway/server.control-ui-root.test.ts
+++ b/src/gateway/server.control-ui-root.test.ts
@@ -30,15 +30,14 @@ async function withGlobalControlUiHardlinkFixture<T>(run: (rootPath: string) => 
 }
 
 describe("gateway.controlUi.root", () => {
-  test("serves GET / when configured root points at global OpenClaw package control-ui", async () => {
+  test("rejects hardlinked index.html when configured root points at global OpenClaw package control-ui", async () => {
     await withGlobalControlUiHardlinkFixture(async (rootPath) => {
       testState.gatewayControlUi = { root: rootPath };
       await withGatewayServer(
         async ({ port }) => {
           const res = await fetch(`http://127.0.0.1:${port}/`);
-          expect(res.status).toBe(200);
-          const body = await res.text();
-          expect(body).toContain("pnpm-hardlink-ui");
+          expect(res.status).toBe(404);
+          expect(await res.text()).toBe("Not Found");
         },
         { serverOptions: { controlUiEnabled: true } },
       );

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -24,6 +24,7 @@ import { resolveMainSessionKey } from "../config/sessions.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
+  isPackageProvenControlUiRootSync,
   resolveControlUiRootOverrideSync,
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
@@ -545,7 +546,16 @@ export async function startGatewayServer(
       });
     }
     controlUiRootState = resolvedRoot
-      ? { kind: "resolved", path: resolvedRoot }
+      ? {
+          kind: isPackageProvenControlUiRootSync(resolvedRoot, {
+            moduleUrl: import.meta.url,
+            argv1: process.argv[1],
+            cwd: process.cwd(),
+          })
+            ? "bundled"
+            : "resolved",
+          path: resolvedRoot,
+        }
       : { kind: "missing" };
   }
 

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -76,6 +76,7 @@ vi.mock("./openclaw-root.js", () => ({
 let resolveControlUiRepoRoot: typeof import("./control-ui-assets.js").resolveControlUiRepoRoot;
 let resolveControlUiDistIndexPath: typeof import("./control-ui-assets.js").resolveControlUiDistIndexPath;
 let resolveControlUiDistIndexHealth: typeof import("./control-ui-assets.js").resolveControlUiDistIndexHealth;
+let isPackageProvenControlUiRootSync: typeof import("./control-ui-assets.js").isPackageProvenControlUiRootSync;
 let resolveControlUiRootOverrideSync: typeof import("./control-ui-assets.js").resolveControlUiRootOverrideSync;
 let resolveControlUiRootSync: typeof import("./control-ui-assets.js").resolveControlUiRootSync;
 let openclawRoot: typeof import("./openclaw-root.js");
@@ -86,6 +87,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
       resolveControlUiRepoRoot,
       resolveControlUiDistIndexPath,
       resolveControlUiDistIndexHealth,
+      isPackageProvenControlUiRootSync,
       resolveControlUiRootOverrideSync,
       resolveControlUiRootSync,
     } = await import("./control-ui-assets.js"));
@@ -222,5 +224,37 @@ describe("control UI assets helpers (fs-mocked)", () => {
     setFile(path.join(uiDir, "index.html"), "<html></html>\n");
 
     expect(resolveControlUiRootSync({ argv1: wrapperArgv1 })).toBe(uiDir);
+  });
+
+  it("detects package-proven control-ui roots", () => {
+    const pkgRoot = abs("fixtures/openclaw-package-root");
+    const uiDir = path.join(pkgRoot, "dist", "control-ui");
+    setDir(uiDir);
+    setFile(path.join(uiDir, "index.html"), "<html></html>\n");
+    (
+      openclawRoot.resolveOpenClawPackageRootSync as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValueOnce(pkgRoot);
+
+    expect(
+      isPackageProvenControlUiRootSync(uiDir, {
+        cwd: abs("fixtures/cwd"),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat fallback roots as package-proven", () => {
+    const pkgRoot = abs("fixtures/openclaw-package-root");
+    const fallbackRoot = abs("fixtures/fallback-root/dist/control-ui");
+    setDir(fallbackRoot);
+    setFile(path.join(fallbackRoot, "index.html"), "<html></html>\n");
+    (
+      openclawRoot.resolveOpenClawPackageRootSync as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValueOnce(pkgRoot);
+
+    expect(
+      isPackageProvenControlUiRootSync(fallbackRoot, {
+        cwd: abs("fixtures/fallback-root"),
+      }),
+    ).toBe(false);
   });
 });

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -123,6 +123,18 @@ describe("control UI assets helpers (fs-mocked)", () => {
     );
   });
 
+  it("resolves dist control-ui index path for symlinked argv1 via realpath", async () => {
+    const pkgRoot = abs("fixtures/bun-global/openclaw");
+    const wrapperArgv1 = abs("fixtures/bin/openclaw");
+    const realEntrypoint = path.join(pkgRoot, "dist", "index.js");
+
+    state.realpaths.set(wrapperArgv1, realEntrypoint);
+
+    await expect(resolveControlUiDistIndexPath(wrapperArgv1)).resolves.toBe(
+      path.join(pkgRoot, "dist", "control-ui", "index.html"),
+    );
+  });
+
   it("uses resolveOpenClawPackageRoot when available", async () => {
     const pkgRoot = abs("fixtures/openclaw");
     (
@@ -198,5 +210,17 @@ describe("control UI assets helpers (fs-mocked)", () => {
     // moduleUrl candidate: <moduleDir>/control-ui
     const moduleUrl = pathToFileURL(path.join(pkgRoot, "dist", "bundle.js")).toString();
     expect(resolveControlUiRootSync({ moduleUrl })).toBe(uiDir);
+  });
+
+  it("resolves control-ui root for symlinked argv1 via realpath", () => {
+    const pkgRoot = abs("fixtures/bun-global/openclaw");
+    const wrapperArgv1 = abs("fixtures/bin/openclaw");
+    const realEntrypoint = path.join(pkgRoot, "dist", "index.js");
+    const uiDir = path.join(pkgRoot, "dist", "control-ui");
+
+    state.realpaths.set(wrapperArgv1, realEntrypoint);
+    setFile(path.join(uiDir, "index.html"), "<html></html>\n");
+
+    expect(resolveControlUiRootSync({ argv1: wrapperArgv1 })).toBe(uiDir);
   });
 });

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -145,6 +145,22 @@ export type ControlUiRootResolveOptions = {
   execPath?: string;
 };
 
+function pathsMatchByRealpathOrResolve(left: string, right: string): boolean {
+  let realLeft: string;
+  let realRight: string;
+  try {
+    realLeft = fs.realpathSync(left);
+  } catch {
+    realLeft = path.resolve(left);
+  }
+  try {
+    realRight = fs.realpathSync(right);
+  } catch {
+    realRight = path.resolve(right);
+  }
+  return realLeft === realRight;
+}
+
 function addCandidate(candidates: Set<string>, value: string | null) {
   if (!value) {
     return;
@@ -231,6 +247,24 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
     }
   }
   return null;
+}
+
+export function isPackageProvenControlUiRootSync(
+  root: string,
+  opts: ControlUiRootResolveOptions = {},
+): boolean {
+  const argv1 = opts.argv1 ?? process.argv[1];
+  const cwd = opts.cwd ?? process.cwd();
+  const packageRoot = resolveOpenClawPackageRootSync({
+    argv1,
+    moduleUrl: opts.moduleUrl,
+    cwd,
+  });
+  if (!packageRoot) {
+    return false;
+  }
+  const packageDistRoot = path.join(packageRoot, "dist", "control-ui");
+  return pathsMatchByRealpathOrResolve(root, packageDistRoot);
 }
 
 export type EnsureControlUiAssetsResult = {

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -79,11 +79,23 @@ export async function resolveControlUiDistIndexPath(
     return null;
   }
   const normalized = path.resolve(argv1);
+  const entrypointCandidates = [normalized];
+  try {
+    const realpathEntrypoint = fs.realpathSync(normalized);
+    if (realpathEntrypoint !== normalized) {
+      entrypointCandidates.push(realpathEntrypoint);
+    }
+  } catch {
+    // Ignore missing/non-realpath argv1 and keep path-based candidates.
+  }
 
-  // Case 1: entrypoint is directly inside dist/ (e.g., dist/entry.js)
-  const distDir = path.dirname(normalized);
-  if (path.basename(distDir) === "dist") {
-    return path.join(distDir, "control-ui", "index.html");
+  // Case 1: entrypoint is directly inside dist/ (e.g., dist/entry.js).
+  // Include symlink-resolved argv1 so global wrappers (e.g. Bun) still map to dist/control-ui.
+  for (const entrypoint of entrypointCandidates) {
+    const distDir = path.dirname(entrypoint);
+    if (path.basename(distDir) === "dist") {
+      return path.join(distDir, "control-ui", "index.html");
+    }
   }
 
   const packageRoot = await resolveOpenClawPackageRoot({ argv1: normalized, moduleUrl });
@@ -93,29 +105,34 @@ export async function resolveControlUiDistIndexPath(
 
   // Fallback: traverse up and find package.json with name "openclaw" + dist/control-ui/index.html
   // This handles global installs where path-based resolution might fail.
-  let dir = path.dirname(normalized);
-  for (let i = 0; i < 8; i++) {
-    const pkgJsonPath = path.join(dir, "package.json");
-    const indexPath = path.join(dir, "dist", "control-ui", "index.html");
-    if (fs.existsSync(pkgJsonPath)) {
-      try {
-        const raw = fs.readFileSync(pkgJsonPath, "utf-8");
-        const parsed = JSON.parse(raw) as { name?: unknown };
-        if (parsed.name === "openclaw") {
-          return fs.existsSync(indexPath) ? indexPath : null;
+  const fallbackStartDirs = new Set(
+    entrypointCandidates.map((candidate) => path.dirname(candidate)),
+  );
+  for (const startDir of fallbackStartDirs) {
+    let dir = startDir;
+    for (let i = 0; i < 8; i++) {
+      const pkgJsonPath = path.join(dir, "package.json");
+      const indexPath = path.join(dir, "dist", "control-ui", "index.html");
+      if (fs.existsSync(pkgJsonPath)) {
+        try {
+          const raw = fs.readFileSync(pkgJsonPath, "utf-8");
+          const parsed = JSON.parse(raw) as { name?: unknown };
+          if (parsed.name === "openclaw") {
+            return fs.existsSync(indexPath) ? indexPath : null;
+          }
+          // Stop at the first package boundary to avoid resolving through unrelated ancestors.
+          break;
+        } catch {
+          // Invalid package.json at package boundary; abort this candidate chain.
+          break;
         }
-        // Stop at the first package boundary to avoid resolving through unrelated ancestors.
-        return null;
-      } catch {
-        // Invalid package.json at package boundary; abort fallback resolution.
-        return null;
       }
+      const parent = path.dirname(dir);
+      if (parent === dir) {
+        break;
+      }
+      dir = parent;
     }
-    const parent = path.dirname(dir);
-    if (parent === dir) {
-      break;
-    }
-    dir = parent;
   }
 
   return null;
@@ -158,6 +175,16 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
   const cwd = opts.cwd ?? process.cwd();
   const moduleDir = opts.moduleUrl ? path.dirname(fileURLToPath(opts.moduleUrl)) : null;
   const argv1Dir = argv1 ? path.dirname(path.resolve(argv1)) : null;
+  const argv1RealpathDir = (() => {
+    if (!argv1) {
+      return null;
+    }
+    try {
+      return path.dirname(fs.realpathSync(path.resolve(argv1)));
+    } catch {
+      return null;
+    }
+  })();
   const execDir = (() => {
     try {
       const execPath = opts.execPath ?? process.execPath;
@@ -186,6 +213,11 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
     // openclaw.mjs or dist/<bundle>.js
     addCandidate(candidates, path.join(argv1Dir, "dist", "control-ui"));
     addCandidate(candidates, path.join(argv1Dir, "control-ui"));
+  }
+  if (argv1RealpathDir && argv1RealpathDir !== argv1Dir) {
+    // Symlinked wrappers (e.g. ~/.bun/bin/openclaw -> .../dist/index.js)
+    addCandidate(candidates, path.join(argv1RealpathDir, "dist", "control-ui"));
+    addCandidate(candidates, path.join(argv1RealpathDir, "control-ui"));
   }
   if (packageRoot) {
     addCandidate(candidates, path.join(packageRoot, "dist", "control-ui"));


### PR DESCRIPTION
## Summary
Fixes the bundled Control UI `404 Not Found` regression for global installs while preserving the configured-root hardlink boundary:

1. symlinked global wrappers (for example `~/.bun/bin/openclaw`) where unresolved `argv1` can miss the real `dist/control-ui` path
2. auto-detected package roots in pnpm/global-store layouts where bundled Control UI assets are hardlinked

## Why
Reports in #39693 and #39621 show dashboard `404` despite valid assets on disk.

- wrapper installs can resolve from wrapper paths instead of the real entrypoint path
- package-manager global trees can expose bundled Control UI files through hardlinks
- configured `gateway.controlUi.root` should remain on the stricter hardlink boundary rather than inheriting special trust from a path shape

## Changes
### 1) Symlink-aware asset discovery
- `src/infra/control-ui-assets.ts`
  - evaluate both `path.resolve(argv1)` and `realpath(argv1)` candidates
  - include realpath-derived fallback traversal candidates
  - include realpath-derived root candidates in `resolveControlUiRootSync`
  - add package-proven bundled root detection

### 2) Bundled vs resolved root handling
- `src/gateway/server.impl.ts`
  - classify explicit `gateway.controlUi.root` overrides as `resolved`
  - classify auto-detected package-proven bundled roots as `bundled`
- `src/gateway/control-ui.ts`
  - allow hardlinks only for `bundled` roots
  - keep hardlink rejection for configured/custom `resolved` roots

### 3) Regression tests
- `src/infra/control-ui-assets.test.ts`
  - symlinked wrapper `argv1` cases
  - package-proven root detection
- `src/gateway/control-ui.http.test.ts`
  - rejects hardlinked assets for resolved roots
  - serves hardlinked assets for bundled roots
- `src/gateway/control-ui.auto-root.http.test.ts`
  - bundled auto-root serves hardlinked assets and SPA fallback
  - non-package auto-root still rejects hardlinked assets
- `src/gateway/server.control-ui-root.test.ts`
  - configured `gateway.controlUi.root` with a package-store hardlinked index still returns `404`

## Validation
- `pnpm test -- src/infra/control-ui-assets.test.ts src/gateway/control-ui.http.test.ts src/gateway/control-ui.auto-root.http.test.ts src/gateway/server.control-ui-root.test.ts`

Fixes #39693
Refs #39621
