### PR TITLE
fix(session-store): display token usage for promptTokens-only providers

### DIFF
--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -79,25 +79,34 @@ export async function updateSessionStoreAfterAgentRun(params: {
   if (result.meta.systemPromptReport) {
     next.systemPromptReport = result.meta.systemPromptReport;
   }
+
+  // Always derive totalTokens to support promptTokens-only providers (e.g., Kimi)
+  const totalTokens = deriveSessionTotalTokens({
+    usage,
+    contextTokens,
+    promptTokens,
+  });
+
   if (hasNonzeroUsage(usage)) {
     const input = usage.input ?? 0;
     const output = usage.output ?? 0;
-    const totalTokens = deriveSessionTotalTokens({
-      usage,
-      contextTokens,
-      promptTokens,
-    });
     next.inputTokens = input;
     next.outputTokens = output;
-    if (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0) {
-      next.totalTokens = totalTokens;
-      next.totalTokensFresh = true;
-    } else {
-      next.totalTokens = undefined;
-      next.totalTokensFresh = false;
-    }
     next.cacheRead = usage.cacheRead ?? 0;
     next.cacheWrite = usage.cacheWrite ?? 0;
+  }
+
+  // Update totalTokens when valid, or mark stale if we have usage/promptTokens but invalid total.
+  // If no token data at all, preserve previous totalTokens.
+  if (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0) {
+    next.totalTokens = totalTokens;
+    next.totalTokensFresh = true;
+  } else if (
+    hasNonzeroUsage(usage) ||
+    (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0)
+  ) {
+    next.totalTokens = undefined;
+    next.totalTokensFresh = false;
   }
   if (compactionsThisRun > 0) {
     next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;


### PR DESCRIPTION
Fixes #39620

Moves totalTokens calculation outside the hasNonzeroUsage guard to support providers like Kimi that only return promptTokens without structured usage.

The fix preserves backward compatibility: when no token data is available (e.g., aborted/failed runs), the previous totalTokens value is retained instead of being reset to undefined.