### PR TITLE
fix(exec): stop implicit auto-backgrounding for long-running commands

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -101,7 +101,7 @@ export const execSchema = Type.Object({
   env: Type.Optional(Type.Record(Type.String(), Type.String())),
   yieldMs: Type.Optional(
     Type.Number({
-      description: "Milliseconds to wait before backgrounding (default 10000)",
+      description: "Milliseconds to wait before backgrounding when yield mode is requested",
     }),
   ),
   background: Type.Optional(Type.Boolean({ description: "Run in background immediately" })),

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -238,12 +238,9 @@ export function createExecTool(
       const yieldWindow = allowBackground
         ? backgroundRequested
           ? 0
-          : clampWithDefault(
-              params.yieldMs ?? defaultBackgroundMs,
-              defaultBackgroundMs,
-              10,
-              120_000,
-            )
+          : yieldRequested
+            ? clampWithDefault(params.yieldMs, defaultBackgroundMs, 10, 120_000)
+            : null
         : null;
       const elevatedDefaults = defaults?.elevated;
       const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -447,6 +447,16 @@ describe("exec tool backgrounding", () => {
     isWin ? 15_000 : 5_000,
   );
 
+  it("does not auto-background unless yield/background is explicitly requested", async () => {
+    const tool = createTestExecTool({ backgroundMs: 10 });
+    const result = await executeExecCommand(
+      tool,
+      joinCommands([longDelayCmd, shellEcho(OUTPUT_DONE)]),
+    );
+    expect(readProcessStatus(result.details)).toBe(PROCESS_STATUS_COMPLETED);
+    expect(readTextContent(result.content) ?? "").toContain(OUTPUT_DONE);
+  });
+
   it("supports explicit background and derives session name from the command", async () => {
     const sessionId = await startBackgroundCommand(execTool, COMMAND_ECHO_HELLO);
 

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -242,7 +242,7 @@ export type ExecToolConfig = {
   safeBinTrustedDirs?: string[];
   /** Optional custom safe-bin profiles for entries in tools.exec.safeBins. */
   safeBinProfiles?: Record<string, SafeBinProfileFixture>;
-  /** Default time (ms) before an exec command auto-backgrounds. */
+  /** Default yield window (ms) used when exec is explicitly requested to yield/background. */
   backgroundMs?: number;
   /** Default timeout (seconds) before auto-killing exec commands. */
   timeoutSec?: number;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The `exec` tool could auto-background long-running commands after the default background window even when the model did not explicitly request `yieldMs` or `background`.
- Why it matters: This can produce premature “Command still running” flows and allow the agent to continue as if work finished, causing incorrect “task complete” responses for commands like `sleep 600`.
- What changed: Updated `exec` backgrounding logic to require explicit yield intent (`background: true` or `yieldMs`) before returning a running session; added a regression test to lock this behavior; updated related config/schema descriptions to match runtime behavior.
- What did NOT change (scope boundary): No changes to process polling semantics, process tool APIs, supervisor behavior, timeout mechanics, approvals/security gates, or transport/channel integrations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40040
- Related #

## User-visible / Behavior Changes

- `exec` no longer auto-backgrounds by default just because a command runs past the default background window.
- `exec` now returns `status=running` only when explicitly requested (`background: true` or `yieldMs` provided).
- The `yieldMs`/`backgroundMs` descriptions were clarified to reflect explicit-yield behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows (local dev test host)
- Runtime/container: Node.js + Vitest
- Model/provider: N/A (tool-layer unit/integration tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config; targeted exec defaults in tests

### Steps

1. Run `exec` with a long command (for example, `sleep ...`) without `background` and without `yieldMs`.
2. Observe tool result status and output.
3. Run `exec` again with explicit `background: true` or `yieldMs` and observe running-session behavior.

### Expected

- Without explicit yield/background request, `exec` waits for completion and returns completed output.
- With explicit yield/background request, `exec` returns running status and requires follow-up via `process`.

### Actual

- Matches expected after this fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added and ran regression test: `does not auto-background unless yield/background is explicitly requested`.
  - Ran existing background/poll flow tests to confirm explicit background still works.
  - Ran adjacent PTY/background-abort tests to confirm no regressions in related execution paths.
- Edge cases checked:
  - Explicit `background: true` path still returns running session.
  - Explicit `yieldMs` path still yields as expected.
  - Non-yield path completes normally for long-running command fixture.
- What you did **not** verify:
  - Live end-to-end behavior against external model providers/channels in a real chat session.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit (single logic block in exec backgrounding path).
- Files/config to restore:
  - `src/agents/bash-tools.exec.ts`
  - `src/agents/bash-tools.test.ts`
  - `src/agents/bash-tools.exec-runtime.ts`
  - `src/config/types.tools.ts`
- Known bad symptoms reviewers should watch for:
  - Commands unexpectedly returning immediate `status=running` without explicit `background`/`yieldMs`.
  - Explicit background or yield requests no longer returning running sessions.

## Risks and Mitigations

- Risk: Some workflows may have unintentionally relied on implicit auto-backgrounding for long commands.
  - Mitigation: Explicit behavior remains fully supported (`background: true` / `yieldMs`), and regression tests now enforce the intended contract.