### PR TITLE
fix(googlechat): clear typing indicator on NO_REPLY

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -337,6 +337,15 @@ async function processMessageWithPipeline(params: {
     },
     replyOptions: {
       onModelSelected,
+      onTypingCleanup: () => {
+        if (typingMessageName) {
+          const name = typingMessageName;
+          typingMessageName = undefined;
+          deleteGoogleChatMessage({ account, messageName: name }).catch((err) => {
+            runtime.error?.(`Google Chat typing cleanup on NO_REPLY failed: ${String(err)}`);
+          });
+        }
+      },
     },
   });
 }


### PR DESCRIPTION
## Summary

- Pass `onTypingCleanup` callback to the reply dispatcher so the typing controller can delete the "is typing..." message when the model run completes with `NO_REPLY`
- The callback captures and nullifies `typingMessageName` to avoid double-delete if a delivery already replaced it

## Problem

When an agent reacts with an emoji and returns `NO_REPLY`, the typing indicator message persists indefinitely. This happens because:
1. The typing message is sent and `typingMessageName` is stored
2. `deliverGoogleChatReply()` receives an empty payload (NO_REPLY stripped)
3. Neither the media path (`mediaList.length > 0`) nor text path (`payload.text`) is taken
4. `typingMessageName` is only cleared inside the `deliver` callback, but the typing controller's `onTypingCleanup` was never wired up

## Fix

Wire the existing `onTypingCleanup` callback (already supported by the typing controller and reply dispatcher) to delete the typing message when `NO_REPLY` ends the run without any delivery.

Fixes #39843