### PR TITLE
Reject SecretRef placeholders from runtime auth fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -297,6 +304,9 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -314,6 +324,11 @@ jobs:
               [ -f "$path" ] || continue
               changed_files+=("$path")
             done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+          fi
+
+          if [ "${#changed_files[@]}" -eq 0 ] && [ -n "${PR_NUMBER:-}" ]; then
+            echo "Git diff returned no changed files; loading PR file list from GitHub API."
+            mapfile -t changed_files < <(node scripts/ci-list-pr-files.mjs "$PR_NUMBER")
           fi
 
           if [ "${#changed_files[@]}" -gt 0 ]; then

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE"
+        "SSLKEYLOGFILE",
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME"
+        "CURL_HOME",
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_"
+        "NPM_CONFIG_",
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_"
+        "BASH_FUNC_",
     ]
 }

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE",
+        "SSLKEYLOGFILE"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME",
+        "CURL_HOME"
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_",
+        "NPM_CONFIG_"
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "BASH_FUNC_"
     ]
 }

--- a/scripts/ci-list-pr-files.mjs
+++ b/scripts/ci-list-pr-files.mjs
@@ -1,0 +1,50 @@
+const repo = (process.env.GITHUB_REPOSITORY ?? "").trim();
+const token = (process.env.GITHUB_TOKEN ?? "").trim();
+const prNumber = (process.argv[2] ?? process.env.PR_NUMBER ?? "").trim();
+
+if (!repo || !token || !prNumber) {
+  process.exit(0);
+}
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  Authorization: `Bearer ${token}`,
+  "User-Agent": "openclaw-ci",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+const validStatuses = new Set(["added", "copied", "modified", "renamed"]);
+
+function getNextPage(linkHeader) {
+  for (const part of (linkHeader ?? "").split(",")) {
+    if (!part.includes('rel="next"')) {
+      continue;
+    }
+    const start = part.indexOf("<");
+    const end = part.indexOf(">", start + 1);
+    if (start !== -1 && end !== -1) {
+      return part.slice(start + 1, end);
+    }
+  }
+  return "";
+}
+
+let url = new URL(`https://api.github.com/repos/${repo}/pulls/${prNumber}/files`);
+url.searchParams.set("per_page", "100");
+
+while (url) {
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to list PR files: ${response.status} ${response.statusText}`);
+  }
+
+  const files = await response.json();
+  for (const file of Array.isArray(files) ? files : []) {
+    if (!file || typeof file.filename !== "string" || !validStatuses.has(file.status)) {
+      continue;
+    }
+    console.log(file.filename);
+  }
+
+  const nextPage = getNextPage(response.headers.get("link"));
+  url = nextPage ? new URL(nextPage) : null;
+}

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -263,7 +263,7 @@ describe("getApiKeyForModel", () => {
             providers: {
               custom: {
                 apiKey: "secretref-managed", // pragma: allowlist secret
-                api: "openai-compatible",
+                api: "openai-completions",
                 baseUrl: "https://provider.example/v1",
                 models: [],
               },

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -253,6 +253,27 @@ describe("getApiKeyForModel", () => {
     });
   });
 
+  it("rejects non-secret SecretRef markers as runtime api keys", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "custom",
+        store: { version: 1, profiles: {} },
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                apiKey: "secretref-managed", // pragma: allowlist secret
+                api: "openai-compatible",
+                baseUrl: "https://provider.example/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow('No API key found for provider "custom".');
+  });
+
   it("prefers explicit OLLAMA_API_KEY over synthetic local key", async () => {
     await withEnvAsync({ [envVar("OLLAMA", "API", "KEY")]: "env-ollama-key" }, async () => {
       // pragma: allowlist secret

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -17,7 +17,7 @@ import {
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
 import { PROVIDER_ENV_API_KEY_CANDIDATES } from "./model-auth-env-vars.js";
-import { OLLAMA_LOCAL_AUTH_MARKER } from "./model-auth-markers.js";
+import { isNonSecretApiKeyMarker, OLLAMA_LOCAL_AUTH_MARKER } from "./model-auth-markers.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 export { ensureAuthProfileStore, resolveAuthProfileOrder } from "./auth-profiles.js";
@@ -234,7 +234,7 @@ export async function resolveApiKeyForProvider(params: {
   }
 
   const customKey = getCustomProviderApiKey(cfg, provider);
-  if (customKey) {
+  if (customKey && !isNonSecretApiKeyMarker(customKey)) {
     return { apiKey: customKey, source: "models.json", mode: "api-key" };
   }
 

--- a/src/agents/pi-model-discovery.auth.test.ts
+++ b/src/agents/pi-model-discovery.auth.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { saveAuthProfileStore } from "./auth-profiles.js";
-import { discoverAuthStorage } from "./pi-model-discovery.js";
+import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
 
 async function createAgentDir(): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-auth-storage-"));
@@ -147,6 +147,44 @@ describe("discoverAuthStorage", () => {
           process.env.OPENCLAW_AUTH_STORE_READONLY = previous;
         }
       }
+    });
+  });
+});
+
+describe("discoverModels", () => {
+  it("drops non-env auth markers from registry fallbacks and injected headers", async () => {
+    await withAgentDir(async (agentDir) => {
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://example.com/v1",
+                api: "openai-responses",
+                apiKey: "secretref-managed",
+                authHeader: true,
+                headers: {
+                  "X-Managed": "secretref-managed",
+                  "X-Static": "tenant-a",
+                },
+                models: [{ id: "custom-model" }],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const authStorage = discoverAuthStorage(agentDir);
+      const modelRegistry = discoverModels(authStorage, agentDir);
+
+      await expect(authStorage.getApiKey("custom")).resolves.toBeUndefined();
+      expect(modelRegistry.find("custom", "custom-model")?.headers).toEqual({
+        "X-Static": "tenant-a",
+      });
     });
   });
 });

--- a/src/agents/pi-model-discovery.auth.test.ts
+++ b/src/agents/pi-model-discovery.auth.test.ts
@@ -162,7 +162,7 @@ describe("discoverModels", () => {
               custom: {
                 baseUrl: "https://example.com/v1",
                 api: "openai-responses",
-                apiKey: "secretref-managed",
+                apiKey: "secretref-managed", // pragma: allowlist secret -- placeholder fixture
                 authHeader: true,
                 headers: {
                   "X-Managed": "secretref-managed",

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -6,6 +6,7 @@ import type {
   ModelRegistry as PiModelRegistry,
 } from "@mariozechner/pi-coding-agent";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
+import { isNonSecretApiKeyMarker, isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import { resolvePiCredentialMapFromStore, type PiCredentialMap } from "./pi-auth-credentials.js";
 
 const PiAuthStorageClass = PiCodingAgent.AuthStorage;
@@ -139,6 +140,60 @@ function resolvePiCredentials(agentDir: string): PiCredentialMap {
   return resolvePiCredentialMapFromStore(store);
 }
 
+function isPlaceholderBearerAuthorizationHeader(value: string): boolean {
+  const match = /^\s*bearer\s+(.+)$/i.exec(value);
+  const token = match?.[1]?.trim();
+  return Boolean(token && isNonSecretApiKeyMarker(token, { includeEnvVarName: false }));
+}
+
+function sanitizeDiscoveredHeaders(headers: unknown): Record<string, string> | undefined {
+  if (!isRecord(headers)) {
+    return undefined;
+  }
+
+  const sanitized: Record<string, string> = {};
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    if (typeof headerValue !== "string") {
+      continue;
+    }
+    if (isSecretRefHeaderValueMarker(headerValue)) {
+      continue;
+    }
+    if (
+      headerName.toLowerCase() === "authorization" &&
+      isPlaceholderBearerAuthorizationHeader(headerValue)
+    ) {
+      continue;
+    }
+    sanitized[headerName] = headerValue;
+  }
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+function scrubDiscoveredRegistryPlaceholders(registry: PiModelRegistry): void {
+  const withInternalState = registry as PiModelRegistry & {
+    customProviderApiKeys?: Map<string, string>;
+    models?: Array<{ headers?: unknown }>;
+  };
+
+  if (withInternalState.customProviderApiKeys instanceof Map) {
+    for (const [provider, keyConfig] of withInternalState.customProviderApiKeys.entries()) {
+      if (!isNonSecretApiKeyMarker(keyConfig, { includeEnvVarName: false })) {
+        continue;
+      }
+      // Keep models.json persistence markers from becoming runtime fallback credentials.
+      withInternalState.customProviderApiKeys.delete(provider);
+    }
+  }
+
+  if (!Array.isArray(withInternalState.models)) {
+    return;
+  }
+  for (const model of withInternalState.models) {
+    model.headers = sanitizeDiscoveredHeaders(model.headers);
+  }
+}
+
 // Compatibility helpers for pi-coding-agent 0.50+ (discover* helpers removed).
 export function discoverAuthStorage(agentDir: string): PiAuthStorage {
   const credentials = resolvePiCredentials(agentDir);
@@ -148,5 +203,7 @@ export function discoverAuthStorage(agentDir: string): PiAuthStorage {
 }
 
 export function discoverModels(authStorage: PiAuthStorage, agentDir: string): PiModelRegistry {
-  return new PiModelRegistryClass(authStorage, path.join(agentDir, "models.json"));
+  const registry = new PiModelRegistryClass(authStorage, path.join(agentDir, "models.json"));
+  scrubDiscoveredRegistryPlaceholders(registry);
+  return registry;
 }

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -171,9 +171,9 @@ function sanitizeDiscoveredHeaders(headers: unknown): Record<string, string> | u
 }
 
 function scrubDiscoveredRegistryPlaceholders(registry: PiModelRegistry): void {
-  const withInternalState = registry as PiModelRegistry & {
-    customProviderApiKeys?: Map<string, string>;
-    models?: Array<{ headers?: unknown }>;
+  const withInternalState = registry as unknown as {
+    customProviderApiKeys?: unknown;
+    models?: unknown;
   };
 
   if (withInternalState.customProviderApiKeys instanceof Map) {
@@ -190,6 +190,9 @@ function scrubDiscoveredRegistryPlaceholders(registry: PiModelRegistry): void {
     return;
   }
   for (const model of withInternalState.models) {
+    if (!isRecord(model)) {
+      continue;
+    }
     model.headers = sanitizeDiscoveredHeaders(model.headers);
   }
 }


### PR DESCRIPTION
Closes #39823

## Summary
- reject non-secret SecretRef markers as runtime provider API keys
- scrub placeholder auth headers from discovered PI model registry fallbacks
- add regression coverage for both model-auth and discoverModels paths

## Reproduction
- `origin/main` could carry `apiKey: "secretref-managed"` through custom provider fallback resolution
- PI model discovery could then expose `Authorization: Bearer secretref-managed` from registry fallbacks

## Validation
- `npx -y pnpm@10.23.0 exec vitest run src/agents/model-auth.profiles.test.ts src/agents/pi-model-discovery.auth.test.ts src/agents/pi-embedded-runner/model.test.ts src/media-understanding/providers/image.test.ts`