### PR TITLE
status: surface global tool profile hints in overview

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -36,7 +36,7 @@ import { pickGatewaySelfPresence } from "./status-all/gateway.js";
 import { buildStatusAllReportLines } from "./status-all/report-lines.js";
 import { readServiceStatusSummary } from "./status.service-summary.js";
 import { formatUpdateOneLiner } from "./status.update.js";
-import { formatStatusToolProfileValue } from "./status.tool-profile.js";
+import { formatGlobalStatusToolProfileValue } from "./status.tool-profile.js";
 
 export async function statusAllCommand(
   runtime: RuntimeEnv,
@@ -275,7 +275,7 @@ export async function statusAllCommand(
       (a) => a.lastActiveAgeMs != null && a.lastActiveAgeMs <= aliveThresholdMs,
     ).length;
 
-    const toolProfileValue = formatStatusToolProfileValue(cfg.tools?.profile);
+    const toolProfileValue = formatGlobalStatusToolProfileValue(cfg.tools?.profile);
 
     const overviewRows = [
       { Item: "Version", Value: VERSION },
@@ -298,7 +298,9 @@ export async function statusAllCommand(
               : `${tailscaleMode} · ${tailscale.backendState ?? "unknown"} · magicdns unknown`,
       },
       { Item: "Channel", Value: channelLabel },
-      ...(toolProfileValue ? [{ Item: "Tools profile", Value: toolProfileValue }] : []),
+      ...(toolProfileValue
+        ? [{ Item: "Global tools profile", Value: toolProfileValue }]
+        : []),
       ...(gitLabel ? [{ Item: "Git", Value: gitLabel }] : []),
       { Item: "Update", Value: updateLine },
       {

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -274,6 +274,20 @@ export async function statusAllCommand(
       (a) => a.lastActiveAgeMs != null && a.lastActiveAgeMs <= aliveThresholdMs,
     ).length;
 
+    const toolProfileValue = (() => {
+      const profile = cfg.tools?.profile;
+      if (!profile) {
+        return null;
+      }
+      if (profile === "messaging") {
+        return `${profile} · intentionally narrow by design; use \`tools.profile: \"full\"\` for broader command/control access`;
+      }
+      if (profile === "full") {
+        return `${profile} · broadest command/control surface`;
+      }
+      return profile;
+    })();
+
     const overviewRows = [
       { Item: "Version", Value: VERSION },
       { Item: "OS", Value: osSummary.label },
@@ -295,6 +309,7 @@ export async function statusAllCommand(
               : `${tailscaleMode} · ${tailscale.backendState ?? "unknown"} · magicdns unknown`,
       },
       { Item: "Channel", Value: channelLabel },
+      ...(toolProfileValue ? [{ Item: "Tools profile", Value: toolProfileValue }] : []),
       ...(gitLabel ? [{ Item: "Git", Value: gitLabel }] : []),
       { Item: "Update", Value: updateLine },
       {

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -36,6 +36,7 @@ import { pickGatewaySelfPresence } from "./status-all/gateway.js";
 import { buildStatusAllReportLines } from "./status-all/report-lines.js";
 import { readServiceStatusSummary } from "./status.service-summary.js";
 import { formatUpdateOneLiner } from "./status.update.js";
+import { formatStatusToolProfileValue } from "./status.tool-profile.js";
 
 export async function statusAllCommand(
   runtime: RuntimeEnv,
@@ -274,19 +275,7 @@ export async function statusAllCommand(
       (a) => a.lastActiveAgeMs != null && a.lastActiveAgeMs <= aliveThresholdMs,
     ).length;
 
-    const toolProfileValue = (() => {
-      const profile = cfg.tools?.profile;
-      if (!profile) {
-        return null;
-      }
-      if (profile === "messaging") {
-        return `${profile} · intentionally narrow by design; use \`tools.profile: \"full\"\` for broader command/control access`;
-      }
-      if (profile === "full") {
-        return `${profile} · broadest command/control surface`;
-      }
-      return profile;
-    })();
+    const toolProfileValue = formatStatusToolProfileValue(cfg.tools?.profile);
 
     const overviewRows = [
       { Item: "Version", Value: VERSION },

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -24,6 +24,7 @@ import { statusAllCommand } from "./status-all.js";
 import { groupChannelIssuesByChannel } from "./status-all/channel-issues.js";
 import { formatGatewayAuthUsed } from "./status-all/format.js";
 import { getDaemonStatusSummary, getNodeDaemonStatusSummary } from "./status.daemon.js";
+import { formatStatusToolProfileValue } from "./status.tool-profile.js";
 import {
   formatDuration,
   formatKTokens,
@@ -406,19 +407,7 @@ export async function statusCommand(
   const channelLabel = channelInfo.label;
   const gitLabel = formatGitInstallLabel(update);
 
-  const toolProfileValue = (() => {
-    const profile = cfg.tools?.profile;
-    if (!profile) {
-      return null;
-    }
-    if (profile === "messaging") {
-      return `${profile} · intentionally narrow by design; use \`tools.profile: \"full\"\` for broader command/control access`;
-    }
-    if (profile === "full") {
-      return `${profile} · broadest command/control surface`;
-    }
-    return profile;
-  })();
+  const toolProfileValue = formatStatusToolProfileValue(cfg.tools?.profile);
 
   const overviewRows = [
     { Item: "Dashboard", Value: dashboard },

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -24,7 +24,7 @@ import { statusAllCommand } from "./status-all.js";
 import { groupChannelIssuesByChannel } from "./status-all/channel-issues.js";
 import { formatGatewayAuthUsed } from "./status-all/format.js";
 import { getDaemonStatusSummary, getNodeDaemonStatusSummary } from "./status.daemon.js";
-import { formatStatusToolProfileValue } from "./status.tool-profile.js";
+import { formatGlobalStatusToolProfileValue } from "./status.tool-profile.js";
 import {
   formatDuration,
   formatKTokens,
@@ -407,7 +407,7 @@ export async function statusCommand(
   const channelLabel = channelInfo.label;
   const gitLabel = formatGitInstallLabel(update);
 
-  const toolProfileValue = formatStatusToolProfileValue(cfg.tools?.profile);
+  const toolProfileValue = formatGlobalStatusToolProfileValue(cfg.tools?.profile);
 
   const overviewRows = [
     { Item: "Dashboard", Value: dashboard },
@@ -422,7 +422,7 @@ export async function statusCommand(
             : warn(`${tailscaleMode} · magicdns unknown`),
     },
     { Item: "Channel", Value: channelLabel },
-    ...(toolProfileValue ? [{ Item: "Tools profile", Value: toolProfileValue }] : []),
+    ...(toolProfileValue ? [{ Item: "Global tools profile", Value: toolProfileValue }] : []),
     ...(gitLabel ? [{ Item: "Git", Value: gitLabel }] : []),
     {
       Item: "Update",

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -422,7 +422,9 @@ export async function statusCommand(
             : warn(`${tailscaleMode} · magicdns unknown`),
     },
     { Item: "Channel", Value: channelLabel },
-    ...(toolProfileValue ? [{ Item: "Global tools profile", Value: toolProfileValue }] : []),
+    ...(toolProfileValue
+      ? [{ Item: "Global tools profile", Value: toolProfileValue }]
+      : []),
     ...(gitLabel ? [{ Item: "Git", Value: gitLabel }] : []),
     {
       Item: "Update",

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -406,6 +406,20 @@ export async function statusCommand(
   const channelLabel = channelInfo.label;
   const gitLabel = formatGitInstallLabel(update);
 
+  const toolProfileValue = (() => {
+    const profile = cfg.tools?.profile;
+    if (!profile) {
+      return null;
+    }
+    if (profile === "messaging") {
+      return `${profile} · intentionally narrow by design; use \`tools.profile: \"full\"\` for broader command/control access`;
+    }
+    if (profile === "full") {
+      return `${profile} · broadest command/control surface`;
+    }
+    return profile;
+  })();
+
   const overviewRows = [
     { Item: "Dashboard", Value: dashboard },
     { Item: "OS", Value: `${osSummary.label} · node ${process.versions.node}` },
@@ -419,6 +433,7 @@ export async function statusCommand(
             : warn(`${tailscaleMode} · magicdns unknown`),
     },
     { Item: "Channel", Value: channelLabel },
+    ...(toolProfileValue ? [{ Item: "Tools profile", Value: toolProfileValue }] : []),
     ...(gitLabel ? [{ Item: "Git", Value: gitLabel }] : []),
     {
       Item: "Update",

--- a/src/commands/status.tool-profile.ts
+++ b/src/commands/status.tool-profile.ts
@@ -1,0 +1,14 @@
+export function formatStatusToolProfileValue(
+  profile: string | null | undefined,
+): string | null {
+  if (!profile) {
+    return null;
+  }
+  if (profile === "messaging") {
+    return `${profile} · intentionally narrow by design; use \`tools.profile: "full"\` for broader command/control access`;
+  }
+  if (profile === "full") {
+    return `${profile} · broadest command/control surface`;
+  }
+  return profile;
+}

--- a/src/commands/status.tool-profile.ts
+++ b/src/commands/status.tool-profile.ts
@@ -1,14 +1,14 @@
-export function formatStatusToolProfileValue(
+export function formatGlobalStatusToolProfileValue(
   profile: string | null | undefined,
 ): string | null {
   if (!profile) {
     return null;
   }
   if (profile === "messaging") {
-    return `${profile} · intentionally narrow by design; use \`tools.profile: "full"\` for broader command/control access`;
+    return `${profile} · global config baseline; intentionally narrow by design. Per-agent/provider overrides may still differ. Use \`tools.profile: "full"\` for broader global command/control access.`;
   }
   if (profile === "full") {
-    return `${profile} · broadest command/control surface`;
+    return `${profile} · broadest global command/control baseline`;
   }
   return profile;
 }


### PR DESCRIPTION
## Summary
- surface the configured global tool profile baseline in `openclaw status` overview output
- surface the configured global tool profile baseline in `openclaw status --all` overview output
- add a practical hint when the global `tools.profile` is set to `messaging`

## Why
A messaging-first setup can feel unexpectedly limited even when the configuration is valid. Surfacing the global tool profile baseline directly in status output makes that easier to diagnose without digging through config files, while staying explicit that per-agent and provider overrides may differ.

## Changes
- add a `Global tools profile` overview row to `openclaw status`
- add the same `Global tools profile` overview row to `openclaw status --all`
- include a practical hint for `tools.profile: "messaging"`
- include a short descriptive note for `tools.profile: "full"`
- keep the wording scoped to the global config baseline rather than the effective resolved runtime profile

## What did not change
- no runtime behavior
- no tool policy logic
- no config schema values
- no effective-profile resolution logic

## Change Type
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Related #39954
- Related #39963

## User-visible / Behavior Changes
`openclaw status` and `openclaw status --all` now show the configured global tool profile baseline in the Overview section when one is set. For `messaging`, the output explains that it is intentionally narrow by design and points users toward `tools.profile: "full"` for a broader global command/control baseline. Per-agent and provider overrides may still differ.

## Security Impact
- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification
### Environment
- OS: Windows 11
- Runtime/container: local clone
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): `tools.profile`

### Steps
1. Set `tools.profile` in config (for example `messaging` or `full`)
2. Run `openclaw status`
3. Run `openclaw status --all`
4. Inspect the Overview section

### Expected
- status output surfaces the configured global tool profile baseline when one is set
- `messaging` output includes a practical hint that the global profile is intentionally narrow

### Actual
- updated status overview code now adds a `Global tools profile` row in both commands

## Evidence
- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification
- Verified scenarios: reviewed the exact diff and confirmed the row is added to both status renderers; user verified the behavior in a local dev environment.
- Edge cases checked: no row is shown when no tool profile is set; other profiles still render plainly; wording stays scoped to the global config baseline rather than implying effective runtime resolution.
- What I did not personally verify: cross-environment behavior outside the user's local dev setup.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/commands/status.command.ts`, `src/commands/status-all.ts`, `src/commands/status.tool-profile.ts`
- Known bad symptoms reviewers should watch for: misleading wording or overly verbose status output

## Risks and Mitigations
- Risk: maintainers may prefer the hint in a different status surface or wording style
- Mitigation: kept the change limited to overview rows in the two existing status commands without changing behavior and made the wording explicit about global scope
