### PR TITLE
docs: add OpenClawDreams to community plugins listing

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **OpenClawDreams** — A reflection engine that gives your agent an encrypted dream cycle. Captures daily conversations, synthesizes them through web + Moltbook context, generates surreal dream narratives at night, and surfaces a "Waking Realization" each morning. Notifies operator with "I had a dream..." on supported channels.
+  npm: `openclawdreams`
+  repo: `https://github.com/RogueCtrl/OpenClawDreams`
+  install: `openclaw plugins install openclawdreams`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Summary

Adds **OpenClawDreams** to the community plugins page.

- **npm:** `openclawdreams` (v1.6.1, latest)
- **repo:** https://github.com/RogueCtrl/OpenClawDreams
- **install:** `openclaw plugins install openclawdreams`

### What it does

OpenClawDreams gives your agent an encrypted dream cycle. It captures conversation summaries and workspace file diffs at session end, synthesizes them with web and Moltbook context throughout the day, and generates a surreal dream narrative at 2am. Each morning it surfaces a logical "Waking Realization" grounded in yesterday's activity and notifies the operator via their configured channel (Telegram, Discord, Slack, etc.).

### Quality bar

- ✅ Published on npm (`openclawdreams`)
- ✅ Public GitHub repo with README, AGENTS.md, CONTRIBUTING.md, setup skill
- ✅ TypeScript, strict mode, ESLint, Prettier, 100 passing tests
- ✅ Compatible with OpenClaw ≥ 2026.03.07
- ✅ Actively maintained (v1.6.1 shipped today)