### PR TITLE
fix(plugins): route Mattermost parseStrictPositiveInteger through plugin-sdk

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -28,9 +28,9 @@ import {
   resolveChannelMediaMaxBytes,
   warnMissingProviderGroupPolicyFallbackOnce,
   listSkillCommandsForAgents,
+  parseStrictPositiveInteger,
   type HistoryEntry,
 } from "openclaw/plugin-sdk/mattermost";
-import { parseStrictPositiveInteger } from "../../../../src/infra/parse-finite-number.js";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -99,4 +99,5 @@ export { evaluateSenderGroupAccessForPolicy } from "./group-access.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
 export { loadOutboundMediaFromUrl } from "./outbound-media.js";
+export { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 export { createScopedPairingAccess } from "./pairing-access.js";


### PR DESCRIPTION
## Summary

- **Problem:** Mattermost extension plugin fails to load on v2026.3.7 because `monitor.ts` imports `parseStrictPositiveInteger` via a source-tree relative path (`../../../../src/infra/parse-finite-number.js`) that does not exist in the published npm package.
- **Why it matters:** The entire Mattermost channel fails to start — no `[mattermost] connected` message appears, breaking the integration for all Mattermost users.
- **What changed:** Re-exported `parseStrictPositiveInteger` from `src/plugin-sdk/mattermost.ts` and updated `monitor.ts` to import it from `openclaw/plugin-sdk/mattermost` (matching all other imports in the file).
- **What did NOT change (scope boundary):** No logic changes, no new dependencies, no other plugin-sdk surfaces touched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #40014

## User-visible / Behavior Changes

Mattermost channel plugin loads successfully again after upgrading to v2026.3.7+.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu / macOS
- Runtime/container: Node.js v22
- Integration/channel: Mattermost

### Steps

1. Install openclaw v2026.3.7 via `npm install -g openclaw`
2. Configure a Mattermost channel
3. Run `openclaw gateway run`

### Expected

- Mattermost plugin loads, `[mattermost] connected` appears

### Actual

- Before fix: `Error: Cannot find module '../../../../src/infra/parse-finite-number.js'`
- After fix: Plugin loads normally

## Evidence

- [x] `pnpm build` passes — the new export resolves correctly
- [x] `pnpm check` passes — no lint/format issues
- [x] `pnpm test` passes — 863 test files, 6985 tests, 0 failures

## Human Verification (required)

- Verified scenarios: Build compiles, all lint checks pass, full test suite green
- Edge cases checked: Confirmed `parseStrictPositiveInteger` is only used once in `monitor.ts` (line 367 for `OPENCLAW_GATEWAY_PORT` parsing) and the function signature matches
- What I did **not** verify: Live Mattermost instance end-to-end test (no Mattermost server available)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two-file diff; the workaround from #40014 (inline function) also works
- Files/config to restore: `src/plugin-sdk/mattermost.ts`, `extensions/mattermost/src/mattermost/monitor.ts`
- Known bad symptoms reviewers should watch for: Mattermost plugin load failure in gateway logs

## Risks and Mitigations

- Risk: Adding a new export to the plugin-sdk surface widens the public API slightly
  - Mitigation: `parseStrictPositiveInteger` is a pure utility function with no side effects; it was already depended on by the Mattermost extension, just via a broken path

AI-assisted (Claude) — fully tested with `pnpm build && pnpm check && pnpm test`
