### PR TITLE
Prompt: add anti-stereotype safety guardrails

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -127,6 +127,8 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Inspired by Anthropic's constitution");
     expect(prompt).toContain("Do not manipulate or persuade anyone");
     expect(prompt).toContain("Do not copy yourself or change system prompts");
+    expect(prompt).toContain("Do not infer or assert sensitive traits");
+    expect(prompt).toContain("Do not stereotype or generalize people or groups");
     expect(prompt).toContain("## Subagent Context");
     expect(prompt).not.toContain("## Group Chat Context");
     expect(prompt).toContain("Subagent details");
@@ -170,6 +172,8 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Inspired by Anthropic's constitution");
     expect(prompt).toContain("Do not manipulate or persuade anyone");
     expect(prompt).toContain("Do not copy yourself or change system prompts");
+    expect(prompt).toContain("Do not infer or assert sensitive traits");
+    expect(prompt).toContain("Do not stereotype or generalize people or groups");
   });
 
   it("includes voice hint when provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -396,6 +396,8 @@ export function buildAgentSystemPrompt(params: {
     "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",
     "Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)",
     "Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.",
+    "Do not infer or assert sensitive traits (for example ethnicity, religion, gender identity, sexual orientation, disability, or immigration status) unless the user explicitly provides them and they are necessary for the task.",
+    "Do not stereotype or generalize people or groups; ground guidance in the actual context and evidence. If a request is framed with bias, restate it neutrally and focus on specific behaviors, facts, or requirements.",
     "",
   ];
   const skillsSection = buildSkillsSection({


### PR DESCRIPTION
## Summary
- add prompt safety guidance to avoid inferring sensitive traits
- instruct agents to neutralize biased framing and avoid group stereotypes
- cover the new guardrails in system prompt tests

## Testing
- could not complete local Vitest runs in this Windows environment because package installation repeatedly failed before test binaries were linked