### PR TITLE
config: hint when plugin config keys are misplaced outside .config

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -37,6 +37,8 @@ describe("config plugin validation", () => {
   let badPluginDir = "";
   let enumPluginDir = "";
   let bluebubblesPluginDir = "";
+  let dottedPluginDir = "";
+  let workspacePluginDir = "";
   let voiceCallSchemaPluginDir = "";
   const envSnapshot = {
     OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
@@ -84,6 +86,36 @@ describe("config plugin validation", () => {
       channels: ["bluebubbles"],
       schema: { type: "object" },
     });
+    dottedPluginDir = path.join(suiteHome, "dotted-plugin");
+    await writePluginFixture({
+      dir: dottedPluginDir,
+      id: "pack.one",
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          permissionMode: { type: "string", enum: ["approve-all", "approve-reads"] },
+        },
+      },
+    });
+    workspacePluginDir = path.join(
+      suiteHome,
+      "workspace",
+      ".openclaw",
+      "extensions",
+      "workspace-hint",
+    );
+    await writePluginFixture({
+      dir: workspacePluginDir,
+      id: "workspace-hint",
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          queueOwnerTtlSeconds: { type: "number", minimum: 0 },
+        },
+      },
+    });
     voiceCallSchemaPluginDir = path.join(suiteHome, "voice-call-schema-plugin");
     const voiceCallManifestPath = path.join(
       process.cwd(),
@@ -110,7 +142,9 @@ describe("config plugin validation", () => {
     validateInSuite({
       plugins: {
         enabled: false,
-        load: { paths: [badPluginDir, bluebubblesPluginDir, voiceCallSchemaPluginDir] },
+        load: {
+          paths: [badPluginDir, bluebubblesPluginDir, dottedPluginDir, voiceCallSchemaPluginDir],
+        },
       },
     });
   });
@@ -277,6 +311,153 @@ describe("config plugin validation", () => {
       },
     });
     expect(res.ok).toBe(true);
+  });
+
+  it("suggests .config nesting for misplaced plugin config keys", async () => {
+    const wrong = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        entries: {
+          acpx: {
+            enabled: true,
+            permissionMode: "approve-all",
+          },
+        },
+      },
+    });
+    expect(wrong.ok).toBe(false);
+    if (!wrong.ok) {
+      expect(wrong.issues).toContainEqual({
+        path: "plugins.entries.acpx",
+        message:
+          'Unrecognized key: "permissionMode". Did you mean "plugins.entries.acpx.config.permissionMode"?',
+      });
+    }
+
+    const right = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        entries: {
+          acpx: {
+            enabled: true,
+            config: {
+              permissionMode: "approve-all",
+            },
+          },
+        },
+      },
+    });
+    expect(right.ok).toBe(true);
+  });
+
+  it("suggests .config nesting for dotted plugin ids too", async () => {
+    const wrong = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: true,
+        load: { paths: [dottedPluginDir] },
+        entries: {
+          "pack.one": {
+            enabled: true,
+            permissionMode: "approve-all",
+          },
+        },
+      },
+    });
+    expect(wrong.ok).toBe(false);
+    if (!wrong.ok) {
+      expect(wrong.issues).toContainEqual({
+        path: "plugins.entries.pack.one",
+        message:
+          'Unrecognized key: "permissionMode". Did you mean "plugins.entries.pack.one.config.permissionMode"?',
+      });
+    }
+  });
+
+  it("suggests .config nesting for multiple misplaced plugin config keys", async () => {
+    const wrong = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        entries: {
+          acpx: {
+            enabled: true,
+            permissionMode: "approve-all",
+            nonInteractivePermissions: "fail",
+          },
+        },
+      },
+    });
+    expect(wrong.ok).toBe(false);
+    if (!wrong.ok) {
+      expect(wrong.issues).toContainEqual({
+        path: "plugins.entries.acpx",
+        message:
+          'Unrecognized keys: "permissionMode", "nonInteractivePermissions". Did you mean "plugins.entries.acpx.config.permissionMode", "plugins.entries.acpx.config.nonInteractivePermissions"?',
+      });
+    }
+  });
+
+  it("suggests .config nesting for workspace-installed plugins", async () => {
+    const wrong = validateInSuite({
+      agents: {
+        defaults: {
+          workspace: path.join(suiteHome, "workspace"),
+        },
+        list: [{ id: "pi" }],
+      },
+      plugins: {
+        entries: {
+          "workspace-hint": {
+            enabled: true,
+            queueOwnerTtlSeconds: 5,
+          },
+        },
+      },
+    });
+    expect(wrong.ok).toBe(false);
+    if (!wrong.ok) {
+      expect(wrong.issues).toContainEqual({
+        path: "plugins.entries.workspace-hint",
+        message:
+          'Unrecognized key: "queueOwnerTtlSeconds". Did you mean "plugins.entries.workspace-hint.config.queueOwnerTtlSeconds"?',
+      });
+    }
+  });
+
+  it("keeps workspace plugin hints even when unrelated agents config is invalid", async () => {
+    const wrong = validateInSuite({
+      agents: {
+        defaults: {
+          workspace: path.join(suiteHome, "workspace"),
+          timeoutSeconds: "nope",
+        },
+        list: [{ id: "pi" }],
+      },
+      plugins: {
+        entries: {
+          "workspace-hint": {
+            enabled: true,
+            queueOwnerTtlSeconds: 5,
+          },
+        },
+      },
+    });
+    expect(wrong.ok).toBe(false);
+    if (!wrong.ok) {
+      expect(wrong.issues).toEqual(
+        expect.arrayContaining([
+          {
+            path: "agents.defaults.timeoutSeconds",
+            message: expect.stringContaining("number"),
+          },
+          {
+            path: "plugins.entries.workspace-hint",
+            message:
+              'Unrecognized key: "queueOwnerTtlSeconds". Did you mean "plugins.entries.workspace-hint.config.queueOwnerTtlSeconds"?',
+          },
+        ]),
+      );
+    }
   });
 
   it("accepts known plugin ids and valid channel/heartbeat enums", async () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -305,13 +305,117 @@ export function validateConfigObjectRawWithPlugins(raw: unknown): ValidateConfig
   return validateConfigObjectWithPluginsBase(raw, { applyDefaults: false });
 }
 
+function resolveWorkspaceDirFromRawConfig(raw: unknown): string | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const agents = isRecord(raw.agents) ? raw.agents : null;
+  const defaults = agents && isRecord(agents.defaults) ? agents.defaults : null;
+  const workspace = defaults?.workspace;
+  if (typeof workspace === "string" && workspace.trim() !== "") {
+    return workspace.trim();
+  }
+
+  const agentsConfig = agents ? { agents } : {};
+  const validatedAgentsConfig = validateConfigObjectRaw(agentsConfig);
+  return validatedAgentsConfig.ok
+    ? resolveAgentWorkspaceDir(
+        validatedAgentsConfig.config,
+        resolveDefaultAgentId(validatedAgentsConfig.config),
+      )
+    : undefined;
+}
+
+function parseUnrecognizedKeyNames(message: string): string[] {
+  const singular = /^Unrecognized key: "([^"]+)"$/.exec(message);
+  if (singular) {
+    return [singular[1]];
+  }
+  const plural = /^Unrecognized keys: (.+)$/.exec(message);
+  if (!plural) {
+    return [];
+  }
+  return plural[1]
+    .split(",")
+    .map((part) => part.trim())
+    .map((part) => /^"([^"]+)"$/.exec(part)?.[1] ?? "")
+    .filter(Boolean);
+}
+
+function resolveMisplacedPluginConfigHints(
+  raw: unknown,
+  issues: ConfigValidationIssue[],
+): ConfigValidationIssue[] {
+  if (!isRecord(raw)) {
+    return issues;
+  }
+
+  const rawPlugins = isRecord(raw.plugins) ? raw.plugins : null;
+  const rawEntries = rawPlugins && isRecord(rawPlugins.entries) ? rawPlugins.entries : null;
+  if (!rawEntries) {
+    return issues;
+  }
+
+  const agentsConfig = isRecord(raw.agents) ? { agents: raw.agents } : {};
+  const workspaceDir = resolveWorkspaceDirFromRawConfig(raw);
+
+  const registry = loadPluginManifestRegistry({
+    config: { ...agentsConfig, plugins: rawPlugins } as OpenClawConfig,
+    workspaceDir: workspaceDir ?? undefined,
+    cache: false,
+  });
+  const pluginSchemas = new Map(
+    registry.plugins.map((record) => [record.id, record.configSchema] as const),
+  );
+
+  return issues.map((issue) => {
+    const misplacedKeys = parseUnrecognizedKeyNames(issue.message);
+    const prefix = "plugins.entries.";
+    if (!issue.path.startsWith(prefix) || misplacedKeys.length === 0) {
+      return issue;
+    }
+
+    const pluginId = issue.path.slice(prefix.length);
+    if (!pluginId) {
+      return issue;
+    }
+    const pluginSchema = pluginSchemas.get(pluginId);
+    const schemaProperties =
+      pluginSchema && typeof pluginSchema === "object" && !Array.isArray(pluginSchema)
+        ? (pluginSchema as { properties?: Record<string, unknown> }).properties
+        : undefined;
+    if (!schemaProperties) {
+      return issue;
+    }
+
+    const hintedPaths = misplacedKeys
+      .filter((misplacedKey) =>
+        Object.prototype.hasOwnProperty.call(schemaProperties, misplacedKey),
+      )
+      .map((misplacedKey) => `"plugins.entries.${pluginId}.config.${misplacedKey}"`);
+    if (hintedPaths.length === 0) {
+      return issue;
+    }
+
+    const suggestion = hintedPaths.length === 1 ? hintedPaths[0] : hintedPaths.join(", ");
+    return {
+      ...issue,
+      message: `${issue.message}. Did you mean ${suggestion}?`,
+    };
+  });
+}
+
 function validateConfigObjectWithPluginsBase(
   raw: unknown,
   opts: { applyDefaults: boolean },
 ): ValidateConfigWithPluginsResult {
   const base = opts.applyDefaults ? validateConfigObject(raw) : validateConfigObjectRaw(raw);
   if (!base.ok) {
-    return { ok: false, issues: base.issues, warnings: [] };
+    return {
+      ok: false,
+      issues: resolveMisplacedPluginConfigHints(raw, base.issues),
+      warnings: [],
+    };
   }
 
   const config = base.config;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -326,7 +326,13 @@ function resolveWorkspaceDirFromRawConfig(raw: unknown): string | undefined {
     : undefined;
 }
 
+function hasPluginEntryIssue(issues: ConfigValidationIssue[]): boolean {
+  return issues.some((issue) => issue.path.startsWith("plugins.entries."));
+}
+
 function parseUnrecognizedKeyNames(message: string): string[] {
+  // Coupled to Zod's current strict-object wording; if that changes,
+  // this helper degrades by skipping hints rather than emitting bad paths.
   const singular = /^Unrecognized key: "([^"]+)"$/.exec(message);
   if (singular) {
     return [singular[1]];
@@ -352,7 +358,7 @@ function resolveMisplacedPluginConfigHints(
 
   const rawPlugins = isRecord(raw.plugins) ? raw.plugins : null;
   const rawEntries = rawPlugins && isRecord(rawPlugins.entries) ? rawPlugins.entries : null;
-  if (!rawEntries) {
+  if (!rawEntries || !hasPluginEntryIssue(issues)) {
     return issues;
   }
 
@@ -361,12 +367,16 @@ function resolveMisplacedPluginConfigHints(
 
   const registry = loadPluginManifestRegistry({
     config: { ...agentsConfig, plugins: rawPlugins } as OpenClawConfig,
-    workspaceDir: workspaceDir ?? undefined,
+    workspaceDir,
     cache: false,
   });
-  const pluginSchemas = new Map(
-    registry.plugins.map((record) => [record.id, record.configSchema] as const),
-  );
+  const pluginSchemas = new Map<string, Record<string, unknown>>();
+  for (const record of registry.plugins) {
+    if (!record.configSchema || pluginSchemas.has(record.id)) {
+      continue;
+    }
+    pluginSchemas.set(record.id, record.configSchema);
+  }
 
   return issues.map((issue) => {
     const misplacedKeys = parseUnrecognizedKeyNames(issue.message);


### PR DESCRIPTION
## Summary

- Problem: when plugin-specific config fields are mistakenly placed directly under `plugins.entries.<id>` instead of `plugins.entries.<id>.config`, validation fails with a generic `Unrecognized key` message.
- What changed:
  - Added a targeted validation hint for misplaced plugin config keys.
  - If the unknown key matches a real plugin config field, validation now suggests the correct nested path, e.g.:
    - `plugins.entries.acpx.permissionMode`
    - -> `plugins.entries.acpx.config.permissionMode`
  - Supports:
    - single misplaced keys
    - multiple misplaced keys in one entry
    - dotted plugin ids
    - workspace-installed plugins
- Scope boundary:
  - No config semantics changed.
  - No plugin schema behavior changed.
  - This is validation UX only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #39535

## User-visible / Behavior Changes

- Validation errors for misplaced plugin config keys are now more actionable.
- Example:
  - Before: `Unrecognized key: "permissionMode"`
  - After: `Unrecognized key: "permissionMode". Did you mean "plugins.entries.acpx.config.permissionMode"?`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Commands run

```bash
pnpm exec vitest run src/config/config.plugin-validation.test.ts
```

### Result

- 14 tests passed
- Added coverage for:
  - single misplaced plugin config key
  - dotted plugin ids
  - multiple misplaced keys
  - workspace-installed plugins
  - workspace-installed plugins with unrelated `agents` validation errors in the same config

## Human Verification (required)

- Manually reproduced both shapes:
  - incorrect: `plugins.entries.acpx.permissionMode`
  - correct: `plugins.entries.acpx.config.permissionMode`
- Confirmed validation remains unchanged for the correct nested path and only the error message becomes more helpful for the incorrect one.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery

- Revert this PR commit to restore previous generic validation messages.
- No data or config migration required.

## Risks and Mitigations

- Risk:
  - Hinting could be misleading if it guessed plugin config fields incorrectly.
- Mitigation:
  - Hints are only added when the key is present in the plugin's actual `configSchema`.
