### PR TITLE
fix(browser): avoid immediate SIGKILL during Chrome shutdown

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -94,6 +94,7 @@ function makeChromeTestProc(overrides?: Partial<{ killed: boolean; exitCode: num
   return {
     killed: overrides?.killed ?? false,
     exitCode: overrides?.exitCode ?? null,
+    signalCode: null,
     kill: vi.fn(),
   };
 }
@@ -360,6 +361,7 @@ describe("browser chrome helpers", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
     const proc = makeChromeTestProc();
     await stopChromeWithProc(proc, 10);
+    expect(proc.kill).toHaveBeenCalledTimes(1);
     expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
   });
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -407,13 +407,17 @@ export async function stopOpenClawChrome(
 
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    if (!proc.exitCode && proc.killed) {
-      break;
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      return;
     }
     if (!(await isChromeReachable(cdpUrlForPort(running.cdpPort), CHROME_STOP_PROBE_TIMEOUT_MS))) {
       return;
     }
     await new Promise((r) => setTimeout(r, 100));
+  }
+
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return;
   }
 
   try {


### PR DESCRIPTION
## Summary

This PR fixes the graceful browser shutdown path in `stopOpenClawChrome`.

Today the loop treats `proc.killed` as if it means "the child has already exited":

```ts
if (!proc.exitCode && proc.killed) {
  break;
}
```

In Node, `proc.killed` flips to `true` as soon as `kill()` is called. That means the current code can go from `SIGTERM` straight to `SIGKILL` without waiting for Chrome to actually exit, even when the browser is already going down cleanly.

This patch waits for an actual process exit signal (`exitCode` / `signalCode`) before skipping the hard-kill fallback.

## Why

This is the narrowest fix that matches the clean-shutdown bug discussed in:

- #11257

It improves the graceful shutdown path for the managed browser without expanding scope into separate crash/supervisor cleanup behavior.

## Change

- treat `exitCode !== null || signalCode !== null` as the "already exited" condition
- keep the existing CDP reachability probe
- only send `SIGKILL` if Chrome still has not exited after the timeout
- strengthen the browser test so the clean-shutdown case fails if `SIGKILL` is sent immediately

## Testing

- [x] AI-assisted PR
- [x] I understand the code path changed
- [x] Focused test passed:
  - `pnpm -s vitest run src/browser/chrome.test.ts`
- [x] Build passed:
  - `pnpm build`
- [ ] Full `pnpm check`
  - failed on an unrelated existing repo issue in `src/agents/models-config.merge.test.ts`
- [ ] Full `pnpm test`
  - during the repo-wide run, unrelated failures appeared in `src/memory/embeddings.test.ts` and `src/memory/embeddings-voyage.test.ts`

## Notes

I intentionally did not broaden this into launchd/systemd process-tree cleanup or startup orphan reaping. Those are separate concerns and would make the PR much less reviewable.
