### PR TITLE
fix(control-ui): send deviceToken in auth for signature verification

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -225,6 +225,7 @@ export class GatewayBrowserClient {
       authToken || this.opts.password
         ? {
             token: authToken,
+            deviceToken,
             password: this.opts.password,
           }
         : undefined;


### PR DESCRIPTION
Fixes #39667

Addresses Peter Steinberger's feedback on previous PR #39721.

The minimal fix: include deviceToken in the auth object sent during WebSocket connect handshake, allowing the server to correctly verify device signatures while preserving upstream's deviceToken priority logic.

Client and server now consistently use auth.token (authToken) for both signing and verification, resolving device signature invalid errors.

No behavior change for existing flows; only adds optional deviceToken field for server awareness.