### PR TITLE
Gateway: support chrome-extension://* in gateway.controlUi.allowedOrigins

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -58,6 +58,30 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts exact chrome-extension origins", () => {
+    const result = checkBrowserOrigin({
+      origin: "chrome-extension://abcdefghijklmnop",
+      allowedOrigins: ["chrome-extension://abcdefghijklmnop"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts chrome-extension wildcard allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      origin: "chrome-extension://abcdefghijklmnop",
+      allowedOrigins: ["chrome-extension://*"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects non-extension origins for chrome-extension wildcard", () => {
+    const result = checkBrowserOrigin({
+      origin: "https://control.example.com",
+      allowedOrigins: ["chrome-extension://*"],
+    });
+    expect(result.ok).toBe(false);
+  });
+
   it("rejects missing origin", () => {
     const result = checkBrowserOrigin({
       requestHost: "gateway.example.com:18789",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -9,17 +9,27 @@ type OriginCheckResult =
 
 function parseOrigin(
   originRaw?: string,
-): { origin: string; host: string; hostname: string } | null {
+): { origin: string; host: string; hostname: string; protocol: string } | null {
   const trimmed = (originRaw ?? "").trim();
   if (!trimmed || trimmed === "null") {
     return null;
   }
   try {
     const url = new URL(trimmed);
+    const normalizedOrigin =
+      url.origin && url.origin !== "null"
+        ? url.origin.toLowerCase()
+        : url.host
+          ? `${url.protocol}//${url.host}`.toLowerCase()
+          : "";
+    if (!normalizedOrigin) {
+      return null;
+    }
     return {
-      origin: url.origin.toLowerCase(),
+      origin: normalizedOrigin,
       host: url.host.toLowerCase(),
       hostname: url.hostname.toLowerCase(),
+      protocol: url.protocol.toLowerCase(),
     };
   } catch {
     return null;
@@ -41,7 +51,9 @@ export function checkBrowserOrigin(params: {
   const allowlist = new Set(
     (params.allowedOrigins ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean),
   );
-  if (allowlist.has("*") || allowlist.has(parsedOrigin.origin)) {
+  const hasChromeExtensionWildcard =
+    allowlist.has("chrome-extension://*") && parsedOrigin.protocol === "chrome-extension:";
+  if (allowlist.has("*") || allowlist.has(parsedOrigin.origin) || hasChromeExtensionWildcard) {
     return { ok: true, matchedBy: "allowlist" };
   }
 


### PR DESCRIPTION
## Summary

- Problem: `gateway.controlUi.allowedOrigins` could not correctly match Chrome extension origins (`chrome-extension://<id>`), and did not support `chrome-extension://*`.
- Why it matters: Control UI/WebChat websocket connections from Chrome extensions could be incorrectly rejected.
- What changed:
  - Updated `src/gateway/origin-check.ts` to normalize non-standard origins when `URL.origin` is `"null"` (fallback to `protocol://host`).
  - Added support for `chrome-extension://*` in allowlist matching (restricted to `chrome-extension:` protocol).
  - Added unit tests covering exact extension origin, wildcard extension origin, and negative non-extension matching.
- What did NOT change (scope boundary): No changes to host-header fallback behavior, loopback fallback behavior, gateway auth flow, config schema, or security audit rules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39739
- Related #

## User-visible / Behavior Changes

- `gateway.controlUi.allowedOrigins` now supports `chrome-extension://*` to allow Chrome extension websocket origins.
- Exact extension origins such as `chrome-extension://abcdefghijklmnop` are now correctly matched.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI/WebChat websocket origin check
- Relevant config (redacted): `gateway.controlUi.allowedOrigins`

### Steps

1. Set `gateway.controlUi.allowedOrigins` to `["chrome-extension://*"]` (or an exact extension origin).
2. Run origin validation with `origin: "chrome-extension://abcdefghijklmnop"`.
3. Verify allowlist behavior and run the targeted unit test.

### Expected

- Extension origin is accepted when allowlisted by exact value or `chrome-extension://*`.
- Non-extension origins are not accepted by `chrome-extension://*`.

### Actual

- Behavior matches expected results.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Exact extension origin allowlist match succeeds.
  - `chrome-extension://*` wildcard allowlist match succeeds.
  - Non-extension origin does not match `chrome-extension://*`.
- Edge cases checked:
  - Existing `*` wildcard behavior remains unchanged.
  - Existing explicit HTTPS origin allowlist behavior remains unchanged.
- What you did **not** verify:
  - Full gateway E2E runtime/manual websocket flow outside unit tests.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/gateway/origin-check.ts`
  - `src/gateway/origin-check.test.ts`
- Known bad symptoms reviewers should watch for:
  - Extension origins still rejected when explicitly allowlisted.
  - Non-extension origins unexpectedly accepted via `chrome-extension://*`.

## Risks and Mitigations

- Risk: Normalizing non-standard origins could affect edge-case protocol handling.
  - Mitigation: Fallback is only applied when `URL.origin === "null"`, and new tests cover exact/wildcard/negative extension cases.