### PR TITLE
fix(discord): apply effective maxLinesPerMessage in live replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - ACP/follow-up hardening: make session restore and prompt completion degrade gracefully on transcript/update failures, enforce bounded tool-location traversal, and skip non-image ACPX turns the runtime cannot serialize. (#41464) Thanks @mbelinky.
 - Agents/fallback observability: add structured, sanitized model-fallback decision and auth-profile failure-state events with correlated run IDs so cooldown probes and failover paths are easier to trace in logs. (#41337) thanks @altaywtf.
 - Protocol/Swift model sync: regenerate pending node work Swift bindings after the landed `node.pending.*` schema additions so generated protocol artifacts are consistent again. (#41477) Thanks @mbelinky.
+- Discord/reply chunking: resolve the effective `maxLinesPerMessage` config across live reply paths and preserve `chunkMode` in the fast send path so long Discord replies no longer split unexpectedly at the default 17-line limit. (#40133) thanks @rbutera.
 
 ## 2026.3.8
 

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveDiscordAccount } from "./accounts.js";
+import { resolveDiscordAccount, resolveDiscordMaxLinesPerMessage } from "./accounts.js";
 
 describe("resolveDiscordAccount allowFrom precedence", () => {
   it("prefers accounts.default.allowFrom over top-level for default account", () => {
@@ -54,5 +54,62 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
     });
 
     expect(resolved.config.allowFrom).toBeUndefined();
+  });
+
+  it("falls back to merged root discord maxLinesPerMessage when runtime config omits it", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              default: { token: "token-default" },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(120);
+  });
+
+  it("prefers explicit runtime discord maxLinesPerMessage over merged config", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              default: { token: "token-default", maxLinesPerMessage: 80 },
+            },
+          },
+        },
+      },
+      discordConfig: { maxLinesPerMessage: 55 },
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(55);
+  });
+
+  it("uses per-account discord maxLinesPerMessage over the root value when runtime config omits it", () => {
+    const resolved = resolveDiscordMaxLinesPerMessage({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+            accounts: {
+              work: { token: "token-work", maxLinesPerMessage: 80 },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "work",
+    });
+
+    expect(resolved).toBe(80);
   });
 });

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -55,7 +55,9 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
 
     expect(resolved.config.allowFrom).toBeUndefined();
   });
+});
 
+describe("resolveDiscordMaxLinesPerMessage", () => {
   it("falls back to merged root discord maxLinesPerMessage when runtime config omits it", () => {
     const resolved = resolveDiscordMaxLinesPerMessage({
       cfg: {

--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -68,6 +68,20 @@ export function resolveDiscordAccount(params: {
   };
 }
 
+export function resolveDiscordMaxLinesPerMessage(params: {
+  cfg: OpenClawConfig;
+  discordConfig?: DiscordAccountConfig | null;
+  accountId?: string | null;
+}): number | undefined {
+  if (typeof params.discordConfig?.maxLinesPerMessage === "number") {
+    return params.discordConfig.maxLinesPerMessage;
+  }
+  return resolveDiscordAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  }).config.maxLinesPerMessage;
+}
+
 export function listEnabledDiscordAccounts(cfg: OpenClawConfig): ResolvedDiscordAccount[] {
   return listDiscordAccountIds(cfg)
     .map((accountId) => resolveDiscordAccount({ cfg, accountId }))

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -43,6 +43,7 @@ import {
   readStoreAllowFromForDmPolicy,
   resolvePinnedMainDmOwnerFromAllowlist,
 } from "../../security/dm-policy-shared.js";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { resolveDiscordComponentEntry, resolveDiscordModalEntry } from "../components-registry.js";
 import {
   createDiscordFormModal,
@@ -1017,7 +1018,11 @@ async function dispatchDiscordComponentEvent(params: {
           replyToId,
           replyToMode,
           textLimit,
-          maxLinesPerMessage: ctx.discordConfig?.maxLinesPerMessage,
+          maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({
+            cfg: ctx.cfg,
+            discordConfig: ctx.discordConfig,
+            accountId,
+          }),
           tableMode,
           chunkMode: resolveChunkMode(ctx.cfg, "discord", accountId),
           mediaLocalRoots,

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -502,6 +502,38 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
+  it("uses root discord maxLinesPerMessage for preview finalization when runtime config omits it", async () => {
+    const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: longReply });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      cfg: {
+        messages: { ackReaction: "👀" },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+        channels: {
+          discord: {
+            maxLinesPerMessage: 120,
+          },
+        },
+      },
+      discordConfig: { streamMode: "partial" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(editMessageDiscord).toHaveBeenCalledWith(
+      "c1",
+      "preview-1",
+      { content: longReply },
+      { rest: {} },
+    );
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
   it("suppresses reasoning payload delivery to Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -32,6 +32,7 @@ import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../routing/session-key.js";
 import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { truncateUtf16Safe } from "../../utils.js";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
@@ -426,6 +427,11 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     channel: "discord",
     accountId,
   });
+  const maxLinesPerMessage = resolveDiscordMaxLinesPerMessage({
+    cfg,
+    discordConfig,
+    accountId,
+  });
   const chunkMode = resolveChunkMode(cfg, "discord", accountId);
 
   const typingCallbacks = createTypingCallbacks({
@@ -484,7 +490,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     const formatted = convertMarkdownTables(text, tableMode);
     const chunks = chunkDiscordTextWithMode(formatted, {
       maxChars: draftMaxChars,
-      maxLines: discordConfig?.maxLinesPerMessage,
+      maxLines: maxLinesPerMessage,
       chunkMode,
     });
     if (!chunks.length && formatted) {
@@ -687,7 +693,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           replyToId,
           replyToMode,
           textLimit,
-          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          maxLinesPerMessage,
           tableMode,
           chunkMode,
           sessionKey: ctxPayload.SessionKey,

--- a/src/discord/monitor/native-command.commands-allowfrom.test.ts
+++ b/src/discord/monitor/native-command.commands-allowfrom.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { DiscordAccountConfig } from "../../config/types.discord.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import {
@@ -49,7 +50,7 @@ function createConfig(): OpenClawConfig {
   } as OpenClawConfig;
 }
 
-function createCommand(cfg: OpenClawConfig) {
+function createCommand(cfg: OpenClawConfig, discordConfig?: DiscordAccountConfig) {
   const commandSpec: NativeCommandSpec = {
     name: "status",
     description: "Status",
@@ -58,7 +59,7 @@ function createCommand(cfg: OpenClawConfig) {
   return createDiscordNativeCommand({
     command: commandSpec,
     cfg,
-    discordConfig: cfg.channels?.discord ?? {},
+    discordConfig: discordConfig ?? cfg.channels?.discord ?? {},
     accountId: "default",
     sessionPrefix: "discord:slash",
     ephemeralDefault: true,
@@ -79,10 +80,11 @@ function createDispatchSpy() {
 async function runGuildSlashCommand(params?: {
   userId?: string;
   mutateConfig?: (cfg: OpenClawConfig) => void;
+  runtimeDiscordConfig?: DiscordAccountConfig;
 }) {
   const cfg = createConfig();
   params?.mutateConfig?.(cfg);
-  const command = createCommand(cfg);
+  const command = createCommand(cfg, params?.runtimeDiscordConfig);
   const interaction = createInteraction({ userId: params?.userId });
   vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
   const dispatchSpy = createDispatchSpy();
@@ -163,5 +165,42 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     });
     expect(dispatchSpy).not.toHaveBeenCalled();
     expectUnauthorizedReply(interaction);
+  });
+
+  it("uses the root discord maxLinesPerMessage when runtime discordConfig omits it", async () => {
+    const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
+    const { interaction } = await runGuildSlashCommand({
+      mutateConfig: (cfg) => {
+        cfg.channels = {
+          ...cfg.channels,
+          discord: {
+            ...cfg.channels?.discord,
+            maxLinesPerMessage: 120,
+          },
+        };
+      },
+      runtimeDiscordConfig: {
+        groupPolicy: "allowlist",
+        guilds: {
+          "345678901234567890": {
+            channels: {
+              "234567890123456789": {
+                allow: true,
+                requireMention: false,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const dispatchCall = vi.mocked(dispatcherModule.dispatchReplyWithDispatcher).mock
+      .calls[0]?.[0] as
+      | Parameters<typeof dispatcherModule.dispatchReplyWithDispatcher>[0]
+      | undefined;
+    await dispatchCall?.dispatcherOptions.deliver({ text: longReply }, { kind: "final" });
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: longReply }));
+    expect(interaction.followUp).not.toHaveBeenCalled();
   });
 });

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -56,6 +56,7 @@ import type { ResolvedAgentRoute } from "../../routing/resolve-route.js";
 import { chunkItems } from "../../utils/chunk-items.js";
 import { withTimeout } from "../../utils/with-timeout.js";
 import { loadWebMedia } from "../../web/media.js";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import {
   isDiscordGroupAllowedByPolicy,
@@ -1571,7 +1572,7 @@ async function dispatchDiscordCommandInteraction(params: {
       textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
         fallbackLimit: 2000,
       }),
-      maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+      maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
       preferFollowUp,
       chunkMode: resolveChunkMode(cfg, "discord", accountId),
     });
@@ -1706,7 +1707,7 @@ async function dispatchDiscordCommandInteraction(params: {
             textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
               fallbackLimit: 2000,
             }),
-            maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+            maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
             preferFollowUp: preferFollowUp || didReply,
             chunkMode: resolveChunkMode(cfg, "discord", accountId),
           });

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -256,6 +256,26 @@ describe("deliverDiscordReply", () => {
     expect(sendDiscordTextMock.mock.calls[1]?.[1]).toBe("789");
   });
 
+  it("passes maxLinesPerMessage and chunkMode through the fast path", async () => {
+    const fakeRest = {} as import("@buape/carbon").RequestClient;
+
+    await deliverDiscordReply({
+      replies: [{ text: Array.from({ length: 18 }, (_, index) => `line ${index + 1}`).join("\n") }],
+      target: "channel:789",
+      token: "token",
+      rest: fakeRest,
+      runtime,
+      textLimit: 2000,
+      maxLinesPerMessage: 120,
+      chunkMode: "newline",
+    });
+
+    expect(sendMessageDiscordMock).not.toHaveBeenCalled();
+    expect(sendDiscordTextMock).toHaveBeenCalledTimes(1);
+    expect(sendDiscordTextMock.mock.calls[0]?.[5]).toBe(120);
+    expect(sendDiscordTextMock.mock.calls[0]?.[8]).toBe("newline");
+  });
+
   it("falls back to sendMessageDiscord when rest is not provided", async () => {
     await deliverDiscordReply({
       replies: [{ text: "single chunk" }],

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -272,8 +272,11 @@ describe("deliverDiscordReply", () => {
 
     expect(sendMessageDiscordMock).not.toHaveBeenCalled();
     expect(sendDiscordTextMock).toHaveBeenCalledTimes(1);
-    expect(sendDiscordTextMock.mock.calls[0]?.[5]).toBe(120);
-    expect(sendDiscordTextMock.mock.calls[0]?.[8]).toBe("newline");
+    const firstSendDiscordTextCall = sendDiscordTextMock.mock.calls[0];
+    const [, , , , , maxLinesPerMessageArg, , , chunkModeArg] = firstSendDiscordTextCall ?? [];
+
+    expect(maxLinesPerMessageArg).toBe(120);
+    expect(chunkModeArg).toBe("newline");
   });
 
   it("falls back to sendMessageDiscord when rest is not provided", async () => {

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -130,9 +130,11 @@ async function sendDiscordChunkWithFallback(params: {
   text: string;
   token: string;
   accountId?: string;
+  maxLinesPerMessage?: number;
   rest?: RequestClient;
   replyTo?: string;
   binding?: DiscordThreadBindingLookupRecord;
+  chunkMode?: ChunkMode;
   username?: string;
   avatarUrl?: string;
   /** Pre-resolved channel ID to bypass redundant resolution per chunk. */
@@ -169,7 +171,18 @@ async function sendDiscordChunkWithFallback(params: {
   if (params.channelId && params.request && params.rest) {
     const { channelId, request, rest } = params;
     await sendWithRetry(
-      () => sendDiscordText(rest, channelId, text, params.replyTo, request),
+      () =>
+        sendDiscordText(
+          rest,
+          channelId,
+          text,
+          params.replyTo,
+          request,
+          params.maxLinesPerMessage,
+          undefined,
+          undefined,
+          params.chunkMode,
+        ),
       params.retryConfig,
     );
     return;
@@ -294,8 +307,10 @@ export async function deliverDiscordReply(params: {
           token: params.token,
           rest: params.rest,
           accountId: params.accountId,
+          maxLinesPerMessage: params.maxLinesPerMessage,
           replyTo,
           binding,
+          chunkMode: params.chunkMode,
           username: persona.username,
           avatarUrl: persona.avatarUrl,
           channelId,
@@ -329,8 +344,10 @@ export async function deliverDiscordReply(params: {
         token: params.token,
         rest: params.rest,
         accountId: params.accountId,
+        maxLinesPerMessage: params.maxLinesPerMessage,
         replyTo: resolveReplyTo(),
         binding,
+        chunkMode: params.chunkMode,
         username: persona.username,
         avatarUrl: persona.avatarUrl,
         channelId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem 1: Discord live reply surfaces could read a partial runtime `discordConfig` object, miss `maxLinesPerMessage`, and silently fall back to the default 17-line chunking even when the effective account config was higher.
- Problem 2: Discord auto-replies could still be split at 17 lines even after the effective value was resolved correctly, because the optimized fast path dropped `maxLinesPerMessage` and `chunkMode` before calling `sendDiscordText(...)`, causing a second re-chunking pass to use defaults.
- Why it matters: Users configured for longer Discord replies still saw noisy multi-message splits in normal live replies, preview/final delivery, slash replies, component replies, and auto-replies that should have remained within the configured line cap.
- What changed: Added `resolveDiscordMaxLinesPerMessage(...)` in `src/discord/accounts.ts`, switched the live Discord reply surfaces to use explicit runtime value first and then merged effective account config, and threaded `maxLinesPerMessage` plus `chunkMode` through the reply-delivery fast path so already-valid chunks are not re-split at 17 lines; added regressions for root-level fallback, per-account override, higher-level slash/native reply handling, and fast-path propagation.
- What did NOT change (scope boundary): This PR does not change Discord chunking defaults, Discord character-limit behavior, account selection/routing rules, webhook/thread-binding semantics, or non-Discord channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40128
- Closes #41017

## User-visible / Behavior Changes

- Discord live replies now honor the effective `maxLinesPerMessage` value for the active Discord account instead of falling back to the default 17-line chunking when the runtime `discordConfig` object is partial.
- Root `channels.discord.maxLinesPerMessage` now applies correctly to live reply paths when no per-account override is set.
- Per-account `channels.discord.accounts.<account>.maxLinesPerMessage` continues to override the root Discord value in live reply paths.
- Discord auto-replies sent through the optimized `deliverDiscordReply(...)` fast path now preserve `maxLinesPerMessage` and `chunkMode` all the way into `sendDiscordText(...)`, so a chunk that is already valid under the configured limit is not re-split at the default 17-line boundary.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: source checkout / `pnpm dev`
- Model/provider: N/A for the regression coverage added here
- Integration/channel (if any): Discord
- Relevant config (redacted): `channels.discord.maxLinesPerMessage: 120`; verified account-level override with `channels.discord.accounts.work.maxLinesPerMessage: 80`

### Steps

1. Configure Discord with `channels.discord.maxLinesPerMessage: 120` and optionally `channels.discord.accounts.work.maxLinesPerMessage: 80`.
2. Exercise a live Discord reply path with a runtime `discordConfig` object that omits `maxLinesPerMessage`.
3. Send or generate a reply with more than 17 short lines but fewer than the effective configured line cap.
4. Exercise the optimized auto-reply fast path so the reply is delivered through `deliverDiscordReply(...)` and then `sendDiscordText(...)`.

### Expected

- The live reply path uses the effective Discord account config when runtime `discordConfig` omits `maxLinesPerMessage`.
- A reply or already-chunked reply that is still under the configured line cap is delivered without being re-split at the default 17-line boundary.

### Actual

- Before the first fix, some live reply surfaces could treat `maxLinesPerMessage` as missing and fall back directly to the default 17-line limit.
- Before the second fix, even when outer delivery used the configured limit, the fast path could drop `maxLinesPerMessage` and `chunkMode` before `sendDiscordText(...)`, causing a second chunking pass to re-split at 17 lines.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test src/discord/accounts.test.ts src/discord/monitor/message-handler.process.test.ts src/discord/monitor/native-command.commands-allowfrom.test.ts`; confirmed root fallback, per-account override, explicit runtime override precedence, live message-handler preview/finalization, and a higher-level slash/native reply path. Also ran `pnpm test src/discord/monitor/reply-delivery.test.ts`; confirmed the fast path preserves `maxLinesPerMessage` and `chunkMode` instead of re-splitting at 17. Ran `pnpm build` after the follow-up fast-path fix.
- Edge cases checked: runtime `discordConfig` omits `maxLinesPerMessage`; explicit runtime value still wins; per-account override beats root config; a reply chunk longer than 17 lines but shorter than the configured limit is not re-split in the fast path.
- What you did **not** verify: no manual Discord UI run against a live gateway session in this branch; no webhook/thread-binding-specific manual smoke test beyond the updated code-path coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `6acb57223` and `0b5d29b46`, or restore the previous direct `discordConfig?.maxLinesPerMessage` reads in live reply paths plus the previous fast-path `sendDiscordText(...)` call.
- Files/config to restore: `src/discord/accounts.ts`, `src/discord/monitor/message-handler.process.ts`, `src/discord/monitor/native-command.ts`, `src/discord/monitor/agent-components.ts`, `src/discord/monitor/reply-delivery.ts`, `src/discord/monitor/reply-delivery.test.ts`
- Known bad symptoms reviewers should watch for: Discord live replies unexpectedly splitting at 17 lines again when only root-level Discord config is set, or Discord auto-replies that were already chunked under the configured cap getting split again in the fast path.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A live Discord path could still bypass the new resolver if another reply surface sources chunking limits independently.
  - Mitigation: This patch updates the known live surfaces that previously used raw `discordConfig?.maxLinesPerMessage` and adds direct plus higher-level regressions around the known failing paths.
- Risk: The fallback could hide a miswired runtime config object by making behavior look correct via merged account config.
  - Mitigation: The tests explicitly cover runtime omission, root fallback, per-account override, and explicit runtime precedence so the intended resolution order stays documented and enforced.
- Risk: The optimized delivery path could regress again if future chunking options are added to `sendDiscordText(...)` but not threaded through `sendDiscordChunkWithFallback(...)`.
  - Mitigation: The new regression in `src/discord/monitor/reply-delivery.test.ts` asserts the fast path forwards both `maxLinesPerMessage` and `chunkMode`.
