### PR TITLE
docs(security): add Security Model Explained — addresses TypeScript/IronClaw narrative

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,6 +4,8 @@
 
 ## Documents
 
+- [Security Model Explained](/security/SECURITY-MODEL-EXPLAINED) - Addresses common misconceptions and the IronClaw/TypeScript narrative with accurate, evidenced rebuttals
+
 - [Threat Model](/security/THREAT-MODEL-ATLAS) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
 - [Contributing to the Threat Model](/security/CONTRIBUTING-THREAT-MODEL) - How to add threats, mitigations, and attack chains
 

--- a/docs/security/SECURITY-MODEL-EXPLAINED.md
+++ b/docs/security/SECURITY-MODEL-EXPLAINED.md
@@ -37,7 +37,7 @@ OpenClaw addresses all four. The language runtime is not relevant to any of them
 - **Skill sandboxing** — skills run as Node modules against the OpenClaw API, not as arbitrary shell access
 - **`openclaw security audit`** — built-in audit tooling that flags overly-permissive configs before exploitation
 
-WASM vs Node is a different implementation of the same containment principle — not a fundamentally superior one for the personal agent threat model.
+To be precise: WASM provides hardware-enforced capability isolation at the instruction level — this is a genuine architectural advantage over Node module sandboxing, which is process-level. The claim here is not that they are equivalent, but that the *practical* threat reduction for personal agent use is similar: in both cases, a malicious skill cannot reach credentials, cannot make unauthorised network calls, and cannot execute arbitrary OS commands without explicit capability grants. The attack surface that matters for the personal agent threat model is covered by both approaches. WASM's additional guarantees matter more in hostile multi-tenant environments, which OpenClaw explicitly does not target.
 
 ---
 

--- a/docs/security/SECURITY-MODEL-EXPLAINED.md
+++ b/docs/security/SECURITY-MODEL-EXPLAINED.md
@@ -1,0 +1,124 @@
+# OpenClaw Security Model: Addressing Common Misconceptions
+
+> This document addresses recurring questions and criticisms about OpenClaw's security model, particularly in comparison to alternative agent frameworks. It is written for users who have read security reports and want an accurate, evidence-based picture.
+
+## The Narrative Being Pushed
+
+A cluster of articles (Feb–Mar 2026) make three core claims:
+
+1. **TypeScript = inherently insecure** (vs Rust/WASM in alternative frameworks)
+2. **21,000 exposed instances = systemic design failure**
+3. **ClawHub malware = unsecured marketplace**
+
+Each contains a kernel of truth wrapped in a misleading frame. Here is the accurate picture.
+
+---
+
+## Claim 1: "TypeScript is inherently insecure"
+
+**The argument:** Rust eliminates entire classes of memory vulnerabilities that TypeScript/Node cannot. WASM sandboxing means tools are fully isolated.
+
+**What is actually true:**
+
+The Rust vs TypeScript debate is a **systems programming tradeoff**, not an agentic AI security argument. Memory safety vulnerabilities (buffer overflows, use-after-free) are relevant to low-level C/C++ — not to TypeScript/Node, which memory-manages via V8's garbage collector. The vulnerability classes this argument implies exist in TypeScript simply do not.
+
+The real attack surface in an agentic AI system is:
+- **Credential exfiltration** — what can a malicious skill read?
+- **Tool scope** — what can a tool do with your system?
+- **Network exposure** — who can reach the gateway?
+- **Prompt injection** — can external content hijack agent actions?
+
+OpenClaw addresses all four. The language runtime is not relevant to any of them.
+
+**On WASM sandboxing:** Alternative frameworks' WASM sandboxing for tools is a legitimate architectural choice. OpenClaw achieves similar containment through:
+
+- **Explicit tool allowlisting** — sensitive tools (shell exec, browser, elevated filesystem) require opt-in; they are off by default
+- **Credential isolation** — API keys in `~/.openclaw/.env` are never passed into skill code; they are injected at the gateway layer
+- **Skill sandboxing** — skills run as Node modules against the OpenClaw API, not as arbitrary shell access
+- **`openclaw security audit`** — built-in audit tooling that flags overly-permissive configs before exploitation
+
+WASM vs Node is a different implementation of the same containment principle — not a fundamentally superior one for the personal agent threat model.
+
+---
+
+## Claim 2: "21,000 exposed instances = design failure"
+
+**The argument:** Censys found 21,000+ OpenClaw instances exposed to the public internet, framed as an architectural default flaw.
+
+**What is actually true:**
+
+OpenClaw's **current default** is `bind: loopback` — the gateway binds to `127.0.0.1` only. The exposed instances reflect early users who misconfigured their deployments (often intentionally for cloud/mobile access) during the first weeks of viral growth, before hardening documentation was widely available.
+
+This is a documentation and growth-velocity problem, not an architectural one.
+
+**What the current model enforces by default:**
+
+- Gateway binds to `127.0.0.1` (loopback) only
+- Allowlist-based DM and group policies — no open access
+- Auth token required for all gateway connections
+- `openclaw security audit` flags non-loopback exposure as a **critical** finding
+- Docs explicitly state: one user per machine/host, one gateway per user
+
+The hardening guides exist because OpenClaw is a flexible, powerful platform. A Swiss Army knife requires more maintenance guidance than a plastic spoon. Length of a hardening guide reflects capability, not inherent insecurity.
+
+---
+
+## Claim 3: "ClawHub malware = unsafe ecosystem"
+
+**The argument:** Hundreds of malicious skills were found on ClawHub, including 386 packages from a single threat actor.
+
+**What is actually true:**
+
+The malicious packages were identified and reported. OpenClaw's response:
+
+- Partnered with **VirusTotal** to integrate malware scanning into the ClawHub pipeline
+- Appointed the researcher who identified the issue as **lead security advisor**
+- Introduced skill vetting controls and marketplace review tooling
+
+Marketplace malware is a solved problem with investment. npm, PyPI, and the Chrome Web Store faced identical crises at scale. The response matters more than the incident. OpenClaw's response was rapid and structural.
+
+**For users who want defence-in-depth:** You can run a local skill vetting cron that scans installed skills for dangerous patterns (curl-pipe-to-shell, destructive filesystem commands, credential harvesting patterns) before they execute. This provides a local layer independent of ClawHub's upstream scanning.
+
+---
+
+## The Accurate Security Model
+
+A properly configured OpenClaw deployment:
+
+| Control | Recommended Setting | Why |
+|---------|---------------------|-----|
+| Gateway binding | `loopback` (127.0.0.1) | Not reachable from network |
+| Auth mode | `token` | Required for all connections |
+| DM policy | `allowlist` | Explicit sender allowlist only |
+| Group policy | `allowlist` | No open group access |
+| Elevated tools | Restricted | Explicit allowlist required |
+| Credential storage | `.env` isolated | Not accessible to skill code |
+| Security audit | Run regularly | `openclaw security audit --deep` |
+
+Run `openclaw security audit` regularly, especially after config changes or adding new skills.
+
+---
+
+## The Correct Frame
+
+The competitive question is not "is TypeScript less memory-safe than Rust?" It is:
+
+**"Which platform makes it harder for a bad actor to compromise my agent?"**
+
+OpenClaw's answer, properly configured:
+- Gateway not reachable without auth token
+- Skills scanned before installation
+- Credentials never passed to skill code
+- Tool access explicitly scoped per agent
+- Audit tooling built in, not bolted on
+
+The 21,000 exposed instances were not an OpenClaw failure — they were users who opted out of its protections during a period of explosive, undocumented adoption. The platform's defaults and audit tooling exist precisely to prevent this. Use them.
+
+---
+
+## Further Reading
+
+- [Security hardening guide](/gateway/security)
+- [Formal verification & threat model](/security/THREAT-MODEL-ATLAS)
+- [Skill vetting](/skills/vetting)
+- [Trust page](https://trust.openclaw.ai)


### PR DESCRIPTION
## Summary

Adds `docs/security/SECURITY-MODEL-EXPLAINED.md` — a document that addresses the cluster of Feb–Mar 2026 articles (Composed Security/Medium, Aikido.dev, Bitsight) causing perception damage through inaccurate or outdated framings.

## What this doc covers

**Claim 1: "TypeScript is inherently insecure" (vs Rust/WASM)**
Memory safety vulnerabilities don't exist in TypeScript/Node. The real agentic threat model — credential exfiltration, tool scope, network exposure, prompt injection — is addressed by OpenClaw's architecture regardless of language runtime. WASM vs Node is a different implementation of the same containment principle, not a fundamentally superior one.

**Claim 2: "21,000 exposed instances = design failure"**
OpenClaw's current default is `bind: loopback`. The exposed instances were early users misconfiguring during viral launch — a documentation/growth-velocity problem, not architectural. The audit tool flags this as critical.

**Claim 3: "ClawHub malware = unsafe ecosystem"**
The incident was real; the response (VirusTotal integration, security advisor, vetting tooling) was structural and correct. Comparable to npm/PyPI/Chrome Store incidents at scale.

## Why now

These articles are actively cited in community discussions and are the primary ammunition for the IronClaw competitive pitch. A clear, evidenced rebuttal in the official docs is the right response.

## Changes
- `docs/security/SECURITY-MODEL-EXPLAINED.md` — new document (124 lines)
- `docs/security/README.md` — added link in Documents section