### PR TITLE
fix(gateway): avoid false stuck restarts with fresh events

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -267,6 +267,26 @@ describe("channel-health-monitor", () => {
     await expectRestartedChannel(manager, "discord");
   });
 
+  it("does not restart connected busy channels that still receive fresh events", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager({
+      discord: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          lastStartAt: now - 27 * 60_000,
+          activeRuns: 1,
+          busy: true,
+          lastRunActivityAt: now - 26 * 60_000,
+          lastEventAt: now - 5_000,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
   it("restarts disconnected channels when busy flags are inherited from a prior lifecycle", async () => {
     const now = Date.now();
     const manager = createSnapshotManager({

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -80,6 +80,54 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
   });
 
+  it("keeps connected busy channels healthy when fresh events still arrive", () => {
+    const now = 100_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: now - 27 * 60_000,
+        activeRuns: 1,
+        busy: true,
+        lastRunActivityAt: now - 26 * 60_000,
+        lastEventAt: now - 5_000,
+      },
+      {
+        channelId: "discord",
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("does not trust future event timestamps to suppress stuck recovery", () => {
+    const now = 100_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: now - 27 * 60_000,
+        activeRuns: 1,
+        busy: true,
+        lastRunActivityAt: now - 26 * 60_000,
+        lastEventAt: now + 60_000,
+      },
+      {
+        channelId: "discord",
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
+  });
+
   it("ignores inherited busy flags until current lifecycle reports run activity", () => {
     const now = 100_000;
     const evaluation = evaluateChannelHealth(

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -54,6 +54,27 @@ const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
 export const DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
 export const DEFAULT_CHANNEL_CONNECT_GRACE_MS = 120_000;
 
+function hasFreshCurrentLifecycleEvent(
+  snapshot: ChannelHealthSnapshot,
+  policy: ChannelHealthPolicy,
+  lastStartAt: number | null,
+): boolean {
+  if (
+    policy.channelId === "telegram" ||
+    snapshot.mode === "webhook" ||
+    snapshot.connected !== true ||
+    typeof snapshot.lastEventAt !== "number" ||
+    !Number.isFinite(snapshot.lastEventAt)
+  ) {
+    return false;
+  }
+  if (lastStartAt != null && snapshot.lastEventAt < lastStartAt) {
+    return false;
+  }
+  const eventAge = policy.now - snapshot.lastEventAt;
+  return eventAge >= 0 && eventAge <= policy.staleEventThresholdMs;
+}
+
 export function evaluateChannelHealth(
   snapshot: ChannelHealthSnapshot,
   policy: ChannelHealthPolicy,
@@ -93,6 +114,9 @@ export function evaluateChannelHealth(
           : Math.max(0, policy.now - lastRunActivityAt);
       if (runActivityAge < BUSY_ACTIVITY_STALE_THRESHOLD_MS) {
         return { healthy: true, reason: "busy" };
+      }
+      if (hasFreshCurrentLifecycleEvent(snapshot, policy, lastStartAt)) {
+        return { healthy: true, reason: "healthy" };
       }
       return { healthy: false, reason: "stuck" };
     }


### PR DESCRIPTION
## Summary
- keep connected busy channels healthy when the current lifecycle is still receiving fresh events
- ignore future `lastEventAt` values so clock skew cannot suppress real stuck recovery
- add policy and monitor regression coverage for the false-positive restart path

Fixes #39096

## Root cause
The busy-channel branch returned `stuck` as soon as `lastRunActivityAt` went stale. That bypassed the existing event-liveness signal, so Discord channels that were still receiving fresh gateway events could be restarted anyway.

## What changed
- add a fresh-event guard inside the stale busy path
- require the event to belong to the current lifecycle
- reject future event timestamps when deciding whether to skip recovery

## Verification
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/vitest run src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxfmt --check src/gateway/channel-health-policy.ts src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxlint src/gateway/channel-health-policy.ts src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts`
