### PR TITLE
refactor(agents): tighten codex inline api fallback follow-up

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -641,14 +641,12 @@ describe("resolveModel", () => {
   it("uses codex fallback when inline model omits api (#39682)", () => {
     mockOpenAICodexTemplateModel();
 
-    // When a user lists gpt-5.4 under openai-codex models without specifying
-    // an api, the inline match must not shadow the forward-compat resolver
-    // that supplies "openai-codex-responses".
     const cfg: OpenClawConfig = {
       models: {
         providers: {
           "openai-codex": {
             baseUrl: "https://custom.example.com",
+            headers: { "X-Custom-Auth": "token-123" },
             models: [{ id: "gpt-5.4" }],
           },
         },
@@ -659,6 +657,8 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
       api: "openai-codex-responses",
+      baseUrl: "https://custom.example.com",
+      headers: { "X-Custom-Auth": "token-123" },
       id: "gpt-5.4",
       provider: "openai-codex",
     });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -160,13 +160,8 @@ export function resolveModelWithRegistry(params: {
   const inlineMatch = inlineModels.find(
     (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
   );
-  if (inlineMatch) {
-    // When the inline model already carries a concrete api, use it as-is.
-    // Otherwise fall through so forward-compat resolvers can supply the
-    // correct api (e.g. "openai-codex-responses" for gpt-5.4).  #39682
-    if (inlineMatch.api) {
-      return normalizeModelCompat(inlineMatch as Model<Api>);
-    }
+  if (inlineMatch?.api) {
+    return normalizeModelCompat(inlineMatch as Model<Api>);
   }
 
   // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.


### PR DESCRIPTION
## Summary
- simplify the inline-model guard to avoid unnecessary line churn
- extend the regression to assert configured `baseUrl` and headers still survive the codex forward-compat path
- follow up on #39753, which merged the functional fix but not this cleanup

## Testing
- pnpm check
- pnpm build
- pnpm test
