### PR TITLE
fix(outbound): strip echoed inbound metadata before channel delivery

### DIFF
--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1235,6 +1235,20 @@ describe("normalizeOutboundPayloads", () => {
     ]);
     expect(normalized).toEqual([{ text: "final answer", mediaUrls: [] }]);
   });
+
+  it("strips echoed inbound metadata from outbound text", () => {
+    const contaminated = [
+      "Sender (untrusted metadata):",
+      "```json",
+      '{"label":"Alice","id":"12345"}',
+      "```",
+      "",
+      "Here is your answer.",
+    ].join("\n");
+    const normalized = normalizeOutboundPayloads([{ text: contaminated }]);
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0].text).toBe("Here is your answer.");
+  });
 });
 
 describe("formatOutboundPayloadLog", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -3,6 +3,7 @@ import {
   isRenderablePayload,
   shouldSuppressReasoningPayload,
 } from "../../auto-reply/reply/reply-payloads.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 
 export type NormalizedOutboundPayload = {
@@ -48,7 +49,8 @@ export function normalizeReplyPayloadsForDelivery(
     if (shouldSuppressReasoningPayload(payload)) {
       continue;
     }
-    const parsed = parseReplyDirectives(payload.text ?? "");
+    const sanitizedText = stripInboundMetadata(payload.text ?? "");
+    const parsed = parseReplyDirectives(sanitizedText);
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
     const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
     const mergedMedia = mergeMediaUrls(


### PR DESCRIPTION
## Summary

- `normalizeReplyPayloadsForDelivery` passed raw payload text to `parseReplyDirectives` without first removing OpenClaw-injected inbound metadata blocks.
- When an LLM echoed these blocks (Conversation info, Sender info, etc.) in its response, the metadata leaked through the delivery pipeline to external channels like Discord.
- The fix calls `stripInboundMetadata` on the payload text **before** directive parsing so contaminated responses are sanitized before any channel receives them.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39847

## User-visible / Behavior Changes

- Outbound messages to external channels (Discord, Telegram, WhatsApp, etc.) will no longer contain leaked internal metadata blocks when the LLM echoes them.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Trigger a session where the LLM echoes inbound metadata (Conversation info, Sender info) in its response.
2. Without this fix, the metadata appears as visible bot messages on Discord/Telegram.
3. With this fix, `stripInboundMetadata` removes the blocks before delivery.

### Expected

Internal metadata blocks are stripped from outbound payloads before delivery.

### Actual (before fix)

Metadata blocks like `Sender (untrusted metadata):` followed by JSON fences leak to channel surfaces.

## Evidence

- [x] Failing test/log before + passing after

New test: `normalizeOutboundPayloads > strips echoed inbound metadata from outbound text`

## Human Verification (required)

- Verified the `stripInboundMetadata` function correctly strips sentinel blocks with JSON fences.
- Verified the new test passes and covers the contamination scenario.
- Verified existing tests remain green.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this PR to restore previous behavior.
- `src/infra/outbound/payloads.ts` is the only production file changed.

## Risks and Mitigations

- Risk: `stripInboundMetadata` is called on every outbound payload.
  - Mitigation: The function has a zero-allocation fast path (regex pre-check) that returns the original string reference when no metadata is present — negligible overhead for normal payloads.

## AI Assistance

- AI-assisted: Yes (Claude Opus 4.6)
- Degree of testing: fully tested
- Reviewed the generated changes and verified test behavior before opening this PR.