### PR TITLE
docs: fix FAQ cross-context messaging config path

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2919,27 +2919,27 @@ Most commands must be sent as a **standalone** message that starts with `/`, but
 OpenClaw blocks **cross-provider** messaging by default. If a tool call is bound
 to Telegram, it won't send to Discord unless you explicitly allow it.
 
-Enable cross-provider messaging for the agent:
+Enable cross-provider messaging in the global tools config:
 
 ```json5
 {
-  agents: {
-    defaults: {
-      tools: {
-        message: {
-          crossContext: {
-            allowAcrossProviders: true,
-            marker: { enabled: true, prefix: "[from {channel}] " },
-          },
-        },
+  tools: {
+    message: {
+      crossContext: {
+        allowAcrossProviders: true,
+        marker: { enabled: true, prefix: "[from {channel}] " },
       },
     },
   },
 }
 ```
 
-Restart the gateway after editing config. If you only want this for a single
-agent, set it under `agents.list[].tools.message` instead.
+Restart the gateway after editing config.
+
+`crossContext` is configured under `tools.message`.
+Agent-scoped paths like `agents.defaults.tools.message` and
+`agents.list[].tools.message` are not valid config keys, so they will be
+rejected or ignored.
 
 ### Why does it feel like the bot ignores rapidfire messages
 


### PR DESCRIPTION
## Summary

- Problem: the FAQ documented unsupported agent-scoped config paths for cross-context messaging (`agents.defaults.tools.message` / `agents.list[].tools.message`)
- Why it matters: users following the FAQ hit config validation failures or silently ignored settings instead of enabling the behavior they wanted
- What changed: updated the FAQ example to use the supported global `tools.message.crossContext` path and explicitly called out the invalid paths
- What did NOT change (scope boundary): no runtime, schema, or tool behavior changed in this PR

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related #24936

## User-visible / Behavior Changes

- The FAQ now points users to the supported `tools.message.crossContext` config path for cross-provider messaging.
- The FAQ now warns that `agents.defaults.tools.message` and `agents.list[].tools.message` are invalid for this setting.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): docs-only
- Relevant config (redacted): N/A

### Steps

1. Open `docs/help/faq.md` and navigate to the cross-context messaging FAQ entry.
2. Compare the documented config path against the current config schema, which accepts `tools.message.crossContext`.
3. Run `pnpm check:docs` after updating the docs.

### Expected

- The FAQ should show a valid config path that matches the current schema.
- Docs formatting, linting, and link checks should pass.

### Actual

- Before this change, the FAQ pointed users at invalid agent-scoped config paths.
- After this change, the FAQ uses the supported global tools config path and docs checks pass.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence:
- `git diff --check`
- `pnpm check:docs`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked the FAQ snippet against the live schema location in `src/config/zod-schema.agent-runtime.ts` and confirmed the supported path is `tools.message.crossContext`
- Edge cases checked: confirmed the previously documented agent-scoped paths are not supported for this setting
- What you did **not** verify: no runtime integration behavior was exercised because this PR only changes docs

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `docs/help/faq.md`
- Known bad symptoms reviewers should watch for: none beyond incorrect FAQ guidance resurfacing

## Risks and Mitigations

- Risk: the documentation could still drift from schema behavior again later
  - Mitigation: this change aligns the FAQ with the current schema and explicitly narrows the documented path

## AI Assistance Notes

- AI-assisted: Codex
- Testing degree: fully tested for this docs change via `pnpm check:docs`
- Prompt/session summary: scanned open upstream issues and PRs for an easy maintainer-friendly contribution, verified the FAQ/schema mismatch on current `main`, applied the docs-only fix, and ran docs verification locally
- I understand the change: it updates documentation only and does not modify runtime behavior
