### PR TITLE
fix(telegram): keep quoted DM preview streaming in one reply

### DIFF
--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE",
+        "SSLKEYLOGFILE"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME",
+        "CURL_HOME"
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_",
+        "NPM_CONFIG_"
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "BASH_FUNC_"
     ]
 }

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -248,7 +248,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     For text-only replies:
 
-    - DM: OpenClaw updates the draft in place (no extra preview message)
+    - DM without a reply target: OpenClaw updates the native draft in place
+    - DM when replying to a specific message: OpenClaw uses a real preview message + `editMessageText` so the stream stays attached to the quoted reply
     - group/topic: OpenClaw keeps the same preview message and performs a final edit in place (no second message)
 
     For complex replies (for example media payloads), OpenClaw falls back to normal final delivery and then cleans up the preview message.
@@ -872,7 +873,7 @@ Primary reference:
 - `channels.telegram.textChunkLimit`: outbound chunk size (chars).
 - `channels.telegram.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
-- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). In DMs, `partial` uses native `sendMessageDraft` when available.
+- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). In DMs, `partial` uses native `sendMessageDraft` when available, except quoted replies, which use a real preview message so `reply_to_message_id` is preserved.
 - `channels.telegram.mediaMaxMb`: inbound/outbound Telegram media cap (MB, default: 100).
 - `channels.telegram.retry`: retry policy for Telegram send helpers (CLI/tools/actions) on recoverable outbound API errors (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to enabled on Node 22+, with WSL2 defaulting to disabled.

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -143,6 +143,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     telegramCfg?: Parameters<typeof dispatchTelegramMessage>[0]["telegramCfg"];
     streamMode?: Parameters<typeof dispatchTelegramMessage>[0]["streamMode"];
     bot?: Bot;
+    replyToMode?: Parameters<typeof dispatchTelegramMessage>[0]["replyToMode"];
   }) {
     const bot = params.bot ?? createBot();
     await dispatchTelegramMessage({
@@ -150,7 +151,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       bot,
       cfg: {},
       runtime: createRuntime(),
-      replyToMode: "first",
+      replyToMode: params.replyToMode ?? "first",
       streamMode: params.streamMode ?? "partial",
       textLimit: 4096,
       telegramCfg: params.telegramCfg ?? {},
@@ -1184,7 +1185,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
 
-    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "partial",
+      replyToMode: "off",
+    });
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(2);
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
@@ -1196,6 +1201,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
+        previewTransport: "message",
+      }),
+    );
+  });
+
+  it("uses message preview transport for quoted DM answer previews", async () => {
+    setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        thread: { id: 777, scope: "dm" },
+        replyToMessageId: 456,
         previewTransport: "message",
       }),
     );
@@ -1217,7 +1245,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     deliverReplies.mockResolvedValue({ delivered: true });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      replyToMode: "off",
+    });
 
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
@@ -1228,6 +1260,43 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("edits quoted DM previews in place without sending a duplicate final message", async () => {
+    const answerDraftStream = createDraftStream(321);
+    const reasoningDraftStream = createDraftStream(111);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "321" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        thread: { id: 777, scope: "dm" },
+        replyToMessageId: 456,
+        previewTransport: "message",
+      }),
+    );
+    expect(answerDraftStream.materialize).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      321,
+      "Checking the directory...",
+      expect.objectContaining({
+        linkPreview: undefined,
+      }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("keeps reasoning and answer streaming in separate preview lanes", async () => {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1227,6 +1227,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
         previewTransport: "message",
       }),
     );
+    expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        thread: { id: 777, scope: "dm" },
+        replyToMessageId: 456,
+        previewTransport: "message",
+      }),
+    );
   });
 
   it("materializes DM answer draft final without sending a duplicate final message", async () => {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -194,6 +194,11 @@ export const dispatchTelegramMessage = async ({
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
+    // Telegram's native draft preview does not support reply_to_message_id.
+    // When we are replying to a specific message, prefer a real message that
+    // we edit in place so the streamed preview stays attached to the quote.
+    const useMessagePreviewTransportForQuotedReply =
+      threadSpec?.scope === "dm" && draftReplyToMessageId != null;
     const useMessagePreviewTransportForDmReasoning =
       laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
     const stream = enabled
@@ -202,7 +207,10 @@ export const dispatchTelegramMessage = async ({
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
-          previewTransport: useMessagePreviewTransportForDmReasoning ? "message" : "auto",
+          previewTransport:
+            useMessagePreviewTransportForQuotedReply || useMessagePreviewTransportForDmReasoning
+              ? "message"
+              : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram DM preview streaming prefers native `sendMessageDraft` even when the reply is attached to a specific incoming message.
- Why it matters: `sendMessageDraft` has no `reply_to_message_id`, so quoted DM replies preview in a temporary draft bubble, then a second permanent quoted reply arrives and the draft disappears.
- What changed: quoted DM previews now prefer message transport (`sendMessage` + `editMessageText`) so the stream stays attached to the quoted reply from the first visible update through the final answer.
- What did NOT change (scope boundary): unquoted DM draft streaming still uses native `sendMessageDraft`; group/topic preview behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Quoted Telegram DMs now stream inside a single quoted reply message instead of showing a temporary draft preview and then sending a second quoted final message.
- Unquoted Telegram DMs still use native `sendMessageDraft` when available.
- Telegram channel docs now call out the quoted-reply exception explicitly.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu on WSL2
- Runtime/container: local Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram DM quoted replies with `channels.telegram.streaming: partial`
- Relevant config (redacted): `channels.telegram.replyToMode=first|all`, `channels.telegram.streaming=partial`

### Steps

1. In a Telegram DM, send a message that the bot will quote-reply to.
2. Trigger a response that emits partial answer streaming before the final payload.
3. Observe the preview transport and final delivery behavior.

### Expected

- One quoted reply message appears.
- The content streams in place and finalizes without a second quoted message.

### Actual

- Before this change, the preview used a temporary draft bubble with no quote attachment, then a second permanent quoted reply was sent and the draft disappeared.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing after:

- `pnpm exec vitest run --config vitest.channels.config.ts src/telegram/draft-stream.test.ts src/telegram/bot-message-dispatch.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the latest `origin/main` implementation, reproduced the quoted-DM preview path in source, and verified the patched behavior through Telegram channel tests.
- Edge cases checked: unquoted DM draft streaming still keeps `sendMessageDraft`; reasoning lane message transport behavior remains covered; final delivery avoids duplicate normal sends in both draft and quoted-message modes.
- What you did **not** verify: live Telegram manual UI testing against a real bot from this branch.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or temporarily set `channels.telegram.streaming: off` to disable preview streaming.
- Files/config to restore: `src/telegram/bot-message-dispatch.ts`, `docs/channels/telegram.md`
- Known bad symptoms reviewers should watch for: quoted DM previews no longer appearing, or quoted DM finals falling back to a second message again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: changing DM preview transport for quoted replies could regress the previous native-draft UX in that narrow path.
  - Mitigation: the switch is gated to quoted DM replies only; unquoted DMs keep the existing native `sendMessageDraft` path, and regression tests cover both modes.
