### PR TITLE
fix(macos): disable KeepAlive in app launch agent to allow proper quit

### DIFF
--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -42,7 +42,7 @@ enum LaunchAgentManager {
           <key>RunAtLoad</key>
           <true/>
           <key>KeepAlive</key>
-          <true/>
+          <false/>
           <key>EnvironmentVariables</key>
           <dict>
             <key>PATH</key>


### PR DESCRIPTION
## Problem
When KeepAlive is set to true in the launchd plist, macOS automatically restarts the OpenClaw app whenever it exits, even after user quit (Cmd+Q).

This prevents users from fully exiting the application.

## Solution
Change KeepAlive from true to false in the launch agent plist generation code, so the app stays closed after user-initiated quit.

## Testing
- [x] pnpm build: PASS
- [x] pnpm lint: PASS
- [x] pnpm format:check: PASS
- [x] pnpm tsgo: PASS
- [x] pnpm test: PASS

The fix is minimal (1 line change in LaunchAgentManager.swift) and affects only the launchd plist KeepAlive directive for the UI app launcher.

Fixes #39868