### PR TITLE
fix(replies): strip leaked tool markers from user-facing replies

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -38,6 +38,18 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
 
+  it("preserves standalone function call wrapper lines without tool pipe tags", () => {
+    const text = ["These wrappers are literal:", "<function_calls>", "</function_calls>"].join(
+      "\n",
+    );
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("preserves trailing newlines after removing marker-only lines", () => {
+    const input = ["Hello", "<|tool_list_end|>", "", "World", ""].join("\n");
+    expect(sanitizeUserFacingText(input)).toBe("Hello\n\nWorld\n");
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -45,6 +45,27 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
 
+  it("preserves standalone function call wrapper lines when tool tags appear in another block", () => {
+    const input = [
+      "These wrappers are literal:",
+      "<function_calls>",
+      "</function_calls>",
+      "",
+      "Visible reply",
+      "<|tool_list_end|>",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe(
+      [
+        "These wrappers are literal:",
+        "<function_calls>",
+        "</function_calls>",
+        "",
+        "Visible reply",
+      ].join("\n"),
+    );
+  });
+
   it("preserves trailing newlines after removing marker-only lines", () => {
     const input = ["Hello", "<|tool_list_end|>", "", "World", ""].join("\n");
     expect(sanitizeUserFacingText(input)).toBe("Hello\n\nWorld\n");

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -15,6 +15,29 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips leaked internal tool markers", () => {
+    const input = [
+      "<|tool_call_result_begin|>",
+      "<function_calls>",
+      "</function_calls>",
+      "<|tool_call_result_end|>",
+      "Visible reply",
+      "<|tool_list_end|>",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Visible reply");
+  });
+
+  it("does not strip unrelated pipe tags", () => {
+    const text = "Explain what <|assistant|> means in this transcript format.";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("preserves inline mentions of tool markers and wrappers", () => {
+    const text = "Explain <function_calls> and <|tool_call_result_begin|> tags.";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -181,6 +181,8 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
 const ERROR_PAYLOAD_PREFIX_RE =
   /^(?:error|api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)[:\s-]+/i;
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
+const INTERNAL_TOOL_PIPE_TAG_RE = /<\|\s*tool_[a-z0-9_:-]+\s*\|>/gi;
+const FUNCTION_CALLS_TAG_RE = /<\s*\/?\s*function_calls\s*>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -397,6 +399,28 @@ function stripFinalTagsFromText(text: string): string {
     return text;
   }
   return text.replace(FINAL_TAG_RE, "");
+}
+
+function stripInternalToolMarkersFromText(text: string): string {
+  if (!text) {
+    return text;
+  }
+  let removedAny = false;
+  const keptLines = text.split("\n").filter((line) => {
+    const strippedLine = line
+      .replace(INTERNAL_TOOL_PIPE_TAG_RE, "")
+      .replace(FUNCTION_CALLS_TAG_RE, "");
+    const isMarkerOnlyLine = strippedLine.trim().length === 0 && strippedLine !== line;
+    if (isMarkerOnlyLine) {
+      removedAny = true;
+      return false;
+    }
+    return true;
+  });
+  if (!removedAny) {
+    return text;
+  }
+  return keptLines.join("\n").replace(/(?:\r?\n[ \t]*)+$/, "");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {
@@ -716,7 +740,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return text;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripFinalTagsFromText(text);
+  const stripped = stripInternalToolMarkersFromText(stripFinalTagsFromText(text));
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -405,11 +405,13 @@ function stripInternalToolMarkersFromText(text: string): string {
   if (!text) {
     return text;
   }
+  const shouldStripFunctionCallWrappers = text.search(INTERNAL_TOOL_PIPE_TAG_RE) !== -1;
   let removedAny = false;
   const keptLines = text.split("\n").filter((line) => {
-    const strippedLine = line
-      .replace(INTERNAL_TOOL_PIPE_TAG_RE, "")
-      .replace(FUNCTION_CALLS_TAG_RE, "");
+    const withoutPipeTags = line.replace(INTERNAL_TOOL_PIPE_TAG_RE, "");
+    const strippedLine = shouldStripFunctionCallWrappers
+      ? withoutPipeTags.replace(FUNCTION_CALLS_TAG_RE, "")
+      : withoutPipeTags;
     const isMarkerOnlyLine = strippedLine.trim().length === 0 && strippedLine !== line;
     if (isMarkerOnlyLine) {
       removedAny = true;
@@ -420,7 +422,7 @@ function stripInternalToolMarkersFromText(text: string): string {
   if (!removedAny) {
     return text;
   }
-  return keptLines.join("\n").replace(/(?:\r?\n[ \t]*)+$/, "");
+  return keptLines.join("\n");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -401,19 +401,55 @@ function stripFinalTagsFromText(text: string): string {
   return text.replace(FINAL_TAG_RE, "");
 }
 
+type ToolMarkerLineType = "pipe" | "wrapper" | null;
+
+function getToolMarkerLineType(line: string): ToolMarkerLineType {
+  const withoutPipeTags = line.replace(INTERNAL_TOOL_PIPE_TAG_RE, "");
+  if (withoutPipeTags.trim().length === 0 && withoutPipeTags !== line) {
+    return "pipe";
+  }
+  const withoutWrappers = line.replace(FUNCTION_CALLS_TAG_RE, "");
+  return withoutWrappers.trim().length === 0 && withoutWrappers !== line ? "wrapper" : null;
+}
+
+function getWrapperLinesInPipeMarkerBlocks(lineTypes: ToolMarkerLineType[]): Set<number> {
+  const wrapperLines = new Set<number>();
+  for (let index = 0; index < lineTypes.length; ) {
+    if (lineTypes[index] === null) {
+      index++;
+      continue;
+    }
+    let hasPipe = false;
+    let blockEnd = index;
+    while (blockEnd < lineTypes.length && lineTypes[blockEnd] !== null) {
+      hasPipe ||= lineTypes[blockEnd] === "pipe";
+      blockEnd++;
+    }
+    if (hasPipe) {
+      for (let blockIndex = index; blockIndex < blockEnd; blockIndex++) {
+        if (lineTypes[blockIndex] === "wrapper") {
+          wrapperLines.add(blockIndex);
+        }
+      }
+    }
+    index = blockEnd;
+  }
+  return wrapperLines;
+}
+
 function stripInternalToolMarkersFromText(text: string): string {
   if (!text) {
     return text;
   }
-  const shouldStripFunctionCallWrappers = text.search(INTERNAL_TOOL_PIPE_TAG_RE) !== -1;
+  const lines = text.split("\n");
+  const lineTypes = lines.map(getToolMarkerLineType);
+  const wrapperLinesInPipeBlocks = getWrapperLinesInPipeMarkerBlocks(lineTypes);
   let removedAny = false;
-  const keptLines = text.split("\n").filter((line) => {
-    const withoutPipeTags = line.replace(INTERNAL_TOOL_PIPE_TAG_RE, "");
-    const strippedLine = shouldStripFunctionCallWrappers
-      ? withoutPipeTags.replace(FUNCTION_CALLS_TAG_RE, "")
-      : withoutPipeTags;
-    const isMarkerOnlyLine = strippedLine.trim().length === 0 && strippedLine !== line;
-    if (isMarkerOnlyLine) {
+  const keptLines = lines.filter((line, index) => {
+    const lineType = lineTypes[index];
+    const shouldDrop =
+      lineType === "pipe" || (lineType === "wrapper" && wrapperLinesInPipeBlocks.has(index));
+    if (shouldDrop) {
       removedAny = true;
       return false;
     }

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -158,6 +158,21 @@ describe("normalizeReplyPayload", () => {
 
     expect(result).toBeNull();
   });
+
+  it("keeps standalone function call wrapper lines when no tool pipe tags are present", () => {
+    const text = "These wrappers are literal:\n<function_calls>\n</function_calls>";
+    const result = normalizeReplyPayload({ text });
+
+    expect(result).toEqual({ text });
+  });
+
+  it("preserves trailing newlines after removing leaked internal tool markers", () => {
+    const result = normalizeReplyPayload({
+      text: "Hello\n<|tool_list_end|>\n\nWorld\n",
+    });
+
+    expect(result).toEqual({ text: "Hello\n\nWorld\n" });
+  });
 });
 
 describe("typing controller", () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -150,6 +150,14 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toBe("");
     expect(result!.mediaUrl).toBe("https://example.com/img.png");
   });
+
+  it("suppresses payloads that only contain leaked internal tool markers", () => {
+    const result = normalizeReplyPayload({
+      text: "<|tool_call_result_begin|>\n<function_calls>\n</function_calls>\n<|tool_list_end|>",
+    });
+
+    expect(result).toBeNull();
+  });
 });
 
 describe("typing controller", () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -166,6 +166,28 @@ describe("normalizeReplyPayload", () => {
     expect(result).toEqual({ text });
   });
 
+  it("keeps standalone function call wrapper lines when tool tags are in another block", () => {
+    const input = [
+      "These wrappers are literal:",
+      "<function_calls>",
+      "</function_calls>",
+      "",
+      "Visible reply",
+      "<|tool_list_end|>",
+    ].join("\n");
+    const result = normalizeReplyPayload({ text: input });
+
+    expect(result).toEqual({
+      text: [
+        "These wrappers are literal:",
+        "<function_calls>",
+        "</function_calls>",
+        "",
+        "Visible reply",
+      ].join("\n"),
+    });
+  });
+
   it("preserves trailing newlines after removing leaked internal tool markers", () => {
     const result = normalizeReplyPayload({
       text: "Hello\n<|tool_list_end|>\n\nWorld\n",


### PR DESCRIPTION
## Summary

- Problem: standalone internal tool markers like `<|tool_call_result_begin|>` / `<|tool_list_end|>` and `<function_calls>` wrappers can leak into user-visible replies.
- Why it matters: replies look corrupted, and marker-only payloads can make it all the way to delivery surfaces.
- What changed: hardened the shared `sanitizeUserFacingText(...)` path to drop only marker-only lines, preserved inline literal mentions, and added unit/integration regressions.
- What did NOT change (scope boundary): this does not attempt to fix the separate Telegram idle-delivery symptom or the later `tool_use ids must be unique` error mentioned in the issue report.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40020
- Related #4700

## User-visible / Behavior Changes

- Final replies now strip standalone leaked internal tool-marker lines before delivery.
- Replies that only contain leaked marker lines are suppressed instead of being sent as garbage output.
- Literal inline mentions such as `Explain <function_calls> and <|tool_call_result_begin|> tags.` are preserved.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 25 / pnpm 10
- Model/provider: not applicable
- Integration/channel (if any): reply normalization / shared user-facing text sanitization
- Relevant config (redacted): none

### Steps

1. Build a reply containing only leaked tool markers, or a reply with marker-only lines around visible text.
2. Pass it through `sanitizeUserFacingText(...)` / `normalizeReplyPayload(...)`.
3. Observe whether marker-only lines are removed while inline literal mentions remain intact.

### Expected

- Standalone leaked marker lines are stripped before delivery.
- Marker-only payloads are suppressed.
- Inline explanatory mentions of those marker strings stay visible.

### Actual

- Before this change, leaked marker lines remained in the final user-visible payload.
- Marker-only payloads were not suppressed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `sanitizeUserFacingText(...)` strips standalone leaked tool-marker lines
  - `normalizeReplyPayload(...)` suppresses marker-only leaked payloads
  - inline literal mentions of `<function_calls>` and `<|tool_call_result_begin|>` remain unchanged
- Edge cases checked:
  - unrelated `<|assistant|>` inline tags remain intact
  - nearby consumers in `pi-embedded-utils` and `sessions` tests stay green
- What you did **not** verify:
  - end-to-end Telegram/UI reproduction
  - the separate idle-delivery / unique-id symptoms from the same issue report

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms reviewers should watch for: legitimate inline marker explanations disappearing, or leaked standalone marker lines still reaching final replies

## Risks and Mitigations

- Risk: over-stripping legitimate user-facing text that mentions marker strings literally.
  - Mitigation: the sanitizer only strips marker-only lines; added regression tests preserve inline literal mentions.
- Risk: issue #40020 may include adjacent bugs beyond final-reply sanitization.
  - Mitigation: kept this PR scoped to the title bug only and called out the non-goals above.

## AI / Testing Notes

- AI-assisted: Yes. Implemented with Codex; I reviewed and understand the change.
- Testing degree: fully tested locally for this scope.
- Prompt/session summary: find a current, unclaimed OpenClaw bug that is likely mergeable, implement the smallest material fix, verify it, and submit it as `bde1` following the repo instructions.
- Local verification:
  - `pnpm exec vitest run src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-utils.test.ts src/agents/tools/sessions.test.ts src/auto-reply/reply/reply-utils.test.ts`
  - `pnpm build`
  - `pnpm test`
  - `pnpm check` currently fails on untouched upstream file `src/agents/models-config.merge.test.ts:55` with `TS2352`; this branch does not touch that file.
