### PR TITLE
fix(utils): replace maskApiKey partial exposure with full redaction

### DIFF
--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -220,11 +220,11 @@ describe("modelsStatusCommand auth overview", () => {
     const anthropic = providers.find((p) => p.provider === "anthropic");
     expect(anthropic).toBeTruthy();
     expect(anthropic?.profiles.labels.join(" ")).toContain("OAuth");
-    expect(anthropic?.profiles.labels.join(" ")).toContain("...");
+    expect(anthropic?.profiles.labels.join(" ")).toContain("****");
 
     const openai = providers.find((p) => p.provider === "openai");
     expect(openai?.env?.source).toContain("OPENAI_API_KEY");
-    expect(openai?.env?.value).toContain("...");
+    expect(openai?.env?.value).toContain("****");
 
     expect(
       (payload.auth.providersWithOAuth as string[]).some((e) => e.startsWith("anthropic")),
@@ -256,7 +256,7 @@ describe("modelsStatusCommand auth overview", () => {
       }>;
       const openai = providers.find((p) => p.provider === "openai");
       const labels = openai?.profiles.labels ?? [];
-      expect(labels.join(" ")).toContain("...");
+      expect(labels.join(" ")).toContain("****");
       expect(labels.join(" ")).not.toContain(shortSecret);
     } finally {
       mocks.store.profiles = originalProfiles;

--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -2,19 +2,15 @@ import { describe, expect, it } from "vitest";
 import { maskApiKey } from "./mask-api-key.js";
 
 describe("maskApiKey", () => {
-  it("returns missing for empty values", () => {
+  it("returns 'missing' for empty or whitespace-only values", () => {
     expect(maskApiKey("")).toBe("missing");
     expect(maskApiKey("   ")).toBe("missing");
   });
 
-  it("masks short and medium values without returning raw secrets", () => {
-    expect(maskApiKey(" abcdefghijklmnop ")).toBe("ab...op");
-    expect(maskApiKey(" short ")).toBe("s...t");
-    expect(maskApiKey(" a ")).toBe("a...a");
-    expect(maskApiKey(" ab ")).toBe("a...b");
-  });
-
-  it("masks long values with first and last 8 chars", () => {
-    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("12345678...ijklmnop"); // pragma: allowlist secret
+  it("returns masked placeholder for any non-empty key", () => {
+    expect(maskApiKey("short")).toBe("****");
+    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("****");
+    expect(maskApiKey(" a ")).toBe("****");
+    expect(maskApiKey(" ab ")).toBe("****");
   });
 });

--- a/src/utils/mask-api-key.ts
+++ b/src/utils/mask-api-key.ts
@@ -1,13 +1,6 @@
 export const maskApiKey = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) {
+  if (!value.trim()) {
     return "missing";
   }
-  if (trimmed.length <= 6) {
-    return `${trimmed.slice(0, 1)}...${trimmed.slice(-1)}`;
-  }
-  if (trimmed.length <= 16) {
-    return `${trimmed.slice(0, 2)}...${trimmed.slice(-2)}`;
-  }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return "****";
 };


### PR DESCRIPTION
## Summary

**Problem:** `maskApiKey()` exposes up to 16 characters of API keys in `/models` and `/model status` output (first 8 + last 8 for keys > 16 chars). This is enough to identify or partially reconstruct keys, especially for shorter provider keys.

**Why it matters:** API keys shown in chat output can be captured by prompt injection, logged by middleware, or displayed to unauthorized channel members. The masked output is intended for presence/absence checks only — partial key content provides no diagnostic value.

**What changed:** Replaced the length-based partial exposure logic with a constant `"****"` return value. Empty/whitespace-only keys still return `"missing"`. Updated integration test expectations in `list.status.test.ts` to match the new format.

**What did NOT change:** The function signature, call sites, and `"missing"` behavior for empty keys are unchanged.

## Change Type

- [x] Bug fix (security hardening)

## Scope

- [x] CLI (commands)

## Linked Issue/PR

Fixes #34452. Supersedes #27474 (closed — rebased on current main).

## User-visible / Behavior Changes

| Before | After |
|--------|-------|
| `/models` shows `12345678...ijklmnop` | `/models` shows `****` |
| `/model status` shows `ab...op` | `/model status` shows `****` |
| Empty key shows `missing` | Empty key shows `missing` (unchanged) |

## Security Impact

1. Does this change how secrets, tokens, or credentials are handled? **Yes — reduces exposure from up to 16 chars to zero.**
2. Does this change authentication or authorization logic? **No**
3. Does this change what data is logged or exposed in error messages? **Yes — `/models` and `/model status` output now shows `****` instead of partial keys.**
4. Does this change file system access patterns or permissions? **No**
5. Does this change network access or external API calls? **No**

## Repro + Verification

**Environment:** Any OpenClaw installation with API keys configured.

**Steps:**
1. Run `openclaw models` or `/models` in chat
2. Observe API key column

**Expected:** `****` for all configured keys, `missing` for unconfigured keys.
**Actual (before fix):** Partial key content visible (e.g. `12345678...ijklmnop`).

## Evidence

Unit + integration tests: 9/9 pass.

```
✓ src/utils/mask-api-key.test.ts (2 tests) 2ms
✓ src/commands/models/list.status.test.ts (7 tests) 10ms
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

## Human Verification

- [x] Verified all unit tests pass (mask-api-key.test.ts: 2/2)
- [x] Verified all integration tests pass (list.status.test.ts: 7/7, including 3 updated expectations)
- [x] Verified all 6 call sites in `list.auth-overview.ts` and `directive-handling.auth.ts` — all use return value as display text only
- [x] Verified `"missing"` behavior for empty keys is preserved
- [x] Verified trim boundary cases (` a `, ` ab `) return `"****"`
- [ ] Not verified: visual output in `/models` command (no local gateway on this branch per PR workflow)

## Compatibility / Migration

No breaking changes. The function signature is unchanged. All call sites use the return value for display purposes only — no logic depends on the masked key format.

## Failure Recovery

**Revert:** `git revert <commit>` — single commit, no migration needed.
**Symptom if reverted:** API key snippets visible again in `/models` output — cosmetic/security regression only, no functional impact.

## Risks and Mitigations

| Risk | Likelihood | Mitigation |
|------|-----------|------------|
| Users can no longer distinguish which key is configured for a provider | Low | `"missing"` vs `"****"` still distinguishes presence/absence. profileId and source are displayed alongside the masked value for identification. |