### PR TITLE
[codex] iMessage: fix audioAsVoice delivery and chunking

### DIFF
--- a/src/channels/plugins/outbound/imessage.test.ts
+++ b/src/channels/plugins/outbound/imessage.test.ts
@@ -66,4 +66,66 @@ describe("imessageOutbound", () => {
     );
     expect(result).toEqual({ channel: "imessage", messageId: "media-1" });
   });
+
+  it("routes audioAsVoice payloads through sendPayload and sends text separately", async () => {
+    const sendIMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "voice-1" })
+      .mockResolvedValueOnce({ messageId: "text-1" })
+      .mockResolvedValueOnce({ messageId: "extra-1" });
+    const sendPayload = imessageOutbound.sendPayload;
+    expect(sendPayload).toBeDefined();
+
+    const result = await sendPayload!({
+      cfg,
+      to: "chat_id:123",
+      text: "voice caption",
+      payload: {
+        text: "voice caption",
+        mediaUrls: ["https://example.com/voice.m4a", "https://example.com/extra.png"],
+        audioAsVoice: true,
+      },
+      mediaLocalRoots: ["/tmp"],
+      accountId: "acct-1",
+      replyToId: "msg-voice",
+      deps: { sendIMessage },
+    });
+
+    expect(sendIMessage).toHaveBeenNthCalledWith(
+      1,
+      "chat_id:123",
+      "",
+      expect.objectContaining({
+        audioAsVoice: true,
+        mediaUrl: "https://example.com/voice.m4a",
+        mediaLocalRoots: ["/tmp"],
+        replyToId: "msg-voice",
+        accountId: "acct-1",
+        maxBytes: 2 * 1024 * 1024,
+      }),
+    );
+    expect(sendIMessage).toHaveBeenNthCalledWith(
+      2,
+      "chat_id:123",
+      "voice caption",
+      expect.objectContaining({
+        replyToId: "msg-voice",
+        accountId: "acct-1",
+        maxBytes: 2 * 1024 * 1024,
+      }),
+    );
+    expect(sendIMessage).toHaveBeenNthCalledWith(
+      3,
+      "chat_id:123",
+      "",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/extra.png",
+        mediaLocalRoots: ["/tmp"],
+        replyToId: "msg-voice",
+        accountId: "acct-1",
+        maxBytes: 2 * 1024 * 1024,
+      }),
+    );
+    expect(result).toEqual({ channel: "imessage", messageId: "extra-1" });
+  });
 });

--- a/src/channels/plugins/outbound/imessage.test.ts
+++ b/src/channels/plugins/outbound/imessage.test.ts
@@ -128,4 +128,27 @@ describe("imessageOutbound", () => {
     );
     expect(result).toEqual({ channel: "imessage", messageId: "extra-1" });
   });
+
+  it("does not send empty channelData-only payloads", async () => {
+    const sendIMessage = vi.fn().mockResolvedValue({ messageId: "unexpected" });
+    const sendPayload = imessageOutbound.sendPayload;
+    expect(sendPayload).toBeDefined();
+
+    const result = await sendPayload!({
+      cfg,
+      to: "chat_id:123",
+      text: "",
+      payload: {
+        text: "",
+        channelData: { mode: "noop" },
+      },
+      mediaLocalRoots: ["/tmp"],
+      accountId: "acct-1",
+      replyToId: "msg-empty",
+      deps: { sendIMessage },
+    });
+
+    expect(sendIMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "imessage", messageId: "" });
+  });
 });

--- a/src/channels/plugins/outbound/imessage.ts
+++ b/src/channels/plugins/outbound/imessage.ts
@@ -1,3 +1,4 @@
+import { chunkText } from "../../../auto-reply/chunk.js";
 import { sendMessageIMessage } from "../../../imessage/send.js";
 import type { OutboundSendDeps } from "../../../infra/outbound/deliver.js";
 import type { ChannelOutboundAdapter } from "../types.js";
@@ -9,7 +10,7 @@ function resolveIMessageSender(deps: OutboundSendDeps | undefined) {
 
 export const imessageOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
-  chunker: null,
+  chunker: chunkText,
   chunkerMode: "text",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {

--- a/src/channels/plugins/outbound/imessage.ts
+++ b/src/channels/plugins/outbound/imessage.ts
@@ -1,30 +1,111 @@
 import { sendMessageIMessage } from "../../../imessage/send.js";
 import type { OutboundSendDeps } from "../../../infra/outbound/deliver.js";
-import {
-  createScopedChannelMediaMaxBytesResolver,
-  createDirectTextMediaOutbound,
-} from "./direct-text-media.js";
+import type { ChannelOutboundAdapter } from "../types.js";
+import { createScopedChannelMediaMaxBytesResolver } from "./direct-text-media.js";
 
 function resolveIMessageSender(deps: OutboundSendDeps | undefined) {
   return deps?.sendIMessage ?? sendMessageIMessage;
 }
 
-export const imessageOutbound = createDirectTextMediaOutbound({
-  channel: "imessage",
-  resolveSender: resolveIMessageSender,
-  resolveMaxBytes: createScopedChannelMediaMaxBytesResolver("imessage"),
-  buildTextOptions: ({ cfg, maxBytes, accountId, replyToId }) => ({
-    config: cfg,
-    maxBytes,
-    accountId: accountId ?? undefined,
-    replyToId: replyToId ?? undefined,
-  }),
-  buildMediaOptions: ({ cfg, mediaUrl, maxBytes, accountId, replyToId, mediaLocalRoots }) => ({
-    config: cfg,
-    mediaUrl,
-    maxBytes,
-    accountId: accountId ?? undefined,
-    replyToId: replyToId ?? undefined,
-    mediaLocalRoots,
-  }),
-});
+export const imessageOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  chunker: null,
+  chunkerMode: "text",
+  textChunkLimit: 4000,
+  sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
+    const send = resolveIMessageSender(deps);
+    const maxBytes = createScopedChannelMediaMaxBytesResolver("imessage")({
+      cfg,
+      accountId,
+    });
+    const result = await send(to, text, {
+      config: cfg,
+      maxBytes,
+      accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
+    });
+    return { channel: "imessage" as const, ...result };
+  },
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId }) => {
+    const send = resolveIMessageSender(deps);
+    const maxBytes = createScopedChannelMediaMaxBytesResolver("imessage")({
+      cfg,
+      accountId,
+    });
+    const result = await send(to, text, {
+      config: cfg,
+      mediaUrl,
+      maxBytes,
+      accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
+      mediaLocalRoots,
+    });
+    return { channel: "imessage" as const, ...result };
+  },
+  sendPayload: async ({ cfg, to, payload, mediaLocalRoots, accountId, deps, replyToId }) => {
+    const send = resolveIMessageSender(deps);
+    const maxBytes = createScopedChannelMediaMaxBytesResolver("imessage")({
+      cfg,
+      accountId,
+    });
+    const mediaUrls = payload.mediaUrls?.length
+      ? payload.mediaUrls
+      : payload.mediaUrl
+        ? [payload.mediaUrl]
+        : [];
+    const text = payload.text ?? "";
+
+    if (!payload.audioAsVoice || mediaUrls.length === 0) {
+      if (mediaUrls.length === 0) {
+        const result = await send(to, text, {
+          config: cfg,
+          maxBytes,
+          accountId: accountId ?? undefined,
+          replyToId: replyToId ?? undefined,
+        });
+        return { channel: "imessage" as const, ...result };
+      }
+      let finalResult: Awaited<ReturnType<ReturnType<typeof resolveIMessageSender>>> | undefined;
+      for (let index = 0; index < mediaUrls.length; index += 1) {
+        finalResult = await send(to, index === 0 ? text : "", {
+          config: cfg,
+          mediaUrl: mediaUrls[index],
+          maxBytes,
+          accountId: accountId ?? undefined,
+          replyToId: replyToId ?? undefined,
+          mediaLocalRoots,
+        });
+      }
+      return { channel: "imessage" as const, ...(finalResult ?? { messageId: "unknown" }) };
+    }
+
+    let finalResult = await send(to, "", {
+      config: cfg,
+      mediaUrl: mediaUrls[0],
+      maxBytes,
+      accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
+      mediaLocalRoots,
+      audioAsVoice: true,
+    });
+    if (text.trim()) {
+      finalResult = await send(to, text, {
+        config: cfg,
+        maxBytes,
+        accountId: accountId ?? undefined,
+        replyToId: replyToId ?? undefined,
+      });
+    }
+    for (const mediaUrl of mediaUrls.slice(1)) {
+      finalResult = await send(to, "", {
+        config: cfg,
+        mediaUrl,
+        maxBytes,
+        accountId: accountId ?? undefined,
+        replyToId: replyToId ?? undefined,
+        mediaLocalRoots,
+      });
+    }
+    return { channel: "imessage" as const, ...finalResult };
+  },
+};

--- a/src/channels/plugins/outbound/imessage.ts
+++ b/src/channels/plugins/outbound/imessage.ts
@@ -55,6 +55,9 @@ export const imessageOutbound: ChannelOutboundAdapter = {
         ? [payload.mediaUrl]
         : [];
     const text = payload.text ?? "";
+    if (!text && mediaUrls.length === 0) {
+      return { channel: "imessage" as const, messageId: "" };
+    }
 
     if (!payload.audioAsVoice || mediaUrls.length === 0) {
       if (mediaUrls.length === 0) {

--- a/src/imessage/send.test.ts
+++ b/src/imessage/send.test.ts
@@ -84,6 +84,20 @@ describe("sendMessageIMessage", () => {
     expect(params.text).toBe("<media:audio>");
   });
 
+  it("skips placeholder text for audioAsVoice attachments", async () => {
+    await sendWithDefaults("chat_id:7", "", {
+      mediaUrl: "http://x/voice",
+      audioAsVoice: true,
+      resolveAttachmentImpl: async () => ({
+        path: "/tmp/imessage-voice.m4a",
+        contentType: "audio/mp4",
+      }),
+    });
+    const params = getSentParams();
+    expect(params.file).toBe("/tmp/imessage-voice.m4a");
+    expect(params.text).toBe("");
+  });
+
   it("returns message id when rpc provides one", async () => {
     requestMock.mockResolvedValue({ ok: true, id: 123 });
     const result = await sendWithDefaults("chat_id:7", "hello");

--- a/src/imessage/send.test.ts
+++ b/src/imessage/send.test.ts
@@ -98,6 +98,21 @@ describe("sendMessageIMessage", () => {
     expect(params.text).toBe("");
   });
 
+  it("keeps audioAsVoice attachments text-free when replyToId is present", async () => {
+    await sendWithDefaults("chat_id:7", "", {
+      mediaUrl: "http://x/voice",
+      audioAsVoice: true,
+      replyToId: "abc-123",
+      resolveAttachmentImpl: async () => ({
+        path: "/tmp/imessage-voice.m4a",
+        contentType: "audio/mp4",
+      }),
+    });
+    const params = getSentParams();
+    expect(params.file).toBe("/tmp/imessage-voice.m4a");
+    expect(params.text).toBe("");
+  });
+
   it("returns message id when rpc provides one", async () => {
     requestMock.mockResolvedValue({ ok: true, id: 123 });
     const result = await sendWithDefaults("chat_id:7", "hello");

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -18,6 +18,7 @@ export type IMessageSendOpts = {
   mediaLocalRoots?: readonly string[];
   maxBytes?: number;
   timeoutMs?: number;
+  audioAsVoice?: boolean;
   chatId?: number;
   client?: IMessageRpcClient;
   config?: ReturnType<typeof loadConfig>;
@@ -130,7 +131,7 @@ export async function sendMessageIMessage(
     filePath = resolved.path;
     if (!message.trim()) {
       const kind = kindFromMime(resolved.contentType ?? undefined);
-      if (kind) {
+      if (kind && !(opts.audioAsVoice && kind === "audio")) {
         message = kind === "image" ? "<media:image>" : `<media:${kind}>`;
       }
     }

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -122,6 +122,7 @@ export async function sendMessageIMessage(
         : 16 * 1024 * 1024;
   let message = text ?? "";
   let filePath: string | undefined;
+  let keepReplyTagOutOfText = false;
 
   if (opts.mediaUrl?.trim()) {
     const resolveAttachmentFn = opts.resolveAttachmentImpl ?? resolveOutboundAttachmentFromUrl;
@@ -133,6 +134,8 @@ export async function sendMessageIMessage(
       const kind = kindFromMime(resolved.contentType ?? undefined);
       if (kind && !(opts.audioAsVoice && kind === "audio")) {
         message = kind === "image" ? "<media:image>" : `<media:${kind}>`;
+      } else if (kind === "audio" && opts.audioAsVoice) {
+        keepReplyTagOutOfText = true;
       }
     }
   }
@@ -148,7 +151,9 @@ export async function sendMessageIMessage(
     });
     message = convertMarkdownTables(message, tableMode);
   }
-  message = prependReplyTagIfNeeded(message, opts.replyToId);
+  if (!keepReplyTagOutOfText || message.trim()) {
+    message = prependReplyTagIfNeeded(message, opts.replyToId);
+  }
 
   const params: Record<string, unknown> = {
     text: message,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -403,6 +403,75 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("routes iMessage audioAsVoice payloads through sendPayload semantics", async () => {
+    const sendIMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "voice-1" })
+      .mockResolvedValueOnce({ messageId: "text-1" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "imessage",
+      to: "chat_id:42",
+      payloads: [
+        {
+          text: "voice caption",
+          mediaUrl: "https://example.com/voice.m4a",
+          audioAsVoice: true,
+        },
+      ],
+      deps: { sendIMessage },
+    });
+
+    expect(sendIMessage).toHaveBeenCalledTimes(2);
+    expect(sendIMessage).toHaveBeenNthCalledWith(
+      1,
+      "chat_id:42",
+      "",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/voice.m4a",
+        audioAsVoice: true,
+      }),
+    );
+    expect(sendIMessage).toHaveBeenNthCalledWith(
+      2,
+      "chat_id:42",
+      "voice caption",
+      expect.not.objectContaining({
+        mediaUrl: expect.anything(),
+      }),
+    );
+  });
+
+  it("chunks iMessage text using configured textChunkLimit", async () => {
+    const sendIMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "i1" })
+      .mockResolvedValueOnce({ messageId: "i2" });
+
+    await deliverOutboundPayloads({
+      cfg: { channels: { imessage: { textChunkLimit: 2 } } },
+      channel: "imessage",
+      to: "chat_id:42",
+      payloads: [{ text: "abcd" }],
+      deps: { sendIMessage },
+    });
+
+    expect(sendIMessage).toHaveBeenCalledTimes(2);
+    expect(sendIMessage).toHaveBeenNthCalledWith(
+      1,
+      "chat_id:42",
+      "ab",
+      expect.objectContaining({ accountId: undefined }),
+    );
+    expect(sendIMessage).toHaveBeenNthCalledWith(
+      2,
+      "chat_id:42",
+      "cd",
+      expect.objectContaining({ accountId: undefined }),
+    );
+  });
+
   it("uses signal media maxBytes from config", async () => {
     const sendSignal = vi.fn().mockResolvedValue({ messageId: "s1", timestamp: 123 });
     const cfg: OpenClawConfig = { channels: { signal: { mediaMaxMb: 2 } } };

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -472,6 +472,21 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("preserves empty channelData-only payloads for imessage without sending", async () => {
+    const sendIMessage = vi.fn().mockResolvedValue({ messageId: "unexpected" });
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "imessage",
+      to: "chat_id:42",
+      payloads: [{ text: " \n\t ", channelData: { mode: "custom" } }],
+      deps: { sendIMessage },
+    });
+
+    expect(sendIMessage).not.toHaveBeenCalled();
+    expect(results).toEqual([{ channel: "imessage", messageId: "" }]);
+  });
+
   it("uses signal media maxBytes from config", async () => {
     const sendSignal = vi.fn().mockResolvedValue({ messageId: "s1", timestamp: 123 });
     const cfg: OpenClawConfig = { channels: { signal: { mediaMaxMb: 2 } } };

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -713,7 +713,10 @@ async function deliverOutboundPayloadsCore(
         replyToId: effectivePayload.replyToId ?? params.replyToId ?? undefined,
         threadId: params.threadId ?? undefined,
       };
-      if (handler.sendPayload && effectivePayload.channelData) {
+      const shouldUsePayloadAdapter =
+        Boolean(effectivePayload.channelData) ||
+        (effectivePayload.audioAsVoice === true && payloadSummary.mediaUrls.length > 0);
+      if (handler.sendPayload && shouldUsePayloadAdapter) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
         results.push(delivery);
         emitMessageSent({


### PR DESCRIPTION
## Summary

- Problem: the iMessage outbound refactor added `audioAsVoice` handling in `sendPayload`, but the real delivery pipeline only dispatched `sendPayload` for `channelData` payloads.
- Why it matters: iMessage audio-as-voice payloads still fell back to the generic media path, and the same refactor also disabled existing iMessage text chunking.
- What changed: route media-bearing `audioAsVoice` payloads through the payload adapter, restore `chunkText` for iMessage outbound, and add regression tests at the delivery layer.
- What did NOT change (scope boundary): this does not add private-API/SIP-based native iMessage voice-bubble sending.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- iMessage `audioAsVoice` payloads with media now use the iMessage payload-adapter path instead of the generic media path.
- `channels.imessage.textChunkLimit` continues to apply after the outbound adapter change.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Bun test environment
- Model/provider: N/A
- Integration/channel (if any): iMessage outbound delivery
- Relevant config (redacted): `channels.imessage.textChunkLimit`, iMessage outbound media payloads

### Steps

1. Create an iMessage payload with `audioAsVoice=true` and a media URL.
2. Send it through `deliverOutboundPayloads`.
3. Send a long iMessage text with `channels.imessage.textChunkLimit` set small.

### Expected

- The audio payload uses the iMessage payload-adapter semantics.
- Long iMessage text is chunked according to config.

### Actual

- Before this change, `audioAsVoice` payloads did not reach `sendPayload` in the real delivery path.
- Before this change, iMessage text chunking was disabled by `chunker: null`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `audioAsVoice` payloads now trigger iMessage payload-adapter delivery in `deliverOutboundPayloads`
  - iMessage long text is chunked again via `channels.imessage.textChunkLimit`
- Edge cases checked:
  - existing `src/channels/plugins/outbound/imessage.test.ts`
  - existing `src/imessage/send.test.ts`
- What you did **not** verify:
  - live iMessage delivery against a real macOS Messages session

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert commits `216a69c38` and `8b9a88d11`
- Files/config to restore:
  - `src/channels/plugins/outbound/imessage.ts`
  - `src/infra/outbound/deliver.ts`
  - `src/infra/outbound/deliver.test.ts`
- Known bad symptoms reviewers should watch for:
  - `audioAsVoice` payloads still sending as generic media
  - iMessage long text no longer chunking

## Risks and Mitigations

- Risk:
  - Expanding `sendPayload` dispatch could affect future payload features that also live outside `channelData`.
  - Mitigation:
    - the new condition is intentionally narrow: only media-bearing `audioAsVoice` payloads take this path.
- Risk:
  - Restoring iMessage chunking could alter behavior for callers that had started depending on the accidental single-send regression.
  - Mitigation:
    - this restores documented/configured behavior and is covered by regression tests.
