### PR TITLE
fix(ui): fall back to gateway token when signing device payload on first connect [AI-assisted]

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -244,7 +244,7 @@ export class GatewayBrowserClient {
         role,
         scopes,
         signedAtMs,
-        token: deviceToken ?? null,
+        token: deviceToken ?? authToken ?? null,
         nonce,
       });
       const signature = await signDevicePayload(deviceIdentity.privateKey, payload);


### PR DESCRIPTION
## Summary

- **Problem:** On a fresh browser connect (no stored per-device token yet), the Control UI signs the device auth payload with `token: null` instead of the shared gateway token.
- **Why it matters:** The server verifies the signature against the actual auth token — with `null` the signature never matches, so the connection is rejected with `device signature invalid` before the pairing flow can even start. This breaks the dashboard for every new Docker install.
- **What changed:** `ui/src/ui/gateway.ts` line 247: `token: deviceToken ?? null` → `token: deviceToken ?? authToken ?? null`, matching the exact same fallback already used in the CLI gateway client (`src/gateway/client.ts:289`).
- **What did NOT change:** No protocol, pairing flow, or server-side changes.

## Change Type

- [x] Bug fix

## Scope

- [x] Auth / tokens
- [x] UI / DX

## Linked Issue/PR

None (discovered during fresh Docker install troubleshooting)

## User-visible / Behavior Changes

Fresh browser connects to the dashboard now correctly reach the pairing step instead of being rejected immediately with "device signature invalid".

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — the gateway token was already being sent in the `auth` field; this just ensures the device signature payload includes it consistently, matching existing CLI behavior.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu (Linux)
- Runtime/container: Docker (docker-setup.sh)
- Model/provider: Gemini

### Steps

1. Fresh `bash docker-setup.sh` install
2. Open browser at `http://localhost:18789/?token=<gateway-token>`
3. See "device signature invalid" in gateway logs; no pending device in `devices list`
4. Apply fix, rebuild, clear `localStorage`, reload
5. See "pairing required" in UI; pending device appears in `devices list`
6. Approve with `devices approve <requestId>` → dashboard connects

### Expected

Browser reaches pairing step and dashboard connects after approval.

### Actual (before fix)

Gateway rejects with `device signature invalid`; no pairing request created.

## Evidence

- [x] Trace/log snippets

Before fix (gateway logs):
```
[ws] closed before connect ... code=1008 reason=device signature invalid
```

After fix:
```
[ws] closed before connect ... code=1008 reason=pairing required
```
Then after `devices approve`: dashboard connects successfully.

## Human Verification

- Verified on a live Docker install that the fix resolves the issue end-to-end
- Confirmed the fix matches the existing pattern in `src/gateway/client.ts:289`
- Did not verify: HTTPS contexts (where `crypto.subtle` is available and device identity already works)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert by changing `token: deviceToken ?? authToken ?? null` back to `token: deviceToken ?? null`
- Known bad symptoms: none expected; worst case reverts to previous behavior

## Risks and Mitigations

- Risk: Paired devices with a stored `deviceToken` are unaffected (deviceToken takes precedence)
  - Mitigation: The `??` chain preserves existing behavior for already-paired devices

---

🤖 AI-assisted (GitHub Copilot). Fully tested on a live Docker install. Change understood and reviewed by contributor.