### PR TITLE
feat(feishu): add owner transfer support to permission tool

### DIFF
--- a/extensions/feishu/skills/feishu-perm/SKILL.md
+++ b/extensions/feishu/skills/feishu-perm/SKILL.md
@@ -6,7 +6,7 @@ description: |
 
 # Feishu Permission Tool
 
-Single tool `feishu_perm` for managing file/document permissions.
+Single tool `feishu_perm` for managing file/document permissions and ownership transfer.
 
 ## Actions
 
@@ -43,6 +43,27 @@ Returns: members with member_type, member_id, perm, name.
 }
 ```
 
+### Transfer Ownership
+
+```json
+{
+  "action": "transfer",
+  "token": "ABC123",
+  "type": "docx",
+  "member_type": "openid",
+  "member_id": "ou_xxx",
+  "remove_old_owner": true,
+  "old_owner_perm": "view"
+}
+```
+
+Optional transfer fields:
+
+- `need_notification` (default `false`)
+- `remove_old_owner`
+- `stay_put`
+- `old_owner_perm`
+
 ## Token Types
 
 | Type       | Description             |
@@ -55,6 +76,8 @@ Returns: members with member_type, member_id, perm, name.
 | `file`     | Uploaded file           |
 | `wiki`     | Wiki node               |
 | `mindnote` | Mind map                |
+| `minutes`  | Meeting minutes         |
+| `slides`   | Slides                  |
 
 ## Member Types
 
@@ -66,6 +89,8 @@ Returns: members with member_type, member_id, perm, name.
 | `unionid`          | User union_id      |
 | `openchat`         | Group chat open_id |
 | `opendepartmentid` | Department open_id |
+
+Ownership transfer only accepts `member_type` values: `email`, `openid`, `userid`.
 
 ## Permission Levels
 

--- a/extensions/feishu/skills/feishu-perm/SKILL.md
+++ b/extensions/feishu/skills/feishu-perm/SKILL.md
@@ -52,7 +52,7 @@ Returns: members with member_type, member_id, perm, name.
   "type": "docx",
   "member_type": "openid",
   "member_id": "ou_xxx",
-  "remove_old_owner": true,
+  "remove_old_owner": false,
   "old_owner_perm": "view"
 }
 ```
@@ -63,6 +63,8 @@ Optional transfer fields:
 - `remove_old_owner`
 - `stay_put`
 - `old_owner_perm`
+
+Do not combine `remove_old_owner: true` with `old_owner_perm`, since the old owner cannot both be removed and retain a permission.
 
 ## Token Types
 

--- a/extensions/feishu/src/perm-schema.ts
+++ b/extensions/feishu/src/perm-schema.ts
@@ -9,6 +9,21 @@ const TokenType = Type.Union([
   Type.Literal("file"),
   Type.Literal("wiki"),
   Type.Literal("mindnote"),
+  Type.Literal("minutes"),
+  Type.Literal("slides"),
+]);
+
+const TransferTokenType = Type.Union([
+  Type.Literal("doc"),
+  Type.Literal("sheet"),
+  Type.Literal("file"),
+  Type.Literal("wiki"),
+  Type.Literal("bitable"),
+  Type.Literal("docx"),
+  Type.Literal("mindnote"),
+  Type.Literal("minutes"),
+  Type.Literal("slides"),
+  Type.Literal("folder"),
 ]);
 
 const MemberType = Type.Union([
@@ -18,6 +33,12 @@ const MemberType = Type.Union([
   Type.Literal("unionid"),
   Type.Literal("openchat"),
   Type.Literal("opendepartmentid"),
+]);
+
+const TransferMemberType = Type.Union([
+  Type.Literal("email"),
+  Type.Literal("openid"),
+  Type.Literal("userid"),
 ]);
 
 const Permission = Type.Union([
@@ -46,6 +67,25 @@ export const FeishuPermSchema = Type.Union([
     type: TokenType,
     member_type: MemberType,
     member_id: Type.String({ description: "Member ID to remove" }),
+  }),
+  Type.Object({
+    action: Type.Literal("transfer"),
+    token: Type.String({ description: "File token" }),
+    type: TransferTokenType,
+    member_type: TransferMemberType,
+    member_id: Type.String({ description: "New owner member ID" }),
+    need_notification: Type.Optional(
+      Type.Boolean({ description: "Whether to notify the new owner (default: false)" }),
+    ),
+    remove_old_owner: Type.Optional(
+      Type.Boolean({ description: "Whether to remove the old owner after transfer" }),
+    ),
+    stay_put: Type.Optional(
+      Type.Boolean({ description: "Whether the old owner stays in place after transfer" }),
+    ),
+    old_owner_perm: Type.Optional(
+      Type.String({ description: "Permission to keep for the old owner after transfer" }),
+    ),
   }),
 ]);
 

--- a/extensions/feishu/src/perm.test.ts
+++ b/extensions/feishu/src/perm.test.ts
@@ -1,0 +1,128 @@
+import { Value } from "@sinclair/typebox/value";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeishuPermSchema } from "./perm-schema.js";
+import { registerFeishuPermTools } from "./perm.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const listMock = vi.hoisted(() => vi.fn());
+const createMock = vi.hoisted(() => vi.fn());
+const deleteMock = vi.hoisted(() => vi.fn());
+const transferOwnerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: () => ({
+    drive: {
+      permissionMember: {
+        list: listMock,
+        create: createMock,
+        delete: deleteMock,
+        transferOwner: transferOwnerMock,
+      },
+    },
+  }),
+}));
+
+function createConfig(): OpenClawPluginApi["config"] {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          default: {
+            appId: "app-id",
+            appSecret: "app-secret", // pragma: allowlist secret
+            tools: {
+              perm: true,
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawPluginApi["config"];
+}
+
+describe("feishu perm tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts minutes and slides token types for non-transfer actions", () => {
+    expect(
+      Value.Check(FeishuPermSchema, {
+        action: "list",
+        token: "minutes-token",
+        type: "minutes",
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(FeishuPermSchema, {
+        action: "add",
+        token: "slides-token",
+        type: "slides",
+        member_type: "openid",
+        member_id: "ou_member",
+        perm: "view",
+      }),
+    ).toBe(true);
+  });
+
+  it("transfers ownership with the expected SDK payload and defaults", async () => {
+    transferOwnerMock.mockResolvedValue({ code: 0, msg: "ok" });
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm");
+    const result = await tool.execute("call", {
+      action: "transfer",
+      token: "doxcn123",
+      type: "docx",
+      member_type: "openid",
+      member_id: "ou_new_owner",
+      remove_old_owner: true,
+      stay_put: false,
+      old_owner_perm: "view",
+    });
+
+    expect(transferOwnerMock).toHaveBeenCalledWith({
+      path: { token: "doxcn123" },
+      params: {
+        type: "docx",
+        need_notification: false,
+        remove_old_owner: true,
+        stay_put: false,
+        old_owner_perm: "view",
+      },
+      data: {
+        member_type: "openid",
+        member_id: "ou_new_owner",
+      },
+    });
+    expect(result).toEqual({
+      content: [{ type: "text", text: '{\n  "success": true\n}' }],
+      details: { success: true },
+    });
+  });
+
+  it("returns a tool error when ownership transfer fails", async () => {
+    transferOwnerMock.mockResolvedValue({ code: 999, msg: "transfer denied" });
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm");
+    const result = await tool.execute("call", {
+      action: "transfer",
+      token: "doxcn123",
+      type: "docx",
+      member_type: "userid",
+      member_id: "ou_new_owner",
+    });
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: '{\n  "error": "transfer denied"\n}' }],
+      details: { error: "transfer denied" },
+    });
+  });
+});

--- a/extensions/feishu/src/perm.test.ts
+++ b/extensions/feishu/src/perm.test.ts
@@ -80,7 +80,7 @@ describe("feishu perm tool", () => {
       type: "docx",
       member_type: "openid",
       member_id: "ou_new_owner",
-      remove_old_owner: true,
+      remove_old_owner: false,
       stay_put: false,
       old_owner_perm: "view",
     });
@@ -90,7 +90,7 @@ describe("feishu perm tool", () => {
       params: {
         type: "docx",
         need_notification: false,
-        remove_old_owner: true,
+        remove_old_owner: false,
         stay_put: false,
         old_owner_perm: "view",
       },
@@ -102,6 +102,33 @@ describe("feishu perm tool", () => {
     expect(result).toEqual({
       content: [{ type: "text", text: '{\n  "success": true\n}' }],
       details: { success: true },
+    });
+  });
+
+  it("rejects contradictory old-owner transfer options before calling the SDK", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm");
+    const result = await tool.execute("call", {
+      action: "transfer",
+      token: "doxcn123",
+      type: "docx",
+      member_type: "openid",
+      member_id: "ou_new_owner",
+      remove_old_owner: true,
+      old_owner_perm: "view",
+    });
+
+    expect(transferOwnerMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: '{\n  "error": "remove_old_owner cannot be combined with old_owner_perm"\n}',
+        },
+      ],
+      details: { error: "remove_old_owner cannot be combined with old_owner_perm" },
     });
   });
 

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -30,6 +30,17 @@ type CreateTokenType =
   | "mindnote"
   | "minutes"
   | "slides";
+type TransferTokenType =
+  | "doc"
+  | "sheet"
+  | "file"
+  | "wiki"
+  | "bitable"
+  | "docx"
+  | "mindnote"
+  | "minutes"
+  | "slides"
+  | "folder";
 type MemberType =
   | "email"
   | "openid"
@@ -39,6 +50,7 @@ type MemberType =
   | "userid"
   | "groupid"
   | "wikispaceid";
+type TransferMemberType = "email" | "openid" | "userid";
 type PermType = "view" | "edit" | "full_access";
 
 // ============ Actions ============
@@ -110,6 +122,44 @@ async function removeMember(
   };
 }
 
+async function transferOwner(
+  client: Lark.Client,
+  token: string,
+  type: string,
+  memberType: string,
+  memberId: string,
+  options: {
+    need_notification?: boolean;
+    remove_old_owner?: boolean;
+    stay_put?: boolean;
+    old_owner_perm?: string;
+  },
+) {
+  const res = await client.drive.permissionMember.transferOwner({
+    path: { token },
+    params: {
+      type: type as TransferTokenType,
+      need_notification: options.need_notification ?? false,
+      ...(typeof options.remove_old_owner === "boolean"
+        ? { remove_old_owner: options.remove_old_owner }
+        : {}),
+      ...(typeof options.stay_put === "boolean" ? { stay_put: options.stay_put } : {}),
+      ...(options.old_owner_perm ? { old_owner_perm: options.old_owner_perm } : {}),
+    },
+    data: {
+      member_type: memberType as TransferMemberType,
+      member_id: memberId,
+    },
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    success: true,
+  };
+}
+
 // ============ Tool Registration ============
 
 export function registerFeishuPermTools(api: OpenClawPluginApi) {
@@ -138,7 +188,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
       return {
         name: "feishu_perm",
         label: "Feishu Perm",
-        description: "Feishu permission management. Actions: list, add, remove",
+        description: "Feishu permission management. Actions: list, add, remove, transfer",
         parameters: FeishuPermSchema,
         async execute(_toolCallId, params) {
           const p = params as FeishuPermExecuteParams;
@@ -158,6 +208,15 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
               case "remove":
                 return jsonToolResult(
                   await removeMember(client, p.token, p.type, p.member_type, p.member_id),
+                );
+              case "transfer":
+                return jsonToolResult(
+                  await transferOwner(client, p.token, p.type, p.member_type, p.member_id, {
+                    need_notification: p.need_notification,
+                    remove_old_owner: p.remove_old_owner,
+                    stay_put: p.stay_put,
+                    old_owner_perm: p.old_owner_perm,
+                  }),
                 );
               default:
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -135,6 +135,8 @@ async function transferOwner(
     old_owner_perm?: string;
   },
 ) {
+  validateTransferOptions(options);
+
   const res = await client.drive.permissionMember.transferOwner({
     path: { token },
     params: {
@@ -158,6 +160,12 @@ async function transferOwner(
   return {
     success: true,
   };
+}
+
+function validateTransferOptions(options: { remove_old_owner?: boolean; old_owner_perm?: string }) {
+  if (options.remove_old_owner === true && options.old_owner_perm) {
+    throw new Error("remove_old_owner cannot be combined with old_owner_perm");
+  }
 }
 
 // ============ Tool Registration ============


### PR DESCRIPTION
## Summary
- add a `transfer` action to `feishu_perm` backed by the Feishu/Lark `permissionMember.transferOwner` API
- extend the permission tool schema and skill docs for owner transfer support
- reject conflicting transfer options (`remove_old_owner=true` together with `old_owner_perm`) before calling the SDK
- add targeted tests for success, API failure, and conflicting transfer flag validation

## Testing
- pnpm test extensions/feishu/src/perm.test.ts