### PR TITLE
feat(telegram): persist inbound webhooks to survive restarts

### DIFF
--- a/src/infra/webhook-queue.test.ts
+++ b/src/infra/webhook-queue.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { dequeueWebhook, enqueueWebhook, replayPendingWebhooks } from "./webhook-queue.js";
+
+describe("webhook-queue", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "webhook-queue-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(stateDir, { recursive: true, force: true });
+  });
+
+  const payload = { update_id: 100, message: { text: "hello" } };
+
+  it("enqueue writes a file and dequeue removes it", async () => {
+    await enqueueWebhook("telegram", "100", payload, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toEqual(["telegram_100.json"]);
+
+    const content = JSON.parse(await fs.promises.readFile(path.join(queueDir, files[0]), "utf-8"));
+    expect(content.channelId).toBe("telegram");
+    expect(content.deduplicationId).toBe("100");
+    expect(content.payload).toEqual(payload);
+    expect(typeof content.enqueuedAt).toBe("number");
+
+    await dequeueWebhook("telegram", "100", stateDir);
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining).toEqual([]);
+  });
+
+  it("dequeue is idempotent (no error on missing file)", async () => {
+    await expect(dequeueWebhook("telegram", "999", stateDir)).resolves.toBeUndefined();
+  });
+
+  it("replayPendingWebhooks returns entries sorted by enqueue time", async () => {
+    const now = Date.now();
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+    // Ensure distinct timestamps.
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const file1 = path.join(queueDir, "telegram_1.json");
+    const entry1 = JSON.parse(await fs.promises.readFile(file1, "utf-8"));
+    entry1.enqueuedAt = now - 2000;
+    await fs.promises.writeFile(file1, JSON.stringify(entry1));
+
+    await enqueueWebhook("telegram", "2", { update_id: 2 }, stateDir);
+    const file2 = path.join(queueDir, "telegram_2.json");
+    const entry2 = JSON.parse(await fs.promises.readFile(file2, "utf-8"));
+    entry2.enqueuedAt = now - 5000; // Earlier timestamp.
+    await fs.promises.writeFile(file2, JSON.stringify(entry2));
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(2);
+    expect(pending[0].deduplicationId).toBe("2"); // Earlier first.
+    expect(pending[1].deduplicationId).toBe("1");
+  });
+
+  it("replayPendingWebhooks deduplicates by deduplicationId", async () => {
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 1 }, stateDir);
+    // Write a second file with the same deduplicationId but different channelId
+    // to test dedup across channels — only the earliest should survive.
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const dup: Record<string, unknown> = {
+      channelId: "other",
+      deduplicationId: "100",
+      enqueuedAt: Date.now() + 1000,
+      payload: { update_id: 100, v: 2 },
+    };
+    await fs.promises.writeFile(path.join(queueDir, "other_100.json"), JSON.stringify(dup));
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect((pending[0].payload as Record<string, unknown>).v).toBe(1);
+  });
+
+  it("replayPendingWebhooks filters by channelId when specified", async () => {
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+    await enqueueWebhook("whatsapp", "2", { id: "abc" }, stateDir);
+
+    const telegramOnly = await replayPendingWebhooks("telegram", stateDir);
+    expect(telegramOnly).toHaveLength(1);
+    expect(telegramOnly[0].channelId).toBe("telegram");
+  });
+
+  it("replayPendingWebhooks cleans up entries older than 1 hour", async () => {
+    await enqueueWebhook("telegram", "old", { update_id: 1 }, stateDir);
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const oldFile = path.join(queueDir, "telegram_old.json");
+    const entry = JSON.parse(await fs.promises.readFile(oldFile, "utf-8"));
+    entry.enqueuedAt = Date.now() - 2 * 60 * 60 * 1000; // 2 hours ago.
+    await fs.promises.writeFile(oldFile, JSON.stringify(entry));
+
+    await enqueueWebhook("telegram", "fresh", { update_id: 2 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("fresh");
+
+    // Old file should be deleted.
+    await expect(fs.promises.access(oldFile)).rejects.toThrow();
+  });
+
+  it("replayPendingWebhooks returns empty array when queue dir does not exist", async () => {
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toEqual([]);
+  });
+
+  it("replayPendingWebhooks skips malformed files", async () => {
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    await fs.promises.writeFile(path.join(queueDir, "bad-file.json"), "not json{{{");
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("1");
+  });
+
+  it("handles many queued messages replayed in order", async () => {
+    const now = Date.now();
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    for (let i = 0; i < 50; i++) {
+      const entry = {
+        channelId: "telegram",
+        deduplicationId: String(i),
+        enqueuedAt: now - (50 - i) * 100, // Reverse ID order to test sorting.
+        payload: { update_id: i },
+      };
+      await fs.promises.writeFile(path.join(queueDir, `telegram_${i}.json`), JSON.stringify(entry));
+    }
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(50);
+    // Sorted by enqueuedAt ascending: update_id 0 has earliest enqueuedAt.
+    expect(pending[0].deduplicationId).toBe("0");
+    expect(pending[49].deduplicationId).toBe("49");
+  });
+
+  it("replayPendingWebhooks breaks timestamp ties by deduplicationId", async () => {
+    const now = Date.now();
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    // Three entries with the same timestamp — order must be deterministic.
+    for (const id of ["300", "100", "200"]) {
+      const entry = { channelId: "telegram", deduplicationId: id, enqueuedAt: now, payload: {} };
+      await fs.promises.writeFile(
+        path.join(queueDir, `telegram_${id}.json`),
+        JSON.stringify(entry),
+      );
+    }
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending.map((e) => e.deduplicationId)).toEqual(["100", "200", "300"]);
+  });
+
+  it("replayPendingWebhooks cleans up orphaned .tmp files", async () => {
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    // Simulate an orphaned temp file from an interrupted write.
+    await fs.promises.writeFile(path.join(queueDir, "telegram_42.json.12345.tmp"), "partial");
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("1");
+
+    // Orphaned tmp file should be deleted.
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining.some((f) => f.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("enqueue overwrites existing entry with same deduplicationId", async () => {
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 1 }, stateDir);
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 2 }, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toHaveLength(1);
+
+    const content = JSON.parse(await fs.promises.readFile(path.join(queueDir, files[0]), "utf-8"));
+    expect(content.payload.v).toBe(2);
+  });
+});

--- a/src/infra/webhook-queue.ts
+++ b/src/infra/webhook-queue.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+const QUEUE_DIRNAME = "webhook-queue";
+const MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+export interface WebhookQueueEntry {
+  channelId: string;
+  deduplicationId: string;
+  enqueuedAt: number;
+  payload: unknown;
+}
+
+function resolveQueueDir(stateDir?: string): string {
+  const base = stateDir ?? resolveStateDir();
+  return path.join(base, QUEUE_DIRNAME);
+}
+
+function entryFilename(channelId: string, deduplicationId: string): string {
+  return `${channelId}_${deduplicationId}.json`;
+}
+
+async function ensureQueueDir(queueDir: string): Promise<void> {
+  await fs.promises.mkdir(queueDir, { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Persist an inbound webhook payload to disk before acknowledging receipt.
+ * Write failure must NOT block normal processing — callers should catch errors.
+ */
+export async function enqueueWebhook(
+  channelId: string,
+  deduplicationId: string,
+  payload: unknown,
+  stateDir?: string,
+): Promise<void> {
+  const queueDir = resolveQueueDir(stateDir);
+  await ensureQueueDir(queueDir);
+  const entry: WebhookQueueEntry = {
+    channelId,
+    deduplicationId,
+    enqueuedAt: Date.now(),
+    payload,
+  };
+  const filePath = path.join(queueDir, entryFilename(channelId, deduplicationId));
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await fs.promises.writeFile(tmp, JSON.stringify(entry), { encoding: "utf-8", mode: 0o600 });
+  await fs.promises.rename(tmp, filePath);
+}
+
+/** Remove a processed webhook entry from the queue. */
+export async function dequeueWebhook(
+  channelId: string,
+  deduplicationId: string,
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveQueueDir(stateDir), entryFilename(channelId, deduplicationId));
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code === "ENOENT"
+    ) {
+      return; // Already removed — no-op.
+    }
+    throw err;
+  }
+}
+
+/**
+ * Load all pending webhook entries, sorted by enqueue time, deduplicated by
+ * deduplicationId. Entries older than 1 hour are deleted (cleanup).
+ */
+export async function replayPendingWebhooks(
+  channelId?: string,
+  stateDir?: string,
+): Promise<WebhookQueueEntry[]> {
+  const queueDir = resolveQueueDir(stateDir);
+  let files: string[];
+  try {
+    files = await fs.promises.readdir(queueDir);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code !== "ENOENT"
+    ) {
+      console.warn("[webhook-queue] failed to read queue directory:", err);
+    }
+    return [];
+  }
+
+  const now = Date.now();
+  const entries: WebhookQueueEntry[] = [];
+
+  for (const file of files) {
+    // Clean up orphaned temp files from interrupted writes.
+    if (file.endsWith(".tmp")) {
+      await fs.promises.unlink(path.join(queueDir, file)).catch(() => {});
+      continue;
+    }
+    if (!file.endsWith(".json")) {
+      continue;
+    }
+    const filePath = path.join(queueDir, file);
+    try {
+      const raw = await fs.promises.readFile(filePath, "utf-8");
+      const entry = JSON.parse(raw) as WebhookQueueEntry;
+
+      // Validate required fields to avoid sort/dedup errors from malformed entries.
+      if (typeof entry.deduplicationId !== "string" || typeof entry.enqueuedAt !== "number") {
+        continue;
+      }
+
+      // Cleanup: delete entries older than 1 hour.
+      if (now - entry.enqueuedAt > MAX_AGE_MS) {
+        await fs.promises.unlink(filePath).catch(() => {});
+        continue;
+      }
+
+      // Filter by channel if specified.
+      if (channelId && entry.channelId !== channelId) {
+        continue;
+      }
+
+      entries.push(entry);
+    } catch {
+      // Skip malformed or inaccessible entries.
+    }
+  }
+
+  // Sort oldest first; break timestamp ties deterministically by deduplicationId.
+  entries.sort(
+    (a, b) => a.enqueuedAt - b.enqueuedAt || a.deduplicationId.localeCompare(b.deduplicationId),
+  );
+
+  // Deduplicate by deduplicationId (keep earliest).
+  const seen = new Set<string>();
+  return entries.filter((e) => {
+    if (seen.has(e.deduplicationId)) {
+      return false;
+    }
+    seen.add(e.deduplicationId);
+    return true;
+  });
+}

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -44,6 +44,7 @@ import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
   MEDIA_GROUP_TIMEOUT_MS,
   type MediaGroupEntry,
+  resolveTelegramUpdateId,
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
@@ -125,6 +126,7 @@ export const registerTelegramHandlers = ({
   shouldSkipUpdate,
   processMessage,
   logger,
+  registerDeferredWork,
 }: RegisterTelegramHandlerParams) => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
@@ -149,9 +151,19 @@ export const registerTelegramHandlers = ({
     key: string;
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     timer: ReturnType<typeof setTimeout>;
+    /** Deferred-work resolvers for webhook queue tracking. */
+    deferredResolvers?: Array<() => void>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
   let textFragmentProcessing: Promise<void> = Promise.resolve();
+
+  // Register a deferred-work promise for the given update_id so the webhook
+  // queue does not dequeue the update until the deferred processing completes.
+  const registerDeferred = (updateId: number | undefined, promise: Promise<void>) => {
+    if (typeof updateId === "number" && registerDeferredWork) {
+      registerDeferredWork(updateId, promise);
+    }
+  };
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
   const FORWARD_BURST_DEBOUNCE_MS = 80;
@@ -164,6 +176,8 @@ export const registerTelegramHandlers = ({
     debounceKey: string | null;
     debounceLane: TelegramDebounceLane;
     botUsername?: string;
+    /** Resolve function for webhook queue deferred-work tracking. */
+    deferredResolve?: () => void;
   };
   const resolveTelegramDebounceLane = (msg: Message): TelegramDebounceLane => {
     const forwardMeta = msg as {
@@ -228,43 +242,52 @@ export const registerTelegramHandlers = ({
       return entry.allMedia.length === 0;
     },
     onFlush: async (entries) => {
-      const last = entries.at(-1);
-      if (!last) {
-        return;
+      try {
+        const last = entries.at(-1);
+        if (!last) {
+          return;
+        }
+        if (entries.length === 1) {
+          const replyMedia = await resolveReplyMediaForMessage(last.ctx, last.msg);
+          await processMessage(last.ctx, last.allMedia, last.storeAllowFrom, undefined, replyMedia);
+          return;
+        }
+        const combinedText = entries
+          .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
+          .filter(Boolean)
+          .join("\n");
+        const combinedMedia = entries.flatMap((entry) => entry.allMedia);
+        if (!combinedText.trim() && combinedMedia.length === 0) {
+          return;
+        }
+        const first = entries[0];
+        const baseCtx = first.ctx;
+        const syntheticMessage = buildSyntheticTextMessage({
+          base: first.msg,
+          text: combinedText,
+          date: last.msg.date ?? first.msg.date,
+        });
+        const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
+        const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
+        const replyMedia = await resolveReplyMediaForMessage(baseCtx, syntheticMessage);
+        await processMessage(
+          syntheticCtx,
+          combinedMedia,
+          first.storeAllowFrom,
+          messageIdOverride ? { messageIdOverride } : undefined,
+          replyMedia,
+        );
+      } finally {
+        for (const entry of entries) {
+          entry.deferredResolve?.();
+        }
       }
-      if (entries.length === 1) {
-        const replyMedia = await resolveReplyMediaForMessage(last.ctx, last.msg);
-        await processMessage(last.ctx, last.allMedia, last.storeAllowFrom, undefined, replyMedia);
-        return;
-      }
-      const combinedText = entries
-        .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
-        .filter(Boolean)
-        .join("\n");
-      const combinedMedia = entries.flatMap((entry) => entry.allMedia);
-      if (!combinedText.trim() && combinedMedia.length === 0) {
-        return;
-      }
-      const first = entries[0];
-      const baseCtx = first.ctx;
-      const syntheticMessage = buildSyntheticTextMessage({
-        base: first.msg,
-        text: combinedText,
-        date: last.msg.date ?? first.msg.date,
-      });
-      const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
-      const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
-      const replyMedia = await resolveReplyMediaForMessage(baseCtx, syntheticMessage);
-      await processMessage(
-        syntheticCtx,
-        combinedMedia,
-        first.storeAllowFrom,
-        messageIdOverride ? { messageIdOverride } : undefined,
-        replyMedia,
-      );
     },
     onError: (err, items) => {
       runtime.error?.(danger(`telegram debounce flush failed: ${String(err)}`));
+      for (const item of items) {
+        item.deferredResolve?.();
+      }
       const chatId = items[0]?.msg.chat.id;
       if (chatId != null) {
         const threadId = items[0]?.msg.message_thread_id;
@@ -387,6 +410,10 @@ export const registerTelegramHandlers = ({
       await processMessage(primaryEntry.ctx, allMedia, storeAllowFrom, undefined, replyMedia);
     } catch (err) {
       runtime.error?.(danger(`media group handler failed: ${String(err)}`));
+    } finally {
+      for (const resolve of entry.deferredResolvers ?? []) {
+        resolve();
+      }
     }
   };
 
@@ -419,6 +446,10 @@ export const registerTelegramHandlers = ({
       });
     } catch (err) {
       runtime.error?.(danger(`text fragment handler failed: ${String(err)}`));
+    } finally {
+      for (const resolve of entry.deferredResolvers ?? []) {
+        resolve();
+      }
     }
   };
 
@@ -866,6 +897,8 @@ export const registerTelegramHandlers = ({
     storeAllowFrom: string[];
     sendOversizeWarning: boolean;
     oversizeLogMessage: string;
+    /** Telegram update_id for deferred-work tracking (webhook queue). */
+    updateId?: number;
   }) => {
     const {
       ctx,
@@ -876,6 +909,7 @@ export const registerTelegramHandlers = ({
       storeAllowFrom,
       sendOversizeWarning,
       oversizeLogMessage,
+      updateId,
     } = params;
 
     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
@@ -913,6 +947,12 @@ export const registerTelegramHandlers = ({
             nextTotalChars <= TELEGRAM_TEXT_FRAGMENT_MAX_TOTAL_CHARS
           ) {
             existing.messages.push({ msg, ctx, receivedAtMs: nowMs });
+            if (typeof updateId === "number" && registerDeferredWork) {
+              const deferred = new Promise<void>((resolve) => {
+                (existing.deferredResolvers ??= []).push(resolve);
+              });
+              registerDeferred(updateId, deferred);
+            }
             scheduleTextFragmentFlush(existing);
             return;
           }
@@ -936,6 +976,12 @@ export const registerTelegramHandlers = ({
           messages: [{ msg, ctx, receivedAtMs: nowMs }],
           timer: setTimeout(() => {}, TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS),
         };
+        if (typeof updateId === "number" && registerDeferredWork) {
+          const deferred = new Promise<void>((resolve) => {
+            (entry.deferredResolvers ??= []).push(resolve);
+          });
+          registerDeferred(updateId, deferred);
+        }
         textFragmentBuffer.set(key, entry);
         scheduleTextFragmentFlush(entry);
         return;
@@ -949,6 +995,12 @@ export const registerTelegramHandlers = ({
       if (existing) {
         clearTimeout(existing.timer);
         existing.messages.push({ msg, ctx });
+        if (typeof updateId === "number" && registerDeferredWork) {
+          const deferred = new Promise<void>((resolve) => {
+            (existing.deferredResolvers ??= []).push(resolve);
+          });
+          registerDeferred(updateId, deferred);
+        }
         existing.timer = setTimeout(async () => {
           mediaGroupBuffer.delete(mediaGroupId);
           mediaGroupProcessing = mediaGroupProcessing
@@ -971,6 +1023,12 @@ export const registerTelegramHandlers = ({
             await mediaGroupProcessing;
           }, mediaGroupTimeoutMs),
         };
+        if (typeof updateId === "number" && registerDeferredWork) {
+          const deferred = new Promise<void>((resolve) => {
+            (entry.deferredResolvers ??= []).push(resolve);
+          });
+          registerDeferred(updateId, deferred);
+        }
         mediaGroupBuffer.set(mediaGroupId, entry);
       }
       return;
@@ -1032,6 +1090,13 @@ export const registerTelegramHandlers = ({
     const debounceKey = senderId
       ? `telegram:${accountId ?? "default"}:${conversationKey}:${senderId}:${debounceLane}`
       : null;
+    let deferredResolve: (() => void) | undefined;
+    if (typeof updateId === "number" && registerDeferredWork) {
+      const deferred = new Promise<void>((resolve) => {
+        deferredResolve = resolve;
+      });
+      registerDeferred(updateId, deferred);
+    }
     await inboundDebouncer.enqueue({
       ctx,
       msg,
@@ -1040,6 +1105,7 @@ export const registerTelegramHandlers = ({
       debounceKey,
       debounceLane,
       botUsername: ctx.me?.username,
+      deferredResolve,
     });
   };
   bot.on("callback_query", async (ctx) => {
@@ -1482,6 +1548,7 @@ export const registerTelegramHandlers = ({
         storeAllowFrom,
         sendOversizeWarning: event.sendOversizeWarning,
         oversizeLogMessage: event.oversizeLogMessage,
+        updateId: resolveTelegramUpdateId(event.ctxForDedupe),
       });
     } catch (err) {
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -114,6 +114,10 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
+  /** Register a promise that must settle before the webhook queue dequeues
+   *  the update. Used by deferred handlers (media group, text fragment,
+   *  inbound debounce) to prevent premature dequeue. */
+  registerDeferredWork?: (updateId: number, promise: Promise<void>) => void;
 };
 
 type RegisterTelegramNativeCommandsParams = {

--- a/src/telegram/bot-updates.ts
+++ b/src/telegram/bot-updates.ts
@@ -12,6 +12,8 @@ export type MediaGroupEntry = {
     ctx: TelegramContext;
   }>;
   timer: ReturnType<typeof setTimeout>;
+  /** Deferred-work resolvers for webhook queue tracking. */
+  deferredResolvers?: Array<() => void>;
 };
 
 export type TelegramUpdateKeyContext = {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -64,6 +64,8 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /** Called when a Telegram update has been fully processed (for webhook queue dequeue). */
+  onUpdateProcessed?: (updateId: number) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -218,6 +220,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     return skipped;
   };
 
+  // Track deferred processing promises per update_id. Handlers that buffer
+  // messages (media groups, text fragments, inbound debouncing) register a
+  // promise here so `onUpdateProcessed` only fires after the deferred work
+  // completes — not when the middleware `next()` returns.
+  const deferredWork = new Map<number, Promise<void>[]>();
+  const registerDeferredWork = (updateId: number, promise: Promise<void>) => {
+    const existing = deferredWork.get(updateId);
+    if (existing) {
+      existing.push(promise);
+    } else {
+      deferredWork.set(updateId, [promise]);
+    }
+  };
+
   bot.use(async (ctx, next) => {
     const updateId = resolveTelegramUpdateId(ctx);
     if (typeof updateId === "number") {
@@ -225,8 +241,19 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     }
     try {
       await next();
+      if (typeof updateId === "number") {
+        // Wait for any deferred processing (debounce, media group, text
+        // fragment buffering) before signaling the update as processed.
+        const deferred = deferredWork.get(updateId);
+        if (deferred) {
+          deferredWork.delete(updateId);
+          await Promise.all(deferred);
+        }
+        opts.onUpdateProcessed?.(updateId);
+      }
     } finally {
       if (typeof updateId === "number") {
+        deferredWork.delete(updateId);
         pendingUpdateIds.delete(updateId);
         if (highestCompletedUpdateId === null || updateId > highestCompletedUpdateId) {
           highestCompletedUpdateId = updateId;
@@ -449,6 +476,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     shouldSkipUpdate,
     processMessage,
     logger,
+    registerDeferredWork,
   });
 
   const originalStop = bot.stop.bind(bot);

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -605,6 +605,73 @@ describe("startTelegramWebhook", () => {
     );
   });
 
+  it("dequeues webhook file when onUpdateProcessed fires", async () => {
+    // Capture the onUpdateProcessed callback passed to createTelegramBot.
+    let capturedOnUpdateProcessed: ((updateId: number) => void) | undefined;
+    createTelegramBotSpy.mockImplementationOnce((opts: Record<string, unknown>) => {
+      capturedOnUpdateProcessed = opts.onUpdateProcessed as typeof capturedOnUpdateProcessed;
+      return {
+        init: initSpy,
+        api: { setWebhook: setWebhookSpy, deleteWebhook: deleteWebhookSpy },
+        stop: stopSpy,
+      };
+    });
+
+    // The webhookCallback handler should invoke the Grammy middleware which
+    // eventually calls onUpdateProcessed. In this mock we control it manually.
+    handlerSpy.mockImplementationOnce(
+      (
+        update: unknown,
+        reply: (json: string) => Promise<void>,
+        _secretHeader: string | undefined,
+        _unauthorized: () => Promise<void>,
+      ) => {
+        void reply("ok");
+      },
+    );
+
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "wh-dequeue-test-"));
+
+    try {
+      await withStartedWebhook(
+        {
+          secret: TELEGRAM_SECRET,
+          path: TELEGRAM_WEBHOOK_PATH,
+          stateDir,
+        },
+        async ({ port }) => {
+          const payload = JSON.stringify({ update_id: 42, message: { text: "test" } });
+          const response = await postWebhookJson({
+            url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+            payload,
+            secret: TELEGRAM_SECRET,
+          });
+          expect(response.status).toBe(200);
+
+          // Webhook file should be on disk (enqueued before processing).
+          const queueDir = path.join(stateDir, "webhook-queue");
+          const filesAfterEnqueue = await fs.promises.readdir(queueDir);
+          expect(filesAfterEnqueue.some((f: string) => f.includes("42"))).toBe(true);
+
+          // Simulate middleware completing — fire onUpdateProcessed.
+          expect(capturedOnUpdateProcessed).toBeDefined();
+          capturedOnUpdateProcessed!(42);
+
+          // Wait for async dequeue to complete.
+          await new Promise((r) => setTimeout(r, 50));
+
+          const filesAfterDequeue = await fs.promises.readdir(queueDir);
+          expect(filesAfterDequeue.some((f: string) => f.includes("42"))).toBe(false);
+        },
+      );
+    } finally {
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("de-registers webhook when shutting down", async () => {
     deleteWebhookSpy.mockClear();
     const abort = new AbortController();

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { readJsonBodyWithLimit } from "../infra/http-body.js";
+import { dequeueWebhook, enqueueWebhook, replayPendingWebhooks } from "../infra/webhook-queue.js";
 import {
   logWebhookError,
   logWebhookProcessed,
@@ -88,6 +89,8 @@ export async function startTelegramWebhook(opts: {
   healthPath?: string;
   publicUrl?: string;
   webhookCertPath?: string;
+  /** Override state directory for webhook queue (tests). */
+  stateDir?: string;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -102,18 +105,41 @@ export async function startTelegramWebhook(opts: {
   }
   const runtime = opts.runtime ?? defaultRuntime;
   const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
+  const queueChannelId = opts.accountId ? `telegram_${opts.accountId}` : "telegram";
   const bot = createTelegramBot({
     token: opts.token,
     runtime,
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    onUpdateProcessed: (updateId) => {
+      dequeueWebhook(queueChannelId, String(updateId), opts.stateDir).catch(() => {});
+    },
   });
   await initializeTelegramWebhookBot({
     bot,
     runtime,
     abortSignal: opts.abortSignal,
   });
+
+  // Replay any webhook payloads that were enqueued but not fully processed
+  // before the last shutdown.
+  const pending = await replayPendingWebhooks(queueChannelId, opts.stateDir);
+  for (const entry of pending) {
+    try {
+      await bot.handleUpdate(entry.payload as Parameters<typeof bot.handleUpdate>[0]);
+      // Dequeue happens via onUpdateProcessed in the bot middleware on success.
+    } catch (err) {
+      runtime.log?.(
+        `webhook replay failed for update ${entry.deduplicationId}: ${formatErrorMessage(err)}`,
+      );
+      // Leave entry on disk — will be retried on next restart (1h TTL cleanup).
+    }
+  }
+  if (pending.length > 0) {
+    runtime.log?.(`webhook queue: replayed ${pending.length} pending update(s)`);
+  }
+
   const handler = webhookCallback(bot, "callback", {
     secretToken: secret,
     onTimeout: "return",
@@ -191,6 +217,25 @@ export async function startTelegramWebhook(opts: {
       };
       const secretHeaderRaw = req.headers["x-telegram-bot-api-secret-token"];
       const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
+
+      // Validate webhook secret before persisting anything to disk.
+      if (secretHeader !== secret) {
+        await unauthorized();
+        return;
+      }
+
+      // Persist payload to disk before processing so it survives a restart.
+      const updateId =
+        body.value && typeof body.value === "object" && "update_id" in body.value
+          ? (body.value as { update_id?: unknown }).update_id
+          : undefined;
+      if (typeof updateId === "number") {
+        try {
+          await enqueueWebhook(queueChannelId, String(updateId), body.value, opts.stateDir);
+        } catch {
+          // Queue write failure must not block normal processing.
+        }
+      }
 
       await handler(body.value, reply, secretHeader, unauthorized);
       if (!replied) {


### PR DESCRIPTION
### Problem

Telegram webhook mode acknowledges messages with 200 OK immediately. If a gateway restart happens mid-processing, queued messages are lost permanently - Telegram already considers them delivered.

### Solution

Persist inbound webhook payloads to disk before processing. On restart, replay any unprocessed payloads.

### How it works

1. `enqueueWebhook()` writes the raw payload to `~/.openclaw/webhook-queue/<deduplicationId>.json` via atomic rename (write to `.tmp`, then `rename`)
2. Handler processes the message normally
3. `dequeueWebhook()` deletes the file after successful processing
4. On startup, `replayPendingWebhooks()` scans the queue directory and re-dispatches any remaining payloads in `enqueuedAt` order (with `deduplicationId` tie-breaking for same-timestamp bursts)

### Security

- Webhook secret validation happens BEFORE enqueue - unauthenticated payloads are never persisted
- Orphaned `.tmp` files (from crashes between write and rename) are cleaned up during replay

### Config

No config needed - webhook queue activates automatically for Telegram webhook mode. Queue directory is created lazily on first webhook.

Supersedes #34702 (force-push after rebase broke reopen).

## Validation
- `pnpm build` -- clean
- `pnpm check` -- clean
- `pnpm test src/infra/webhook-queue.test.ts` -- passed

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Closes #42157