### PR TITLE
fix: resolve live config paths in status and gateway metadata

### DIFF
--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -25,7 +25,7 @@ import {
 } from "../../agents/model-selection.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { withProgressTotals } from "../../cli/progress.js";
-import { CONFIG_PATH } from "../../config/config.js";
+import { createConfigIO } from "../../config/config.js";
 import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
@@ -77,6 +77,7 @@ export async function modelsStatusCommand(
   if (opts.plain && opts.probe) {
     throw new Error("--probe cannot be used with --plain output.");
   }
+  const configPath = createConfigIO().configPath;
   const cfg = await loadModelsConfig({ commandName: "models status", runtime });
   const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
   const agentDir = agentId ? resolveAgentDir(cfg, agentId) : resolveOpenClawAgentDir();
@@ -326,7 +327,7 @@ export async function modelsStatusCommand(
     runtime.log(
       JSON.stringify(
         {
-          configPath: CONFIG_PATH,
+          configPath,
           ...(agentId ? { agentId } : {}),
           agentDir,
           defaultModel: defaultLabel,
@@ -389,7 +390,7 @@ export async function modelsStatusCommand(
     rawModel && rawModel !== resolvedLabel ? `${resolvedLabel} (from ${rawModel})` : resolvedLabel;
 
   runtime.log(
-    `${label("Config")}${colorize(rich, theme.muted, ":")} ${colorize(rich, theme.info, shortenHomePath(CONFIG_PATH))}`,
+    `${label("Config")}${colorize(rich, theme.muted, ":")} ${colorize(rich, theme.info, shortenHomePath(configPath))}`,
   );
   runtime.log(
     `${label("Agent dir")}${colorize(rich, theme.muted, ":")} ${colorize(

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -64,6 +64,9 @@ const mocks = vi.hoisted(() => {
     getCustomProviderApiKey: vi.fn().mockReturnValue(undefined),
     getShellEnvAppliedKeys: vi.fn().mockReturnValue(["OPENAI_API_KEY", "ANTHROPIC_OAUTH_TOKEN"]),
     shouldEnableShellEnvFallback: vi.fn().mockReturnValue(true),
+    createConfigIO: vi.fn().mockReturnValue({
+      configPath: "/tmp/openclaw-dev/openclaw.json",
+    }),
     loadConfig: vi.fn().mockReturnValue({
       agents: {
         defaults: {
@@ -115,6 +118,7 @@ vi.mock("../../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config/config.js")>();
   return {
     ...actual,
+    createConfigIO: mocks.createConfigIO,
     loadConfig: mocks.loadConfig,
   };
 });
@@ -200,6 +204,7 @@ describe("modelsStatusCommand auth overview", () => {
 
     expect(mocks.resolveOpenClawAgentDir).toHaveBeenCalled();
     expect(payload.defaultModel).toBe("anthropic/claude-opus-4-5");
+    expect(payload.configPath).toBe("/tmp/openclaw-dev/openclaw.json");
     expect(payload.auth.storePath).toBe("/tmp/openclaw-agent/auth-profiles.json");
     expect(payload.auth.shellEnvFallback.enabled).toBe(true);
     expect(payload.auth.shellEnvFallback.appliedKeys).toContain("OPENAI_API_KEY");

--- a/src/config/logging.test.ts
+++ b/src/config/logging.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createConfigIO: vi.fn().mockReturnValue({
+    configPath: "/tmp/openclaw-dev/openclaw.json",
+  }),
+}));
+
+vi.mock("./io.js", () => ({
+  createConfigIO: mocks.createConfigIO,
+}));
+
+import { formatConfigPath, logConfigUpdated } from "./logging.js";
+
+describe("config logging", () => {
+  it("formats the live config path when no explicit path is provided", () => {
+    expect(formatConfigPath()).toBe("/tmp/openclaw-dev/openclaw.json");
+  });
+
+  it("logs the live config path when no explicit path is provided", () => {
+    const runtime = { log: vi.fn() };
+    logConfigUpdated(runtime as never);
+    expect(runtime.log).toHaveBeenCalledWith("Updated /tmp/openclaw-dev/openclaw.json");
+  });
+});

--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -1,18 +1,18 @@
 import type { RuntimeEnv } from "../runtime.js";
 import { displayPath } from "../utils.js";
-import { CONFIG_PATH } from "./paths.js";
+import { createConfigIO } from "./io.js";
 
 type LogConfigUpdatedOptions = {
   path?: string;
   suffix?: string;
 };
 
-export function formatConfigPath(path: string = CONFIG_PATH): string {
+export function formatConfigPath(path: string = createConfigIO().configPath): string {
   return displayPath(path);
 }
 
 export function logConfigUpdated(runtime: RuntimeEnv, opts: LogConfigUpdatedOptions = {}): void {
-  const path = formatConfigPath(opts.path ?? CONFIG_PATH);
+  const path = formatConfigPath(opts.path ?? createConfigIO().configPath);
   const suffix = opts.suffix ? ` ${opts.suffix}` : "";
   runtime.log(`Updated ${path}${suffix}`);
 }

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -324,7 +324,7 @@ export const configHandlers: GatewayRequestHandlers = {
       true,
       {
         ok: true,
-        path: CONFIG_PATH,
+        path: createConfigIO().configPath,
         config: redactConfigObject(parsed.config, parsed.schema.uiHints),
       },
       undefined,
@@ -441,7 +441,7 @@ export const configHandlers: GatewayRequestHandlers = {
       true,
       {
         ok: true,
-        path: CONFIG_PATH,
+        path: createConfigIO().configPath,
         config: redactConfigObject(validated.config, schemaPatch.uiHints),
         restart,
         sentinel: {
@@ -501,7 +501,7 @@ export const configHandlers: GatewayRequestHandlers = {
       true,
       {
         ok: true,
-        path: CONFIG_PATH,
+        path: createConfigIO().configPath,
         config: redactConfigObject(parsed.config, parsed.schema.uiHints),
         restart,
         sentinel: {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,7 +1,7 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import {
-  CONFIG_PATH,
+  createConfigIO,
   loadConfig,
   parseConfigJson5,
   readConfigFileSnapshot,
@@ -197,6 +197,7 @@ function buildConfigRestartSentinelPayload(params: {
   threadId: ReturnType<typeof extractDeliveryInfo>["threadId"];
   note: string | undefined;
 }): RestartSentinelPayload {
+  const configPath = createConfigIO().configPath;
   return {
     kind: params.kind,
     status: "ok",
@@ -208,7 +209,7 @@ function buildConfigRestartSentinelPayload(params: {
     doctorHint: formatDoctorNonInteractiveHint(),
     stats: {
       mode: params.mode,
-      root: CONFIG_PATH,
+      root: configPath,
     },
   };
 }

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -94,7 +94,7 @@ export function registerDefaultAuthTokenSuite(): void {
     });
 
     test("connect (req) handshake returns hello-ok payload", async () => {
-      const { CONFIG_PATH, STATE_DIR } = await import("../config/config.js");
+      const { STATE_DIR } = await import("../config/config.js");
       const ws = await openWs(port);
 
       const res = await connectReq(ws);
@@ -106,7 +106,7 @@ export function registerDefaultAuthTokenSuite(): void {
           }
         | undefined;
       expect(payload?.type).toBe("hello-ok");
-      expect(payload?.snapshot?.configPath).toBe(CONFIG_PATH);
+      expect(payload?.snapshot?.configPath).toBe(process.env.OPENCLAW_CONFIG_PATH);
       expect(payload?.snapshot?.stateDir).toBe(STATE_DIR);
 
       ws.close();

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -94,7 +94,7 @@ export function registerDefaultAuthTokenSuite(): void {
     });
 
     test("connect (req) handshake returns hello-ok payload", async () => {
-      const { STATE_DIR } = await import("../config/config.js");
+      const { STATE_DIR, createConfigIO } = await import("../config/config.js");
       const ws = await openWs(port);
 
       const res = await connectReq(ws);
@@ -106,7 +106,7 @@ export function registerDefaultAuthTokenSuite(): void {
           }
         | undefined;
       expect(payload?.type).toBe("hello-ok");
-      expect(payload?.snapshot?.configPath).toBe(process.env.OPENCLAW_CONFIG_PATH);
+      expect(payload?.snapshot?.configPath).toBe(createConfigIO().configPath);
       expect(payload?.snapshot?.stateDir).toBe(STATE_DIR);
 
       ws.close();

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -47,6 +47,31 @@ async function resetTempDir(name: string): Promise<string> {
 }
 
 describe("gateway config methods", () => {
+  it("round-trips config.set and returns the live config path", async () => {
+    const { createConfigIO } = await import("../config/config.js");
+    const current = await rpcReq<{
+      raw?: unknown;
+      hash?: string;
+      config?: Record<string, unknown>;
+    }>(requireWs(), "config.get", {});
+    expect(current.ok).toBe(true);
+    expect(typeof current.payload?.hash).toBe("string");
+    expect(current.payload?.config).toBeTruthy();
+
+    const res = await rpcReq<{
+      ok?: boolean;
+      path?: string;
+      config?: Record<string, unknown>;
+    }>(requireWs(), "config.set", {
+      raw: JSON.stringify(current.payload?.config ?? {}, null, 2),
+      baseHash: current.payload?.hash,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.payload?.path).toBe(createConfigIO().configPath);
+    expect(res.payload?.config).toBeTruthy();
+  });
+
   it("returns a path-scoped config schema lookup", async () => {
     const res = await rpcReq<{
       path: string;

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -1,6 +1,6 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getHealthSnapshot, type HealthSummary } from "../../commands/health.js";
-import { CONFIG_PATH, STATE_DIR, loadConfig } from "../../config/config.js";
+import { STATE_DIR, createConfigIO, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
@@ -16,6 +16,7 @@ let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
+  const configPath = createConfigIO().configPath;
   const defaultAgentId = resolveDefaultAgentId(cfg);
   const mainKey = normalizeMainKey(cfg.session?.mainKey);
   const mainSessionKey = resolveMainSessionKey(cfg);
@@ -32,7 +33,7 @@ export function buildGatewaySnapshot(): Snapshot {
     stateVersion: { presence: presenceVersion, health: healthVersion },
     uptimeMs,
     // Surface resolved paths so UIs can display the true config location.
-    configPath: CONFIG_PATH,
+    configPath,
     stateDir: STATE_DIR,
     sessionDefaults: {
       defaultAgentId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: several operator-visible surfaces reported a stale config path derived from module-scope `CONFIG_PATH`, which could disagree with the active `--dev` or `--profile` config.
- Why it matters: status output, config-update logs, and gateway-emitted metadata could point at `~/.openclaw/openclaw.json` while runtime behavior was correctly using a profile-specific config.
- What changed: `models status`, shared config logging, gateway snapshot metadata, and config restart-sentinel metadata now resolve the live config path at runtime.
- What did NOT change (scope boundary): config loading semantics, auth resolution, and gateway behavior other than surfaced config-path reporting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none)
- Related # (none)

## User-visible / Behavior Changes

- `openclaw --dev models status` now reports `~/.openclaw-dev/openclaw.json` instead of the default-profile config path.
- Commands using shared `logConfigUpdated` now report the live config path for the active profile.
- Gateway snapshot and config restart metadata now emit the live config path instead of a stale module-scope path.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node CLI in git worktree
- Model/provider: MiniMax OAuth dev profile used for repro
- Integration/channel (if any): gateway/operator surfaces
- Relevant config (redacted): default profile at `~/.openclaw/openclaw.json`, dev profile at `~/.openclaw-dev/openclaw.json`

### Steps

1. Configure different default and dev profiles so `~/.openclaw/openclaw.json` and `~/.openclaw-dev/openclaw.json` diverge.
2. Run `pnpm openclaw --dev models status` and inspect the reported `Config` path.
3. Run focused tests covering status output, config logging, and gateway snapshot path emission.

### Expected

- Commands and gateway metadata report the live config path for the active profile.

### Actual

- Before the fix, some surfaces reported the default-profile path even when the dev/profile-specific config was active.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm openclaw --dev models status` now reports `~/.openclaw-dev/openclaw.json`; default profile still reports `~/.openclaw/openclaw.json`.
- Edge cases checked: shared `logConfigUpdated` default path resolution; gateway hello snapshot configPath under env-driven config path.
- What you did **not** verify: full end-to-end UI rendering of gateway snapshot consumers beyond the existing gateway handshake test.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `542a8976e9`
- Files/config to restore: `src/commands/models/list.status-command.ts`, `src/config/logging.ts`, `src/gateway/server/health-state.ts`, `src/gateway/server-methods/config.ts`
- Known bad symptoms reviewers should watch for: config-path output regressing to `~/.openclaw/openclaw.json` under `--dev` or another named profile

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: another runtime-visible surface elsewhere may still read the module-scope `CONFIG_PATH` constant.
  - Mitigation: this PR covers the confirmed operator-visible surfaces found during audit and adds focused tests around the fixed helpers and gateway snapshot path.
