### PR TITLE
Fix stop aborting long-running exec scopes

### DIFF
--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -31,6 +31,16 @@ const commandQueueMocks = vi.hoisted(() => ({
 
 vi.mock("../../process/command-queue.js", () => commandQueueMocks);
 
+const supervisorMocks = vi.hoisted(() => ({
+  cancelScope: vi.fn(),
+}));
+
+vi.mock("../../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({
+    cancelScope: supervisorMocks.cancelScope,
+  }),
+}));
+
 const subagentRegistryMocks = vi.hoisted(() => ({
   listSubagentRunsForRequester: vi.fn<(requesterSessionKey: string) => SubagentRunRecord[]>(
     () => [],
@@ -165,6 +175,7 @@ describe("abort detection", () => {
     resetAbortMemoryForTest();
     acpManagerMocks.resolveSession.mockReset().mockReturnValue({ kind: "none" });
     acpManagerMocks.cancelSession.mockReset().mockResolvedValue(undefined);
+    supervisorMocks.cancelScope.mockReset();
   });
 
   it("triggerBodyNormalized extracts /stop from RawBody for abort detection", async () => {
@@ -402,6 +413,45 @@ describe("abort detection", () => {
     expect(result.handled).toBe(true);
     expect(getFollowupQueueDepth(sessionKey)).toBe(0);
     expectSessionLaneCleared(sessionKey);
+  });
+
+  it("fast-abort cancels the process supervisor scope for the target session", async () => {
+    const sessionKey = "telegram:123";
+    const sessionId = "session-123";
+    const { cfg } = await createAbortConfig({
+      sessionIdsByKey: { [sessionKey]: sessionId },
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey,
+      from: "telegram:123",
+      to: "telegram:123",
+    });
+
+    expect(result.handled).toBe(true);
+    expect(supervisorMocks.cancelScope).toHaveBeenCalledWith(sessionKey, "manual-cancel");
+  });
+
+  it("native /stop cancels the targeted session scope instead of the command session scope", async () => {
+    const slashSessionKey = "telegram:slash:123";
+    const targetSessionKey = "agent:main:telegram:group:123";
+    const targetSessionId = "session-target";
+    const { cfg } = await createAbortConfig({
+      sessionIdsByKey: { [targetSessionKey]: targetSessionId },
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey: slashSessionKey,
+      from: "telegram:123",
+      to: "telegram:123",
+      targetSessionKey,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(supervisorMocks.cancelScope).toHaveBeenCalledWith(targetSessionKey, "manual-cancel");
+    expect(supervisorMocks.cancelScope).not.toHaveBeenCalledWith(slashSessionKey, "manual-cancel");
   });
 
   it("plain-language stop on ACP-bound session triggers ACP cancel", async () => {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -18,6 +18,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
+import { getProcessSupervisor } from "../../process/supervisor/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import { normalizeCommandBody, type CommandNormalizeOptions } from "../commands-registry.js";
@@ -333,6 +334,7 @@ export async function tryFastAbortFromMessage(params: {
     }
     const sessionId = entry?.sessionId;
     const aborted = sessionId ? abortEmbeddedPiRun(sessionId) : false;
+    getProcessSupervisor().cancelScope(resolvedTargetKey, "manual-cancel");
     const cleared = clearSessionQueues([resolvedTargetKey, sessionId]);
     if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
       logVerbose(

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -2,6 +2,7 @@ import { abortEmbeddedPiRun } from "../../agents/pi-embedded.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { getProcessSupervisor } from "../../process/supervisor/index.js";
 import {
   resolveAbortCutoffFromContext,
   shouldPersistAbortCutoff,
@@ -72,6 +73,9 @@ async function applyAbortTarget(params: {
   const { abortTarget } = params;
   if (abortTarget.sessionId) {
     abortEmbeddedPiRun(abortTarget.sessionId);
+  }
+  if (abortTarget.key) {
+    getProcessSupervisor().cancelScope(abortTarget.key, "manual-cancel");
   }
 
   const persisted = await persistAbortTargetEntry({


### PR DESCRIPTION
## Summary

Fixes `stop` so it actually terminates long-running exec-backed work in the target session instead of only aborting the embedded run wrapper.

Closes #39960.

## Reproduction

1. Start a long-running exec-backed task in a session.
2. Send `stop` or `/stop` targeting that session.
3. Before this change, the embedded run was aborted, but the process supervisor scope kept running, so the underlying process survived and the session backlog kept accumulating.

## Root Cause

`/stop` and fast-abort only called `abortEmbeddedPiRun(sessionId)` and queue clearing. That interrupts the agent turn, but it does not cancel the process supervisor scope that owns long-running `exec` children.

The broken invariant was: when a user stops a session, all work owned by that session scope must stop, not just the model-side wrapper.

## Fix

Bridge both abort entry points to the process supervisor scope:

- `tryFastAbortFromMessage()` now cancels the resolved target session scope.
- `applyAbortTarget()` now cancels the resolved abort target scope.

This keeps the fix at the owning layer instead of adding more retries or command-specific kill logic.

## Why This Fix

I rejected two weaker options during RCA:

- Only changing the text-command path would still miss the fast-abort path.
- Adding ad-hoc process killing in exec-specific code would duplicate scope ownership that already exists in the supervisor.

Canceling the existing supervisor scope is the smallest source-level repair that matches the stop semantics.

## Tests

- `pnpm exec vitest run src/auto-reply/reply/abort.test.ts src/agents/bash-tools.exec.background-abort.test.ts`

Added regressions for:

- fast-abort canceling the target session scope
- native `/stop` canceling the targeted session scope rather than the slash-command session
