### PR TITLE
fix(cli): suppress doctor stdout and banner for acp command

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -86,6 +86,7 @@ describe("registerPreActionHooks", () => {
     program.command("agents").action(() => {});
     program.command("configure").action(() => {});
     program.command("onboard").action(() => {});
+    program.command("acp").action(() => {});
     program
       .command("update")
       .command("status")
@@ -205,6 +206,20 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["config", "set"],
+    });
+  });
+
+  it("suppresses doctor stdout and banner for acp command", async () => {
+    await runPreAction({
+      parseArgv: ["acp"],
+      processArgv: ["node", "openclaw", "acp"],
+    });
+
+    expect(emitCliBannerMock).not.toHaveBeenCalled();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["acp"],
+      suppressDoctorStdout: true,
     });
   });
 

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -87,6 +87,10 @@ function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
   return typeof logLevel === "string" ? (logLevel as LogLevel) : undefined;
 }
 
+// Commands that use stdout as a structured protocol channel (e.g. ND-JSON).
+// Any non-protocol text on stdout (banners, doctor warnings) corrupts the stream.
+const STDOUT_PROTOCOL_COMMANDS = new Set(["acp"]);
+
 function isJsonOutputMode(commandPath: string[], argv: string[]): boolean {
   if (!hasFlag(argv, "--json")) {
     return false;
@@ -96,6 +100,10 @@ function isJsonOutputMode(commandPath: string[], argv: string[]): boolean {
     return false;
   }
   return true;
+}
+
+function needsCleanStdout(commandPath: string[], argv: string[]): boolean {
+  return isJsonOutputMode(commandPath, argv) || STDOUT_PROTOCOL_COMMANDS.has(commandPath[0]);
 }
 
 export function registerPreActionHooks(program: Command, programVersion: string) {
@@ -110,6 +118,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       isTruthyEnvValue(process.env.OPENCLAW_HIDE_BANNER) ||
       commandPath[0] === "update" ||
       commandPath[0] === "completion" ||
+      STDOUT_PROTOCOL_COMMANDS.has(commandPath[0]) ||
       (commandPath[0] === "plugins" && commandPath[1] === "update");
     if (!hideBanner) {
       emitCliBanner(programVersion);
@@ -126,7 +135,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (shouldBypassConfigGuard(commandPath)) {
       return;
     }
-    const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
+    const suppressDoctorStdout = needsCleanStdout(commandPath, argv);
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,


### PR DESCRIPTION
## Summary

- The ACP server uses `process.stdout` for ND-JSON protocol communication with ACP clients.
- During CLI startup, doctor warnings and the banner were written to stdout, corrupting the ND-JSON stream and causing `SyntaxError: Unexpected token` failures in ACP clients.
- The fix adds `"acp"` to a new `STDOUT_PROTOCOL_COMMANDS` set so the preaction hook suppresses both the banner and doctor output when stdout is reserved for structured protocol traffic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39789

## User-visible / Behavior Changes

- `openclaw acp` no longer prints the CLI banner or doctor warnings to stdout, preventing ND-JSON stream corruption.
- Doctor config migration still runs; warnings are simply suppressed from stdout output.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Have a doctor config warning (e.g. state dir migration skipped).
2. Run `openclaw acp client`.
3. Without fix: ASCII art doctor boxes appear on stdout, ACP client crashes with JSON parse error.
4. With fix: stdout is clean ND-JSON only, ACP session works.

### Expected

ACP protocol stream on stdout contains only valid ND-JSON messages.

### Actual (before fix)

Doctor warnings and banner pollute stdout, breaking the ACP SDK's ndjson parser.

## Evidence

- [x] Failing test/log before + passing after

New test: `registerPreActionHooks > suppresses doctor stdout and banner for acp command`

## Human Verification (required)

- Verified the `STDOUT_PROTOCOL_COMMANDS` set correctly triggers `suppressDoctorStdout` and banner suppression.
- Verified the new test passes.
- Verified existing tests remain green (--json suppression, config guard bypass, etc.).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this PR to restore previous behavior.
- `src/cli/program/preaction.ts` is the only production file changed.

## Risks and Mitigations

- Risk: Future commands that use stdout for protocols need to be added to `STDOUT_PROTOCOL_COMMANDS`.
  - Mitigation: The set is co-located with the banner/config-guard logic and clearly documented. Adding a new entry is a one-line change.

## AI Assistance

- AI-assisted: Yes (Claude Opus 4.6)
- Degree of testing: fully tested
- Reviewed the generated changes and verified test behavior before opening this PR.