### PR TITLE
feat: add iplay media player control skill

### DIFF
--- a/skills/iplay/SKILL.md
+++ b/skills/iplay/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: iplay
+description: Control the iPlay media player to play videos or streams from URLs. Use when the user asks to play a video, watch a stream, or open a link in iPlay. Supports YouTube, Bilibili, and direct media links (mp4, m3u8, etc.).
+homepage: https://iplay.saltpi.cn
+metadata: { "openclaw": { "emoji": "▶️", "requires": { "bins": ["python3"] } } }
+---
+
+# iPlay Skill
+
+Control your iPlay desktop application to play media from any URL.
+
+## Quick Start
+
+To play a video or stream:
+
+```bash
+{baseDir}/scripts/iplay_play.py "https://www.youtube.com/watch?v=..."
+```
+
+## Features
+
+- **Protocol Handling**: Automatically handles `iplay://` URI schemes.
+- **Universal Support**: Works with any URL supported by your iPlay installation (including those requiring `yt-dlp`).
+- **Base64 Encoding**: Encodes target URLs to ensure compatibility with complex query parameters.
+
+## Requirements
+
+1. **iPlay**: Must be installed on the host machine.
+2. **System**: macOS (v1.2.8+), Windows (v1.0.614+), or Linux with `xdg-open`.
+3. **Python 3**: Required to run the helper script.
+
+## Notes
+
+- This skill triggers the player asynchronously; it does not track playback progress.
+- For streaming sites like Bilibili or YouTube, ensure `yt-dlp` is configured within your iPlay settings.

--- a/skills/iplay/scripts/iplay_play.py
+++ b/skills/iplay/scripts/iplay_play.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import base64
+import platform
+import subprocess
+import sys
+
+
+def open_iplay(url):
+    """
+    Encodes the URL to Base64 and opens it in iPlay using the iplay:// scheme.
+    """
+    # Encode URL to Base64 to avoid URI character conflicts
+    encoded_url = base64.b64encode(url.encode("utf-8")).decode("utf-8")
+    iplay_uri = f"iplay://play/any?type=url&url={encoded_url}"
+
+    system = platform.system()
+    try:
+        if system == "Darwin":  # macOS
+            subprocess.run(["open", iplay_uri], check=True)
+        elif system == "Windows":
+            # Fixed: Quote URI to prevent '&' being interpreted as command separator by shell=True
+            subprocess.run(f'start "" "{iplay_uri}"', shell=True, check=True)
+        else:  # Linux
+            subprocess.run(["xdg-open", iplay_uri], check=True)
+        print(f"Successfully sent URL to iPlay: {url}")
+    except Exception as e:
+        print(f"Error opening iPlay: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: iplay_play.py <URL>")
+        sys.exit(1)
+    open_iplay(sys.argv[1])
+


### PR DESCRIPTION
This PR adds a new skill to control the iPlay media player via its URL scheme (iplay://). Includes a Python helper for Base64 encoding and cross-platform URI opening.