### PR TITLE
fix: prefer bundled channel plugins over npm duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/channel onboarding: prefer bundled channel plugins over duplicate npm-installed copies during onboarding and release-channel sync, preventing bundled plugins from being shadowed by npm installs with the same plugin ID. (#40092)
 - macOS app/chat UI: route browser proxy through the local node browser service, preserve plain-text paste semantics, strip completed assistant trace/debug wrapper noise from transcripts, refresh permission state after returning from System Settings, and tolerate malformed cron rows in the macOS tab. (#39516) Thanks @Imhermes1.
 - Mattermost replies: keep `root_id` pinned to the existing thread root when an agent replies inside a thread, while still using reply-target threading for top-level posts. (#27744) thanks @hnykda.
 - Agents/failover: detect Amazon Bedrock `Too many tokens per day` quota errors as rate limits across fallback, cron retry, and memory embeddings while keeping context-window `too many tokens per request` errors out of the rate-limit lane. (#39377) Thanks @gambletan.

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
 import {
+  resolveBundledInstallPlanForCatalogEntry,
   resolveBundledInstallPlanBeforeNpm,
   resolveBundledInstallPlanForNpmFailure,
 } from "./plugin-install-plan.js";
@@ -31,6 +32,53 @@ describe("plugin install plan helpers", () => {
     });
 
     expect(findBundledSource).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("prefers bundled catalog plugin by id before npm spec", () => {
+    const findBundledSource = vi
+      .fn()
+      .mockImplementation(({ kind, value }: { kind: "pluginId" | "npmSpec"; value: string }) => {
+        if (kind === "pluginId" && value === "voice-call") {
+          return {
+            pluginId: "voice-call",
+            localPath: "/tmp/extensions/voice-call",
+            npmSpec: "@openclaw/voice-call",
+          };
+        }
+        return undefined;
+      });
+
+    const result = resolveBundledInstallPlanForCatalogEntry({
+      pluginId: "voice-call",
+      npmSpec: "@openclaw/voice-call",
+      findBundledSource,
+    });
+
+    expect(findBundledSource).toHaveBeenCalledWith({ kind: "pluginId", value: "voice-call" });
+    expect(result?.bundledSource.localPath).toBe("/tmp/extensions/voice-call");
+  });
+
+  it("rejects npm-spec matches that resolve to a different plugin id", () => {
+    const findBundledSource = vi
+      .fn()
+      .mockImplementation(({ kind }: { kind: "pluginId" | "npmSpec"; value: string }) => {
+        if (kind === "npmSpec") {
+          return {
+            pluginId: "not-voice-call",
+            localPath: "/tmp/extensions/not-voice-call",
+            npmSpec: "@openclaw/voice-call",
+          };
+        }
+        return undefined;
+      });
+
+    const result = resolveBundledInstallPlanForCatalogEntry({
+      pluginId: "voice-call",
+      npmSpec: "@openclaw/voice-call",
+      findBundledSource,
+    });
+
     expect(result).toBeNull();
   });
 

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -12,6 +12,36 @@ function isBareNpmPackageName(spec: string): boolean {
   return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
 }
 
+export function resolveBundledInstallPlanForCatalogEntry(params: {
+  pluginId: string;
+  npmSpec: string;
+  findBundledSource: BundledLookup;
+}): { bundledSource: BundledPluginSource } | null {
+  const pluginId = params.pluginId.trim();
+  const npmSpec = params.npmSpec.trim();
+  if (!pluginId || !npmSpec) {
+    return null;
+  }
+
+  const bundledById = params.findBundledSource({
+    kind: "pluginId",
+    value: pluginId,
+  });
+  if (bundledById?.pluginId === pluginId) {
+    return { bundledSource: bundledById };
+  }
+
+  const bundledBySpec = params.findBundledSource({
+    kind: "npmSpec",
+    value: npmSpec,
+  });
+  if (bundledBySpec?.pluginId === pluginId) {
+    return { bundledSource: bundledBySpec };
+  }
+
+  return null;
+}
+
 export function resolveBundledInstallPlanBeforeNpm(params: {
   rawSpec: string;
   findBundledSource: BundledLookup;

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
+  const existsSync = vi.fn();
   return {
     ...actual,
+    existsSync,
     default: {
-      ...actual.default,
-      existsSync: vi.fn(),
+      ...actual,
+      existsSync,
     },
   };
 });

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -1,15 +1,25 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("node:fs", () => ({
-  default: {
-    existsSync: vi.fn(),
-  },
-}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      existsSync: vi.fn(),
+    },
+  };
+});
 
 const installPluginFromNpmSpec = vi.fn();
 vi.mock("../../plugins/install.js", () => ({
   installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpec(...args),
+}));
+
+const findBundledPluginSource = vi.fn();
+vi.mock("../../plugins/bundled-sources.js", () => ({
+  findBundledPluginSource: (...args: unknown[]) => findBundledPluginSource(...args),
 }));
 
 vi.mock("../../plugins/loader.js", () => ({
@@ -41,6 +51,7 @@ const baseEntry: ChannelPluginCatalogEntry = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  findBundledPluginSource.mockReturnValue(undefined);
 });
 
 function mockRepoLocalPathExists() {
@@ -134,6 +145,38 @@ describe("ensureOnboardingPluginInstalled", () => {
 
   it("defaults to npm on beta channel even when local path exists", async () => {
     expect(await runInitialValueForChannel("beta")).toBe("npm");
+  });
+
+  it("defaults to bundled local path on beta channel when available", async () => {
+    const runtime = makeRuntime();
+    const select = vi.fn((async <T extends string>() => "skip" as T) as WizardPrompter["select"]);
+    const prompter = makePrompter({ select: select as unknown as WizardPrompter["select"] });
+    const cfg: OpenClawConfig = { update: { channel: "beta" } };
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    findBundledPluginSource.mockReturnValue({
+      pluginId: "zalo",
+      localPath: "/opt/openclaw/extensions/zalo",
+      npmSpec: "@openclaw/zalo",
+    });
+
+    await ensureOnboardingPluginInstalled({
+      cfg,
+      entry: baseEntry,
+      prompter,
+      runtime,
+    });
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValue: "local",
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            value: "local",
+            hint: "/opt/openclaw/extensions/zalo",
+          }),
+        ]),
+      }),
+    );
   });
 
   it("falls back to local path after npm install failure", async () => {

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -17,9 +17,30 @@ vi.mock("../../plugins/install.js", () => ({
   installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpec(...args),
 }));
 
-const findBundledPluginSource = vi.fn();
+const resolveBundledPluginSources = vi.fn();
 vi.mock("../../plugins/bundled-sources.js", () => ({
-  findBundledPluginSource: (...args: unknown[]) => findBundledPluginSource(...args),
+  findBundledPluginSourceInMap: ({
+    bundled,
+    lookup,
+  }: {
+    bundled: ReadonlyMap<string, { pluginId: string; localPath: string; npmSpec?: string }>;
+    lookup: { kind: "pluginId" | "npmSpec"; value: string };
+  }) => {
+    const targetValue = lookup.value.trim();
+    if (!targetValue) {
+      return undefined;
+    }
+    if (lookup.kind === "pluginId") {
+      return bundled.get(targetValue);
+    }
+    for (const source of bundled.values()) {
+      if (source.npmSpec === targetValue) {
+        return source;
+      }
+    }
+    return undefined;
+  },
+  resolveBundledPluginSources: (...args: unknown[]) => resolveBundledPluginSources(...args),
 }));
 
 vi.mock("../../plugins/loader.js", () => ({
@@ -51,7 +72,7 @@ const baseEntry: ChannelPluginCatalogEntry = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  findBundledPluginSource.mockReturnValue(undefined);
+  resolveBundledPluginSources.mockReturnValue(new Map());
 });
 
 function mockRepoLocalPathExists() {
@@ -153,11 +174,18 @@ describe("ensureOnboardingPluginInstalled", () => {
     const prompter = makePrompter({ select: select as unknown as WizardPrompter["select"] });
     const cfg: OpenClawConfig = { update: { channel: "beta" } };
     vi.mocked(fs.existsSync).mockReturnValue(false);
-    findBundledPluginSource.mockReturnValue({
-      pluginId: "zalo",
-      localPath: "/opt/openclaw/extensions/zalo",
-      npmSpec: "@openclaw/zalo",
-    });
+    resolveBundledPluginSources.mockReturnValue(
+      new Map([
+        [
+          "zalo",
+          {
+            pluginId: "zalo",
+            localPath: "/opt/openclaw/extensions/zalo",
+            npmSpec: "@openclaw/zalo",
+          },
+        ],
+      ]),
+    );
 
     await ensureOnboardingPluginInstalled({
       cfg,

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -2,8 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
+import { resolveBundledInstallPlanForCatalogEntry } from "../../cli/plugin-install-plan.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { findBundledPluginSource } from "../../plugins/bundled-sources.js";
 import { enablePluginInConfig } from "../../plugins/enable.js";
 import { installPluginFromNpmSpec } from "../../plugins/install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "../../plugins/installs.js";
@@ -107,8 +109,12 @@ function resolveInstallDefaultChoice(params: {
   cfg: OpenClawConfig;
   entry: ChannelPluginCatalogEntry;
   localPath?: string | null;
+  bundledLocalPath?: string | null;
 }): InstallChoice {
-  const { cfg, entry, localPath } = params;
+  const { cfg, entry, localPath, bundledLocalPath } = params;
+  if (bundledLocalPath) {
+    return "local";
+  }
   const updateChannel = cfg.update?.channel;
   if (updateChannel === "dev") {
     return localPath ? "local" : "npm";
@@ -136,11 +142,18 @@ export async function ensureOnboardingPluginInstalled(params: {
   const { entry, prompter, runtime, workspaceDir } = params;
   let next = params.cfg;
   const allowLocal = hasGitWorkspace(workspaceDir);
-  const localPath = resolveLocalPath(entry, workspaceDir, allowLocal);
+  const bundledLocalPath =
+    resolveBundledInstallPlanForCatalogEntry({
+      pluginId: entry.id,
+      npmSpec: entry.install.npmSpec,
+      findBundledSource: (lookup) => findBundledPluginSource({ lookup, workspaceDir }),
+    })?.bundledSource.localPath ?? null;
+  const localPath = bundledLocalPath ?? resolveLocalPath(entry, workspaceDir, allowLocal);
   const defaultChoice = resolveInstallDefaultChoice({
     cfg: next,
     entry,
     localPath,
+    bundledLocalPath,
   });
   const choice = await promptInstallChoice({
     entry,

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -5,7 +5,10 @@ import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.j
 import { resolveBundledInstallPlanForCatalogEntry } from "../../cli/plugin-install-plan.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { findBundledPluginSource } from "../../plugins/bundled-sources.js";
+import {
+  findBundledPluginSourceInMap,
+  resolveBundledPluginSources,
+} from "../../plugins/bundled-sources.js";
 import { enablePluginInConfig } from "../../plugins/enable.js";
 import { installPluginFromNpmSpec } from "../../plugins/install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "../../plugins/installs.js";
@@ -142,11 +145,13 @@ export async function ensureOnboardingPluginInstalled(params: {
   const { entry, prompter, runtime, workspaceDir } = params;
   let next = params.cfg;
   const allowLocal = hasGitWorkspace(workspaceDir);
+  const bundledSources = resolveBundledPluginSources({ workspaceDir });
   const bundledLocalPath =
     resolveBundledInstallPlanForCatalogEntry({
       pluginId: entry.id,
       npmSpec: entry.install.npmSpec,
-      findBundledSource: (lookup) => findBundledPluginSource({ lookup, workspaceDir }),
+      findBundledSource: (lookup) =>
+        findBundledPluginSourceInMap({ bundled: bundledSources, lookup }),
     })?.bundledSource.localPath ?? null;
   const localPath = bundledLocalPath ?? resolveLocalPath(entry, workspaceDir, allowLocal);
   const defaultChoice = resolveInstallDefaultChoice({

--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { findBundledPluginSource, resolveBundledPluginSources } from "./bundled-sources.js";
+import {
+  findBundledPluginSource,
+  findBundledPluginSourceInMap,
+  resolveBundledPluginSources,
+} from "./bundled-sources.js";
 
 const discoverOpenClawPluginsMock = vi.fn();
 const loadPluginManifestMock = vi.fn();
@@ -123,5 +127,35 @@ describe("bundled plugin sources", () => {
     expect(resolved?.pluginId).toBe("diffs");
     expect(resolved?.localPath).toBe("/app/extensions/diffs");
     expect(missing).toBeUndefined();
+  });
+
+  it("reuses a pre-resolved bundled map for repeated lookups", () => {
+    const bundled = new Map([
+      [
+        "feishu",
+        {
+          pluginId: "feishu",
+          localPath: "/app/extensions/feishu",
+          npmSpec: "@openclaw/feishu",
+        },
+      ],
+    ]);
+
+    expect(
+      findBundledPluginSourceInMap({
+        bundled,
+        lookup: { kind: "pluginId", value: "feishu" },
+      }),
+    ).toEqual({
+      pluginId: "feishu",
+      localPath: "/app/extensions/feishu",
+      npmSpec: "@openclaw/feishu",
+    });
+    expect(
+      findBundledPluginSourceInMap({
+        bundled,
+        lookup: { kind: "npmSpec", value: "@openclaw/feishu" },
+      })?.pluginId,
+    ).toBe("feishu");
   });
 });

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -11,6 +11,25 @@ export type BundledPluginLookup =
   | { kind: "npmSpec"; value: string }
   | { kind: "pluginId"; value: string };
 
+export function findBundledPluginSourceInMap(params: {
+  bundled: ReadonlyMap<string, BundledPluginSource>;
+  lookup: BundledPluginLookup;
+}): BundledPluginSource | undefined {
+  const targetValue = params.lookup.value.trim();
+  if (!targetValue) {
+    return undefined;
+  }
+  if (params.lookup.kind === "pluginId") {
+    return params.bundled.get(targetValue);
+  }
+  for (const source of params.bundled.values()) {
+    if (source.npmSpec === targetValue) {
+      return source;
+    }
+  }
+  return undefined;
+}
+
 export function resolveBundledPluginSources(params: {
   workspaceDir?: string;
 }): Map<string, BundledPluginSource> {
@@ -49,18 +68,9 @@ export function findBundledPluginSource(params: {
   lookup: BundledPluginLookup;
   workspaceDir?: string;
 }): BundledPluginSource | undefined {
-  const targetValue = params.lookup.value.trim();
-  if (!targetValue) {
-    return undefined;
-  }
   const bundled = resolveBundledPluginSources({ workspaceDir: params.workspaceDir });
-  if (params.lookup.kind === "pluginId") {
-    return bundled.get(targetValue);
-  }
-  for (const source of bundled.values()) {
-    if (source.npmSpec === targetValue) {
-      return source;
-    }
-  }
-  return undefined;
+  return findBundledPluginSourceInMap({
+    bundled,
+    lookup: params.lookup,
+  });
 }

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const installPluginFromNpmSpecMock = vi.fn();
+const resolveBundledPluginSourcesMock = vi.fn();
 
 vi.mock("./install.js", () => ({
   installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpecMock(...args),
@@ -10,9 +11,14 @@ vi.mock("./install.js", () => ({
   },
 }));
 
+vi.mock("./bundled-sources.js", () => ({
+  resolveBundledPluginSources: (...args: unknown[]) => resolveBundledPluginSourcesMock(...args),
+}));
+
 describe("updateNpmInstalledPlugins", () => {
   beforeEach(() => {
     installPluginFromNpmSpecMock.mockReset();
+    resolveBundledPluginSourcesMock.mockReset();
   });
 
   it("skips integrity drift checks for unpinned npm specs during dry-run updates", async () => {
@@ -149,5 +155,51 @@ describe("updateNpmInstalledPlugins", () => {
         message: "Failed to check bad: unsupported npm spec: github:evil/evil",
       },
     ]);
+  });
+});
+
+describe("syncPluginsForUpdateChannel", () => {
+  beforeEach(() => {
+    installPluginFromNpmSpecMock.mockReset();
+    resolveBundledPluginSourcesMock.mockReset();
+  });
+
+  it("keeps bundled path installs on beta without reinstalling from npm", async () => {
+    resolveBundledPluginSourcesMock.mockReturnValue(
+      new Map([
+        [
+          "feishu",
+          {
+            pluginId: "feishu",
+            localPath: "/app/extensions/feishu",
+            npmSpec: "@openclaw/feishu",
+          },
+        ],
+      ]),
+    );
+
+    const { syncPluginsForUpdateChannel } = await import("./update.js");
+    const result = await syncPluginsForUpdateChannel({
+      channel: "beta",
+      config: {
+        plugins: {
+          load: { paths: ["/app/extensions/feishu"] },
+          installs: {
+            feishu: {
+              source: "path",
+              sourcePath: "/app/extensions/feishu",
+              installPath: "/app/extensions/feishu",
+              spec: "@openclaw/feishu",
+            },
+          },
+        },
+      },
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(result.changed).toBe(false);
+    expect(result.summary.switchedToNpm).toEqual([]);
+    expect(result.config.plugins?.load?.paths).toEqual(["/app/extensions/feishu"]);
+    expect(result.config.plugins?.installs?.feishu?.source).toBe("path");
   });
 });

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -202,4 +202,47 @@ describe("syncPluginsForUpdateChannel", () => {
     expect(result.config.plugins?.load?.paths).toEqual(["/app/extensions/feishu"]);
     expect(result.config.plugins?.installs?.feishu?.source).toBe("path");
   });
+
+  it("repairs bundled install metadata when the load path is re-added", async () => {
+    resolveBundledPluginSourcesMock.mockReturnValue(
+      new Map([
+        [
+          "feishu",
+          {
+            pluginId: "feishu",
+            localPath: "/app/extensions/feishu",
+            npmSpec: "@openclaw/feishu",
+          },
+        ],
+      ]),
+    );
+
+    const { syncPluginsForUpdateChannel } = await import("./update.js");
+    const result = await syncPluginsForUpdateChannel({
+      channel: "beta",
+      config: {
+        plugins: {
+          load: { paths: [] },
+          installs: {
+            feishu: {
+              source: "path",
+              sourcePath: "/app/extensions/feishu",
+              installPath: "/tmp/old-feishu",
+              spec: "@openclaw/feishu",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.load?.paths).toEqual(["/app/extensions/feishu"]);
+    expect(result.config.plugins?.installs?.feishu).toMatchObject({
+      source: "path",
+      sourcePath: "/app/extensions/feishu",
+      installPath: "/app/extensions/feishu",
+      spec: "@openclaw/feishu",
+    });
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -462,6 +462,23 @@ export async function syncPluginsForUpdateChannel(params: {
       // Keep explicit bundled installs on release channels. Replacing them with
       // npm installs can reintroduce duplicate-id shadowing and packaging drift.
       loadHelpers.addPath(bundledInfo.localPath);
+      const alreadyBundled =
+        record.source === "path" &&
+        pathsEqual(record.sourcePath, bundledInfo.localPath) &&
+        pathsEqual(record.installPath, bundledInfo.localPath);
+      if (alreadyBundled) {
+        continue;
+      }
+
+      next = recordPluginInstall(next, {
+        pluginId,
+        source: "path",
+        sourcePath: bundledInfo.localPath,
+        installPath: bundledInfo.localPath,
+        spec: record.spec ?? bundledInfo.npmSpec,
+        version: record.version,
+      });
+      changed = true;
     }
   }
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -459,42 +459,9 @@ export async function syncPluginsForUpdateChannel(params: {
       if (!pathsEqual(record.sourcePath, bundledInfo.localPath)) {
         continue;
       }
-
-      const spec = record.spec ?? bundledInfo.npmSpec;
-      if (!spec) {
-        summary.warnings.push(`Missing npm spec for ${pluginId}; keeping local path.`);
-        continue;
-      }
-
-      let result: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
-      try {
-        result = await installPluginFromNpmSpec({
-          spec,
-          mode: "update",
-          expectedPluginId: pluginId,
-          logger: params.logger,
-        });
-      } catch (err) {
-        summary.errors.push(`Failed to install ${pluginId}: ${String(err)}`);
-        continue;
-      }
-      if (!result.ok) {
-        summary.errors.push(`Failed to install ${pluginId}: ${result.error}`);
-        continue;
-      }
-
-      next = recordPluginInstall(next, {
-        pluginId,
-        source: "npm",
-        spec,
-        installPath: result.targetDir,
-        version: result.version,
-        ...buildNpmResolutionInstallFields(result.npmResolution),
-        sourcePath: undefined,
-      });
-      summary.switchedToNpm.push(pluginId);
-      changed = true;
-      loadHelpers.removePath(bundledInfo.localPath);
+      // Keep explicit bundled installs on release channels. Replacing them with
+      // npm installs can reintroduce duplicate-id shadowing and packaging drift.
+      loadHelpers.addPath(bundledInfo.localPath);
     }
   }
 


### PR DESCRIPTION
## Summary

- Problem: bundled channel onboarding and release-channel plugin sync could prefer an npm-installed plugin even when the same plugin was already bundled locally.
- Why it matters: that creates duplicate plugin IDs, lets the npm copy shadow the bundled one, and exposes packaging gaps as channel install/runtime failures.
- What changed: onboarding now resolves bundled catalog entries through a shared install-plan helper and defaults to the bundled local path when available; release-channel sync now keeps explicit bundled path installs instead of converting them back to npm.
- What did NOT change (scope boundary): this PR does not attempt to mirror every bundled extension dependency into the root package or change plugin packaging for unrelated channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40092
- Related #40006
- Related #32967

## User-visible / Behavior Changes

- Channel onboarding now prefers the bundled plugin copy when a matching bundled channel plugin already exists locally.
- Release-channel plugin sync no longer converts explicit bundled path installs back to npm for bundled channel plugins.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node + npm install layout
- Model/provider: N/A
- Integration/channel (if any): bundled channel plugins (for example Feishu / Microsoft Teams)
- Relevant config (redacted): plugin onboarding defaults on release channels

### Steps

1. Install or update OpenClaw on a release channel with bundled channel plugins available locally.
2. Enter channel onboarding for a bundled plugin with an npm install path.
3. Confirm the default selection and plugin sync behavior.

### Expected

- The bundled plugin is preferred when already present locally.
- Release-channel sync preserves explicit bundled path installs.

### Actual

- Verified by focused tests covering onboarding bundled selection and release-channel sync behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: bundled catalog-entry selection is resolved through the shared helper; onboarding defaults to bundled local path when present; release-channel sync preserves explicit bundled path installs.
- Edge cases checked: mismatched `npmSpec` lookups that resolve to a different plugin ID are rejected; beta-channel onboarding without a bundled source still defaults to npm.
- What you did **not** verify: live end-to-end npm global installs against a published package tarball.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or reinstall the affected plugin explicitly from npm if bundled preference needs to be bypassed temporarily.
- Files/config to restore: plugin install-selection helpers and plugin sync behavior in `src/commands/onboarding/plugin-install.ts`, `src/cli/plugin-install-plan.ts`, and `src/plugins/update.ts`.
- Known bad symptoms reviewers should watch for: onboarding defaulting back to npm when a bundled copy exists, or plugin sync rewriting bundled path installs to npm on stable/beta.

## Risks and Mitigations

- Risk: bundled-plugin selection could diverge between onboarding and CLI install flows.
  - Mitigation: the bundled catalog-entry lookup now lives in the shared install-plan helper and is covered by focused tests.
