### PR TITLE
voice-call: document staleCallReaperSeconds schema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -251,7 +251,9 @@
       },
       "staleCallReaperSeconds": {
         "type": "integer",
-        "minimum": 0
+        "minimum": 0,
+        "default": 0,
+        "description": "When > 0, ends calls older than this many seconds to prevent stuck calls when terminal webhooks are missing."
       },
       "silenceTimeoutMs": {
         "type": "integer",

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -216,3 +216,16 @@ describe("normalizeVoiceCallConfig", () => {
     expect(normalized.tts?.elevenlabs?.voiceSettings).toEqual({ speed: 1.1 });
   });
 });
+
+describe("voice-call plugin config schema", () => {
+  it("includes staleCallReaperSeconds default and description", async () => {
+    const plugin = (await import("../openclaw.plugin.json")).default as {
+      configSchema?: { properties?: Record<string, unknown> };
+    };
+    const props = plugin.configSchema?.properties as Record<string, any> | undefined;
+    const stale = props?.staleCallReaperSeconds as Record<string, unknown> | undefined;
+    expect(stale).toBeTruthy();
+    expect(stale?.default).toBe(0);
+    expect(String(stale?.description || "")).toContain("terminal webhooks");
+  });
+});


### PR DESCRIPTION
Summary
- Updates the voice-call plugin config schema for `staleCallReaperSeconds` to include a `default` and a short `description`.
- This is schema metadata only (no runtime behavior change).

What did NOT change
- No changes to call lifecycle behavior; only config schema metadata + a small regression test.

Tests (local)
- `pnpm test extensions/voice-call/src/config.test.ts`

AI-assisted: yes.