### PR TITLE
fix(hooks): use resolveAgentIdFromSessionKey in runBeforeReset 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - macOS Talk Mode: set the speech recognition request `taskHint` to `.dictation` for mic capture, and add regression coverage for the request defaults. (#38445) Thanks @dmiv.
 - macOS release packaging: default `scripts/package-mac-app.sh` to universal binaries for `BUILD_CONFIG=release`, and clarify that `scripts/package-mac-dist.sh` already produces the release zip + DMG. (#33891) Thanks @cgdusek.
 - Tools/web search: restore Perplexity OpenRouter/Sonar compatibility for legacy `OPENROUTER_API_KEY`, `sk-or-...`, and explicit `perplexity.baseUrl` / `model` setups while keeping direct Perplexity keys on the native Search API path. (#39937) Thanks @obviyus.
+- Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
 
 ## 2026.3.7
 

--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookRunner } from "../../plugins/hooks.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+const hookRunnerMocks = vi.hoisted(() => ({
+  hasHooks: vi.fn<HookRunner["hasHooks"]>(),
+  runBeforeReset: vi.fn<HookRunner["runBeforeReset"]>(),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () =>
+    ({
+      hasHooks: hookRunnerMocks.hasHooks,
+      runBeforeReset: hookRunnerMocks.runBeforeReset,
+    }) as unknown as HookRunner,
+}));
+
+const { emitResetCommandHooks } = await import("./commands-core.js");
+
+describe("emitResetCommandHooks", () => {
+  beforeEach(() => {
+    hookRunnerMocks.hasHooks.mockReset();
+    hookRunnerMocks.runBeforeReset.mockReset();
+    hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
+    hookRunnerMocks.runBeforeReset.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes the bound agent id to before_reset hooks for multi-agent session keys", async () => {
+    const command = {
+      surface: "discord",
+      senderId: "rai",
+      channel: "discord",
+      from: "discord:rai",
+      to: "discord:bot",
+      resetHookTriggered: false,
+    } as HandleCommandsParams["command"];
+
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command,
+      sessionKey: "agent:navi:main",
+      previousSessionEntry: {
+        sessionId: "prev-session",
+      } as HandleCommandsParams["previousSessionEntry"],
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+    const [, ctx] = hookRunnerMocks.runBeforeReset.mock.calls[0] ?? [];
+    expect(ctx).toMatchObject({
+      agentId: "navi",
+      sessionKey: "agent:navi:main",
+      sessionId: "prev-session",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -18,18 +18,7 @@ vi.mock("../../plugins/hook-runner-global.js", () => ({
 const { emitResetCommandHooks } = await import("./commands-core.js");
 
 describe("emitResetCommandHooks", () => {
-  beforeEach(() => {
-    hookRunnerMocks.hasHooks.mockReset();
-    hookRunnerMocks.runBeforeReset.mockReset();
-    hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
-    hookRunnerMocks.runBeforeReset.mockResolvedValue(undefined);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("passes the bound agent id to before_reset hooks for multi-agent session keys", async () => {
+  async function runBeforeResetContext(sessionKey?: string) {
     const command = {
       surface: "discord",
       senderId: "rai",
@@ -44,7 +33,7 @@ describe("emitResetCommandHooks", () => {
       ctx: {} as HandleCommandsParams["ctx"],
       cfg: {} as HandleCommandsParams["cfg"],
       command,
-      sessionKey: "agent:navi:main",
+      sessionKey,
       previousSessionEntry: {
         sessionId: "prev-session",
       } as HandleCommandsParams["previousSessionEntry"],
@@ -53,9 +42,45 @@ describe("emitResetCommandHooks", () => {
 
     await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
     const [, ctx] = hookRunnerMocks.runBeforeReset.mock.calls[0] ?? [];
+    return ctx;
+  }
+
+  beforeEach(() => {
+    hookRunnerMocks.hasHooks.mockReset();
+    hookRunnerMocks.runBeforeReset.mockReset();
+    hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
+    hookRunnerMocks.runBeforeReset.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes the bound agent id to before_reset hooks for multi-agent session keys", async () => {
+    const ctx = await runBeforeResetContext("agent:navi:main");
     expect(ctx).toMatchObject({
       agentId: "navi",
       sessionKey: "agent:navi:main",
+      sessionId: "prev-session",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+  });
+
+  it("falls back to main when the reset hook has no session key", async () => {
+    const ctx = await runBeforeResetContext(undefined);
+    expect(ctx).toMatchObject({
+      agentId: "main",
+      sessionKey: undefined,
+      sessionId: "prev-session",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+  });
+
+  it("keeps the main-agent path on the main agent workspace", async () => {
+    const ctx = await runBeforeResetContext("agent:main:main");
+    expect(ctx).toMatchObject({
+      agentId: "main",
+      sessionKey: "agent:main:main",
       sessionId: "prev-session",
       workspaceDir: "/tmp/openclaw-workspace",
     });

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -3,7 +3,7 @@ import { resetAcpSessionInPlace } from "../../acp/persistent-bindings.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { isAcpSessionKey } from "../../routing/session-key.js";
+import { isAcpSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAcpCommand } from "./commands-acp.js";
@@ -120,7 +120,7 @@ export async function emitResetCommandHooks(params: {
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {
-            agentId: params.sessionKey?.split(":")[0] ?? "main",
+            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -63,6 +63,7 @@ export async function emitResetCommandHooks(params: {
     previousSessionEntry: params.previousSessionEntry,
     commandSource: params.command.surface,
     senderId: params.command.senderId,
+    workspaceDir: params.workspaceDir,
     cfg: params.cfg, // Pass config for LLM slug generation
   });
   await triggerInternalHook(hookEvent);

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1138,6 +1138,9 @@ describe("handleCommands hooks", () => {
         type: "command",
         action: "new",
         sessionKey: "agent:main:telegram:direct:123",
+        context: expect.objectContaining({
+          workspaceDir: testWorkspaceDir,
+        }),
       }),
     );
     spy.mockRestore();

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -65,15 +65,23 @@ async function runNewWithPreviousSessionEntry(params: {
   previousSessionEntry: { sessionId: string; sessionFile?: string };
   cfg?: OpenClawConfig;
   action?: "new" | "reset";
+  sessionKey?: string;
+  workspaceDirOverride?: string;
 }): Promise<{ files: string[]; memoryContent: string }> {
-  const event = createHookEvent("command", params.action ?? "new", "agent:main:main", {
-    cfg:
-      params.cfg ??
-      ({
-        agents: { defaults: { workspace: params.tempDir } },
-      } satisfies OpenClawConfig),
-    previousSessionEntry: params.previousSessionEntry,
-  });
+  const event = createHookEvent(
+    "command",
+    params.action ?? "new",
+    params.sessionKey ?? "agent:main:main",
+    {
+      cfg:
+        params.cfg ??
+        ({
+          agents: { defaults: { workspace: params.tempDir } },
+        } satisfies OpenClawConfig),
+      previousSessionEntry: params.previousSessionEntry,
+      ...(params.workspaceDirOverride ? { workspaceDir: params.workspaceDirOverride } : {}),
+    },
+  );
 
   await handler(event);
 
@@ -240,6 +248,45 @@ describe("session-memory hook", () => {
     expect(files.length).toBe(1);
     expect(memoryContent).toContain("user: Please reset and keep notes");
     expect(memoryContent).toContain("assistant: Captured before reset");
+  });
+
+  it("prefers workspaceDir from hook context when sessionKey points at main", async () => {
+    const mainWorkspace = await createCaseWorkspace("workspace-main");
+    const naviWorkspace = await createCaseWorkspace("workspace-navi");
+    const naviSessionsDir = path.join(naviWorkspace, "sessions");
+    await fs.mkdir(naviSessionsDir, { recursive: true });
+
+    const sessionFile = await writeWorkspaceFile({
+      dir: naviSessionsDir,
+      name: "navi-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Remember this under Navi" },
+        { role: "assistant", content: "Stored in the bound workspace" },
+      ]),
+    });
+
+    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir: naviWorkspace,
+      cfg: {
+        agents: {
+          defaults: { workspace: mainWorkspace },
+          list: {
+            navi: { workspace: naviWorkspace },
+          },
+        },
+      } satisfies OpenClawConfig,
+      sessionKey: "agent:main:main",
+      workspaceDirOverride: naviWorkspace,
+      previousSessionEntry: {
+        sessionId: "navi-session",
+        sessionFile,
+      },
+    });
+
+    expect(files.length).toBe(1);
+    expect(memoryContent).toContain("user: Remember this under Navi");
+    expect(memoryContent).toContain("assistant: Stored in the bound workspace");
+    await expect(fs.access(path.join(mainWorkspace, "memory"))).rejects.toThrow();
   });
 
   it("filters out non-message entries (tool calls, system)", async () => {

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -270,9 +270,7 @@ describe("session-memory hook", () => {
       cfg: {
         agents: {
           defaults: { workspace: mainWorkspace },
-          list: {
-            navi: { workspace: naviWorkspace },
-          },
+          list: [{ id: "navi", workspace: naviWorkspace }],
         },
       } satisfies OpenClawConfig,
       sessionKey: "agent:main:main",
@@ -286,6 +284,7 @@ describe("session-memory hook", () => {
     expect(files.length).toBe(1);
     expect(memoryContent).toContain("user: Remember this under Navi");
     expect(memoryContent).toContain("assistant: Stored in the bound workspace");
+    expect(memoryContent).toContain("- **Session Key**: agent:navi:main");
     await expect(fs.access(path.join(mainWorkspace, "memory"))).rejects.toThrow();
   });
 

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -8,18 +8,44 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import {
+  resolveAgentIdByWorkspacePath,
+  resolveAgentWorkspaceDir,
+} from "../../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
-import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
+import {
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+  toAgentStoreSessionKey,
+} from "../../../routing/session-key.js";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
+
+function resolveDisplaySessionKey(params: {
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  sessionKey: string;
+}): string {
+  if (!params.cfg || !params.workspaceDir) {
+    return params.sessionKey;
+  }
+  const workspaceAgentId = resolveAgentIdByWorkspacePath(params.cfg, params.workspaceDir);
+  const parsed = parseAgentSessionKey(params.sessionKey);
+  if (!workspaceAgentId || !parsed || workspaceAgentId === parsed.agentId) {
+    return params.sessionKey;
+  }
+  return toAgentStoreSessionKey({
+    agentId: workspaceAgentId,
+    requestKey: parsed.rest,
+  });
+}
 
 /**
  * Read recent messages from session file for slug generation
@@ -192,6 +218,11 @@ const saveSessionToMemory: HookHandler = async (event) => {
       (cfg
         ? resolveAgentWorkspaceDir(cfg, agentId)
         : path.join(resolveStateDir(process.env, os.homedir), "workspace"));
+    const displaySessionKey = resolveDisplaySessionKey({
+      cfg,
+      workspaceDir: contextWorkspaceDir,
+      sessionKey: event.sessionKey,
+    });
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
@@ -299,7 +330,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const entryParts = [
       `# Session: ${dateStr} ${timeStr} UTC`,
       "",
-      `- **Session Key**: ${event.sessionKey}`,
+      `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,
       `- **Source**: ${source}`,
       "",

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -182,10 +182,16 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
+    const contextWorkspaceDir =
+      typeof context.workspaceDir === "string" && context.workspaceDir.trim().length > 0
+        ? context.workspaceDir
+        : undefined;
     const agentId = resolveAgentIdFromSessionKey(event.sessionKey);
-    const workspaceDir = cfg
-      ? resolveAgentWorkspaceDir(cfg, agentId)
-      : path.join(resolveStateDir(process.env, os.homedir), "workspace");
+    const workspaceDir =
+      contextWorkspaceDir ||
+      (cfg
+        ? resolveAgentWorkspaceDir(cfg, agentId)
+        : path.join(resolveStateDir(process.env, os.homedir), "workspace"));
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 


### PR DESCRIPTION
## Summary

- **Problem:** In multi-agent setups, `/new` and `/reset` were writing session-memory artifacts into `workspace-main` instead of the bound agent's workspace (e.g. `workspace-navi`), causing a workspace split-brain state.
- **Why it matters:** This caused stale/inconsistent continuity reads on restart, wrong memory placement, and replay-style weirdness — all symptoms observed in production with a Navi agent bound to a Discord DM.
- **What changed:** One line in `src/auto-reply/reply/commands-core.ts` — `params.sessionKey?.split(":")[0]` replaced with `resolveAgentIdFromSessionKey(params.sessionKey)`. Import updated accordingly. Tests added.
- **What did NOT change:** Session-memory handler (`src/hooks/bundled/session-memory/handler.ts`) already used `resolveAgentIdFromSessionKey` correctly — no change needed there. No config, API, or schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39816
- Related #39521 (same split pattern in agent_end hook — separate issue)
- Related #29203 (internal hooks not triggered in auto-reply path)

## User-visible / Behavior Changes

In multi-agent setups using non-main agents (e.g. `agentId: navi` with `workspace-navi`), `/new` and `/reset` will now correctly write session-memory and reset artifacts into the bound agent's workspace instead of `workspace-main`. No change for single-agent / main-agent setups.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (WSL2, Ubuntu-style)
- Runtime/container: Node.js v25.6.1, source install from main
- Model/provider: anthropic/claude-sonnet-4-6
- Integration/channel: Discord DM, bound agent (`agentId: navi`, `workspace: ~/.openclaw/workspace-navi`)
- Relevant config: `agents.list[navi].workspace = ~/.openclaw/workspace-navi`

### Steps

1. Configure a non-main agent bound to a Discord DM: `agentId: navi`, `workspace: ~/.openclaw/workspace-navi`
2. Use the agent in a real conversation
3. Trigger `/new` or `/reset`
4. Inspect `~/.openclaw/workspace-main/memory/` and `~/.openclaw/workspace-navi/memory/`

### Expected

Reset/session-memory artifacts written to `~/.openclaw/workspace-navi/memory/`

### Actual (before fix)

Artifacts written to `~/.openclaw/workspace-main/memory/` with session key `agent:main:main` — because `"agent:navi:main".split(":")[0]` returns `"agent"`, not `"navi"`

## Evidence

- [x] Trace/log snippets
- [x] Failing test before + passing after (see `commands-core.test.ts`)

Stray files observed on disk before fix:
- `~/.openclaw/workspace-main/memory/2026-03-07-2106.md`
- `~/.openclaw/workspace-main/memory/2026-03-07-session-greeting.md`
- `~/.openclaw/workspace-main/memory/2026-03-08-session-start.md`

Regression traced to commit `aec41a588b` (fix(hooks): backfill reset command hooks for native /new path, 2026-02-24).

## Human Verification (required)

- Verified scenarios: confirmed stray files appearing in `workspace-main` before the fix; confirmed `resolveAgentIdFromSessionKey` already existed and correctly parses `"agent:navi:main"` → `"navi"`; confirmed `session-memory/handler.ts` already used the correct function (no change needed there)
- Edge cases checked: session key `undefined` (falls back to `"main"` via `resolveAgentIdFromSessionKey`); main agent (unaffected); non-main agent (fixed)
- What I did **not** verify: whether the same split pattern in the `agent_end` hook path (issue #39521) is also triggering the same workspace resolution error — that is a separate issue

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

Note: users who have accumulated stray session-memory files in `workspace-main` from the regression window (v2026.3.2–v2026.3.7) may want to manually remove or ignore those files. They are safe to delete.

## Failure Recovery (if this breaks)

- Revert: `git revert f55e714f7`
- Files to restore: `src/auto-reply/reply/commands-core.ts` (single line change)
- Known bad symptoms: session-memory files landing in wrong workspace directory (same as the original bug)

## Risks and Mitigations

- Risk: `resolveAgentIdFromSessionKey(undefined)` behaves differently from `undefined?.split(":")[0] ?? "main"`
  - Mitigation: verified `resolveAgentIdFromSessionKey` handles undefined/null input and returns `"main"` as fallback — same behaviour as before
