### PR TITLE
feat(memory): pluggable system prompt section for memory plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Web tools/Tavily: add Tavily as a bundled web-search provider with dedicated `tavily_search` and `tavily_extract` tools, using canonical plugin-owned config under `plugins.entries.tavily.config.webSearch.*`. (#49200) thanks @lakshyaag-tavily.
 - Docs/plugins: add the community DingTalk plugin listing to the docs catalog. (#29913) Thanks @sliverp.
 - Docs/plugins: add the community QQbot plugin listing to the docs catalog. (#29898) Thanks @sliverp.
+- Memory/plugins: let the active memory plugin register its own system-prompt section while preserving cache-clear and snapshot-load prompt isolation. (#40126) Thanks @jarimustonen.
 - Plugins/context engines: pass the embedded runner `modelId` into context-engine `assemble()` so plugins can adapt context formatting per model. (#47437) thanks @jscianna.
 - Plugins/context engines: add transcript maintenance rewrites for context engines, preserve active-branch transcript metadata during rewrites, and harden overflow-recovery truncation to rewrite sessions under the normal session write lock. (#51191) Thanks @jalehman.
 - Telegram/apiRoot: add per-account custom Bot API endpoint support across send, probe, setup, doctor repair, and inbound media download paths so proxied or self-hosted Telegram deployments work end to end. (#48842) Thanks @Cypherm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Docs: https://docs.openclaw.ai
 - Web tools/Tavily: add Tavily as a bundled web-search provider with dedicated `tavily_search` and `tavily_extract` tools, using canonical plugin-owned config under `plugins.entries.tavily.config.webSearch.*`. (#49200) thanks @lakshyaag-tavily.
 - Docs/plugins: add the community DingTalk plugin listing to the docs catalog. (#29913) Thanks @sliverp.
 - Docs/plugins: add the community QQbot plugin listing to the docs catalog. (#29898) Thanks @sliverp.
-- Memory/plugins: let the active memory plugin register its own system-prompt section while preserving cache-clear and snapshot-load prompt isolation. (#40126) Thanks @jarimustonen.
 - Plugins/context engines: pass the embedded runner `modelId` into context-engine `assemble()` so plugins can adapt context formatting per model. (#47437) thanks @jscianna.
 - Plugins/context engines: add transcript maintenance rewrites for context engines, preserve active-branch transcript metadata during rewrites, and harden overflow-recovery truncation to rewrite sessions under the normal session write lock. (#51191) Thanks @jalehman.
 - Telegram/apiRoot: add per-account custom Bot API endpoint support across send, probe, setup, doctor repair, and inbound media download paths so proxied or self-hosted Telegram deployments work end to end. (#48842) Thanks @Cypherm.
@@ -62,6 +61,7 @@ Docs: https://docs.openclaw.ai
 - Models/GitHub Copilot: allow forward-compat dynamic model ids without code updates, while preserving configured provider and per-model overrides for those synthetic models. (#51325) Thanks @fuller-stack-dev.
 - Agents/compaction: notify users when followup auto-compaction starts and finishes, keeping those notices out of TTS and preserving reply threading for the real assistant reply. (#38805) Thanks @zidongdesign.
 - Models/OpenAI: switch the default OpenAI setup model to `openai/gpt-5.4`, keep Codex on `openai-codex/gpt-5.4`, and centralize OpenAI chat, image, TTS, transcription, and embedding defaults in one shared module so future default-model updates stay low-churn. Thanks @vincentkoc.
+- Memory/plugins: let the active memory plugin register its own system-prompt section while preserving cache-clear and snapshot-load prompt isolation. (#40126) Thanks @jarimustonen.
 
 ### Fixes
 

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -54,6 +54,7 @@ function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi 
     registerHttpRoute() {},
     registerCommand() {},
     registerContextEngine() {},
+    registerMemoryPromptSection() {},
     on() {},
     resolvePath: (p) => p,
     ...overrides,

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildPromptSection } from "./index.js";
+
+describe("buildPromptSection", () => {
+  it("returns empty when no memory tools are available", () => {
+    expect(buildPromptSection({ availableTools: new Set() })).toEqual([]);
+  });
+
+  it("returns Memory Recall section when memory_search is available", () => {
+    const result = buildPromptSection({ availableTools: new Set(["memory_search"]) });
+    expect(result[0]).toBe("## Memory Recall");
+    expect(result).toContain(
+      "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
+    );
+    expect(result.at(-1)).toBe("");
+  });
+
+  it("returns Memory Recall section when memory_get is available", () => {
+    const result = buildPromptSection({ availableTools: new Set(["memory_get"]) });
+    expect(result[0]).toBe("## Memory Recall");
+  });
+
+  it("includes citations-off instruction when citationsMode is off", () => {
+    const result = buildPromptSection({
+      availableTools: new Set(["memory_search"]),
+      citationsMode: "off",
+    });
+    expect(result).toContain(
+      "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
+    );
+  });
+});

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,7 +1,10 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
 import type { MemoryPromptSectionBuilder } from "openclaw/plugin-sdk/memory-core";
 
-const buildPromptSection: MemoryPromptSectionBuilder = ({ availableTools, citationsMode }) => {
+export const buildPromptSection: MemoryPromptSectionBuilder = ({
+  availableTools,
+  citationsMode,
+}) => {
   if (!availableTools.has("memory_search") && !availableTools.has("memory_get")) {
     return [];
   }

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,4 +1,26 @@
+import type { MemoryPromptSectionBuilder } from "openclaw/plugin-sdk/memory-core";
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
+
+const buildPromptSection: MemoryPromptSectionBuilder = ({ availableTools, citationsMode }) => {
+  if (!availableTools.has("memory_search") && !availableTools.has("memory_get")) {
+    return [];
+  }
+  const lines = [
+    "## Memory Recall",
+    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
+  ];
+  if (citationsMode === "off") {
+    lines.push(
+      "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
+    );
+  } else {
+    lines.push(
+      "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
+    );
+  }
+  lines.push("");
+  return lines;
+};
 
 export default definePluginEntry({
   id: "memory-core",
@@ -6,6 +28,8 @@ export default definePluginEntry({
   description: "File-backed memory search tools and CLI",
   kind: "memory",
   register(api) {
+    api.registerMemoryPromptSection(buildPromptSection);
+
     api.registerTool(
       (ctx) => {
         const memorySearchTool = api.runtime.tools.createMemorySearchTool({

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,5 +1,5 @@
-import type { MemoryPromptSectionBuilder } from "openclaw/plugin-sdk/memory-core";
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import type { MemoryPromptSectionBuilder } from "openclaw/plugin-sdk/memory-core";
 
 const buildPromptSection: MemoryPromptSectionBuilder = ({ availableTools, citationsMode }) => {
   if (!availableTools.has("memory_search") && !availableTools.has("memory_get")) {

--- a/package.json
+++ b/package.json
@@ -313,6 +313,10 @@
       "types": "./dist/plugin-sdk/llm-task.d.ts",
       "default": "./dist/plugin-sdk/llm-task.js"
     },
+    "./plugin-sdk/memory-core": {
+      "types": "./dist/plugin-sdk/memory-core.d.ts",
+      "default": "./dist/plugin-sdk/memory-core.js"
+    },
     "./plugin-sdk/memory-lancedb": {
       "types": "./dist/plugin-sdk/memory-lancedb.d.ts",
       "default": "./dist/plugin-sdk/memory-lancedb.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -68,6 +68,7 @@
   "json-store",
   "keyed-async-queue",
   "llm-task",
+  "memory-core",
   "memory-lancedb",
   "provider-auth",
   "provider-auth-api-key",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -2,6 +2,7 @@ import { createHmac, createHash } from "node:crypto";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
+import { buildMemoryPromptSection } from "../memory/prompt-section.js";
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -43,24 +44,10 @@ function buildMemorySection(params: {
   if (params.isMinimal) {
     return [];
   }
-  if (!params.availableTools.has("memory_search") && !params.availableTools.has("memory_get")) {
-    return [];
-  }
-  const lines = [
-    "## Memory Recall",
-    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
-  ];
-  if (params.citationsMode === "off") {
-    lines.push(
-      "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
-    );
-  } else {
-    lines.push(
-      "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
-    );
-  }
-  lines.push("");
-  return lines;
+  return buildMemoryPromptSection({
+    availableTools: params.availableTools,
+    citationsMode: params.citationsMode,
+  });
 }
 
 function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: boolean) {

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { DaemonActionResponse } from "./response.js";
 import { captureFullEnv } from "../../test-utils/env.js";
+import type { DaemonActionResponse } from "./response.js";
 
 const resolveAutoNodeExtraCaCertsMock = vi.hoisted(() => vi.fn());
 const loadConfigMock = vi.hoisted(() => vi.fn());

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -1,4 +1,3 @@
-import type { DaemonInstallOptions } from "./types.js";
 import { resolveAutoNodeExtraCaCerts } from "../../bootstrap/node-extra-ca-certs.js";
 import { buildGatewayInstallPlan } from "../../commands/daemon-install-helpers.js";
 import {
@@ -17,6 +16,7 @@ import {
   failIfNixDaemonInstallMode,
   parsePort,
 } from "./shared.js";
+import type { DaemonInstallOptions } from "./types.js";
 
 export async function runDaemonInstall(opts: DaemonInstallOptions) {
   const { json, stdout, warnings, emit, fail } = createDaemonInstallActionContext(opts.json);
@@ -141,11 +141,12 @@ async function gatewayServiceNeedsAutoNodeExtraCaCertsRefresh(params: {
     if (!currentExecPath) {
       return false;
     }
-    const currentNodeExtraCaCerts = currentCommand?.environment?.NODE_EXTRA_CA_CERTS?.trim();
+    const currentEnvironment = currentCommand?.environment ?? {};
+    const currentNodeExtraCaCerts = currentEnvironment.NODE_EXTRA_CA_CERTS?.trim();
     const expectedNodeExtraCaCerts = resolveAutoNodeExtraCaCerts({
       env: {
         ...params.env,
-        ...currentCommand.environment,
+        ...currentEnvironment,
         NODE_EXTRA_CA_CERTS: undefined,
       },
       execPath: currentExecPath,

--- a/src/memory/prompt-section.test.ts
+++ b/src/memory/prompt-section.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   registerMemoryPromptSection,
   buildMemoryPromptSection,
+  clearMemoryPromptSection,
   _resetMemoryPromptSection,
 } from "./prompt-section.js";
 
@@ -19,7 +20,9 @@ describe("memory prompt section registry", () => {
 
   it("delegates to the registered builder", () => {
     registerMemoryPromptSection(({ availableTools }) => {
-      if (!availableTools.has("memory_search")) return [];
+      if (!availableTools.has("memory_search")) {
+        return [];
+      }
       return ["## Custom Memory", "Use custom memory tools.", ""];
     });
 
@@ -48,5 +51,14 @@ describe("memory prompt section registry", () => {
 
     const result = buildMemoryPromptSection({ availableTools: new Set() });
     expect(result).toEqual(["second"]);
+  });
+
+  it("clearMemoryPromptSection resets the builder", () => {
+    registerMemoryPromptSection(() => ["stale section"]);
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["stale section"]);
+
+    clearMemoryPromptSection();
+
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([]);
   });
 });

--- a/src/memory/prompt-section.test.ts
+++ b/src/memory/prompt-section.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  registerMemoryPromptSection,
+  buildMemoryPromptSection,
+  _resetMemoryPromptSection,
+} from "./prompt-section.js";
+
+describe("memory prompt section registry", () => {
+  beforeEach(() => {
+    _resetMemoryPromptSection();
+  });
+
+  it("returns empty array when no builder is registered", () => {
+    const result = buildMemoryPromptSection({
+      availableTools: new Set(["memory_search", "memory_get"]),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("delegates to the registered builder", () => {
+    registerMemoryPromptSection(({ availableTools }) => {
+      if (!availableTools.has("memory_search")) return [];
+      return ["## Custom Memory", "Use custom memory tools.", ""];
+    });
+
+    const result = buildMemoryPromptSection({
+      availableTools: new Set(["memory_search"]),
+    });
+    expect(result).toEqual(["## Custom Memory", "Use custom memory tools.", ""]);
+  });
+
+  it("passes citationsMode to the builder", () => {
+    registerMemoryPromptSection(({ citationsMode }) => {
+      return [`citations: ${citationsMode ?? "default"}`];
+    });
+
+    expect(
+      buildMemoryPromptSection({
+        availableTools: new Set(),
+        citationsMode: "off",
+      }),
+    ).toEqual(["citations: off"]);
+  });
+
+  it("last registration wins", () => {
+    registerMemoryPromptSection(() => ["first"]);
+    registerMemoryPromptSection(() => ["second"]);
+
+    const result = buildMemoryPromptSection({ availableTools: new Set() });
+    expect(result).toEqual(["second"]);
+  });
+});

--- a/src/memory/prompt-section.ts
+++ b/src/memory/prompt-section.ts
@@ -23,7 +23,10 @@ export function buildMemoryPromptSection(params: {
   return _builder?.(params) ?? [];
 }
 
-/** Reset state (for tests). */
-export function _resetMemoryPromptSection(): void {
+/** Clear the registered builder (called on plugin reload and in tests). */
+export function clearMemoryPromptSection(): void {
   _builder = undefined;
 }
+
+/** @deprecated Use {@link clearMemoryPromptSection}. */
+export const _resetMemoryPromptSection = clearMemoryPromptSection;

--- a/src/memory/prompt-section.ts
+++ b/src/memory/prompt-section.ts
@@ -23,6 +23,16 @@ export function buildMemoryPromptSection(params: {
   return _builder?.(params) ?? [];
 }
 
+/** Return the current builder (used by the plugin cache to snapshot state). */
+export function getMemoryPromptSectionBuilder(): MemoryPromptSectionBuilder | undefined {
+  return _builder;
+}
+
+/** Restore a previously-snapshotted builder (used on plugin cache hits). */
+export function restoreMemoryPromptSection(builder: MemoryPromptSectionBuilder | undefined): void {
+  _builder = builder;
+}
+
 /** Clear the registered builder (called on plugin reload and in tests). */
 export function clearMemoryPromptSection(): void {
   _builder = undefined;

--- a/src/memory/prompt-section.ts
+++ b/src/memory/prompt-section.ts
@@ -1,0 +1,29 @@
+import type { MemoryCitationsMode } from "../config/types.memory.js";
+
+/**
+ * Callback that the active memory plugin provides to build
+ * its section of the agent system prompt.
+ */
+export type MemoryPromptSectionBuilder = (params: {
+  availableTools: Set<string>;
+  citationsMode?: MemoryCitationsMode;
+}) => string[];
+
+// Module-level singleton — only one memory plugin can be active (exclusive slot).
+let _builder: MemoryPromptSectionBuilder | undefined;
+
+export function registerMemoryPromptSection(builder: MemoryPromptSectionBuilder): void {
+  _builder = builder;
+}
+
+export function buildMemoryPromptSection(params: {
+  availableTools: Set<string>;
+  citationsMode?: MemoryCitationsMode;
+}): string[] {
+  return _builder?.(params) ?? [];
+}
+
+/** Reset state (for tests). */
+export function _resetMemoryPromptSection(): void {
+  _builder = undefined;
+}

--- a/src/plugin-sdk/memory-core.ts
+++ b/src/plugin-sdk/memory-core.ts
@@ -2,4 +2,5 @@
 // Keep this list additive and scoped to symbols used under extensions/memory-core.
 
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { MemoryPromptSectionBuilder } from "../memory/prompt-section.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1208,6 +1208,73 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     clearPluginCommands();
   });
 
+  it("does not replace the active memory prompt section during non-activating loads", () => {
+    useNoBundledPlugins();
+    registerMemoryPromptSection(() => ["active memory section"]);
+    const plugin = writePlugin({
+      id: "snapshot-memory",
+      filename: "snapshot-memory.cjs",
+      body: `module.exports = {
+        id: "snapshot-memory",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryPromptSection(() => ["snapshot memory section"]);
+        },
+      };`,
+    });
+
+    const scoped = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["snapshot-memory"],
+          slots: { memory: "snapshot-memory" },
+        },
+      },
+      onlyPluginIds: ["snapshot-memory"],
+    });
+
+    expect(scoped.plugins.find((entry) => entry.id === "snapshot-memory")?.status).toBe("loaded");
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
+      "active memory section",
+    ]);
+  });
+
+  it("clears a newly-registered memory prompt section when plugin register fails", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "failing-memory",
+      filename: "failing-memory.cjs",
+      body: `module.exports = {
+        id: "failing-memory",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryPromptSection(() => ["stale failure section"]);
+          throw new Error("memory register failed");
+        },
+      };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["failing-memory"],
+          slots: { memory: "failing-memory" },
+        },
+      },
+      onlyPluginIds: ["failing-memory"],
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "failing-memory")?.status).toBe("error");
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([]);
+  });
+
   it("throws when activate:false is used without cache:false", () => {
     expect(() => loadOpenClawPlugins({ activate: false })).toThrow(
       "activate:false requires cache:false",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -23,12 +23,13 @@ async function importFreshPluginTestModules() {
   vi.doUnmock("./hooks.js");
   vi.doUnmock("./loader.js");
   vi.doUnmock("jiti");
-  const [loader, hookRunnerGlobal, hooks, runtime, registry] = await Promise.all([
+  const [loader, hookRunnerGlobal, hooks, runtime, registry, promptSection] = await Promise.all([
     import("./loader.js"),
     import("./hook-runner-global.js"),
     import("./hooks.js"),
     import("./runtime.js"),
     import("./registry.js"),
+    import("../memory/prompt-section.js"),
   ]);
   return {
     ...loader,
@@ -36,11 +37,13 @@ async function importFreshPluginTestModules() {
     ...hooks,
     ...runtime,
     ...registry,
+    ...promptSection,
   };
 }
 
 const {
   __testing,
+  buildMemoryPromptSection,
   clearPluginLoaderCache,
   createHookRunner,
   createEmptyPluginRegistry,
@@ -48,6 +51,7 @@ const {
   getActivePluginRegistryKey,
   getGlobalHookRunner,
   loadOpenClawPlugins,
+  registerMemoryPromptSection,
   resetGlobalHookRunner,
   setActivePluginRegistry,
 } = await importFreshPluginTestModules();
@@ -3785,5 +3789,18 @@ export const runtimeValue = helperValue;`,
       env,
     });
     expect(resolved).toBe(expected === "dist" ? fixture.distFile : fixture.srcFile);
+  });
+});
+
+describe("clearPluginLoaderCache", () => {
+  it("resets the registered memory prompt section builder", () => {
+    registerMemoryPromptSection(() => ["stale memory section"]);
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
+      "stale memory section",
+    ]);
+
+    clearPluginLoaderCache();
+
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([]);
   });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1283,6 +1283,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       hookPolicy: entry?.hooks,
       registrationMode,
     });
+    const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
 
     try {
       const result = register(api);
@@ -1294,9 +1295,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           message: "plugin register returned a promise; async registration is ignored",
         });
       }
+      // Snapshot loads should not replace process-global runtime prompt state.
+      if (!shouldActivate) {
+        restoreMemoryPromptSection(previousMemoryPromptBuilder);
+      }
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
     } catch (err) {
+      restoreMemoryPromptSection(previousMemoryPromptBuilder);
       recordPluginError({
         logger,
         registry,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -9,8 +9,12 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  clearMemoryPromptSection,
+  getMemoryPromptSectionBuilder,
+  restoreMemoryPromptSection,
+} from "../memory/prompt-section.js";
 import { resolveUserPath } from "../utils.js";
-import { clearMemoryPromptSection } from "../memory/prompt-section.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
 import { clearPluginCommands } from "./commands.js";
 import {
@@ -91,8 +95,13 @@ export class PluginLoadFailureError extends Error {
   }
 }
 
+type CachedPluginState = {
+  registry: PluginRegistry;
+  memoryPromptBuilder: ReturnType<typeof getMemoryPromptSectionBuilder>;
+};
+
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
-const registryCache = new Map<string, PluginRegistry>();
+const registryCache = new Map<string, CachedPluginState>();
 const openAllowlistWarningCache = new Set<string>();
 const LAZY_RUNTIME_REFLECTION_KEYS = [
   "version",
@@ -211,7 +220,7 @@ export const __testing = {
   maxPluginRegistryCacheEntries: MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
 };
 
-function getCachedPluginRegistry(cacheKey: string): PluginRegistry | undefined {
+function getCachedPluginRegistry(cacheKey: string): CachedPluginState | undefined {
   const cached = registryCache.get(cacheKey);
   if (!cached) {
     return undefined;
@@ -222,11 +231,11 @@ function getCachedPluginRegistry(cacheKey: string): PluginRegistry | undefined {
   return cached;
 }
 
-function setCachedPluginRegistry(cacheKey: string, registry: PluginRegistry): void {
+function setCachedPluginRegistry(cacheKey: string, state: CachedPluginState): void {
   if (registryCache.has(cacheKey)) {
     registryCache.delete(cacheKey);
   }
-  registryCache.set(cacheKey, registry);
+  registryCache.set(cacheKey, state);
   while (registryCache.size > MAX_PLUGIN_REGISTRY_CACHE_ENTRIES) {
     const oldestKey = registryCache.keys().next().value;
     if (!oldestKey) {
@@ -765,10 +774,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
+      restoreMemoryPromptSection(cached.memoryPromptBuilder);
       if (shouldActivate) {
-        activatePluginRegistry(cached, cacheKey);
+        activatePluginRegistry(cached.registry, cacheKey);
       }
-      return cached;
+      return cached.registry;
     }
   }
 
@@ -1320,7 +1330,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   maybeThrowOnPluginLoadError(registry, options.throwOnLoadError);
 
   if (cacheEnabled) {
-    setCachedPluginRegistry(cacheKey, registry);
+    setCachedPluginRegistry(cacheKey, {
+      registry,
+      memoryPromptBuilder: getMemoryPromptSectionBuilder(),
+    });
   }
   if (shouldActivate) {
     activatePluginRegistry(registry, cacheKey);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -10,6 +10,7 @@ import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
+import { clearMemoryPromptSection } from "../memory/prompt-section.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
 import { clearPluginCommands } from "./commands.js";
 import {
@@ -113,6 +114,7 @@ const LAZY_RUNTIME_REFLECTION_KEYS = [
 export function clearPluginLoaderCache(): void {
   registryCache.clear();
   openAllowlistWarningCache.clear();
+  clearMemoryPromptSection();
 }
 
 const defaultLogger = () => createSubsystemLogger("plugins");
@@ -770,11 +772,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
   }
 
-  // Clear previously registered plugin commands before reloading.
+  // Clear previously registered plugin state before reloading.
   // Skip for non-activating (snapshot) loads to avoid wiping commands from other plugins.
   if (shouldActivate) {
     clearPluginCommands();
     clearPluginInteractiveHandlers();
+    clearMemoryPromptSection();
   }
 
   // Lazy: avoid creating the Jiti loader when all plugins are disabled (common in unit tests).

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,13 +2,13 @@ import path from "node:path";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { registerContextEngineForOwner } from "../context-engine/registry.js";
-import { registerMemoryPromptSection } from "../memory/prompt-section.js";
 import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
 } from "../gateway/server-methods/types.js";
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
+import { registerMemoryPromptSection } from "../memory/prompt-section.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand, validatePluginCommandDefinition } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { registerContextEngineForOwner } from "../context-engine/registry.js";
+import { registerMemoryPromptSection } from "../memory/prompt-section.js";
 import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
@@ -978,6 +979,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
             message: `context engine already registered: ${id} (${result.existingOwner})`,
           });
         }
+      },
+      registerMemoryPromptSection: (builder) => {
+        if (registrationMode !== "full") {
+          return;
+        }
+        if (record.kind !== "memory") {
+          pushDiagnostic({
+            level: "error",
+            pluginId: record.id,
+            source: record.source,
+            message: "only memory plugins can register a memory prompt section",
+          });
+          return;
+        }
+        registerMemoryPromptSection(builder);
       },
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) =>

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1347,6 +1347,10 @@ export type OpenClawPluginApi = {
     id: string,
     factory: import("../context-engine/registry.js").ContextEngineFactory,
   ) => void;
+  /** Register the system prompt section builder for this memory plugin (exclusive slot). */
+  registerMemoryPromptSection: (
+    builder: import("../memory/prompt-section.js").MemoryPromptSectionBuilder,
+  ) => void;
   resolvePath: (input: string) => string;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(

--- a/test/helpers/extensions/plugin-api.ts
+++ b/test/helpers/extensions/plugin-api.ts
@@ -23,6 +23,7 @@ export function createTestPluginApi(api: TestPluginApiInput): OpenClawPluginApi 
     onConversationBindingResolved() {},
     registerCommand() {},
     registerContextEngine() {},
+    registerMemoryPromptSection() {},
     resolvePath(input: string) {
       return input;
     },


### PR DESCRIPTION
## Summary

- Problem: The system prompt "Memory Recall" section is hardcoded in `system-prompt.ts`, providing memory-core-specific instructions. When a third-party memory plugin is active (via the exclusive memory slot), these instructions are misleading.
- Why it matters: Third-party memory plugins need to provide their own system prompt guidance for their tools instead of the hardcoded memory-core instructions.
- What changed: Added `registerMemoryPromptSection(builder)` to the plugin API. The active memory plugin registers its own system prompt builder callback. Moved the existing "Memory Recall" logic into `memory-core` as its registration. `buildMemorySection()` delegates to the registered callback.
- What did NOT change (scope boundary): Default behavior is identical — memory-core registers the same prompt content. No changes to memory tools, compaction, or other plugin APIs.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

None for default memory-core users. Memory plugins with `kind: "memory"` can now register a custom system prompt section via `api.registerMemoryPromptSection(builder)`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun
- Model/provider: N/A (system prompt wiring)
- Integration/channel (if any): Telegram (for human test)

### Steps

1. Install a memory plugin that calls `api.registerMemoryPromptSection(builder)`
2. Start a session
3. Observe that the system prompt contains the plugin's memory section instead of the hardcoded one

### Expected

- With memory-core (default): system prompt contains "Memory Recall" section as before
- With custom memory plugin: system prompt contains the plugin's custom section
- With no memory plugin: memory section is omitted

### Actual (before fix)

- Hardcoded "Memory Recall" section always present regardless of active memory plugin

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New unit tests in `prompt-section.test.ts`: delegation, citationsMode passthrough, no-builder returns empty, last-registration-wins. All 43 existing `system-prompt.test.ts` tests pass.

## Human Verification (required)

- Verified scenarios: Tested on two separate OpenClaw bots (Telegram) with memory-core active — memory instructions present as expected, no regression observed
- Edge cases checked: None
- What you did **not** verify: No memory plugin active (section omitted), custom third-party memory plugin providing its own section

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; hardcoded prompt returns
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Missing "Memory Recall" section in system prompt when memory-core is active

## Risks and Mitigations

None. Additive API change. Default behavior is identical — memory-core registers the same prompt content it previously hardcoded.