### PR TITLE
feat(agent): add text repetition guard for streaming output

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -23,6 +23,8 @@ import {
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
+import { resolveTextRepetitionGuardConfig } from "./pi-tools.js";
+import { detectTextRepetition } from "./text-repetition-guard.js";
 
 const stripTrailingDirective = (text: string): string => {
   const openIndex = text.lastIndexOf("[[");
@@ -182,6 +184,11 @@ export function handleMessageStart(
   // may deliver late text_end updates after message_end, which would otherwise
   // re-trigger block replies.
   ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
+  // Resolve text-repetition-guard config once per message to avoid re-parsing on every tick.
+  ctx.state.resolvedTextRepetitionGuardConfig = resolveTextRepetitionGuardConfig({
+    cfg: ctx.params.config,
+    agentId: ctx.params.agentId,
+  });
   // Use assistant message_start as the earliest "writing" signal for typing.
   void ctx.params.onAssistantMessageStart?.();
 }
@@ -279,6 +286,21 @@ export function handleMessageUpdate(
       ctx.blockChunker.append(chunk);
     } else {
       ctx.state.blockBuffer += chunk;
+    }
+  }
+
+  // Text repetition guard: throttle checks to every N chars of new content.
+  const guardConfig = ctx.state.resolvedTextRepetitionGuardConfig;
+  if (guardConfig && guardConfig.enabled) {
+    const checkInterval = guardConfig.checkIntervalChars;
+    if (ctx.state.deltaBuffer.length - ctx.state.textRepetitionLastCheckedLen >= checkInterval) {
+      ctx.state.textRepetitionLastCheckedLen = ctx.state.deltaBuffer.length;
+      const result = detectTextRepetition(ctx.state.deltaBuffer, guardConfig);
+      if (result.looping) {
+        ctx.state.abortedByTextRepetitionGuard = true;
+        void ctx.params.session.abort();
+        return;
+      }
     }
   }
 
@@ -518,10 +540,10 @@ export function handleMessageEnd(
     text &&
     onBlockReply
   ) {
-    if (ctx.blockChunker?.hasBuffered()) {
+    if (ctx.blockChunker?.hasBuffered() && !ctx.state.abortedByTextRepetitionGuard) {
       ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
       ctx.blockChunker.reset();
-    } else if (text !== ctx.state.lastBlockReplyText) {
+    } else if (text !== ctx.state.lastBlockReplyText && !ctx.state.abortedByTextRepetitionGuard) {
       // Check for duplicates before emitting (same logic as emitBlockChunk).
       const normalizedText = normalizeTextForComparison(text);
       if (
@@ -553,6 +575,7 @@ export function handleMessageEnd(
 
   const finalizeMessageEnd = () => {
     ctx.state.deltaBuffer = "";
+    ctx.state.textRepetitionLastCheckedLen = 0;
     ctx.state.blockBuffer = "";
     ctx.blockChunker?.reset();
     ctx.state.blockState.thinking = false;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -10,6 +10,7 @@ import type {
   BlockReplyChunking,
   SubscribeEmbeddedPiSessionParams,
 } from "./pi-embedded-subscribe.types.js";
+import type { ResolvedTextRepetitionGuardConfig } from "./text-repetition-guard.js";
 import type { ToolErrorSummary } from "./tool-error-summary.js";
 import type { NormalizedUsage } from "./usage.js";
 
@@ -54,6 +55,13 @@ export type EmbeddedPiSubscribeState = {
   assistantTextBaseline: number;
   suppressBlockChunks: boolean;
   lastReasoningSent?: string;
+
+  /** deltaBuffer length at last text-repetition-guard check (throttle). */
+  textRepetitionLastCheckedLen: number;
+  /** Resolved text-repetition-guard config, cached at message start. */
+  resolvedTextRepetitionGuardConfig?: ResolvedTextRepetitionGuardConfig;
+  /** Set when the text-repetition guard fires; prevents blockChunker drain in handleMessageEnd. */
+  abortedByTextRepetitionGuard: boolean;
 
   compactionInFlight: boolean;
   pendingCompactionRetry: number;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -69,6 +69,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     assistantTextBaseline: 0,
     suppressBlockChunks: false, // Avoid late chunk inserts after final text merge.
     lastReasoningSent: undefined,
+    textRepetitionLastCheckedLen: 0,
+    abortedByTextRepetitionGuard: false,
     compactionInFlight: false,
     pendingCompactionRetry: 0,
     compactionRetryResolve: undefined,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -46,6 +46,10 @@ import {
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
+import {
+  type ResolvedTextRepetitionGuardConfig,
+  resolveConfig as resolveTextRepetitionDefaults,
+} from "./text-repetition-guard.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import {
   applyToolPolicyPipeline,
@@ -206,6 +210,20 @@ export function resolveToolLoopDetectionConfig(params: {
       ...agent.detectors,
     },
   };
+}
+
+export function resolveTextRepetitionGuardConfig(params: {
+  cfg?: OpenClawConfig;
+  agentId?: string;
+}): ResolvedTextRepetitionGuardConfig {
+  const global = params.cfg?.tools?.textRepetitionGuard;
+  const agent =
+    params.agentId && params.cfg
+      ? resolveAgentConfig(params.cfg, params.agentId)?.tools?.textRepetitionGuard
+      : undefined;
+
+  const merged = agent && global ? { ...global, ...agent } : (agent ?? global);
+  return resolveTextRepetitionDefaults(merged);
 }
 
 export const __testing = {

--- a/src/agents/text-repetition-guard.test.ts
+++ b/src/agents/text-repetition-guard.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TEXT_REPETITION_GUARD_CONFIG,
+  detectTextRepetition,
+} from "./text-repetition-guard.js";
+
+describe("text-repetition-guard", () => {
+  const cfg = DEFAULT_TEXT_REPETITION_GUARD_CONFIG;
+
+  // -----------------------------------------------------------------------
+  // Should detect
+  // -----------------------------------------------------------------------
+
+  it("detects 'Wait/Check/Done/Sent' loop (real Gemini failure mode)", () => {
+    // Real failure mode: model emits same boilerplate without variation.
+    let text = "I will now verify each item:\n";
+    for (let i = 0; i < 30; i++) {
+      text += "Wait, I should check this item... Done. Sent.\n";
+    }
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(true);
+  });
+
+  it("detects consecutive identical lines", () => {
+    const text = "Starting analysis...\n" + "Wait, I should check this again.\n".repeat(20);
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(true);
+    if (result.looping) {
+      expect(result.detector).toBe("identical_lines");
+    }
+  });
+
+  it("detects suffix cycle pattern", () => {
+    const text = "Let me verify the details. ".repeat(5) + "Check. Verify. Done. ".repeat(30);
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(true);
+    if (result.looping) {
+      expect(result.detector).toBe("suffix_cycle");
+    }
+  });
+
+  it("detects line-group cycle", () => {
+    let text = "Starting the verification process now:\n";
+    for (let i = 0; i < 30; i++) {
+      text += "Step A: checking the verification status\nStep B: verifying the check result\n";
+    }
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(true);
+  });
+
+  it("detects HEARTBEAT_OK spam", () => {
+    const text = "HEARTBEAT_OK\n".repeat(80);
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(true);
+  });
+
+  it("detects CJK (Chinese) repetition", () => {
+    const text = "等一下，让我再确认一下这个问题。已完成确认。\n".repeat(30);
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Should NOT detect (false positive checks)
+  // -----------------------------------------------------------------------
+
+  it("passes normal prose text", () => {
+    const sentences = [
+      "The weather is nice today.",
+      "I found several interesting results.",
+      "Let me explain the architecture.",
+      "The database uses PostgreSQL.",
+      "Authentication is handled via JWT.",
+      "The frontend is built with React.",
+      "CI/CD runs on GitHub Actions.",
+      "Deployment targets are AWS and GCP.",
+      "Monitoring uses Prometheus and Grafana.",
+      "The API follows REST conventions.",
+    ];
+    const text = sentences
+      .map((s, i) => `${i + 1}. ${s}`)
+      .join("\n")
+      .repeat(3);
+    // Ensure sufficient length
+    const padded =
+      text.length >= 700
+        ? text
+        : text + "\nAdditional unique content for padding purposes.".repeat(10);
+    const result = detectTextRepetition(padded, cfg);
+    expect(result.looping).toBe(false);
+  });
+
+  it("passes code blocks with similar structure", () => {
+    let code = "Here is the implementation:\n```typescript\n";
+    for (let i = 0; i < 15; i++) {
+      code += `  const item${i} = await fetch(url${i});\n`;
+      code += `  results.push(item${i}.json());\n`;
+    }
+    code += "```\n";
+    const padded =
+      code.length >= 700 ? code : code + "\nThe code above handles data fetching.".repeat(5);
+    const result = detectTextRepetition(padded, cfg);
+    expect(result.looping).toBe(false);
+  });
+
+  it("passes numbered lists with unique items", () => {
+    let text = "";
+    for (let i = 1; i <= 30; i++) {
+      text += `${i}. Item number ${i} with unique description about topic ${i}\n`;
+    }
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(false);
+  });
+
+  it("passes templated steps with shared stem but progressive numbering", () => {
+    // "Step 1: process item...", "Step 2: process item..." share a 30-char
+    // stem but are progressive, not looping.
+    let text = "Here is the plan:\n";
+    for (let i = 1; i <= 30; i++) {
+      text += `Step ${i}: process item and verify the output result\n`;
+    }
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(false);
+  });
+
+  it("passes progressive content where repeated ngrams come from distinct lines", () => {
+    // Each line shares a long common suffix but the lines themselves differ
+    // (e.g. numbered items with the same tail). The ngram detector should
+    // recognise the line diversity and skip.
+    let text = "";
+    for (let i = 1; i <= 30; i++) {
+      text += `Item ${i}: verify the output result and confirm correctness of this entry\n`;
+    }
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(false);
+  });
+
+  it("passes short text below minimum threshold", () => {
+    const text = "Done. Sent. ".repeat(10);
+    const result = detectTextRepetition(text, cfg);
+    expect(result.looping).toBe(false);
+  });
+
+  it("returns looping=false when disabled", () => {
+    const text = "repeat this line\n".repeat(100);
+    const result = detectTextRepetition(text, { ...cfg, enabled: false });
+    expect(result.looping).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Config resolution
+  // -----------------------------------------------------------------------
+
+  it("uses defaults when partial config provided", () => {
+    const text = "repeat this exact line over and over!\n".repeat(50);
+    // Only override enabled
+    const result = detectTextRepetition(text, { enabled: true });
+    expect(result.looping).toBe(true);
+  });
+});

--- a/src/agents/text-repetition-guard.ts
+++ b/src/agents/text-repetition-guard.ts
@@ -1,0 +1,302 @@
+/**
+ * Text Repetition Guard
+ *
+ * Detects and aborts repetitive text generation loops in LLM output.
+ * Complements tool-loop-detection (which only monitors tool calls) by
+ * catching "text loops" where a model gets stuck emitting the same
+ * patterns without invoking any tools.
+ *
+ * Intended integration point: the streaming message handler, after each
+ * text chunk is appended to the delta buffer.
+ */
+
+import type { TextRepetitionGuardConfig } from "../config/types.tools.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agents/text-repetition-guard");
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export type { TextRepetitionGuardConfig } from "../config/types.tools.js";
+
+/** Fully resolved (all-required) config. */
+export type ResolvedTextRepetitionGuardConfig = Required<TextRepetitionGuardConfig>;
+
+export const DEFAULT_TEXT_REPETITION_GUARD_CONFIG: ResolvedTextRepetitionGuardConfig = {
+  enabled: true,
+  windowSize: 2000,
+  ngramSize: 30,
+  maxNgramRepetitions: 6,
+  maxIdenticalLines: 8,
+  minCyclePatternLength: 10,
+  maxCyclePatternLength: 150,
+  minCycleRepeats: 4,
+  checkIntervalChars: 200,
+};
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export type TextRepetitionDetectorKind =
+  | "ngram"
+  | "identical_lines"
+  | "suffix_cycle"
+  | "line_group_cycle";
+
+export type TextRepetitionResult =
+  | { looping: false }
+  | {
+      looping: true;
+      detector: TextRepetitionDetectorKind;
+      pattern: string;
+      count: number;
+      message: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function resolveConfig(
+  partial?: TextRepetitionGuardConfig,
+): ResolvedTextRepetitionGuardConfig {
+  const merged = { ...DEFAULT_TEXT_REPETITION_GUARD_CONFIG, ...partial };
+  // Sanitize numeric config to prevent infinite loops / nonsensical values.
+  merged.minCyclePatternLength = Math.max(1, merged.minCyclePatternLength);
+  merged.maxCyclePatternLength = Math.max(
+    merged.minCyclePatternLength,
+    merged.maxCyclePatternLength,
+  );
+  merged.ngramSize = Math.max(1, merged.ngramSize);
+  merged.checkIntervalChars = Math.max(1, merged.checkIntervalChars);
+  merged.windowSize = Math.max(100, merged.windowSize);
+  merged.maxNgramRepetitions = Math.max(1, merged.maxNgramRepetitions);
+  merged.maxIdenticalLines = Math.max(1, merged.maxIdenticalLines);
+  merged.minCycleRepeats = Math.max(2, merged.minCycleRepeats);
+  return merged;
+}
+
+function isFullyResolved(c: TextRepetitionGuardConfig): c is ResolvedTextRepetitionGuardConfig {
+  return (
+    c.enabled !== undefined &&
+    c.windowSize !== undefined &&
+    c.ngramSize !== undefined &&
+    c.maxNgramRepetitions !== undefined &&
+    c.maxIdenticalLines !== undefined &&
+    c.minCyclePatternLength !== undefined &&
+    c.maxCyclePatternLength !== undefined &&
+    c.minCycleRepeats !== undefined &&
+    c.checkIntervalChars !== undefined
+  );
+}
+
+/** True when a string is mostly whitespace or a single repeated character. */
+function isDegenerate(s: string, minDensity = 0.3): boolean {
+  const stripped = s.replace(/\s/g, "");
+  if (stripped.length < s.length * minDensity) {
+    return true;
+  }
+  // A pattern made of ≤2 distinct chars (after whitespace removal) is trivial
+  // noise — but only skip it when it's too short to carry real signal.
+  // Short strings (≤ ngramSize default) with 2 unique chars are degenerate;
+  // longer strings with exactly 2 unique chars may still be a real repetition.
+  if (stripped.length <= 30 && new Set(stripped).size <= 2) {
+    return true;
+  }
+  if (new Set(stripped).size <= 1) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export function detectTextRepetition(
+  buffer: string,
+  config?: TextRepetitionGuardConfig | ResolvedTextRepetitionGuardConfig,
+): TextRepetitionResult {
+  // Skip re-resolving when caller already passed a fully resolved config.
+  const cfg = config && isFullyResolved(config) ? config : resolveConfig(config);
+  if (!cfg.enabled) {
+    return { looping: false };
+  }
+
+  // Don't analyse tiny buffers — not enough signal.
+  if (buffer.length < cfg.windowSize * 0.3) {
+    return { looping: false };
+  }
+
+  const window = buffer.slice(-cfg.windowSize);
+
+  // --- Strategy 1: N-gram frequency ---
+  // Uses leading context to avoid false positives on templated output
+  // (e.g. "Step 1: process item...", "Step 2: process item...") where
+  // the 30-char stem repeats but surrounding content differs.
+  {
+    const ngrams = new Map<string, { count: number; lines: Set<string> }>();
+    const step = Math.max(1, Math.floor(cfg.ngramSize / 3));
+    const contextLen = Math.ceil(cfg.ngramSize / 2);
+    // Pre-split lines for line-diversity lookup.
+    const windowLines = window.split("\n");
+    let charOffset = 0;
+    const lineStartOffsets: number[] = [];
+    for (const line of windowLines) {
+      lineStartOffsets.push(charOffset);
+      charOffset += line.length + 1; // +1 for '\n'
+    }
+    /** Find the full line text containing offset `pos`. */
+    const lineAt = (pos: number): string => {
+      let lo = 0;
+      let hi = lineStartOffsets.length - 1;
+      while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (lineStartOffsets[mid] <= pos) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      return windowLines[lo];
+    };
+
+    for (let i = 0; i <= window.length - cfg.ngramSize; i += step) {
+      const gram = window.slice(i, i + cfg.ngramSize);
+      if (isDegenerate(gram)) {
+        continue;
+      }
+      // Include leading + trailing context in the map key so n-grams that
+      // share a stem but appear in different surrounding text are counted
+      // separately (e.g. "Step 1: do X..." vs "Step 2: do X...").
+      const contextStart = Math.max(0, i - contextLen);
+      const contextEnd = Math.min(window.length, i + cfg.ngramSize + contextLen);
+      const contextualKey = window.slice(contextStart, contextEnd);
+      const entry = ngrams.get(contextualKey) ?? { count: 0, lines: new Set<string>() };
+      entry.count++;
+      entry.lines.add(lineAt(i));
+      if (entry.count >= cfg.maxNgramRepetitions) {
+        // Line-diversity escape: if the repeated ngrams come from many
+        // distinct lines, this is progressive content (e.g. numbered steps
+        // that share a long suffix) rather than a true loop.
+        if (entry.lines.size > entry.count / 2) {
+          ngrams.set(contextualKey, entry);
+          continue;
+        }
+        const msg = `Text repetition detected (ngram): pattern repeated ${entry.count} times`;
+        log.warn(msg, { pattern: gram.slice(0, 60) });
+        return {
+          looping: true,
+          detector: "ngram",
+          pattern: gram.slice(0, 80),
+          count: entry.count,
+          message: msg,
+        };
+      }
+      ngrams.set(contextualKey, entry);
+    }
+  }
+
+  // --- Strategy 2: Consecutive identical non-empty lines ---
+  {
+    const lines = window.split("\n");
+    let consecutive = 1;
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i] === lines[i - 1] && lines[i].trim().length > 5) {
+        consecutive++;
+        if (consecutive >= cfg.maxIdenticalLines) {
+          const msg = `Text repetition detected (identical lines): ${consecutive} consecutive identical lines`;
+          log.warn(msg, { line: lines[i].slice(0, 60) });
+          return {
+            looping: true,
+            detector: "identical_lines",
+            pattern: lines[i].slice(0, 80),
+            count: consecutive,
+            message: msg,
+          };
+        }
+      } else {
+        consecutive = 1;
+      }
+    }
+  }
+
+  // --- Strategy 3: Suffix cycle ---
+  {
+    const tail = window.slice(-600);
+    const maxP = Math.min(cfg.maxCyclePatternLength, Math.floor(tail.length / cfg.minCycleRepeats));
+    for (let pLen = cfg.minCyclePatternLength; pLen <= maxP; pLen++) {
+      const pat = tail.slice(-pLen);
+      if (isDegenerate(pat)) {
+        continue;
+      }
+      let repeats = 0;
+      for (let i = tail.length - pLen; i >= 0; i -= pLen) {
+        if (tail.slice(i, i + pLen) === pat) {
+          repeats++;
+          if (repeats >= cfg.minCycleRepeats) {
+            break;
+          }
+        } else {
+          break;
+        }
+      }
+      if (repeats >= cfg.minCycleRepeats) {
+        const msg = `Text repetition detected (suffix cycle): pattern of length ${pLen} repeated ${repeats} times`;
+        log.warn(msg, { pattern: pat.slice(0, 60) });
+        return {
+          looping: true,
+          detector: "suffix_cycle",
+          pattern: pat.slice(0, 80),
+          count: repeats,
+          message: msg,
+        };
+      }
+    }
+  }
+
+  // --- Strategy 4: Line-group cycle ---
+  {
+    const nonEmpty = window.split("\n").filter((l) => l.trim().length > 0);
+    // Minimum lines needed: smallest group size (2) * minCycleRepeats
+    const minLinesNeeded = 2 * cfg.minCycleRepeats;
+    if (nonEmpty.length >= minLinesNeeded) {
+      for (let groupSize = 2; groupSize <= 5; groupSize++) {
+        const lastGroup = nonEmpty.slice(-groupSize);
+        // Skip groups where every line is too short to carry real signal.
+        if (lastGroup.every((l) => l.trim().length <= 5)) {
+          continue;
+        }
+        let groupRepeats = 0;
+        for (let i = nonEmpty.length - groupSize; i >= 0; i -= groupSize) {
+          const block = nonEmpty.slice(i, i + groupSize);
+          if (
+            block.length === lastGroup.length &&
+            block.every((line, idx) => line === lastGroup[idx])
+          ) {
+            groupRepeats++;
+          } else {
+            break;
+          }
+        }
+        if (groupRepeats >= cfg.minCycleRepeats) {
+          const patternPreview = lastGroup.join(" | ").slice(0, 80);
+          const msg = `Text repetition detected (line group cycle): group of ${groupSize} lines repeated ${groupRepeats} times`;
+          log.warn(msg, { pattern: patternPreview });
+          return {
+            looping: true,
+            detector: "line_group_cycle",
+            pattern: patternPreview,
+            count: groupRepeats,
+            message: msg,
+          };
+        }
+      }
+    }
+  }
+
+  return { looping: false };
+}

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -166,6 +166,27 @@ export type ToolLoopDetectionConfig = {
   detectors?: ToolLoopDetectionDetectorConfig;
 };
 
+export type TextRepetitionGuardConfig = {
+  /** Enable text repetition detection during streaming (default: true). */
+  enabled?: boolean;
+  /** Only analyse the last `windowSize` characters of the buffer. */
+  windowSize?: number;
+  /** N-gram length (characters) for frequency analysis. */
+  ngramSize?: number;
+  /** An n-gram appearing this many times triggers detection. */
+  maxNgramRepetitions?: number;
+  /** Consecutive identical non-empty lines triggering detection. */
+  maxIdenticalLines?: number;
+  /** Minimum pattern length for suffix-cycle detection. */
+  minCyclePatternLength?: number;
+  /** Maximum pattern length for suffix-cycle detection. */
+  maxCyclePatternLength?: number;
+  /** How many consecutive suffix repeats trigger detection. */
+  minCycleRepeats?: number;
+  /** How many characters of new content between repetition checks (default: 200). */
+  checkIntervalChars?: number;
+};
+
 export type SessionsToolsVisibility = "self" | "tree" | "agent" | "all";
 
 export type ToolPolicyConfig = {
@@ -310,6 +331,8 @@ export type AgentToolsConfig = {
   fs?: FsToolsConfig;
   /** Runtime loop detection for repetitive/ stuck tool-call patterns. */
   loopDetection?: ToolLoopDetectionConfig;
+  /** Runtime text repetition guard for detecting stuck text generation loops. */
+  textRepetitionGuard?: TextRepetitionGuardConfig;
   sandbox?: {
     tools?: {
       allow?: string[];
@@ -604,6 +627,8 @@ export type ToolsConfig = {
   fs?: FsToolsConfig;
   /** Runtime loop detection for repetitive/ stuck tool-call patterns. */
   loopDetection?: ToolLoopDetectionConfig;
+  /** Runtime text repetition guard for detecting stuck text generation loops. */
+  textRepetitionGuard?: TextRepetitionGuardConfig;
   /** Sub-agent tool policy defaults (deny wins). */
   subagents?: {
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */


### PR DESCRIPTION
## Problem

LLMs (especially Gemini) can enter self-reinforcing text generation loops where they repeatedly emit the same patterns without invoking any tools. For example:

```
Wait, I should check item 1... Done. Sent.
Wait, I should check item 2... Done. Sent.
Wait, I should check item 3... Done. Sent.
... (repeats indefinitely until token limit)
```

The existing `tool-loop-detection` module only monitors tool calls. When a model loops in pure text output, there is currently **no detection or abort mechanism**, causing:
- Token/cost waste (entire context window consumed by repetition)
- User-facing message spam
- Session becoming unrecoverable

## Related Issues

- #25627 — Coder agent repeats messages on exec running retries (text repetition aspect)
- #24800 — Context overflow from undetected loops
- #40396 — Agent trapped in infinite thought loop after upgrade

## Solution

Add a `text-repetition-guard` module that detects streaming text-generation loops using four complementary strategies:

1. **N-gram frequency** — Detects repeated phrases via sliding window
2. **Consecutive identical lines** — Catches copy-paste style repetition
3. **Suffix cycle detection** — Identifies repeating tail patterns
4. **Line-group cycle detection** — Catches multi-line block repetition

The guard is integrated into `handleMessageUpdate` and runs every `checkIntervalChars` characters (default: 200). On detection, it sets an `abortedByTextRepetitionGuard` flag and calls `session.abort()`.

### Key implementation details

- **Config** integrated into standard `ToolsConfig` / `AgentToolsConfig` system
- **Resolved config cached** at message start (zero per-tick resolution overhead)
- **False-positive mitigations**: degenerate content filtering, progressive content detection (e.g. "Step 1..., Step 2..."), n-gram source-line diversity check
- **blockChunker drain prevention**: When the guard fires, a state flag prevents `handleMessageEnd` from draining buffered repetitive content (addresses Greptile review feedback)

## Tests

15 test cases covering all 4 detection strategies, edge cases, progressive content (no false positive), and configuration.
