### PR TITLE
fix: complete allowSyntheticToolResults parameter propagation

### DIFF
--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -342,6 +342,7 @@ export async function summarizeInStages(params: {
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
   parts?: number;
+  allowSyntheticToolResults?: boolean;
   minMessagesForSplit?: number;
 }): Promise<string> {
   const { messages } = params;
@@ -400,6 +401,7 @@ export function pruneHistoryForContextShare(params: {
   maxContextTokens: number;
   maxHistoryShare?: number;
   parts?: number;
+  allowSyntheticToolResults?: boolean;
 }): {
   messages: AgentMessage[];
   droppedMessagesList: AgentMessage[];
@@ -431,7 +433,11 @@ export function pruneHistoryForContextShare(params: {
     // orphaned tool_results (whose tool_use was in the dropped chunk).
     // repairToolUseResultPairing drops orphaned tool_results, preventing
     // "unexpected tool_use_id" errors from Anthropic's API.
-    const repairReport = repairToolUseResultPairing(flatRest);
+    // When allowSyntheticToolResults is false, don't create synthetic errors for
+    // missing tool results (they may be in progress, e.g., after gateway restarts).
+    const repairReport = repairToolUseResultPairing(flatRest, {
+      allowSyntheticToolResults: params.allowSyntheticToolResults,
+    });
     const repairedKept = repairReport.messages;
 
     // Track orphaned tool_results as dropped (they were in kept but their tool_use was dropped)

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -636,7 +636,9 @@ export async function compactEmbeddedPiSessionDirect(
         // limitHistoryTurns can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
         const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
+          ? sanitizeToolUseResultPairing(truncated, {
+              allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+            })
           : truncated;
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -556,7 +556,9 @@ export async function sanitizeSessionHistory(params: {
     allowedToolNames: params.allowedToolNames,
   });
   const repairedTools = policy.repairToolUseResultPairing
-    ? sanitizeToolUseResultPairing(sanitizedToolCalls)
+    ? sanitizeToolUseResultPairing(sanitizedToolCalls, {
+        allowSyntheticToolResults: policy.allowSyntheticToolResults,
+      })
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
   const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1407,7 +1407,9 @@ export async function runEmbeddedAttempt(
         // limitHistoryTurns can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
         const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
+          ? sanitizeToolUseResultPairing(truncated, {
+              allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+            })
           : truncated;
         cacheTrace?.recordStage("session:limited", { messages: limited });
         if (limited.length > 0) {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -258,6 +258,7 @@ function formatNonTextPlaceholder(content: unknown): string | null {
 function splitPreservedRecentTurns(params: {
   messages: AgentMessage[];
   recentTurnsPreserve: number;
+  allowSyntheticToolResults?: boolean;
 }): { summarizableMessages: AgentMessage[]; preservedMessages: AgentMessage[] } {
   const preserveTurns = Math.min(
     MAX_RECENT_TURNS_PRESERVE,
@@ -353,7 +354,11 @@ function splitPreservedRecentTurns(params: {
   const summarizableMessages = params.messages.filter((_, idx) => !preservedIndexSet.has(idx));
   // Preserving recent assistant turns can orphan downstream toolResult messages.
   // Repair pairings here so compaction summarization doesn't trip strict providers.
-  const repairedSummarizableMessages = repairToolUseResultPairing(summarizableMessages).messages;
+  // When allowSyntheticToolResults is false, don't create synthetic errors for
+  // missing tool results (they may be in progress, e.g., after gateway restarts).
+  const repairedSummarizableMessages = repairToolUseResultPairing(summarizableMessages, {
+    allowSyntheticToolResults: params.allowSyntheticToolResults,
+  }).messages;
   const preservedMessages = params.messages
     .filter((_, idx) => preservedIndexSet.has(idx))
     .filter((msg) => {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -783,6 +783,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             maxContextTokens: contextWindowTokens,
             maxHistoryShare,
             parts: 2,
+            allowSyntheticToolResults: runtime?.allowSyntheticToolResults,
           });
           if (pruned.droppedChunks > 0) {
             const newContentRatio = (newContentTokens / contextWindowTokens) * 100;
@@ -836,6 +837,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       } = splitPreservedRecentTurns({
         messages: messagesToSummarize,
         recentTurnsPreserve,
+        allowSyntheticToolResults: runtime?.allowSyntheticToolResults,
       });
       messagesToSummarize = summaryTargetMessages;
       const preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -327,8 +327,11 @@ export function sanitizeToolCallInputs(
   return repairToolCallInputs(messages, options).messages;
 }
 
-export function sanitizeToolUseResultPairing(messages: AgentMessage[]): AgentMessage[] {
-  return repairToolUseResultPairing(messages).messages;
+export function sanitizeToolUseResultPairing(
+  messages: AgentMessage[],
+  options?: { allowSyntheticToolResults?: boolean },
+): AgentMessage[] {
+  return repairToolUseResultPairing(messages, options).messages;
 }
 
 export type ToolUseRepairReport = {
@@ -339,13 +342,17 @@ export type ToolUseRepairReport = {
   moved: boolean;
 };
 
-export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRepairReport {
+export function repairToolUseResultPairing(
+  messages: AgentMessage[],
+  options?: { allowSyntheticToolResults?: boolean },
+): ToolUseRepairReport {
   // Anthropic (and Cloud Code Assist) reject transcripts where assistant tool calls are not
   // immediately followed by matching tool results. Session files can end up with results
   // displaced (e.g. after user turns) or duplicated. Repair by:
   // - moving matching toolResult messages directly after their assistant toolCall turn
-  // - inserting synthetic error toolResults for missing ids
+  // - inserting synthetic error toolResults for missing ids (when allowSyntheticToolResults is true)
   // - dropping duplicate toolResults for the same id (anywhere in the transcript)
+  const allowSyntheticToolResults = options?.allowSyntheticToolResults ?? true;
   const out: AgentMessage[] = [];
   const added: Array<Extract<AgentMessage, { role: "toolResult" }>> = [];
   const seenToolResultIds = new Set<string>();
@@ -470,7 +477,10 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
       const existing = spanResultsById.get(call.id);
       if (existing) {
         pushToolResult(existing);
-      } else {
+      } else if (allowSyntheticToolResults) {
+        // Only create synthetic tool results when explicitly allowed.
+        // During gateway restarts or with long-running commands, missing tool results
+        // may be legitimate (not yet written) rather than errors.
         const missing = makeMissingToolResult({
           toolCallId: call.id,
           toolName: call.name,
@@ -479,6 +489,8 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
         changed = true;
         pushToolResult(missing);
       }
+      // When allowSyntheticToolResults is false, we simply skip tool calls without results
+      // (they may still be in progress, especially after gateway restarts)
     }
 
     for (const rem of remainder) {


### PR DESCRIPTION
## Problem

PR #38493 has incomplete implementation (Greptile 2/5 score).

Two critical call sites are missing the `allowSyntheticToolResults` parameter:
1. `splitPreservedRecentTurns` call at line 836
2. `pruneHistoryForContextShare` call at line 781

## Root Cause

The parameter was added to function signatures but not propagated to call sites in `compaction-safeguard.ts`.

## Solution

- Add `allowSyntheticToolResults: runtime?.allowSyntheticToolResults` to both call sites
- This ensures the fix works on all code paths

## Testing

- ✅ TypeScript compilation
- ✅ Maintains backward compatibility
- ✅ Completes PR #38493 implementation

Fixes #38432
Supersedes #38493