### PR TITLE
fix(telegram): allow fallback models in /model validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/main-session routing: keep TUI and other `mode:UI` main-session sends on the internal surface when `deliver` is enabled, so replies no longer inherit the session's persisted Telegram/WhatsApp route. (#43918) Thanks @obviyus.
 - Doctor/gateway service audit: canonicalize service entrypoint paths before comparing them so symlink-vs-realpath installs no longer trigger false "entrypoint does not match the current install" repair prompts. (#43882) Thanks @ngutman.
 - Doctor/gateway service audit: earlier groundwork for this fix landed in the superseded #28338 branch. Thanks @realriphub.
+- Telegram/model picker: make inline model button selections persist the chosen session model correctly, clear overrides when selecting the configured default, and include effective fallback models in `/models` button validation. (#40105) Thanks @avirweb.
 
 ## 2026.3.11
 
@@ -204,6 +205,7 @@ Docs: https://docs.openclaw.ai
 - macOS Talk Mode: set the speech recognition request `taskHint` to `.dictation` for mic capture, and add regression coverage for the request defaults. (#38445) Thanks @dmiv.
 - macOS release packaging: default `scripts/package-mac-app.sh` to universal binaries for `BUILD_CONFIG=release`, and clarify that `scripts/package-mac-dist.sh` already produces the release zip + DMG. (#33891) Thanks @cgdusek.
 - Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
+  <<<<<<< HEAD
 - Sessions/model switch: clear stale cached `contextTokens` when a session changes models so status and runtime paths recompute against the active model window. (#38044) thanks @yuweuii.
 - ACP/session history: persist transcripts for successful ACP child runs, preserve exact transcript text, record ACP spawned-session lineage, and keep spawn-time transcript-path persistence best-effort so history storage failures do not block execution. (#40137) thanks @mbelinky.
 - Docs/browser: add a layered WSL2 + Windows remote Chrome CDP troubleshooting guide, including Control UI origin pitfalls and extension-relay bind-address guidance. (#39407) Thanks @Owlock.
@@ -233,7 +235,9 @@ Docs: https://docs.openclaw.ai
 - macOS/browser proxy: serialize non-GET browser proxy request bodies through `AnyCodable.foundationValue` so nested JSON bodies no longer crash the macOS app with `Invalid type in JSON write (__SwiftValue)`. (#43069) Thanks @Effet.
 - CLI/skills tables: keep terminal table borders aligned for wide graphemes, use full reported terminal width, and switch a few ambiguous skill icons to Terminal-safe emoji so `openclaw skills` renders more consistently in Terminal.app and iTerm. Thanks @vincentkoc.
 - Memory/Gemini: normalize returned Gemini embeddings across direct query, direct batch, and async batch paths so memory search uses consistent vector handling for Gemini too. (#43409) Thanks @gumadeiras.
-- Agents/failover: recognize additional serialized network errno strings plus `EHOSTDOWN` and `EPIPE` structured codes so transient transport failures trigger timeout failover more reliably. (#42830) Thanks @jnMetaCode.
+- # Agents/failover: recognize additional serialized network errno strings plus `EHOSTDOWN` and `EPIPE` structured codes so transient transport failures trigger timeout failover more reliably. (#42830) Thanks @jnMetaCode.
+- Telegram/model picker: make inline model button selections persist the chosen session model correctly, clear overrides when selecting the configured default, and include effective fallback models in `/models` button validation. (#40105) Thanks @avirweb.
+  > > > > > > > 5b3994705 (fix(telegram): align model picker overrides and fallback allowlists)
 
 ## 2026.3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,6 @@ Docs: https://docs.openclaw.ai
 - macOS Talk Mode: set the speech recognition request `taskHint` to `.dictation` for mic capture, and add regression coverage for the request defaults. (#38445) Thanks @dmiv.
 - macOS release packaging: default `scripts/package-mac-app.sh` to universal binaries for `BUILD_CONFIG=release`, and clarify that `scripts/package-mac-dist.sh` already produces the release zip + DMG. (#33891) Thanks @cgdusek.
 - Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
-  <<<<<<< HEAD
 - Sessions/model switch: clear stale cached `contextTokens` when a session changes models so status and runtime paths recompute against the active model window. (#38044) thanks @yuweuii.
 - ACP/session history: persist transcripts for successful ACP child runs, preserve exact transcript text, record ACP spawned-session lineage, and keep spawn-time transcript-path persistence best-effort so history storage failures do not block execution. (#40137) thanks @mbelinky.
 - Docs/browser: add a layered WSL2 + Windows remote Chrome CDP troubleshooting guide, including Control UI origin pitfalls and extension-relay bind-address guidance. (#39407) Thanks @Owlock.
@@ -235,9 +234,8 @@ Docs: https://docs.openclaw.ai
 - macOS/browser proxy: serialize non-GET browser proxy request bodies through `AnyCodable.foundationValue` so nested JSON bodies no longer crash the macOS app with `Invalid type in JSON write (__SwiftValue)`. (#43069) Thanks @Effet.
 - CLI/skills tables: keep terminal table borders aligned for wide graphemes, use full reported terminal width, and switch a few ambiguous skill icons to Terminal-safe emoji so `openclaw skills` renders more consistently in Terminal.app and iTerm. Thanks @vincentkoc.
 - Memory/Gemini: normalize returned Gemini embeddings across direct query, direct batch, and async batch paths so memory search uses consistent vector handling for Gemini too. (#43409) Thanks @gumadeiras.
-- # Agents/failover: recognize additional serialized network errno strings plus `EHOSTDOWN` and `EPIPE` structured codes so transient transport failures trigger timeout failover more reliably. (#42830) Thanks @jnMetaCode.
+- Agents/failover: recognize additional serialized network errno strings plus `EHOSTDOWN` and `EPIPE` structured codes so transient transport failures trigger timeout failover more reliably. (#42830) Thanks @jnMetaCode.
 - Telegram/model picker: make inline model button selections persist the chosen session model correctly, clear overrides when selecting the configured default, and include effective fallback models in `/models` button validation. (#40105) Thanks @avirweb.
-  > > > > > > > 5b3994705 (fix(telegram): align model picker overrides and fallback allowlists)
 
 ## 2026.3.7
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -322,6 +322,60 @@ describe("model-selection", () => {
         { provider: "anthropic", id: "claude-sonnet-4-6", name: "claude-sonnet-4-6" },
       ]);
     });
+
+    it("includes fallback models in allowed set", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-4o": {},
+            },
+            model: {
+              primary: "openai/gpt-4o",
+              fallbacks: ["anthropic/claude-sonnet-4-6", "google/gemini-3-pro"],
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [],
+        defaultProvider: "openai",
+        defaultModel: "gpt-4o",
+      });
+
+      expect(result.allowedKeys.has("openai/gpt-4o")).toBe(true);
+      expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(true);
+      expect(result.allowedKeys.has("google/gemini-3-pro-preview")).toBe(true);
+      expect(result.allowAny).toBe(false);
+    });
+
+    it("handles empty fallbacks gracefully", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-4o": {},
+            },
+            model: {
+              primary: "openai/gpt-4o",
+              fallbacks: [],
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [],
+        defaultProvider: "openai",
+        defaultModel: "gpt-4o",
+      });
+
+      expect(result.allowedKeys.has("openai/gpt-4o")).toBe(true);
+      expect(result.allowAny).toBe(false);
+    });
   });
 
   describe("resolveAllowedModelRef", () => {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -376,6 +376,44 @@ describe("model-selection", () => {
       expect(result.allowedKeys.has("openai/gpt-4o")).toBe(true);
       expect(result.allowAny).toBe(false);
     });
+
+    it("prefers per-agent fallback overrides when agentId is provided", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-4o": {},
+            },
+            model: {
+              primary: "openai/gpt-4o",
+              fallbacks: ["google/gemini-3-pro"],
+            },
+          },
+          list: [
+            {
+              id: "coder",
+              model: {
+                primary: "openai/gpt-4o",
+                fallbacks: ["anthropic/claude-sonnet-4-6"],
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [],
+        defaultProvider: "openai",
+        defaultModel: "gpt-4o",
+        agentId: "coder",
+      });
+
+      expect(result.allowedKeys.has("openai/gpt-4o")).toBe(true);
+      expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(true);
+      expect(result.allowedKeys.has("google/gemini-3-pro-preview")).toBe(false);
+      expect(result.allowAny).toBe(false);
+    });
   });
 
   describe("resolveAllowedModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -1,8 +1,16 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveAgentModelPrimaryValue, toAgentModelListLike } from "../config/model-input.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+  toAgentModelListLike,
+} from "../config/model-input.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
-import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentEffectiveModelPrimary,
+  resolveAgentModelFallbacksOverride,
+} from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
@@ -382,6 +390,16 @@ export function resolveDefaultModelForAgent(params: {
   });
 }
 
+function resolveAllowedFallbacks(params: { cfg: OpenClawConfig; agentId?: string }): string[] {
+  if (params.agentId) {
+    const override = resolveAgentModelFallbacksOverride(params.cfg, params.agentId);
+    if (override !== undefined) {
+      return override;
+    }
+  }
+  return resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
+}
+
 export function resolveSubagentConfiguredModelSelection(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -419,6 +437,7 @@ export function buildAllowedModelSet(params: {
   catalog: ModelCatalogEntry[];
   defaultProvider: string;
   defaultModel?: string;
+  agentId?: string;
 }): {
   allowAny: boolean;
   allowedCatalog: ModelCatalogEntry[];
@@ -469,21 +488,21 @@ export function buildAllowedModelSet(params: {
     }
   }
 
-  const fallbackConfig = params.cfg.agents?.defaults?.model;
-  if (fallbackConfig && typeof fallbackConfig === "object") {
-    for (const fallback of fallbackConfig.fallbacks ?? []) {
-      const parsed = parseModelRef(String(fallback), params.defaultProvider);
-      if (parsed) {
-        const key = modelKey(parsed.provider, parsed.model);
-        allowedKeys.add(key);
+  for (const fallback of resolveAllowedFallbacks({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  })) {
+    const parsed = parseModelRef(String(fallback), params.defaultProvider);
+    if (parsed) {
+      const key = modelKey(parsed.provider, parsed.model);
+      allowedKeys.add(key);
 
-        if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
-          syntheticCatalogEntries.set(key, {
-            id: parsed.model,
-            name: parsed.model,
-            provider: parsed.provider,
-          });
-        }
+      if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
+        syntheticCatalogEntries.set(key, {
+          id: parsed.model,
+          name: parsed.model,
+          provider: parsed.provider,
+        });
       }
     }
   }

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -469,6 +469,25 @@ export function buildAllowedModelSet(params: {
     }
   }
 
+  const fallbackConfig = params.cfg.agents?.defaults?.model;
+  if (fallbackConfig && typeof fallbackConfig === "object") {
+    for (const fallback of fallbackConfig.fallbacks ?? []) {
+      const parsed = parseModelRef(String(fallback), params.defaultProvider);
+      if (parsed) {
+        const key = modelKey(parsed.provider, parsed.model);
+        allowedKeys.add(key);
+
+        if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
+          syntheticCatalogEntries.set(key, {
+            id: parsed.model,
+            name: parsed.model,
+            provider: parsed.provider,
+          });
+        }
+      }
+    }
+  }
+
   if (defaultKey) {
     allowedKeys.add(defaultKey);
   }

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -151,6 +151,7 @@ async function resolveModelOverride(params: {
     catalog,
     defaultProvider: currentProvider,
     defaultModel: currentModel,
+    agentId: params.agentId,
   });
 
   const resolved = resolveModelRefFromString({

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -49,6 +49,7 @@ export async function buildModelsProviderData(
     catalog,
     defaultProvider: resolvedDefault.provider,
     defaultModel: resolvedDefault.model,
+    agentId,
   });
 
   const aliasIndex = buildModelAliasIndex({

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -373,6 +373,7 @@ export async function resolveReplyDirectives(params: {
 
   const modelState = await createModelSelectionState({
     cfg,
+    agentId,
     agentCfg,
     sessionEntry,
     sessionStore,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -175,6 +175,7 @@ export async function getReplyFromConfig(
 
   await applyResetModelOverride({
     cfg,
+    agentId,
     resetTriggered,
     bodyStripped,
     sessionCtx,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -263,6 +263,7 @@ function scoreFuzzyMatch(params: {
 
 export async function createModelSelectionState(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
@@ -315,6 +316,7 @@ export async function createModelSelectionState(params: {
       catalog: modelCatalog,
       defaultProvider,
       defaultModel,
+      agentId: params.agentId,
     });
     allowedModelCatalog = allowed.allowedCatalog;
     allowedModelKeys = allowed.allowedKeys;

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -87,6 +87,7 @@ function applySelectionToSession(params: {
 
 export async function applyResetModelOverride(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   resetTriggered: boolean;
   bodyStripped?: string;
   sessionCtx: TemplateContext;
@@ -118,6 +119,7 @@ export async function applyResetModelOverride(params: {
     catalog,
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
+    agentId: params.agentId,
   });
   const allowedModelKeys = allowed.allowedKeys;
   if (allowedModelKeys.size === 0) {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -950,6 +950,7 @@ async function agentCommandInternal(
         catalog: modelCatalog,
         defaultProvider,
         defaultModel,
+        agentId: sessionAgentId,
       });
       allowedModelKeys = allowed.allowedKeys;
       allowedModelCatalog = allowed.allowedCatalog;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -20,6 +20,7 @@ import {
   loadSessionStore,
   resolveSessionStoreEntry,
   resolveStorePath,
+  updateSessionStore,
 } from "../config/sessions.js";
 import type { DmPolicy } from "../config/types.base.js";
 import type {
@@ -33,6 +34,7 @@ import { MediaFetchError } from "../media/fetch.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
+import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   isSenderAllowed,
@@ -300,6 +302,7 @@ export const registerTelegramHandlers = ({
   }): {
     agentId: string;
     sessionEntry: ReturnType<typeof loadSessionStore>[string] | undefined;
+    sessionKey: string;
     model?: string;
   } => {
     const resolvedThreadId =
@@ -339,6 +342,7 @@ export const registerTelegramHandlers = ({
       return {
         agentId: route.agentId,
         sessionEntry: entry,
+        sessionKey,
         model: storedOverride.provider
           ? `${storedOverride.provider}/${storedOverride.model}`
           : storedOverride.model,
@@ -350,6 +354,7 @@ export const registerTelegramHandlers = ({
       return {
         agentId: route.agentId,
         sessionEntry: entry,
+        sessionKey,
         model: `${provider}/${model}`,
       };
     }
@@ -357,6 +362,7 @@ export const registerTelegramHandlers = ({
     return {
       agentId: route.agentId,
       sessionEntry: entry,
+      sessionKey,
       model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
     };
   };
@@ -1374,16 +1380,69 @@ export const registerTelegramHandlers = ({
             );
             return;
           }
-          // Process model selection as a synthetic message with /model command
-          const syntheticMessage = buildSyntheticTextMessage({
-            base: callbackMessage,
-            from: callback.from,
-            text: `/model ${selection.provider}/${selection.model}`,
-          });
-          await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
-            forceWasMentioned: true,
-            messageIdOverride: callback.id,
-          });
+
+          const modelSet = byProvider.get(selection.provider);
+          if (!modelSet?.has(selection.model)) {
+            await editMessageWithButtons(
+              `❌ Model "${selection.provider}/${selection.model}" is not allowed.`,
+              [],
+            );
+            return;
+          }
+
+          // Directly set model override in session
+          try {
+            // Get session store path
+            const storePath = resolveStorePath(cfg.session?.store, {
+              agentId: sessionState.agentId,
+            });
+
+            const agentConfig = cfg.agents?.list?.find((a) => a.id === sessionState.agentId);
+            const agentModelConfig = agentConfig?.model ?? cfg.agents?.defaults?.model;
+            const rawModelRef =
+              typeof agentModelConfig === "string" ? agentModelConfig : agentModelConfig?.primary;
+
+            let resolvedDefaultRef = sessionState.model;
+            if (rawModelRef) {
+              const trimmed = rawModelRef.trim();
+              if (trimmed.includes("/")) {
+                resolvedDefaultRef = trimmed;
+              } else {
+                const currentProvider = sessionState.model?.split("/")[0];
+                resolvedDefaultRef = currentProvider
+                  ? `${currentProvider}/${trimmed}`
+                  : sessionState.model;
+              }
+            }
+
+            const isDefaultSelection =
+              `${selection.provider}/${selection.model}` === resolvedDefaultRef;
+
+            await updateSessionStore(storePath, (store) => {
+              const sessionKey = sessionState.sessionKey;
+              const entry = store[sessionKey] ?? {};
+              store[sessionKey] = entry;
+              applyModelOverrideToSessionEntry({
+                entry,
+                selection: {
+                  provider: selection.provider,
+                  model: selection.model,
+                  isDefault: isDefaultSelection,
+                },
+              });
+            });
+
+            // Update message to show success with visual feedback
+            const actionText = isDefaultSelection
+              ? "reset to default"
+              : `changed to **${selection.provider}/${selection.model}**`;
+            await editMessageWithButtons(
+              `✅ Model ${actionText}\n\nThis model will be used for your next message.`,
+              [], // Empty buttons = remove inline keyboard
+            );
+          } catch (err) {
+            await editMessageWithButtons(`❌ Failed to change model: ${String(err)}`, []);
+          }
           return;
         }
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,6 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
@@ -1397,26 +1398,13 @@ export const registerTelegramHandlers = ({
               agentId: sessionState.agentId,
             });
 
-            const agentConfig = cfg.agents?.list?.find((a) => a.id === sessionState.agentId);
-            const agentModelConfig = agentConfig?.model ?? cfg.agents?.defaults?.model;
-            const rawModelRef =
-              typeof agentModelConfig === "string" ? agentModelConfig : agentModelConfig?.primary;
-
-            let resolvedDefaultRef = sessionState.model;
-            if (rawModelRef) {
-              const trimmed = rawModelRef.trim();
-              if (trimmed.includes("/")) {
-                resolvedDefaultRef = trimmed;
-              } else {
-                const currentProvider = sessionState.model?.split("/")[0];
-                resolvedDefaultRef = currentProvider
-                  ? `${currentProvider}/${trimmed}`
-                  : sessionState.model;
-              }
-            }
-
+            const resolvedDefault = resolveDefaultModelForAgent({
+              cfg,
+              agentId: sessionState.agentId,
+            });
             const isDefaultSelection =
-              `${selection.provider}/${selection.model}` === resolvedDefaultRef;
+              selection.provider === resolvedDefault.provider &&
+              selection.model === resolvedDefault.model;
 
             await updateSessionStore(storePath, (store) => {
               const sessionKey = sessionState.sessionKey;

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1,3 +1,4 @@
+import { rm } from "node:fs/promises";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../test/helpers/envelope-timestamp.js";
 import { expectInboundContextContract } from "../../test/helpers/inbound-contract.js";
@@ -5,6 +6,7 @@ import {
   listNativeCommandSpecs,
   listNativeCommandSpecsForConfig,
 } from "../auto-reply/commands-registry.js";
+import { loadSessionStore } from "../config/sessions.js";
 import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
 import {
   answerCallbackQuerySpy,
@@ -531,49 +533,127 @@ describe("createTelegramBot", () => {
   it("routes compact model callbacks by inferring provider", async () => {
     onSpy.mockClear();
     replySpy.mockClear();
+    editMessageTextSpy.mockClear();
 
     const modelId = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
+    const storePath = `/tmp/openclaw-telegram-model-compact-${process.pid}-${Date.now()}.json`;
 
-    createTelegramBot({
-      token: "tok",
-      config: {
-        agents: {
-          defaults: {
-            model: `bedrock/${modelId}`,
+    await rm(storePath, { force: true });
+    try {
+      createTelegramBot({
+        token: "tok",
+        config: {
+          agents: {
+            defaults: {
+              model: `bedrock/${modelId}`,
+            },
+          },
+          channels: {
+            telegram: {
+              dmPolicy: "open",
+              allowFrom: ["*"],
+            },
+          },
+          session: {
+            store: storePath,
           },
         },
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            allowFrom: ["*"],
+      });
+      const callbackHandler = onSpy.mock.calls.find(
+        (call) => call[0] === "callback_query",
+      )?.[1] as (ctx: Record<string, unknown>) => Promise<void>;
+      expect(callbackHandler).toBeDefined();
+
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-model-compact-1",
+          data: `mdl_sel/${modelId}`,
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 14,
           },
         },
-      },
-    });
-    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-    expect(callbackHandler).toBeDefined();
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
 
-    await callbackHandler({
-      callbackQuery: {
-        id: "cbq-model-compact-1",
-        data: `mdl_sel/${modelId}`,
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 14,
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+      expect(editMessageTextSpy.mock.calls[0]?.[2]).toContain("✅ Model reset to default");
+
+      const entry = Object.values(loadSessionStore(storePath, { skipCache: true }))[0];
+      expect(entry?.providerOverride).toBeUndefined();
+      expect(entry?.modelOverride).toBeUndefined();
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-compact-1");
+    } finally {
+      await rm(storePath, { force: true });
+    }
+  });
+
+  it("resets overrides when selecting the configured default model", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    editMessageTextSpy.mockClear();
+
+    const storePath = `/tmp/openclaw-telegram-model-default-${process.pid}-${Date.now()}.json`;
+
+    await rm(storePath, { force: true });
+    try {
+      createTelegramBot({
+        token: "tok",
+        config: {
+          agents: {
+            defaults: {
+              model: "claude-opus-4-6",
+              models: {
+                "anthropic/claude-opus-4-6": {},
+              },
+            },
+          },
+          channels: {
+            telegram: {
+              dmPolicy: "open",
+              allowFrom: ["*"],
+            },
+          },
+          session: {
+            store: storePath,
+          },
         },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+      });
+      const callbackHandler = onSpy.mock.calls.find(
+        (call) => call[0] === "callback_query",
+      )?.[1] as (ctx: Record<string, unknown>) => Promise<void>;
+      expect(callbackHandler).toBeDefined();
 
-    expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = replySpy.mock.calls[0]?.[0];
-    expect(payload?.Body).toContain(`/model amazon-bedrock/${modelId}`);
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-compact-1");
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-model-default-1",
+          data: "mdl_sel_anthropic/claude-opus-4-6",
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 16,
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+      expect(editMessageTextSpy.mock.calls[0]?.[2]).toContain("✅ Model reset to default");
+
+      const entry = Object.values(loadSessionStore(storePath, { skipCache: true }))[0];
+      expect(entry?.providerOverride).toBeUndefined();
+      expect(entry?.modelOverride).toBeUndefined();
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-default-1");
+    } finally {
+      await rm(storePath, { force: true });
+    }
   });
 
   it("rejects ambiguous compact model callbacks and returns provider list", async () => {


### PR DESCRIPTION
# PR Description: Fix Telegram Model Button Selection

## Problem Statement

Telegram inline button model selection was broken in two ways:

### Issue 1: Model buttons don't actually change the model (CRITICAL BUG)
When clicking a model button in Telegram (e.g., "gpt-5.3-codex"), the button click was registered but the model **never actually changed**. The synthetic message approach (`/model provider/model` via `processMessage()`) silently failed - the callback query was answered, no error was shown, but the model remained unchanged.

**Root Cause:** The synthetic message processing pipeline doesn't properly trigger model overrides in the session store. The code created a fake `/model` message and passed it through `processMessage()`, but this never actually updated the session's model override fields.

### Issue 2: Fallback models not shown in model picker
Fallback models configured in `agents.defaults.model.fallbacks` were not included in the `/models` command output, making them inaccessible via the Telegram UI.

## Solution

### Fix 1: Direct Session Store Model Override (bot-handlers.ts)
Replaced the broken synthetic message approach with direct session store updates:

**Key Changes:**
- Replaced synthetic `/model` command with `updateSessionStore()` + `applyModelOverrideToSessionEntry()`
- Added visual feedback: success message with ✅ emoji, error with ❌
- Inline keyboard removed after selection
- **Auth preserved**: All authorization checks (inlineButtonsScope, sender authorization) are applied before reaching the model handler (lines 1108-1157)
- **Default behavior preserved**: Selecting the default model clears the override (isDefault: true), matching `/model` command behavior

**Code:**
```typescript
const isDefaultSelection =
  `${selection.provider}/${selection.model}` === defaultModelRef;

await updateSessionStore(storePath, (store) => {
  const entry = store[sessionKey] ?? {};
  store[sessionKey] = entry;
  applyModelOverrideToSessionEntry({
    entry,
    selection: {
      provider: selection.provider,
      model: selection.model,
      isDefault: isDefaultSelection, // Clear override if default selected
    },
  });
});
```

### Fix 2: Include Fallback Models in Allowed Set (model-selection.ts)
Added fallback models to the allowed model set so they appear in the `/models` command.

## Files Changed

1. `src/telegram/bot-handlers.ts` - Fixed model button click with proper auth and default handling
2. `src/agents/model-selection.ts` - Added fallback models to allowed set  
3. `src/agents/model-selection.test.ts` - Added tests for fallback model inclusion

## Testing

### Test Scenario 1: Model Button Click
1. Type `/models` in Telegram
2. Click a provider (e.g., "openai-codex")
3. Click a model (e.g., "gpt-5.3-codex")
4. **Expected:** "✅ Model changed to **openai-codex/gpt-5.3-codex**"
5. **Expected:** Buttons disappear, next message uses selected model

### Test Scenario 2: Select Default Model
1. With default model "openai-codex/gpt-5.3-codex"
2. Click that model in the picker
3. **Expected:** "✅ Model reset to default" (clears override, doesn't pin)

### Test Scenario 3: After /reset
1. Type `/reset` to clear session
2. Type `/models`
3. Click a model
4. **Expected:** Model changes successfully

## Security Notes

- Authorization is enforced via existing `inlineButtonsScope` and `authorizeTelegramEventSender` checks (lines 1108-1157)
- Callbacks respect the same DM/group/allowlist policies as regular commands
- No bypass of command access controls

## Related Issues

- Bug introduced in PR #8193 (Feb 2026) which used synthetic message approach

## Checklist

- [x] Bug fix (non-breaking)
- [x] Code follows project style
- [x] Tests added
- [x] Manual testing in Telegram
- [x] Auth checks preserved
- [x] Default behavior preserved
