### PR TITLE
fix(ui): prefer matching object variant in config coercion

### DIFF
--- a/ui/src/ui/controllers/config/form-coerce.ts
+++ b/ui/src/ui/controllers/config/form-coerce.ts
@@ -26,6 +26,37 @@ function coerceBooleanString(value: string): boolean | string {
   return value;
 }
 
+function matchesConstConstraints(value: unknown, schema: JsonSchema): boolean {
+  if (schema.const !== undefined) {
+    return value === schema.const;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return true;
+  }
+  const record = value as Record<string, unknown>;
+  for (const [key, propSchema] of Object.entries(schema.properties ?? {})) {
+    if (propSchema.const === undefined) {
+      continue;
+    }
+    if (record[key] !== propSchema.const) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function pickMatchingObjectVariant(value: unknown, variants: JsonSchema[]): JsonSchema | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const objectVariants = variants.filter((variant) => schemaType(variant) === "object");
+  if (objectVariants.length === 0) {
+    return null;
+  }
+  const constMatched = objectVariants.filter((variant) => matchesConstConstraints(value, variant));
+  return constMatched[0] ?? objectVariants[0] ?? null;
+}
+
 /**
  * Walk a form value tree alongside its JSON Schema and coerce string values
  * to their schema-defined types (number, boolean).
@@ -81,12 +112,14 @@ export function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
       }
     }
 
-    // For non-string values (objects, arrays), try to recurse into matching variant
+    const matchedObjectVariant = pickMatchingObjectVariant(value, variants);
+    if (matchedObjectVariant) {
+      return coerceFormValues(value, matchedObjectVariant);
+    }
+
+    // For non-string values (arrays), try to recurse into matching variant
     for (const variant of variants) {
       const variantType = schemaType(variant);
-      if (variantType === "object" && typeof value === "object" && !Array.isArray(value)) {
-        return coerceFormValues(value, variant);
-      }
       if (variantType === "array" && Array.isArray(value)) {
         return coerceFormValues(value, variant);
       }

--- a/ui/src/ui/controllers/config/form-coerce.ts
+++ b/ui/src/ui/controllers/config/form-coerce.ts
@@ -34,15 +34,17 @@ function matchesConstConstraints(value: unknown, schema: JsonSchema): boolean {
     return true;
   }
   const record = value as Record<string, unknown>;
+  let sawConst = false;
   for (const [key, propSchema] of Object.entries(schema.properties ?? {})) {
     if (propSchema.const === undefined) {
       continue;
     }
+    sawConst = true;
     if (record[key] !== propSchema.const) {
       return false;
     }
   }
-  return true;
+  return sawConst;
 }
 
 function pickMatchingObjectVariant(value: unknown, variants: JsonSchema[]): JsonSchema | null {

--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -452,4 +452,64 @@ describe("coerceFormValues", () => {
     const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
     expect(coerced.flag).toBe(true);
   });
+
+  it("prefers matching anyOf object variant before coercing nested fields", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        settings: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                kind: { type: "string", const: "numeric" },
+                retries: { type: "number" },
+              },
+            },
+            {
+              type: "object",
+              properties: {
+                kind: { type: "string", const: "named" },
+                retries: { type: "string" },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const form = { settings: { kind: "named", retries: "03" } };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    const settings = coerced.settings as Record<string, unknown>;
+    expect(settings.retries).toBe("03");
+  });
+
+  it("prefers matching oneOf object variant before coercing nested fields", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        settings: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                mode: { type: "string", const: "numeric" },
+                retries: { type: "number" },
+              },
+            },
+            {
+              type: "object",
+              properties: {
+                mode: { type: "string", const: "named" },
+                retries: { type: "string" },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const form = { settings: { mode: "named", retries: "03" } };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    const settings = coerced.settings as Record<string, unknown>;
+    expect(settings.retries).toBe("03");
+  });
 });

--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -512,4 +512,33 @@ describe("coerceFormValues", () => {
     const settings = coerced.settings as Record<string, unknown>;
     expect(settings.retries).toBe("03");
   });
+
+  it("does not let unconstrained object variants outrank matching const variants", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        settings: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                retries: { type: "number" },
+              },
+            },
+            {
+              type: "object",
+              properties: {
+                kind: { type: "string", const: "named" },
+                retries: { type: "string" },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const form = { settings: { kind: "named", retries: "03" } };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    const settings = coerced.settings as Record<string, unknown>;
+    expect(settings.retries).toBe("03");
+  });
 });


### PR DESCRIPTION
## Summary

Prefer the matching object variant when coercing config form values through `anyOf` / `oneOf` unions.

## Problem

`coerceFormValues()` previously recursed into the first object variant it encountered for object-valued unions. In schemas that distinguish object variants using `const` discriminator fields, this could coerce nested values using the wrong variant.

For example, a value like `{ kind: "named", retries: "03" }` could be coerced using a preceding `numeric` variant and incorrectly turn `retries` into `3`.

## Changes

- prefer object variants whose top-level property `const` constraints match the current value- fall back to the first object variant only when no discriminator match exists- add regression tests for both `anyOf` and `oneOf` object unions

## Notes

This keeps coercion behavior unchanged for string/number/boolean unions while making object-union coercion more accurate for discriminated schemas.