### PR TITLE
fix(browser-relay): guard last tab close and add tab validation retries

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -56,16 +56,33 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function isMissingTabError(err) {
+  const message = (err instanceof Error ? err.message : String(err || '')).toLowerCase()
+  return (
+    message.includes('no tab with id') ||
+    message.includes('no tab with given id') ||
+    message.includes('tab not found')
+  )
+}
+
 async function validateAttachedTab(tabId) {
+  try {
+    await chrome.tabs.get(tabId)
+  } catch {
+    return false
+  }
+
   for (let attempt = 0; attempt < TAB_VALIDATION_ATTEMPTS; attempt++) {
     try {
-      await chrome.tabs.get(tabId)
       await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
         expression: '1',
         returnByValue: true,
       })
       return true
-    } catch {
+    } catch (err) {
+      if (isMissingTabError(err)) {
+        return false
+      }
       if (attempt < TAB_VALIDATION_ATTEMPTS - 1) {
         await sleep(TAB_VALIDATION_RETRY_DELAY_MS)
       }

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -41,12 +41,37 @@ const reattachPending = new Set()
 let reconnectAttempt = 0
 let reconnectTimer = null
 
+const TAB_VALIDATION_ATTEMPTS = 2
+const TAB_VALIDATION_RETRY_DELAY_MS = 1000
+
 function nowStack() {
   try {
     return new Error().stack || ''
   } catch {
     return ''
   }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function validateAttachedTab(tabId) {
+  for (let attempt = 0; attempt < TAB_VALIDATION_ATTEMPTS; attempt++) {
+    try {
+      await chrome.tabs.get(tabId)
+      await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+        expression: '1',
+        returnByValue: true,
+      })
+      return true
+    } catch {
+      if (attempt < TAB_VALIDATION_ATTEMPTS - 1) {
+        await sleep(TAB_VALIDATION_RETRY_DELAY_MS)
+      }
+    }
+  }
+  return false
 }
 
 async function getRelayPort() {
@@ -109,14 +134,10 @@ async function rehydrateState() {
       setBadge(entry.tabId, 'on')
     }
     // Phase 2: validate asynchronously, remove dead tabs.
+    // Retry once to avoid dropping tabs during transient busy/navigation states.
     for (const entry of entries) {
-      try {
-        await chrome.tabs.get(entry.tabId)
-        await chrome.debugger.sendCommand({ tabId: entry.tabId }, 'Runtime.evaluate', {
-          expression: '1',
-          returnByValue: true,
-        })
-      } catch {
+      const valid = await validateAttachedTab(entry.tabId)
+      if (!valid) {
         tabs.delete(entry.tabId)
         tabBySession.delete(entry.sessionId)
         setBadge(entry.tabId, 'off')
@@ -260,12 +281,9 @@ async function reannounceAttachedTabs() {
     if (tab.state !== 'connected' || !tab.sessionId || !tab.targetId) continue
 
     // Verify debugger is still attached.
-    try {
-      await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
-        expression: '1',
-        returnByValue: true,
-      })
-    } catch {
+    // Retry once to tolerate transient failures right after relay reconnect.
+    const valid = await validateAttachedTab(tabId)
+    if (!valid) {
       tabs.delete(tabId)
       if (tab.sessionId) tabBySession.delete(tab.sessionId)
       setBadge(tabId, 'off')
@@ -672,6 +690,11 @@ async function handleForwardCdpCommand(msg) {
     const toClose = target ? getTabByTargetId(target) : tabId
     if (!toClose) return { success: false }
     try {
+      const allTabs = await chrome.tabs.query({})
+      if (allTabs.length <= 1) {
+        console.warn('Refusing to close the last tab: this would kill the browser process')
+        return { success: false, error: 'Cannot close the last tab' }
+      }
       await chrome.tabs.remove(toClose)
     } catch {
       return { success: false }


### PR DESCRIPTION
## Summary
- prevent `Target.closeTarget` from closing the last remaining browser tab
- add retry-based tab validation during MV3 rehydration to avoid false tab drops
- apply the same retry-based validation during relay reannounce after reconnect

## Why
Browser relay can lose tab state after MV3 service worker restarts or relay reconnects when tabs are temporarily busy. Also, closing the final tab can terminate the browser process.

## Scope
- `assets/chrome-extension/background.js` only

## Behavior changes
- `Target.closeTarget` now returns `{ success: false, error: 'Cannot close the last tab' }` when there is only one tab left.
- tab validation retries once (1s delay) before dropping a tab from relay state.

Fixes #40037
