### PR TITLE
feat(ecs): ECS extension plugin for inter-agent task orchestration

### DIFF
--- a/extensions/ecs/AGENTS.md
+++ b/extensions/ecs/AGENTS.md
@@ -1,0 +1,56 @@
+# ECS Extension Plugin
+
+Inter-agent task orchestration via Discord with control plane callbacks.
+
+## Build & Deploy
+
+- Build: `pnpm build` from repo root (builds dist/plugin-sdk/ecs.js along with everything else)
+- Deploy to miniclaw: `scripts/deploy-miniclaw.sh` (builds, rsyncs, restarts gateway)
+- Tests: `pnpm test extensions/ecs`
+
+## Adding a new plugin-sdk subpath (6-place checklist)
+
+When adding a new `openclaw/plugin-sdk/<name>` entry, you must update ALL 6 files or you'll get subtle failures:
+
+| #   | File                           | Array/Section                    | Failure if missing                                        |
+| --- | ------------------------------ | -------------------------------- | --------------------------------------------------------- |
+| 1   | `src/plugin-sdk/<name>.ts`     | (new file)                       | Nothing to build                                          |
+| 2   | `package.json`                 | `exports["./plugin-sdk/<name>"]` | TypeScript can't resolve types                            |
+| 3   | `tsconfig.plugin-sdk.dts.json` | `include`                        | No `.d.ts` emitted                                        |
+| 4   | `tsdown.config.ts`             | `pluginSdkEntrypoints`           | No `.js` in dist (silent!)                                |
+| 5   | `src/plugins/loader.ts`        | `pluginSdkScopedAliasEntries`    | Runtime crash: `Cannot find module root-alias.cjs/<name>` |
+| 6   | `vitest.config.ts`             | `pluginSdkSubpaths`              | Tests can't resolve the import                            |
+
+The most dangerous are #4 and #5: missing #4 silently skips the JS build, and missing #5 causes a runtime-only crash (jiti falls through to CJS resolution via `root-alias.cjs` and appends the subpath as a file path).
+
+## Miniclaw Deploy Notes
+
+- Gateway is managed by the Mac app (auto-respawns on kill)
+- Real logs: `~/.openclaw/logs/gateway.log` on the openclaw user
+- Config: `/Users/openclaw/.openclaw/openclaw.json` — ECS config lives at `plugins.entries.ecs.config`
+- After deploy, the deploy script kills the gateway; the Mac app respawns it with the new dist
+- If Mac app isn't running, start manually: `sudo su - openclaw -c 'cd /Users/openclaw/projects/openclaw-ecs && node dist/entry.js gateway run --bind loopback --port 18789 --verbose'`
+
+## Architecture
+
+```
+ECS Control Plane ──POST /ecs/tasks──> OpenClaw Gateway (ECS Plugin)
+       ^                                      │
+       │ callbacks                    subagent.run()
+       │                                      │
+       │                              Subagent Session
+       │                              (has 4 ECS tools)
+       │                                      │
+       └──────────────────────────── Discord Channels
+                                    #ecs-status / #ecs-info / #ecs-issues
+```
+
+## Key Files
+
+- `index.ts` — plugin registration (hooks, tools, HTTP route)
+- `src/task-dispatcher.ts` — dispatches tasks via `api.runtime.subagent.run()`
+- `src/tools.ts` — 4 agent tools (status_update, ask_question, raise_issue, set_persona)
+- `src/api-handler.ts` — HTTP API handler for /ecs/\* routes
+- `src/question-relay.ts` — Discord thread-based Q&A blocking
+- `src/discord-channels.ts` — Discord REST client for status/info/issues channels
+- `openclaw.plugin.json` — plugin manifest (required for discovery)

--- a/extensions/ecs/CLAUDE.md
+++ b/extensions/ecs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/extensions/ecs/index.ts
+++ b/extensions/ecs/index.ts
@@ -6,12 +6,14 @@
  * back to an ECS control plane.
  */
 
+import { RequestClient } from "@buape/carbon";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/ecs";
 import { EcsApiCallback } from "./src/api-callback.js";
 import { createEcsApiHandler } from "./src/api-handler.js";
 import { resolveEcsAgentsConfig, type EcsConfig } from "./src/config.js";
 import { EcsDiscordChannels } from "./src/discord-channels.js";
 import { clearActivePersona } from "./src/persona-registry.js";
+import { ProjectChannelManager } from "./src/project-channel-manager.js";
 import { EcsQuestionRelay } from "./src/question-relay.js";
 import { EcsTaskTracker } from "./src/task-tracker.js";
 import {
@@ -88,10 +90,28 @@ const ecsPlugin = {
     // Initialize modules.
     const tracker = new EcsTaskTracker();
     const callback = new EcsApiCallback(pluginCfg.controlPlane ?? {});
-    const discord = new EcsDiscordChannels(
-      discordToken ?? "",
-      pluginCfg.discord ?? { guildId: "", channels: { status: "", info: "", issues: "" } },
-    );
+    const discordCfg = pluginCfg.discord ?? {
+      guildId: "",
+      channels: { status: "", info: "", issues: "" },
+    };
+
+    // Project channel manager: auto-provisions per-project Discord categories.
+    let projectManager: ProjectChannelManager | undefined;
+    if (discordToken && discordCfg.guildId) {
+      projectManager = new ProjectChannelManager(
+        new RequestClient(discordToken),
+        discordCfg.guildId,
+        discordCfg.channels,
+        {
+          maxProjects: discordCfg.maxProjectChannels,
+          projectChannels: discordCfg.projectChannels,
+          log: (msg) => log.info(msg),
+        },
+      );
+      projectManager.load();
+    }
+
+    const discord = new EcsDiscordChannels(discordToken ?? "", discordCfg, projectManager);
     const agentsConfig = resolveEcsAgentsConfig(pluginCfg.agents);
     const questionRelay = new EcsQuestionRelay({
       discord,
@@ -106,6 +126,7 @@ const ecsPlugin = {
       callback,
       subagent: api.runtime.subagent,
       apiConfig: pluginCfg.api ?? {},
+      projectManager,
     });
 
     api.registerHttpRoute({
@@ -156,14 +177,17 @@ const ecsPlugin = {
           await callback.reportCompleted(taskId, summary, { sessionId: sessionKey });
         }
 
-        await discord.postTaskCompleted({
-          taskId,
-          agentId: active.agentId,
-          status: isError ? "error" : "complete",
-          summary,
-          durationMs: Date.now() - active.startedAt,
-          threadId: active.discordThreadId,
-        });
+        await discord.postTaskCompleted(
+          {
+            taskId,
+            agentId: active.agentId,
+            status: isError ? "error" : "complete",
+            summary,
+            durationMs: Date.now() - active.startedAt,
+            threadId: active.discordThreadId,
+          },
+          active.task.projectId,
+        );
 
         tracker.remove(taskId);
         clearActivePersona(sessionKey);

--- a/extensions/ecs/index.ts
+++ b/extensions/ecs/index.ts
@@ -127,6 +127,7 @@ const ecsPlugin = {
       subagent: api.runtime.subagent,
       apiConfig: pluginCfg.api ?? {},
       projectManager,
+      questionRelay,
     });
 
     api.registerHttpRoute({

--- a/extensions/ecs/index.ts
+++ b/extensions/ecs/index.ts
@@ -22,6 +22,13 @@ import {
   type EcsToolDeps,
 } from "./src/tools.js";
 
+/** Extract raw Discord ID from conversationId (strips "channel:" / "user:" prefix). */
+function extractDiscordId(conversationId: string | undefined): string | undefined {
+  if (!conversationId) return undefined;
+  const colonIdx = conversationId.indexOf(":");
+  return colonIdx >= 0 ? conversationId.slice(colonIdx + 1) : conversationId;
+}
+
 /** Normalize a Discord bot token (strip env-var prefix, trim whitespace). */
 function normalizeDiscordToken(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
@@ -169,20 +176,24 @@ const ecsPlugin = {
     api.on(
       "message_received",
       async (event, ctx) => {
-        const threadId = ctx.conversationId;
-        if (!threadId || !event.content) return;
+        const rawId = extractDiscordId(ctx.conversationId);
+        if (!rawId || !event.content) return;
 
-        if (questionRelay.hasPending(threadId)) {
+        log.info(
+          `[ecs] message_received: conversationId=${ctx.conversationId} rawId=${rawId} from=${event.from} isEcs=${discord.isEcsChannel(rawId)} hasPending=${questionRelay.hasPending(rawId)}`,
+        );
+
+        if (questionRelay.hasPending(rawId)) {
           const answeredBy = event.from ?? "unknown";
-          questionRelay.resolveQuestion(threadId, event.content, answeredBy);
-          log.info(`[ecs] question in thread ${threadId} answered by ${answeredBy}`);
+          questionRelay.resolveQuestion(rawId, event.content, answeredBy);
+          log.info(`[ecs] question in thread ${rawId} answered by ${answeredBy}`);
         }
 
         // Forward ECS-channel messages to the control plane.
-        if (discord.isEcsChannel(threadId)) {
+        if (discord.isEcsChannel(rawId)) {
           void callback
             .reportMessage({
-              channel_id: threadId,
+              channel_id: rawId,
               direction: "inbound",
               author: event.from,
               content: event.content,
@@ -197,11 +208,12 @@ const ecsPlugin = {
     api.on(
       "message_sent",
       async (event, ctx) => {
-        if (!ctx.conversationId || !event.success) return;
-        if (discord.isEcsChannel(ctx.conversationId)) {
+        const rawId = extractDiscordId(ctx.conversationId);
+        if (!rawId || !event.success) return;
+        if (discord.isEcsChannel(rawId)) {
           void callback
             .reportMessage({
-              channel_id: ctx.conversationId,
+              channel_id: rawId,
               direction: "outbound",
               content: event.content,
             })

--- a/extensions/ecs/index.ts
+++ b/extensions/ecs/index.ts
@@ -1,0 +1,263 @@
+/**
+ * OpenClaw ECS (Execution Control System) Plugin
+ *
+ * Inter-agent task orchestration layer that dispatches work to subagents,
+ * tracks execution, provides blocking Q&A via Discord threads, and reports
+ * back to an ECS control plane.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/ecs";
+import { EcsApiCallback } from "./src/api-callback.js";
+import { createEcsApiHandler } from "./src/api-handler.js";
+import { resolveEcsAgentsConfig, type EcsConfig } from "./src/config.js";
+import { EcsDiscordChannels } from "./src/discord-channels.js";
+import { clearActivePersona } from "./src/persona-registry.js";
+import { EcsQuestionRelay } from "./src/question-relay.js";
+import { EcsTaskTracker } from "./src/task-tracker.js";
+import {
+  createEcsAskQuestionTool,
+  createEcsRaiseIssueTool,
+  createEcsSetPersonaTool,
+  createEcsStatusUpdateTool,
+  type EcsToolDeps,
+} from "./src/tools.js";
+
+/** Normalize a Discord bot token (strip env-var prefix, trim whitespace). */
+function normalizeDiscordToken(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim().replace(/^DISCORD_BOT_TOKEN=/, "");
+  return trimmed || undefined;
+}
+
+/** Resolve Discord token from env var or OpenClaw config. */
+function resolveDiscordToken(config: Record<string, unknown>): string | undefined {
+  const envToken = normalizeDiscordToken(process.env.DISCORD_BOT_TOKEN);
+  if (envToken) return envToken;
+
+  // Try from Discord channel config (first account token).
+  const channels = config.channels as Record<string, unknown> | undefined;
+  const discordConfig = channels?.discord as Record<string, unknown> | undefined;
+  if (!discordConfig) return undefined;
+
+  if (typeof discordConfig.token === "string") {
+    return normalizeDiscordToken(discordConfig.token) ?? undefined;
+  }
+
+  const accounts = discordConfig.accounts as Record<string, { token?: string }> | undefined;
+  if (accounts) {
+    for (const account of Object.values(accounts)) {
+      const t = normalizeDiscordToken(account.token);
+      if (t) return t;
+    }
+  }
+
+  return undefined;
+}
+
+const ecsPlugin = {
+  id: "ecs",
+  name: "ECS (Execution Control System)",
+  description: "Inter-agent task orchestration via Discord with control plane callbacks",
+
+  register(api: OpenClawPluginApi) {
+    const pluginCfg = (api.pluginConfig ?? {}) as EcsConfig;
+    if (!pluginCfg.enabled) {
+      api.logger.info("[ecs] plugin loaded but not enabled");
+      return;
+    }
+
+    const log = api.logger;
+    log.info("[ecs] initializing ECS plugin");
+
+    // Resolve Discord token.
+    const discordToken = resolveDiscordToken(api.config as unknown as Record<string, unknown>);
+    if (!discordToken) {
+      log.warn("[ecs] no Discord bot token found; Discord posting will fail");
+    }
+    if (!pluginCfg.discord) {
+      log.warn("[ecs] ecs.discord config missing; Discord channels not configured");
+    }
+
+    // Initialize modules.
+    const tracker = new EcsTaskTracker();
+    const callback = new EcsApiCallback(pluginCfg.controlPlane ?? {});
+    const discord = new EcsDiscordChannels(
+      discordToken ?? "",
+      pluginCfg.discord ?? { guildId: "", channels: { status: "", info: "", issues: "" } },
+    );
+    const agentsConfig = resolveEcsAgentsConfig(pluginCfg.agents);
+    const questionRelay = new EcsQuestionRelay({
+      discord,
+      defaultTimeoutMs: agentsConfig.questionTimeoutMs,
+      escalateOnTimeout: agentsConfig.questionEscalateOnTimeout,
+    });
+
+    // --- HTTP route: /ecs/* ---
+    const apiHandler = createEcsApiHandler({
+      tracker,
+      discord,
+      callback,
+      subagent: api.runtime.subagent,
+      apiConfig: pluginCfg.api ?? {},
+    });
+
+    api.registerHttpRoute({
+      path: "/ecs",
+      match: "prefix",
+      auth: "plugin",
+      handler: async (req, res) => {
+        await apiHandler(req, res);
+        return true;
+      },
+    });
+
+    // --- Tools ---
+    const toolDeps: EcsToolDeps = { tracker, discord, callback, questionRelay };
+
+    api.registerTool(
+      (ctx) => [
+        createEcsStatusUpdateTool(toolDeps, { sessionKey: ctx.sessionKey, agentId: ctx.agentId }),
+        createEcsAskQuestionTool(toolDeps, { sessionKey: ctx.sessionKey, agentId: ctx.agentId }),
+        createEcsRaiseIssueTool(toolDeps, { sessionKey: ctx.sessionKey, agentId: ctx.agentId }),
+        createEcsSetPersonaTool(toolDeps, { sessionKey: ctx.sessionKey, agentId: ctx.agentId }),
+      ],
+      {
+        names: ["ecs_status_update", "ecs_ask_question", "ecs_raise_issue", "ecs_set_persona"],
+        optional: false,
+      },
+    );
+
+    // --- Hooks ---
+
+    // Hook: auto-report task completion when a subagent ends.
+    api.on(
+      "subagent_ended",
+      async (event) => {
+        const sessionKey = event.targetSessionKey;
+        if (!sessionKey) return;
+
+        const active = tracker.getBySessionKey(sessionKey);
+        if (!active) return;
+
+        const taskId = active.task.taskId;
+        const isError = event.outcome === "error" || event.outcome === "timeout";
+        const summary = event.reason ?? (isError ? "Task failed" : "Task completed");
+
+        if (isError) {
+          await callback.reportError(taskId, summary, { sessionId: sessionKey });
+        } else {
+          await callback.reportCompleted(taskId, summary, { sessionId: sessionKey });
+        }
+
+        await discord.postTaskCompleted({
+          taskId,
+          agentId: active.agentId,
+          status: isError ? "error" : "complete",
+          summary,
+          durationMs: Date.now() - active.startedAt,
+          threadId: active.discordThreadId,
+        });
+
+        tracker.remove(taskId);
+        clearActivePersona(sessionKey);
+        log.info(`[ecs] task ${taskId} ended: ${event.outcome ?? "unknown"}`);
+      },
+      { priority: 100 },
+    );
+
+    // Hook: detect replies in ECS info threads to resolve pending questions.
+    api.on(
+      "message_received",
+      async (event, ctx) => {
+        const threadId = ctx.conversationId;
+        if (!threadId || !event.content) return;
+
+        if (questionRelay.hasPending(threadId)) {
+          const answeredBy = event.from ?? "unknown";
+          questionRelay.resolveQuestion(threadId, event.content, answeredBy);
+          log.info(`[ecs] question in thread ${threadId} answered by ${answeredBy}`);
+        }
+
+        // Forward ECS-channel messages to the control plane.
+        if (discord.isEcsChannel(threadId)) {
+          void callback
+            .reportMessage({
+              channel_id: threadId,
+              direction: "inbound",
+              author: event.from,
+              content: event.content,
+            })
+            .catch((err) => log.warn(`[ecs] inbound message callback failed: ${err}`));
+        }
+      },
+      { priority: 50 },
+    );
+
+    // Hook: forward outbound auto-reply messages to control plane.
+    api.on(
+      "message_sent",
+      async (event, ctx) => {
+        if (!ctx.conversationId || !event.success) return;
+        if (discord.isEcsChannel(ctx.conversationId)) {
+          void callback
+            .reportMessage({
+              channel_id: ctx.conversationId,
+              direction: "outbound",
+              content: event.content,
+            })
+            .catch((err) => log.warn(`[ecs] outbound message callback failed: ${err}`));
+        }
+      },
+      { priority: 50 },
+    );
+
+    // Wire ECS system posts (embeds) to control plane.
+    discord.setOnPost((info) => {
+      void callback
+        .reportMessage({
+          channel_id: info.channelId,
+          direction: "outbound",
+          embed_title: info.embedTitle,
+          content: info.content,
+        })
+        .catch((err) => log.warn(`[ecs] ecs-post callback failed: ${err}`));
+    });
+
+    // Hook: gateway started — post a heartbeat embed.
+    api.on(
+      "gateway_start",
+      async (event) => {
+        await discord.postSystemEvent({
+          title: "Gateway Online",
+          description: `Gateway started on port ${event.port}.`,
+          color: 0x2ecc71, // green
+        });
+      },
+      { priority: 200 },
+    );
+
+    // Hook: subagent spawned — track when a new agent session starts.
+    api.on(
+      "subagent_spawned",
+      async (event) => {
+        const ecsTask = tracker.getBySessionKey(event.childSessionKey);
+        // Only post for ECS-managed tasks (not random subagents).
+        if (!ecsTask) return;
+        await discord.postSystemEvent({
+          title: "Agent Session Started",
+          color: 0x3498db, // blue
+          fields: [
+            { name: "Task", value: ecsTask.task.title, inline: true },
+            { name: "Agent", value: event.agentId, inline: true },
+            { name: "Mode", value: event.mode, inline: true },
+          ],
+        });
+      },
+      { priority: 200 },
+    );
+
+    log.info("[ecs] plugin initialized");
+  },
+};
+
+export default ecsPlugin;

--- a/extensions/ecs/openclaw.plugin.json
+++ b/extensions/ecs/openclaw.plugin.json
@@ -1,0 +1,59 @@
+{
+  "id": "ecs",
+  "name": "ECS (Execution Control System)",
+  "description": "Inter-agent task orchestration via Discord with control plane callbacks.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean", "description": "Enable the ECS integration." },
+      "discord": {
+        "type": "object",
+        "properties": {
+          "guildId": { "type": "string", "description": "Discord guild (server) ID." },
+          "channels": {
+            "type": "object",
+            "properties": {
+              "status": { "type": "string", "description": "Channel ID for status/progress." },
+              "info": { "type": "string", "description": "Channel ID for blocking Q&A." },
+              "issues": { "type": "string", "description": "Channel ID for issue escalation." }
+            }
+          }
+        }
+      },
+      "api": {
+        "type": "object",
+        "properties": {
+          "authToken": {
+            "type": "string",
+            "description": "Bearer token for inbound ECS API requests."
+          }
+        }
+      },
+      "controlPlane": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string", "description": "Base URL of the ECS control plane." },
+          "apiKey": { "type": "string", "description": "API key for control plane callbacks." }
+        }
+      },
+      "agents": {
+        "type": "object",
+        "properties": {
+          "statusIntervalSec": {
+            "type": "number",
+            "description": "Status heartbeat interval in seconds."
+          },
+          "questionTimeoutMs": {
+            "type": "number",
+            "description": "Timeout before unanswered question auto-escalates."
+          },
+          "questionEscalateOnTimeout": {
+            "type": "boolean",
+            "description": "Escalate unanswered questions to #ecs-issues."
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/ecs/package.json
+++ b/extensions/ecs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/ecs",
+  "version": "2026.3.7",
+  "private": true,
+  "description": "OpenClaw ECS (Execution Control System) — inter-agent task orchestration via Discord",
+  "type": "module",
+  "dependencies": {
+    "@buape/carbon": "0.0.0-beta-20260216184201",
+    "@sinclair/typebox": "0.34.48",
+    "discord-api-types": "^0.38.41"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/ecs/src/api-callback.ts
+++ b/extensions/ecs/src/api-callback.ts
@@ -1,0 +1,133 @@
+/**
+ * HTTP client for calling the ECS control plane's agent_task_callback endpoint.
+ * Replaces the fragile curl-in-prompt pattern with reliable server-side callbacks.
+ */
+
+import type { EcsControlPlaneConfig } from "./config.js";
+
+export type EcsCallbackEvent = "started" | "completed" | "error" | "status" | "message";
+
+export type EcsCallbackPayload = {
+  agent_task_id: string;
+  event: EcsCallbackEvent;
+  session_id?: string;
+  agent_id?: string;
+  result?: { summary: string };
+  output?: string;
+  error?: string;
+  timestamp?: string;
+};
+
+export class EcsApiCallback {
+  private baseUrl: string;
+  private apiKey: string | undefined;
+
+  constructor(config: EcsControlPlaneConfig) {
+    this.baseUrl = (config.url ?? "").replace(/\/+$/, "");
+    this.apiKey = config.apiKey;
+  }
+
+  private async post(
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<{ ok: boolean; status?: number }> {
+    if (!this.baseUrl) {
+      return { ok: false };
+    }
+
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+
+    try {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          ...body,
+          timestamp: (body.timestamp as string) ?? new Date().toISOString(),
+        }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      return { ok: resp.ok, status: resp.status };
+    } catch (err) {
+      console.warn(`[ecs] callback to ${url} failed:`, err instanceof Error ? err.message : err);
+      return { ok: false };
+    }
+  }
+
+  async report(payload: EcsCallbackPayload): Promise<{ ok: boolean; status?: number }> {
+    return this.post("/agent_task_callback", payload);
+  }
+
+  async reportMessage(msg: {
+    channel_id: string;
+    direction: "inbound" | "outbound";
+    author?: string;
+    content?: string;
+    embed_title?: string;
+  }): Promise<{ ok: boolean; status?: number }> {
+    return this.post("/agent_message_callback", {
+      event: "message" as const,
+      ...msg,
+    });
+  }
+
+  async reportStarted(
+    agentTaskId: string,
+    sessionId?: string,
+    agentId?: string,
+  ): Promise<{ ok: boolean }> {
+    return this.report({
+      agent_task_id: agentTaskId,
+      event: "started",
+      session_id: sessionId,
+      agent_id: agentId,
+    });
+  }
+
+  async reportCompleted(
+    agentTaskId: string,
+    summary: string,
+    opts?: { sessionId?: string; agentId?: string; output?: string },
+  ): Promise<{ ok: boolean }> {
+    return this.report({
+      agent_task_id: agentTaskId,
+      event: "completed",
+      result: { summary },
+      session_id: opts?.sessionId,
+      agent_id: opts?.agentId,
+      output: opts?.output,
+    });
+  }
+
+  async reportError(
+    agentTaskId: string,
+    error: string,
+    opts?: { sessionId?: string; agentId?: string },
+  ): Promise<{ ok: boolean }> {
+    return this.report({
+      agent_task_id: agentTaskId,
+      event: "error",
+      error,
+      session_id: opts?.sessionId,
+      agent_id: opts?.agentId,
+    });
+  }
+
+  async reportStatus(
+    agentTaskId: string,
+    summary: string,
+    opts?: { sessionId?: string; agentId?: string },
+  ): Promise<{ ok: boolean }> {
+    return this.report({
+      agent_task_id: agentTaskId,
+      event: "status",
+      result: { summary },
+      session_id: opts?.sessionId,
+      agent_id: opts?.agentId,
+    });
+  }
+}

--- a/extensions/ecs/src/api-callback.ts
+++ b/extensions/ecs/src/api-callback.ts
@@ -130,4 +130,19 @@ export class EcsApiCallback {
       agent_id: opts?.agentId,
     });
   }
+
+  async reportQuestion(payload: {
+    question_id: string;
+    agent_task_id: string | null;
+    question_text: string;
+    context: string | null;
+    asked_by: string | null;
+    discord_thread_id: string;
+    discord_channel: string;
+  }): Promise<{ ok: boolean }> {
+    return this.post("/agent_question_callback", {
+      ...payload,
+      event: "question_asked",
+    });
+  }
 }

--- a/extensions/ecs/src/api-handler.ts
+++ b/extensions/ecs/src/api-handler.ts
@@ -1,0 +1,191 @@
+/**
+ * HTTP endpoints for the ECS API, registered via registerHttpRoute().
+ * - POST /ecs/tasks — Assign a new task
+ * - GET /ecs/tasks/:taskId/status — Poll task status
+ * - POST /ecs/tasks/:taskId/cancel — Cancel a running task
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { EcsApiConfig } from "./config.js";
+import { dispatchEcsTask, type TaskDispatcherDeps } from "./task-dispatcher.js";
+import type { EcsTaskTracker } from "./task-tracker.js";
+import type { EcsTask } from "./types.js";
+
+/** Constant-time secret comparison (inlined to avoid core dependency). */
+function safeEqualSecret(
+  provided: string | undefined | null,
+  expected: string | undefined | null,
+): boolean {
+  if (typeof provided !== "string" || typeof expected !== "string") {
+    return false;
+  }
+  const hash = (s: string) => createHash("sha256").update(s).digest();
+  return timingSafeEqual(hash(provided), hash(expected));
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function parsePathParams(url: string): { route: string; taskId?: string } {
+  // Expected paths: /ecs/tasks, /ecs/tasks/:taskId/status, /ecs/tasks/:taskId/cancel
+  const match = url.match(/^\/ecs\/tasks(?:\/([^/]+)(?:\/(status|cancel))?)?$/);
+  if (!match) {
+    return { route: "unknown" };
+  }
+  if (!match[1]) {
+    return { route: "tasks" };
+  }
+  return { route: match[2] ?? "task", taskId: match[1] };
+}
+
+export type EcsApiHandlerDeps = TaskDispatcherDeps & {
+  tracker: EcsTaskTracker;
+  apiConfig: EcsApiConfig;
+};
+
+export function createEcsApiHandler(deps: EcsApiHandlerDeps) {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    const url = req.url ?? "";
+    const method = req.method ?? "GET";
+
+    // Auth check: all ECS API requests require a valid Bearer token.
+    if (deps.apiConfig.authToken) {
+      const authHeader = req.headers.authorization ?? "";
+      const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+      if (!safeEqualSecret(token, deps.apiConfig.authToken)) {
+        sendJson(res, 401, { error: "Unauthorized" });
+        return;
+      }
+    }
+
+    const { route, taskId } = parsePathParams(url);
+
+    if (route === "tasks" && method === "POST") {
+      await handleAssignTask(req, res, deps);
+    } else if (route === "status" && taskId && method === "GET") {
+      handleGetStatus(res, deps.tracker, taskId);
+    } else if (route === "cancel" && taskId && method === "POST") {
+      await handleCancelTask(res, deps, taskId);
+    } else {
+      sendJson(res, 404, { error: "Not found" });
+    }
+  };
+}
+
+async function handleAssignTask(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: EcsApiHandlerDeps,
+): Promise<void> {
+  let body: Record<string, unknown>;
+  try {
+    const raw = await readBody(req);
+    body = JSON.parse(raw);
+  } catch {
+    sendJson(res, 400, { error: "Invalid JSON body" });
+    return;
+  }
+
+  // Validate required fields.
+  const rawTaskId = body.agent_task_id;
+  const taskId =
+    typeof body.taskId === "string"
+      ? body.taskId
+      : typeof rawTaskId === "string"
+        ? rawTaskId
+        : typeof rawTaskId === "number"
+          ? String(rawTaskId)
+          : "";
+  const title = typeof body.title === "string" ? body.title : "";
+  const description = typeof body.description === "string" ? body.description : "";
+
+  if (!taskId || !title) {
+    sendJson(res, 400, { error: "taskId and title are required" });
+    return;
+  }
+
+  const task: EcsTask = {
+    taskId,
+    epicId: typeof body.epicId === "string" ? body.epicId : undefined,
+    title,
+    description,
+    assignedAgentId: typeof body.assignedAgentId === "string" ? body.assignedAgentId : undefined,
+    priority: isValidPriority(body.priority) ? body.priority : "medium",
+    deadline: typeof body.deadline === "string" ? body.deadline : undefined,
+    metadata:
+      typeof body.metadata === "object" && body.metadata !== null
+        ? (body.metadata as Record<string, unknown>)
+        : undefined,
+    persona: typeof body.persona === "string" ? body.persona : undefined,
+  };
+
+  const ack = await dispatchEcsTask(task, deps, {
+    agentId: typeof body.agentId === "string" ? body.agentId : undefined,
+  });
+
+  const status = ack.status === "accepted" ? 200 : 400;
+  sendJson(res, status, ack);
+}
+
+function handleGetStatus(res: ServerResponse, tracker: EcsTaskTracker, taskId: string): void {
+  const active = tracker.getByTaskId(taskId);
+  if (!active) {
+    sendJson(res, 404, { error: "Task not found", taskId });
+    return;
+  }
+
+  sendJson(res, 200, {
+    taskId,
+    status: active.status,
+    agentId: active.agentId,
+    sessionKey: active.sessionKey,
+    runId: active.runId,
+    startedAt: active.startedAt,
+    lastStatusUpdate: active.lastStatusUpdate,
+    discordThreadId: active.discordThreadId,
+  });
+}
+
+async function handleCancelTask(
+  res: ServerResponse,
+  deps: EcsApiHandlerDeps,
+  taskId: string,
+): Promise<void> {
+  const active = deps.tracker.getByTaskId(taskId);
+  if (!active) {
+    sendJson(res, 404, { error: "Task not found", taskId });
+    return;
+  }
+
+  deps.tracker.updateStatus(taskId, "error");
+  deps.tracker.remove(taskId);
+
+  // Report cancellation to ECS control plane.
+  await deps.callback.reportError(taskId, "Task cancelled via API");
+
+  // Echo to Discord.
+  await deps.discord.postTaskCompleted({
+    taskId,
+    agentId: active.agentId,
+    status: "cancelled",
+    summary: "Task was cancelled via API.",
+    durationMs: Date.now() - active.startedAt,
+  });
+
+  sendJson(res, 200, { taskId, status: "cancelled" });
+}
+
+function isValidPriority(v: unknown): v is "low" | "medium" | "high" | "critical" {
+  return v === "low" || v === "medium" || v === "high" || v === "critical";
+}

--- a/extensions/ecs/src/api-handler.ts
+++ b/extensions/ecs/src/api-handler.ts
@@ -8,6 +8,7 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { EcsApiConfig } from "./config.js";
+import type { ProjectChannelManager } from "./project-channel-manager.js";
 import { dispatchEcsTask, type TaskDispatcherDeps } from "./task-dispatcher.js";
 import type { EcsTaskTracker } from "./task-tracker.js";
 import type { EcsTask } from "./types.js";
@@ -37,8 +38,17 @@ async function readBody(req: IncomingMessage): Promise<string> {
   return Buffer.concat(chunks).toString("utf8");
 }
 
-function parsePathParams(url: string): { route: string; taskId?: string } {
-  // Expected paths: /ecs/tasks, /ecs/tasks/:taskId/status, /ecs/tasks/:taskId/cancel
+function parsePathParams(url: string): { route: string; taskId?: string; projectId?: string } {
+  // /ecs/projects — list projects
+  if (url === "/ecs/projects") {
+    return { route: "projects" };
+  }
+  // /ecs/projects/:projectId/archive — archive project channels
+  const projMatch = url.match(/^\/ecs\/projects\/([^/]+)\/archive$/);
+  if (projMatch) {
+    return { route: "project-archive", projectId: projMatch[1] };
+  }
+  // /ecs/tasks, /ecs/tasks/:taskId/status, /ecs/tasks/:taskId/cancel
   const match = url.match(/^\/ecs\/tasks(?:\/([^/]+)(?:\/(status|cancel))?)?$/);
   if (!match) {
     return { route: "unknown" };
@@ -52,6 +62,7 @@ function parsePathParams(url: string): { route: string; taskId?: string } {
 export type EcsApiHandlerDeps = TaskDispatcherDeps & {
   tracker: EcsTaskTracker;
   apiConfig: EcsApiConfig;
+  projectManager?: ProjectChannelManager;
 };
 
 export function createEcsApiHandler(deps: EcsApiHandlerDeps) {
@@ -69,7 +80,7 @@ export function createEcsApiHandler(deps: EcsApiHandlerDeps) {
       }
     }
 
-    const { route, taskId } = parsePathParams(url);
+    const { route, taskId, projectId } = parsePathParams(url);
 
     if (route === "tasks" && method === "POST") {
       await handleAssignTask(req, res, deps);
@@ -77,6 +88,10 @@ export function createEcsApiHandler(deps: EcsApiHandlerDeps) {
       handleGetStatus(res, deps.tracker, taskId);
     } else if (route === "cancel" && taskId && method === "POST") {
       await handleCancelTask(res, deps, taskId);
+    } else if (route === "projects" && method === "GET") {
+      handleListProjects(res, deps);
+    } else if (route === "project-archive" && projectId && method === "POST") {
+      await handleArchiveProject(res, deps, projectId);
     } else {
       sendJson(res, 404, { error: "Not found" });
     }
@@ -118,6 +133,7 @@ async function handleAssignTask(
   const task: EcsTask = {
     taskId,
     epicId: typeof body.epicId === "string" ? body.epicId : undefined,
+    projectId: typeof body.projectId === "string" ? body.projectId : undefined,
     title,
     description,
     assignedAgentId: typeof body.assignedAgentId === "string" ? body.assignedAgentId : undefined,
@@ -175,15 +191,43 @@ async function handleCancelTask(
   await deps.callback.reportError(taskId, "Task cancelled via API");
 
   // Echo to Discord.
-  await deps.discord.postTaskCompleted({
-    taskId,
-    agentId: active.agentId,
-    status: "cancelled",
-    summary: "Task was cancelled via API.",
-    durationMs: Date.now() - active.startedAt,
-  });
+  await deps.discord.postTaskCompleted(
+    {
+      taskId,
+      agentId: active.agentId,
+      status: "cancelled",
+      summary: "Task was cancelled via API.",
+      durationMs: Date.now() - active.startedAt,
+    },
+    active.task.projectId,
+  );
 
   sendJson(res, 200, { taskId, status: "cancelled" });
+}
+
+function handleListProjects(res: ServerResponse, deps: EcsApiHandlerDeps): void {
+  if (!deps.projectManager) {
+    sendJson(res, 200, { projects: [] });
+    return;
+  }
+  sendJson(res, 200, { projects: deps.projectManager.listProjects() });
+}
+
+async function handleArchiveProject(
+  res: ServerResponse,
+  deps: EcsApiHandlerDeps,
+  projectId: string,
+): Promise<void> {
+  if (!deps.projectManager) {
+    sendJson(res, 404, { error: "Project channel management not enabled" });
+    return;
+  }
+  const archived = await deps.projectManager.archiveProject(projectId);
+  if (!archived) {
+    sendJson(res, 404, { error: "Project not found", projectId });
+    return;
+  }
+  sendJson(res, 200, { projectId, archived: true });
 }
 
 function isValidPriority(v: unknown): v is "low" | "medium" | "high" | "critical" {

--- a/extensions/ecs/src/api-handler.ts
+++ b/extensions/ecs/src/api-handler.ts
@@ -9,6 +9,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { EcsApiConfig } from "./config.js";
 import type { ProjectChannelManager } from "./project-channel-manager.js";
+import type { EcsQuestionRelay } from "./question-relay.js";
 import { dispatchEcsTask, type TaskDispatcherDeps } from "./task-dispatcher.js";
 import type { EcsTaskTracker } from "./task-tracker.js";
 import type { EcsTask } from "./types.js";
@@ -38,7 +39,12 @@ async function readBody(req: IncomingMessage): Promise<string> {
   return Buffer.concat(chunks).toString("utf8");
 }
 
-function parsePathParams(url: string): { route: string; taskId?: string; projectId?: string } {
+function parsePathParams(url: string): {
+  route: string;
+  taskId?: string;
+  projectId?: string;
+  questionId?: string;
+} {
   // /ecs/projects — list projects
   if (url === "/ecs/projects") {
     return { route: "projects" };
@@ -47,6 +53,11 @@ function parsePathParams(url: string): { route: string; taskId?: string; project
   const projMatch = url.match(/^\/ecs\/projects\/([^/]+)\/archive$/);
   if (projMatch) {
     return { route: "project-archive", projectId: projMatch[1] };
+  }
+  // /ecs/questions/:questionId/answer — answer a pending question
+  const questionMatch = url.match(/^\/ecs\/questions\/([^/]+)\/answer$/);
+  if (questionMatch) {
+    return { route: "question-answer", questionId: questionMatch[1] };
   }
   // /ecs/tasks, /ecs/tasks/:taskId/status, /ecs/tasks/:taskId/cancel
   const match = url.match(/^\/ecs\/tasks(?:\/([^/]+)(?:\/(status|cancel))?)?$/);
@@ -63,6 +74,7 @@ export type EcsApiHandlerDeps = TaskDispatcherDeps & {
   tracker: EcsTaskTracker;
   apiConfig: EcsApiConfig;
   projectManager?: ProjectChannelManager;
+  questionRelay?: EcsQuestionRelay;
 };
 
 export function createEcsApiHandler(deps: EcsApiHandlerDeps) {
@@ -80,7 +92,7 @@ export function createEcsApiHandler(deps: EcsApiHandlerDeps) {
       }
     }
 
-    const { route, taskId, projectId } = parsePathParams(url);
+    const { route, taskId, projectId, questionId } = parsePathParams(url);
 
     if (route === "tasks" && method === "POST") {
       await handleAssignTask(req, res, deps);
@@ -92,6 +104,8 @@ export function createEcsApiHandler(deps: EcsApiHandlerDeps) {
       handleListProjects(res, deps);
     } else if (route === "project-archive" && projectId && method === "POST") {
       await handleArchiveProject(res, deps, projectId);
+    } else if (route === "question-answer" && questionId && method === "POST") {
+      await handleAnswerQuestion(req, res, questionId, deps);
     } else {
       sendJson(res, 404, { error: "Not found" });
     }
@@ -228,6 +242,49 @@ async function handleArchiveProject(
     return;
   }
   sendJson(res, 200, { projectId, archived: true });
+}
+
+async function handleAnswerQuestion(
+  req: IncomingMessage,
+  res: ServerResponse,
+  questionId: string,
+  deps: EcsApiHandlerDeps,
+): Promise<void> {
+  if (!deps.questionRelay) {
+    sendJson(res, 404, { error: "Question relay not configured" });
+    return;
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    const raw = await readBody(req);
+    body = JSON.parse(raw);
+  } catch {
+    sendJson(res, 400, { error: "Invalid JSON body" });
+    return;
+  }
+
+  const answerText = typeof body.answer_text === "string" ? body.answer_text : "";
+  const answeredBy = typeof body.answered_by === "string" ? body.answered_by : "api";
+
+  if (!answerText) {
+    sendJson(res, 400, { error: "answer_text is required" });
+    return;
+  }
+
+  const threadId = deps.questionRelay.getThreadIdByQuestionId(questionId);
+  if (!threadId) {
+    sendJson(res, 404, { error: "No pending question with that ID" });
+    return;
+  }
+
+  const resolved = deps.questionRelay.resolveQuestion(threadId, answerText, answeredBy);
+  if (!resolved) {
+    sendJson(res, 404, { error: "Question already resolved or expired" });
+    return;
+  }
+
+  sendJson(res, 200, { questionId, status: "resolved" });
 }
 
 function isValidPriority(v: unknown): v is "low" | "medium" | "high" | "critical" {

--- a/extensions/ecs/src/config.ts
+++ b/extensions/ecs/src/config.ts
@@ -1,0 +1,66 @@
+/** ECS configuration type and defaults. */
+
+export type EcsDiscordChannelsConfig = {
+  /** Discord channel ID for status/progress broadcasts. */
+  status: string;
+  /** Discord channel ID for blocking Q&A between agents. */
+  info: string;
+  /** Discord channel ID for issue escalation. */
+  issues: string;
+};
+
+export type EcsDiscordConfig = {
+  /** Discord guild (server) ID hosting the ECS channels. */
+  guildId: string;
+  /** Channel IDs for the three intent channels. */
+  channels: EcsDiscordChannelsConfig;
+};
+
+export type EcsApiConfig = {
+  /** Bearer token for authenticating inbound ECS API requests. */
+  authToken?: string;
+};
+
+export type EcsControlPlaneConfig = {
+  /** Base URL of the ECS control plane (Supabase functions or custom API). */
+  url?: string;
+  /** API key or bearer token for authenticating callbacks to the control plane. */
+  apiKey?: string;
+};
+
+export type EcsAgentsConfig = {
+  /** Interval in seconds for periodic status heartbeats. Default: 30. */
+  statusIntervalSec?: number;
+  /** Timeout in ms before an unanswered question auto-escalates. Default: 300000. */
+  questionTimeoutMs?: number;
+  /** If true, unanswered questions escalate to #ecs-issues on timeout. Default: true. */
+  questionEscalateOnTimeout?: boolean;
+};
+
+export type EcsConfig = {
+  /** Enable the ECS integration. Default: false. */
+  enabled?: boolean;
+  /** Discord channel configuration for the three intent channels. */
+  discord?: EcsDiscordConfig;
+  /** API authentication configuration. */
+  api?: EcsApiConfig;
+  /** ECS control plane connection configuration. */
+  controlPlane?: EcsControlPlaneConfig;
+  /** Agent behavior configuration. */
+  agents?: EcsAgentsConfig;
+};
+
+export const ECS_DEFAULTS = {
+  statusIntervalSec: 30,
+  questionTimeoutMs: 300_000,
+  questionEscalateOnTimeout: true,
+} as const;
+
+export function resolveEcsAgentsConfig(cfg?: EcsAgentsConfig): Required<EcsAgentsConfig> {
+  return {
+    statusIntervalSec: cfg?.statusIntervalSec ?? ECS_DEFAULTS.statusIntervalSec,
+    questionTimeoutMs: cfg?.questionTimeoutMs ?? ECS_DEFAULTS.questionTimeoutMs,
+    questionEscalateOnTimeout:
+      cfg?.questionEscalateOnTimeout ?? ECS_DEFAULTS.questionEscalateOnTimeout,
+  };
+}

--- a/extensions/ecs/src/config.ts
+++ b/extensions/ecs/src/config.ts
@@ -14,6 +14,10 @@ export type EcsDiscordConfig = {
   guildId: string;
   /** Channel IDs for the three intent channels. */
   channels: EcsDiscordChannelsConfig;
+  /** Pre-mapped project IDs to existing channel IDs (skip auto-creation). */
+  projectChannels?: Record<string, EcsDiscordChannelsConfig>;
+  /** Max projects with auto-created channels. Default: 100. */
+  maxProjectChannels?: number;
 };
 
 export type EcsApiConfig = {

--- a/extensions/ecs/src/discord-channels.ts
+++ b/extensions/ecs/src/discord-channels.ts
@@ -5,7 +5,8 @@
 
 import { RequestClient } from "@buape/carbon";
 import { Routes } from "discord-api-types/v10";
-import type { EcsDiscordConfig } from "./config.js";
+import type { EcsDiscordChannelsConfig, EcsDiscordConfig } from "./config.js";
+import type { ProjectChannelManager } from "./project-channel-manager.js";
 import type {
   EcsIssue,
   EcsIssueSeverity,
@@ -50,24 +51,33 @@ export class EcsDiscordChannels {
   private channelIdSet: Set<string>;
   private ecsThreadIds = new Set<string>();
   private onPostCallback?: (info: EcsPostInfo) => void;
+  private projectManager?: ProjectChannelManager;
 
-  constructor(token: string, config: EcsDiscordConfig) {
+  constructor(token: string, config: EcsDiscordConfig, projectManager?: ProjectChannelManager) {
     this.rest = new RequestClient(token);
     this.channels = config.channels;
     this.guildId = config.guildId;
     this.channelIdSet = new Set(
       [config.channels.status, config.channels.info, config.channels.issues].filter(Boolean),
     );
+    this.projectManager = projectManager;
   }
 
-  /** Returns the set of ECS channel IDs. */
+  /** Returns the set of ECS channel IDs (default + all project channels). */
   getChannelIds(): Set<string> {
-    return this.channelIdSet;
+    if (!this.projectManager) return this.channelIdSet;
+    const all = new Set(this.channelIdSet);
+    for (const id of this.projectManager.getProjectChannelIds()) {
+      all.add(id);
+    }
+    return all;
   }
 
   /** Check if a channel/thread ID is one of the ECS channels (or a known ECS thread). */
   isEcsChannel(id: string): boolean {
-    return this.channelIdSet.has(id) || this.ecsThreadIds.has(id);
+    if (this.channelIdSet.has(id) || this.ecsThreadIds.has(id)) return true;
+    if (this.projectManager) return this.projectManager.getProjectChannelIds().has(id);
+    return false;
   }
 
   /** Register a callback that fires after every successful post. */
@@ -75,8 +85,15 @@ export class EcsDiscordChannels {
     this.onPostCallback = cb;
   }
 
+  /** Resolve channel set for a project (or fall back to defaults). */
+  private async resolveChannels(projectId?: string): Promise<EcsDiscordChannelsConfig> {
+    if (!projectId || !this.projectManager) return this.channels;
+    return this.projectManager.resolveChannels(projectId);
+  }
+
   /** Post a task assignment notification to #ecs-status. */
   async postTaskAssigned(task: EcsTask): Promise<DiscordPostResult> {
+    const ch = await this.resolveChannels(task.projectId);
     const embed = {
       title: `Task Assigned: ${task.title}`,
       description: truncate(task.description, 1000),
@@ -87,15 +104,17 @@ export class EcsDiscordChannels {
         ...(task.assignedAgentId
           ? [{ name: "Agent", value: task.assignedAgentId, inline: true }]
           : []),
+        ...(task.projectId ? [{ name: "Project", value: task.projectId, inline: true }] : []),
       ],
       timestamp: new Date().toISOString(),
     };
 
-    return this.postEmbed(this.channels.status, embed);
+    return this.postEmbed(ch.status, embed);
   }
 
   /** Post a status update to #ecs-status. */
-  async postStatusUpdate(update: EcsStatusUpdate): Promise<DiscordPostResult> {
+  async postStatusUpdate(update: EcsStatusUpdate, projectId?: string): Promise<DiscordPostResult> {
+    const ch = await this.resolveChannels(projectId);
     const fields = [
       { name: "Task ID", value: update.taskId, inline: true },
       { name: "Status", value: update.status, inline: true },
@@ -115,11 +134,15 @@ export class EcsDiscordChannels {
       timestamp: new Date(update.timestamp).toISOString(),
     };
 
-    return this.postEmbed(this.channels.status, embed);
+    return this.postEmbed(ch.status, embed);
   }
 
   /** Post a task completion to #ecs-status. */
-  async postTaskCompleted(completion: EcsTaskCompletion): Promise<DiscordPostResult> {
+  async postTaskCompleted(
+    completion: EcsTaskCompletion,
+    projectId?: string,
+  ): Promise<DiscordPostResult> {
+    const ch = await this.resolveChannels(projectId);
     const isError = completion.status === "error" || completion.status === "cancelled";
     const embed = {
       title: `Task ${completion.status === "complete" ? "Completed" : completion.status === "error" ? "Failed" : "Cancelled"}`,
@@ -133,7 +156,7 @@ export class EcsDiscordChannels {
       timestamp: new Date().toISOString(),
     };
 
-    const result = await this.postEmbed(this.channels.status, embed);
+    const result = await this.postEmbed(ch.status, embed);
 
     // Also post a summary to the task's Discord thread if available.
     if (completion.threadId) {
@@ -148,7 +171,8 @@ export class EcsDiscordChannels {
   }
 
   /** Post a question to #ecs-info and create a thread for discussion. */
-  async postQuestion(question: EcsQuestion): Promise<DiscordPostResult> {
+  async postQuestion(question: EcsQuestion, projectId?: string): Promise<DiscordPostResult> {
+    const ch = await this.resolveChannels(projectId);
     const embed = {
       title: "Question",
       description: truncate(question.question, 1000),
@@ -163,7 +187,7 @@ export class EcsDiscordChannels {
     };
 
     // Post the embed to #ecs-info.
-    const result = await this.postEmbed(this.channels.info, embed);
+    const result = await this.postEmbed(ch.info, embed);
     if (!result.messageId) {
       return result;
     }
@@ -171,7 +195,7 @@ export class EcsDiscordChannels {
     // Create a thread on the message for discussion.
     try {
       const threadName = `Q: ${truncate(question.question, 80)}`;
-      const thread = (await this.rest.post(Routes.threads(this.channels.info, result.messageId), {
+      const thread = (await this.rest.post(Routes.threads(ch.info, result.messageId), {
         body: { name: threadName, auto_archive_duration: 1440 },
       })) as { id: string };
       this.ecsThreadIds.add(thread.id);
@@ -183,7 +207,8 @@ export class EcsDiscordChannels {
   }
 
   /** Post an issue to #ecs-issues. */
-  async postIssue(issue: EcsIssue): Promise<DiscordPostResult> {
+  async postIssue(issue: EcsIssue, projectId?: string): Promise<DiscordPostResult> {
+    const ch = await this.resolveChannels(projectId);
     const embed = {
       title: `[${issue.severity.toUpperCase()}] ${issue.title}`,
       description: truncate(issue.description, 1000),
@@ -199,11 +224,12 @@ export class EcsDiscordChannels {
       timestamp: new Date().toISOString(),
     };
 
-    return this.postEmbed(this.channels.issues, embed);
+    return this.postEmbed(ch.issues, embed);
   }
 
   /** Post a timeout escalation to #ecs-issues when a question goes unanswered. */
-  async postQuestionTimeout(question: EcsQuestion): Promise<DiscordPostResult> {
+  async postQuestionTimeout(question: EcsQuestion, projectId?: string): Promise<DiscordPostResult> {
+    const ch = await this.resolveChannels(projectId);
     const embed = {
       title: "[WARN] Unanswered Question Escalation",
       description: `Question timed out and was auto-escalated.\n\n**Question:** ${truncate(question.question, 800)}`,
@@ -218,7 +244,7 @@ export class EcsDiscordChannels {
       timestamp: new Date().toISOString(),
     };
 
-    return this.postEmbed(this.channels.issues, embed);
+    return this.postEmbed(ch.issues, embed);
   }
 
   /** Post a message to a specific thread (e.g., for answers to questions). */

--- a/extensions/ecs/src/discord-channels.ts
+++ b/extensions/ecs/src/discord-channels.ts
@@ -1,0 +1,296 @@
+/**
+ * Discord REST posting to the three ECS intent channels.
+ * Uses @buape/carbon RequestClient (same pattern as core Discord send).
+ */
+
+import { RequestClient } from "@buape/carbon";
+import { Routes } from "discord-api-types/v10";
+import type { EcsDiscordConfig } from "./config.js";
+import type {
+  EcsIssue,
+  EcsIssueSeverity,
+  EcsQuestion,
+  EcsStatusUpdate,
+  EcsTask,
+  EcsTaskCompletion,
+} from "./types.js";
+
+// Embed sidebar colors by intent/severity.
+const COLOR_STATUS = 0x3498db; // blue
+const COLOR_INFO = 0xf39c12; // orange
+const COLOR_ISSUE_WARN = 0xf1c40f; // yellow
+const COLOR_ISSUE_ERROR = 0xe74c3c; // red
+const COLOR_ISSUE_CRITICAL = 0x8b0000; // dark red
+const COLOR_COMPLETE = 0x2ecc71; // green
+const COLOR_ERROR = 0xe74c3c; // red
+
+const SEVERITY_COLORS: Record<EcsIssueSeverity, number> = {
+  warn: COLOR_ISSUE_WARN,
+  error: COLOR_ISSUE_ERROR,
+  critical: COLOR_ISSUE_CRITICAL,
+};
+
+export type DiscordPostResult = {
+  messageId?: string;
+  channelId?: string;
+  threadId?: string;
+};
+
+export type EcsPostInfo = {
+  channelId: string;
+  messageId?: string;
+  embedTitle?: string;
+  content?: string;
+};
+
+export class EcsDiscordChannels {
+  private rest: RequestClient;
+  private channels: EcsDiscordConfig["channels"];
+  private guildId: string;
+  private channelIdSet: Set<string>;
+  private onPostCallback?: (info: EcsPostInfo) => void;
+
+  constructor(token: string, config: EcsDiscordConfig) {
+    this.rest = new RequestClient(token);
+    this.channels = config.channels;
+    this.guildId = config.guildId;
+    this.channelIdSet = new Set(
+      [config.channels.status, config.channels.info, config.channels.issues].filter(Boolean),
+    );
+  }
+
+  /** Returns the set of ECS channel IDs. */
+  getChannelIds(): Set<string> {
+    return this.channelIdSet;
+  }
+
+  /** Check if a channel/thread ID is one of the ECS channels. */
+  isEcsChannel(id: string): boolean {
+    return this.channelIdSet.has(id);
+  }
+
+  /** Register a callback that fires after every successful post. */
+  setOnPost(cb: (info: EcsPostInfo) => void): void {
+    this.onPostCallback = cb;
+  }
+
+  /** Post a task assignment notification to #ecs-status. */
+  async postTaskAssigned(task: EcsTask): Promise<DiscordPostResult> {
+    const embed = {
+      title: `Task Assigned: ${task.title}`,
+      description: truncate(task.description, 1000),
+      color: COLOR_STATUS,
+      fields: [
+        { name: "Task ID", value: task.taskId, inline: true },
+        { name: "Priority", value: task.priority, inline: true },
+        ...(task.assignedAgentId
+          ? [{ name: "Agent", value: task.assignedAgentId, inline: true }]
+          : []),
+      ],
+      timestamp: new Date().toISOString(),
+    };
+
+    return this.postEmbed(this.channels.status, embed);
+  }
+
+  /** Post a status update to #ecs-status. */
+  async postStatusUpdate(update: EcsStatusUpdate): Promise<DiscordPostResult> {
+    const fields = [
+      { name: "Task ID", value: update.taskId, inline: true },
+      { name: "Status", value: update.status, inline: true },
+    ];
+    if (update.progressPct !== undefined) {
+      fields.push({ name: "Progress", value: `${update.progressPct}%`, inline: true });
+    }
+    if (update.agentId) {
+      fields.push({ name: "Agent", value: update.agentId, inline: true });
+    }
+
+    const embed = {
+      title: "Status Update",
+      description: truncate(update.summary, 1000),
+      color: COLOR_STATUS,
+      fields,
+      timestamp: new Date(update.timestamp).toISOString(),
+    };
+
+    return this.postEmbed(this.channels.status, embed);
+  }
+
+  /** Post a task completion to #ecs-status. */
+  async postTaskCompleted(completion: EcsTaskCompletion): Promise<DiscordPostResult> {
+    const isError = completion.status === "error" || completion.status === "cancelled";
+    const embed = {
+      title: `Task ${completion.status === "complete" ? "Completed" : completion.status === "error" ? "Failed" : "Cancelled"}`,
+      description: truncate(completion.summary, 1000),
+      color: isError ? COLOR_ERROR : COLOR_COMPLETE,
+      fields: [
+        { name: "Task ID", value: completion.taskId, inline: true },
+        { name: "Duration", value: formatDuration(completion.durationMs), inline: true },
+        ...(completion.agentId ? [{ name: "Agent", value: completion.agentId, inline: true }] : []),
+      ],
+      timestamp: new Date().toISOString(),
+    };
+
+    const result = await this.postEmbed(this.channels.status, embed);
+
+    // Also post a summary to the task's Discord thread if available.
+    if (completion.threadId) {
+      const label = completion.status === "complete" ? "completed" : completion.status;
+      await this.postToThread(
+        completion.threadId,
+        `**Task ${label}** — ${truncate(completion.summary, 500)}`,
+      );
+    }
+
+    return result;
+  }
+
+  /** Post a question to #ecs-info and create a thread for discussion. */
+  async postQuestion(question: EcsQuestion): Promise<DiscordPostResult> {
+    const embed = {
+      title: "Question",
+      description: truncate(question.question, 1000),
+      color: COLOR_INFO,
+      fields: [
+        { name: "Task ID", value: question.taskId, inline: true },
+        { name: "Question ID", value: question.questionId, inline: true },
+        ...(question.toAgentId ? [{ name: "To", value: question.toAgentId, inline: true }] : []),
+        ...(question.context ? [{ name: "Context", value: truncate(question.context, 256) }] : []),
+      ],
+      timestamp: new Date().toISOString(),
+    };
+
+    // Post the embed to #ecs-info.
+    const result = await this.postEmbed(this.channels.info, embed);
+    if (!result.messageId) {
+      return result;
+    }
+
+    // Create a thread on the message for discussion.
+    try {
+      const threadName = `Q: ${truncate(question.question, 80)}`;
+      const thread = (await this.rest.post(Routes.threads(this.channels.info, result.messageId), {
+        body: { name: threadName, auto_archive_duration: 1440 },
+      })) as { id: string };
+      return { ...result, threadId: thread.id };
+    } catch {
+      // Thread creation failed; return without threadId.
+      return result;
+    }
+  }
+
+  /** Post an issue to #ecs-issues. */
+  async postIssue(issue: EcsIssue): Promise<DiscordPostResult> {
+    const embed = {
+      title: `[${issue.severity.toUpperCase()}] ${issue.title}`,
+      description: truncate(issue.description, 1000),
+      color: SEVERITY_COLORS[issue.severity],
+      fields: [
+        { name: "Task ID", value: issue.taskId, inline: true },
+        { name: "Severity", value: issue.severity, inline: true },
+        { name: "Needs Human", value: issue.needsHuman ? "Yes" : "No", inline: true },
+        ...(issue.attempted.length > 0
+          ? [{ name: "Attempted", value: truncate(issue.attempted.join("\n"), 512) }]
+          : []),
+      ],
+      timestamp: new Date().toISOString(),
+    };
+
+    return this.postEmbed(this.channels.issues, embed);
+  }
+
+  /** Post a timeout escalation to #ecs-issues when a question goes unanswered. */
+  async postQuestionTimeout(question: EcsQuestion): Promise<DiscordPostResult> {
+    const embed = {
+      title: "[WARN] Unanswered Question Escalation",
+      description: `Question timed out and was auto-escalated.\n\n**Question:** ${truncate(question.question, 800)}`,
+      color: COLOR_ISSUE_WARN,
+      fields: [
+        { name: "Task ID", value: question.taskId, inline: true },
+        { name: "Question ID", value: question.questionId, inline: true },
+        ...(question.fromAgentId
+          ? [{ name: "From", value: question.fromAgentId, inline: true }]
+          : []),
+      ],
+      timestamp: new Date().toISOString(),
+    };
+
+    return this.postEmbed(this.channels.issues, embed);
+  }
+
+  /** Post a message to a specific thread (e.g., for answers to questions). */
+  async postToThread(threadId: string, text: string): Promise<DiscordPostResult> {
+    try {
+      const msg = (await this.rest.post(Routes.channelMessages(threadId), {
+        body: { content: truncate(text, 2000) },
+      })) as { id: string; channel_id: string };
+      this.onPostCallback?.({
+        channelId: msg.channel_id,
+        messageId: msg.id,
+        content: truncate(text, 2000),
+      });
+      return { messageId: msg.id, channelId: msg.channel_id };
+    } catch {
+      return {};
+    }
+  }
+
+  /** Post a lightweight system-level event to #ecs-status (zero token cost). */
+  async postSystemEvent(params: {
+    title: string;
+    description?: string;
+    color?: number;
+    fields?: { name: string; value: string; inline?: boolean }[];
+  }): Promise<DiscordPostResult> {
+    const embed = {
+      title: params.title,
+      description: params.description,
+      color: params.color ?? 0x95a5a6, // grey
+      fields: params.fields,
+      timestamp: new Date().toISOString(),
+    };
+    return this.postEmbed(this.channels.status, embed);
+  }
+
+  private async postEmbed(
+    channelId: string,
+    embed: Record<string, unknown>,
+  ): Promise<DiscordPostResult> {
+    try {
+      const msg = (await this.rest.post(Routes.channelMessages(channelId), {
+        body: { embeds: [embed] },
+      })) as { id: string; channel_id: string };
+      this.onPostCallback?.({
+        channelId: msg.channel_id,
+        messageId: msg.id,
+        embedTitle: embed.title as string | undefined,
+      });
+      return { messageId: msg.id, channelId: msg.channel_id };
+    } catch {
+      return {};
+    }
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) {
+    return s;
+  }
+  return s.slice(0, max - 3) + "...";
+}
+
+function formatDuration(ms: number): string {
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) {
+    return `${sec}s`;
+  }
+  const min = Math.floor(sec / 60);
+  const remSec = sec % 60;
+  if (min < 60) {
+    return `${min}m ${remSec}s`;
+  }
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  return `${hr}h ${remMin}m`;
+}

--- a/extensions/ecs/src/discord-channels.ts
+++ b/extensions/ecs/src/discord-channels.ts
@@ -48,6 +48,7 @@ export class EcsDiscordChannels {
   private channels: EcsDiscordConfig["channels"];
   private guildId: string;
   private channelIdSet: Set<string>;
+  private ecsThreadIds = new Set<string>();
   private onPostCallback?: (info: EcsPostInfo) => void;
 
   constructor(token: string, config: EcsDiscordConfig) {
@@ -64,9 +65,9 @@ export class EcsDiscordChannels {
     return this.channelIdSet;
   }
 
-  /** Check if a channel/thread ID is one of the ECS channels. */
+  /** Check if a channel/thread ID is one of the ECS channels (or a known ECS thread). */
   isEcsChannel(id: string): boolean {
-    return this.channelIdSet.has(id);
+    return this.channelIdSet.has(id) || this.ecsThreadIds.has(id);
   }
 
   /** Register a callback that fires after every successful post. */
@@ -173,6 +174,7 @@ export class EcsDiscordChannels {
       const thread = (await this.rest.post(Routes.threads(this.channels.info, result.messageId), {
         body: { name: threadName, auto_archive_duration: 1440 },
       })) as { id: string };
+      this.ecsThreadIds.add(thread.id);
       return { ...result, threadId: thread.id };
     } catch {
       // Thread creation failed; return without threadId.

--- a/extensions/ecs/src/persona-registry.ts
+++ b/extensions/ecs/src/persona-registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Active persona tracking (in-memory). Maps session keys to persona names.
+ * Uses globalThis singleton to survive module re-evaluation.
+ */
+
+const PERSONA_REGISTRY = Symbol.for("openclaw.ecsPersonaRegistry");
+type PersonaMap = Map<string, string>;
+type RegistryHolder = { map: PersonaMap };
+
+function getRegistry(): PersonaMap {
+  const g = globalThis as typeof globalThis & { [PERSONA_REGISTRY]?: RegistryHolder };
+  if (!g[PERSONA_REGISTRY]) {
+    g[PERSONA_REGISTRY] = { map: new Map() };
+  }
+  return g[PERSONA_REGISTRY].map;
+}
+
+export function setActivePersona(sessionKey: string, personaName: string): void {
+  getRegistry().set(sessionKey, personaName);
+}
+
+export function getActivePersona(sessionKey: string): string | undefined {
+  return getRegistry().get(sessionKey);
+}
+
+export function clearActivePersona(sessionKey: string): void {
+  getRegistry().delete(sessionKey);
+}
+
+/** Test-only: reset all tracked personas. */
+export const __testing = {
+  clear: () => getRegistry().clear(),
+};

--- a/extensions/ecs/src/persona.ts
+++ b/extensions/ecs/src/persona.ts
@@ -1,0 +1,121 @@
+/**
+ * Persona storage & loading: reads named persona directories from the state dir.
+ * Each persona is a directory under ~/.openclaw/personas/<name>/ containing
+ * workspace doc overrides (SOUL.md, TOOLS.md, AGENTS.md, IDENTITY.md, USER.md).
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+/** Recognized bootstrap filenames that personas may override. */
+const PERSONA_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
+  "AGENTS.md",
+  "SOUL.md",
+  "TOOLS.md",
+  "IDENTITY.md",
+  "USER.md",
+]);
+
+export type PersonaBootstrapFile = {
+  name: string;
+  path: string;
+  content: string;
+  missing: boolean;
+};
+
+function resolveStateDir(env?: NodeJS.ProcessEnv): string {
+  const e = env ?? process.env;
+  return e.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+}
+
+export function resolvePersonasBaseDir(env?: NodeJS.ProcessEnv): string {
+  return path.join(resolveStateDir(env), "personas");
+}
+
+export function resolvePersonaDir(name: string, env?: NodeJS.ProcessEnv): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "-");
+  return path.join(resolvePersonasBaseDir(env), normalized);
+}
+
+export async function listPersonas(env?: NodeJS.ProcessEnv): Promise<string[]> {
+  const baseDir = resolvePersonasBaseDir(env);
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(baseDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const dirPath = path.join(baseDir, entry.name);
+    const files = await fs.readdir(dirPath).catch(() => [] as string[]);
+    if (files.some((f) => f.endsWith(".md"))) {
+      results.push(entry.name);
+    }
+  }
+  return results.toSorted();
+}
+
+export async function loadPersonaBootstrapFiles(
+  name: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<PersonaBootstrapFile[]> {
+  const dir = resolvePersonaDir(name, env);
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const results: PersonaBootstrapFile[] = [];
+  for (const file of files) {
+    if (!PERSONA_BOOTSTRAP_NAMES.has(file)) {
+      continue;
+    }
+    const filePath = path.join(dir, file);
+    try {
+      const content = await fs.readFile(filePath, "utf-8");
+      results.push({
+        name: file,
+        path: filePath,
+        content,
+        missing: false,
+      });
+    } catch {
+      // Skip unreadable files
+    }
+  }
+  return results;
+}
+
+export async function validatePersona(
+  name: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<{ valid: boolean; error?: string }> {
+  const dir = resolvePersonaDir(name, env);
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return { valid: false, error: `Persona directory not found: ${dir}` };
+  }
+
+  const hasMd = files.some((f) => PERSONA_BOOTSTRAP_NAMES.has(f));
+  if (!hasMd) {
+    return {
+      valid: false,
+      error: `Persona "${name}" has no recognized bootstrap files (${[...PERSONA_BOOTSTRAP_NAMES].join(", ")})`,
+    };
+  }
+
+  return { valid: true };
+}

--- a/extensions/ecs/src/project-channel-manager.ts
+++ b/extensions/ecs/src/project-channel-manager.ts
@@ -1,0 +1,252 @@
+/**
+ * Auto-provisions per-project Discord categories + channels for ECS task routing.
+ * Falls back to shared defaults on error or when no projectId is provided.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { RequestClient } from "@buape/carbon";
+import type { EcsDiscordChannelsConfig } from "./config.js";
+
+export type ProjectChannelSet = {
+  projectId: string;
+  categoryId: string;
+  statusChannelId: string;
+  infoChannelId: string;
+  issuesChannelId: string;
+  createdAt: number;
+};
+
+type PersistedData = {
+  projects: Record<string, ProjectChannelSet>;
+};
+
+const DEFAULT_PERSIST_PATH = join(homedir(), ".openclaw", "ecs", "project-channels.json");
+const DEFAULT_MAX_PROJECTS = 100;
+
+// Discord channel types.
+const GUILD_CATEGORY = 4;
+const GUILD_TEXT = 0;
+
+/** Slugify a project ID for Discord channel names. */
+function slugify(projectId: string): string {
+  return projectId
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+}
+
+export class ProjectChannelManager {
+  private rest: RequestClient;
+  private guildId: string;
+  private defaultChannels: EcsDiscordChannelsConfig;
+  private persistPath: string;
+  private maxProjects: number;
+  private configOverrides: Record<string, EcsDiscordChannelsConfig>;
+
+  private projects = new Map<string, ProjectChannelSet>();
+  /** Dedup in-flight provisions: projectId → pending promise. */
+  private inflight = new Map<string, Promise<ProjectChannelSet | null>>();
+
+  private log: (msg: string) => void;
+
+  constructor(
+    rest: RequestClient,
+    guildId: string,
+    defaultChannels: EcsDiscordChannelsConfig,
+    opts?: {
+      persistPath?: string;
+      maxProjects?: number;
+      projectChannels?: Record<string, EcsDiscordChannelsConfig>;
+      log?: (msg: string) => void;
+    },
+  ) {
+    this.rest = rest;
+    this.guildId = guildId;
+    this.defaultChannels = defaultChannels;
+    this.persistPath = opts?.persistPath ?? DEFAULT_PERSIST_PATH;
+    this.maxProjects = opts?.maxProjects ?? DEFAULT_MAX_PROJECTS;
+    this.configOverrides = opts?.projectChannels ?? {};
+    this.log = opts?.log ?? (() => {});
+  }
+
+  /** Load persisted project-channel mappings from disk. */
+  load(): void {
+    try {
+      if (!existsSync(this.persistPath)) return;
+      const raw = readFileSync(this.persistPath, "utf8");
+      const data = JSON.parse(raw) as PersistedData;
+      if (data.projects && typeof data.projects === "object") {
+        for (const [id, set] of Object.entries(data.projects)) {
+          this.projects.set(id, set);
+        }
+      }
+      this.log(`[ecs] loaded ${this.projects.size} project channel mappings`);
+    } catch {
+      // Corrupted JSON or read error — start fresh.
+      this.log("[ecs] project-channels.json corrupted or unreadable, starting fresh");
+    }
+  }
+
+  /** Main routing: resolve channel IDs for a given projectId. */
+  async resolveChannels(projectId?: string): Promise<EcsDiscordChannelsConfig> {
+    if (!projectId) return this.defaultChannels;
+
+    // Config-level overrides take priority.
+    const override = this.configOverrides[projectId];
+    if (override) return override;
+
+    // Already provisioned?
+    const existing = this.projects.get(projectId);
+    if (existing) {
+      return {
+        status: existing.statusChannelId,
+        info: existing.infoChannelId,
+        issues: existing.issuesChannelId,
+      };
+    }
+
+    // Provision new channels.
+    const result = await this.provisionProject(projectId);
+    if (!result) return this.defaultChannels;
+
+    return {
+      status: result.statusChannelId,
+      info: result.infoChannelId,
+      issues: result.issuesChannelId,
+    };
+  }
+
+  /** Deduped provisioning — concurrent callers for the same projectId share one promise. */
+  private provisionProject(projectId: string): Promise<ProjectChannelSet | null> {
+    const existing = this.inflight.get(projectId);
+    if (existing) return existing;
+
+    const promise = this.doProvision(projectId).finally(() => {
+      this.inflight.delete(projectId);
+    });
+    this.inflight.set(projectId, promise);
+    return promise;
+  }
+
+  private async doProvision(projectId: string): Promise<ProjectChannelSet | null> {
+    if (this.projects.size >= this.maxProjects) {
+      this.log(
+        `[ecs] project channel limit (${this.maxProjects}) reached, using defaults for ${projectId}`,
+      );
+      return null;
+    }
+
+    const slug = slugify(projectId);
+    const route = `/guilds/${this.guildId}/channels`;
+
+    try {
+      // Create category.
+      const category = (await this.rest.post(route, {
+        body: { name: `ECS: ${projectId}`, type: GUILD_CATEGORY },
+      })) as { id: string };
+
+      // Create 3 text channels under the category.
+      const [statusCh, infoCh, issuesCh] = (await Promise.all([
+        this.rest.post(route, {
+          body: { name: `ecs-${slug}-status`, type: GUILD_TEXT, parent_id: category.id },
+        }),
+        this.rest.post(route, {
+          body: { name: `ecs-${slug}-info`, type: GUILD_TEXT, parent_id: category.id },
+        }),
+        this.rest.post(route, {
+          body: { name: `ecs-${slug}-issues`, type: GUILD_TEXT, parent_id: category.id },
+        }),
+      ])) as [{ id: string }, { id: string }, { id: string }];
+
+      const channelSet: ProjectChannelSet = {
+        projectId,
+        categoryId: category.id,
+        statusChannelId: statusCh.id,
+        infoChannelId: infoCh.id,
+        issuesChannelId: issuesCh.id,
+        createdAt: Date.now(),
+      };
+
+      this.projects.set(projectId, channelSet);
+      this.persist();
+
+      this.log(
+        `[ecs] provisioned Discord channels for project "${projectId}" (category ${category.id})`,
+      );
+      return channelSet;
+    } catch (err: unknown) {
+      // 403 = missing Manage Channels permission.
+      const status = (err as { status?: number }).status;
+      if (status === 403) {
+        this.log(
+          "[ecs] 403: bot lacks Manage Channels permission — falling back to default channels",
+        );
+      } else {
+        this.log(`[ecs] failed to provision channels for "${projectId}": ${err}`);
+      }
+      return null;
+    }
+  }
+
+  /** Archive a project's channels (rename with [archived] prefix). */
+  async archiveProject(projectId: string): Promise<boolean> {
+    const set = this.projects.get(projectId);
+    if (!set) return false;
+
+    const channelIds = [set.statusChannelId, set.infoChannelId, set.issuesChannelId];
+    try {
+      await Promise.all(
+        channelIds.map((id) =>
+          this.rest.patch(`/channels/${id}`, {
+            body: { name: `archived-${id}` },
+          }),
+        ),
+      );
+      // Also rename category.
+      await this.rest.patch(`/channels/${set.categoryId}`, {
+        body: { name: `[Archived] ECS: ${projectId}` },
+      });
+    } catch (err) {
+      this.log(`[ecs] failed to archive channels for "${projectId}": ${err}`);
+    }
+
+    this.projects.delete(projectId);
+    this.persist();
+    return true;
+  }
+
+  /** All known project channel IDs (for isEcsChannel checks). */
+  getProjectChannelIds(): Set<string> {
+    const ids = new Set<string>();
+    for (const set of this.projects.values()) {
+      ids.add(set.statusChannelId);
+      ids.add(set.infoChannelId);
+      ids.add(set.issuesChannelId);
+    }
+    return ids;
+  }
+
+  /** List all provisioned project mappings. */
+  listProjects(): ProjectChannelSet[] {
+    return [...this.projects.values()];
+  }
+
+  private persist(): void {
+    try {
+      const dir = dirname(this.persistPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      const data: PersistedData = {
+        projects: Object.fromEntries(this.projects),
+      };
+      const tmpPath = this.persistPath + ".tmp";
+      writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+      renameSync(tmpPath, this.persistPath);
+    } catch (err) {
+      this.log(`[ecs] failed to persist project channels: ${err}`);
+    }
+  }
+}

--- a/extensions/ecs/src/question-relay.ts
+++ b/extensions/ecs/src/question-relay.ts
@@ -8,6 +8,7 @@ import type { EcsQuestion, EcsQuestionAnswer } from "./types.js";
 
 export type PendingQuestion = {
   question: EcsQuestion;
+  projectId?: string;
   resolve: (answer: EcsQuestionAnswer | null) => void;
   timeout: ReturnType<typeof setTimeout>;
   threadId: string;
@@ -44,7 +45,11 @@ export class EcsQuestionRelay {
    * Register a pending question and return a Promise that blocks until answered or timed out.
    * The caller should post the question to Discord first and pass the threadId.
    */
-  registerPendingQuestion(question: EcsQuestion, threadId: string): Promise<QuestionResult> {
+  registerPendingQuestion(
+    question: EcsQuestion,
+    threadId: string,
+    projectId?: string,
+  ): Promise<QuestionResult> {
     return new Promise<QuestionResult>((resolve) => {
       const timeoutMs = question.timeoutMs ?? this.defaultTimeoutMs;
 
@@ -54,7 +59,7 @@ export class EcsQuestionRelay {
 
         let escalated = false;
         if (this.escalateOnTimeout) {
-          await this.discord.postQuestionTimeout(question);
+          await this.discord.postQuestionTimeout(question, projectId);
           escalated = true;
         }
 
@@ -67,6 +72,7 @@ export class EcsQuestionRelay {
 
       const entry: PendingQuestion = {
         question,
+        projectId,
         resolve: (qAnswer) => {
           clearTimeout(timeout);
           this.pending.delete(threadId);

--- a/extensions/ecs/src/question-relay.ts
+++ b/extensions/ecs/src/question-relay.ts
@@ -121,6 +121,11 @@ export class EcsQuestionRelay {
     return true;
   }
 
+  /** Reverse-lookup: get the Discord thread ID for a given question ID. */
+  getThreadIdByQuestionId(questionId: string): string | undefined {
+    return this.byQuestionId.get(questionId);
+  }
+
   /** Check if a thread ID has a pending question. */
   hasPending(threadId: string): boolean {
     return this.pending.has(threadId);

--- a/extensions/ecs/src/question-relay.ts
+++ b/extensions/ecs/src/question-relay.ts
@@ -1,0 +1,141 @@
+/**
+ * Blocking Q&A implementation for ECS agent questions.
+ * Maps Discord thread IDs to deferred promises that resolve when an answer arrives.
+ */
+
+import type { EcsDiscordChannels } from "./discord-channels.js";
+import type { EcsQuestion, EcsQuestionAnswer } from "./types.js";
+
+export type PendingQuestion = {
+  question: EcsQuestion;
+  resolve: (answer: EcsQuestionAnswer | null) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  threadId: string;
+};
+
+export type QuestionResult = {
+  answer: string | null;
+  answeredBy?: string;
+  timedOut: boolean;
+  escalatedToIssues: boolean;
+};
+
+export class EcsQuestionRelay {
+  /** Keyed by Discord thread ID. */
+  private pending = new Map<string, PendingQuestion>();
+  /** Keyed by question ID for reverse lookup. */
+  private byQuestionId = new Map<string, string>();
+
+  private discord: EcsDiscordChannels;
+  private defaultTimeoutMs: number;
+  private escalateOnTimeout: boolean;
+
+  constructor(opts: {
+    discord: EcsDiscordChannels;
+    defaultTimeoutMs: number;
+    escalateOnTimeout: boolean;
+  }) {
+    this.discord = opts.discord;
+    this.defaultTimeoutMs = opts.defaultTimeoutMs;
+    this.escalateOnTimeout = opts.escalateOnTimeout;
+  }
+
+  /**
+   * Register a pending question and return a Promise that blocks until answered or timed out.
+   * The caller should post the question to Discord first and pass the threadId.
+   */
+  registerPendingQuestion(question: EcsQuestion, threadId: string): Promise<QuestionResult> {
+    return new Promise<QuestionResult>((resolve) => {
+      const timeoutMs = question.timeoutMs ?? this.defaultTimeoutMs;
+
+      const timeout = setTimeout(async () => {
+        this.pending.delete(threadId);
+        this.byQuestionId.delete(question.questionId);
+
+        let escalated = false;
+        if (this.escalateOnTimeout) {
+          await this.discord.postQuestionTimeout(question);
+          escalated = true;
+        }
+
+        resolve({
+          answer: null,
+          timedOut: true,
+          escalatedToIssues: escalated,
+        });
+      }, timeoutMs);
+
+      const entry: PendingQuestion = {
+        question,
+        resolve: (qAnswer) => {
+          clearTimeout(timeout);
+          this.pending.delete(threadId);
+          this.byQuestionId.delete(question.questionId);
+
+          if (qAnswer) {
+            resolve({
+              answer: qAnswer.answer,
+              answeredBy: qAnswer.answeredBy,
+              timedOut: false,
+              escalatedToIssues: false,
+            });
+          } else {
+            resolve({
+              answer: null,
+              timedOut: false,
+              escalatedToIssues: false,
+            });
+          }
+        },
+        timeout,
+        threadId,
+      };
+
+      this.pending.set(threadId, entry);
+      this.byQuestionId.set(question.questionId, threadId);
+    });
+  }
+
+  /**
+   * Resolve a pending question when a reply is detected in a Discord thread.
+   * Called by the message_received hook when a reply arrives in an ECS info thread.
+   */
+  resolveQuestion(threadId: string, answer: string, answeredBy: string): boolean {
+    const entry = this.pending.get(threadId);
+    if (!entry) {
+      return false;
+    }
+
+    entry.resolve({
+      questionId: entry.question.questionId,
+      answeredBy,
+      answer,
+      timestamp: Date.now(),
+    });
+    return true;
+  }
+
+  /** Check if a thread ID has a pending question. */
+  hasPending(threadId: string): boolean {
+    return this.pending.has(threadId);
+  }
+
+  /** Get the pending question for a thread. */
+  getPending(threadId: string): PendingQuestion | undefined {
+    return this.pending.get(threadId);
+  }
+
+  /** Cancel all pending questions (e.g., on shutdown). */
+  cancelAll(): void {
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timeout);
+      entry.resolve(null);
+    }
+    this.pending.clear();
+    this.byQuestionId.clear();
+  }
+
+  pendingCount(): number {
+    return this.pending.size;
+  }
+}

--- a/extensions/ecs/src/task-dispatcher.ts
+++ b/extensions/ecs/src/task-dispatcher.ts
@@ -7,6 +7,7 @@ import type { SubagentRunResult } from "openclaw/plugin-sdk/ecs";
 import type { EcsApiCallback } from "./api-callback.js";
 import type { EcsDiscordChannels } from "./discord-channels.js";
 import { setActivePersona } from "./persona-registry.js";
+import { loadPersonaBootstrapFiles } from "./persona.js";
 import type { EcsTaskTracker } from "./task-tracker.js";
 import type { EcsTask, EcsTaskAck } from "./types.js";
 
@@ -25,6 +26,18 @@ export type TaskDispatcherDeps = {
   callback: EcsApiCallback;
   subagent: SubagentRunner;
 };
+
+/**
+ * Load persona bootstrap files and format them into a system prompt section.
+ * Falls back to a bare label when the persona directory has no files.
+ */
+export async function buildPersonaSystemPrompt(personaName: string): Promise<string> {
+  const files = await loadPersonaBootstrapFiles(personaName);
+  if (files.length === 0) return `Active persona: ${personaName}`;
+
+  const sections = files.map((f) => `## ${f.name}\n\n${f.content.trim()}`);
+  return `# Persona: ${personaName}\n\n${sections.join("\n\n---\n\n")}`;
+}
 
 /**
  * Build the structured prompt for a spawned ECS agent.
@@ -87,10 +100,14 @@ export async function dispatchEcsTask(
   const sessionKey = `${agentId}-ecs-${task.taskId}`;
 
   try {
+    const extraSystemPrompt = task.persona
+      ? await buildPersonaSystemPrompt(task.persona)
+      : undefined;
+
     const result = await deps.subagent.run({
       sessionKey,
       message: prompt,
-      extraSystemPrompt: task.persona ? `Active persona: ${task.persona}` : undefined,
+      extraSystemPrompt,
       deliver: false, // headless, no external delivery
     });
 

--- a/extensions/ecs/src/task-dispatcher.ts
+++ b/extensions/ecs/src/task-dispatcher.ts
@@ -1,0 +1,131 @@
+/**
+ * Receives a task from the ECS API, spawns a subagent session via the plugin
+ * runtime, and registers tracking.
+ */
+
+import type { SubagentRunResult } from "openclaw/plugin-sdk/ecs";
+import type { EcsApiCallback } from "./api-callback.js";
+import type { EcsDiscordChannels } from "./discord-channels.js";
+import { setActivePersona } from "./persona-registry.js";
+import type { EcsTaskTracker } from "./task-tracker.js";
+import type { EcsTask, EcsTaskAck } from "./types.js";
+
+export type SubagentRunner = {
+  run: (params: {
+    sessionKey: string;
+    message: string;
+    extraSystemPrompt?: string;
+    deliver?: boolean;
+  }) => Promise<SubagentRunResult>;
+};
+
+export type TaskDispatcherDeps = {
+  tracker: EcsTaskTracker;
+  discord: EcsDiscordChannels;
+  callback: EcsApiCallback;
+  subagent: SubagentRunner;
+};
+
+/**
+ * Build the structured prompt for a spawned ECS agent.
+ * Includes task context and ECS tool usage instructions.
+ */
+function buildAgentPrompt(task: EcsTask): string {
+  const lines = [
+    `You are executing ECS Agent Task #${task.taskId}.`,
+    "",
+    `## Task: ${task.title}`,
+    "",
+    task.description,
+    "",
+    "---",
+    "",
+    "## ECS Tools Available",
+    "",
+    "You have three ECS tools available. Use them throughout your work:",
+    "",
+    "1. **ecs_status_update** — Post progress updates (non-blocking).",
+    '   Call this periodically to report your status (e.g., "running", progress %).',
+    "",
+    "2. **ecs_ask_question** — Ask a blocking question when you need clarification.",
+    "   Your execution will pause until an answer is received.",
+    "",
+    "3. **ecs_raise_issue** — Escalate a blocker you cannot resolve.",
+    "",
+    "## Execution Protocol",
+    "",
+    '1. Call `ecs_status_update` with status "running" before you begin work.',
+    "2. Complete the task described above. Work carefully and verify each step.",
+    "3. Call `ecs_status_update` periodically with progress updates.",
+    "4. If blocked, use `ecs_ask_question` or `ecs_raise_issue` as appropriate.",
+    '5. When done, call `ecs_status_update` with status "complete" and a summary.',
+    "",
+    "**Important:** Always report your start and completion via the ECS tools.",
+  ];
+
+  if (task.persona) {
+    lines.push("", `**Active Persona:** ${task.persona}`);
+  }
+
+  if (task.priority === "critical") {
+    lines.push("", "**Priority: CRITICAL** — This task requires immediate attention.");
+  }
+
+  return lines.join("\n");
+}
+
+export async function dispatchEcsTask(
+  task: EcsTask,
+  deps: TaskDispatcherDeps,
+  opts?: {
+    agentId?: string;
+  },
+): Promise<EcsTaskAck> {
+  const prompt = buildAgentPrompt(task);
+  const agentId = task.assignedAgentId ?? opts?.agentId ?? "coding";
+  // Session key format: <agentId>-ecs-<taskId> — the gateway infers agent ID from the prefix.
+  const sessionKey = `${agentId}-ecs-${task.taskId}`;
+
+  try {
+    const result = await deps.subagent.run({
+      sessionKey,
+      message: prompt,
+      extraSystemPrompt: task.persona ? `Active persona: ${task.persona}` : undefined,
+      deliver: false, // headless, no external delivery
+    });
+
+    // Register in tracker.
+    deps.tracker.register(task, sessionKey, result.runId, agentId);
+
+    // Activate persona for this session so the bootstrap hook can overlay files.
+    if (task.persona) {
+      setActivePersona(sessionKey, task.persona);
+    }
+
+    // Report started to ECS control plane.
+    await deps.callback.reportStarted(task.taskId, sessionKey, agentId);
+
+    // Echo task assignment to Discord.
+    const discordResult = await deps.discord.postTaskAssigned(task);
+    if (discordResult.threadId) {
+      deps.tracker.setDiscordThread(task.taskId, discordResult.threadId);
+    }
+
+    return {
+      taskId: task.taskId,
+      status: "accepted",
+      agentSessionKey: sessionKey,
+      runId: result.runId,
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+
+    await deps.callback.reportError(task.taskId, errorMessage);
+
+    return {
+      taskId: task.taskId,
+      status: "rejected",
+      reason: errorMessage,
+    };
+  }
+}

--- a/extensions/ecs/src/task-tracker.ts
+++ b/extensions/ecs/src/task-tracker.ts
@@ -1,0 +1,67 @@
+/** In-memory tracking of active ECS tasks. */
+
+import type { EcsActiveTask, EcsTask, EcsTaskStatus } from "./types.js";
+
+export class EcsTaskTracker {
+  private byTaskId = new Map<string, EcsActiveTask>();
+  private bySessionKey = new Map<string, EcsActiveTask>();
+
+  register(task: EcsTask, sessionKey: string, runId?: string, agentId?: string): EcsActiveTask {
+    const active: EcsActiveTask = {
+      task,
+      sessionKey,
+      runId,
+      agentId,
+      status: "accepted",
+      startedAt: Date.now(),
+    };
+    this.byTaskId.set(task.taskId, active);
+    this.bySessionKey.set(sessionKey, active);
+    return active;
+  }
+
+  getByTaskId(taskId: string): EcsActiveTask | undefined {
+    return this.byTaskId.get(taskId);
+  }
+
+  getBySessionKey(sessionKey: string): EcsActiveTask | undefined {
+    return this.bySessionKey.get(sessionKey);
+  }
+
+  updateStatus(taskId: string, status: EcsTaskStatus): void {
+    const active = this.byTaskId.get(taskId);
+    if (active) {
+      active.status = status;
+      active.lastStatusUpdate = Date.now();
+    }
+  }
+
+  setDiscordThread(taskId: string, threadId: string): void {
+    const active = this.byTaskId.get(taskId);
+    if (active) {
+      active.discordThreadId = threadId;
+    }
+  }
+
+  remove(taskId: string): EcsActiveTask | undefined {
+    const active = this.byTaskId.get(taskId);
+    if (active) {
+      this.byTaskId.delete(taskId);
+      this.bySessionKey.delete(active.sessionKey);
+    }
+    return active;
+  }
+
+  all(): EcsActiveTask[] {
+    return [...this.byTaskId.values()];
+  }
+
+  size(): number {
+    return this.byTaskId.size;
+  }
+
+  clear(): void {
+    this.byTaskId.clear();
+    this.bySessionKey.clear();
+  }
+}

--- a/extensions/ecs/src/tools.ts
+++ b/extensions/ecs/src/tools.ts
@@ -1,0 +1,254 @@
+/**
+ * ECS agent tools: ecs_status_update, ecs_ask_question, ecs_raise_issue, ecs_set_persona.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/ecs";
+import { jsonResult, readStringParam, stringEnum } from "openclaw/plugin-sdk/ecs";
+import type { EcsApiCallback } from "./api-callback.js";
+import type { EcsDiscordChannels } from "./discord-channels.js";
+import { setActivePersona } from "./persona-registry.js";
+import { validatePersona } from "./persona.js";
+import type { EcsQuestionRelay } from "./question-relay.js";
+import type { EcsTaskTracker } from "./task-tracker.js";
+import type { EcsIssueSeverity, EcsQuestion, EcsStatusUpdate, EcsTaskStatus } from "./types.js";
+
+const ECS_TASK_STATUSES = ["accepted", "running", "blocked", "complete", "error"] as const;
+const ECS_ISSUE_SEVERITIES = ["warn", "error", "critical"] as const;
+
+// --- ecs_status_update ---
+
+const EcsStatusUpdateSchema = Type.Object({
+  status: stringEnum(ECS_TASK_STATUSES, {
+    description: "Current task status",
+  }),
+  progressPct: Type.Optional(
+    Type.Number({ minimum: 0, maximum: 100, description: "Progress percentage (0-100)" }),
+  ),
+  summary: Type.String({ description: "Brief summary of current progress" }),
+  details: Type.Optional(Type.String({ description: "Additional details" })),
+});
+
+// --- ecs_ask_question ---
+
+const EcsAskQuestionSchema = Type.Object({
+  question: Type.String({ description: "The question to ask" }),
+  toAgentId: Type.Optional(
+    Type.String({ description: "Target agent ID (omit to ask the coordinator)" }),
+  ),
+  context: Type.Optional(Type.String({ description: "Additional context for the question" })),
+  timeoutMs: Type.Optional(
+    Type.Number({
+      minimum: 5000,
+      maximum: 3_600_000,
+      description: "Timeout in ms before auto-escalation (default: 5min)",
+    }),
+  ),
+});
+
+// --- ecs_raise_issue ---
+
+const EcsRaiseIssueSchema = Type.Object({
+  severity: stringEnum(ECS_ISSUE_SEVERITIES, {
+    description: "Issue severity level",
+  }),
+  title: Type.String({ description: "Short issue title" }),
+  description: Type.String({ description: "Detailed description of the issue" }),
+  attempted: Type.Array(Type.String(), { description: "List of things already attempted" }),
+});
+
+export type EcsToolDeps = {
+  tracker: EcsTaskTracker;
+  discord: EcsDiscordChannels;
+  callback: EcsApiCallback;
+  questionRelay: EcsQuestionRelay;
+};
+
+export type EcsToolContext = {
+  sessionKey?: string;
+  agentId?: string;
+};
+
+export function createEcsStatusUpdateTool(deps: EcsToolDeps, ctx: EcsToolContext): AnyAgentTool {
+  return {
+    label: "ECS",
+    name: "ecs_status_update",
+    description:
+      "Post a progress/status update for the current ECS task. Non-blocking. Updates are echoed to the #ecs-status Discord channel and reported to the ECS control plane.",
+    parameters: EcsStatusUpdateSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const status = readStringParam(params, "status", { required: true }) as EcsTaskStatus;
+      const summary = readStringParam(params, "summary", { required: true });
+      const details = readStringParam(params, "details");
+      const progressPct = typeof params.progressPct === "number" ? params.progressPct : undefined;
+
+      // Find the active task for this session.
+      const active = ctx.sessionKey ? deps.tracker.getBySessionKey(ctx.sessionKey) : undefined;
+      const taskId = active?.task.taskId ?? "unknown";
+
+      // Update tracker.
+      if (active) {
+        deps.tracker.updateStatus(taskId, status);
+      }
+
+      const update: EcsStatusUpdate = {
+        taskId,
+        agentId: ctx.agentId ?? active?.agentId,
+        status,
+        progressPct,
+        summary,
+        details,
+        timestamp: Date.now(),
+      };
+
+      // Post to Discord and callback to ECS (fire-and-forget).
+      const [discordResult] = await Promise.all([
+        deps.discord.postStatusUpdate(update),
+        deps.callback.reportStatus(taskId, summary, {
+          sessionId: ctx.sessionKey,
+          agentId: ctx.agentId,
+        }),
+      ]);
+
+      return jsonResult({
+        posted: true,
+        taskId,
+        status,
+        discordMessageId: discordResult.messageId ?? null,
+      });
+    },
+  };
+}
+
+export function createEcsAskQuestionTool(deps: EcsToolDeps, ctx: EcsToolContext): AnyAgentTool {
+  return {
+    label: "ECS",
+    name: "ecs_ask_question",
+    description:
+      "Ask a blocking question via the #ecs-info Discord channel. Execution suspends until an answer is received or the question times out. On timeout, the question auto-escalates to #ecs-issues.",
+    parameters: EcsAskQuestionSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const questionText = readStringParam(params, "question", { required: true });
+      const toAgentId = readStringParam(params, "toAgentId");
+      const context = readStringParam(params, "context");
+      const timeoutMs = typeof params.timeoutMs === "number" ? params.timeoutMs : undefined;
+
+      const active = ctx.sessionKey ? deps.tracker.getBySessionKey(ctx.sessionKey) : undefined;
+      const taskId = active?.task.taskId ?? "unknown";
+
+      const question: EcsQuestion = {
+        questionId: `q-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        fromAgentId: ctx.agentId,
+        toAgentId,
+        taskId,
+        question: questionText,
+        context,
+        timeoutMs,
+      };
+
+      // Post question to Discord and create thread.
+      const discordResult = await deps.discord.postQuestion(question);
+      const threadId = discordResult.threadId;
+
+      if (!threadId) {
+        return jsonResult({
+          answer: null,
+          timedOut: false,
+          escalatedToIssues: false,
+          error: "Failed to create Discord thread for question",
+        });
+      }
+
+      // Block on the question relay promise.
+      const result = await deps.questionRelay.registerPendingQuestion(question, threadId);
+
+      return jsonResult(result);
+    },
+  };
+}
+
+export function createEcsRaiseIssueTool(deps: EcsToolDeps, ctx: EcsToolContext): AnyAgentTool {
+  return {
+    label: "ECS",
+    name: "ecs_raise_issue",
+    description:
+      "Escalate a blocker or issue to #ecs-issues for human or coordinator intervention. Non-blocking.",
+    parameters: EcsRaiseIssueSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const severity = readStringParam(params, "severity", {
+        required: true,
+      }) as EcsIssueSeverity;
+      const title = readStringParam(params, "title", { required: true });
+      const description = readStringParam(params, "description", { required: true });
+      const attempted = Array.isArray(params.attempted)
+        ? (params.attempted as string[]).map(String)
+        : [];
+
+      const active = ctx.sessionKey ? deps.tracker.getBySessionKey(ctx.sessionKey) : undefined;
+      const taskId = active?.task.taskId ?? "unknown";
+
+      const issue = {
+        issueId: `iss-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        taskId,
+        agentId: ctx.agentId,
+        severity,
+        title,
+        description,
+        attempted,
+        needsHuman: severity === "critical",
+      };
+
+      const discordResult = await deps.discord.postIssue(issue);
+
+      return jsonResult({
+        posted: true,
+        issueId: issue.issueId,
+        taskId,
+        severity,
+        discordMessageId: discordResult.messageId ?? null,
+      });
+    },
+  };
+}
+
+// --- ecs_set_persona ---
+
+const EcsSetPersonaSchema = Type.Object({
+  persona: Type.String({
+    description: "Name of the persona to activate (must exist in ~/.openclaw/personas/)",
+  }),
+});
+
+export function createEcsSetPersonaTool(_deps: EcsToolDeps, ctx: EcsToolContext): AnyAgentTool {
+  return {
+    label: "ECS",
+    name: "ecs_set_persona",
+    description:
+      "Switch this agent's active persona. The persona must exist as a directory under ~/.openclaw/personas/ with at least one recognized .md file. Takes effect on the next bootstrap cycle.",
+    parameters: EcsSetPersonaSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const persona = readStringParam(params, "persona", { required: true });
+
+      if (!ctx.sessionKey) {
+        return jsonResult({ success: false, error: "No session key available" });
+      }
+
+      const validation = await validatePersona(persona);
+      if (!validation.valid) {
+        return jsonResult({ success: false, error: validation.error });
+      }
+
+      setActivePersona(ctx.sessionKey, persona);
+
+      return jsonResult({
+        success: true,
+        persona,
+        sessionKey: ctx.sessionKey,
+      });
+    },
+  };
+}

--- a/extensions/ecs/src/tools.ts
+++ b/extensions/ecs/src/tools.ts
@@ -104,7 +104,7 @@ export function createEcsStatusUpdateTool(deps: EcsToolDeps, ctx: EcsToolContext
 
       // Post to Discord and callback to ECS (fire-and-forget).
       const [discordResult] = await Promise.all([
-        deps.discord.postStatusUpdate(update),
+        deps.discord.postStatusUpdate(update, active?.task.projectId),
         deps.callback.reportStatus(taskId, summary, {
           sessionId: ctx.sessionKey,
           agentId: ctx.agentId,
@@ -149,7 +149,7 @@ export function createEcsAskQuestionTool(deps: EcsToolDeps, ctx: EcsToolContext)
       };
 
       // Post question to Discord and create thread.
-      const discordResult = await deps.discord.postQuestion(question);
+      const discordResult = await deps.discord.postQuestion(question, active?.task.projectId);
       const threadId = discordResult.threadId;
 
       if (!threadId) {
@@ -162,7 +162,11 @@ export function createEcsAskQuestionTool(deps: EcsToolDeps, ctx: EcsToolContext)
       }
 
       // Block on the question relay promise.
-      const result = await deps.questionRelay.registerPendingQuestion(question, threadId);
+      const result = await deps.questionRelay.registerPendingQuestion(
+        question,
+        threadId,
+        active?.task.projectId,
+      );
 
       return jsonResult(result);
     },
@@ -201,7 +205,7 @@ export function createEcsRaiseIssueTool(deps: EcsToolDeps, ctx: EcsToolContext):
         needsHuman: severity === "critical",
       };
 
-      const discordResult = await deps.discord.postIssue(issue);
+      const discordResult = await deps.discord.postIssue(issue, active?.task.projectId);
 
       return jsonResult({
         posted: true,

--- a/extensions/ecs/src/tools.ts
+++ b/extensions/ecs/src/tools.ts
@@ -161,6 +161,19 @@ export function createEcsAskQuestionTool(deps: EcsToolDeps, ctx: EcsToolContext)
         });
       }
 
+      // Fire-and-forget: notify control plane about the question.
+      deps.callback
+        .reportQuestion({
+          question_id: question.questionId,
+          agent_task_id: question.taskId ?? null,
+          question_text: question.question,
+          context: question.context ?? null,
+          asked_by: question.fromAgentId ?? null,
+          discord_thread_id: threadId,
+          discord_channel: "info",
+        })
+        .catch(() => {});
+
       // Block on the question relay promise.
       const result = await deps.questionRelay.registerPendingQuestion(
         question,

--- a/extensions/ecs/src/types.ts
+++ b/extensions/ecs/src/types.ts
@@ -1,0 +1,88 @@
+/** Core ECS type definitions for task management and inter-agent communication. */
+
+export type EcsTaskPriority = "low" | "medium" | "high" | "critical";
+
+export type EcsTaskStatus = "accepted" | "running" | "blocked" | "complete" | "error";
+
+export type EcsIssueSeverity = "warn" | "error" | "critical";
+
+export type EcsTask = {
+  taskId: string;
+  epicId?: string;
+  title: string;
+  description: string;
+  assignedAgentId?: string;
+  dependencies?: string[];
+  priority: EcsTaskPriority;
+  deadline?: string;
+  metadata?: Record<string, unknown>;
+  persona?: string;
+};
+
+export type EcsTaskAck = {
+  taskId: string;
+  status: "accepted" | "rejected";
+  agentSessionKey?: string;
+  runId?: string;
+  reason?: string;
+};
+
+export type EcsTaskCompletion = {
+  taskId: string;
+  agentId?: string;
+  status: "complete" | "error" | "cancelled";
+  summary: string;
+  artifacts?: string[];
+  durationMs: number;
+  threadId?: string;
+};
+
+export type EcsStatusUpdate = {
+  taskId: string;
+  agentId?: string;
+  status: EcsTaskStatus;
+  progressPct?: number;
+  summary: string;
+  details?: string;
+  timestamp: number;
+};
+
+export type EcsQuestion = {
+  questionId: string;
+  fromAgentId?: string;
+  toAgentId?: string;
+  taskId: string;
+  question: string;
+  context?: string;
+  timeoutMs?: number;
+};
+
+export type EcsQuestionAnswer = {
+  questionId: string;
+  answeredBy: string;
+  answer: string;
+  timestamp: number;
+};
+
+export type EcsIssue = {
+  issueId: string;
+  taskId: string;
+  agentId?: string;
+  severity: EcsIssueSeverity;
+  title: string;
+  description: string;
+  attempted: string[];
+  needsHuman: boolean;
+};
+
+/** Runtime tracking state for an active ECS task. */
+export type EcsActiveTask = {
+  task: EcsTask;
+  sessionKey: string;
+  runId?: string;
+  agentId?: string;
+  status: EcsTaskStatus;
+  discordThreadId?: string;
+  startedAt: number;
+  lastStatusUpdate?: number;
+};

--- a/extensions/ecs/src/types.ts
+++ b/extensions/ecs/src/types.ts
@@ -9,6 +9,7 @@ export type EcsIssueSeverity = "warn" | "error" | "critical";
 export type EcsTask = {
   taskId: string;
   epicId?: string;
+  projectId?: string;
   title: string;
   description: string;
   assignedAgentId?: string;

--- a/extensions/ecs/tests/api-handler-answer.test.ts
+++ b/extensions/ecs/tests/api-handler-answer.test.ts
@@ -1,0 +1,135 @@
+import { createServer, type Server } from "node:http";
+import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
+import { createEcsApiHandler, type EcsApiHandlerDeps } from "../src/api-handler.js";
+import { EcsQuestionRelay } from "../src/question-relay.js";
+import { EcsTaskTracker } from "../src/task-tracker.js";
+
+function makeDeps(questionRelay: EcsQuestionRelay): EcsApiHandlerDeps {
+  return {
+    tracker: new EcsTaskTracker(),
+    discord: {} as never,
+    callback: {
+      report: vi.fn().mockResolvedValue({ ok: true }),
+      reportError: vi.fn().mockResolvedValue({ ok: true }),
+    } as never,
+    subagent: {} as never,
+    apiConfig: {},
+    questionRelay,
+  };
+}
+
+function makeRelay(): EcsQuestionRelay {
+  return new EcsQuestionRelay({
+    discord: { postQuestionTimeout: vi.fn() } as never,
+    defaultTimeoutMs: 60_000,
+    escalateOnTimeout: false,
+  });
+}
+
+async function request(
+  port: number,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const resp = await fetch(`http://127.0.0.1:${port}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: resp.status, body: (await resp.json()) as Record<string, unknown> };
+}
+
+describe("POST /ecs/questions/:questionId/answer", () => {
+  let server: Server;
+  let port: number;
+  let relay: EcsQuestionRelay;
+
+  beforeAll(async () => {
+    relay = makeRelay();
+    const handler = createEcsApiHandler(makeDeps(relay));
+    server = createServer((req, res) => {
+      void handler(req, res);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const addr = server.address();
+    port = typeof addr === "object" && addr !== null ? addr.port : 0;
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("returns 400 when answer_text is missing", async () => {
+    const res = await request(port, "/ecs/questions/q-1/answer", {});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("answer_text is required");
+  });
+
+  it("returns 404 for unknown question ID", async () => {
+    const res = await request(port, "/ecs/questions/q-nonexistent/answer", {
+      answer_text: "hello",
+    });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("No pending question with that ID");
+  });
+
+  it("resolves a pending question and returns 200", async () => {
+    // Register a pending question (non-blocking — we'll resolve it via the endpoint).
+    const questionPromise = relay.registerPendingQuestion(
+      {
+        questionId: "q-test-1",
+        question: "What is 2+2?",
+        taskId: "task-1",
+      },
+      "thread-abc",
+    );
+
+    const res = await request(port, "/ecs/questions/q-test-1/answer", {
+      answer_text: "4",
+      answered_by: "human-user",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.questionId).toBe("q-test-1");
+    expect(res.body.status).toBe("resolved");
+
+    // The pending promise should now resolve with the answer.
+    const result = await questionPromise;
+    expect(result.answer).toBe("4");
+    expect(result.answeredBy).toBe("human-user");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("returns 404 when question is already resolved (idempotent)", async () => {
+    // Register and immediately resolve.
+    void relay.registerPendingQuestion({ questionId: "q-test-2", question: "x?" }, "thread-def");
+
+    // First answer succeeds.
+    const first = await request(port, "/ecs/questions/q-test-2/answer", {
+      answer_text: "yes",
+    });
+    expect(first.status).toBe(200);
+
+    // Second answer for same question returns 404 (already resolved).
+    const second = await request(port, "/ecs/questions/q-test-2/answer", {
+      answer_text: "no",
+    });
+    expect(second.status).toBe(404);
+  });
+
+  it("defaults answered_by to 'api' when not provided", async () => {
+    const questionPromise = relay.registerPendingQuestion(
+      { questionId: "q-test-3", question: "default test" },
+      "thread-ghi",
+    );
+
+    await request(port, "/ecs/questions/q-test-3/answer", {
+      answer_text: "answer",
+    });
+
+    const result = await questionPromise;
+    expect(result.answeredBy).toBe("api");
+  });
+});

--- a/extensions/ecs/tests/persona-registry.test.ts
+++ b/extensions/ecs/tests/persona-registry.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __testing,
+  clearActivePersona,
+  getActivePersona,
+  setActivePersona,
+} from "../src/persona-registry.js";
+
+describe("persona-registry", () => {
+  afterEach(() => {
+    __testing.clear();
+  });
+
+  it("set and get persona for a session", () => {
+    setActivePersona("session-1", "js-dev");
+    expect(getActivePersona("session-1")).toBe("js-dev");
+  });
+
+  it("returns undefined for unknown session", () => {
+    expect(getActivePersona("unknown")).toBeUndefined();
+  });
+
+  it("clears persona for a session", () => {
+    setActivePersona("session-1", "ios-dev");
+    clearActivePersona("session-1");
+    expect(getActivePersona("session-1")).toBeUndefined();
+  });
+
+  it("tracks multiple sessions independently", () => {
+    setActivePersona("session-a", "js-dev");
+    setActivePersona("session-b", "ios-dev");
+    expect(getActivePersona("session-a")).toBe("js-dev");
+    expect(getActivePersona("session-b")).toBe("ios-dev");
+  });
+
+  it("overwrites persona for same session", () => {
+    setActivePersona("session-1", "js-dev");
+    setActivePersona("session-1", "ios-dev");
+    expect(getActivePersona("session-1")).toBe("ios-dev");
+  });
+});

--- a/extensions/ecs/tests/persona.test.ts
+++ b/extensions/ecs/tests/persona.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  listPersonas,
+  loadPersonaBootstrapFiles,
+  resolvePersonaDir,
+  resolvePersonasBaseDir,
+  validatePersona,
+} from "../src/persona.js";
+
+describe("persona", () => {
+  let tmpHome: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-persona-test-"));
+    const stateDir = path.join(tmpHome, ".openclaw");
+    await fs.mkdir(stateDir, { recursive: true });
+    env = { OPENCLAW_STATE_DIR: stateDir };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  describe("resolvePersonasBaseDir", () => {
+    it("returns personas dir under state dir", () => {
+      const base = resolvePersonasBaseDir(env);
+      expect(base).toBe(path.join(tmpHome, ".openclaw", "personas"));
+    });
+  });
+
+  describe("resolvePersonaDir", () => {
+    it("normalizes persona name", () => {
+      const dir = resolvePersonaDir("iOS Developer!", env);
+      expect(path.basename(dir)).toBe("ios-developer-");
+    });
+  });
+
+  describe("listPersonas", () => {
+    it("returns empty array when no personas dir", async () => {
+      const result = await listPersonas(env);
+      expect(result).toEqual([]);
+    });
+
+    it("lists directories with .md files", async () => {
+      const baseDir = resolvePersonasBaseDir(env);
+      const personaDir = path.join(baseDir, "js-dev");
+      await fs.mkdir(personaDir, { recursive: true });
+      await fs.writeFile(path.join(personaDir, "SOUL.md"), "You are a JS dev.");
+
+      // Create a dir without .md files (should be excluded)
+      const emptyDir = path.join(baseDir, "empty");
+      await fs.mkdir(emptyDir, { recursive: true });
+      await fs.writeFile(path.join(emptyDir, "notes.txt"), "not a persona");
+
+      const result = await listPersonas(env);
+      expect(result).toEqual(["js-dev"]);
+    });
+  });
+
+  describe("loadPersonaBootstrapFiles", () => {
+    it("loads recognized .md files from persona dir", async () => {
+      const personaDir = resolvePersonaDir("test-persona", env);
+      await fs.mkdir(personaDir, { recursive: true });
+      await fs.writeFile(path.join(personaDir, "SOUL.md"), "soul content");
+      await fs.writeFile(path.join(personaDir, "TOOLS.md"), "tools content");
+      // Non-recognized file should be ignored
+      await fs.writeFile(path.join(personaDir, "NOTES.md"), "ignored");
+
+      const files = await loadPersonaBootstrapFiles("test-persona", env);
+      expect(files).toHaveLength(2);
+      expect(files.map((f) => f.name).toSorted()).toEqual(["SOUL.md", "TOOLS.md"]);
+      expect(files.find((f) => f.name === "SOUL.md")?.content).toBe("soul content");
+      expect(files.every((f) => !f.missing)).toBe(true);
+    });
+
+    it("returns empty array for missing persona", async () => {
+      const files = await loadPersonaBootstrapFiles("nonexistent", env);
+      expect(files).toEqual([]);
+    });
+  });
+
+  describe("validatePersona", () => {
+    it("returns valid for persona with recognized files", async () => {
+      const personaDir = resolvePersonaDir("valid-persona", env);
+      await fs.mkdir(personaDir, { recursive: true });
+      await fs.writeFile(path.join(personaDir, "AGENTS.md"), "agents");
+
+      const result = await validatePersona("valid-persona", env);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("returns invalid for missing directory", async () => {
+      const result = await validatePersona("missing", env);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("not found");
+    });
+
+    it("returns invalid for dir without recognized .md files", async () => {
+      const personaDir = resolvePersonaDir("no-md", env);
+      await fs.mkdir(personaDir, { recursive: true });
+      await fs.writeFile(path.join(personaDir, "README.md"), "not recognized");
+
+      const result = await validatePersona("no-md", env);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("no recognized bootstrap files");
+    });
+  });
+});

--- a/extensions/ecs/tests/plugin.test.ts
+++ b/extensions/ecs/tests/plugin.test.ts
@@ -1,0 +1,158 @@
+import type { OpenClawPluginApi, PluginLogger } from "openclaw/plugin-sdk/ecs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ecsPlugin from "../index.js";
+import { EcsTaskTracker } from "../src/task-tracker.js";
+
+// Mock api-handler to avoid pulling in deep deps.
+vi.mock("../src/api-handler.js", () => ({
+  createEcsApiHandler: () => async () => {},
+}));
+
+function makeLogger(): PluginLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function makeEcsPluginConfig() {
+  return {
+    enabled: true,
+    discord: {
+      guildId: "g-1",
+      channels: { status: "ch-status", info: "ch-info", issues: "ch-issues" },
+    },
+    api: {},
+    controlPlane: {},
+    agents: {},
+  };
+}
+
+type RegisteredHook = {
+  hookName: string;
+  handler: (...args: never[]) => unknown;
+  priority?: number;
+};
+type RegisteredTool = {
+  factory: (ctx: Record<string, unknown>) => unknown;
+  names?: string[];
+  optional?: boolean;
+};
+type RegisteredHttpRoute = {
+  path: string;
+  match?: string;
+  auth?: string;
+  handler: (...args: never[]) => unknown;
+};
+
+function createMockApi(pluginConfig: Record<string, unknown>): {
+  api: OpenClawPluginApi;
+  hooks: RegisteredHook[];
+  tools: RegisteredTool[];
+  httpRoutes: RegisteredHttpRoute[];
+} {
+  const hooks: RegisteredHook[] = [];
+  const tools: RegisteredTool[] = [];
+  const httpRoutes: RegisteredHttpRoute[] = [];
+
+  const api = {
+    id: "ecs",
+    name: "ECS",
+    source: "test",
+    config: {} as Record<string, unknown>,
+    pluginConfig,
+    logger: makeLogger(),
+    runtime: {
+      subagent: {
+        run: vi.fn().mockResolvedValue({ runId: "run-1" }),
+        waitForRun: vi.fn().mockResolvedValue({ status: "ok" }),
+        getSessionMessages: vi.fn().mockResolvedValue({ messages: [] }),
+        deleteSession: vi.fn(),
+      },
+      channel: {},
+    },
+    registerTool: vi.fn((factory: unknown, opts: unknown) => {
+      tools.push({
+        factory: factory as RegisteredTool["factory"],
+        ...(opts as Record<string, unknown>),
+      } as RegisteredTool);
+    }),
+    registerHook: vi.fn(),
+    registerHttpRoute: vi.fn((params: unknown) => {
+      httpRoutes.push(params as RegisteredHttpRoute);
+    }),
+    registerChannel: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerCli: vi.fn(),
+    registerService: vi.fn(),
+    registerProvider: vi.fn(),
+    registerCommand: vi.fn(),
+    registerContextEngine: vi.fn(),
+    resolvePath: vi.fn((p: string) => p),
+    on: vi.fn(
+      (hookName: string, handler: (...args: never[]) => unknown, opts?: { priority?: number }) => {
+        hooks.push({ hookName, handler, priority: opts?.priority });
+      },
+    ),
+  } as unknown as OpenClawPluginApi;
+
+  return { api, hooks, tools, httpRoutes };
+}
+
+describe("ECS plugin registration", () => {
+  it("does not register anything when not enabled", () => {
+    const { api, hooks, tools, httpRoutes } = createMockApi({ enabled: false });
+    ecsPlugin.register(api);
+    expect(hooks).toHaveLength(0);
+    expect(tools).toHaveLength(0);
+    expect(httpRoutes).toHaveLength(0);
+  });
+
+  it("registers hooks, tools, and HTTP route when enabled", () => {
+    const { api, hooks, tools, httpRoutes } = createMockApi(makeEcsPluginConfig());
+    ecsPlugin.register(api);
+
+    // Should register 5 hooks: subagent_ended, message_received, message_sent, gateway_start, subagent_spawned
+    expect(hooks).toHaveLength(5);
+    expect(hooks.map((h) => h.hookName).toSorted()).toEqual([
+      "gateway_start",
+      "message_received",
+      "message_sent",
+      "subagent_ended",
+      "subagent_spawned",
+    ]);
+
+    // Should register 1 tool factory (producing 4 tools).
+    expect(tools).toHaveLength(1);
+    expect(tools[0].names).toEqual([
+      "ecs_status_update",
+      "ecs_ask_question",
+      "ecs_raise_issue",
+      "ecs_set_persona",
+    ]);
+    expect(tools[0].optional).toBe(false);
+
+    // Should register 1 HTTP route.
+    expect(httpRoutes).toHaveLength(1);
+    expect(httpRoutes[0].path).toBe("/ecs");
+    expect(httpRoutes[0].match).toBe("prefix");
+    expect(httpRoutes[0].auth).toBe("plugin");
+  });
+
+  it("tool factory produces tools with session context", () => {
+    const { api, tools } = createMockApi(makeEcsPluginConfig());
+    ecsPlugin.register(api);
+
+    const factory = tools[0].factory;
+    const result = factory({ sessionKey: "sess-1", agentId: "agent-1" }) as { name: string }[];
+    expect(result).toHaveLength(4);
+    expect(result.map((t) => t.name)).toEqual([
+      "ecs_status_update",
+      "ecs_ask_question",
+      "ecs_raise_issue",
+      "ecs_set_persona",
+    ]);
+  });
+});

--- a/extensions/ecs/tests/plugin.test.ts
+++ b/extensions/ecs/tests/plugin.test.ts
@@ -101,6 +101,48 @@ function createMockApi(pluginConfig: Record<string, unknown>): {
   return { api, hooks, tools, httpRoutes };
 }
 
+describe("extractDiscordId (via message hooks)", () => {
+  it("message_received hook strips channel: prefix and forwards ECS messages", async () => {
+    const { api, hooks } = createMockApi(makeEcsPluginConfig());
+    ecsPlugin.register(api);
+
+    const hook = hooks.find((h) => h.hookName === "message_received");
+    expect(hook).toBeDefined();
+
+    // With "channel:" prefix — should match ch-info and forward.
+    await hook!.handler(
+      { content: "test msg", from: "user" } as never,
+      { channelId: "discord", conversationId: "channel:ch-info" } as never,
+    );
+    // No crash = prefix was stripped correctly.
+  });
+
+  it("message_sent hook strips channel: prefix", async () => {
+    const { api, hooks } = createMockApi(makeEcsPluginConfig());
+    ecsPlugin.register(api);
+
+    const hook = hooks.find((h) => h.hookName === "message_sent");
+    expect(hook).toBeDefined();
+
+    await hook!.handler(
+      { content: "reply", success: true } as never,
+      { channelId: "discord", conversationId: "channel:ch-status" } as never,
+    );
+  });
+
+  it("message_received handles raw IDs without prefix", async () => {
+    const { api, hooks } = createMockApi(makeEcsPluginConfig());
+    ecsPlugin.register(api);
+
+    const hook = hooks.find((h) => h.hookName === "message_received");
+
+    await hook!.handler(
+      { content: "raw msg", from: "user" } as never,
+      { channelId: "discord", conversationId: "ch-info" } as never,
+    );
+  });
+});
+
 describe("ECS plugin registration", () => {
   it("does not register anything when not enabled", () => {
     const { api, hooks, tools, httpRoutes } = createMockApi({ enabled: false });

--- a/extensions/ecs/tests/project-channel-manager.test.ts
+++ b/extensions/ecs/tests/project-channel-manager.test.ts
@@ -1,0 +1,302 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EcsDiscordChannelsConfig } from "../src/config.js";
+import { ProjectChannelManager } from "../src/project-channel-manager.js";
+
+const defaultChannels: EcsDiscordChannelsConfig = {
+  status: "default-status-id",
+  info: "default-info-id",
+  issues: "default-issues-id",
+};
+
+let tmpDir: string;
+let persistPath: string;
+let postCalls: { route: string; body: Record<string, unknown> }[];
+let mockRest: { post: ReturnType<typeof vi.fn>; patch: ReturnType<typeof vi.fn> };
+
+function makeMockRest() {
+  let channelCounter = 0;
+  postCalls = [];
+
+  const post = vi.fn(async (route: string, opts: { body: Record<string, unknown> }) => {
+    postCalls.push({ route, body: opts.body });
+    channelCounter++;
+    return { id: `ch-${channelCounter}` };
+  });
+
+  const patch = vi.fn(async () => ({}));
+
+  return { post, patch } as unknown as {
+    post: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeManager(opts?: {
+  maxProjects?: number;
+  projectChannels?: Record<string, EcsDiscordChannelsConfig>;
+}) {
+  return new ProjectChannelManager(mockRest as never, "guild-1", defaultChannels, {
+    persistPath,
+    maxProjects: opts?.maxProjects,
+    projectChannels: opts?.projectChannels,
+    log: () => {},
+  });
+}
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `ecs-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tmpDir, { recursive: true });
+  persistPath = join(tmpDir, "project-channels.json");
+  mockRest = makeMockRest();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("ProjectChannelManager", () => {
+  describe("resolveChannels", () => {
+    it("returns default channels when no projectId", async () => {
+      const manager = makeManager();
+      const result = await manager.resolveChannels();
+      expect(result).toEqual(defaultChannels);
+    });
+
+    it("returns default channels for undefined projectId", async () => {
+      const manager = makeManager();
+      const result = await manager.resolveChannels(undefined);
+      expect(result).toEqual(defaultChannels);
+    });
+
+    it("returns config overrides when present", async () => {
+      const override: EcsDiscordChannelsConfig = {
+        status: "override-status",
+        info: "override-info",
+        issues: "override-issues",
+      };
+      const manager = makeManager({ projectChannels: { "my-project": override } });
+      const result = await manager.resolveChannels("my-project");
+      expect(result).toEqual(override);
+      // No Discord API calls should be made.
+      expect(mockRest.post).not.toHaveBeenCalled();
+    });
+
+    it("provisions new channels for unknown project", async () => {
+      const manager = makeManager();
+      const result = await manager.resolveChannels("alpha");
+
+      // Should have created 1 category + 3 text channels = 4 API calls.
+      expect(mockRest.post).toHaveBeenCalledTimes(4);
+
+      // Category call.
+      expect(postCalls[0].body).toEqual({
+        name: "ECS: alpha",
+        type: 4, // GuildCategory
+      });
+
+      // Text channels under the category.
+      expect(postCalls[1].body).toEqual({
+        name: "ecs-alpha-status",
+        type: 0,
+        parent_id: "ch-1", // category ID
+      });
+      expect(postCalls[2].body).toEqual({
+        name: "ecs-alpha-info",
+        type: 0,
+        parent_id: "ch-1",
+      });
+      expect(postCalls[3].body).toEqual({
+        name: "ecs-alpha-issues",
+        type: 0,
+        parent_id: "ch-1",
+      });
+
+      expect(result).toEqual({
+        status: "ch-2",
+        info: "ch-3",
+        issues: "ch-4",
+      });
+    });
+
+    it("reuses cached channels on second call", async () => {
+      const manager = makeManager();
+      const first = await manager.resolveChannels("alpha");
+      const second = await manager.resolveChannels("alpha");
+
+      expect(first).toEqual(second);
+      // Only 4 calls total (no extra provisioning).
+      expect(mockRest.post).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("concurrency dedup", () => {
+    it("deduplicates concurrent provisions for the same project", async () => {
+      const manager = makeManager();
+      const [r1, r2] = await Promise.all([
+        manager.resolveChannels("beta"),
+        manager.resolveChannels("beta"),
+      ]);
+
+      expect(r1).toEqual(r2);
+      // Should still be only 4 API calls (one provision).
+      expect(mockRest.post).toHaveBeenCalledTimes(4);
+    });
+
+    it("provisions separately for different projects", async () => {
+      const manager = makeManager();
+      const [r1, r2] = await Promise.all([
+        manager.resolveChannels("alpha"),
+        manager.resolveChannels("beta"),
+      ]);
+
+      expect(r1).not.toEqual(r2);
+      // 4 calls per project = 8 total.
+      expect(mockRest.post).toHaveBeenCalledTimes(8);
+    });
+  });
+
+  describe("limit enforcement", () => {
+    it("falls back to defaults when limit is reached", async () => {
+      const manager = makeManager({ maxProjects: 1 });
+
+      // First project succeeds.
+      const first = await manager.resolveChannels("alpha");
+      expect(first.status).toBe("ch-2");
+
+      // Second project hits the limit — falls back to defaults.
+      const second = await manager.resolveChannels("beta");
+      expect(second).toEqual(defaultChannels);
+      // Only 4 API calls from the first project.
+      expect(mockRest.post).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("persistence", () => {
+    it("writes to disk after provisioning", async () => {
+      const manager = makeManager();
+      await manager.resolveChannels("alpha");
+
+      expect(existsSync(persistPath)).toBe(true);
+      const data = JSON.parse(readFileSync(persistPath, "utf8"));
+      expect(data.projects.alpha).toBeDefined();
+      expect(data.projects.alpha.categoryId).toBe("ch-1");
+      expect(data.projects.alpha.statusChannelId).toBe("ch-2");
+    });
+
+    it("loads persisted data on startup", async () => {
+      // Write persisted data.
+      const dir = join(tmpDir);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        persistPath,
+        JSON.stringify({
+          projects: {
+            "saved-proj": {
+              projectId: "saved-proj",
+              categoryId: "cat-1",
+              statusChannelId: "s-1",
+              infoChannelId: "i-1",
+              issuesChannelId: "iss-1",
+              createdAt: 1000,
+            },
+          },
+        }),
+      );
+
+      const manager = makeManager();
+      manager.load();
+
+      const result = await manager.resolveChannels("saved-proj");
+      expect(result).toEqual({ status: "s-1", info: "i-1", issues: "iss-1" });
+      // No API calls — loaded from disk.
+      expect(mockRest.post).not.toHaveBeenCalled();
+    });
+
+    it("handles corrupted JSON gracefully", () => {
+      writeFileSync(persistPath, "not-json{{{");
+      const manager = makeManager();
+      // Should not throw.
+      manager.load();
+      expect(manager.listProjects()).toEqual([]);
+    });
+
+    it("handles missing file gracefully", () => {
+      const manager = makeManager();
+      manager.load();
+      expect(manager.listProjects()).toEqual([]);
+    });
+  });
+
+  describe("error handling", () => {
+    it("falls back to defaults on 403", async () => {
+      const err = new Error("Forbidden") as Error & { status: number };
+      err.status = 403;
+      mockRest.post.mockRejectedValueOnce(err);
+
+      const manager = makeManager();
+      const result = await manager.resolveChannels("locked-project");
+      expect(result).toEqual(defaultChannels);
+    });
+
+    it("falls back to defaults on generic error", async () => {
+      mockRest.post.mockRejectedValueOnce(new Error("Network error"));
+
+      const manager = makeManager();
+      const result = await manager.resolveChannels("broken-project");
+      expect(result).toEqual(defaultChannels);
+    });
+  });
+
+  describe("slugify", () => {
+    it("handles special characters in project names", async () => {
+      const manager = makeManager();
+      await manager.resolveChannels("My Cool Project! v2.0");
+
+      // Check the category name and slugified channel name.
+      expect(postCalls[0].body.name).toBe("ECS: My Cool Project! v2.0");
+      expect(postCalls[1].body.name).toBe("ecs-my-cool-project-v2-0-status");
+    });
+  });
+
+  describe("archiveProject", () => {
+    it("renames channels and removes from memory", async () => {
+      const manager = makeManager();
+      await manager.resolveChannels("alpha");
+      expect(manager.listProjects()).toHaveLength(1);
+
+      const archived = await manager.archiveProject("alpha");
+      expect(archived).toBe(true);
+      expect(manager.listProjects()).toHaveLength(0);
+
+      // Patch calls for 3 channels + 1 category = 4 calls.
+      expect(mockRest.patch).toHaveBeenCalledTimes(4);
+    });
+
+    it("returns false for unknown project", async () => {
+      const manager = makeManager();
+      const result = await manager.archiveProject("nonexistent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getProjectChannelIds", () => {
+    it("returns all provisioned channel IDs", async () => {
+      const manager = makeManager();
+      await manager.resolveChannels("alpha");
+
+      const ids = manager.getProjectChannelIds();
+      expect(ids.size).toBe(3);
+      expect(ids.has("ch-2")).toBe(true); // status
+      expect(ids.has("ch-3")).toBe(true); // info
+      expect(ids.has("ch-4")).toBe(true); // issues
+    });
+
+    it("returns empty set when no projects provisioned", () => {
+      const manager = makeManager();
+      expect(manager.getProjectChannelIds().size).toBe(0);
+    });
+  });
+});

--- a/extensions/ecs/tests/task-dispatcher.test.ts
+++ b/extensions/ecs/tests/task-dispatcher.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPersonaSystemPrompt,
+  dispatchEcsTask,
+  type TaskDispatcherDeps,
+} from "../src/task-dispatcher.js";
+import type { EcsTask } from "../src/types.js";
+
+vi.mock("../src/persona.js", () => ({
+  loadPersonaBootstrapFiles: vi.fn().mockResolvedValue([]),
+}));
+
+// Import the mocked module so we can control return values per test.
+import { loadPersonaBootstrapFiles } from "../src/persona.js";
+const mockLoadFiles = vi.mocked(loadPersonaBootstrapFiles);
+
+function makeTask(overrides?: Partial<EcsTask>): EcsTask {
+  return {
+    taskId: "task-1",
+    title: "Test task",
+    description: "Do the thing",
+    priority: "medium",
+    ...overrides,
+  };
+}
+
+function makeDeps(): TaskDispatcherDeps & { subagentCalls: Record<string, unknown>[] } {
+  const subagentCalls: Record<string, unknown>[] = [];
+  return {
+    subagentCalls,
+    tracker: {
+      register: vi.fn(),
+      setDiscordThread: vi.fn(),
+    } as unknown as TaskDispatcherDeps["tracker"],
+    discord: {
+      postTaskAssigned: vi.fn().mockResolvedValue({}),
+    } as unknown as TaskDispatcherDeps["discord"],
+    callback: {
+      reportStarted: vi.fn().mockResolvedValue(undefined),
+      reportError: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TaskDispatcherDeps["callback"],
+    subagent: {
+      run: vi.fn(async (params: Record<string, unknown>) => {
+        subagentCalls.push(params);
+        return { runId: "run-1" };
+      }),
+    },
+  };
+}
+
+describe("buildPersonaSystemPrompt", () => {
+  it("returns bare label when persona has no files", async () => {
+    mockLoadFiles.mockResolvedValueOnce([]);
+    const result = await buildPersonaSystemPrompt("empty-persona");
+    expect(result).toBe("Active persona: empty-persona");
+  });
+
+  it("formats file contents into a structured prompt", async () => {
+    mockLoadFiles.mockResolvedValueOnce([
+      {
+        name: "IDENTITY.md",
+        path: "/p/IDENTITY.md",
+        content: "You are a specialist.",
+        missing: false,
+      },
+      { name: "TOOLS.md", path: "/p/TOOLS.md", content: "Use xcode-build.", missing: false },
+    ]);
+
+    const result = await buildPersonaSystemPrompt("ios-developer");
+    expect(result).toContain("# Persona: ios-developer");
+    expect(result).toContain("## IDENTITY.md");
+    expect(result).toContain("You are a specialist.");
+    expect(result).toContain("## TOOLS.md");
+    expect(result).toContain("Use xcode-build.");
+    expect(result).toContain("---");
+  });
+
+  it("trims whitespace from file contents", async () => {
+    mockLoadFiles.mockResolvedValueOnce([
+      { name: "SOUL.md", path: "/p/SOUL.md", content: "  padded content  \n\n", missing: false },
+    ]);
+
+    const result = await buildPersonaSystemPrompt("trimmed");
+    expect(result).toContain("padded content");
+    expect(result).not.toContain("  padded content  \n\n");
+  });
+});
+
+describe("dispatchEcsTask persona injection", () => {
+  it("passes extraSystemPrompt with persona file contents", async () => {
+    mockLoadFiles.mockResolvedValueOnce([
+      { name: "IDENTITY.md", path: "/p/IDENTITY.md", content: "iOS expert", missing: false },
+    ]);
+
+    const deps = makeDeps();
+    const task = makeTask({ persona: "ios-developer" });
+    const ack = await dispatchEcsTask(task, deps);
+
+    expect(ack.status).toBe("accepted");
+    expect(deps.subagentCalls).toHaveLength(1);
+    const call = deps.subagentCalls[0];
+    expect(call.extraSystemPrompt).toContain("# Persona: ios-developer");
+    expect(call.extraSystemPrompt).toContain("iOS expert");
+  });
+
+  it("passes undefined extraSystemPrompt when no persona", async () => {
+    const callsBefore = mockLoadFiles.mock.calls.length;
+    const deps = makeDeps();
+    const task = makeTask({ persona: undefined });
+    await dispatchEcsTask(task, deps);
+
+    expect(deps.subagentCalls).toHaveLength(1);
+    expect(deps.subagentCalls[0].extraSystemPrompt).toBeUndefined();
+    // loadPersonaBootstrapFiles should not have been called for this dispatch.
+    expect(mockLoadFiles.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("falls back to bare label when persona dir is empty", async () => {
+    mockLoadFiles.mockResolvedValueOnce([]);
+
+    const deps = makeDeps();
+    const task = makeTask({ persona: "ghost" });
+    await dispatchEcsTask(task, deps);
+
+    expect(deps.subagentCalls).toHaveLength(1);
+    expect(deps.subagentCalls[0].extraSystemPrompt).toBe("Active persona: ghost");
+  });
+});

--- a/extensions/ecs/tests/task-tracker.test.ts
+++ b/extensions/ecs/tests/task-tracker.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { EcsTaskTracker } from "../src/task-tracker.js";
+import type { EcsTask } from "../src/types.js";
+
+function makeTask(id = "task-1"): EcsTask {
+  return {
+    taskId: id,
+    title: "Test task",
+    description: "A test task",
+    priority: "medium",
+  };
+}
+
+describe("EcsTaskTracker", () => {
+  it("registers and retrieves by taskId and sessionKey", () => {
+    const tracker = new EcsTaskTracker();
+    const task = makeTask();
+    const active = tracker.register(task, "sess-1", "run-1", "agent-1");
+
+    expect(active.task).toBe(task);
+    expect(active.sessionKey).toBe("sess-1");
+    expect(active.runId).toBe("run-1");
+    expect(active.agentId).toBe("agent-1");
+    expect(active.status).toBe("accepted");
+    expect(active.startedAt).toBeGreaterThan(0);
+
+    expect(tracker.getByTaskId("task-1")).toBe(active);
+    expect(tracker.getBySessionKey("sess-1")).toBe(active);
+  });
+
+  it("returns undefined for unknown keys", () => {
+    const tracker = new EcsTaskTracker();
+    expect(tracker.getByTaskId("nope")).toBeUndefined();
+    expect(tracker.getBySessionKey("nope")).toBeUndefined();
+  });
+
+  it("updateStatus mutates the active task", () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1");
+
+    tracker.updateStatus("task-1", "running");
+    const active = tracker.getByTaskId("task-1")!;
+    expect(active.status).toBe("running");
+    expect(active.lastStatusUpdate).toBeGreaterThan(0);
+  });
+
+  it("updateStatus is a no-op for unknown taskId", () => {
+    const tracker = new EcsTaskTracker();
+    // Should not throw.
+    tracker.updateStatus("unknown", "error");
+  });
+
+  it("setDiscordThread stores the thread ID", () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1");
+
+    tracker.setDiscordThread("task-1", "thread-abc");
+    expect(tracker.getByTaskId("task-1")!.discordThreadId).toBe("thread-abc");
+  });
+
+  it("remove deletes from both maps", () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1");
+
+    const removed = tracker.remove("task-1");
+    expect(removed).toBeDefined();
+    expect(removed!.task.taskId).toBe("task-1");
+
+    expect(tracker.getByTaskId("task-1")).toBeUndefined();
+    expect(tracker.getBySessionKey("sess-1")).toBeUndefined();
+    expect(tracker.size()).toBe(0);
+  });
+
+  it("remove returns undefined for unknown taskId", () => {
+    const tracker = new EcsTaskTracker();
+    expect(tracker.remove("nope")).toBeUndefined();
+  });
+
+  it("all() returns all active tasks", () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask("t-1"), "s-1");
+    tracker.register(makeTask("t-2"), "s-2");
+
+    const all = tracker.all();
+    expect(all).toHaveLength(2);
+    expect(all.map((a) => a.task.taskId).toSorted()).toEqual(["t-1", "t-2"]);
+  });
+
+  it("clear() empties the tracker", () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask("t-1"), "s-1");
+    tracker.register(makeTask("t-2"), "s-2");
+
+    tracker.clear();
+    expect(tracker.size()).toBe(0);
+    expect(tracker.all()).toEqual([]);
+  });
+
+  it("tracks multiple tasks independently", () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask("t-1"), "s-1", undefined, "agent-a");
+    tracker.register(makeTask("t-2"), "s-2", undefined, "agent-b");
+
+    tracker.updateStatus("t-1", "running");
+    tracker.updateStatus("t-2", "error");
+
+    expect(tracker.getByTaskId("t-1")!.status).toBe("running");
+    expect(tracker.getByTaskId("t-2")!.status).toBe("error");
+
+    tracker.remove("t-1");
+    expect(tracker.size()).toBe(1);
+    expect(tracker.getBySessionKey("s-2")).toBeDefined();
+  });
+});

--- a/extensions/ecs/tests/tools.test.ts
+++ b/extensions/ecs/tests/tools.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { EcsTaskTracker } from "../src/task-tracker.js";
+import {
+  createEcsAskQuestionTool,
+  createEcsRaiseIssueTool,
+  createEcsStatusUpdateTool,
+  type EcsToolDeps,
+} from "../src/tools.js";
+import type { EcsTask } from "../src/types.js";
+
+// Store mock references at the top level so lint's unbound-method rule is satisfied.
+const mocks = {
+  postStatusUpdate: vi.fn().mockResolvedValue({ messageId: "msg-1" }),
+  postQuestion: vi.fn().mockResolvedValue({ messageId: "msg-1", threadId: "thread-1" }),
+  postIssue: vi.fn().mockResolvedValue({ messageId: "msg-1" }),
+  reportStatus: vi.fn().mockResolvedValue({ ok: true }),
+  reportCompleted: vi.fn().mockResolvedValue({ ok: true }),
+  reportError: vi.fn().mockResolvedValue({ ok: true }),
+  registerPendingQuestion: vi.fn().mockResolvedValue({
+    answer: "42",
+    answeredBy: "human",
+    timedOut: false,
+    escalatedToIssues: false,
+  }),
+};
+
+function makeDeps(tracker?: EcsTaskTracker): EcsToolDeps {
+  // Reset all mocks between calls.
+  for (const m of Object.values(mocks)) {
+    m.mockClear();
+  }
+
+  return {
+    tracker: tracker ?? new EcsTaskTracker(),
+    discord: {
+      postStatusUpdate: mocks.postStatusUpdate,
+      postQuestion: mocks.postQuestion,
+      postIssue: mocks.postIssue,
+    } as never,
+    callback: {
+      reportStatus: mocks.reportStatus,
+      reportCompleted: mocks.reportCompleted,
+      reportError: mocks.reportError,
+    } as never,
+    questionRelay: {
+      registerPendingQuestion: mocks.registerPendingQuestion,
+    } as never,
+  };
+}
+
+function makeTask(id = "task-1"): EcsTask {
+  return {
+    taskId: id,
+    title: "Test task",
+    description: "A test task",
+    priority: "medium",
+  };
+}
+
+function parseResult(result: { content: { type: string; text: string }[] }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("ecs_status_update", () => {
+  it("posts status for an active ECS task", async () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1", undefined, "agent-1");
+    const deps = makeDeps(tracker);
+
+    const tool = createEcsStatusUpdateTool(deps, { sessionKey: "sess-1", agentId: "agent-1" });
+    const result = await tool.execute("call-1", {
+      status: "running",
+      summary: "Working on it",
+      progressPct: 50,
+    });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.posted).toBe(true);
+    expect(parsed.taskId).toBe("task-1");
+    expect(parsed.status).toBe("running");
+    expect(mocks.postStatusUpdate).toHaveBeenCalled();
+    expect(mocks.reportStatus).toHaveBeenCalled();
+
+    // Tracker should be updated.
+    expect(tracker.getByTaskId("task-1")!.status).toBe("running");
+  });
+
+  it("gracefully handles no active ECS task (non-ECS session)", async () => {
+    const deps = makeDeps();
+    const tool = createEcsStatusUpdateTool(deps, { sessionKey: "no-task" });
+
+    const result = await tool.execute("call-1", {
+      status: "running",
+      summary: "Just checking",
+    });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.posted).toBe(true);
+    expect(parsed.taskId).toBe("unknown");
+  });
+
+  it("gracefully handles undefined sessionKey", async () => {
+    const deps = makeDeps();
+    const tool = createEcsStatusUpdateTool(deps, {});
+
+    const result = await tool.execute("call-1", {
+      status: "accepted",
+      summary: "No session",
+    });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.taskId).toBe("unknown");
+  });
+});
+
+describe("ecs_ask_question", () => {
+  it("posts a question and returns the relay result", async () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1");
+    const deps = makeDeps(tracker);
+
+    const tool = createEcsAskQuestionTool(deps, { sessionKey: "sess-1", agentId: "agent-1" });
+    const result = await tool.execute("call-1", {
+      question: "What color is the sky?",
+    });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.answer).toBe("42");
+    expect(parsed.timedOut).toBe(false);
+    expect(mocks.postQuestion).toHaveBeenCalled();
+    expect(mocks.registerPendingQuestion).toHaveBeenCalled();
+  });
+
+  it("returns error when thread creation fails", async () => {
+    const deps = makeDeps();
+    mocks.postQuestion.mockResolvedValue({});
+
+    const tool = createEcsAskQuestionTool(deps, { sessionKey: "sess-1" });
+    const result = await tool.execute("call-1", { question: "Help?" });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.answer).toBeNull();
+    expect(parsed.error).toContain("Failed to create Discord thread");
+  });
+});
+
+describe("ecs_raise_issue", () => {
+  it("posts an issue to Discord", async () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1");
+    const deps = makeDeps(tracker);
+
+    const tool = createEcsRaiseIssueTool(deps, { sessionKey: "sess-1", agentId: "agent-1" });
+    const result = await tool.execute("call-1", {
+      severity: "error",
+      title: "Build failed",
+      description: "npm run build exits with code 1",
+      attempted: ["cleared cache", "reinstalled deps"],
+    });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.posted).toBe(true);
+    expect(parsed.taskId).toBe("task-1");
+    expect(parsed.severity).toBe("error");
+    expect(mocks.postIssue).toHaveBeenCalled();
+  });
+
+  it("uses 'unknown' taskId when no active task", async () => {
+    const deps = makeDeps();
+    const tool = createEcsRaiseIssueTool(deps, {});
+
+    const result = await tool.execute("call-1", {
+      severity: "warn",
+      title: "Minor issue",
+      description: "Something odd",
+      attempted: [],
+    });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.taskId).toBe("unknown");
+  });
+});

--- a/extensions/ecs/tests/tools.test.ts
+++ b/extensions/ecs/tests/tools.test.ts
@@ -16,6 +16,7 @@ const mocks = {
   reportStatus: vi.fn().mockResolvedValue({ ok: true }),
   reportCompleted: vi.fn().mockResolvedValue({ ok: true }),
   reportError: vi.fn().mockResolvedValue({ ok: true }),
+  reportQuestion: vi.fn().mockResolvedValue({ ok: true }),
   registerPendingQuestion: vi.fn().mockResolvedValue({
     answer: "42",
     answeredBy: "human",
@@ -41,6 +42,7 @@ function makeDeps(tracker?: EcsTaskTracker): EcsToolDeps {
       reportStatus: mocks.reportStatus,
       reportCompleted: mocks.reportCompleted,
       reportError: mocks.reportError,
+      reportQuestion: mocks.reportQuestion,
     } as never,
     questionRelay: {
       registerPendingQuestion: mocks.registerPendingQuestion,
@@ -129,6 +131,38 @@ describe("ecs_ask_question", () => {
     expect(parsed.timedOut).toBe(false);
     expect(mocks.postQuestion).toHaveBeenCalled();
     expect(mocks.registerPendingQuestion).toHaveBeenCalled();
+  });
+
+  it("fires reportQuestion callback after Discord post", async () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1");
+    const deps = makeDeps(tracker);
+
+    const tool = createEcsAskQuestionTool(deps, { sessionKey: "sess-1", agentId: "agent-1" });
+    await tool.execute("call-1", { question: "What color is the sky?" });
+
+    expect(mocks.reportQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question_text: "What color is the sky?",
+        agent_task_id: "task-1",
+        asked_by: "agent-1",
+        discord_thread_id: "thread-1",
+        discord_channel: "info",
+      }),
+    );
+  });
+
+  it("does not block when reportQuestion fails", async () => {
+    const tracker = new EcsTaskTracker();
+    tracker.register(makeTask(), "sess-1");
+    const deps = makeDeps(tracker);
+    mocks.reportQuestion.mockRejectedValue(new Error("network error"));
+
+    const tool = createEcsAskQuestionTool(deps, { sessionKey: "sess-1" });
+    const result = await tool.execute("call-1", { question: "Help?" });
+
+    const parsed = parseResult(result as never) as Record<string, unknown>;
+    expect(parsed.answer).toBe("42");
   });
 
   it("returns error when thread creation fails", async () => {

--- a/package.json
+++ b/package.json
@@ -212,6 +212,10 @@
       "types": "./dist/plugin-sdk/keyed-async-queue.d.ts",
       "default": "./dist/plugin-sdk/keyed-async-queue.js"
     },
+    "./plugin-sdk/ecs": {
+      "types": "./dist/plugin-sdk/ecs.d.ts",
+      "default": "./dist/plugin-sdk/ecs.js"
+    },
     "./cli-entry": "./openclaw.mjs"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,18 @@ importers:
 
   extensions/discord: {}
 
+  extensions/ecs:
+    dependencies:
+      '@buape/carbon':
+        specifier: 0.0.0-beta-20260216184201
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+      discord-api-types:
+        specifier: ^0.38.41
+        version: 0.38.41
+
   extensions/feishu:
     dependencies:
       '@larksuiteoapi/node-sdk':
@@ -4131,9 +4143,6 @@ packages:
 
   discord-api-types@0.38.37:
     resolution: {integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==}
-
-  discord-api-types@0.38.40:
-    resolution: {integrity: sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ==}
 
   discord-api-types@0.38.41:
     resolution: {integrity: sha512-yMECyR8j9c2fVTvCQ+Qc24pweYFIZk/XoxDOmt1UvPeSw5tK6gXBd/2hhP+FEAe9Y6ny8pRMaf618XDK4U53OQ==}
@@ -11053,8 +11062,6 @@ snapshots:
 
   discord-api-types@0.38.37: {}
 
-  discord-api-types@0.38.40: {}
-
   discord-api-types@0.38.41: {}
 
   doctypes@1.1.0: {}
@@ -12529,7 +12536,7 @@ snapshots:
       cli-highlight: 2.1.11
       commander: 14.0.3
       croner: 10.0.1
-      discord-api-types: 0.38.40
+      discord-api-types: 0.38.41
       dotenv: 17.3.1
       express: 5.2.1
       file-type: 21.3.0

--- a/scripts/deploy-miniclaw.sh
+++ b/scripts/deploy-miniclaw.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Deploy openclaw to the Mac Mini (miniclaw).
+#
+# Builds locally, rsyncs dist + deps to the openclaw user's repo,
+# and restarts the gateway. No git pull on the remote needed.
+#
+# Usage: scripts/deploy-miniclaw.sh [--skip-build] [--skip-restart]
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE_HOST="miniclaw"
+REMOTE_USER="openclaw"
+REMOTE_DIR="/Users/${REMOTE_USER}/projects/openclaw-ecs"
+
+SKIP_BUILD=0
+SKIP_RESTART=0
+
+for arg in "$@"; do
+  case "${arg}" in
+    --skip-build)   SKIP_BUILD=1 ;;
+    --skip-restart) SKIP_RESTART=1 ;;
+    --help|-h)
+      echo "Usage: $(basename "$0") [--skip-build] [--skip-restart]"
+      echo "  --skip-build    Skip local build, rsync existing dist/"
+      echo "  --skip-restart  Deploy files but don't restart the gateway"
+      exit 0
+      ;;
+  esac
+done
+
+log() { printf '==> %s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+cd "${ROOT_DIR}"
+
+# 1) Build locally
+if [[ "${SKIP_BUILD}" -eq 0 ]]; then
+  log "Building locally"
+  pnpm build
+else
+  log "Skipping build (--skip-build)"
+fi
+
+[[ -f dist/entry.js ]] || fail "dist/entry.js not found — run pnpm build first"
+
+# 2) Rsync to remote
+log "Syncing to ${REMOTE_HOST}:${REMOTE_DIR}"
+rsync -az --delete \
+  --rsync-path="sudo rsync" \
+  dist/ \
+  "${REMOTE_HOST}:${REMOTE_DIR}/dist/"
+
+rsync -az --delete \
+  --rsync-path="sudo rsync" \
+  node_modules/ \
+  "${REMOTE_HOST}:${REMOTE_DIR}/node_modules/"
+
+rsync -az --delete \
+  --rsync-path="sudo rsync" \
+  extensions/ \
+  "${REMOTE_HOST}:${REMOTE_DIR}/extensions/"
+
+# Sync essential root files
+rsync -az \
+  --rsync-path="sudo rsync" \
+  package.json openclaw.mjs pnpm-lock.yaml pnpm-workspace.yaml \
+  "${REMOTE_HOST}:${REMOTE_DIR}/"
+
+# Fix ownership back to openclaw user
+ssh "${REMOTE_HOST}" "sudo chown -R ${REMOTE_USER}:staff ${REMOTE_DIR}/dist ${REMOTE_DIR}/node_modules ${REMOTE_DIR}/extensions ${REMOTE_DIR}/package.json ${REMOTE_DIR}/openclaw.mjs ${REMOTE_DIR}/pnpm-lock.yaml ${REMOTE_DIR}/pnpm-workspace.yaml"
+
+log "Sync complete"
+
+# 3) Restart gateway
+# The OpenClaw Mac app auto-respawns the gateway when killed (PPID=1).
+# We just need to kill the old process and let the Mac app restart it
+# with the newly synced dist. No manual start needed.
+if [[ "${SKIP_RESTART}" -eq 0 ]]; then
+  log "Restarting gateway on ${REMOTE_HOST} (kill + let Mac app respawn)"
+  ssh "${REMOTE_HOST}" "sudo kill -9 \$(lsof -iTCP:18789 -sTCP:LISTEN -t 2>/dev/null) 2>/dev/null || true"
+
+  # Wait for the Mac app to respawn the gateway
+  sleep 8
+  log "Verifying gateway"
+  ssh "${REMOTE_HOST}" "
+    if lsof -iTCP:18789 -sTCP:LISTEN >/dev/null 2>&1; then
+      echo \"OK: gateway listening on port 18789\"
+    else
+      echo \"WARN: gateway not yet listening on 18789\"
+      echo \"The Mac app may need a moment to respawn, or check the app is running.\"
+    fi
+  "
+else
+  log "Skipping restart (--skip-restart)"
+fi
+
+log "Deploy complete"

--- a/scripts/ecs-callback-server.ts
+++ b/scripts/ecs-callback-server.ts
@@ -1,0 +1,63 @@
+/**
+ * Simple ECS callback listener.
+ * Receives task status updates from miniclaw's OpenClaw gateway.
+ *
+ * Usage: npx tsx scripts/ecs-callback-server.ts
+ * Listens on port 18800 by default.
+ */
+
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.ECS_CALLBACK_PORT ?? 18800);
+const SECRET =
+  process.env.OPENCLAW_CALLBACK_SECRET ??
+  "4215429347a2403618f0893f0057c480f6a726ea736ef62e54b825faadf60a50";
+
+const server = createServer(async (req, res) => {
+  if (req.method === "POST" && req.url === "/agent_task_callback") {
+    // Auth check
+    const authHeader = req.headers.authorization ?? "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    if (token !== SECRET) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+
+    // Read body
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+    // Log the callback
+    const timestamp = new Date().toISOString();
+    const event = body.event ?? "unknown";
+    const taskId = body.agent_task_id ?? "?";
+    const summary = body.result?.summary ?? body.error ?? body.output ?? "";
+
+    console.log(`\n[${timestamp}] ECS Callback: ${event.toUpperCase()}`);
+    console.log(`  Task: ${taskId}`);
+    if (body.agent_id) {
+      console.log(`  Agent: ${body.agent_id}`);
+    }
+    if (body.session_id) {
+      console.log(`  Session: ${body.session_id}`);
+    }
+    if (summary) {
+      console.log(`  Detail: ${summary}`);
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  } else {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+  }
+});
+
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`ECS callback server listening on http://0.0.0.0:${PORT}/agent_task_callback`);
+  console.log(`Waiting for callbacks from miniclaw...`);
+});

--- a/src/plugin-sdk/ecs.ts
+++ b/src/plugin-sdk/ecs.ts
@@ -1,0 +1,12 @@
+// Narrow plugin-sdk surface for the ECS extension plugin.
+// Keep this list additive and scoped to symbols used under extensions/ecs.
+
+export type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginConfigSchema,
+  PluginLogger,
+} from "../plugins/types.js";
+export type { SubagentRunResult } from "../plugins/runtime/types.js";
+export { jsonResult, readStringParam } from "../agents/tools/common.js";
+export { stringEnum } from "../agents/schema/typebox.js";

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -177,6 +177,7 @@ const pluginSdkScopedAliasEntries = [
     srcFile: "keyed-async-queue.ts",
     distFile: "keyed-async-queue.js",
   },
+  { subpath: "ecs", srcFile: "ecs.ts", distFile: "ecs.js" },
 ] as const;
 
 const resolvePluginSdkScopedAliasMap = (): Record<string, string> => {

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -55,6 +55,7 @@
     "src/plugin-sdk/voice-call.ts",
     "src/plugin-sdk/zalo.ts",
     "src/plugin-sdk/zalouser.ts",
+    "src/plugin-sdk/ecs.ts",
     "src/types/**/*.d.ts"
   ],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"]

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -49,6 +49,7 @@ const pluginSdkEntrypoints = [
   "zalouser",
   "account-id",
   "keyed-async-queue",
+  "ecs",
 ] as const;
 
 export default defineConfig([

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ const pluginSdkSubpaths = [
   "zalo",
   "zalouser",
   "keyed-async-queue",
+  "ecs",
 ] as const;
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Adds the ECS (Execution Control System) extension plugin: inter-agent task orchestration via Discord with control plane callbacks
- Plugin-SDK `/ecs` subpath with typed tool schemas, task dispatcher, question relay, and project channel routing
- HTTP API for task assignment, status polling, cancellation, project management, and question answering
- Blocking Q&A via Discord threads with timeout escalation and HTTP answer delivery
- Fire-and-forget question inbox callback to the ECS control plane
- Per-agent persona injection and switching
- Full test coverage for tools, task tracker, dispatcher, question relay, persona, project channels, and API answer endpoint

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test -- extensions/ecs` — 69 tests pass across 8 test files
- [ ] Deploy to miniclaw and verify gateway starts with ECS plugin enabled
- [ ] POST /ecs/tasks assigns and dispatches a task
- [ ] POST /ecs/questions/:id/answer resolves a pending agent question

🤖 Generated with [Claude Code](https://claude.com/claude-code)