### PR TITLE
Emit model.usage diagnostic event from CLI agent path

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -17,7 +17,8 @@ import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session
 import { resolveBootstrapWarningSignaturesSeen } from "../agents/bootstrap-budget.js";
 import { runCliAgent } from "../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../agents/cli-session.js";
-import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { lookupContextTokens } from "../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { formatAgentInternalEventsForPrompt } from "../agents/internal-events.js";
 import { AGENT_LANE_SUBAGENT } from "../agents/lanes.js";
@@ -38,6 +39,7 @@ import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { normalizeSpawnedRunMetadata } from "../agents/spawned-context.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
+import { hasNonzeroUsage } from "../agents/usage.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import { normalizeReplyPayload } from "../auto-reply/reply/normalize-reply.js";
 import {
@@ -79,6 +81,7 @@ import {
   emitAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
+import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -87,6 +90,7 @@ import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
@@ -1094,6 +1098,51 @@ async function agentCommandInternal(
         fallbackProvider,
         fallbackModel,
         result,
+      });
+    }
+
+    // Emit model.usage diagnostic event for the CLI agent path.
+    // Previously this was only emitted from the reply-runner (Telegram/WhatsApp/heartbeat),
+    // which meant CLI agent runs were invisible to OTEL-based token tracking.
+    const usage = result.meta?.agentMeta?.usage;
+    const modelUsed = result.meta?.agentMeta?.model ?? fallbackModel ?? model;
+    const providerUsed = result.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
+    if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
+      const input = usage.input ?? 0;
+      const output = usage.output ?? 0;
+      const cacheRead = usage.cacheRead ?? 0;
+      const cacheWrite = usage.cacheWrite ?? 0;
+      const promptTokens = input + cacheRead + cacheWrite;
+      const totalTokens = usage.total ?? promptTokens + output;
+      const contextTokensUsed =
+        agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      const costConfig = resolveModelCostConfig({
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+      });
+      const costUsd = estimateUsageCost({ usage, cost: costConfig });
+      emitDiagnosticEvent({
+        type: "model.usage",
+        sessionKey,
+        sessionId,
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead,
+          cacheWrite,
+          promptTokens,
+          total: totalTokens,
+        },
+        lastCallUsage: result.meta?.agentMeta?.lastCallUsage,
+        context: {
+          limit: contextTokensUsed,
+          used: totalTokens,
+        },
+        costUsd,
+        durationMs: Date.now() - startedAt,
       });
     }
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1115,7 +1115,10 @@ async function agentCommandInternal(
       const promptTokens = input + cacheRead + cacheWrite;
       const totalTokens = usage.total ?? promptTokens + output;
       const contextTokensUsed =
-        agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+        agentCfg?.contextTokens ??
+        sessionEntry?.contextTokens ??
+        lookupContextTokens(modelUsed) ??
+        DEFAULT_CONTEXT_TOKENS;
       const costConfig = resolveModelCostConfig({
         provider: providerUsed,
         model: modelUsed,
@@ -1126,6 +1129,7 @@ async function agentCommandInternal(
         type: "model.usage",
         sessionKey,
         sessionId,
+        channel: "cli",
         provider: providerUsed,
         model: modelUsed,
         usage: {


### PR DESCRIPTION
## Summary

- The `model.usage` diagnostic event was only emitted from the reply-runner path (Telegram/WhatsApp/heartbeat), meaning CLI agent runs via `openclaw agent` were invisible to OTEL-based token tracking
- This adds the same emission pattern to `agentCommandInternal()` in `src/commands/agent.ts`, after `updateSessionStoreAfterAgentRun()` completes
- Uses the identical structure from `agent-runner.ts`: extracts usage from `result.meta.agentMeta`, computes cost via `resolveModelCostConfig`/`estimateUsageCost`, and calls `emitDiagnosticEvent` with full token breakdown

## Motivation

When using the diagnostics-otel plugin to track token usage across OpenClaw instances, CLI agent sessions (`openclaw agent`) produced zero OTEL metrics. Only sessions originating from messaging channels (Telegram, WhatsApp, heartbeat) emitted `model.usage` events. This made it impossible to reconcile OTEL-reported usage against cloud provider billing (Bedrock/Vertex) for CLI-heavy deployments.

## Test plan

- [ ] Verify TypeScript compilation passes (confirmed: `tsc --noEmit` reports no new errors)
- [ ] Linter passes (confirmed: biome reports 0 warnings, 0 errors)
- [ ] Run `openclaw agent` with diagnostics-otel enabled and verify `model.usage` events appear in the OTEL collector output
- [ ] Verify reply-runner path still emits as before (no regression)
- [ ] Compare OTEL token totals against cloud billing to confirm coverage improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)