### PR TITLE
Keep sessions active through async media delivery

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -15,6 +15,7 @@ export {
   isEmbeddedPiRunActive,
   isEmbeddedPiRunStreaming,
   queueEmbeddedPiMessage,
+  retainEmbeddedPiRunActivity,
   waitForEmbeddedPiRunEnd,
 } from "./pi-embedded-runner/runs.js";
 export { buildEmbeddedSandboxInfo } from "./pi-embedded-runner/sandbox-info.js";

--- a/src/agents/pi-embedded-runner/runs.activity-hold.test.ts
+++ b/src/agents/pi-embedded-runner/runs.activity-hold.test.ts
@@ -1,0 +1,59 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  clearActiveEmbeddedRun,
+  getActiveEmbeddedRunCount,
+  isEmbeddedPiRunActive,
+  retainEmbeddedPiRunActivity,
+  setActiveEmbeddedRun,
+  waitForEmbeddedPiRunEnd,
+} from "./runs.js";
+
+function createHandle() {
+  return {
+    queueMessage: async (_text: string) => {},
+    isStreaming: () => false,
+    isCompacting: () => false,
+    abort: () => {},
+  };
+}
+
+describe("embedded run activity holds", () => {
+  it("keeps a session active until post-run activity is released", () => {
+    const sessionId = `hold-${crypto.randomUUID()}`;
+    const handle = createHandle();
+    setActiveEmbeddedRun(sessionId, handle);
+    const release = retainEmbeddedPiRunActivity(sessionId);
+
+    clearActiveEmbeddedRun(sessionId, handle);
+
+    expect(isEmbeddedPiRunActive(sessionId)).toBe(true);
+    expect(getActiveEmbeddedRunCount()).toBeGreaterThanOrEqual(1);
+
+    release();
+
+    expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
+  });
+
+  it("waits for post-run activity to finish before resolving run end", async () => {
+    const sessionId = `wait-${crypto.randomUUID()}`;
+    const handle = createHandle();
+    setActiveEmbeddedRun(sessionId, handle);
+    const release = retainEmbeddedPiRunActivity(sessionId);
+    clearActiveEmbeddedRun(sessionId, handle);
+
+    let settled = false;
+    const waitPromise = waitForEmbeddedPiRunEnd(sessionId, 1_000).then((ended) => {
+      settled = true;
+      return ended;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    release();
+
+    await expect(waitPromise).resolves.toBe(true);
+    expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -12,11 +12,20 @@ type EmbeddedPiQueueHandle = {
 };
 
 const ACTIVE_EMBEDDED_RUNS = new Map<string, EmbeddedPiQueueHandle>();
+const ACTIVE_EMBEDDED_RUN_HOLDS = new Map<string, number>();
 type EmbeddedRunWaiter = {
   resolve: (ended: boolean) => void;
   timer: NodeJS.Timeout;
 };
 const EMBEDDED_RUN_WAITERS = new Map<string, Set<EmbeddedRunWaiter>>();
+
+function getEmbeddedRunHoldCount(sessionId: string): number {
+  return ACTIVE_EMBEDDED_RUN_HOLDS.get(sessionId) ?? 0;
+}
+
+function hasEmbeddedPiRunActivity(sessionId: string): boolean {
+  return ACTIVE_EMBEDDED_RUNS.has(sessionId) || getEmbeddedRunHoldCount(sessionId) > 0;
+}
 
 export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean {
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
@@ -49,7 +58,7 @@ export function abortEmbeddedPiRun(sessionId: string): boolean {
 }
 
 export function isEmbeddedPiRunActive(sessionId: string): boolean {
-  const active = ACTIVE_EMBEDDED_RUNS.has(sessionId);
+  const active = hasEmbeddedPiRunActivity(sessionId);
   if (active) {
     diag.debug(`run active check: sessionId=${sessionId} active=true`);
   }
@@ -65,11 +74,17 @@ export function isEmbeddedPiRunStreaming(sessionId: string): boolean {
 }
 
 export function getActiveEmbeddedRunCount(): number {
-  return ACTIVE_EMBEDDED_RUNS.size;
+  const sessionIds = new Set<string>(ACTIVE_EMBEDDED_RUNS.keys());
+  for (const [sessionId, holdCount] of ACTIVE_EMBEDDED_RUN_HOLDS) {
+    if (holdCount > 0) {
+      sessionIds.add(sessionId);
+    }
+  }
+  return sessionIds.size;
 }
 
 export function waitForEmbeddedPiRunEnd(sessionId: string, timeoutMs = 15_000): Promise<boolean> {
-  if (!sessionId || !ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
+  if (!sessionId || !hasEmbeddedPiRunActivity(sessionId)) {
     return Promise.resolve(true);
   }
   diag.debug(`waiting for run end: sessionId=${sessionId} timeoutMs=${timeoutMs}`);
@@ -91,7 +106,7 @@ export function waitForEmbeddedPiRunEnd(sessionId: string, timeoutMs = 15_000): 
     };
     waiters.add(waiter);
     EMBEDDED_RUN_WAITERS.set(sessionId, waiters);
-    if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
+    if (!hasEmbeddedPiRunActivity(sessionId)) {
       waiters.delete(waiter);
       if (waiters.size === 0) {
         EMBEDDED_RUN_WAITERS.delete(sessionId);
@@ -144,10 +159,36 @@ export function clearActiveEmbeddedRun(
     if (!sessionId.startsWith("probe-")) {
       diag.debug(`run cleared: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
     }
-    notifyEmbeddedRunEnded(sessionId);
+    if (!hasEmbeddedPiRunActivity(sessionId)) {
+      notifyEmbeddedRunEnded(sessionId);
+    }
   } else {
     diag.debug(`run clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
   }
+}
+
+export function retainEmbeddedPiRunActivity(sessionId: string): () => void {
+  const cleaned = sessionId.trim();
+  if (!cleaned) {
+    return () => {};
+  }
+  ACTIVE_EMBEDDED_RUN_HOLDS.set(cleaned, getEmbeddedRunHoldCount(cleaned) + 1);
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const current = getEmbeddedRunHoldCount(cleaned);
+    if (current <= 1) {
+      ACTIVE_EMBEDDED_RUN_HOLDS.delete(cleaned);
+    } else {
+      ACTIVE_EMBEDDED_RUN_HOLDS.set(cleaned, current - 1);
+    }
+    if (!hasEmbeddedPiRunActivity(cleaned)) {
+      notifyEmbeddedRunEnded(cleaned);
+    }
+  };
 }
 
 export type { EmbeddedPiQueueHandle };

--- a/src/agents/pi-embedded.ts
+++ b/src/agents/pi-embedded.ts
@@ -10,6 +10,7 @@ export {
   isEmbeddedPiRunActive,
   isEmbeddedPiRunStreaming,
   queueEmbeddedPiMessage,
+  retainEmbeddedPiRunActivity,
   resolveEmbeddedSessionLane,
   runEmbeddedPiAgent,
   waitForEmbeddedPiRunEnd,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,7 +12,7 @@ import {
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
-import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { retainEmbeddedPiRunActivity, runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -436,7 +436,10 @@ export async function runAgentTurnWithFallback(params: {
                     // See: https://github.com/openclaw/openclaw/issues/11044
                     let toolResultChain: Promise<void> = Promise.resolve();
                     return (payload: ReplyPayload) => {
-                      toolResultChain = toolResultChain
+                      const releaseActivity = retainEmbeddedPiRunActivity(
+                        params.followupRun.run.sessionId,
+                      );
+                      const nextTask = toolResultChain
                         .then(async () => {
                           const { text, skip } = normalizeStreamingText(payload);
                           if (skip) {
@@ -452,9 +455,11 @@ export async function runAgentTurnWithFallback(params: {
                           // Keep chain healthy after an error so later tool results still deliver.
                           logVerbose(`tool result delivery failed: ${String(err)}`);
                         });
-                      const task = toolResultChain.finally(() => {
+                      const task = nextTask.finally(() => {
+                        releaseActivity();
                         params.pendingToolTasks.delete(task);
                       });
+                      toolResultChain = task;
                       params.pendingToolTasks.add(task);
                     };
                   })()

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -316,6 +316,107 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
   });
 });
 
+describe("runReplyAgent post-run tool deliveries", () => {
+  function createRun(params?: {
+    opts?: {
+      onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
+    };
+  }) {
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:123",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session-tool",
+        sessionKey: "agent:main:telegram:direct:123",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    return runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      opts: params?.opts,
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+  }
+
+  it("retains embedded-run activity until async tool-result delivery settles", async () => {
+    const { isEmbeddedPiRunActive } = await import("../../agents/pi-embedded.js");
+    let resolveDelivery: (() => void) | null = null;
+    const deliveryDone = new Promise<void>((resolve) => {
+      resolveDelivery = resolve;
+    });
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (params: {
+        onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+      }) => {
+        await params.onToolResult?.({ mediaUrls: ["/tmp/result.png"] });
+        return { payloads: [], meta: {} };
+      },
+    );
+
+    const runPromise = createRun({
+      opts: {
+        onToolResult: async () => {
+          await deliveryDone;
+        },
+      },
+    });
+
+    for (let attempt = 0; attempt < 5 && !isEmbeddedPiRunActive("session-tool"); attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(isEmbeddedPiRunActive("session-tool")).toBe(true);
+
+    resolveDelivery?.();
+    await runPromise;
+
+    expect(isEmbeddedPiRunActive("session-tool")).toBe(false);
+  });
+});
+
 describe("runReplyAgent auto-compaction token update", () => {
   type EmbeddedRunParams = {
     prompt?: string;


### PR DESCRIPTION
## Summary

Keep a session marked active until async media/tool-result delivery has actually settled, so inbound messages arriving during that delivery window are queued instead of being lost.

Closes #39993.

## Reproduction

1. Let the agent send multiple media messages through the `message` tool.
2. Send a new user message while the media delivery chain is still in progress.
3. Before this change, the embedded run cleared its active state as soon as model execution ended, even though async tool-result delivery was still running.
4. The new inbound message was then misclassified as arriving with no active run and could be dropped instead of being queued into the same session.

## Root Cause

The active-session check in reply routing relied on `isEmbeddedPiRunActive(sessionId)`. That state was cleared at the end of the embedded run itself, but async `onToolResult` delivery continued afterward.

The broken invariant was: a session must remain active for queueing purposes until all user-visible delivery work for that turn is finished.

## Fix

Add an explicit post-run activity hold in the embedded runner:

- `runs.ts` now tracks hold counts alongside active runs.
- `isEmbeddedPiRunActive()` and `waitForEmbeddedPiRunEnd()` treat either a live run or a delivery hold as active.
- async tool-result delivery acquires a hold before chaining work and releases it in `finally`.

This fixes the ownership boundary directly in the shared activity state instead of patching a single channel or queue caller.

## Why This Fix

I rejected two weaker options during RCA:

- Patching Telegram-specific routing would miss the shared post-run race.
- Tweaking followup queue policy alone would preserve the wrong activity semantics and leave other callers inconsistent.

The activity state itself needed to represent the real lifetime of the turn.

## Tests

- `pnpm exec vitest run src/agents/pi-embedded-runner/runs.activity-hold.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts`

Added regressions for:

- hold-based activity surviving past embedded-run completion
- waiters not resolving until delivery holds release
- runReplyAgent keeping the session active until async tool-result delivery settles
