### PR TITLE
feat: inject sessionId into runtime context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/system prompt: include the current session UUID as `session=<uuid>` in Runtime metadata so prompt-aware tooling can correlate turns without exposing raw session keys. (#40044) Thanks @Feya.
 - iOS/Gateway: add an authenticated `node.presence.alive` protocol event and `node.list` last-seen fields so background iOS wakes can mark paired nodes recently alive without treating them as connected. Carries forward #63123. Thanks @ngutman.
 - Gateway/chat: accept non-image attachments through `chat.send` by staging them as agent-readable media paths, while keeping unsupported RPC attachment paths explicit instead of silently dropping files. Fixes #48123. (#67572) Thanks @samzong.
 - Security/networking: add opt-in operator-managed outbound proxy routing (proxy.enabled + proxy.proxyUrl/OPENCLAW_PROXY_URL) with strict http:// forward-proxy validation, loopback-only Gateway bypass, and cleanup of proxy env/dispatcher state on exit. (#70044) Thanks @jesse-merhi and @joshavant.

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -24,6 +24,7 @@ export type RuntimeInfoInput = {
   capabilities?: string[];
   /** Supported message actions for the current channel (e.g., react, edit, unsend) */
   channelActions?: string[];
+  sessionId?: string;
   repoRoot?: string;
   canvasRootDir?: string;
 };

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -849,6 +849,7 @@ describe("buildAgentSystemPrompt", () => {
     const line = buildRuntimeLine(
       {
         agentId: "work",
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
         host: "host",
         repoRoot: "/repo",
         os: "macOS",
@@ -863,6 +864,7 @@ describe("buildAgentSystemPrompt", () => {
     );
 
     expect(line).toContain("agent=work");
+    expect(line).toContain("session=550e8400-e29b-41d4-a716-446655440000");
     expect(line).toContain("host=host");
     expect(line).toContain("repo=/repo");
     expect(line).toContain("os=macOS (arm64)");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -480,6 +480,7 @@ export function buildAgentSystemPrompt(params: {
   nativeCommandGuidanceLines?: string[];
   runtimeInfo?: {
     agentId?: string;
+    sessionId?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -1017,6 +1018,7 @@ export function buildAgentSystemPrompt(params: {
 export function buildRuntimeLine(
   runtimeInfo?: {
     agentId?: string;
+    sessionId?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -1033,6 +1035,7 @@ export function buildRuntimeLine(
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
   return `Runtime: ${[
     runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
+    runtimeInfo?.sessionId ? `session=${runtimeInfo.sessionId}` : "",
     runtimeInfo?.host ? `host=${runtimeInfo.host}` : "",
     runtimeInfo?.repoRoot ? `repo=${runtimeInfo.repoRoot}` : "",
     runtimeInfo?.os

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -122,6 +122,7 @@ export async function resolveCommandsSystemPromptBundle(
       node: process.version,
       model: `${params.provider}/${params.model}`,
       defaultModel: defaultModelLabel,
+      sessionId: params.sessionEntry?.sessionId,
     },
   });
   const fullAccessState = resolveEmbeddedFullAccessState({


### PR DESCRIPTION
## Summary

Expose the current session UUID in the `Runtime:` line of the system prompt, so agents can reference it in memory files and cross-session links without needing to infer it from filesystem paths.

## Motivation

Currently, the agent has no way to know its own session ID from the runtime context. The only workaround is reading the most recent `.jsonl` filename from disk — fragile and unnecessary when the value is already available in `sessionEntry`.

Use case: when an agent logs events to daily memory files, it helps to include `session: <uuid>` references for traceability. This is impossible without the session ID in context.

## Changes

3 files, +5 lines:

- **`system-prompt-params.ts`** — add `sessionId?: string` to `RuntimeInfoInput`
- **`system-prompt.ts`** — add `sessionId` to the `buildRuntimeLine` type signatures and render `session=<uuid>` in the Runtime line
- **`commands-system-prompt.ts`** — pass `params.sessionEntry?.sessionId` into the runtime object

The Runtime line will now include:
```
Runtime: agent=main | session=04163e3f-... | host=... | ...
```

## Testing

- `tsc --noEmit` passes
- All 50 tests in `system-prompt.test.ts` pass
- No breaking changes (field is optional)