### PR TITLE
Hide direct-chat sender metadata from model context

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -18,14 +18,6 @@ function parseConversationInfoPayload(text: string): Record<string, unknown> {
   return JSON.parse(match[1]) as Record<string, unknown>;
 }
 
-function parseSenderInfoPayload(text: string): Record<string, unknown> {
-  const match = text.match(/Sender \(untrusted metadata\):\n```json\n([\s\S]*?)\n```/);
-  if (!match?.[1]) {
-    throw new Error("missing sender info json block");
-  }
-  return JSON.parse(match[1]) as Record<string, unknown>;
-}
-
 describe("buildInboundMetaSystemPrompt", () => {
   it("includes session-stable routing fields", () => {
     const prompt = buildInboundMetaSystemPrompt({
@@ -134,7 +126,8 @@ describe("buildInboundUserContextPrefix", () => {
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["message_id"]).toBe("short-id");
     expect(conversationInfo["message_id_full"]).toBeUndefined();
-    expect(conversationInfo["sender"]).toBe("+15551234567");
+    expect(conversationInfo["sender"]).toBeUndefined();
+    expect(conversationInfo["sender_id"]).toBeUndefined();
     expect(conversationInfo["conversation_label"]).toBeUndefined();
   });
 
@@ -194,16 +187,14 @@ describe("buildInboundUserContextPrefix", () => {
     expect(conversationInfo["sender"]).toBe("Tyler");
   });
 
-  it("includes sender metadata block for direct chats", () => {
+  it("omits sender metadata block for direct chats", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",
       SenderName: "Tyler",
       SenderId: "+15551234567",
     } as TemplateContext);
 
-    const senderInfo = parseSenderInfoPayload(text);
-    expect(senderInfo["label"]).toBe("Tyler (+15551234567)");
-    expect(senderInfo["id"]).toBe("+15551234567");
+    expect(text).not.toContain("Sender (untrusted metadata):");
   });
 
   it("includes formatted timestamp in conversation info when provided", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -90,6 +90,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     directChannelValue && directChannelValue !== "webchat",
   );
   const shouldIncludeConversationInfo = !isDirect || includeDirectConversationInfo;
+  const shouldExposeSenderIdentity = !isDirect;
 
   const messageId = safeTrim(ctx.MessageSid);
   const messageIdFull = safeTrim(ctx.MessageSidFull);
@@ -99,14 +100,18 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
-    sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
+    sender_id:
+      shouldIncludeConversationInfo && shouldExposeSenderIdentity
+        ? safeTrim(ctx.SenderId)
+        : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
-    sender: shouldIncludeConversationInfo
-      ? (safeTrim(ctx.SenderName) ??
-        safeTrim(ctx.SenderE164) ??
-        safeTrim(ctx.SenderId) ??
-        safeTrim(ctx.SenderUsername))
-      : undefined,
+    sender:
+      shouldIncludeConversationInfo && shouldExposeSenderIdentity
+        ? (safeTrim(ctx.SenderName) ??
+          safeTrim(ctx.SenderE164) ??
+          safeTrim(ctx.SenderId) ??
+          safeTrim(ctx.SenderUsername))
+        : undefined,
     timestamp: timestampStr,
     group_subject: safeTrim(ctx.GroupSubject),
     group_channel: safeTrim(ctx.GroupChannel),
@@ -136,18 +141,20 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   }
 
   const senderInfo = {
-    label: resolveSenderLabel({
-      name: safeTrim(ctx.SenderName),
-      username: safeTrim(ctx.SenderUsername),
-      tag: safeTrim(ctx.SenderTag),
-      e164: safeTrim(ctx.SenderE164),
-      id: safeTrim(ctx.SenderId),
-    }),
-    id: safeTrim(ctx.SenderId),
-    name: safeTrim(ctx.SenderName),
-    username: safeTrim(ctx.SenderUsername),
-    tag: safeTrim(ctx.SenderTag),
-    e164: safeTrim(ctx.SenderE164),
+    label: shouldExposeSenderIdentity
+      ? resolveSenderLabel({
+          name: safeTrim(ctx.SenderName),
+          username: safeTrim(ctx.SenderUsername),
+          tag: safeTrim(ctx.SenderTag),
+          e164: safeTrim(ctx.SenderE164),
+          id: safeTrim(ctx.SenderId),
+        })
+      : undefined,
+    id: shouldExposeSenderIdentity ? safeTrim(ctx.SenderId) : undefined,
+    name: shouldExposeSenderIdentity ? safeTrim(ctx.SenderName) : undefined,
+    username: shouldExposeSenderIdentity ? safeTrim(ctx.SenderUsername) : undefined,
+    tag: shouldExposeSenderIdentity ? safeTrim(ctx.SenderTag) : undefined,
+    e164: shouldExposeSenderIdentity ? safeTrim(ctx.SenderE164) : undefined,
   };
   if (senderInfo?.label) {
     blocks.push(


### PR DESCRIPTION
Title: Hide direct-chat sender metadata from model context

Body:

## Summary

This PR stops OpenClaw from injecting direct-chat sender identity fields into the model-visible inbound metadata prefix.

For direct chats, `buildInboundUserContextPrefix()` now keeps message-level context such as `message_id`, but omits:

- `sender_id`
- `sender`
- the `Sender (untrusted metadata)` block

Group-chat behavior is unchanged.

## Why

In a live Tiffany LINE deployment, the agent correctly used user identity for routing/session continuity, but the model could also see raw sender identity fields in the direct-chat metadata prefix and sometimes echoed them back to the end user.

This change narrows the model-visible context for direct chats while preserving routing/session behavior outside the model prompt.

## Testing

- AI-assisted change
- Verified live on a local Tiffany LINE deployment: direct-chat replies no longer exposed raw LINE user IDs after the hotfix was loaded
- `pnpm exec vitest run src/auto-reply/reply/inbound-meta.test.ts`

## Notes

- I did not run the full `pnpm build && pnpm check && pnpm test` suite in this branch; only the focused inbound metadata test was run for this patch.
- This PR is intentionally scoped to direct-chat sender metadata exposure only.
