### PR TITLE
Fix openai-codex OAuth email profile detection

### DIFF
--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -24,6 +24,16 @@ vi.mock("./oauth-tls-preflight.js", () => ({
 
 import { loginOpenAICodexOAuth } from "./openai-codex-oauth.js";
 
+function buildAccessTokenWithEmail(email: string) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/profile": { email },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
 function createPrompter() {
   const spin = { update: vi.fn(), stop: vi.fn() };
   const prompter: Pick<WizardPrompter, "note" | "progress"> = {
@@ -113,6 +123,30 @@ describe("loginOpenAICodexOAuth", () => {
     expect(event.url).toBe(
       "https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access&state=abc",
     );
+  });
+
+  it("backfills email from the access token when pi-ai omits it", async () => {
+    const access = buildAccessTokenWithEmail("decoded@example.com");
+    mocks.createVpsAwareOAuthHandlers.mockReturnValue({
+      onAuth: vi.fn(),
+      onPrompt: vi.fn(),
+    });
+    mocks.loginOpenAICodex.mockResolvedValue({
+      provider: "openai-codex" as const,
+      access,
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      accountId: "acct-123",
+    });
+
+    const { result } = await runCodexOAuth({ isRemote: false });
+
+    expect(result).toMatchObject({
+      access,
+      refresh: "refresh-token",
+      accountId: "acct-123",
+      email: "decoded@example.com",
+    });
   });
 
   it("reports oauth errors and rethrows", async () => {

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -8,6 +8,29 @@ import {
   runOpenAIOAuthTlsPreflight,
 } from "./oauth-tls-preflight.js";
 
+const OPENAI_PROFILE_CLAIM_PATH = "https://api.openai.com/profile";
+
+function extractEmailFromAccessToken(token: string | undefined): string | undefined {
+  if (typeof token !== "string" || !token.trim()) {
+    return undefined;
+  }
+
+  try {
+    const [, payload] = token.split(".", 3);
+    if (!payload) {
+      return undefined;
+    }
+    const decoded = Buffer.from(payload, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded) as {
+      [OPENAI_PROFILE_CLAIM_PATH]?: { email?: string };
+    };
+    const email = parsed?.[OPENAI_PROFILE_CLAIM_PATH]?.email?.trim();
+    return email || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function loginOpenAICodexOAuth(params: {
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
@@ -56,7 +79,19 @@ export async function loginOpenAICodexOAuth(params: {
       onProgress: (msg) => spin.update(msg),
     });
     spin.stop("OpenAI OAuth complete");
-    return creds ?? null;
+    if (!creds) {
+      return null;
+    }
+    return {
+      ...creds,
+      ...(typeof creds.email === "string" && creds.email.trim()
+        ? {}
+        : {
+            email: extractEmailFromAccessToken(
+              typeof creds.access === "string" ? creds.access : undefined,
+            ),
+          }),
+    };
   } catch (err) {
     spin.stop("OpenAI OAuth failed");
     runtime.error(String(err));


### PR DESCRIPTION
## Summary

- Problem: `openai-codex` OAuth logins can be persisted as `openai-codex:default` even when the access token already carries the ChatGPT account email claim.
- Why it matters: repeated logins overwrite the same default profile, so single-agent auth profile ordering and rate-limit rotation cannot work for multiple ChatGPT accounts.
- What changed: `loginOpenAICodexOAuth()` now backfills `email` from the OpenAI access token JWT when `pi-ai` returns only `{ access, refresh, expires, accountId }`, and a regression test covers that response shape.
- What did NOT change (scope boundary): no changes to upstream `pi-ai`, token refresh semantics, failover policy, or auth order resolution logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40106
- Related # (none)

## User-visible / Behavior Changes

- When the OpenAI access token contains `https://api.openai.com/profile.email`, `openai-codex` OAuth logins now persist as `openai-codex:<email>` instead of falling back to `openai-codex:default`.
- Repeated `openclaw models auth login --provider openai-codex` logins for different ChatGPT accounts can now produce distinct auth profiles, which unblocks documented auth profile ordering / rotation behavior.
- If the upstream OAuth helper already returns `email`, behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node CLI in git worktree
- Model/provider: `openai-codex`
- Integration/channel (if any): CLI auth flow
- Relevant config (redacted): default auth profile store

### Steps

1. Run `openclaw models auth login --provider openai-codex` with a `pi-ai` response shape that contains `access`, `refresh`, `expires`, and `accountId`, but omits `email`.
2. Persist the returned credentials through the normal OpenClaw auth-choice flow.
3. Inspect the resulting auth profile id.

### Expected

- The stored profile id uses the email embedded in the OpenAI JWT, e.g. `openai-codex:user@example.com`.

### Actual

- Before the fix, the missing `email` field forced persistence to `openai-codex:default`, so later logins overwrote the same profile.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification command:

```bash
pnpm exec vitest run src/commands/openai-codex-oauth.test.ts src/commands/auth-choice.test.ts
```

## Human Verification (required)

- Verified scenarios: `loginOpenAICodexOAuth()` preserves upstream-provided `email`; when upstream omits `email` but the JWT contains the OpenAI profile claim, the helper backfills it and downstream auth-choice stores an email-based profile id.
- Edge cases checked: invalid / undecodable access token payloads still fall back to existing behavior; non-null credential results remain unchanged apart from email backfill.
- What you did **not** verify: a live end-to-end OpenAI OAuth login against real ChatGPT accounts in this worktree.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the email backfill block in `src/commands/openai-codex-oauth.ts`.
- Files/config to restore: `src/commands/openai-codex-oauth.ts`, `src/commands/openai-codex-oauth.test.ts`
- Known bad symptoms reviewers should watch for: `openai-codex` OAuth logins continuing to persist only as `openai-codex:default`, or malformed-token handling unexpectedly throwing instead of falling back.

## Risks and Mitigations

- Risk: the OpenAI JWT profile claim shape could change upstream and stop exposing `https://api.openai.com/profile.email`.
  - Mitigation: the backfill is best-effort only; failures fall back to existing `default` behavior instead of breaking login.
- Risk: reviewers may expect the fix to live in `pi-ai` instead of OpenClaw.
  - Mitigation: this keeps the change minimal and local while still matching current OpenClaw test expectations for email-based `openai-codex` profiles.
