### PR TITLE
fix(kimi-coding): use native Anthropic tool format

### DIFF
--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -14,8 +14,8 @@ const DEFAULT_PROVIDER_CAPABILITIES: ProviderCapabilities = {
 
 const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
   "kimi-coding": {
-    anthropicToolSchemaMode: "openai-functions",
-    anthropicToolChoiceMode: "openai-string-modes",
+    anthropicToolSchemaMode: "native",
+    anthropicToolChoiceMode: "native",
     preserveAnthropicThinkingSignatures: false,
   },
 };


### PR DESCRIPTION
## Summary

Fixes tool calling for Kimi Coding's anthropic-messages endpoint by configuring it to use native Anthropic tool format instead of OpenAI format transformation.

## Problem

When using Kimi Coding with tools, the API returns text descriptions like `exec(command: 'whoami')` instead of actually executing the tools. This is because the current configuration transforms Anthropic tool format to OpenAI format, which Kimi's anthropic-messages endpoint doesn't handle correctly.

## Root Cause

In `provider-capabilities.ts`, kimi-coding was configured with:
- `anthropicToolSchemaMode: "openai-functions"` 
- `anthropicToolChoiceMode: "openai-string-modes"`

This causes tools to be transformed from Anthropic format (`tools[].name + input_schema`) to OpenAI format (`tools[].function`), which breaks tool execution.

## Solution

Update `provider-capabilities.ts` to use native Anthropic format:
- `anthropicToolSchemaMode: "native"`
- `anthropicToolChoiceMode: "native"`

## Verification

Tested with direct API calls and confirmed:
- ✅ Native Anthropic format: tools execute correctly
- ❌ OpenAI format: returns text descriptions instead of executing

## Changes

- Modified `src/agents/provider-capabilities.ts` (2 lines changed)

This is a minimal configuration fix that leverages the existing provider-capabilities system introduced in #39959.