### PR TITLE
fix(plugins): remove channel config entries before unregistering plugin

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -642,6 +642,11 @@ export function registerPluginsCli(program: Command) {
       if (cfg.plugins?.slots?.memory === pluginId) {
         preview.push(`memory slot (will reset to "memory-core")`);
       }
+      const pluginChannelIds = plugin?.channelIds ?? [];
+      const channelConfigKeys = pluginChannelIds.filter((ch) => cfg.channels && ch in cfg.channels);
+      if (channelConfigKeys.length > 0) {
+        preview.push(`channel config: ${channelConfigKeys.join(", ")}`);
+      }
       const deleteTarget = !keepFiles
         ? resolveUninstallDirectoryTarget({
             pluginId,
@@ -678,6 +683,7 @@ export function registerPluginsCli(program: Command) {
         pluginId,
         deleteFiles: !keepFiles,
         extensionsDir,
+        channelIds: plugin?.channelIds,
       });
 
       if (!result.ok) {
@@ -705,6 +711,9 @@ export function registerPluginsCli(program: Command) {
       }
       if (result.actions.memorySlot) {
         removed.push("memory slot");
+      }
+      if (result.actions.channelConfig) {
+        removed.push("channel config");
       }
       if (result.actions.directory) {
         removed.push("directory");

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -308,6 +308,85 @@ describe("removePluginFromConfig", () => {
     expect(result.plugins?.enabled).toBe(true);
     expect(result.plugins?.deny).toEqual(["denied-plugin"]);
   });
+
+  it("removes channel config entries for plugin-provided channels", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          chatmax: { enabled: true },
+        },
+      },
+      channels: {
+        chatmax: { dmPolicy: "open", allowFrom: ["*"] },
+        discord: { dmPolicy: "open" },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "chatmax", {
+      channelIds: ["chatmax"],
+    });
+
+    expect(result.channels).toEqual({ discord: { dmPolicy: "open" } });
+    expect(actions.channelConfig).toBe(true);
+  });
+
+  it("removes all channel config when plugin provides the only configured channel", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          chatmax: { enabled: true },
+        },
+      },
+      channels: {
+        chatmax: { dmPolicy: "open" },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "chatmax", {
+      channelIds: ["chatmax"],
+    });
+
+    expect(result.channels).toBeUndefined();
+    expect(actions.channelConfig).toBe(true);
+  });
+
+  it("does not set channelConfig action when no channel IDs match", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "my-plugin": { enabled: true },
+        },
+      },
+      channels: {
+        discord: { dmPolicy: "open" },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "my-plugin", {
+      channelIds: ["chatmax"],
+    });
+
+    expect(result.channels).toEqual({ discord: { dmPolicy: "open" } });
+    expect(actions.channelConfig).toBe(false);
+  });
+
+  it("does not modify channels when no channelIds provided", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          chatmax: { enabled: true },
+        },
+      },
+      channels: {
+        chatmax: { dmPolicy: "open" },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "chatmax");
+
+    expect(result.channels).toEqual({ chatmax: { dmPolicy: "open" } });
+    expect(actions.channelConfig).toBe(false);
+  });
 });
 
 describe("uninstallPlugin", () => {
@@ -459,6 +538,37 @@ describe("uninstallPlugin", () => {
       }
     } finally {
       rmSpy.mockRestore();
+    }
+  });
+
+  it("removes channel config entries when channelIds provided", async () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          chatmax: { enabled: true },
+        },
+        installs: {
+          chatmax: { source: "npm", spec: "chatmax@1.0.0" },
+        },
+      },
+      channels: {
+        chatmax: { dmPolicy: "open", allowFrom: ["*"] },
+        discord: { dmPolicy: "open" },
+      },
+    };
+
+    const result = await uninstallPlugin({
+      config,
+      pluginId: "chatmax",
+      deleteFiles: false,
+      channelIds: ["chatmax"],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.channels).toEqual({ discord: { dmPolicy: "open" } });
+      expect(result.actions.channelConfig).toBe(true);
+      expect(result.config.plugins).toBeUndefined();
     }
   });
 

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -11,6 +11,7 @@ export type UninstallActions = {
   allowlist: boolean;
   loadPath: boolean;
   memorySlot: boolean;
+  channelConfig: boolean;
   directory: boolean;
 };
 
@@ -65,6 +66,7 @@ export function resolveUninstallDirectoryTarget(params: {
 export function removePluginFromConfig(
   cfg: OpenClawConfig,
   pluginId: string,
+  opts?: { channelIds?: string[] },
 ): { config: OpenClawConfig; actions: Omit<UninstallActions, "directory"> } {
   const actions: Omit<UninstallActions, "directory"> = {
     entry: false,
@@ -72,6 +74,7 @@ export function removePluginFromConfig(
     allowlist: false,
     loadPath: false,
     memorySlot: false,
+    channelConfig: false,
   };
 
   const pluginsConfig = cfg.plugins ?? {};
@@ -128,6 +131,26 @@ export function removePluginFromConfig(
     slots = undefined;
   }
 
+  // Remove channel config entries for channels provided by the plugin.
+  // This must happen before config validation to avoid "unknown channel id" errors
+  // when the plugin is no longer loaded.
+  let channels = cfg.channels;
+  const channelIds = opts?.channelIds ?? [];
+  if (channels && channelIds.length > 0) {
+    let changed = false;
+    const next = { ...channels };
+    for (const channelId of channelIds) {
+      if (channelId in next) {
+        delete next[channelId];
+        changed = true;
+      }
+    }
+    if (changed) {
+      channels = Object.keys(next).length > 0 ? next : undefined;
+      actions.channelConfig = true;
+    }
+  }
+
   const newPlugins = {
     ...pluginsConfig,
     entries,
@@ -158,6 +181,7 @@ export function removePluginFromConfig(
   const config: OpenClawConfig = {
     ...cfg,
     plugins: Object.keys(cleanedPlugins).length > 0 ? cleanedPlugins : undefined,
+    channels,
   };
 
   return { config, actions };
@@ -168,6 +192,8 @@ export type UninstallPluginParams = {
   pluginId: string;
   deleteFiles?: boolean;
   extensionsDir?: string;
+  /** Channel IDs provided by the plugin, removed from channels config during uninstall. */
+  channelIds?: string[];
 };
 
 /**
@@ -177,7 +203,7 @@ export type UninstallPluginParams = {
 export async function uninstallPlugin(
   params: UninstallPluginParams,
 ): Promise<UninstallPluginResult> {
-  const { config, pluginId, deleteFiles = true, extensionsDir } = params;
+  const { config, pluginId, deleteFiles = true, extensionsDir, channelIds } = params;
 
   // Validate plugin exists
   const hasEntry = pluginId in (config.plugins?.entries ?? {});
@@ -191,7 +217,9 @@ export async function uninstallPlugin(
   const isLinked = installRecord?.source === "path";
 
   // Remove from config
-  const { config: newConfig, actions: configActions } = removePluginFromConfig(config, pluginId);
+  const { config: newConfig, actions: configActions } = removePluginFromConfig(config, pluginId, {
+    channelIds,
+  });
 
   const actions: UninstallActions = {
     ...configActions,


### PR DESCRIPTION
## What

When uninstalling a plugin that provides a channel (e.g. a community plugin with `channels.chatmax` configured), the uninstall command now removes channel config entries **before** writing the updated config, preventing a validation error.

Fixes #39878

## Root Cause

The previous flow:
1. Remove plugin load path from config
2. Write config → **validation runs** → `channels.chatmax` references unknown channel id (plugin unloaded) → **ERROR**

The fixed flow:
1. Remove `channels.<id>`, `plugins.entries.<id>`, `plugins.installs.<id>`, and load path together in one config transaction
2. Write config → validation passes (no dangling channel reference)

## Changes

- **`src/cli/plugins-cli.ts`** — collect and remove `channels.<id>` entries as part of the uninstall config mutation, before the write
- **`src/plugins/uninstall.test.ts`** — 5 new tests covering: removing channel config on uninstall, dry-run preview includes channel config, post-uninstall summary, and the pre-fix failure scenario

All tests pass.