### PR TITLE
fix(gateway): improve handshake timeout diagnostics and error surfacing

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -497,7 +497,7 @@ export function createAgentEventHandler({
       sessionKey,
       seq,
       state: "error" as const,
-      errorMessage: error ? formatForLog(error) : undefined,
+      errorMessage: error ? formatForLog(error) : "Agent run failed.",
     };
     broadcast("chat", payload);
     nodeSendToSession(sessionKey, "chat", payload);

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -268,11 +268,28 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";
+        const logUa = sanitizeLogValue(requestUserAgent);
+        const logOrigin = sanitizeLogValue(requestOrigin);
         setCloseCause("handshake-timeout", {
           handshakeMs: Date.now() - openedAt,
+          userAgent: logUa,
+          origin: logOrigin,
         });
-        logWsControl.warn(`handshake timeout conn=${connId} remote=${remoteAddr ?? "?"}`);
-        close();
+        logWsControl.warn(
+          `handshake timeout conn=${connId} remote=${remoteAddr ?? "?"} ua=${logUa || "n/a"} origin=${logOrigin || "n/a"}`,
+        );
+        // Send an error frame before closing so incompatible clients receive a
+        // clear rejection rather than a silent TCP close.
+        send({
+          type: "event",
+          event: "connect.error",
+          payload: {
+            code: "HANDSHAKE_TIMEOUT",
+            message:
+              "Handshake was not completed in time. Ensure your client uses the challenge/connect protocol.",
+          },
+        });
+        close(1002, "handshake timeout");
       }
     }, handshakeTimeoutMs);
 


### PR DESCRIPTION
## Summary

- **Problem:** When incompatible/legacy clients connect to the gateway, handshake timeouts log only `connId` and `remoteAddr`, making it difficult to identify which process is failing. Additionally, timed-out clients receive a silent TCP close with no explanation, and webchat error events can arrive with no error message.
- **Why it matters:** Users debugging duplicate-client or legacy-bridge issues (as described in #40082) cannot identify the offending process from logs alone, and the webchat UI may show a blank error state.
- **What changed:**
  - Handshake timeout logs now include `user-agent` and `origin` headers, and these are recorded in close-cause metadata
  - Gateway sends a `connect.error` frame (`HANDSHAKE_TIMEOUT`) before closing the socket, so incompatible clients receive a clear rejection with an actionable message
  - Close code changed from `1000` (normal) to `1002` (protocol error) for handshake timeouts
  - Webchat chat error payloads now always include an `errorMessage` (defaults to `"Agent run failed."` when no specific error text is available)
- **What did NOT change (scope boundary):** Agent execution logic, orchestrator fallback behavior, task status transitions, and reconnection handling are unchanged. This PR addresses diagnostic visibility only.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #40082

## User-visible / Behavior Changes

- Handshake timeout log messages now include `ua=` and `origin=` fields
- Clients that fail the handshake now receive a `connect.error` event with code `HANDSHAKE_TIMEOUT` and a descriptive message before disconnection
- Webchat error states now always display an error message instead of potentially showing nothing

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: n/a
- Integration/channel (if any): Webchat / WebSocket

### Steps

1. Connect a client that does not complete the challenge/connect handshake
2. Wait for handshake timeout (10s default)
3. Observe enhanced log output with `ua=` and `origin=`
4. Observe the client receives a `connect.error` frame before close

### Expected

- Log shows client identity info
- Client receives clear error frame

### Actual

- Confirmed via code review and existing test suite

## Evidence

- [x] Trace/log snippets (enhanced log format verified in code)

## Human Verification (required)

- Verified scenarios: Build passes, lint/format clean, 27 gateway tests pass
- Edge cases checked: `sanitizeLogValue` handles undefined user-agent/origin gracefully (logs `n/a`)
- What you did **not** verify: Live gateway with actual legacy client connections

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `src/gateway/server/ws-connection.ts`, `src/gateway/server-chat.ts`
- Known bad symptoms reviewers should watch for: Clients not receiving the error frame before close (WebSocket send on closing socket)

## Risks and Mitigations

- Risk: `send()` on a WebSocket that is about to close may silently fail
  - Mitigation: `send()` already wraps in try/catch; the close follows immediately after, so worst case is the client just sees the TCP close as before