### PR TITLE
fix(telegram): emit message:sent internal hook for Telegram delivery path

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -442,6 +442,9 @@ export const dispatchTelegramMessage = async ({
     chunkMode,
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
+    sessionKey: ctxPayload.SessionKey,
+    isGroup,
+    groupId: isGroup ? String(chatId) : undefined,
   };
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -4,6 +4,12 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import { danger, logVerbose } from "../../globals.js";
+import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import {
+  buildCanonicalSentMessageHookContext,
+  toInternalMessageSentContext,
+} from "../../hooks/message-hook-mappers.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildOutboundMediaLoadOptions } from "../../media/load-options.js";
 import { isGifMedia, kindFromMime } from "../../media/mime.js";
@@ -512,6 +518,12 @@ export async function deliverReplies(params: {
   linkPreview?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
+  /** Session key for emitting message:sent internal hooks. */
+  sessionKey?: string;
+  /** Whether the conversation is a group chat (for hook context). */
+  isGroup?: boolean;
+  /** Group identifier for hook context. */
+  groupId?: string;
 }): Promise<{ delivered: boolean }> {
   const progress: DeliveryProgress = {
     hasReplied: false,
@@ -637,6 +649,33 @@ export async function deliverReplies(params: {
           },
         );
       }
+      if (params.sessionKey) {
+        const deliveredThisReply = progress.deliveredCount > deliveredCountBeforeReply;
+        const canonical = buildCanonicalSentMessageHookContext({
+          to: params.chatId,
+          content: contentForSentHook,
+          success: deliveredThisReply,
+          channelId: "telegram",
+          accountId: params.accountId,
+          conversationId: params.chatId,
+          isGroup: params.isGroup,
+          groupId: params.groupId,
+        });
+        fireAndForgetHook(
+          triggerInternalHook(
+            createInternalHookEvent(
+              "message",
+              "sent",
+              params.sessionKey,
+              toInternalMessageSentContext(canonical),
+            ),
+          ),
+          "telegram deliverReplies: message:sent internal hook failed",
+          (message) => {
+            logVerbose(message);
+          },
+        );
+      }
     } catch (error) {
       if (hasMessageSentHooks) {
         void hookRunner?.runMessageSent(
@@ -650,6 +689,33 @@ export async function deliverReplies(params: {
             channelId: "telegram",
             accountId: params.accountId,
             conversationId: params.chatId,
+          },
+        );
+      }
+      if (params.sessionKey) {
+        const canonical = buildCanonicalSentMessageHookContext({
+          to: params.chatId,
+          content: contentForSentHook,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          channelId: "telegram",
+          accountId: params.accountId,
+          conversationId: params.chatId,
+          isGroup: params.isGroup,
+          groupId: params.groupId,
+        });
+        fireAndForgetHook(
+          triggerInternalHook(
+            createInternalHookEvent(
+              "message",
+              "sent",
+              params.sessionKey,
+              toInternalMessageSentContext(canonical),
+            ),
+          ),
+          "telegram deliverReplies: message:sent internal hook failed",
+          (message) => {
+            logVerbose(message);
           },
         );
       }

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -23,8 +23,34 @@ type DeliverWithParams = Omit<
   Partial<Pick<DeliverRepliesParams, "replyToMode" | "textLimit">>;
 type RuntimeStub = Pick<RuntimeEnv, "error" | "log" | "exit">;
 
+const triggerInternalHookMock = vi.fn().mockResolvedValue(undefined);
+
 vi.mock("../../web/media.js", () => ({
   loadWebMedia: (...args: unknown[]) => loadWebMedia(...args),
+}));
+
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: (
+    type: string,
+    action: string,
+    sessionKey: string,
+    context: unknown,
+  ) => ({
+    type,
+    action,
+    sessionKey,
+    context,
+  }),
+  triggerInternalHook: (...args: unknown[]) => triggerInternalHookMock(...args),
+}));
+
+vi.mock("../../hooks/fire-and-forget.js", () => ({
+  fireAndForgetHook: (promise: Promise<void>) => void promise.catch(() => {}),
+}));
+
+vi.mock("../../hooks/message-hook-mappers.js", () => ({
+  buildCanonicalSentMessageHookContext: (params: Record<string, unknown>) => params,
+  toInternalMessageSentContext: (canonical: Record<string, unknown>) => canonical,
 }));
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
@@ -112,6 +138,7 @@ describe("deliverReplies", () => {
     messageHookRunner.hasHooks.mockReturnValue(false);
     messageHookRunner.runMessageSending.mockReset();
     messageHookRunner.runMessageSent.mockReset();
+    triggerInternalHookMock.mockClear();
   });
 
   it("skips audioAsVoice-only payloads without logging an error", async () => {
@@ -764,5 +791,69 @@ describe("deliverReplies", () => {
 
     expect(sendVoice).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("emits message:sent internal hook when sessionKey is provided", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 42, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      ...baseDeliveryParams,
+      replies: [{ text: "hello" }],
+      runtime,
+      bot,
+      sessionKey: "telegram:123",
+      isGroup: false,
+    });
+
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        action: "sent",
+        sessionKey: "telegram:123",
+      }),
+    );
+  });
+
+  it("does not emit message:sent internal hook when sessionKey is absent", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 43, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      ...baseDeliveryParams,
+      replies: [{ text: "hello" }],
+      runtime,
+      bot,
+    });
+
+    expect(triggerInternalHookMock).not.toHaveBeenCalled();
+  });
+
+  it("emits message:sent internal hook with success=false on delivery error", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockRejectedValue(new Error("send failed"));
+    const bot = createBot({ sendMessage });
+
+    await expect(
+      deliverReplies({
+        ...baseDeliveryParams,
+        replies: [{ text: "hello" }],
+        runtime,
+        bot,
+        sessionKey: "telegram:456",
+      }),
+    ).rejects.toThrow("send failed");
+
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        action: "sent",
+        sessionKey: "telegram:456",
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Problem: The `message:sent` internal hook event is never emitted when messages are sent via the Telegram channel. Plugin hooks (`hookRunner.runMessageSent()`) fire correctly, but internal hooks (`triggerInternalHook("message", "sent", ...)`) are skipped because the Telegram delivery path (`dispatchTelegramMessage → deliverReplies`) bypasses the shared `deliverOutboundPayloads()` path where internal hooks are emitted.
- Why it matters: Users who define SKILL.md event handlers for `message:sent` (e.g., for logging, analytics, or post-send workflows) get no events from Telegram — the most popular messaging channel.
- What changed: Added `triggerInternalHook("message", "sent", ...)` calls in `deliverReplies()` (alongside the existing plugin hook), gated on an optional `sessionKey` parameter. Passed `sessionKey`, `isGroup`, and `groupId` from `dispatchTelegramMessage` via `deliveryBaseOptions`.
- What did NOT change (scope boundary): Plugin hooks (`hookRunner.runMessageSent()`) are untouched. The `deliverOutboundPayloads()` shared path is untouched. Native command delivery (`bot-native-commands.ts`) does not pass `sessionKey` and thus does not emit internal hooks (these are not normal agent message replies).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #39955

## User-visible / Behavior Changes

`message:sent` internal hook events now fire for Telegram channel messages. Previously only the `message:received` hook worked for Telegram; now both directions are covered.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Telegram

### Steps

1. Create a SKILL.md hook listening for `message:sent` event
2. Send a message to the bot via Telegram
3. Observe whether the hook fires

### Expected

- `message:sent` hook fires after the bot successfully delivers a reply

### Actual (before fix)

- Hook never fires — no console output, no errors

## Evidence

- [x] Failing test/log before + passing after

Three new test cases added to `src/telegram/bot/delivery.test.ts`:

| Test | What it verifies |
|------|-----------------|
| `emits message:sent internal hook when sessionKey is provided` | Internal hook fires on successful delivery |
| `does not emit message:sent internal hook when sessionKey is absent` | No internal hook when sessionKey is not passed (backward compat) |
| `emits message:sent internal hook with success=false on delivery error` | Internal hook fires with error context on failed delivery |

## Human Verification (required)

- Verified scenarios: All 88 existing tests pass (26→29 in delivery.test.ts, 59 in bot-message-dispatch.test.ts). New tests confirm internal hook emission on success, absence without sessionKey, and emission on error.
- Edge cases checked: Missing sessionKey (no hook emitted), delivery failure (hook emitted with success=false and error message)
- What I did **not** verify: Live Telegram bot testing (requires real bot token and running gateway)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — `sessionKey`, `isGroup`, and `groupId` are all optional parameters
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; internal hook emission is additive and isolated
- Files/config to restore: `src/telegram/bot/delivery.replies.ts`, `src/telegram/bot-message-dispatch.ts`
- Known bad symptoms reviewers should watch for: Unexpected errors in gateway logs containing "message:sent internal hook failed"

## Risks and Mitigations

- Risk: Internal hook handler throws, blocking delivery
  - Mitigation: `fireAndForgetHook()` wraps the hook call — exceptions are caught and logged, never propagated to the delivery path