### PR TITLE
fix: synthesize implicit openai-codex runtime provider

### DIFF
--- a/src/agents/models-config.providers.openai-codex.test.ts
+++ b/src/agents/models-config.providers.openai-codex.test.ts
@@ -135,6 +135,7 @@ describe("openai-codex implicit provider", () => {
             mode: "merge",
             providers: {
               "openai-codex": {
+                baseUrl: "",
                 api: "openai-codex-responses",
                 models: [],
               },

--- a/src/agents/models-config.providers.openai-codex.test.ts
+++ b/src/agents/models-config.providers.openai-codex.test.ts
@@ -56,6 +56,7 @@ describe("openai-codex implicit provider", () => {
           api: "openai-codex-responses",
           models: [],
         });
+        expect(providers?.["openai-codex"]).not.toHaveProperty("apiKey");
       });
     });
   });
@@ -93,6 +94,53 @@ describe("openai-codex implicit provider", () => {
         );
 
         await ensureOpenClawModelsJson({});
+
+        const parsed = await readGeneratedModelsJson<{
+          providers: Record<string, { baseUrl?: string; api?: string }>;
+        }>();
+        expect(parsed.providers["openai-codex"]).toMatchObject({
+          baseUrl: "https://chatgpt.com/backend-api",
+          api: "openai-codex-responses",
+        });
+      });
+    });
+  });
+
+  it("preserves an existing baseUrl for explicit openai-codex config without oauth synthesis", async () => {
+    await withModelsTempHome(async () => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+        const agentDir = resolveOpenClawAgentDir();
+        await fs.mkdir(agentDir, { recursive: true });
+        await fs.writeFile(
+          path.join(agentDir, "models.json"),
+          JSON.stringify(
+            {
+              providers: {
+                "openai-codex": {
+                  baseUrl: "https://chatgpt.com/backend-api",
+                  api: "openai-codex-responses",
+                  models: [],
+                },
+              },
+            },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+
+        await ensureOpenClawModelsJson({
+          models: {
+            mode: "merge",
+            providers: {
+              "openai-codex": {
+                api: "openai-codex-responses",
+                models: [],
+              },
+            },
+          },
+        });
 
         const parsed = await readGeneratedModelsJson<{
           providers: Record<string, { baseUrl?: string; api?: string }>;

--- a/src/agents/models-config.providers.openai-codex.test.ts
+++ b/src/agents/models-config.providers.openai-codex.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import {
+  installModelsConfigTestHooks,
+  MODELS_CONFIG_IMPLICIT_ENV_VARS,
+  unsetEnv,
+  withModelsTempHome,
+  withTempEnv,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+import { readGeneratedModelsJson } from "./models-config.test-utils.js";
+
+installModelsConfigTestHooks();
+
+async function writeCodexOauthProfile(agentDir: string) {
+  await fs.mkdir(agentDir, { recursive: true });
+  await fs.writeFile(
+    path.join(agentDir, "auth-profiles.json"),
+    JSON.stringify(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:default"],
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+describe("openai-codex implicit provider", () => {
+  it("injects an implicit provider when Codex OAuth exists", async () => {
+    await withModelsTempHome(async () => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+        const agentDir = resolveOpenClawAgentDir();
+        await writeCodexOauthProfile(agentDir);
+
+        const providers = await resolveImplicitProviders({ agentDir });
+        expect(providers?.["openai-codex"]).toMatchObject({
+          baseUrl: "https://chatgpt.com/backend-api",
+          api: "openai-codex-responses",
+          models: [],
+        });
+      });
+    });
+  });
+
+  it("replaces stale openai-codex baseUrl in generated models.json", async () => {
+    await withModelsTempHome(async () => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+        const agentDir = resolveOpenClawAgentDir();
+        await writeCodexOauthProfile(agentDir);
+        await fs.writeFile(
+          path.join(agentDir, "models.json"),
+          JSON.stringify(
+            {
+              providers: {
+                "openai-codex": {
+                  baseUrl: "https://api.openai.com/v1",
+                  api: "openai-responses",
+                  models: [
+                    {
+                      id: "gpt-5.4",
+                      name: "GPT-5.4",
+                      api: "openai-responses",
+                      contextWindow: 1_000_000,
+                      maxTokens: 100_000,
+                    },
+                  ],
+                },
+              },
+            },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+
+        await ensureOpenClawModelsJson({});
+
+        const parsed = await readGeneratedModelsJson<{
+          providers: Record<string, { baseUrl?: string; api?: string }>;
+        }>();
+        expect(parsed.providers["openai-codex"]).toMatchObject({
+          baseUrl: "https://chatgpt.com/backend-api",
+          api: "openai-codex-responses",
+        });
+      });
+    });
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -991,6 +991,8 @@ function buildOpenAICodexProvider(): ProviderConfig {
   return {
     baseUrl: OPENAI_CODEX_BASE_URL,
     api: "openai-codex-responses",
+    // Like Copilot, Codex resolves OAuth credentials from auth-profiles at
+    // runtime, so the snapshot only needs the canonical API surface.
     models: [],
   };
 }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -206,6 +206,8 @@ const NVIDIA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
+
 const log = createSubsystemLogger("agents/model-providers");
 
 interface OllamaModel {
@@ -985,6 +987,14 @@ function buildOpenrouterProvider(): ProviderConfig {
   };
 }
 
+function buildOpenAICodexProvider(): ProviderConfig {
+  return {
+    baseUrl: OPENAI_CODEX_BASE_URL,
+    api: "openai-codex-responses",
+    models: [],
+  };
+}
+
 async function buildVllmProvider(params?: {
   baseUrl?: string;
   apiKey?: string;
@@ -1283,6 +1293,11 @@ export async function resolveImplicitProviders(params: {
   const openrouterKey = resolveProviderApiKey("openrouter").apiKey;
   if (openrouterKey) {
     providers.openrouter = { ...buildOpenrouterProvider(), apiKey: openrouterKey };
+  }
+
+  const openaiCodexProfiles = listProfilesForProvider(authStore, "openai-codex");
+  if (openaiCodexProfiles.length > 0) {
+    providers["openai-codex"] = buildOpenAICodexProvider();
   }
 
   const nvidiaKey = resolveProviderApiKey("nvidia").apiKey;

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -22,6 +22,7 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 
 const DEFAULT_MODE: NonNullable<ModelsConfig["mode"]> = "merge";
 const MODELS_JSON_WRITE_LOCKS = new Map<string, Promise<void>>();
+const AUTHORITATIVE_IMPLICIT_BASEURL_PROVIDERS = new Set(["openai-codex"]);
 
 function isPositiveFiniteTokenLimit(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
@@ -198,6 +199,7 @@ function mergeWithExistingProviderSecrets(params: {
       preserved.apiKey = existing.apiKey;
     }
     if (
+      !AUTHORITATIVE_IMPLICIT_BASEURL_PROVIDERS.has(key) &&
       !explicitBaseUrlProviders.has(key) &&
       typeof existing.baseUrl === "string" &&
       existing.baseUrl

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -142,10 +142,16 @@ async function readJson(pathname: string): Promise<unknown> {
 async function resolveProvidersForModelsJson(params: {
   cfg: OpenClawConfig;
   agentDir: string;
-}): Promise<Record<string, ProviderConfig>> {
+}): Promise<{
+  providers: Record<string, ProviderConfig>;
+  authoritativeImplicitBaseUrlProviders: ReadonlySet<string>;
+}> {
   const { cfg, agentDir } = params;
   const explicitProviders = cfg.models?.providers ?? {};
   const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });
+  const authoritativeImplicitBaseUrlProviders = new Set<string>(
+    [...AUTHORITATIVE_IMPLICIT_BASEURL_PROVIDERS].filter((key) => Boolean(implicitProviders[key])),
+  );
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,
@@ -163,7 +169,7 @@ async function resolveProvidersForModelsJson(params: {
   if (implicitCopilot && !providers["github-copilot"]) {
     providers["github-copilot"] = implicitCopilot;
   }
-  return providers;
+  return { providers, authoritativeImplicitBaseUrlProviders };
 }
 
 function mergeWithExistingProviderSecrets(params: {
@@ -171,9 +177,15 @@ function mergeWithExistingProviderSecrets(params: {
   existingProviders: Record<string, NonNullable<ModelsConfig["providers"]>[string]>;
   secretRefManagedProviders: ReadonlySet<string>;
   explicitBaseUrlProviders: ReadonlySet<string>;
+  authoritativeImplicitBaseUrlProviders: ReadonlySet<string>;
 }): Record<string, ProviderConfig> {
-  const { nextProviders, existingProviders, secretRefManagedProviders, explicitBaseUrlProviders } =
-    params;
+  const {
+    nextProviders,
+    existingProviders,
+    secretRefManagedProviders,
+    explicitBaseUrlProviders,
+    authoritativeImplicitBaseUrlProviders,
+  } = params;
   const mergedProviders: Record<string, ProviderConfig> = {};
   for (const [key, entry] of Object.entries(existingProviders)) {
     mergedProviders[key] = entry;
@@ -199,7 +211,7 @@ function mergeWithExistingProviderSecrets(params: {
       preserved.apiKey = existing.apiKey;
     }
     if (
-      !AUTHORITATIVE_IMPLICIT_BASEURL_PROVIDERS.has(key) &&
+      !authoritativeImplicitBaseUrlProviders.has(key) &&
       !explicitBaseUrlProviders.has(key) &&
       typeof existing.baseUrl === "string" &&
       existing.baseUrl
@@ -217,6 +229,7 @@ async function resolveProvidersForMode(params: {
   providers: Record<string, ProviderConfig>;
   secretRefManagedProviders: ReadonlySet<string>;
   explicitBaseUrlProviders: ReadonlySet<string>;
+  authoritativeImplicitBaseUrlProviders: ReadonlySet<string>;
 }): Promise<Record<string, ProviderConfig>> {
   if (params.mode !== "merge") {
     return params.providers;
@@ -234,6 +247,7 @@ async function resolveProvidersForMode(params: {
     existingProviders,
     secretRefManagedProviders: params.secretRefManagedProviders,
     explicitBaseUrlProviders: params.explicitBaseUrlProviders,
+    authoritativeImplicitBaseUrlProviders: params.authoritativeImplicitBaseUrlProviders,
   });
 }
 
@@ -300,7 +314,8 @@ export async function ensureOpenClawModelsJson(
     // through the full loadConfig() pipeline which applies these.
     applyConfigEnvVars(cfg);
 
-    const providers = await resolveProvidersForModelsJson({ cfg, agentDir });
+    const { providers, authoritativeImplicitBaseUrlProviders } =
+      await resolveProvidersForModelsJson({ cfg, agentDir });
 
     if (Object.keys(providers).length === 0) {
       return { agentDir, wrote: false };
@@ -331,6 +346,7 @@ export async function ensureOpenClawModelsJson(
       providers: normalizedProviders,
       secretRefManagedProviders,
       explicitBaseUrlProviders,
+      authoritativeImplicitBaseUrlProviders,
     });
     const next = `${JSON.stringify({ providers: mergedProviders }, null, 2)}\n`;
     const existingRaw = await readRawFile(targetPath);

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -150,7 +150,9 @@ async function resolveProvidersForModelsJson(params: {
   const explicitProviders = cfg.models?.providers ?? {};
   const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });
   const authoritativeImplicitBaseUrlProviders = new Set<string>(
-    [...AUTHORITATIVE_IMPLICIT_BASEURL_PROVIDERS].filter((key) => Boolean(implicitProviders[key])),
+    [...AUTHORITATIVE_IMPLICIT_BASEURL_PROVIDERS].filter((key) =>
+      Boolean(implicitProviders?.[key]),
+    ),
   );
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,


### PR DESCRIPTION
Fixes #39858

## Summary

This PR fixes a runtime snapshot drift issue for `openai-codex`.

When Codex OAuth is present, OpenClaw should synthesize an implicit `openai-codex` provider entry for generated agent `models.json` snapshots.

Without that implicit provider, stale older transport settings can linger in generated snapshots unless the user manually adds explicit provider config.

## Problem

Today, `models.json` generation can preserve old `openai-codex` snapshot values even when the user's current auth state clearly indicates that the Codex runtime surface should be available.

That means generated agent snapshots can drift from the actual runtime transport for `openai-codex`.

## What this changes

- synthesizes an implicit `openai-codex` provider when Codex OAuth profiles are present
- uses the canonical Codex runtime base URL/API for that implicit provider snapshot
- avoids preserving stale preexisting `baseUrl` values for `openai-codex` during snapshot regeneration
- adds regression tests for provider injection and stale snapshot replacement

## Why this is safe

This PR is intentionally narrow:

- it only affects generated runtime snapshots
- it only applies when `openai-codex` auth is already present
- it does not change model-selection policy beyond keeping the generated provider snapshot aligned with the active runtime surface

## Note

This PR does not try to change the built-in default context window for `openai-codex/gpt-5.4`.
That is a separate policy question; this change is only about making the generated runtime provider snapshot correct and self-healing.

## Validation

- `corepack pnpm exec vitest run src/agents/models-config.providers.openai-codex.test.ts`
