### PR TITLE
docs: add troubleshooting guide for limited tool access

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -59,7 +59,7 @@ Typical symptoms of a narrow profile:
 
 - The assistant can reply, but cannot use filesystem or runtime tools.
 - Messaging/session/status tools are available, but browser, gateway, cron, canvas, or node tools are missing.
-- A messaging-first setup works, but feels "crippled" compared with local or richer sessions.
+- A messaging-first setup works, but feels more limited than local or richer sessions.
 
 Fastest fix path:
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -34,6 +34,43 @@ Good output in one line:
 - `openclaw channels status --probe` → channels report `connected` or `ready`.
 - `openclaw logs --follow` → steady activity, no repeating fatal errors.
 
+## Assistant feels limited or missing tools
+
+If your assistant replies normally but feels unexpectedly limited (for example, missing file access,
+runtime commands, browser automation, or other first-class tools), check the configured tool profile
+before assuming the runtime or channel is broken.
+
+Run:
+
+```bash
+openclaw status
+openclaw status --all
+openclaw doctor
+```
+
+What to check first:
+
+- `tools.profile: "messaging"` is intentionally narrow by design and favors messaging-only workflows.
+- `tools.profile: "full"` provides the broadest global command/control baseline.
+- `tools.profile: "coding"` is a better fit for repo/file/runtime-heavy workflows than `messaging`.
+- Per-agent overrides (`agents.list[].tools.profile`) and provider-specific overrides can still differ from the global baseline.
+
+Typical symptoms of a narrow profile:
+
+- The assistant can reply, but cannot use filesystem or runtime tools.
+- Messaging/session/status tools are available, but browser, gateway, cron, canvas, or node tools are missing.
+- A messaging-first setup works, but feels "crippled" compared with local or richer sessions.
+
+Fastest fix path:
+
+1. Inspect the `Global tools profile` row in `openclaw status` / `openclaw status --all`.
+2. Check `tools.profile` in config.
+3. If you want a broader tool surface, switch to `tools.profile: "full"`.
+4. If only one agent should differ, prefer `agents.list[].tools.profile` instead of changing every agent globally.
+5. Restart the gateway after config changes.
+
+Use the tools docs for the exact profile meanings: [/tools](/tools)
+
 ## Anthropic long context 429
 
 If you see:


### PR DESCRIPTION
## Summary
- add a troubleshooting section for assistants that feel limited or are missing tools
- explain how `tools.profile` affects the default tool surface
- point users to `openclaw status`, `openclaw status --all`, and `openclaw doctor` as the fastest diagnosis path

## Why
A valid messaging-first setup can feel broken when the assistant can reply but lacks broader tools. This adds a symptom-first troubleshooting path that helps users distinguish a narrow profile from an actual runtime or channel failure.

## Changes
- add a new `Assistant feels limited or missing tools` section to `docs/help/troubleshooting.md`
- explain the practical meaning of `tools.profile: "messaging"`, `"coding"`, and `"full"`
- call out typical symptoms of a narrow profile
- provide a short fix path and link back to `/tools`

## What did not change
- no runtime behavior
- no config schema values
- no status output behavior
- no effective-profile resolution logic

## Change Type
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Related #39954
- Related #39963
- Related #39996

## User-visible / Behavior Changes
Users now have a symptom-first troubleshooting section for assistants that reply normally but seem to be missing broader tools. The doc explains what to check first and how to distinguish a narrow tool profile from a broken runtime.

## Security Impact
- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification
### Environment
- OS: Windows 11
- Runtime/container: local clone
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): `tools.profile`, `agents.list[].tools.profile`

### Steps
1. Open `docs/help/troubleshooting.md`
2. Find the new `Assistant feels limited or missing tools` section
3. Verify the guidance matches current docs and status/config-help wording

### Expected
- users can quickly understand why an assistant may feel limited
- users are directed to the right diagnosis commands and config knobs

### Actual
- the troubleshooting page now includes a targeted section covering symptoms, checks, and fix path

## Evidence
- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification
- Verified scenarios: reviewed the exact diff and checked that the wording aligns with the current docs/config-help/status work
- Edge cases checked: guidance stays scoped to the global baseline and notes that per-agent/provider overrides may differ
- What you did **not** verify: rendered docs preview in a local docs server

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `docs/help/troubleshooting.md`
- Known bad symptoms reviewers should watch for: wording that overstates effective-profile certainty

## Risks and Mitigations
- Risk: maintainers may prefer this in FAQ or another troubleshooting page instead
- Mitigation: kept it symptom-first, compact, and linked back to existing tools docs instead of duplicating full profile documentation
