### PR TITLE
feat(config): use datetime suffix for backup rotation instead of numeric

### DIFF
--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -13,6 +13,32 @@ export interface BackupMaintenanceFs extends BackupRotationFs {
   copyFile: (from: string, to: string) => Promise<void>;
 }
 
+/** YYYYMMDD-HHmmss in UTC. */
+function formatBackupTimestamp(date: Date = new Date()): string {
+  const y = date.getUTCFullYear();
+  const mo = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  const h = String(date.getUTCHours()).padStart(2, "0");
+  const mi = String(date.getUTCMinutes()).padStart(2, "0");
+  const s = String(date.getUTCSeconds()).padStart(2, "0");
+  return `${y}${mo}${d}-${h}${mi}${s}`;
+}
+
+/** Pattern that matches a datetime suffix: YYYYMMDD-HHmmss with optional -N collision suffix. */
+const DATETIME_SUFFIX_RE = /^\d{8}-\d{6}(?:-\d+)?$/;
+
+/** Check whether a suffix looks like a datetime backup suffix. */
+export function isDatetimeSuffix(suffix: string): boolean {
+  return DATETIME_SUFFIX_RE.test(suffix);
+}
+
+/**
+ * Rotate the primary `.bak` file into a datetime-stamped slot.
+ *
+ * Previous behavior used numeric rotation (.bak.1, .bak.2, …).
+ * Now we rename `.bak` → `.bak.YYYYMMDD-HHmmss` and rely on
+ * {@link cleanOrphanBackups} to enforce the capacity limit.
+ */
 export async function rotateConfigBackups(
   configPath: string,
   ioFs: BackupRotationFs,
@@ -21,22 +47,30 @@ export async function rotateConfigBackups(
     return;
   }
   const backupBase = `${configPath}.bak`;
-  const maxIndex = CONFIG_BACKUP_COUNT - 1;
-  await ioFs.unlink(`${backupBase}.${maxIndex}`).catch(() => {
-    // best-effort
-  });
-  for (let index = maxIndex - 1; index >= 1; index -= 1) {
-    await ioFs.rename(`${backupBase}.${index}`, `${backupBase}.${index + 1}`).catch(() => {
-      // best-effort
-    });
+  const stamp = formatBackupTimestamp();
+  let dest = `${backupBase}.${stamp}`;
+
+  // Handle sub-second collision: append -2, -3, … suffix.
+  if (ioFs.readdir) {
+    const dir = path.dirname(configPath);
+    const entries = await ioFs.readdir(dir).catch(() => [] as string[]);
+    const destBasename = path.basename(dest);
+    if (entries.includes(destBasename)) {
+      let seq = 2;
+      while (entries.includes(`${destBasename}-${seq}`)) {
+        seq += 1;
+      }
+      dest = `${dest}-${seq}`;
+    }
   }
-  await ioFs.rename(backupBase, `${backupBase}.1`).catch(() => {
-    // best-effort
+
+  await ioFs.rename(backupBase, dest).catch(() => {
+    // best-effort — .bak may not exist yet
   });
 }
 
 /**
- * Harden file permissions on all .bak files in the rotation ring.
+ * Harden file permissions on all .bak files.
  * copyFile does not guarantee permission preservation on all platforms
  * (e.g. Windows, some NFS mounts), so we explicitly chmod each backup
  * to owner-only (0o600) to match the main config file.
@@ -48,26 +82,40 @@ export async function hardenBackupPermissions(
   if (!ioFs.chmod) {
     return;
   }
-  const backupBase = `${configPath}.bak`;
+  const dir = path.dirname(configPath);
+  const base = path.basename(configPath);
+  const bakExact = `${base}.bak`;
+
   // Harden the primary .bak
-  await ioFs.chmod(backupBase, 0o600).catch(() => {
+  await ioFs.chmod(`${configPath}.bak`, 0o600).catch(() => {
     // best-effort
   });
-  // Harden numbered backups
-  for (let i = 1; i < CONFIG_BACKUP_COUNT; i++) {
-    await ioFs.chmod(`${backupBase}.${i}`, 0o600).catch(() => {
-      // best-effort
-    });
+
+  // Harden all datetime-stamped backups
+  if (ioFs.readdir) {
+    const entries = await ioFs.readdir(dir).catch(() => [] as string[]);
+    for (const entry of entries) {
+      if (!entry.startsWith(`${bakExact}.`)) {
+        continue;
+      }
+      const suffix = entry.slice(bakExact.length + 1);
+      if (isDatetimeSuffix(suffix)) {
+        await ioFs.chmod(path.join(dir, entry), 0o600).catch(() => {
+          // best-effort
+        });
+      }
+    }
   }
 }
 
 /**
- * Remove orphan .bak files that fall outside the managed rotation ring.
- * These can accumulate from interrupted writes, manual copies, or PID-stamped
- * backups (e.g. openclaw.json.bak.1772352289, openclaw.json.bak.before-marketing).
+ * Remove backup files that fall outside the managed rotation ring.
  *
- * Only files matching `<configBasename>.bak.*` are considered; the primary
- * `.bak` and numbered `.bak.1` through `.bak.{N-1}` are preserved.
+ * Keeps the N-1 most recent datetime-stamped backups (sorted lexicographically,
+ * which equals chronological order for the YYYYMMDD-HHmmss format).
+ *
+ * Also removes legacy numbered backups (.bak.1, .bak.2, …) and any other
+ * non-datetime orphans (PID-stamped, manual copies, etc.).
  */
 export async function cleanOrphanBackups(
   configPath: string,
@@ -80,12 +128,6 @@ export async function cleanOrphanBackups(
   const base = path.basename(configPath);
   const bakPrefix = `${base}.bak.`;
 
-  // Build the set of valid numbered suffixes: "1", "2", ..., "{N-1}"
-  const validSuffixes = new Set<string>();
-  for (let i = 1; i < CONFIG_BACKUP_COUNT; i++) {
-    validSuffixes.add(String(i));
-  }
-
   let entries: string[];
   try {
     entries = await ioFs.readdir(dir);
@@ -93,24 +135,46 @@ export async function cleanOrphanBackups(
     return; // best-effort
   }
 
+  const datetimeBackups: string[] = [];
+  const orphans: string[] = [];
+
   for (const entry of entries) {
     if (!entry.startsWith(bakPrefix)) {
       continue;
     }
     const suffix = entry.slice(bakPrefix.length);
-    if (validSuffixes.has(suffix)) {
-      continue;
+    if (isDatetimeSuffix(suffix)) {
+      datetimeBackups.push(entry);
+    } else {
+      orphans.push(entry);
     }
-    // This is an orphan — remove it
-    await ioFs.unlink(path.join(dir, entry)).catch(() => {
+  }
+
+  // Remove all non-datetime orphans (legacy numbered, PID-stamped, manual, etc.)
+  for (const orphan of orphans) {
+    await ioFs.unlink(path.join(dir, orphan)).catch(() => {
       // best-effort
     });
+  }
+
+  // Keep the N-1 most recent datetime backups, remove the rest.
+  // (N-1 because the primary .bak also counts toward CONFIG_BACKUP_COUNT.)
+  const maxDatetimeSlots = CONFIG_BACKUP_COUNT - 1;
+  if (datetimeBackups.length > maxDatetimeSlots) {
+    // Lexicographic sort = chronological for YYYYMMDD-HHmmss format.
+    datetimeBackups.sort();
+    const toRemove = datetimeBackups.slice(0, datetimeBackups.length - maxDatetimeSlots);
+    for (const old of toRemove) {
+      await ioFs.unlink(path.join(dir, old)).catch(() => {
+        // best-effort
+      });
+    }
   }
 }
 
 /**
  * Run the full backup maintenance cycle around config writes.
- * Order matters: rotate ring -> create new .bak -> harden modes -> prune orphan .bak.* files.
+ * Order matters: rotate ring -> create new .bak -> harden modes -> prune stale backups.
  */
 export async function maintainConfigBackups(
   configPath: string,

--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -6,7 +6,7 @@ export interface BackupRotationFs {
   unlink: (path: string) => Promise<void>;
   rename: (from: string, to: string) => Promise<void>;
   chmod?: (path: string, mode: number) => Promise<void>;
-  readdir?: (path: string) => Promise<string[]>;
+  readdir: (path: string) => Promise<string[]>;
 }
 
 export interface BackupMaintenanceFs extends BackupRotationFs {
@@ -24,8 +24,12 @@ function formatBackupTimestamp(date: Date = new Date()): string {
   return `${y}${mo}${d}-${h}${mi}${s}`;
 }
 
-/** Pattern that matches a datetime suffix: YYYYMMDD-HHmmss with optional -N collision suffix. */
-const DATETIME_SUFFIX_RE = /^\d{8}-\d{6}(?:-\d+)?$/;
+/**
+ * Pattern that matches a datetime suffix: YYYYMMDD-HHmmss with optional
+ * zero-padded collision suffix (-02, -03, …). The collision counter starts
+ * at 02, so -0 and -1 are never produced and are intentionally excluded.
+ */
+const DATETIME_SUFFIX_RE = /^\d{8}-\d{6}(?:-\d{2,})?$/;
 
 /** Check whether a suffix looks like a datetime backup suffix. */
 export function isDatetimeSuffix(suffix: string): boolean {
@@ -50,18 +54,16 @@ export async function rotateConfigBackups(
   const stamp = formatBackupTimestamp();
   let dest = `${backupBase}.${stamp}`;
 
-  // Handle sub-second collision: append -2, -3, … suffix.
-  if (ioFs.readdir) {
-    const dir = path.dirname(configPath);
-    const entries = await ioFs.readdir(dir).catch(() => [] as string[]);
-    const destBasename = path.basename(dest);
-    if (entries.includes(destBasename)) {
-      let seq = 2;
-      while (entries.includes(`${destBasename}-${seq}`)) {
-        seq += 1;
-      }
-      dest = `${dest}-${seq}`;
+  // Handle sub-second collision: append zero-padded -02, -03, … suffix.
+  const dir = path.dirname(configPath);
+  const entries = await ioFs.readdir(dir).catch(() => [] as string[]);
+  const destBasename = path.basename(dest);
+  if (entries.includes(destBasename)) {
+    let seq = 2;
+    while (entries.includes(`${destBasename}-${String(seq).padStart(2, "0")}`)) {
+      seq += 1;
     }
+    dest = `${dest}-${String(seq).padStart(2, "0")}`;
   }
 
   await ioFs.rename(backupBase, dest).catch(() => {
@@ -92,18 +94,16 @@ export async function hardenBackupPermissions(
   });
 
   // Harden all datetime-stamped backups
-  if (ioFs.readdir) {
-    const entries = await ioFs.readdir(dir).catch(() => [] as string[]);
-    for (const entry of entries) {
-      if (!entry.startsWith(`${bakExact}.`)) {
-        continue;
-      }
-      const suffix = entry.slice(bakExact.length + 1);
-      if (isDatetimeSuffix(suffix)) {
-        await ioFs.chmod(path.join(dir, entry), 0o600).catch(() => {
-          // best-effort
-        });
-      }
+  const entries = await ioFs.readdir(dir).catch(() => [] as string[]);
+  for (const entry of entries) {
+    if (!entry.startsWith(`${bakExact}.`)) {
+      continue;
+    }
+    const suffix = entry.slice(bakExact.length + 1);
+    if (isDatetimeSuffix(suffix)) {
+      await ioFs.chmod(path.join(dir, entry), 0o600).catch(() => {
+        // best-effort
+      });
     }
   }
 }
@@ -121,9 +121,6 @@ export async function cleanOrphanBackups(
   configPath: string,
   ioFs: BackupRotationFs,
 ): Promise<void> {
-  if (!ioFs.readdir) {
-    return;
-  }
   const dir = path.dirname(configPath);
   const base = path.basename(configPath);
   const bakPrefix = `${base}.bak.`;

--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -165,8 +165,21 @@ export async function cleanOrphanBackups(
   // (N-1 because the primary .bak also counts toward CONFIG_BACKUP_COUNT.)
   const maxDatetimeSlots = CONFIG_BACKUP_COUNT - 1;
   if (datetimeBackups.length > maxDatetimeSlots) {
-    // Lexicographic sort = chronological for YYYYMMDD-HHmmss format.
-    datetimeBackups.sort();
+    // Sort chronologically. The YYYYMMDD-HHmmss prefix sorts correctly
+    // lexicographically; for same-second collision suffixes (-02, … -100)
+    // we compare the numeric tail so -100 sorts after -99.
+    datetimeBackups.sort((a, b) => {
+      const suffA = a.slice(bakPrefix.length);
+      const suffB = b.slice(bakPrefix.length);
+      const tsA = suffA.slice(0, 15); // YYYYMMDD-HHmmss = 15 chars
+      const tsB = suffB.slice(0, 15);
+      if (tsA !== tsB) {
+        return tsA < tsB ? -1 : 1;
+      }
+      const seqA = parseInt(suffA.slice(16) || "0", 10); // skip the "-" after timestamp
+      const seqB = parseInt(suffB.slice(16) || "0", 10);
+      return seqA - seqB;
+    });
     const toRemove = datetimeBackups.slice(0, datetimeBackups.length - maxDatetimeSlots);
     for (const old of toRemove) {
       await ioFs.unlink(path.join(dir, old)).catch(() => {

--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -55,10 +55,17 @@ export async function rotateConfigBackups(
   let dest = `${backupBase}.${stamp}`;
 
   // Handle sub-second collision: append zero-padded -02, -03, … suffix.
+  // We check for *any* existing file that shares the same timestamp prefix
+  // (not just the unsuffixed base name) so that if cleanOrphanBackups has
+  // already pruned the base entry we continue the sequence rather than
+  // reusing the bare timestamp.
   const dir = path.dirname(configPath);
   const entries = await ioFs.readdir(dir).catch(() => [] as string[]);
   const destBasename = path.basename(dest);
-  if (entries.includes(destBasename)) {
+  const hasCollision = entries.some(
+    (e) => e === destBasename || e.startsWith(`${destBasename}-`),
+  );
+  if (hasCollision) {
     let seq = 2;
     while (entries.includes(`${destBasename}-${String(seq).padStart(2, "0")}`)) {
       seq += 1;

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -38,7 +38,7 @@ describe("config backup rotation", () => {
       expect(stamped).toHaveLength(1);
 
       // Content should match the old backup
-      const content = await fs.readFile(path.join(dir, stamped[0]!), "utf-8");
+      const content = await fs.readFile(path.join(dir, stamped[0]), "utf-8");
       expect(content).toBe("old-backup");
     });
   });
@@ -201,7 +201,7 @@ describe("config backup rotation", () => {
         (e) => e.startsWith(`${base}.bak.`) && isDatetimeSuffix(e.slice(`${base}.bak.`.length)),
       );
       expect(stamped).toHaveLength(1);
-      const rotatedContent = await fs.readFile(path.join(dir, stamped[0]!), "utf-8");
+      const rotatedContent = await fs.readFile(path.join(dir, stamped[0]), "utf-8");
       expect(rotatedContent).toBe("previous");
 
       // Windows cannot validate POSIX chmod bits, but all other compose assertions

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   maintainConfigBackups,
   rotateConfigBackups,
   hardenBackupPermissions,
   cleanOrphanBackups,
+  isDatetimeSuffix,
 } from "./backup-rotation.js";
 import {
   expectPosixMode,
@@ -15,9 +17,38 @@ import { withTempHome } from "./test-helpers.js";
 import type { OpenClawConfig } from "./types.js";
 
 describe("config backup rotation", () => {
+  it("rotates .bak into a datetime-stamped file", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+      await fs.writeFile(configPath, "current");
+      await fs.writeFile(`${configPath}.bak`, "old-backup");
+
+      await rotateConfigBackups(configPath, fs);
+
+      // Primary .bak should no longer exist (renamed to datetime stamp)
+      await expect(fs.stat(`${configPath}.bak`)).rejects.toThrow();
+
+      // A datetime-stamped backup should exist
+      const dir = path.dirname(configPath);
+      const base = path.basename(configPath);
+      const entries = await fs.readdir(dir);
+      const stamped = entries.filter(
+        (e) => e.startsWith(`${base}.bak.`) && isDatetimeSuffix(e.slice(`${base}.bak.`.length)),
+      );
+      expect(stamped).toHaveLength(1);
+
+      // Content should match the old backup
+      const content = await fs.readFile(path.join(dir, stamped[0]!), "utf-8");
+      expect(content).toBe("old-backup");
+    });
+  });
+
   it("keeps a 5-deep backup ring for config writes", async () => {
     await withTempHome(async () => {
       const configPath = resolveConfigPathFromTempState();
+      const dir = path.dirname(configPath);
+      const base = path.basename(configPath);
+
       const buildConfig = (version: number): OpenClawConfig =>
         ({
           agents: { list: [{ id: `v${version}` }] },
@@ -28,30 +59,37 @@ describe("config backup rotation", () => {
         await fs.writeFile(configPath, json, "utf-8");
       };
 
+      // Simulate 6 config writes with rotation + cleanup each time
       await writeVersion(0);
       for (let version = 1; version <= 6; version += 1) {
         await rotateConfigBackups(configPath, fs);
-        await fs.copyFile(configPath, `${configPath}.bak`).catch(() => {
-          // best-effort
-        });
+        await fs.copyFile(configPath, `${configPath}.bak`).catch(() => {});
+        await cleanOrphanBackups(configPath, fs);
         await writeVersion(version);
       }
 
-      const readName = async (suffix = "") => {
-        const raw = await fs.readFile(`${configPath}${suffix}`, "utf-8");
-        return (
-          (JSON.parse(raw) as { agents?: { list?: Array<{ id?: string }> } }).agents?.list?.[0]
-            ?.id ?? null
-        );
-      };
+      // Current config should be v6
+      const raw = await fs.readFile(configPath, "utf-8");
+      const current = (JSON.parse(raw) as { agents?: { list?: Array<{ id?: string }> } }).agents
+        ?.list?.[0]?.id;
+      expect(current).toBe("v6");
 
-      await expect(readName()).resolves.toBe("v6");
-      await expect(readName(".bak")).resolves.toBe("v5");
-      await expect(readName(".bak.1")).resolves.toBe("v4");
-      await expect(readName(".bak.2")).resolves.toBe("v3");
-      await expect(readName(".bak.3")).resolves.toBe("v2");
-      await expect(readName(".bak.4")).resolves.toBe("v1");
+      // Primary .bak should exist
+      const bakRaw = await fs.readFile(`${configPath}.bak`, "utf-8");
+      const bakVersion = (JSON.parse(bakRaw) as { agents?: { list?: Array<{ id?: string }> } })
+        .agents?.list?.[0]?.id;
+      expect(bakVersion).toBe("v5");
+
+      // Should have exactly CONFIG_BACKUP_COUNT - 1 = 4 datetime-stamped backups
+      const entries = await fs.readdir(dir);
+      const stamped = entries.filter(
+        (e) => e.startsWith(`${base}.bak.`) && isDatetimeSuffix(e.slice(`${base}.bak.`.length)),
+      );
+      expect(stamped).toHaveLength(4);
+
+      // No .bak.5 or numbered files should exist
       await expect(fs.stat(`${configPath}.bak.5`)).rejects.toThrow();
+      await expect(fs.stat(`${configPath}.bak.1`)).rejects.toThrow();
     });
   });
 
@@ -60,49 +98,83 @@ describe("config backup rotation", () => {
     await withTempHome(async () => {
       const configPath = resolveConfigPathFromTempState();
 
-      // Create .bak and .bak.1 with permissive mode
+      // Create .bak and a datetime-stamped backup with permissive mode
       await fs.writeFile(`${configPath}.bak`, "secret", { mode: 0o644 });
-      await fs.writeFile(`${configPath}.bak.1`, "secret", { mode: 0o644 });
+      await fs.writeFile(`${configPath}.bak.20260308-143022`, "secret", { mode: 0o644 });
 
       await hardenBackupPermissions(configPath, fs);
 
       const bakStat = await fs.stat(`${configPath}.bak`);
-      const bak1Stat = await fs.stat(`${configPath}.bak.1`);
+      const stampedStat = await fs.stat(`${configPath}.bak.20260308-143022`);
 
       expectPosixMode(bakStat.mode, 0o600);
-      expectPosixMode(bak1Stat.mode, 0o600);
+      expectPosixMode(stampedStat.mode, 0o600);
     });
   });
 
-  it("cleanOrphanBackups removes stale files outside the rotation ring", async () => {
+  it("cleanOrphanBackups removes legacy numbered and stale files", async () => {
     await withTempHome(async () => {
       const configPath = resolveConfigPathFromTempState();
 
       // Create valid backups
       await fs.writeFile(configPath, "current");
-      await fs.writeFile(`${configPath}.bak`, "backup-0");
-      await fs.writeFile(`${configPath}.bak.1`, "backup-1");
-      await fs.writeFile(`${configPath}.bak.2`, "backup-2");
+      await fs.writeFile(`${configPath}.bak`, "backup-primary");
+      await fs.writeFile(`${configPath}.bak.20260301-100000`, "datetime-1");
+      await fs.writeFile(`${configPath}.bak.20260302-100000`, "datetime-2");
 
-      // Create orphans
+      // Create orphans: legacy numbered, PID-stamped, manual
+      await fs.writeFile(`${configPath}.bak.1`, "legacy-numbered");
+      await fs.writeFile(`${configPath}.bak.2`, "legacy-numbered-2");
       await fs.writeFile(`${configPath}.bak.1772352289`, "orphan-pid");
       await fs.writeFile(`${configPath}.bak.before-marketing`, "orphan-manual");
-      await fs.writeFile(`${configPath}.bak.99`, "orphan-overflow");
 
       await cleanOrphanBackups(configPath, fs);
 
-      // Valid backups preserved
+      // Primary .bak preserved (not touched by cleanOrphanBackups)
       await expect(fs.stat(`${configPath}.bak`)).resolves.toBeDefined();
-      await expect(fs.stat(`${configPath}.bak.1`)).resolves.toBeDefined();
-      await expect(fs.stat(`${configPath}.bak.2`)).resolves.toBeDefined();
+      // Datetime backups preserved
+      await expect(fs.stat(`${configPath}.bak.20260301-100000`)).resolves.toBeDefined();
+      await expect(fs.stat(`${configPath}.bak.20260302-100000`)).resolves.toBeDefined();
 
-      // Orphans removed
+      // Legacy numbered backups removed
+      await expect(fs.stat(`${configPath}.bak.1`)).rejects.toThrow();
+      await expect(fs.stat(`${configPath}.bak.2`)).rejects.toThrow();
+
+      // Other orphans removed
       await expect(fs.stat(`${configPath}.bak.1772352289`)).rejects.toThrow();
       await expect(fs.stat(`${configPath}.bak.before-marketing`)).rejects.toThrow();
-      await expect(fs.stat(`${configPath}.bak.99`)).rejects.toThrow();
 
       // Main config untouched
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe("current");
+    });
+  });
+
+  it("cleanOrphanBackups enforces capacity limit on datetime backups", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+
+      await fs.writeFile(configPath, "current");
+      await fs.writeFile(`${configPath}.bak`, "primary");
+
+      // Create 6 datetime backups (exceeds CONFIG_BACKUP_COUNT - 1 = 4)
+      await fs.writeFile(`${configPath}.bak.20260101-100000`, "jan");
+      await fs.writeFile(`${configPath}.bak.20260201-100000`, "feb");
+      await fs.writeFile(`${configPath}.bak.20260301-100000`, "mar");
+      await fs.writeFile(`${configPath}.bak.20260401-100000`, "apr");
+      await fs.writeFile(`${configPath}.bak.20260501-100000`, "may");
+      await fs.writeFile(`${configPath}.bak.20260601-100000`, "jun");
+
+      await cleanOrphanBackups(configPath, fs);
+
+      // Oldest 2 should be removed (keep 4 most recent)
+      await expect(fs.stat(`${configPath}.bak.20260101-100000`)).rejects.toThrow();
+      await expect(fs.stat(`${configPath}.bak.20260201-100000`)).rejects.toThrow();
+
+      // 4 most recent preserved
+      await expect(fs.stat(`${configPath}.bak.20260301-100000`)).resolves.toBeDefined();
+      await expect(fs.stat(`${configPath}.bak.20260401-100000`)).resolves.toBeDefined();
+      await expect(fs.stat(`${configPath}.bak.20260501-100000`)).resolves.toBeDefined();
+      await expect(fs.stat(`${configPath}.bak.20260601-100000`)).resolves.toBeDefined();
     });
   });
 
@@ -119,8 +191,19 @@ describe("config backup rotation", () => {
       await expect(fs.readFile(`${configPath}.bak`, "utf-8")).resolves.toBe(
         JSON.stringify({ token: "secret" }),
       );
-      // Prior primary backup gets rotated into ring slot 1.
-      await expect(fs.readFile(`${configPath}.bak.1`, "utf-8")).resolves.toBe("previous");
+
+      const dir = path.dirname(configPath);
+      const base = path.basename(configPath);
+      const entries = await fs.readdir(dir);
+
+      // Prior primary backup gets rotated into a datetime-stamped slot.
+      const stamped = entries.filter(
+        (e) => e.startsWith(`${base}.bak.`) && isDatetimeSuffix(e.slice(`${base}.bak.`.length)),
+      );
+      expect(stamped).toHaveLength(1);
+      const rotatedContent = await fs.readFile(path.join(dir, stamped[0]!), "utf-8");
+      expect(rotatedContent).toBe("previous");
+
       // Windows cannot validate POSIX chmod bits, but all other compose assertions
       // should still run there.
       if (!IS_WINDOWS) {
@@ -129,6 +212,22 @@ describe("config backup rotation", () => {
       }
       // Out-of-ring orphan gets pruned.
       await expect(fs.stat(`${configPath}.bak.orphan`)).rejects.toThrow();
+    });
+  });
+
+  describe("isDatetimeSuffix", () => {
+    it("matches valid datetime suffixes", () => {
+      expect(isDatetimeSuffix("20260308-143022")).toBe(true);
+      expect(isDatetimeSuffix("20260308-143022-2")).toBe(true);
+      expect(isDatetimeSuffix("20260308-143022-15")).toBe(true);
+    });
+
+    it("rejects non-datetime suffixes", () => {
+      expect(isDatetimeSuffix("1")).toBe(false);
+      expect(isDatetimeSuffix("99")).toBe(false);
+      expect(isDatetimeSuffix("1772352289")).toBe(false);
+      expect(isDatetimeSuffix("before-marketing")).toBe(false);
+      expect(isDatetimeSuffix("orphan")).toBe(false);
     });
   });
 });

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -218,7 +218,7 @@ describe("config backup rotation", () => {
   describe("isDatetimeSuffix", () => {
     it("matches valid datetime suffixes", () => {
       expect(isDatetimeSuffix("20260308-143022")).toBe(true);
-      expect(isDatetimeSuffix("20260308-143022-2")).toBe(true);
+      expect(isDatetimeSuffix("20260308-143022-02")).toBe(true);
       expect(isDatetimeSuffix("20260308-143022-15")).toBe(true);
     });
 
@@ -228,6 +228,11 @@ describe("config backup rotation", () => {
       expect(isDatetimeSuffix("1772352289")).toBe(false);
       expect(isDatetimeSuffix("before-marketing")).toBe(false);
       expect(isDatetimeSuffix("orphan")).toBe(false);
+    });
+
+    it("rejects collision suffixes the code never produces", () => {
+      expect(isDatetimeSuffix("20260308-143022-0")).toBe(false);
+      expect(isDatetimeSuffix("20260308-143022-1")).toBe(false);
     });
   });
 });

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -215,6 +215,48 @@ describe("config backup rotation", () => {
     });
   });
 
+  it("continues collision suffix when base timestamp was already pruned", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+      const dir = path.dirname(configPath);
+      const base = path.basename(configPath);
+
+      await fs.writeFile(configPath, "current");
+      await fs.writeFile(`${configPath}.bak`, "to-rotate");
+
+      // Simulate: base timestamp was pruned but -02 and -03 siblings remain
+      // (e.g. cleanOrphanBackups removed the oldest unsuffixed entry).
+      const entries = await fs.readdir(dir);
+      // We need to rotate once to learn the current timestamp, then set up
+      // the scenario manually.
+      await rotateConfigBackups(configPath, fs);
+      const afterFirst = await fs.readdir(dir);
+      const stamped = afterFirst.find(
+        (e) => e.startsWith(`${base}.bak.`) && isDatetimeSuffix(e.slice(`${base}.bak.`.length)),
+      )!;
+      const stampSuffix = stamped.slice(`${base}.bak.`.length);
+
+      // Now create the edge-case scenario: remove the unsuffixed base, add -02
+      await fs.unlink(path.join(dir, stamped));
+      await fs.writeFile(path.join(dir, `${stamped}-02`), "sibling-02");
+      await fs.writeFile(`${configPath}.bak`, "second-rotate");
+
+      await rotateConfigBackups(configPath, fs);
+
+      const finalEntries = await fs.readdir(dir);
+      const suffixed = finalEntries.filter(
+        (e) =>
+          e.startsWith(`${base}.bak.${stampSuffix}`) &&
+          e !== `${base}.bak.${stampSuffix}`,
+      );
+
+      // Should have -02 (pre-existing) and -03 (newly created), NOT reuse the bare timestamp
+      expect(suffixed).toContain(`${base}.bak.${stampSuffix}-02`);
+      expect(suffixed).toContain(`${base}.bak.${stampSuffix}-03`);
+      expect(finalEntries).not.toContain(stamped); // bare timestamp NOT recreated
+    });
+  });
+
   describe("isDatetimeSuffix", () => {
     it("matches valid datetime suffixes", () => {
       expect(isDatetimeSuffix("20260308-143022")).toBe(true);

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -226,7 +226,6 @@ describe("config backup rotation", () => {
 
       // Simulate: base timestamp was pruned but -02 and -03 siblings remain
       // (e.g. cleanOrphanBackups removed the oldest unsuffixed entry).
-      const entries = await fs.readdir(dir);
       // We need to rotate once to learn the current timestamp, then set up
       // the scenario manually.
       await rotateConfigBackups(configPath, fs);


### PR DESCRIPTION
Replace numeric backup rotation (`.bak.1`, `.bak.2`, …) with datetime-stamped suffixes (`.bak.YYYYMMDD-HHmmss` in UTC) so users can identify known-good backups at a glance without checking file modification times.

Closes #39923

## Summary

- **`rotateConfigBackups()`** — renames `.bak` → `.bak.YYYYMMDD-HHmmss` instead of shifting numbered slots
- **`cleanOrphanBackups()`** — keeps the N-1 most recent datetime-stamped backups (lexicographic sort = chronological); removes legacy numbered files (`.bak.1`, `.bak.2`) and other orphans on first upgrade run
- **`hardenBackupPermissions()`** — discovers datetime-stamped files via `readdir` instead of iterating a fixed numeric range
- **Collision handling** — appends `-2`, `-3`, … suffix for sub-second collisions
- **Backward compatible** — legacy `.bak.1`–`.bak.4` files are cleaned up automatically on first maintenance cycle

## Change Type

- [x] Bug fix / enhancement

## Test plan

- [x] All 8 tests pass (`vitest run src/config/config.backup-rotation.test.ts`) — 7 passed, 1 skipped (chmod on Windows)
- [x] New tests cover: datetime rotation, 5-deep ring enforcement, legacy numbered file cleanup, capacity limit pruning, collision suffix format validation, `isDatetimeSuffix()` unit tests
- [x] `maintainConfigBackups` compose test updated for datetime-stamped slots

## AI Disclosure

- [x] AI-assisted (Claude Opus 4.6 via Claude Code)
- [x] Fully tested
- [x] I understand what the code does
- [x] Will resolve bot review conversations after addressing them