### PR TITLE
fix: auto-reset session on surrogate encoding error to prevent infinite loop

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -35,6 +35,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isSurrogateEncodingError,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -520,6 +520,13 @@ export function formatAssistantErrorText(
     );
   }
 
+  if (isSurrogateEncodingError(raw)) {
+    return (
+      "⚠️ Session history contains invalid Unicode characters (surrogate encoding error). " +
+      "Use /new to start a fresh session."
+    );
+  }
+
   const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
   if (invalidRequest?.[1]) {
     return `LLM request rejected: ${invalidRequest[1]}`;
@@ -754,6 +761,24 @@ export function isMissingToolCallInputError(raw: string): boolean {
     return false;
   }
   return TOOL_CALL_INPUT_MISSING_RE.test(raw) || TOOL_CALL_INPUT_PATH_RE.test(raw);
+}
+
+/**
+ * Detects Unicode surrogate encoding errors that occur when the conversation
+ * history contains unpaired surrogate characters (e.g. lone \uD800-\uDFFF).
+ * These cause JSON serialization to fail and can create an infinite loop where
+ * the error message itself is appended to history, causing every subsequent
+ * request to also fail.
+ */
+export function isSurrogateEncodingError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  return (
+    (lower.includes("not valid json") || lower.includes("invalid json")) &&
+    (lower.includes("surrogate") || lower.includes("low surrogate") || lower.includes("high surrogate"))
+  );
 }
 
 export function isBillingAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -8,6 +8,7 @@ import {
   isCompactionFailureError,
   isContextOverflowError,
   isLikelyContextOverflowError,
+  isSurrogateEncodingError,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -476,6 +477,7 @@ export async function runAgentTurnWithFallback(params: {
       const isCompactionFailure = isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
+      const isSurrogateError = isSurrogateEncodingError(message);
       const isTransientHttp = isTransientHttpError(message);
 
       if (
@@ -501,6 +503,51 @@ export async function runAgentTurnWithFallback(params: {
             },
           };
         }
+      }
+
+      // Auto-recover from surrogate encoding errors by resetting the session.
+      // These errors occur when the conversation history contains unpaired Unicode
+      // surrogate characters, causing JSON serialization to fail. Without a reset,
+      // the error message itself gets appended to history, causing an infinite loop.
+      if (
+        isSurrogateError &&
+        params.sessionKey &&
+        params.activeSessionStore &&
+        params.storePath
+      ) {
+        const sessionKey = params.sessionKey;
+        const corruptedSessionId = params.getActiveSessionEntry()?.sessionId;
+        defaultRuntime.error(
+          `Session history contains surrogate encoding error. Resetting session: ${params.sessionKey}`,
+        );
+
+        try {
+          if (corruptedSessionId) {
+            const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId);
+            try {
+              fs.unlinkSync(transcriptPath);
+            } catch {
+              // Ignore if file doesn't exist
+            }
+          }
+
+          delete params.activeSessionStore[sessionKey];
+
+          await updateSessionStore(params.storePath, (store) => {
+            delete store[sessionKey];
+          });
+        } catch (cleanupErr) {
+          defaultRuntime.error(
+            `Failed to reset surrogate-corrupted session ${params.sessionKey}: ${String(cleanupErr)}`,
+          );
+        }
+
+        return {
+          kind: "final",
+          payload: {
+            text: "⚠️ Session history contained invalid Unicode characters and has been reset. Please try again!",
+          },
+        };
       }
 
       // Auto-recover from Gemini session corruption by resetting the session


### PR DESCRIPTION
## Problem

When conversation history contains unpaired Unicode surrogate characters (e.g. lone \\uD800\-\\uDFFF\), JSON serialization of the LLM request body fails with:

\\\
LLM request rejected: The request body is not valid JSON: no low surrogate in string
\\\

Previously, this error was surfaced as a chat reply. That reply then got appended to the conversation context, causing every subsequent request to also fail — creating an **infinite loop** that required a manual \/new\ or \/reset\ to escape.

## Fix

- **\isSurrogateEncodingError()\** — new detector in \errors.ts\ matching \
ot valid json\ + \surrogate\ patterns
- **\ormatAssistantErrorText()\** — returns a friendly user-facing message instead of the raw API error
- **\gent-runner-execution.ts\** — auto-resets the session transcript when a surrogate error is detected, following the same pattern used for role-ordering and Gemini corruption errors

## Observed in production

A session accumulated surrogate characters in its history (likely from tool output or file content). Every message — including the error reply itself — re-triggered the failure, looping indefinitely until manually reset.