### PR TITLE
fix(session): prevent reset notice mirror from corrupting conversation history

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -224,6 +224,22 @@ describe("runPreparedReply media-only handling", () => {
     expect(resetNoticeCall?.payload?.text).not.toContain("env:");
   });
 
+  it("sends reset notice with mirror disabled to avoid orphaned assistant messages", async () => {
+    await runPreparedReply(
+      baseParams({
+        resetTriggered: true,
+      }),
+    );
+
+    const resetNoticeCall = vi.mocked(routeReply).mock.calls[0]?.[0] as
+      | { mirror?: boolean }
+      | undefined;
+    // The reset notice must NOT be mirrored into the session transcript.
+    // Mirroring inserts an orphaned assistant message (no preceding user turn)
+    // which breaks providers that enforce strict role ordering (#39830).
+    expect(resetNoticeCall?.mirror).toBe(false);
+  });
+
   it("skips reset notice when only webchat fallback routing is available", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -120,6 +120,13 @@ async function sendResetSessionNotice(params: {
     accountId: params.accountId,
     threadId: params.threadId,
     cfg: params.cfg,
+    // The reset notice is a transient UI notification, not part of the
+    // conversation.  Mirroring it into the session transcript inserts an
+    // orphaned assistant message (no preceding user turn) which corrupts
+    // the message history for providers that enforce strict role ordering
+    // (e.g. LM Studio / llama.cpp jinja templates).  This caused the
+    // Discord /new command to break all subsequent messages (#39830).
+    mirror: false,
   });
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where using the `/new` slash command in Discord (and potentially
other native command channels like Telegram/Slack) would break the conversation, causing
subsequent messages to fail with errors like "No user query found in messages" (especially
noticeable with LM Studio and strict-ordering providers).

### Root Cause

When a user executes the `/new` native command:
1. The session is reset and a new `sessionId` is generated.
2. `sendResetSessionNotice` is called to notify the user via Discord.
3. This notice is sent using `routeReply`, which by default **mirrors** the message into
   the session transcript as an `assistant` message (`delivery-mirror`).
4. Because this happens *before* the greeting prompt is executed, the new session file
   starts with an orphaned `assistant` message (the reset notice) without any preceding
   `user` message.
5. When subsequent messages are sent, the session history violates strict role ordering
   (user → assistant → user), causing providers that enforce this (like LM Studio's jinja
   templates) to fail.

### Fix

Added `mirror: false` to the `routeReply` call in `sendResetSessionNotice`.

The reset notice is a transient UI notification and should not be persisted as part of the
conversation history. By disabling the mirror, the session file correctly starts with the
user's greeting prompt, maintaining proper role ordering.

## Related Issues

Fixes #39830

## Changes Made

- Modified `sendResetSessionNotice` in `src/auto-reply/reply/get-reply-run.ts` to pass
  `mirror: false` to `routeReply`.
- Added a test case in `src/auto-reply/reply/get-reply-run.media-only.test.ts` to verify
  that the reset notice is not mirrored.

## Testing

- [x] Added unit test to verify `mirror: false` is passed for reset notices.
- [x] Ran all tests in `src/auto-reply/reply/` (708 tests passed).
- [x] Ran `src/agents/pi-embedded-runner.sanitize-session-history.test.ts` to ensure
      history sanitization works correctly.
- [x] Simulated the end-to-end flow to confirm the session transcript no longer contains
      the orphaned assistant message.