### PR TITLE
fix(gateway): fail fast when startup model auth is missing

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -28,7 +28,7 @@ import {
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
-import { logAcceptedEnvOption } from "../infra/env.js";
+import { isTruthyEnvValue, logAcceptedEnvOption } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -114,6 +114,7 @@ import {
   mergeGatewayTailscaleConfig,
 } from "./startup-auth.js";
 import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-origins.js";
+import { ensureGatewayModelAuthConfigured } from "./startup-model-auth.js";
 
 export { __resetModelCatalogCacheForTest } from "./server-model-catalog.js";
 
@@ -460,6 +461,13 @@ export async function startGatewayServer(
     writeConfig: writeConfigFile,
     log,
   });
+
+  const skipChannelsAtStartup =
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
+  if (!minimalTestGateway && !skipChannelsAtStartup) {
+    await ensureGatewayModelAuthConfigured({ cfg: cfgAtStart });
+  }
 
   initSubagentRegistry();
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
@@ -1053,3 +1061,4 @@ export async function startGatewayServer(
     },
   };
 }
+

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -455,6 +455,43 @@ describe("gateway server misc", () => {
     });
   });
 
+  test("fails fast when configured startup model has no auth and channels are enabled", async () => {
+    const configPath = process.env.OPENCLAW_CONFIG_PATH;
+    if (!configPath) {
+      throw new Error("Missing OPENCLAW_CONFIG_PATH");
+    }
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          agents: {
+            defaults: {
+              model: {
+                primary: "acme/m1",
+              },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await withEnvAsync(
+      {
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+        OPENCLAW_SKIP_CHANNELS: "0",
+        OPENCLAW_SKIP_PROVIDERS: "0",
+      },
+      async () => {
+        const startup = startGatewayServer(await getFreePort());
+        await expect(startup).rejects.toThrow(/Gateway startup blocked/i);
+        await expect(startup).rejects.toThrow(/acme\/m1/i);
+      },
+    );
+  });
   test("refuses to start when port already bound", async () => {
     const { server: blocker, port: blockedPort } = await occupyPort();
     const startup = startGatewayServer(blockedPort);
@@ -478,3 +515,4 @@ describe("gateway server misc", () => {
     );
   });
 });
+

--- a/src/gateway/startup-model-auth.test.ts
+++ b/src/gateway/startup-model-auth.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveApiKeyForProvider: vi.fn(),
+}));
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveApiKeyForProvider: mocks.resolveApiKeyForProvider,
+}));
+
+import { ensureGatewayModelAuthConfigured } from "./startup-model-auth.js";
+
+describe("ensureGatewayModelAuthConfigured", () => {
+  beforeEach(() => {
+    mocks.resolveApiKeyForProvider.mockReset();
+  });
+
+  it("checks provider auth for the configured model on startup", async () => {
+    mocks.resolveApiKeyForProvider.mockResolvedValue({
+      apiKey: "test-key",
+      source: "env",
+      mode: "api-key",
+    });
+
+    await expect(
+      ensureGatewayModelAuthConfigured({
+        cfg: {},
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        cfg: {},
+      }),
+    );
+  });
+
+  it("skips startup auth preflight for CLI-backed models", async () => {
+    await expect(
+      ensureGatewayModelAuthConfigured({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "codex-cli/gpt-5",
+              },
+            },
+          },
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("throws an actionable startup error when provider auth is missing", async () => {
+    mocks.resolveApiKeyForProvider.mockRejectedValue(
+      new Error('No API key found for provider "anthropic".'),
+    );
+
+    await expect(
+      ensureGatewayModelAuthConfigured({
+        cfg: {},
+      }),
+    ).rejects.toThrow(/Gateway startup blocked/);
+    await expect(
+      ensureGatewayModelAuthConfigured({
+        cfg: {},
+      }),
+    ).rejects.toThrow(/anthropic\/claude-opus-4-6/);
+    await expect(
+      ensureGatewayModelAuthConfigured({
+        cfg: {},
+      }),
+    ).rejects.toThrow(/openclaw configure/);
+    await expect(
+      ensureGatewayModelAuthConfigured({
+        cfg: {},
+      }),
+    ).rejects.toThrow(/openclaw models set/);
+  });
+});
+

--- a/src/gateway/startup-model-auth.ts
+++ b/src/gateway/startup-model-auth.ts
@@ -1,0 +1,42 @@
+import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { isCliProvider, resolveConfiguredModelRef } from "../agents/model-selection.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+export async function ensureGatewayModelAuthConfigured(params: {
+  cfg: OpenClawConfig;
+}): Promise<void> {
+  const modelRef = resolveConfiguredModelRef({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+
+  if (isCliProvider(modelRef.provider, params.cfg)) {
+    return;
+  }
+
+  const defaultAgentId = resolveDefaultAgentId(params.cfg);
+  const agentDir = resolveAgentDir(params.cfg, defaultAgentId);
+  try {
+    await resolveApiKeyForProvider({
+      provider: modelRef.provider,
+      cfg: params.cfg,
+      agentDir,
+    });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    const configuredModelRef = `${modelRef.provider}/${modelRef.model}`;
+    throw new Error(
+      [
+        `Gateway startup blocked: configured model "${configuredModelRef}" has no provider credentials.`,
+        `Run ${formatCliCommand("openclaw configure")} for this profile,`,
+        `or switch models with ${formatCliCommand('openclaw models set "<provider>/<model>"')}.`,
+        `Details: ${details}`,
+      ].join(" "),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: New profiles could start the gateway with a default model (commonly `anthropic/claude-opus-4-6`) even when provider auth was not configured, causing a “started but silent” bot/runtime.
- Why it matters: This is a hidden startup failure mode; users see channels online but get no replies until they manually change model/auth.
- What changed: Added a startup model-auth preflight (`src/gateway/startup-model-auth.ts`) and wired it into gateway startup (`src/gateway/server.impl.ts`) to fail fast with actionable instructions when auth is missing. Added targeted tests for preflight logic and startup behavior.
- What did NOT change (scope boundary): No changes to auth storage format, provider credential resolution rules, model defaults, runtime request handling, or channel implementation behavior beyond startup guardrails.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39903
- Related #N/A

## User-visible / Behavior Changes

- Gateway startup now fails fast when the configured startup model provider has no credentials.
- Error is actionable and points users to `openclaw configure` or `openclaw models set "<provider>/<model>"`.
- Behavior applies when channel startup is enabled (normal runtime path).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- New/changed network calls? (`Yes/No`): `No`
- Command/tool execution surface changed? (`Yes/No`): `No`
- Data access scope changed? (`Yes/No`): `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows (local dev environment)
- Runtime/container: Node.js + Vitest
- Model/provider: default Anthropic path and synthetic test provider (`acme/m1`)
- Integration/channel (if any): Gateway startup path (channels enabled in test)
- Relevant config (redacted): `agents.defaults.model.primary` set without matching auth

### Steps

1. Configure startup model to a provider/model without credentials (example: `acme/m1`).
2. Start gateway with channels enabled.
3. Observe startup behavior.

### Expected

- Gateway should fail at startup with a clear message indicating missing provider auth and suggested remediation commands.

### Actual

- Before fix: gateway could start and later appear non-responsive.
- After fix: startup is blocked immediately with actionable auth/model guidance.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace used:
- `corepack pnpm exec vitest run src/gateway/startup-model-auth.test.ts src/gateway/server.models-voicewake-misc.test.ts`
- Result: `2 passed`, `15 passed tests`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Startup preflight validates auth for configured startup model.
  - CLI-backed model providers are skipped by preflight.
  - Gateway startup fails fast with missing auth when channels are enabled.
- Edge cases checked:
  - Minimal-test gateway path remains unaffected.
  - Existing gateway misc suite still passes with new guard in place.
- What you did **not** verify:
  - Full live end-to-end behavior on real external providers/channels (e.g., Telegram with real credentials).

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR/commit.
  - Temporary operational workaround: start with channel startup disabled (existing skip-channel env path) while fixing auth.
- Files/config to restore:
  - `src/gateway/server.impl.ts`
  - `src/gateway/startup-model-auth.ts`
  - `src/gateway/startup-model-auth.test.ts`
  - `src/gateway/server.models-voicewake-misc.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected startup block for providers that should be credential-free in specific setups.

## Risks and Mitigations

- Risk: Over-eager startup blocking for uncommon provider auth modes.
  - Mitigation: Reuse existing `resolveApiKeyForProvider` resolution logic and explicitly skip CLI-backed providers; covered with targeted tests.