### PR TITLE
fix(swiftformat): exclude generated security policy from formatters

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -48,4 +48,4 @@
 --allman false
 
 # Exclusions
---exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/MoltbotProtocol
+--exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Peekaboo,Swabble,apps/android,apps/ios,apps/shared,apps/macos/Sources/MoltbotProtocol,apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,8 @@ excluded:
   - "*.playground"
   # Generated (protocol-gen-swift.ts)
   - apps/macos/Sources/MoltbotProtocol/GatewayModels.swift
+  # Generated (generate-host-env-security-policy-swift.mjs)
+  - apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
 
 analyzer_rules:
   - unused_declaration


### PR DESCRIPTION
## Summary

Add `HostEnvSecurityPolicy.generated.swift` to `.swiftformat` and `.swiftlint.yml` exclusion lists, matching the existing precedent for generated protocol models (`GatewayModels.swift`).

## Problem

`HostEnvSecurityPolicy.generated.swift` is produced by `scripts/generate-host-env-security-policy-swift.mjs` (from `src/infra/host-env-security-policy.json`). The generator uses `.join(",\n")` to render Swift arrays, which produces **no trailing comma** after the last element. However, SwiftFormat (configured with `--wrapcollections before-first` in `.swiftformat`) enforces trailing commas in Swift array literals.

Since the generated file is not excluded from SwiftFormat's scope, every `swiftformat` pass re-adds trailing commas, and every regeneration removes them. This creates a ping-pong that has broken `pnpm check` (specifically the `check:host-env-policy:swift` step) repeatedly.

### Timeline of drift incidents

| Date | Commit | What happened |
|------|--------|---------------|
| Feb 26 | 4894d907f | File created — generator output, no trailing commas |
| Mar 1 | ac3e1e769 (#31115) | SwiftFormat pass added trailing commas — **Greptile flagged this** as wrong, recommending the generated file not be manually formatted |
| Mar 2 | 7b3f506e6 | Another swiftformat pass re-broke it |
| Mar 2 | 74c1a7b22, 1c0d36eed | Two `fix(ci): resolve generated-policy drift` commits to fix it |
| Mar 3 | 46b62c53f | `fix(ci): restore scope-test require import and sync host policy` — yet another regeneration |
| Mar 7 | e27bbe498 | Legitimate policy JSON update required regeneration |
| Mar 8 | 53fb317e7 | SwiftFormat pass **re-broke it again** |
| Mar 8 | eba9dcc67 (#39959) | Regenerated to fix it — also moved the check to front of `pnpm check` chain |

That's at least **4 swiftformat-induced breakages** in 12 days, each requiring a manual regeneration commit to fix.

### Impact on open PRs

Any PR that rebases onto `main` during a broken window inherits the drift and fails CI, even if the PR itself doesn't touch security policy files. This just hit three of our open PRs (#20067, #35506, #36302), each of which needed a `chore: regenerate HostEnvSecurityPolicy.generated.swift` fixup commit after rebasing.

## Precedent

The repo already solved this exact class of problem for the other generated Swift file:

**`GatewayModels.swift`** (generated by `protocol-gen-swift.ts`):
- `.swiftformat`: excluded via the `--exclude` line (added in #195, commit d9a9f6db7)
- `.swiftlint.yml`: excluded with comment `# Generated (protocol-gen-swift.ts)` (same PR)
- The generator makes no attempt to produce SwiftFormat-compliant output
- CI check (`pnpm protocol:check`) verifies the tracked file matches generator output — same pattern as `check:host-env-policy:swift`

This PR applies the identical pattern to `HostEnvSecurityPolicy.generated.swift`.

## Fix

- `.swiftformat`: append the generated file path to the existing `--exclude` list
- `.swiftlint.yml`: add exclusion entry with comment `# Generated (generate-host-env-security-policy-swift.mjs)`, matching the `GatewayModels.swift` entry format

## Test plan

- [x] `node scripts/generate-host-env-security-policy-swift.mjs --check` passes
- [x] `pnpm check` passes (modulo pre-existing `format:check` issue in `lifecycle.test.ts`)
- [x] Future `swiftformat` runs no longer touch the generated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)