### PR TITLE
Agents: skip workspace cleanup when other agents still reference it

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -271,7 +271,7 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));
 }
 
-function normalizePathForComparison(input: string): string {
+export function normalizePathForComparison(input: string): string {
   const resolved = path.resolve(stripNullBytes(resolveUserPath(input)));
   let normalized = resolved;
   // Prefer realpath when available to normalize aliases/symlinks (for example /tmp -> /private/tmp)
@@ -336,3 +336,4 @@ export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {
   const root = resolveStateDir(process.env);
   return path.join(root, "agents", id, "agent");
 }
+

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,6 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
-import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { listAgentIds, normalizePathForComparison, resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -18,17 +16,6 @@ type AgentsDeleteOptions = {
   force?: boolean;
   json?: boolean;
 };
-
-function normalizePathForComparison(input: string): string {
-  const resolved = path.resolve(input);
-  let normalized = resolved;
-  try {
-    normalized = fs.realpathSync.native(resolved);
-  } catch {
-    // Keep lexical path when the directory no longer exists.
-  }
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
-}
 
 function resolveWorkspaceOwners(cfg: OpenClawConfig, workspaceDir: string): string[] {
   const targetWorkspace = normalizePathForComparison(workspaceDir);
@@ -123,6 +110,7 @@ export async function agentsDeleteCommand(
         {
           agentId,
           workspace: workspaceDir,
+          workspaceRemoved: shouldDeleteWorkspace,
           agentDir,
           sessionsDir,
           removedBindings: result.removedBindings,

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,4 +1,7 @@
-import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import fs from "node:fs";
+import path from "node:path";
+import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
@@ -15,6 +18,31 @@ type AgentsDeleteOptions = {
   force?: boolean;
   json?: boolean;
 };
+
+function normalizePathForComparison(input: string): string {
+  const resolved = path.resolve(input);
+  let normalized = resolved;
+  try {
+    normalized = fs.realpathSync.native(resolved);
+  } catch {
+    // Keep lexical path when the directory no longer exists.
+  }
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function resolveWorkspaceOwners(cfg: OpenClawConfig, workspaceDir: string): string[] {
+  const targetWorkspace = normalizePathForComparison(workspaceDir);
+  const owners: string[] = [];
+
+  for (const id of listAgentIds(cfg)) {
+    const candidateWorkspace = resolveAgentWorkspaceDir(cfg, id);
+    if (normalizePathForComparison(candidateWorkspace) === targetWorkspace) {
+      owners.push(id);
+    }
+  }
+
+  return owners;
+}
 
 export async function agentsDeleteCommand(
   opts: AgentsDeleteOptions,
@@ -70,13 +98,22 @@ export async function agentsDeleteCommand(
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
 
   const result = pruneAgentConfig(cfg, agentId);
+  const workspaceOwners = resolveWorkspaceOwners(result.config, workspaceDir);
+  const shouldDeleteWorkspace = workspaceOwners.length === 0;
+
   await writeConfigFile(result.config);
   if (!opts.json) {
     logConfigUpdated(runtime);
   }
 
   const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
-  await moveToTrash(workspaceDir, quietRuntime);
+  if (shouldDeleteWorkspace) {
+    await moveToTrash(workspaceDir, quietRuntime);
+  } else if (!opts.json) {
+    runtime.log(
+      `Skipped workspace cleanup for "${agentId}"; still used by agent(s): ${workspaceOwners.join(", ")}`,
+    );
+  }
   await moveToTrash(agentDir, quietRuntime);
   await moveToTrash(sessionsDir, quietRuntime);
 

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -113,4 +113,33 @@ describe("agents delete command", () => {
     expect(trashed).toContain(opsAgentDir);
     expect(trashed).toContain("sessions/ops");
   });
+
+  it("reports workspaceRemoved=false in json mode when workspace cleanup is skipped", async () => {
+    const sharedWorkspace = path.resolve("tmp", "workspace-shared-json");
+    const mainAgentDir = path.resolve("tmp", "agent-main-json");
+    const opsAgentDir = path.resolve("tmp", "agent-ops-json");
+
+    requireValidConfigMock.mockResolvedValue({
+      agents: {
+        defaults: { workspace: sharedWorkspace },
+        list: [
+          { id: "main", workspace: sharedWorkspace, agentDir: mainAgentDir },
+          { id: "ops", workspace: sharedWorkspace, agentDir: opsAgentDir },
+        ],
+      },
+    });
+
+    await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+    const trashed = moveToTrashMock.mock.calls.map((call) => call[0]);
+    expect(trashed).not.toContain(sharedWorkspace);
+    expect(trashed).toContain(opsAgentDir);
+    expect(trashed).toContain("sessions/ops");
+
+    const jsonLog = runtime.log.mock.calls.at(-1)?.[0];
+    expect(typeof jsonLog).toBe("string");
+    const payload = JSON.parse(String(jsonLog));
+    expect(payload.workspace).toBe(sharedWorkspace);
+    expect(payload.workspaceRemoved).toBe(false);
+  });
 });

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -1,0 +1,116 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
+
+const requireValidConfigMock = vi.hoisted(() => vi.fn());
+const writeConfigFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const logConfigUpdatedMock = vi.hoisted(() => vi.fn());
+const moveToTrashMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const resolveSessionTranscriptsDirForAgentMock = vi.hoisted(() =>
+  vi.fn((agentId?: string) => `sessions/${agentId ?? "main"}`),
+);
+
+vi.mock("./agents.command-shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agents.command-shared.js")>()),
+  requireValidConfig: requireValidConfigMock,
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
+  writeConfigFile: writeConfigFileMock,
+}));
+
+vi.mock("../config/logging.js", () => ({
+  logConfigUpdated: logConfigUpdatedMock,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  resolveSessionTranscriptsDirForAgent: resolveSessionTranscriptsDirForAgentMock,
+}));
+
+vi.mock("./onboard-helpers.js", () => ({
+  moveToTrash: moveToTrashMock,
+}));
+
+import { agentsDeleteCommand } from "./agents.js";
+
+const runtime = createTestRuntime();
+
+describe("agents delete command", () => {
+  beforeEach(() => {
+    requireValidConfigMock.mockReset();
+    writeConfigFileMock.mockClear();
+    logConfigUpdatedMock.mockClear();
+    moveToTrashMock.mockClear();
+    resolveSessionTranscriptsDirForAgentMock.mockClear();
+    runtime.log.mockClear();
+    runtime.error.mockClear();
+    runtime.exit.mockClear();
+  });
+
+  it("skips workspace cleanup when another configured agent still uses it", async () => {
+    const sharedWorkspace = path.resolve("tmp", "workspace-shared-configured");
+    const mainAgentDir = path.resolve("tmp", "agent-main");
+    const opsAgentDir = path.resolve("tmp", "agent-ops");
+
+    requireValidConfigMock.mockResolvedValue({
+      agents: {
+        defaults: { workspace: sharedWorkspace },
+        list: [
+          { id: "main", workspace: sharedWorkspace, agentDir: mainAgentDir },
+          { id: "ops", workspace: sharedWorkspace, agentDir: opsAgentDir },
+        ],
+      },
+    });
+
+    await agentsDeleteCommand({ id: "ops", force: true }, runtime);
+
+    const trashed = moveToTrashMock.mock.calls.map((call) => call[0]);
+    expect(trashed).not.toContain(sharedWorkspace);
+    expect(trashed).toContain(opsAgentDir);
+    expect(trashed).toContain("sessions/ops");
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Skipped workspace cleanup"));
+  });
+
+  it("removes workspace when no remaining agent uses it", async () => {
+    const mainWorkspace = path.resolve("tmp", "workspace-main");
+    const opsWorkspace = path.resolve("tmp", "workspace-ops");
+    const opsAgentDir = path.resolve("tmp", "agent-ops-unique");
+
+    requireValidConfigMock.mockResolvedValue({
+      agents: {
+        defaults: { workspace: mainWorkspace },
+        list: [
+          { id: "main", workspace: mainWorkspace, agentDir: path.resolve("tmp", "agent-main") },
+          { id: "ops", workspace: opsWorkspace, agentDir: opsAgentDir },
+        ],
+      },
+    });
+
+    await agentsDeleteCommand({ id: "ops", force: true }, runtime);
+
+    const trashed = moveToTrashMock.mock.calls.map((call) => call[0]);
+    expect(trashed).toContain(opsWorkspace);
+    expect(trashed).toContain(opsAgentDir);
+    expect(trashed).toContain("sessions/ops");
+  });
+
+  it("skips workspace cleanup when deletion falls back to implicit main on same workspace", async () => {
+    const sharedWorkspace = path.resolve("tmp", "workspace-shared-implicit-main");
+    const opsAgentDir = path.resolve("tmp", "agent-ops-implicit");
+
+    requireValidConfigMock.mockResolvedValue({
+      agents: {
+        defaults: { workspace: sharedWorkspace },
+        list: [{ id: "ops", workspace: sharedWorkspace, agentDir: opsAgentDir }],
+      },
+    });
+
+    await agentsDeleteCommand({ id: "ops", force: true }, runtime);
+
+    const trashed = moveToTrashMock.mock.calls.map((call) => call[0]);
+    expect(trashed).not.toContain(sharedWorkspace);
+    expect(trashed).toContain(opsAgentDir);
+    expect(trashed).toContain("sessions/ops");
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: `agents delete` always attempted to trash the target agent workspace, even when that workspace was still shared by other agents.
- Why it matters: In shared-workspace setups, deleting one agent could unintentionally remove another agent’s active workspace files.
- What changed:
  - `src/commands/agents.commands.delete.ts` now resolves workspace ownership after config pruning and only deletes workspace when no remaining agent references it.
  - Added `src/commands/agents.delete.test.ts` with coverage for shared workspace, unique workspace, and implicit-main fallback ownership scenarios.
- What did NOT change (scope boundary): No changes to agent config pruning behavior, binding pruning semantics, session directory cleanup policy, or gateway/runtime auth logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39701
- Related #

## User-visible / Behavior Changes

- `openclaw agents delete <id>` no longer removes a workspace directory if another remaining agent still resolves to that same workspace.
- Agent directory and agent session transcript directory are still cleaned up as before.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.workspace`, `agents.list[*].workspace`

### Steps

1. Configure two agents to share the same workspace path.
2. Run `openclaw agents delete <one-agent-id> --force`.
3. Check which paths are moved to trash.

### Expected

- Shared workspace is preserved when still referenced by remaining agents.
- Deleted agent’s `agentDir` and session transcript directory are removed.

### Actual

- Matches expected behavior after the fix.
- Regression tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Shared workspace remains intact when another configured agent still uses it.
  - Unique workspace is removed when no other agent references it.
  - Shared workspace remains intact when ownership remains via implicit `main` fallback after deletion.
- Edge cases checked:
  - Path comparison normalization (including realpath/case normalization behavior).
- What you did **not** verify:
  - Full end-to-end interactive CLI manual run outside unit/integration-level command tests.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/commands/agents.commands.delete.ts`
  - `src/commands/agents.delete.test.ts`
- Known bad symptoms reviewers should watch for:
  - Shared workspace still being removed after deleting one of multiple agents.
  - Workspace not being removed when it is uniquely owned by the deleted agent.

## Risks and Mitigations

- Risk: Workspace ownership check could misclassify paths in edge environments with unusual filesystem aliasing/symlinks.
  - Mitigation: Ownership is evaluated on normalized resolved paths (with `realpath` where available), and covered by targeted tests for shared/unique/fallback ownership behavior.