### PR TITLE
fix: share context engine registry across bundled chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 <<<<<<< HEAD
 - Browser/CDP: normalize loopback direct WebSocket CDP URLs back to HTTP(S) for `/json/*` tab operations so local `ws://` / `wss://` profiles can still list, focus, open, and close tabs after the new direct-WS support lands. (#31085) Thanks @shrey150.
 - Context engine registry: keep context-engine registrations on a `globalThis` singleton so duplicated bundled module copies share one registry map at runtime. (#40115) thanks @jalehman.
+- Context engine registry/bundled builds: share the registry state through a `globalThis` singleton so duplicated bundled module copies can resolve engines registered by each other at runtime, with regression coverage for duplicate-module imports. (#40115) thanks @jalehman.
 
 ## 2026.3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
 - Sessions/model switch: clear stale cached `contextTokens` when a session changes models so status and runtime paths recompute against the active model window. (#38044) thanks @yuweuii.
 - ACP/session history: persist transcripts for successful ACP child runs, preserve exact transcript text, record ACP spawned-session lineage, and keep spawn-time transcript-path persistence best-effort so history storage failures do not block execution. (#40137) thanks @mbelinky.
-<<<<<<< HEAD
 - Browser/CDP: normalize loopback direct WebSocket CDP URLs back to HTTP(S) for `/json/*` tab operations so local `ws://` / `wss://` profiles can still list, focus, open, and close tabs after the new direct-WS support lands. (#31085) Thanks @shrey150.
-- Context engine registry: keep context-engine registrations on a `globalThis` singleton so duplicated bundled module copies share one registry map at runtime. (#40115) thanks @jalehman.
 - Context engine registry/bundled builds: share the registry state through a `globalThis` singleton so duplicated bundled module copies can resolve engines registered by each other at runtime, with regression coverage for duplicate-module imports. (#40115) thanks @jalehman.
 
 ## 2026.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ Docs: https://docs.openclaw.ai
 - Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
 - Sessions/model switch: clear stale cached `contextTokens` when a session changes models so status and runtime paths recompute against the active model window. (#38044) thanks @yuweuii.
 - ACP/session history: persist transcripts for successful ACP child runs, preserve exact transcript text, record ACP spawned-session lineage, and keep spawn-time transcript-path persistence best-effort so history storage failures do not block execution. (#40137) thanks @mbelinky.
+<<<<<<< HEAD
 - Browser/CDP: normalize loopback direct WebSocket CDP URLs back to HTTP(S) for `/json/*` tab operations so local `ws://` / `wss://` profiles can still list, focus, open, and close tabs after the new direct-WS support lands. (#31085) Thanks @shrey150.
+- Context engine registry: keep context-engine registrations on a `globalThis` singleton so duplicated bundled module copies share one registry map at runtime. (#40115) thanks @jalehman.
 
 ## 2026.3.7
 

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -198,6 +198,19 @@ describe("Registry tests", () => {
     expect(getContextEngineFactory("reg-overwrite")).toBe(factory2);
     expect(getContextEngineFactory("reg-overwrite")).not.toBe(factory1);
   });
+
+  it("shares registered engines across duplicate module copies", async () => {
+    const registryUrl = new URL("./registry.ts", import.meta.url).href;
+    const suffix = Date.now().toString(36);
+    const first = await import(/* @vite-ignore */ `${registryUrl}?copy=${suffix}-a`);
+    const second = await import(/* @vite-ignore */ `${registryUrl}?copy=${suffix}-b`);
+
+    const engineId = `dup-copy-${suffix}`;
+    const factory = () => new MockContextEngine();
+    first.registerContextEngine(engineId, factory);
+
+    expect(second.getContextEngineFactory(engineId)).toBe(factory);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -12,27 +12,45 @@ export type ContextEngineFactory = () => ContextEngine | Promise<ContextEngine>;
 // Registry (module-level singleton)
 // ---------------------------------------------------------------------------
 
-const _engines = new Map<string, ContextEngineFactory>();
+const CONTEXT_ENGINE_REGISTRY_STATE = Symbol.for("openclaw.contextEngineRegistryState");
+
+type ContextEngineRegistryState = {
+  engines: Map<string, ContextEngineFactory>;
+};
+
+// Keep context-engine registrations process-global so duplicated dist chunks
+// still share one registry map at runtime.
+function getContextEngineRegistryState(): ContextEngineRegistryState {
+  const globalState = globalThis as typeof globalThis & {
+    [CONTEXT_ENGINE_REGISTRY_STATE]?: ContextEngineRegistryState;
+  };
+  if (!globalState[CONTEXT_ENGINE_REGISTRY_STATE]) {
+    globalState[CONTEXT_ENGINE_REGISTRY_STATE] = {
+      engines: new Map<string, ContextEngineFactory>(),
+    };
+  }
+  return globalState[CONTEXT_ENGINE_REGISTRY_STATE];
+}
 
 /**
  * Register a context engine implementation under the given id.
  */
 export function registerContextEngine(id: string, factory: ContextEngineFactory): void {
-  _engines.set(id, factory);
+  getContextEngineRegistryState().engines.set(id, factory);
 }
 
 /**
  * Return the factory for a registered engine, or undefined.
  */
 export function getContextEngineFactory(id: string): ContextEngineFactory | undefined {
-  return _engines.get(id);
+  return getContextEngineRegistryState().engines.get(id);
 }
 
 /**
  * List all registered engine ids.
  */
 export function listContextEngineIds(): string[] {
-  return [..._engines.keys()];
+  return [...getContextEngineRegistryState().engines.keys()];
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +73,7 @@ export async function resolveContextEngine(config?: OpenClawConfig): Promise<Con
       ? slotValue.trim()
       : defaultSlotIdForKey("contextEngine");
 
-  const factory = _engines.get(engineId);
+  const factory = getContextEngineRegistryState().engines.get(engineId);
   if (!factory) {
     throw new Error(
       `Context engine "${engineId}" is not registered. ` +


### PR DESCRIPTION
## What
This PR moves OpenClaw's context-engine registry state from a module-local map to a process-global `globalThis` singleton and adds a regression test that simulates duplicated module copies.

Closes #39725

## Why
Published builds can emit multiple bundled copies of the context-engine registry module. When plugin loading registers an engine through one copy and agent/runtime resolution later reads from another, OpenClaw reports that the engine is not registered even though the plugin loaded successfully. This fixes the released-build failure behind #40096 without reworking the build pipeline.

## Changes
- Store context engines on `globalThis`
- Keep registry API behavior unchanged
- Add duplicate-module regression test

## Testing
- `pnpm exec vitest run src/context-engine/context-engine.test.ts`
- `pnpm build:strict-smoke`
- Expected: context-engine tests pass and the build smoke completes successfully
