### PR TITLE
fix(discord): remove invalid message_reference from webhook payloads

### DIFF
--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -341,9 +341,6 @@ export async function sendWebhookMessageDiscord(
     throw new Error("Discord webhook id/token are required");
   }
 
-  const replyTo = typeof opts.replyTo === "string" ? opts.replyTo.trim() : "";
-  const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
-
   const response = await fetch(
     resolveWebhookExecutionUrl({
       webhookId,
@@ -360,7 +357,6 @@ export async function sendWebhookMessageDiscord(
         content: text,
         username: opts.username?.trim() || undefined,
         avatar_url: opts.avatarUrl?.trim() || undefined,
-        ...(messageReference ? { message_reference: messageReference } : {}),
       }),
     },
   );


### PR DESCRIPTION
## Summary
- Remove `message_reference` from Discord webhook execute payloads
- The [Execute Webhook](https://docs.discord.com/developers/resources/webhook) endpoint does not support this field; it is only valid on the [Create Message](https://docs.discord.com/developers/resources/message) endpoint (bot-token)
- The field was silently ignored by Discord, but sending unsupported fields risks future rejection

## Test plan
- [ ] Verify webhook sends still succeed without `message_reference`
- [ ] Confirm bot-token reply behavior (`replyTo` via `sendMessageDiscord`) is unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)