### PR TITLE
Preinstall bundled Matrix deps in Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -297,6 +304,9 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -314,6 +324,11 @@ jobs:
               [ -f "$path" ] || continue
               changed_files+=("$path")
             done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+          fi
+
+          if [ "${#changed_files[@]}" -eq 0 ] && [ -n "${PR_NUMBER:-}" ]; then
+            echo "Git diff returned no changed files; loading PR file list from GitHub API."
+            mapfile -t changed_files < <(node scripts/ci-list-pr-files.mjs "$PR_NUMBER")
           fi
 
           if [ "${#changed_files[@]}" -gt 0 ]; then

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           docker run --rm --entrypoint sh openclaw-dockerfile-smoke:local -lc 'which openclaw && openclaw --version'
 
+      - name: Smoke test bundled Matrix runtime deps in root Dockerfile
+        run: |
+          bash scripts/docker/check-bundled-matrix-runtime.sh openclaw-dockerfile-smoke:local
+
       # This smoke only validates that the build-arg path preinstalls selected
       # extension deps without breaking image build or basic CLI startup. It
       # does not exercise runtime loading/registration of diagnostics-otel.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# Opt-in extension dependencies at build time (space-separated directory names).
-# Example: docker build --build-arg OPENCLAW_EXTENSIONS="diagnostics-otel matrix" .
+# Additional opt-in extension dependencies at build time (space-separated
+# directory names).
+# Example: docker build --build-arg OPENCLAW_EXTENSIONS="diagnostics-otel" .
 #
 # Multi-stage build produces a minimal runtime image without build tools,
 # source code, or Bun. Works with Docker, Buildx, and Podman.
@@ -10,6 +11,7 @@
 # Two runtime variants:
 #   Default (bookworm):      docker build .
 #   Slim (bookworm-slim):    docker build --build-arg OPENCLAW_VARIANT=slim .
+ARG OPENCLAW_BUNDLED_RUNTIME_EXTENSIONS="matrix"
 ARG OPENCLAW_EXTENSIONS=""
 ARG OPENCLAW_VARIANT=default
 ARG OPENCLAW_NODE_BOOKWORM_IMAGE="node:22-bookworm@sha256:b501c082306a4f528bc4038cbf2fbb58095d583d0419a259b2114b5ac53d12e9"
@@ -23,11 +25,13 @@ ARG OPENCLAW_NODE_BOOKWORM_SLIM_DIGEST="sha256:9c2c405e3ff9b9afb2873232d24bb0636
 # and replace the digest below with the current multi-arch manifest list entry.
 
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS ext-deps
+ARG OPENCLAW_BUNDLED_RUNTIME_EXTENSIONS
 ARG OPENCLAW_EXTENSIONS
 COPY extensions /tmp/extensions
 # Copy package.json for opted-in extensions so pnpm resolves their deps.
 RUN mkdir -p /out && \
-    for ext in $OPENCLAW_EXTENSIONS; do \
+    for ext in $OPENCLAW_BUNDLED_RUNTIME_EXTENSIONS $OPENCLAW_EXTENSIONS; do \
+      [ -n "$ext" ] || continue; \
       if [ -f "/tmp/extensions/$ext/package.json" ]; then \
         mkdir -p "/out/$ext" && \
         cp "/tmp/extensions/$ext/package.json" "/out/$ext/package.json"; \

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE",
+        "SSLKEYLOGFILE"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME",
+        "CURL_HOME"
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_",
+        "NPM_CONFIG_"
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "BASH_FUNC_"
     ]
 }

--- a/scripts/ci-list-pr-files.mjs
+++ b/scripts/ci-list-pr-files.mjs
@@ -1,0 +1,50 @@
+const repo = (process.env.GITHUB_REPOSITORY ?? "").trim();
+const token = (process.env.GITHUB_TOKEN ?? "").trim();
+const prNumber = (process.argv[2] ?? process.env.PR_NUMBER ?? "").trim();
+
+if (!repo || !token || !prNumber) {
+  process.exit(0);
+}
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  Authorization: `Bearer ${token}`,
+  "User-Agent": "openclaw-ci",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+const validStatuses = new Set(["added", "copied", "modified", "renamed"]);
+
+function getNextPage(linkHeader) {
+  for (const part of (linkHeader ?? "").split(",")) {
+    if (!part.includes('rel="next"')) {
+      continue;
+    }
+    const start = part.indexOf("<");
+    const end = part.indexOf(">", start + 1);
+    if (start !== -1 && end !== -1) {
+      return part.slice(start + 1, end);
+    }
+  }
+  return "";
+}
+
+let url = new URL(`https://api.github.com/repos/${repo}/pulls/${prNumber}/files`);
+url.searchParams.set("per_page", "100");
+
+while (url) {
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to list PR files: ${response.status} ${response.statusText}`);
+  }
+
+  const files = await response.json();
+  for (const file of Array.isArray(files) ? files : []) {
+    if (!file || typeof file.filename !== "string" || !validStatuses.has(file.status)) {
+      continue;
+    }
+    console.log(file.filename);
+  }
+
+  const nextPage = getNextPage(response.headers.get("link"));
+  url = nextPage ? new URL(nextPage) : null;
+}

--- a/scripts/docker/check-bundled-matrix-runtime.sh
+++ b/scripts/docker/check-bundled-matrix-runtime.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="${1:-}"
+if [[ -z "$IMAGE_NAME" ]]; then
+  echo "usage: $0 <docker-image>" >&2
+  exit 64
+fi
+
+docker run --rm --entrypoint bash "$IMAGE_NAME" -lc '
+  set -euo pipefail
+
+  node -e "const { createRequire } = require(\"node:module\"); const req = createRequire(\"/app/extensions/matrix/src/matrix/deps.ts\"); console.log(req.resolve(\"@vector-im/matrix-bot-sdk\")); req(\"@vector-im/matrix-bot-sdk\"); console.log(req.resolve(\"@matrix-org/matrix-sdk-crypto-nodejs\")); req(\"@matrix-org/matrix-sdk-crypto-nodejs\");"
+'

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -102,12 +102,18 @@ const lowMemLocalHost = !isCI && hostMemoryGiB < 64;
 const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
 // vmForks is a big win for transform/import heavy suites, but Node 24 had
 // regressions with Vitest's vm runtime in this repo, and low-memory local hosts
-// are more likely to hit per-worker V8 heap ceilings. Keep it opt-out via
-// OPENCLAW_TEST_VM_FORKS=0, and let users force-enable with =1.
+// are more likely to hit per-worker V8 heap ceilings. macOS CI also showed
+// cross-file mock leakage in Slack monitor suites, so hard-disable vmForks there.
+// Keep it opt-out via OPENCLAW_TEST_VM_FORKS=0, and let users force-enable with =1 elsewhere.
 const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor !== 24 : true;
+const disableVmForksForMacCi = isCI && isMacOS;
 const useVmForks =
-  process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
-  (process.env.OPENCLAW_TEST_VM_FORKS !== "0" && !isWindows && supportsVmForks && !lowMemLocalHost);
+  (process.env.OPENCLAW_TEST_VM_FORKS === "1" && !disableVmForksForMacCi) ||
+  (process.env.OPENCLAW_TEST_VM_FORKS !== "0" &&
+    !disableVmForksForMacCi &&
+    !isWindows &&
+    supportsVmForks &&
+    !lowMemLocalHost);
 const disableIsolation = process.env.OPENCLAW_TEST_NO_ISOLATE === "1";
 const includeGatewaySuite = process.env.OPENCLAW_TEST_INCLUDE_GATEWAY === "1";
 const includeExtensionsSuite = process.env.OPENCLAW_TEST_INCLUDE_EXTENSIONS === "1";


### PR DESCRIPTION
Closes #39666

## Summary
- treat Matrix as a bundled runtime extension when resolving Docker image dependencies
- keep `OPENCLAW_EXTENSIONS` additive for extra opt-in extensions
- add Docker install smoke coverage that verifies bundled Matrix runtime modules are loadable

## Reproduction
- the default root Docker image copied `/app/extensions/matrix` but did not install its dependency tree
- loading the bundled Matrix extension then failed until users manually ran `npm install` inside `/app/extensions/matrix`

## Validation
- `docker build -t openclaw-matrix-smoke:local -f Dockerfile .`
- `docker run --rm --entrypoint sh openclaw-matrix-smoke:local -lc 'which openclaw && openclaw --version'`\n- `bash scripts/docker/check-bundled-matrix-runtime.sh openclaw-matrix-smoke:local`\n- `docker build --build-arg OPENCLAW_EXTENSIONS=diagnostics-otel -t openclaw-39666-fixed-ext -f Dockerfile .`\n- `bash scripts/docker/check-bundled-matrix-runtime.sh openclaw-39666-fixed-ext`