### PR TITLE
fix(update): rollback global install if doctor fails

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -293,10 +293,11 @@ async function runPackageInstallUpdate(params: {
 
   const steps = [updateStep];
   let afterVersion = beforeVersion;
+  let entryPath: string | null = null;
 
   if (pkgRoot) {
     afterVersion = await readPackageVersion(pkgRoot);
-    const entryPath = path.join(pkgRoot, "dist", "entry.js");
+    entryPath = path.join(pkgRoot, "dist", "entry.js");
     if (await pathExists(entryPath)) {
       const doctorStep = await runUpdateStep({
         name: `${CLI_NAME} doctor`,
@@ -305,6 +306,34 @@ async function runPackageInstallUpdate(params: {
         progress: params.progress,
       });
       steps.push(doctorStep);
+
+      // If the post-update doctor fails, try to rollback to the previous installed
+      // version to avoid leaving a broken global install behind.
+      if (doctorStep.exitCode !== 0 && beforeVersion) {
+        const rollbackSpec = `${packageName}@${beforeVersion}`;
+        const rollbackStep = await runUpdateStep({
+          name: `rollback ${rollbackSpec}`,
+          argv: globalInstallArgs(manager, rollbackSpec),
+          timeoutMs: params.timeoutMs,
+          progress: params.progress,
+        });
+        steps.push(rollbackStep);
+        try {
+          afterVersion = await readPackageVersion(pkgRoot);
+        } catch {
+          // ignore
+        }
+
+        if (rollbackStep.exitCode === 0 && entryPath && (await pathExists(entryPath))) {
+          const rollbackDoctorStep = await runUpdateStep({
+            name: `${CLI_NAME} doctor (rollback)`,
+            argv: [resolveNodeRunner(), entryPath, "doctor", "--non-interactive"],
+            timeoutMs: params.timeoutMs,
+            progress: params.progress,
+          });
+          steps.push(rollbackDoctorStep);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## What\nWhen updating a global package install, OpenClaw runs a post-update `openclaw doctor --non-interactive`. If that doctor step fails (e.g. due to a broken/partial install), the system can be left in a broken state until the user manually reinstalls.\n\nThis PR adds a targeted safety net: if the post-update doctor fails and we know the previous version, we automatically reinstall the previous version as a rollback attempt, then optionally rerun doctor on the rolled-back install.\n\n## Why\nWe saw real-world errors like `ERR_MODULE_NOT_FOUND` for dist chunks after update. This change makes updates fail *safer*: we still report the update failure, but we avoid leaving the machine worse off than before.\n\n## Scope\n- Package installs only (npm/pnpm/bun global update path)\n- No behavior change for successful updates\n\n## Notes\n- Rollback only triggers when: doctor exitCode != 0 and beforeVersion is known\n- The update result still reports error so the user can investigate