### PR TITLE
fix(plugins): ship Feishu bundled runtime dependency

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -12,18 +12,16 @@ Feishu (Lark) is a team chat platform used by companies for messaging and collab
 
 ---
 
-## Plugin required
+## Bundled plugin
 
-Install the Feishu plugin:
+Feishu ships bundled with current OpenClaw releases, so no separate plugin install
+is required.
+
+If you are using an older build or a custom install that does not include bundled
+Feishu, install it manually:
 
 ```bash
 openclaw plugins install @openclaw/feishu
-```
-
-Local checkout (when running from a git repo):
-
-```bash
-openclaw plugins install ./extensions/feishu
 ```
 
 ---

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -12,18 +12,14 @@ title: 飞书
 
 ---
 
-## 需要插件
+## 内置插件
 
-安装 Feishu 插件：
+当前版本的 OpenClaw 已内置 Feishu 插件，因此通常不需要单独安装。
+
+如果你使用的是较旧版本，或是没有内置 Feishu 的自定义安装，可手动安装：
 
 ```bash
 openclaw plugins install @openclaw/feishu
-```
-
-本地 checkout（在 git 仓库内运行）：
-
-```bash
-openclaw plugins install ./extensions/feishu
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -340,6 +340,7 @@
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "@line/bot-sdk": "^10.6.0",
     "@lydell/node-pty": "1.2.0-beta.3",
     "@mariozechner/pi-agent-core": "0.55.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@homebridge/ciao':
         specifier: ^1.3.5
         version: 1.3.5
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.59.0
+        version: 1.59.0
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -15,8 +15,11 @@ describe("bundled plugin runtime dependencies", () => {
   it("keeps bundled Feishu runtime deps available from the published root package", () => {
     const rootManifest = readJson<PackageManifest>("package.json");
     const feishuManifest = readJson<PackageManifest>("extensions/feishu/package.json");
+    const feishuSpec = feishuManifest.dependencies?.["@larksuiteoapi/node-sdk"];
+    const rootSpec = rootManifest.dependencies?.["@larksuiteoapi/node-sdk"];
 
-    expect(feishuManifest.dependencies?.["@larksuiteoapi/node-sdk"]).toBeTruthy();
-    expect(rootManifest.dependencies?.["@larksuiteoapi/node-sdk"]).toBeTruthy();
+    expect(feishuSpec).toBeTruthy();
+    expect(rootSpec).toBeTruthy();
+    expect(rootSpec).toBe(feishuSpec);
   });
 });

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+};
+
+function readJson<T>(relativePath: string): T {
+  const absolutePath = path.resolve(process.cwd(), relativePath);
+  return JSON.parse(fs.readFileSync(absolutePath, "utf8")) as T;
+}
+
+describe("bundled plugin runtime dependencies", () => {
+  it("keeps bundled Feishu runtime deps available from the published root package", () => {
+    const rootManifest = readJson<PackageManifest>("package.json");
+    const feishuManifest = readJson<PackageManifest>("extensions/feishu/package.json");
+
+    expect(feishuManifest.dependencies?.["@larksuiteoapi/node-sdk"]).toBeTruthy();
+    expect(rootManifest.dependencies?.["@larksuiteoapi/node-sdk"]).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: bundled Feishu is selected at runtime but its required SDK is not available from the published root package.
- Why it matters: the documented Feishu install/onboarding flow fails for npm-installed OpenClaw users.
- What changed: add `@larksuiteoapi/node-sdk` to root runtime dependencies, sync the lockfile, add a regression test, and update Feishu docs to reflect bundled status.
- What did NOT change: no plugin precedence change, no new fallback rules, and no change to general scoped npm plugin install behavior.

## Change Type (select all)

- [x] Bug fix
- [x] Docs

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Closes #39986

## User-visible / Behavior Changes

- Fixed releases load bundled Feishu without requiring a manual `plugins.load.paths` override.
- Feishu docs now describe the plugin as bundled in current releases.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: npm-installed environment
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): default plugin discovery

### Steps

1. Install `openclaw` from npm.
2. Load bundled Feishu on a build with the fix.
3. Confirm plugin load no longer fails with `Cannot find module '@larksuiteoapi/node-sdk'`.

### Expected

- Bundled Feishu loads without a manual config override.

### Actual

- Before the fix, bundled Feishu fails to load because the published root package lacks the runtime dependency.

## Evidence

- [x] Failing test/log before + passing after

Focused verification command:

```bash
pnpm exec vitest run src/cli/plugin-install-plan.test.ts src/plugins/bundled-runtime-deps.test.ts
```

## Human Verification (required)

- Verified scenarios: bundled Feishu runtime dependency is declared in the published root manifest and guarded by test coverage.
- Edge cases checked: scoped `@openclaw/...` installs still use normal npm semantics and remain updateable/pinnable.
- What you did **not** verify: full end-to-end Feishu onboarding against a live tenant.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the root dependency, lockfile, regression test, and Feishu doc updates together.
- Files/config to restore: `package.json`, `pnpm-lock.yaml`, the new bundled runtime dependency test, and Feishu docs.
- Known bad symptoms reviewers should watch for: any attempt to reintroduce scoped npm-spec install shortcut behavior for bundled plugins.

## Risks and Mitigations

- Risk: the fix scope expands into general plugin install semantics.
- Mitigation: keep the change limited to Feishu packaging, lockfile sync, regression coverage, and docs.
