### PR TITLE
feat(telegram): scope reply and streaming settings per conversation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9796,99 +9796,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 1614
-=======
         "line_number": 1623
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 1630
-=======
         "line_number": 1639
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 1817
-=======
         "line_number": 1824
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 1990
-=======
         "line_number": 1997
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 2046
-=======
         "line_number": 2053
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 2278
-=======
         "line_number": 2285
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 2408
-=======
         "line_number": 2413
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 2661
-=======
         "line_number": 2666
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 2663
-=======
         "line_number": 2668
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       }
     ],
     "docs/gateway/configuration.md": [
@@ -13071,9 +13035,5 @@
       }
     ]
   },
-<<<<<<< HEAD
-  "generated_at": "2026-03-09T01:11:58Z"
-=======
   "generated_at": "2026-03-09T02:36:58Z"
->>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9789,70 +9789,106 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 199
+        "line_number": 209
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 1614
+=======
+        "line_number": 1623
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 1630
+=======
+        "line_number": 1639
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 1817
+=======
+        "line_number": 1824
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 1990
+=======
+        "line_number": 1997
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 2046
+=======
+        "line_number": 2053
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 2278
+=======
+        "line_number": 2285
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 2408
+=======
+        "line_number": 2413
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 2661
+=======
+        "line_number": 2666
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 2663
+=======
+        "line_number": 2668
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
       }
     ],
     "docs/gateway/configuration.md": [
@@ -13035,5 +13071,9 @@
       }
     ]
   },
+<<<<<<< HEAD
   "generated_at": "2026-03-09T01:11:58Z"
+=======
+  "generated_at": "2026-03-09T02:36:58Z"
+>>>>>>> 3d0cf7279b (fix(ci): regenerate swift host env policy and refresh secrets baseline)
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9796,63 +9796,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1623
+        "line_number": 1625
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1639
+        "line_number": 1641
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1824
+        "line_number": 1828
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1997
+        "line_number": 2001
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2053
+        "line_number": 2057
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2285
+        "line_number": 2289
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2413
+        "line_number": 2419
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2666
+        "line_number": 2672
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2668
+        "line_number": 2674
       }
     ],
     "docs/gateway/configuration.md": [
@@ -13035,5 +13035,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-09T02:36:58Z"
+  "generated_at": "2026-03-09T03:16:12Z"
 }

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -247,6 +247,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     For text-only replies:
 
     - DM: OpenClaw keeps the same preview message and performs a final edit in place (no second message)
+    - DM replies preserve `reply_to_message_id` by keeping the preview attached to the quoted message
     - group/topic: OpenClaw keeps the same preview message and performs a final edit in place (no second message)
 
     For complex replies (for example media payloads), OpenClaw falls back to normal final delivery and then cleans up the preview message.
@@ -870,7 +871,7 @@ Primary reference:
 - `channels.telegram.textChunkLimit`: outbound chunk size (chars).
 - `channels.telegram.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
-- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). Telegram preview streaming uses a single preview message that is edited in place.
+- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). Telegram preview streaming uses a single preview message that is edited in place; quoted DM replies preserve `reply_to_message_id` by keeping the preview attached to the quoted message.
 - `channels.telegram.mediaMaxMb`: inbound/outbound Telegram media cap (MB, default: 100).
 - `channels.telegram.retry`: retry policy for Telegram send helpers (CLI/tools/actions) on recoverable outbound API errors (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to enabled on Node 22+, with WSL2 defaulting to disabled.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -237,10 +237,15 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     - direct chats: preview message + `editMessageText`
     - groups/topics: preview message + `editMessageText`
+    - conversation overrides: `direct.<id>`, `groups.<id>`, and `topics.<threadId>` can each
+      choose their own `streaming` mode
 
     Requirement:
 
     - `channels.telegram.streaming` is `off | partial | block | progress` (default: `partial`)
+    - `channels.telegram.direct.<id>.streaming`, `channels.telegram.groups.<id>.streaming`, and
+      `channels.telegram.groups.<id>.topics.<threadId>.streaming` override the account default for
+      that specific conversation
     - `progress` maps to `partial` on Telegram (compat with cross-channel naming)
     - legacy `channels.telegram.streamMode` and boolean `streaming` values are auto-mapped
 
@@ -854,6 +859,8 @@ Primary reference:
 - `channels.telegram.groups`: per-group defaults + allowlist (use `"*"` for global defaults).
   - `channels.telegram.groups.<id>.groupPolicy`: per-group override for groupPolicy (`open | allowlist | disabled`).
   - `channels.telegram.groups.<id>.requireMention`: mention gating default.
+  - `channels.telegram.groups.<id>.replyToMode`: per-group reply threading override (`off | first | all`).
+  - `channels.telegram.groups.<id>.streaming`: per-group preview streaming override (`off | partial | block | progress`).
   - `channels.telegram.groups.<id>.skills`: skill filter (omit = all skills, empty = none).
   - `channels.telegram.groups.<id>.allowFrom`: per-group sender allowlist override.
   - `channels.telegram.groups.<id>.systemPrompt`: extra system prompt for the group.
@@ -862,16 +869,24 @@ Primary reference:
   - `channels.telegram.groups.<id>.topics.<threadId>.agentId`: route this topic to a specific agent (overrides group-level and binding routing).
   - `channels.telegram.groups.<id>.topics.<threadId>.groupPolicy`: per-topic override for groupPolicy (`open | allowlist | disabled`).
   - `channels.telegram.groups.<id>.topics.<threadId>.requireMention`: per-topic mention gating override.
+  - `channels.telegram.groups.<id>.topics.<threadId>.replyToMode`: per-topic reply threading override.
+  - `channels.telegram.groups.<id>.topics.<threadId>.streaming`: per-topic preview streaming override.
   - top-level `bindings[]` with `type: "acp"` and canonical topic id `chatId:topic:topicId` in `match.peer.id`: persistent ACP topic binding fields (see [ACP Agents](/tools/acp-agents#channel-specific-settings)).
+  - `channels.telegram.direct.<id>.replyToMode`: per-DM reply threading override (`off | first | all`).
+  - `channels.telegram.direct.<id>.streaming`: per-DM preview streaming override (`off | partial | block | progress`).
   - `channels.telegram.direct.<id>.topics.<threadId>.agentId`: route DM topics to a specific agent (same behavior as forum topics).
+  - `channels.telegram.direct.<id>.topics.<threadId>.replyToMode`: per-DM-topic reply threading override.
+  - `channels.telegram.direct.<id>.topics.<threadId>.streaming`: per-DM-topic preview streaming override.
 - `channels.telegram.capabilities.inlineButtons`: `off | dm | group | all | allowlist` (default: allowlist).
 - `channels.telegram.accounts.<account>.capabilities.inlineButtons`: per-account override.
 - `channels.telegram.commands.nativeSkills`: enable/disable Telegram native skills commands.
 - `channels.telegram.replyToMode`: `off | first | all` (default: `off`).
+- `channels.telegram.direct.<id>.replyToMode`, `channels.telegram.groups.<id>.replyToMode`, `channels.telegram.groups.<id>.topics.<threadId>.replyToMode`: conversation-scoped reply threading overrides.
 - `channels.telegram.textChunkLimit`: outbound chunk size (chars).
 - `channels.telegram.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
 - `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). Telegram preview streaming uses a single preview message that is edited in place; quoted DM replies preserve `reply_to_message_id` by keeping the preview attached to the quoted message.
+- `channels.telegram.direct.<id>.streaming`, `channels.telegram.groups.<id>.streaming`, `channels.telegram.groups.<id>.topics.<threadId>.streaming`: conversation-scoped preview streaming overrides.
 - `channels.telegram.mediaMaxMb`: inbound/outbound Telegram media cap (MB, default: 100).
 - `channels.telegram.retry`: retry policy for Telegram send helpers (CLI/tools/actions) on recoverable outbound API errors (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to enabled on Node 22+, with WSL2 defaulting to disabled.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -163,14 +163,24 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         "*": { requireMention: true },
         "-1001234567890": {
           allowFrom: ["@admin"],
+          replyToMode: "all",
+          streaming: "block",
           systemPrompt: "Keep answers brief.",
           topics: {
             "99": {
               requireMention: false,
+              replyToMode: "off",
+              streaming: "off",
               skills: ["search"],
               systemPrompt: "Stay on topic.",
             },
           },
+        },
+      },
+      direct: {
+        "123456789": {
+          replyToMode: "off",
+          streaming: "partial",
         },
       },
       customCommands: [
@@ -209,6 +219,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).
 - Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for forum topics (use canonical `chatId:topic:topicId` in `match.peer.id`). Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
 - Telegram stream previews use `sendMessage` + `editMessageText` (works in direct and group chats).
+- `channels.telegram.direct.<id>`, `channels.telegram.groups.<id>`, and `*.topics.<threadId>` can override `replyToMode` and `streaming` per conversation.
 - Retry policy: see [Retry policy](/concepts/retry).
 
 ### Discord

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -184,6 +184,8 @@ export type TelegramTopicConfig = {
   requireMention?: boolean;
   /** Per-topic override for group message policy (open|disabled|allowlist). */
   groupPolicy?: GroupPolicy;
+  /** Per-topic reply threading override (off|first|all). */
+  replyToMode?: ReplyToMode;
   /** If specified, only load these skills for this topic. Omit = all skills; empty = no skills. */
   skills?: string[];
   /** If false, disable the bot for this topic. */
@@ -194,6 +196,10 @@ export type TelegramTopicConfig = {
   systemPrompt?: string;
   /** If true, skip automatic voice-note transcription for mention detection in this topic. */
   disableAudioPreflight?: boolean;
+  /** Per-topic preview streaming override. */
+  streaming?: TelegramStreamingMode | boolean;
+  /** @deprecated Legacy preview mode key; migrated automatically to `streaming`. */
+  streamMode?: "off" | "partial" | "block";
   /** Route this topic to a specific agent (overrides group-level and binding routing). */
   agentId?: string;
 };
@@ -202,6 +208,8 @@ export type TelegramGroupConfig = {
   requireMention?: boolean;
   /** Per-group override for group message policy (open|disabled|allowlist). */
   groupPolicy?: GroupPolicy;
+  /** Per-group reply threading override (off|first|all). */
+  replyToMode?: ReplyToMode;
   /** Optional tool policy overrides for this group. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -217,11 +225,17 @@ export type TelegramGroupConfig = {
   systemPrompt?: string;
   /** If true, skip automatic voice-note transcription for mention detection in this group. */
   disableAudioPreflight?: boolean;
+  /** Per-group preview streaming override. */
+  streaming?: TelegramStreamingMode | boolean;
+  /** @deprecated Legacy preview mode key; migrated automatically to `streaming`. */
+  streamMode?: "off" | "partial" | "block";
 };
 
 export type TelegramDirectConfig = {
   /** Per-DM override for DM message policy (open|disabled|allowlist). */
   dmPolicy?: DmPolicy;
+  /** Per-DM reply threading override (off|first|all). */
+  replyToMode?: ReplyToMode;
   /** Optional tool policy overrides for this DM. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -237,6 +251,10 @@ export type TelegramDirectConfig = {
   allowFrom?: Array<string | number>;
   /** Optional system prompt snippet for this DM. */
   systemPrompt?: string;
+  /** Per-DM preview streaming override. */
+  streaming?: TelegramStreamingMode | boolean;
+  /** @deprecated Legacy preview mode key; migrated automatically to `streaming`. */
+  streamMode?: "off" | "partial" | "block";
 };
 
 export type TelegramConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -64,10 +64,13 @@ export const TelegramTopicSchema = z
     requireMention: z.boolean().optional(),
     disableAudioPreflight: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional(),
+    replyToMode: ReplyToModeSchema.optional(),
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
+    streamMode: z.enum(["off", "partial", "block"]).optional(),
     agentId: z.string().optional(),
   })
   .strict();
@@ -77,12 +80,15 @@ export const TelegramGroupSchema = z
     requireMention: z.boolean().optional(),
     disableAudioPreflight: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional(),
+    replyToMode: ReplyToModeSchema.optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
+    streamMode: z.enum(["off", "partial", "block"]).optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
   })
   .strict();
@@ -90,12 +96,15 @@ export const TelegramGroupSchema = z
 export const TelegramDirectSchema = z
   .object({
     dmPolicy: DmPolicySchema.optional(),
+    replyToMode: ReplyToModeSchema.optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
+    streamMode: z.enum(["off", "partial", "block"]).optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
     requireTopic: z.boolean().optional(),
   })

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -567,7 +567,12 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: {
+                source: "file",
+                path: secretFile,
+                mode: "json",
+                ...(process.platform === "win32" ? { allowInsecurePath: true } : {}),
+              },
             },
           },
           models: {
@@ -658,7 +663,12 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: {
+                source: "file",
+                path: secretFile,
+                mode: "json",
+                ...(process.platform === "win32" ? { allowInsecurePath: true } : {}),
+              },
             },
           },
           models: {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -143,6 +143,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     telegramCfg?: Parameters<typeof dispatchTelegramMessage>[0]["telegramCfg"];
     streamMode?: Parameters<typeof dispatchTelegramMessage>[0]["streamMode"];
     bot?: Bot;
+    replyToMode?: Parameters<typeof dispatchTelegramMessage>[0]["replyToMode"];
   }) {
     const bot = params.bot ?? createBot();
     await dispatchTelegramMessage({
@@ -150,7 +151,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       bot,
       cfg: {},
       runtime: createRuntime(),
-      replyToMode: "first",
+      replyToMode: params.replyToMode ?? "first",
       streamMode: params.streamMode ?? "partial",
       textLimit: 4096,
       telegramCfg: params.telegramCfg ?? {},
@@ -1184,7 +1185,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
 
-    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "partial",
+      replyToMode: "off",
+    });
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(2);
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
@@ -1196,6 +1201,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
+        previewTransport: "message",
+      }),
+    );
+  });
+
+  it("uses message preview transport for quoted DM answer previews", async () => {
+    setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        thread: { id: 777, scope: "dm" },
+        replyToMessageId: 456,
         previewTransport: "message",
       }),
     );
@@ -1216,7 +1244,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     deliverReplies.mockResolvedValue({ delivered: true });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      replyToMode: "off",
+    });
 
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
@@ -1232,6 +1264,43 @@ describe("dispatchTelegramMessage draft streaming", () => {
       "Checking the directory...",
       expect.any(Object),
     );
+  });
+
+  it("edits quoted DM previews in place without sending a duplicate final message", async () => {
+    const answerDraftStream = createDraftStream(321);
+    const reasoningDraftStream = createDraftStream(111);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "321" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        thread: { id: 777, scope: "dm" },
+        replyToMessageId: 456,
+        previewTransport: "message",
+      }),
+    );
+    expect(answerDraftStream.materialize).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      321,
+      "Checking the directory...",
+      expect.objectContaining({
+        linkPreview: undefined,
+      }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("keeps reasoning and answer streaming in separate preview lanes", async () => {

--- a/src/telegram/bot-message.test.ts
+++ b/src/telegram/bot-message.test.ts
@@ -35,7 +35,7 @@ describe("telegram bot message processor", () => {
     resolveGroupRequireMention: () => false,
     resolveTelegramGroupConfig: () => ({}),
     runtime: {},
-    replyToMode: "auto",
+    replyToMode: "off",
     streamMode: "partial",
     textLimit: 4096,
     opts: {},
@@ -43,12 +43,14 @@ describe("telegram bot message processor", () => {
 
   async function processSampleMessage(
     processMessage: ReturnType<typeof createTelegramMessageProcessor>,
+    message?: Record<string, unknown>,
   ) {
     await processMessage(
       {
         message: {
           chat: { id: 123, type: "private", title: "chat" },
           message_id: 456,
+          ...message,
         },
       } as unknown as Parameters<typeof processMessage>[0],
       [],
@@ -64,6 +66,52 @@ describe("telegram bot message processor", () => {
     await processSampleMessage(processMessage);
 
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies direct-scoped reply and streaming overrides before dispatch", async () => {
+    buildTelegramMessageContext.mockResolvedValue({ route: { sessionKey: "agent:main:main" } });
+
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { replyToMode: "all", streaming: "off" },
+      }),
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    await processSampleMessage(processMessage);
+
+    expect(dispatchTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMode: "all",
+        streamMode: "off",
+      }),
+    );
+  });
+
+  it("applies topic overrides above group defaults before dispatch", async () => {
+    buildTelegramMessageContext.mockResolvedValue({ route: { sessionKey: "agent:main:main" } });
+
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      replyToMode: "first",
+      streamMode: "partial",
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { replyToMode: "off", streaming: "block" },
+        topicConfig: { replyToMode: "all", streaming: "off" },
+      }),
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    await processSampleMessage(processMessage, {
+      chat: { id: -100123, type: "supergroup", title: "ops", is_forum: true },
+      message_thread_id: 99,
+    });
+
+    expect(dispatchTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMode: "all",
+        streamMode: "off",
+      }),
+    );
   });
 
   it("skips dispatch when no context is produced", async () => {

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -9,6 +9,11 @@ import {
 } from "./bot-message-context.js";
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import type { TelegramBotOptions } from "./bot.js";
+import {
+  resolveTelegramEffectiveReplyToMode,
+  resolveTelegramEffectiveStreamMode,
+  resolveTelegramThreadSpec,
+} from "./bot/helpers.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
 
 /** Dependencies injected once when creating the message processor. */
@@ -55,6 +60,24 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     options?: { messageIdOverride?: string; forceWasMentioned?: boolean },
     replyMedia?: TelegramMediaRef[],
   ) => {
+    const msg = primaryCtx.message;
+    const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+    const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+    const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+    const threadSpec = resolveTelegramThreadSpec({
+      isGroup,
+      isForum,
+      messageThreadId,
+    });
+    const configThreadId =
+      threadSpec.scope === "forum" || threadSpec.scope === "dm" ? threadSpec.id : undefined;
+    const { groupConfig, topicConfig } = resolveTelegramGroupConfig(msg.chat.id, configThreadId);
+    const effectiveReplyToMode = resolveTelegramEffectiveReplyToMode(topicConfig, groupConfig, {
+      replyToMode,
+    });
+    const effectiveStreamMode = resolveTelegramEffectiveStreamMode(topicConfig, groupConfig, {
+      streaming: streamMode,
+    });
     const context = await buildTelegramMessageContext({
       primaryCtx,
       allMedia,
@@ -85,8 +108,8 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         bot,
         cfg,
         runtime,
-        replyToMode,
-        streamMode,
+        replyToMode: effectiveReplyToMode,
+        streamMode: effectiveStreamMode,
         textLimit,
         telegramCfg,
         opts,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -59,6 +59,7 @@ import {
   buildTelegramThreadParams,
   buildSenderName,
   buildTelegramGroupFrom,
+  resolveTelegramEffectiveReplyToMode,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
@@ -82,7 +83,7 @@ type TelegramCommandAuthResult = {
   resolvedThreadId?: number;
   senderId: string;
   senderUsername: string;
-  groupConfig?: TelegramGroupConfig;
+  groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
   topicConfig?: TelegramTopicConfig;
   commandAuthorized: boolean;
 };
@@ -101,7 +102,10 @@ export type RegisterTelegramHandlerParams = {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  ) => {
+    groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
+    topicConfig?: TelegramTopicConfig;
+  };
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   processMessage: (
     ctx: TelegramContext,
@@ -134,7 +138,10 @@ type RegisterTelegramNativeCommandsParams = {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  ) => {
+    groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
+    topicConfig?: TelegramTopicConfig;
+  };
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   opts: { token: string };
 };
@@ -152,7 +159,10 @@ async function resolveTelegramCommandAuth(params: {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  ) => {
+    groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
+    topicConfig?: TelegramTopicConfig;
+  };
   requireAuth: boolean;
 }): Promise<TelegramCommandAuthResult | null> {
   const {
@@ -518,6 +528,7 @@ export const registerTelegramNativeCommands = ({
     accountId: string;
     mediaLocalRoots?: readonly string[];
     threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
+    replyToMode: ReplyToMode;
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: ReturnType<typeof resolveChunkMode>;
   }) => ({
@@ -527,7 +538,7 @@ export const registerTelegramNativeCommands = ({
     runtime,
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
-    replyToMode,
+    replyToMode: params.replyToMode,
     textLimit,
     thread: params.threadSpec,
     tableMode: params.tableMode,
@@ -589,11 +600,17 @@ export const registerTelegramNativeCommands = ({
             return;
           }
           const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
+          const effectiveReplyToMode = resolveTelegramEffectiveReplyToMode(
+            topicConfig,
+            groupConfig,
+            { replyToMode },
+          );
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
             accountId: route.accountId,
             mediaLocalRoots,
             threadSpec,
+            replyToMode: effectiveReplyToMode,
             tableMode,
             chunkMode,
           });
@@ -824,11 +841,17 @@ export const registerTelegramNativeCommands = ({
             return;
           }
           const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
+          const effectiveReplyToMode = resolveTelegramEffectiveReplyToMode(
+            auth.topicConfig,
+            auth.groupConfig,
+            { replyToMode },
+          );
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
             accountId: route.accountId,
             mediaLocalRoots,
             threadSpec,
+            replyToMode: effectiveReplyToMode,
             tableMode,
             chunkMode,
           });

--- a/src/telegram/bot.helpers.test.ts
+++ b/src/telegram/bot.helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveTelegramStreamMode } from "./bot/helpers.js";
+import {
+  resolveTelegramEffectiveReplyToMode,
+  resolveTelegramEffectiveStreamMode,
+  resolveTelegramStreamMode,
+} from "./bot/helpers.js";
 
 describe("resolveTelegramStreamMode", () => {
   it("defaults to partial when telegram streaming is unset", () => {
@@ -20,5 +24,41 @@ describe("resolveTelegramStreamMode", () => {
 
   it("maps unified progress mode to partial on Telegram", () => {
     expect(resolveTelegramStreamMode({ streaming: "progress" })).toBe("partial");
+  });
+});
+
+describe("resolveTelegramEffectiveReplyToMode", () => {
+  it("prefers topic over group/direct over account defaults", () => {
+    expect(
+      resolveTelegramEffectiveReplyToMode(
+        { replyToMode: "all" },
+        { replyToMode: "first" },
+        { replyToMode: "off" },
+      ),
+    ).toBe("all");
+  });
+
+  it("falls back to off when no override is configured", () => {
+    expect(resolveTelegramEffectiveReplyToMode(undefined, undefined, undefined)).toBe("off");
+  });
+});
+
+describe("resolveTelegramEffectiveStreamMode", () => {
+  it("prefers topic over group/direct over account defaults", () => {
+    expect(
+      resolveTelegramEffectiveStreamMode(
+        { streaming: "off" },
+        { streaming: "block" },
+        { streaming: "partial" },
+      ),
+    ).toBe("off");
+  });
+
+  it("supports legacy streamMode overrides in scoped configs", () => {
+    expect(resolveTelegramEffectiveStreamMode({ streamMode: "block" }, undefined)).toBe("block");
+  });
+
+  it("defaults to partial when no scoped override is configured", () => {
+    expect(resolveTelegramEffectiveStreamMode(undefined, undefined, undefined)).toBe("partial");
   });
 });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -2,6 +2,8 @@ import type { Chat, Message, MessageOrigin, User } from "@grammyjs/types";
 import { formatLocationText, type NormalizedLocation } from "../../channels/location.js";
 import { resolveTelegramPreviewStreamMode } from "../../config/discord-preview-streaming.js";
 import type {
+  ReplyToMode,
+  TelegramAccountConfig,
   TelegramDirectConfig,
   TelegramGroupConfig,
   TelegramTopicConfig,
@@ -169,6 +171,34 @@ export function resolveTelegramStreamMode(telegramCfg?: {
   streamMode?: unknown;
 }): TelegramStreamMode {
   return resolveTelegramPreviewStreamMode(telegramCfg);
+}
+
+type TelegramReplyStreamConfig =
+  | Pick<TelegramAccountConfig, "replyToMode" | "streaming" | "streamMode">
+  | Pick<TelegramGroupConfig, "replyToMode" | "streaming" | "streamMode">
+  | Pick<TelegramDirectConfig, "replyToMode" | "streaming" | "streamMode">
+  | Pick<TelegramTopicConfig, "replyToMode" | "streaming" | "streamMode">;
+
+export function resolveTelegramEffectiveReplyToMode(
+  ...configs: Array<TelegramReplyStreamConfig | undefined>
+): ReplyToMode {
+  for (const cfg of configs) {
+    if (cfg?.replyToMode) {
+      return cfg.replyToMode;
+    }
+  }
+  return "off";
+}
+
+export function resolveTelegramEffectiveStreamMode(
+  ...configs: Array<TelegramReplyStreamConfig | undefined>
+): TelegramStreamMode {
+  for (const cfg of configs) {
+    if (typeof cfg?.streaming !== "undefined" || typeof cfg?.streamMode !== "undefined") {
+      return resolveTelegramStreamMode(cfg);
+    }
+  }
+  return "partial";
 }
 
 export function buildTelegramGroupPeerId(chatId: number | string, messageThreadId?: number) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram `replyToMode` and preview `streaming` were effectively account-wide defaults, so direct chats, groups, and topics could not choose different reply styles.
- Why it matters: some users want quoted live replies, others want plain 1:1 live replies, and Telegram quoted streaming must not regress into the old preview-message + final-message + delete-preview behavior.
- What changed: added Telegram `replyToMode` and `streaming` overrides to `direct`, `groups`, and `topics`; resolved those settings per conversation before dispatch; applied the same reply-threading override to native command replies; documented the new config surface.
- What did NOT change (scope boundary): this PR does not add command-based preference persistence, UI controls, or non-Telegram channel changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #39880

## User-visible / Behavior Changes

- Telegram now accepts conversation-scoped `replyToMode` overrides under:
  - `channels.telegram.direct.<id>.replyToMode`
  - `channels.telegram.groups.<id>.replyToMode`
  - `channels.telegram.groups.<id>.topics.<threadId>.replyToMode`
  - `channels.telegram.direct.<id>.topics.<threadId>.replyToMode`
- Telegram now accepts conversation-scoped preview `streaming` overrides under the matching `direct/group/topic` scopes.
- Telegram auto replies now resolve quoted-vs-non-quoted behavior per conversation instead of forcing one account-wide default.
- Telegram native command replies now honor the same per-conversation reply threading override.
- Quoted DM live streaming stays attached to one reply message instead of creating a temporary preview message, then sending a second final message, then deleting the first one.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu on WSL2
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A (unit/integration-style Telegram channel tests)
- Integration/channel (if any): Telegram
- Relevant config (redacted): account-level `channels.telegram.replyToMode/streaming` plus scoped overrides under `direct`, `groups`, and `topics`

### Steps

1. Configure Telegram account defaults with quoted replies and live preview enabled.
2. Add scoped overrides for one DM / one group / one topic with different `replyToMode` or `streaming` values.
3. Send Telegram replies through the message processor and native command path.
4. Exercise quoted DM preview streaming.

### Expected

- Scoped overrides win over account defaults for the targeted DM/group/topic.
- Quoted DM live preview stays in a single reply message and does not create a second final message.

### Actual

- Before this change, Telegram always used account-level `replyToMode` / `streaming` defaults.
- Before this change, quoted DM live preview could materialize as a temporary streamed message plus a second final reply.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/telegram/bot.helpers.test.ts src/telegram/bot-message.test.ts src/telegram/draft-stream.test.ts src/telegram/bot-message-dispatch.test.ts`
  - `pnpm vitest run src/telegram/bot-native-commands.test.ts src/telegram/bot-native-commands.group-auth.test.ts src/telegram/bot-native-commands.plugin-auth.test.ts src/telegram/bot-native-commands.session-meta.test.ts src/telegram/bot-native-commands.skills-allowlist.test.ts`
  - confirmed processor-level scoped overrides for DM and topic/group paths via updated unit tests
  - confirmed quoted DM preview streaming path still stays on one reply message via existing `draft-stream` coverage in this branch
- Edge cases checked:
  - topic override precedence over group/account defaults
  - legacy scoped `streamMode` still resolves correctly
  - native command replies follow scoped `replyToMode`
- What you did **not** verify:
  - live manual Telegram traffic against the real Bot API from this source checkout
  - non-Telegram channels

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - remove the scoped Telegram overrides and fall back to account-level `channels.telegram.replyToMode` / `channels.telegram.streaming`
  - revert commits `417217f8d2` and `45cba36cdf`
- Files/config to restore:
  - `src/telegram/bot-message.ts`
  - `src/telegram/bot-native-commands.ts`
  - `src/telegram/bot/helpers.ts`
  - `src/config/types.telegram.ts`
  - `src/config/zod-schema.providers-core.ts`
- Known bad symptoms reviewers should watch for:
  - scoped DM/group/topic reply settings appear ignored
  - quoted Telegram streaming creates two messages or deletes the streamed preview after final delivery

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: scoped override precedence could diverge between normal replies and native command replies.
  - Mitigation: both paths now use the same helper-based reply mode resolution, with tests covering processor dispatch and native command delivery.
- Risk: quoted DM streaming could regress back to preview/final double delivery when scoped overrides are enabled.
  - Mitigation: this branch includes the quoted DM single-message preview fix and keeps the dedicated `draft-stream` test coverage green.
