### PR TITLE
docs: clarify bot review conversation ownership

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -92,7 +92,7 @@ What you personally verified (not just CI), and how:
 - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
 - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.
 
-If a bot comment is fixed by this PR, resolve that conversation yourself. Do not leave bot conversation cleanup for maintainers.
+If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.
 
 ## Compatibility / Migration
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -87,6 +87,13 @@ What you personally verified (not just CI), and how:
 - Edge cases checked:
 - What you did **not** verify:
 
+## Review Conversations
+
+- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
+- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.
+
+If a bot comment is fixed by this PR, resolve that conversation yourself. Do not leave bot conversation cleanup for maintainers.
+
 ## Compatibility / Migration
 
 - Backward compatible? (`Yes/No`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - GitHub comment footgun: never use `gh issue/pr comment -b "..."` when body contains backticks or shell chars. Always use single-quoted heredoc (`-F - <<'EOF'`) so no command substitution/escaping corruption.
 - GitHub linking footgun: don’t wrap issue/PR refs like `#24643` in backticks when you want auto-linking. Use plain `#24643` (optionally add full URL).
 - PR landing comments: always make commit SHAs clickable with full commit links (both landed SHA + source SHA when present).
+- PR review conversations: if a bot leaves review conversations on your PR, address them and resolve those conversations yourself once fixed. Leave a conversation unresolved only when reviewer or maintainer judgment is still needed; do not leave bot-conversation cleanup to maintainers.
 - GitHub searching footgun: don't limit yourself to the first 500 issues or PRs when wanting to search all. Unless you're supposed to look at the most recent, keep going until you've reached the last page in the search
 - Security advisory analysis: before triage/severity decisions, read `SECURITY.md` to align with OpenClaw's trust model and design boundaries.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,18 @@ Welcome to the lobster tank! 🦞
 - Ensure CI checks pass
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why
+- Reply to or resolve bot review conversations you addressed before asking for review again
 - **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
+
+## Review Conversations Are Author-Owned
+
+If a review bot leaves review conversations on your PR, you are expected to handle the follow-through:
+
+- Resolve the conversation yourself once the code or explanation fully addresses the bot's concern
+- Reply and leave it open only when you need maintainer or reviewer judgment
+- Do not leave "fixed" bot review conversations for maintainers to clean up for you
+
+This applies to both human-authored and AI-assisted PRs.
 
 ## Control UI Decorators
 
@@ -101,8 +112,9 @@ Please include in your PR:
 - [ ] Note the degree of testing (untested / lightly tested / fully tested)
 - [ ] Include prompts or session logs if possible (super helpful!)
 - [ ] Confirm you understand what the code does
+- [ ] Resolve or reply to bot review conversations after you address them
 
-AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for.
+AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for. If you are using an LLM coding agent, instruct it to resolve bot review conversations it has addressed instead of leaving them for maintainers.
 
 ## Current Focus & Roadmap 🗺
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Contributors and LLM coding agents do not have an explicit repo policy telling them to resolve bot review conversations they have already addressed.
- Why it matters: Maintainers end up spending time and tokens cleaning up already-resolved bot conversations.
- What changed: Added contributor-facing guidance to the PR template, `CONTRIBUTING.md`, and `AGENTS.md` that makes authors responsible for resolving addressed bot review conversations.
- What did NOT change (scope boundary): No CI, automation, merge gates, or code behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: None
- Related: None

## User-visible / Behavior Changes

Contributor expectations are now explicit: authors should resolve bot review conversations they have addressed, and leave conversations open only when reviewer or maintainer judgment is still needed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A (docs-only)
- Model/provider: N/A
- Integration/channel (if any): GitHub PR workflow
- Relevant config (redacted): N/A

### Steps

1. Open the PR template and contributor/agent guidance.
2. Confirm the new policy uses GitHub-accurate `review conversations` terminology.
3. Confirm the policy consistently assigns addressed bot conversations to PR authors.

### Expected

- Contributors and LLM coding agents see the same policy in the PR template, `CONTRIBUTING.md`, and `AGENTS.md`.

### Actual

- The three surfaces now consistently instruct authors to resolve addressed bot review conversations themselves.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification evidence: `git diff` and targeted `rg` checks were used to confirm the wording and remove leftover `review thread` terminology.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Read the PR template, `CONTRIBUTING.md`, and `AGENTS.md` after the edit and confirmed the policy text matches across all three.
- Edge cases checked: Verified the wording uses `review conversations` rather than the less accurate `review threads` terminology.
- What you did **not** verify: No GitHub UI automation or enforcement behavior was tested because this change is docs/template-only.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `.github/pull_request_template.md`, `CONTRIBUTING.md`, `AGENTS.md`
- Known bad symptoms reviewers should watch for: Contributor guidance feels too strict or confusing for docs-only and bot-only review feedback.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Contributors may read the policy as a hard merge gate rather than a workflow expectation.
  - Mitigation: The wording stays in docs/template guidance and does not add automation or blocking checks.
