### PR TITLE
fix(kimi): recover downgraded text/XML tool invocations

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -13,6 +13,7 @@ import {
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
+  wrapStreamFnRecoverTextToolCalls,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
 
@@ -421,6 +422,141 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 
     expect(finalToolCall.name).toBe("read");
     expect(finalToolCall.id).toBe("call_42");
+  });
+});
+
+describe("wrapStreamFnRecoverTextToolCalls", () => {
+  function createFakeStream(params: { events: unknown[]; resultMessage: unknown }): {
+    result: () => Promise<unknown>;
+    [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+  } {
+    return {
+      async result() {
+        return params.resultMessage;
+      },
+      [Symbol.asyncIterator]() {
+        return (async function* () {
+          for (const event of params.events) {
+            yield event;
+          }
+        })();
+      },
+    };
+  }
+
+  async function invokeRecoveredStream(
+    baseFn: (...args: never[]) => unknown,
+    allowedToolNames?: Set<string>,
+  ) {
+    const wrappedFn = wrapStreamFnRecoverTextToolCalls(baseFn as never, allowedToolNames);
+    return await wrappedFn({} as never, {} as never, {} as never);
+  }
+
+  it("recovers bare Kimi text tool calls into structured toolCall blocks", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: 'exec({"command":"pwd","timeout":120000})' }],
+    };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeRecoveredStream(baseFn, new Set(["exec"]));
+    const result = await stream.result();
+
+    expect(result).toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          name: "exec",
+          arguments: { command: "pwd", timeout: 120000 },
+        },
+      ],
+    });
+  });
+
+  it("recovers XML invoke blocks into structured toolCall blocks", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `<invoke name="Read">
+<parameter name="path">/tmp/demo.txt</parameter>
+</invoke>`,
+        },
+      ],
+    };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeRecoveredStream(baseFn, new Set(["read"]));
+    const result = await stream.result();
+
+    expect(result).toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "/tmp/demo.txt" },
+        },
+      ],
+    });
+  });
+
+  it("preserves surrounding prose while recovering tool calls", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "I'll check that. exec({\"command\":\"ls\"}) Done.",
+        },
+      ],
+    };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeRecoveredStream(baseFn, new Set(["exec"]));
+    const result = await stream.result();
+
+    expect(result).toEqual({
+      role: "assistant",
+      content: [
+        { type: "text", text: "I'll check that." },
+        {
+          type: "toolCall",
+          name: "exec",
+          arguments: { command: "ls" },
+        },
+        { type: "text", text: "Done." },
+      ],
+    });
+  });
+
+  it("maps recovered prefixed tool names to canonical allowed tools", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'functions.read({"path":"/tmp/a"})',
+        },
+      ],
+    };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeRecoveredStream(baseFn, new Set(["read"]));
+    const result = await stream.result();
+
+    expect(result).toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "/tmp/a" },
+        },
+      ],
+    });
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -433,6 +433,377 @@ export function wrapStreamFnTrimToolCallNames(
   };
 }
 
+type RecoveredTextToolCall = {
+  start: number;
+  end: number;
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
+type RecoveredTextToolPart =
+  | { type: "text"; text: string }
+  | { type: "toolCall"; name: string; arguments: Record<string, unknown> };
+
+const BASIC_XML_ENTITY_RE = /&(?:amp|lt|gt|quot|apos|#39);/i;
+const XML_INVOKE_RE =
+  /<invoke\b[^>]*\bname=(?:"([^"]+)"|'([^']+)')[^>]*>([\s\S]*?)<\/invoke>(?:\s*<\/[a-z0-9:_-]+>)?/gi;
+const XML_PARAMETER_RE =
+  /<parameter\b[^>]*\bname=(?:"([^"]+)"|'([^']+)')[^>]*>([\s\S]*?)<\/parameter>/gi;
+const TEXT_TOOL_CALL_START_RE = /(^|[\s([{"'`,;:])([A-Za-z][A-Za-z0-9_./-]*)\s*\(/g;
+
+function decodeBasicXmlEntities(text: string): string {
+  if (!BASIC_XML_ENTITY_RE.test(text)) {
+    return text;
+  }
+  return text
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&amp;/gi, "&");
+}
+
+function parseLooseJsonValue(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseObjectToolArguments(text: string): Record<string, unknown> | undefined {
+  const parsed = parseLooseJsonValue(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function consumeParenthesizedToolArgs(text: string, openIndex: number): number | null {
+  if (text[openIndex] !== "(") {
+    return null;
+  }
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = openIndex; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "(") {
+      depth += 1;
+      continue;
+    }
+    if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return i + 1;
+      }
+    }
+  }
+  return null;
+}
+
+function resolveRecoveredToolCallName(
+  rawName: string,
+  allowedToolNames?: Set<string>,
+): string | undefined {
+  const trimmed = rawName.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalizedDelimiter = trimmed.replace(/\//g, ".");
+  const segments = normalizedDelimiter
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  const candidates = new Set<string>([trimmed, normalizedDelimiter, normalizeToolName(trimmed)]);
+  if (segments.length > 1) {
+    for (let index = 1; index < segments.length; index += 1) {
+      const suffix = segments.slice(index).join(".");
+      candidates.add(suffix);
+      candidates.add(normalizeToolName(suffix));
+    }
+  }
+  if (!allowedToolNames || allowedToolNames.size === 0) {
+    return [...candidates][0] ?? trimmed;
+  }
+  for (const candidate of candidates) {
+    if (allowedToolNames.has(candidate)) {
+      return candidate;
+    }
+  }
+  for (const candidate of candidates) {
+    const folded = candidate.toLowerCase();
+    for (const allowedName of allowedToolNames) {
+      if (allowedName.toLowerCase() === folded) {
+        return allowedName;
+      }
+    }
+  }
+  return undefined;
+}
+
+function findXmlTextToolCalls(
+  text: string,
+  allowedToolNames?: Set<string>,
+): RecoveredTextToolCall[] {
+  const recovered: RecoveredTextToolCall[] = [];
+  XML_INVOKE_RE.lastIndex = 0;
+  for (const match of text.matchAll(XML_INVOKE_RE)) {
+    const rawName = (match[1] ?? match[2] ?? "").trim();
+    if (!rawName) {
+      continue;
+    }
+    const normalizedName = resolveRecoveredToolCallName(rawName, allowedToolNames);
+    if (!normalizedName) {
+      continue;
+    }
+    const body = match[3] ?? "";
+    const args: Record<string, unknown> = {};
+    XML_PARAMETER_RE.lastIndex = 0;
+    for (const paramMatch of body.matchAll(XML_PARAMETER_RE)) {
+      const paramName = (paramMatch[1] ?? paramMatch[2] ?? "").trim();
+      if (!paramName) {
+        continue;
+      }
+      const rawValue = decodeBasicXmlEntities((paramMatch[3] ?? "").trim());
+      const parsedValue = parseLooseJsonValue(rawValue);
+      args[paramName] = parsedValue === undefined ? rawValue : parsedValue;
+    }
+    if (Object.keys(args).length === 0) {
+      continue;
+    }
+    const start = match.index ?? 0;
+    recovered.push({
+      start,
+      end: start + match[0].length,
+      name: normalizedName,
+      arguments: args,
+    });
+  }
+  return recovered;
+}
+
+function findBareTextToolCalls(
+  text: string,
+  allowedToolNames?: Set<string>,
+): RecoveredTextToolCall[] {
+  if (!allowedToolNames || allowedToolNames.size === 0) {
+    return [];
+  }
+  const recovered: RecoveredTextToolCall[] = [];
+  TEXT_TOOL_CALL_START_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TEXT_TOOL_CALL_START_RE.exec(text))) {
+    const prefix = match[1] ?? "";
+    const rawName = (match[2] ?? "").trim();
+    if (!rawName) {
+      continue;
+    }
+    const normalizedName = resolveRecoveredToolCallName(rawName, allowedToolNames);
+    if (!normalizedName) {
+      continue;
+    }
+    const nameStart = (match.index ?? 0) + prefix.length;
+    const parenIndex = (match.index ?? 0) + match[0].lastIndexOf("(");
+    const closeIndex = consumeParenthesizedToolArgs(text, parenIndex);
+    if (closeIndex === null) {
+      continue;
+    }
+    const args = parseObjectToolArguments(text.slice(parenIndex + 1, closeIndex - 1));
+    if (!args) {
+      continue;
+    }
+    let end = closeIndex;
+    while (end < text.length && (text[end] === " " || text[end] === "	")) {
+      end += 1;
+    }
+    if (text[end] === ";") {
+      end += 1;
+    }
+    recovered.push({ start: nameStart, end, name: normalizedName, arguments: args });
+    TEXT_TOOL_CALL_START_RE.lastIndex = end;
+  }
+  return recovered;
+}
+
+function splitTextBlockIntoRecoveredToolCalls(
+  text: string,
+  allowedToolNames?: Set<string>,
+): RecoveredTextToolPart[] | null {
+  const recovered = [
+    ...findXmlTextToolCalls(text, allowedToolNames),
+    ...findBareTextToolCalls(text, allowedToolNames),
+  ].toSorted((a, b) => a.start - b.start || a.end - b.end);
+  if (recovered.length === 0) {
+    return null;
+  }
+
+  const deduped: RecoveredTextToolCall[] = [];
+  let lastEnd = -1;
+  for (const toolCall of recovered) {
+    if (toolCall.start < lastEnd) {
+      continue;
+    }
+    deduped.push(toolCall);
+    lastEnd = toolCall.end;
+  }
+
+  const parts: RecoveredTextToolPart[] = [];
+  let cursor = 0;
+  for (const toolCall of deduped) {
+    if (toolCall.start > cursor) {
+      const textPart = text.slice(cursor, toolCall.start);
+      if (textPart.trim()) {
+        parts.push({ type: "text", text: textPart.trim() });
+      }
+    }
+    parts.push({
+      type: "toolCall",
+      name: toolCall.name,
+      arguments: toolCall.arguments,
+    });
+    cursor = toolCall.end;
+  }
+  if (cursor < text.length) {
+    const trailing = text.slice(cursor);
+    if (trailing.trim()) {
+      parts.push({ type: "text", text: trailing.trim() });
+    }
+  }
+  return parts.length > 0 ? parts : null;
+}
+
+function recoverTextToolCallsInMessage(message: unknown, allowedToolNames?: Set<string>): void {
+  if (!message || typeof message !== "object" || !allowedToolNames || allowedToolNames.size === 0) {
+    return;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content) || content.length === 0) {
+    return;
+  }
+  if (
+    content.some(
+      (block) =>
+        block &&
+        typeof block === "object" &&
+        isToolCallBlockType((block as { type?: unknown }).type),
+    )
+  ) {
+    return;
+  }
+
+  const nextContent: unknown[] = [];
+  let recoveredAny = false;
+  for (const block of content) {
+    if (
+      !block ||
+      typeof block !== "object" ||
+      (block as { type?: unknown }).type !== "text" ||
+      typeof (block as { text?: unknown }).text !== "string"
+    ) {
+      nextContent.push(block);
+      continue;
+    }
+
+    const textBlock = block as { text: string } & Record<string, unknown>;
+    const recoveredParts = splitTextBlockIntoRecoveredToolCalls(textBlock.text, allowedToolNames);
+    if (!recoveredParts) {
+      nextContent.push(block);
+      continue;
+    }
+
+    recoveredAny = true;
+    for (const part of recoveredParts) {
+      if (part.type === "text") {
+        nextContent.push({ ...textBlock, text: part.text });
+        continue;
+      }
+      nextContent.push({
+        type: "toolCall",
+        name: part.name,
+        arguments: part.arguments,
+      });
+    }
+  }
+
+  if (!recoveredAny) {
+    return;
+  }
+
+  (message as { content: unknown[] }).content = nextContent;
+}
+
+function wrapStreamRecoverTextToolCalls(
+  stream: ReturnType<typeof streamSimple>,
+  allowedToolNames?: Set<string>,
+): ReturnType<typeof streamSimple> {
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    recoverTextToolCallsInMessage(message, allowedToolNames);
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            const event = result.value as { partial?: unknown; message?: unknown };
+            recoverTextToolCallsInMessage(event.partial, allowedToolNames);
+            recoverTextToolCallsInMessage(event.message, allowedToolNames);
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+      };
+    };
+
+  return stream;
+}
+
+export function wrapStreamFnRecoverTextToolCalls(
+  baseFn: StreamFn,
+  allowedToolNames?: Set<string>,
+): StreamFn {
+  return (model, context, options) => {
+    const maybeStream = baseFn(model, context, options);
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) =>
+        wrapStreamRecoverTextToolCalls(stream, allowedToolNames),
+      );
+    }
+    return wrapStreamRecoverTextToolCalls(maybeStream, allowedToolNames);
+  };
+}
+
 // ---------------------------------------------------------------------------
 // xAI / Grok: decode HTML entities in tool call arguments
 // ---------------------------------------------------------------------------
@@ -1363,6 +1734,17 @@ export async function runEmbeddedAttempt(
           } as unknown;
           return inner(model, nextContext as typeof context, options);
         };
+      }
+
+      // Kimi coding can occasionally downgrade tool calls into plain text/XML
+      // invocations (e.g. exec({...}) or <invoke name="Read">...</invoke>).
+      // Recover those into structured toolCall blocks before dispatch so the
+      // agent still executes the intended tool.
+      if (normalizeProviderId(params.provider) === "kimi-coding") {
+        activeSession.agent.streamFn = wrapStreamFnRecoverTextToolCalls(
+          activeSession.agent.streamFn,
+          allowedToolNames,
+        );
       }
 
       // Some models emit tool names with surrounding whitespace (e.g. " read ").


### PR DESCRIPTION
## Summary
- recover bare Kimi text tool invocations like `exec({...})` into structured `toolCall` blocks
- recover XML-style `<invoke name="...">` tool invocations into structured tool calls
- keep surrounding prose intact and normalize provider-prefixed tool names to canonical OpenClaw tools

Closes #39907

## Testing
- `corepack pnpm vitest run src/agents/pi-embedded-runner/run/attempt.test.ts`
- `corepack pnpm exec oxlint src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.test.ts`