### PR TITLE
Fix: Correctly estimate CJK character token count in context pruner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - LINE/ACP: add current-conversation binding and inbound binding-routing parity so `/acp spawn ... --thread here`, configured ACP bindings, and active conversation-bound ACP sessions work on LINE like the other conversation channels.
 - TTS/Microsoft: auto-switch the default Edge voice to Chinese for CJK-dominant text without overriding explicitly selected Microsoft voices. (#52355) Thanks @extrasmall0.
+- Agents/context pruning: count supplementary-plane CJK characters with the shared code-point-aware estimator so context pruning stops underestimating Japanese and Chinese text that uses Extension B ideographs. (#39985) Thanks @Edward-Qiang-2024.
 - macOS/local gateway: stop OpenClaw.app from killing healthy local gateway listeners after startup by recognizing the current `openclaw-gateway` process title and using the current `openclaw gateway` launch shape.
 - Memory/QMD: resolve slugified `memory_search` file hints back to the indexed filesystem path before returning search hits, so `memory_get` works again for mixed-case and spaced paths. (#50313) Thanks @erra9x.
 - Memory/QMD: weight CJK-heavy text correctly when estimating chunk sizes, preserve surrogate-pair characters during fine splits, and keep long Latin lines on the old chunk boundaries so memory indexing produces better-sized chunks for CJK notes. (#40271) Thanks @AaronLuo00.

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -269,6 +269,34 @@ describe("context-pruning", () => {
     expect(toolText(findToolResult(next, "t3"))).toContain("z".repeat(20_000));
   });
 
+  it("accounts for CJK Extension B text when deciding whether to prune", () => {
+    const extensionBText = "𠀀".repeat(50);
+    const messages: AgentMessage[] = [
+      makeUser(extensionBText),
+      makeToolResult({
+        toolCallId: "t1",
+        toolName: "exec",
+        text: "keep me",
+      }),
+    ];
+
+    const next = pruneContextMessages({
+      messages,
+      settings: makeAggressiveSettings({
+        keepLastAssistants: 0,
+        softTrimRatio: 1,
+        hardClearRatio: 1,
+        minPrunableToolChars: 0,
+        hardClear: { enabled: true, placeholder: "[cleared]" },
+      }),
+      ctx: CONTEXT_WINDOW_1000,
+      contextWindowTokensOverride: 40,
+      isToolPrunable: () => true,
+    });
+
+    expect(toolText(findToolResult(next, "t1"))).toBe("[cleared]");
+  });
+
   it("uses contextWindow override when ctx.model is missing", () => {
     const messages = makeSimpleToolPruningMessages(true);
 

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -1,24 +1,12 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent, TextContent, ToolResultMessage } from "@mariozechner/pi-ai";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../../../utils/cjk-chars.js";
 import type { EffectiveContextPruningSettings } from "./settings.js";
 import { makeToolPrunablePredicate } from "./tools.js";
 
-const CHARS_PER_TOKEN_ESTIMATE = 4;
 const IMAGE_CHAR_ESTIMATE = 8_000;
 const PRUNED_CONTEXT_IMAGE_MARKER = "[image removed during context pruning]";
-
-/**
- * Regex for CJK (Chinese, Japanese, Korean) characters.
- * Covers:
- * - CJK Unified Ideographs: U+4E00-U+9FFF (common Chinese/Kanji)
- * - CJK Unified Ideographs Extension A: U+3400-U+4DBF (rare Chinese)
- * - Hiragana: U+3040-U+309F (Japanese)
- * - Katakana: U+30A0-U+30FF (Japanese)
- * - Hangul Syllables: U+AC00-U+D7AF (Korean)
- * - Halfwidth and Fullwidth Forms: U+FF00-U+FFEF (fullwidth Latin, Katakana)
- */
-const CJK_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\uff00-\uffef]/g;
 
 function asText(text: string): TextContent {
   return { type: "text", text };
@@ -123,17 +111,15 @@ function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boo
   return false;
 }
 
+function estimateWeightedTextChars(text: string): number {
+  return estimateStringChars(text);
+}
+
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
     if (block.type === "text") {
-      // Count CJK characters (Chinese, Japanese, Korean) separately
-      // CJK characters are roughly 1 token each, not 0.25 like English
-      CJK_REGEX.lastIndex = 0;
-      const cjkCount = (block.text.match(CJK_REGEX) || []).length;
-      const latinCount = block.text.length - cjkCount;
-      // CJK characters count as 4 chars (1 char ≈ 1 token, but we divide by CHARS_PER_TOKEN_ESTIMATE later)
-      chars += latinCount + cjkCount * 4;
+      chars += estimateWeightedTextChars(block.text);
     }
     if (block.type === "image") {
       chars += IMAGE_CHAR_ESTIMATE;
@@ -146,11 +132,7 @@ function estimateMessageChars(message: AgentMessage): number {
   if (message.role === "user") {
     const content = message.content;
     if (typeof content === "string") {
-      // Count CJK characters separately for string content
-      CJK_REGEX.lastIndex = 0;
-      const cjkCount = (content.match(CJK_REGEX) || []).length;
-      const latinCount = content.length - cjkCount;
-      return latinCount + cjkCount * 4;
+      return estimateWeightedTextChars(content);
     }
     return estimateTextAndImageChars(content);
   }
@@ -162,18 +144,10 @@ function estimateMessageChars(message: AgentMessage): number {
         continue;
       }
       if (b.type === "text" && typeof b.text === "string") {
-        // Count CJK characters separately
-        CJK_REGEX.lastIndex = 0;
-        const cjkCount = (b.text.match(CJK_REGEX) || []).length;
-        const latinCount = b.text.length - cjkCount;
-        chars += latinCount + cjkCount * 4;
+        chars += estimateWeightedTextChars(b.text);
       }
       if (b.type === "thinking" && typeof b.thinking === "string") {
-        // Count CJK characters separately
-        CJK_REGEX.lastIndex = 0;
-        const cjkCount = (b.thinking.match(CJK_REGEX) || []).length;
-        const latinCount = b.thinking.length - cjkCount;
-        chars += latinCount + cjkCount * 4;
+        chars += estimateWeightedTextChars(b.thinking);
       }
       if (b.type === "toolCall") {
         try {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -115,7 +115,13 @@ function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageCon
   let chars = 0;
   for (const block of content) {
     if (block.type === "text") {
-      chars += block.text.length;
+      // Count CJK characters (Chinese, Japanese, Korean) separately
+      // CJK characters are roughly 1 token each, not 0.25 like English
+      const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
+      const cjkCount = (block.text.match(cjkRegex) || []).length;
+      const latinCount = block.text.length - cjkCount;
+      // CJK characters count as 4 chars (1 char ≈ 1 token, but we divide by CHARS_PER_TOKEN_ESTIMATE later)
+      chars += latinCount + cjkCount * 4;
     }
     if (block.type === "image") {
       chars += IMAGE_CHAR_ESTIMATE;
@@ -128,7 +134,11 @@ function estimateMessageChars(message: AgentMessage): number {
   if (message.role === "user") {
     const content = message.content;
     if (typeof content === "string") {
-      return content.length;
+      // Count CJK characters separately for string content
+      const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
+      const cjkCount = (content.match(cjkRegex) || []).length;
+      const latinCount = content.length - cjkCount;
+      return latinCount + cjkCount * 4;
     }
     return estimateTextAndImageChars(content);
   }
@@ -140,10 +150,18 @@ function estimateMessageChars(message: AgentMessage): number {
         continue;
       }
       if (b.type === "text" && typeof b.text === "string") {
-        chars += b.text.length;
+        // Count CJK characters separately
+        const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
+        const cjkCount = (b.text.match(cjkRegex) || []).length;
+        const latinCount = b.text.length - cjkCount;
+        chars += latinCount + cjkCount * 4;
       }
       if (b.type === "thinking" && typeof b.thinking === "string") {
-        chars += b.thinking.length;
+        // Count CJK characters separately
+        const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
+        const cjkCount = (b.thinking.match(cjkRegex) || []).length;
+        const latinCount = b.thinking.length - cjkCount;
+        chars += latinCount + cjkCount * 4;
       }
       if (b.type === "toolCall") {
         try {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -8,6 +8,18 @@ const CHARS_PER_TOKEN_ESTIMATE = 4;
 const IMAGE_CHAR_ESTIMATE = 8_000;
 const PRUNED_CONTEXT_IMAGE_MARKER = "[image removed during context pruning]";
 
+/**
+ * Regex for CJK (Chinese, Japanese, Korean) characters.
+ * Covers:
+ * - CJK Unified Ideographs: U+4E00-U+9FFF (common Chinese/Kanji)
+ * - CJK Unified Ideographs Extension A: U+3400-U+4DBF (rare Chinese)
+ * - Hiragana: U+3040-U+309F (Japanese)
+ * - Katakana: U+30A0-U+30FF (Japanese)
+ * - Hangul Syllables: U+AC00-U+D7AF (Korean)
+ * - Halfwidth and Fullwidth Forms: U+FF00-U+FFEF (fullwidth Latin, Katakana)
+ */
+const CJK_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\uff00-\uffef]/g;
+
 function asText(text: string): TextContent {
   return { type: "text", text };
 }
@@ -117,8 +129,8 @@ function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageCon
     if (block.type === "text") {
       // Count CJK characters (Chinese, Japanese, Korean) separately
       // CJK characters are roughly 1 token each, not 0.25 like English
-      const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
-      const cjkCount = (block.text.match(cjkRegex) || []).length;
+      CJK_REGEX.lastIndex = 0;
+      const cjkCount = (block.text.match(CJK_REGEX) || []).length;
       const latinCount = block.text.length - cjkCount;
       // CJK characters count as 4 chars (1 char ≈ 1 token, but we divide by CHARS_PER_TOKEN_ESTIMATE later)
       chars += latinCount + cjkCount * 4;
@@ -135,8 +147,8 @@ function estimateMessageChars(message: AgentMessage): number {
     const content = message.content;
     if (typeof content === "string") {
       // Count CJK characters separately for string content
-      const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
-      const cjkCount = (content.match(cjkRegex) || []).length;
+      CJK_REGEX.lastIndex = 0;
+      const cjkCount = (content.match(CJK_REGEX) || []).length;
       const latinCount = content.length - cjkCount;
       return latinCount + cjkCount * 4;
     }
@@ -151,15 +163,15 @@ function estimateMessageChars(message: AgentMessage): number {
       }
       if (b.type === "text" && typeof b.text === "string") {
         // Count CJK characters separately
-        const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
-        const cjkCount = (b.text.match(cjkRegex) || []).length;
+        CJK_REGEX.lastIndex = 0;
+        const cjkCount = (b.text.match(CJK_REGEX) || []).length;
         const latinCount = b.text.length - cjkCount;
         chars += latinCount + cjkCount * 4;
       }
       if (b.type === "thinking" && typeof b.thinking === "string") {
         // Count CJK characters separately
-        const cjkRegex = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/g;
-        const cjkCount = (b.thinking.match(cjkRegex) || []).length;
+        CJK_REGEX.lastIndex = 0;
+        const cjkCount = (b.thinking.match(CJK_REGEX) || []).length;
         const latinCount = b.thinking.length - cjkCount;
         chars += latinCount + cjkCount * 4;
       }


### PR DESCRIPTION
Fixes #39968

## Summary
Fixed character estimation for CJK (Chinese, Japanese, Korean) characters in the context pruner.

## Problem
The pruner was using `text.length` for all characters, but CJK characters are roughly 1 token each (not 0.25 tokens like English). This caused the pruning ratio to be underestimated for non-English content.

## Root Cause
```typescript
// Before: All characters counted equally
chars += block.text.length;  // ❌ CJK underestimated by 4x
```

## Solution
- Detect CJK characters using Unicode ranges
- Multiply CJK character count by 4 before dividing by `CHARS_PER_TOKEN_ESTIMATE`
- This gives a more accurate token estimation: 1 CJK char ≈ 1 token

### Modified Functions
1. `estimateTextAndImageChars()` - Text content blocks
2. `estimateMessageChars()` - User string content
3. `estimateMessageChars()` - Assistant text/thinking blocks

### CJK Unicode Ranges
- Chinese: \u4e00-\u9fa5 (CJK Unified Ideographs)
- Japanese: \u3040-\u30ff (Hiragana, Katakana)
- Korean: \uac00-\ud7af (Hangul)

## Testing
- Tested with Chinese, Japanese, and Korean text
- Verified pruning ratio is now correctly estimated
- No impact on English content

## Impact
- ✅ More accurate context pruning for non-English content
- ✅ Prevents premature pruning when using CJK languages
- ✅ Fixes #39968

## Example
```typescript
// Before: 100 Chinese chars = 25 estimated tokens (wrong)
// After: 100 Chinese chars = 100 estimated tokens (correct)
```