### PR TITLE
fix(acp): persist spawned child session history

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -10198,21 +10198,21 @@
         "filename": "docs/tools/web.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 135
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 224
+        "line_number": 228
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "674397e2c0c2faaa85961c708d2a96a7cc7af217",
         "is_verified": false,
-        "line_number": 328
+        "line_number": 332
       }
     ],
     "docs/tts.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T18:14:00Z"
+  "generated_at": "2026-03-08T18:30:57Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web search: restore Perplexity OpenRouter/Sonar compatibility for legacy `OPENROUTER_API_KEY`, `sk-or-...`, and explicit `perplexity.baseUrl` / `model` setups while keeping direct Perplexity keys on the native Search API path. (#39937) Thanks @obviyus.
 - Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
 - Sessions/model switch: clear stale cached `contextTokens` when a session changes models so status and runtime paths recompute against the active model window. (#38044) thanks @yuweuii.
+- ACP/session history: persist transcripts for successful ACP child runs, preserve exact transcript text, record ACP spawned-session lineage, and keep spawn-time transcript-path persistence best-effort so history storage failures do not block execution. (#40137) thanks @mbelinky.
 
 ## 2026.3.7
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -36,11 +36,8 @@ const hoisted = vi.hoisted(() => {
   const startAcpSpawnParentStreamRelayMock = vi.fn();
   const resolveAcpSpawnStreamLogPathMock = vi.fn();
   const loadSessionStoreMock = vi.fn();
-  const resolveAndPersistSessionFileMock = vi.fn();
   const resolveStorePathMock = vi.fn();
-  const resolveSessionTranscriptPathMock = vi.fn();
-  const resolveSessionFilePathOptionsMock = vi.fn();
-  const parseSessionThreadInfoMock = vi.fn();
+  const resolveSessionTranscriptFileMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
@@ -56,11 +53,8 @@ const hoisted = vi.hoisted(() => {
     startAcpSpawnParentStreamRelayMock,
     resolveAcpSpawnStreamLogPathMock,
     loadSessionStoreMock,
-    resolveAndPersistSessionFileMock,
     resolveStorePathMock,
-    resolveSessionTranscriptPathMock,
-    resolveSessionFilePathOptionsMock,
-    parseSessionThreadInfoMock,
+    resolveSessionTranscriptFileMock,
     state,
   };
 });
@@ -103,15 +97,16 @@ vi.mock("../config/sessions.js", async (importOriginal) => {
   return {
     ...actual,
     loadSessionStore: (storePath: string) => hoisted.loadSessionStoreMock(storePath),
-    resolveAndPersistSessionFile: (params: unknown) =>
-      hoisted.resolveAndPersistSessionFileMock(params),
     resolveStorePath: (store: unknown, opts: unknown) => hoisted.resolveStorePathMock(store, opts),
-    resolveSessionTranscriptPath: (...args: unknown[]) =>
-      hoisted.resolveSessionTranscriptPathMock(...args),
-    resolveSessionFilePathOptions: (params: unknown) =>
-      hoisted.resolveSessionFilePathOptionsMock(params),
-    parseSessionThreadInfo: (sessionKey: string | undefined) =>
-      hoisted.parseSessionThreadInfoMock(sessionKey),
+  };
+});
+
+vi.mock("../config/sessions/transcript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/transcript.js")>();
+  return {
+    ...actual,
+    resolveSessionTranscriptFile: (params: unknown) =>
+      hoisted.resolveSessionTranscriptFileMock(params),
   };
 });
 
@@ -304,25 +299,13 @@ describe("spawnAcpDirect", () => {
         },
       });
     });
-    hoisted.parseSessionThreadInfoMock
-      .mockReset()
-      .mockReturnValue({ baseSessionKey: "agent:codex:acp:test-session", threadId: undefined });
-    hoisted.resolveSessionTranscriptPathMock
-      .mockReset()
-      .mockImplementation((sessionId: string, _agentId: string, threadId?: string) =>
-        threadId
-          ? `/tmp/agents/codex/sessions/${sessionId}-topic-${threadId}.jsonl`
-          : `/tmp/agents/codex/sessions/${sessionId}.jsonl`,
-      );
-    hoisted.resolveSessionFilePathOptionsMock
-      .mockReset()
-      .mockReturnValue({ sessionsDir: "/tmp/agents/codex/sessions", agentId: "codex" });
-    hoisted.resolveAndPersistSessionFileMock
+    hoisted.resolveSessionTranscriptFileMock
       .mockReset()
       .mockImplementation(async (params: unknown) => {
-        const typed = params as { fallbackSessionFile?: string };
-        const sessionFile =
-          typed.fallbackSessionFile ?? "/tmp/agents/codex/sessions/sess-123.jsonl";
+        const typed = params as { threadId?: string };
+        const sessionFile = typed.threadId
+          ? `/tmp/agents/codex/sessions/sess-123-topic-${typed.threadId}.jsonl`
+          : "/tmp/agents/codex/sessions/sess-123.jsonl";
         return {
           sessionFile,
           sessionEntry: {
@@ -355,6 +338,13 @@ describe("spawnAcpDirect", () => {
     expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
     expect(result.runId).toBe("run-1");
     expect(result.mode).toBe("session");
+    const patchCalls = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .filter((request) => request.method === "sessions.patch");
+    expect(patchCalls[0]?.params).toMatchObject({
+      key: result.childSessionKey,
+      spawnedBy: "agent:main:main",
+    });
     expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
       expect.objectContaining({
         targetKind: "session",
@@ -377,16 +367,12 @@ describe("spawnAcpDirect", () => {
         mode: "persistent",
       }),
     );
-    const transcriptCalls = hoisted.resolveAndPersistSessionFileMock.mock.calls.map(
-      (call: unknown[]) => call[0] as { fallbackSessionFile?: string },
+    const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
+      (call: unknown[]) => call[0] as { threadId?: string },
     );
     expect(transcriptCalls).toHaveLength(2);
-    expect(transcriptCalls[0]?.fallbackSessionFile).toBe(
-      "/tmp/agents/codex/sessions/sess-123.jsonl",
-    );
-    expect(transcriptCalls[1]?.fallbackSessionFile).toBe(
-      "/tmp/agents/codex/sessions/sess-123-topic-child-thread.jsonl",
-    );
+    expect(transcriptCalls[0]?.threadId).toBeUndefined();
+    expect(transcriptCalls[1]?.threadId).toBe("child-thread");
   });
 
   it("does not inline delivery for fresh oneshot ACP runs", async () => {
@@ -407,11 +393,11 @@ describe("spawnAcpDirect", () => {
 
     expect(result.status).toBe("accepted");
     expect(result.mode).toBe("run");
-    expect(hoisted.resolveAndPersistSessionFileMock).toHaveBeenCalledWith(
+    expect(hoisted.resolveSessionTranscriptFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: "sess-123",
-        agentId: "codex",
         storePath: "/tmp/codex-sessions.json",
+        agentId: "codex",
       }),
     );
     const agentCall = hoisted.callGatewayMock.mock.calls
@@ -421,6 +407,32 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.channel).toBeUndefined();
     expect(agentCall?.params?.to).toBeUndefined();
     expect(agentCall?.params?.threadId).toBeUndefined();
+  });
+
+  it("keeps ACP spawn running when session-file persistence fails", async () => {
+    hoisted.resolveSessionTranscriptFileMock.mockRejectedValueOnce(new Error("disk full"));
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "run",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:6098642967",
+        agentThreadId: "1",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
+    const agentCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "agent");
+    expect(agentCall?.params?.sessionKey).toBe(result.childSessionKey);
   });
 
   it("includes cwd in ACP thread intro banner when provided at spawn time", async () => {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -35,6 +35,12 @@ const hoisted = vi.hoisted(() => {
   const initializeSessionMock = vi.fn();
   const startAcpSpawnParentStreamRelayMock = vi.fn();
   const resolveAcpSpawnStreamLogPathMock = vi.fn();
+  const loadSessionStoreMock = vi.fn();
+  const resolveAndPersistSessionFileMock = vi.fn();
+  const resolveStorePathMock = vi.fn();
+  const resolveSessionTranscriptPathMock = vi.fn();
+  const resolveSessionFilePathOptionsMock = vi.fn();
+  const parseSessionThreadInfoMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
@@ -49,6 +55,12 @@ const hoisted = vi.hoisted(() => {
     initializeSessionMock,
     startAcpSpawnParentStreamRelayMock,
     resolveAcpSpawnStreamLogPathMock,
+    loadSessionStoreMock,
+    resolveAndPersistSessionFileMock,
+    resolveStorePathMock,
+    resolveSessionTranscriptPathMock,
+    resolveSessionFilePathOptionsMock,
+    parseSessionThreadInfoMock,
     state,
   };
 });
@@ -85,6 +97,23 @@ vi.mock("../config/config.js", async (importOriginal) => {
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => hoisted.callGatewayMock(opts),
 }));
+
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    loadSessionStore: (storePath: string) => hoisted.loadSessionStoreMock(storePath),
+    resolveAndPersistSessionFile: (params: unknown) =>
+      hoisted.resolveAndPersistSessionFileMock(params),
+    resolveStorePath: (store: unknown, opts: unknown) => hoisted.resolveStorePathMock(store, opts),
+    resolveSessionTranscriptPath: (...args: unknown[]) =>
+      hoisted.resolveSessionTranscriptPathMock(...args),
+    resolveSessionFilePathOptions: (params: unknown) =>
+      hoisted.resolveSessionFilePathOptionsMock(params),
+    parseSessionThreadInfo: (sessionKey: string | undefined) =>
+      hoisted.parseSessionThreadInfoMock(sessionKey),
+  };
+});
 
 vi.mock("../acp/control-plane/manager.js", () => {
   return {
@@ -263,6 +292,46 @@ describe("spawnAcpDirect", () => {
     hoisted.resolveAcpSpawnStreamLogPathMock
       .mockReset()
       .mockReturnValue("/tmp/sess-main.acp-stream.jsonl");
+    hoisted.resolveStorePathMock.mockReset().mockReturnValue("/tmp/codex-sessions.json");
+    hoisted.loadSessionStoreMock.mockReset().mockImplementation(() => {
+      const store: Record<string, { sessionId: string; updatedAt: number }> = {};
+      return new Proxy(store, {
+        get(_target, prop) {
+          if (typeof prop === "string" && prop.startsWith("agent:codex:acp:")) {
+            return { sessionId: "sess-123", updatedAt: Date.now() };
+          }
+          return undefined;
+        },
+      });
+    });
+    hoisted.parseSessionThreadInfoMock
+      .mockReset()
+      .mockReturnValue({ baseSessionKey: "agent:codex:acp:test-session", threadId: undefined });
+    hoisted.resolveSessionTranscriptPathMock
+      .mockReset()
+      .mockImplementation((sessionId: string, _agentId: string, threadId?: string) =>
+        threadId
+          ? `/tmp/agents/codex/sessions/${sessionId}-topic-${threadId}.jsonl`
+          : `/tmp/agents/codex/sessions/${sessionId}.jsonl`,
+      );
+    hoisted.resolveSessionFilePathOptionsMock
+      .mockReset()
+      .mockReturnValue({ sessionsDir: "/tmp/agents/codex/sessions", agentId: "codex" });
+    hoisted.resolveAndPersistSessionFileMock
+      .mockReset()
+      .mockImplementation(async (params: unknown) => {
+        const typed = params as { fallbackSessionFile?: string };
+        const sessionFile =
+          typed.fallbackSessionFile ?? "/tmp/agents/codex/sessions/sess-123.jsonl";
+        return {
+          sessionFile,
+          sessionEntry: {
+            sessionId: "sess-123",
+            updatedAt: Date.now(),
+            sessionFile,
+          },
+        };
+      });
   });
 
   it("spawns ACP session, binds a new thread, and dispatches initial task", async () => {
@@ -308,6 +377,16 @@ describe("spawnAcpDirect", () => {
         mode: "persistent",
       }),
     );
+    const transcriptCalls = hoisted.resolveAndPersistSessionFileMock.mock.calls.map(
+      (call: unknown[]) => call[0] as { fallbackSessionFile?: string },
+    );
+    expect(transcriptCalls).toHaveLength(2);
+    expect(transcriptCalls[0]?.fallbackSessionFile).toBe(
+      "/tmp/agents/codex/sessions/sess-123.jsonl",
+    );
+    expect(transcriptCalls[1]?.fallbackSessionFile).toBe(
+      "/tmp/agents/codex/sessions/sess-123-topic-child-thread.jsonl",
+    );
   });
 
   it("does not inline delivery for fresh oneshot ACP runs", async () => {
@@ -328,6 +407,13 @@ describe("spawnAcpDirect", () => {
 
     expect(result.status).toBe("accepted");
     expect(result.mode).toBe("run");
+    expect(hoisted.resolveAndPersistSessionFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "sess-123",
+        agentId: "codex",
+        storePath: "/tmp/codex-sessions.json",
+      }),
+    );
     const agentCall = hoisted.callGatewayMock.mock.calls
       .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
       .find((request) => request.method === "agent");

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -23,14 +23,8 @@ import {
 } from "../channels/thread-bindings-policy.js";
 import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  loadSessionStore,
-  parseSessionThreadInfo,
-  resolveAndPersistSessionFile,
-  resolveSessionFilePathOptions,
-  resolveSessionTranscriptPath,
-  resolveStorePath,
-} from "../config/sessions.js";
+import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
+import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import { callGateway } from "../gateway/call.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
 import {
@@ -38,6 +32,7 @@ import {
   isSessionBindingError,
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import {
@@ -46,6 +41,9 @@ import {
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+
+const log = createSubsystemLogger("agents/acp-spawn");
 
 export const ACP_SPAWN_MODES = ["run", "session"] as const;
 export type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
@@ -170,6 +168,50 @@ function summarizeError(err: unknown): string {
   return "error";
 }
 
+function resolveRequesterInternalSessionKey(params: {
+  cfg: OpenClawConfig;
+  requesterSessionKey?: string;
+}): string {
+  const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
+  const requesterSessionKey = params.requesterSessionKey?.trim();
+  return requesterSessionKey
+    ? resolveInternalSessionKey({
+        key: requesterSessionKey,
+        alias,
+        mainKey,
+      })
+    : alias;
+}
+
+async function persistAcpSpawnSessionFileBestEffort(params: {
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore: Record<string, SessionEntry>;
+  storePath: string;
+  agentId: string;
+  threadId?: string | number;
+  stage: "spawn" | "thread-bind";
+}): Promise<SessionEntry | undefined> {
+  try {
+    const resolvedSessionFile = await resolveSessionTranscriptFile({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      storePath: params.storePath,
+      agentId: params.agentId,
+      threadId: params.threadId,
+    });
+    return resolvedSessionFile.sessionEntry;
+  } catch (error) {
+    log.warn(
+      `ACP session-file persistence failed during ${params.stage} for ${params.sessionKey}: ${summarizeError(error)}`,
+    );
+    return params.sessionEntry;
+  }
+}
+
 function resolveConversationIdForThreadBinding(params: {
   to?: string;
   threadId?: string | number;
@@ -265,6 +307,10 @@ export async function spawnAcpDirect(
   ctx: SpawnAcpContext,
 ): Promise<SpawnAcpResult> {
   const cfg = loadConfig();
+  const requesterInternalKey = resolveRequesterInternalSessionKey({
+    cfg,
+    requesterSessionKey: ctx.agentSessionKey,
+  });
   if (!isAcpEnabledByPolicy(cfg)) {
     return {
       status: "forbidden",
@@ -354,6 +400,7 @@ export async function spawnAcpDirect(
       method: "sessions.patch",
       params: {
         key: sessionKey,
+        spawnedBy: requesterInternalKey,
         ...(params.label ? { label: params.label } : {}),
       },
       timeoutMs: 10_000,
@@ -364,24 +411,15 @@ export async function spawnAcpDirect(
     let sessionEntry = sessionStore[sessionKey];
     const sessionId = sessionEntry?.sessionId;
     if (sessionId) {
-      const threadIdFromSessionKey = parseSessionThreadInfo(sessionKey).threadId;
-      const fallbackSessionFile = !sessionEntry?.sessionFile
-        ? resolveSessionTranscriptPath(sessionId, targetAgentId, threadIdFromSessionKey)
-        : undefined;
-      const resolvedSessionFile = await resolveAndPersistSessionFile({
+      sessionEntry = await persistAcpSpawnSessionFileBestEffort({
         sessionId,
         sessionKey,
         sessionStore,
         storePath,
         sessionEntry,
         agentId: targetAgentId,
-        sessionsDir: resolveSessionFilePathOptions({
-          agentId: targetAgentId,
-          storePath,
-        })?.sessionsDir,
-        fallbackSessionFile,
+        stage: "spawn",
       });
-      sessionEntry = resolvedSessionFile.sessionEntry;
     }
     const initialized = await acpManager.initializeSession({
       cfg,
@@ -443,24 +481,16 @@ export async function spawnAcpDirect(
       if (sessionId) {
         const boundThreadId = String(binding.conversation.conversationId).trim() || undefined;
         if (boundThreadId) {
-          const resolvedSessionFile = await resolveAndPersistSessionFile({
+          sessionEntry = await persistAcpSpawnSessionFileBestEffort({
             sessionId,
             sessionKey,
             sessionStore,
             storePath,
             sessionEntry,
             agentId: targetAgentId,
-            sessionsDir: resolveSessionFilePathOptions({
-              agentId: targetAgentId,
-              storePath,
-            })?.sessionsDir,
-            fallbackSessionFile: resolveSessionTranscriptPath(
-              sessionId,
-              targetAgentId,
-              boundThreadId,
-            ),
+            threadId: boundThreadId,
+            stage: "thread-bind",
           });
-          sessionEntry = resolvedSessionFile.sessionEntry;
         }
       }
     }

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -23,6 +23,14 @@ import {
 } from "../channels/thread-bindings-policy.js";
 import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  parseSessionThreadInfo,
+  resolveAndPersistSessionFile,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPath,
+  resolveStorePath,
+} from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
 import {
@@ -351,6 +359,30 @@ export async function spawnAcpDirect(
       timeoutMs: 10_000,
     });
     sessionCreated = true;
+    const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
+    const sessionStore = loadSessionStore(storePath);
+    let sessionEntry = sessionStore[sessionKey];
+    const sessionId = sessionEntry?.sessionId;
+    if (sessionId) {
+      const threadIdFromSessionKey = parseSessionThreadInfo(sessionKey).threadId;
+      const fallbackSessionFile = !sessionEntry?.sessionFile
+        ? resolveSessionTranscriptPath(sessionId, targetAgentId, threadIdFromSessionKey)
+        : undefined;
+      const resolvedSessionFile = await resolveAndPersistSessionFile({
+        sessionId,
+        sessionKey,
+        sessionStore,
+        storePath,
+        sessionEntry,
+        agentId: targetAgentId,
+        sessionsDir: resolveSessionFilePathOptions({
+          agentId: targetAgentId,
+          storePath,
+        })?.sessionsDir,
+        fallbackSessionFile,
+      });
+      sessionEntry = resolvedSessionFile.sessionEntry;
+    }
     const initialized = await acpManager.initializeSession({
       cfg,
       sessionKey,
@@ -407,6 +439,29 @@ export async function spawnAcpDirect(
         throw new Error(
           `Failed to create and bind a ${preparedBinding.channel} thread for this ACP session.`,
         );
+      }
+      if (sessionId) {
+        const boundThreadId = String(binding.conversation.conversationId).trim() || undefined;
+        if (boundThreadId) {
+          const resolvedSessionFile = await resolveAndPersistSessionFile({
+            sessionId,
+            sessionKey,
+            sessionStore,
+            storePath,
+            sessionEntry,
+            agentId: targetAgentId,
+            sessionsDir: resolveSessionFilePathOptions({
+              agentId: targetAgentId,
+              storePath,
+            })?.sessionsDir,
+            fallbackSessionFile: resolveSessionTranscriptPath(
+              sessionId,
+              targetAgentId,
+              boundThreadId,
+            ),
+          });
+          sessionEntry = resolvedSessionFile.sessionEntry;
+        }
       }
     }
   } catch (err) {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -408,7 +408,7 @@ export async function spawnAcpDirect(
     sessionCreated = true;
     const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
     const sessionStore = loadSessionStore(storePath);
-    let sessionEntry = sessionStore[sessionKey];
+    let sessionEntry: SessionEntry | undefined = sessionStore[sessionKey];
     const sessionId = sessionEntry?.sessionId;
     if (sessionId) {
       sessionEntry = await persistAcpSpawnSessionFileBestEffort({

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -260,6 +260,34 @@ describe("agentCommand ACP runtime routing", () => {
     });
   });
 
+  it("preserves exact ACP transcript text without trimming whitespace", async () => {
+    await withAcpSessionEnvInfo(async ({ storePath }) => {
+      const runTurn = createRunTurnFromTextDeltas(["  ACP_OK\n"]);
+
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      await agentCommand({ message: "  ping\n", sessionKey: "agent:codex:acp:test" }, runtime);
+
+      const persistedStore = JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<
+        string,
+        { sessionFile?: string }
+      >;
+      const sessionFile = persistedStore["agent:codex:acp:test"]?.sessionFile;
+      const messages = readSessionMessages("acp-session-1", storePath, sessionFile);
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "  ping\n",
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "  ACP_OK\n" }],
+      });
+    });
+  });
+
   it("suppresses ACP NO_REPLY lead fragments before emitting assistant text", async () => {
     await withAcpSessionEnv(async () => {
       const { assistantEvents, stop } = subscribeAssistantEvents();

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -7,6 +7,7 @@ import { AcpRuntimeError } from "../acp/runtime/errors.js";
 import * as embeddedModule from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
+import { readSessionMessages } from "../gateway/session-utils.fs.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { agentCommand } from "./agent.js";
@@ -133,6 +134,17 @@ async function withAcpSessionEnv(fn: () => Promise<void>) {
   });
 }
 
+async function withAcpSessionEnvInfo(
+  fn: (env: { home: string; storePath: string }) => Promise<void>,
+) {
+  await withTempHome(async (home) => {
+    const storePath = path.join(home, "sessions.json");
+    writeAcpSessionStore(storePath);
+    mockConfig(home, storePath);
+    await fn({ home, storePath });
+  });
+}
+
 function createRunTurnFromTextDeltas(chunks: string[]) {
   return vi.fn(async (paramsUnknown: unknown) => {
     const params = paramsUnknown as {
@@ -217,6 +229,34 @@ describe("agentCommand ACP runtime routing", () => {
         .mocked(runtime.log)
         .mock.calls.some(([first]) => typeof first === "string" && first.includes("ACP_OK"));
       expect(hasAckLog).toBe(true);
+    });
+  });
+
+  it("persists ACP child session history to the transcript store", async () => {
+    await withAcpSessionEnvInfo(async ({ storePath }) => {
+      const runTurn = createRunTurnFromTextDeltas(["ACP_", "OK"]);
+
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      await agentCommand({ message: "ping", sessionKey: "agent:codex:acp:test" }, runtime);
+
+      const persistedStore = JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<
+        string,
+        { sessionFile?: string }
+      >;
+      const sessionFile = persistedStore["agent:codex:acp:test"]?.sessionFile;
+      const messages = readSessionMessages("acp-session-1", storePath, sessionFile);
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "ping",
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "ACP_OK" }],
+      });
     });
   });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../acp/policy.js";
 import { toAcpRuntimeError } from "../acp/runtime/errors.js";
+import { resolveAcpSessionCwd } from "../acp/runtime/session-identifiers.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("commands/agent");
@@ -68,15 +69,11 @@ import {
 } from "../config/config.js";
 import {
   mergeSessionEntry,
-  parseSessionThreadInfo,
-  resolveAndPersistSessionFile,
   resolveAgentIdFromSessionKey,
-  resolveSessionFilePath,
-  resolveSessionFilePathOptions,
-  resolveSessionTranscriptPath,
   type SessionEntry,
   updateSessionStore,
 } from "../config/sessions.js";
+import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import {
   clearAgentRunContext,
   emitAgentEvent,
@@ -234,6 +231,9 @@ function createAcpVisibleTextAccumulator() {
     finalize(): string {
       return visibleText.trim();
     },
+    finalizeRaw(): string {
+      return visibleText;
+    },
   };
 }
 
@@ -252,51 +252,6 @@ const ACP_TRANSCRIPT_USAGE = {
   },
 } as const;
 
-async function resolveAcpTranscriptSessionFile(params: {
-  sessionId: string;
-  sessionKey: string;
-  sessionEntry: SessionEntry | undefined;
-  sessionStore?: Record<string, SessionEntry>;
-  storePath?: string;
-  sessionAgentId: string;
-  threadId?: string | number;
-}): Promise<{ sessionFile: string; sessionEntry: SessionEntry | undefined }> {
-  const sessionPathOpts = resolveSessionFilePathOptions({
-    agentId: params.sessionAgentId,
-    storePath: params.storePath,
-  });
-  let sessionFile = resolveSessionFilePath(params.sessionId, params.sessionEntry, sessionPathOpts);
-  let sessionEntry = params.sessionEntry;
-
-  if (params.sessionStore && params.storePath) {
-    const threadIdFromSessionKey = parseSessionThreadInfo(params.sessionKey).threadId;
-    const fallbackSessionFile = !sessionEntry?.sessionFile
-      ? resolveSessionTranscriptPath(
-          params.sessionId,
-          params.sessionAgentId,
-          params.threadId ?? threadIdFromSessionKey,
-        )
-      : undefined;
-    const resolvedSessionFile = await resolveAndPersistSessionFile({
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionStore: params.sessionStore,
-      storePath: params.storePath,
-      sessionEntry,
-      agentId: sessionPathOpts?.agentId,
-      sessionsDir: sessionPathOpts?.sessionsDir,
-      fallbackSessionFile,
-    });
-    sessionFile = resolvedSessionFile.sessionFile;
-    sessionEntry = resolvedSessionFile.sessionEntry;
-  }
-
-  return {
-    sessionFile,
-    sessionEntry,
-  };
-}
-
 async function persistAcpTurnTranscript(params: {
   body: string;
   finalText: string;
@@ -307,21 +262,21 @@ async function persistAcpTurnTranscript(params: {
   storePath?: string;
   sessionAgentId: string;
   threadId?: string | number;
-  workspaceDir: string;
+  sessionCwd: string;
 }): Promise<SessionEntry | undefined> {
-  const promptText = params.body.trim();
-  const replyText = params.finalText.trim();
+  const promptText = params.body;
+  const replyText = params.finalText;
   if (!promptText && !replyText) {
     return params.sessionEntry;
   }
 
-  const { sessionFile, sessionEntry } = await resolveAcpTranscriptSessionFile({
+  const { sessionFile, sessionEntry } = await resolveSessionTranscriptFile({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     sessionEntry: params.sessionEntry,
     sessionStore: params.sessionStore,
     storePath: params.storePath,
-    sessionAgentId: params.sessionAgentId,
+    agentId: params.sessionAgentId,
     threadId: params.threadId,
   });
   const hadSessionFile = await fs
@@ -334,7 +289,7 @@ async function persistAcpTurnTranscript(params: {
     sessionFile,
     hadSessionFile,
     sessionId: params.sessionId,
-    cwd: params.workspaceDir,
+    cwd: params.sessionCwd,
   });
 
   if (promptText) {
@@ -550,8 +505,8 @@ async function prepareAgentCommandExecution(
   opts: AgentCommandOpts & { senderIsOwner: boolean },
   runtime: RuntimeEnv,
 ) {
-  const message = (opts.message ?? "").trim();
-  if (!message) {
+  const message = opts.message ?? "";
+  if (!message.trim()) {
     throw new Error("Message (--message) is required");
   }
   const body = prependInternalEventContext(message, opts.internalEvents);
@@ -861,11 +816,12 @@ async function agentCommandInternal(
         },
       });
 
+      const finalTextRaw = visibleTextAccumulator.finalizeRaw();
       const finalText = visibleTextAccumulator.finalize();
       try {
         sessionEntry = await persistAcpTurnTranscript({
           body,
-          finalText,
+          finalText: finalTextRaw,
           sessionId,
           sessionKey,
           sessionEntry,
@@ -873,7 +829,7 @@ async function agentCommandInternal(
           storePath,
           sessionAgentId,
           threadId: opts.threadId,
-          workspaceDir,
+          sessionCwd: resolveAcpSessionCwd(acpResolution.meta) ?? workspaceDir,
         });
       } catch (error) {
         log.warn(

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1049,29 +1049,27 @@ async function agentCommandInternal(
         });
       }
     }
-    const sessionPathOpts = resolveSessionFilePathOptions({
-      agentId: sessionAgentId,
-      storePath,
-    });
-    let sessionFile = resolveSessionFilePath(sessionId, sessionEntry, sessionPathOpts);
+    let sessionFile: string | undefined;
     if (sessionStore && sessionKey) {
-      const threadIdFromSessionKey = parseSessionThreadInfo(sessionKey).threadId;
-      const fallbackSessionFile = !sessionEntry?.sessionFile
-        ? resolveSessionTranscriptPath(
-            sessionId,
-            sessionAgentId,
-            opts.threadId ?? threadIdFromSessionKey,
-          )
-        : undefined;
-      const resolvedSessionFile = await resolveAndPersistSessionFile({
+      const resolvedSessionFile = await resolveSessionTranscriptFile({
         sessionId,
         sessionKey,
         sessionStore,
         storePath,
         sessionEntry,
-        agentId: sessionPathOpts?.agentId,
-        sessionsDir: sessionPathOpts?.sessionsDir,
-        fallbackSessionFile,
+        agentId: sessionAgentId,
+        threadId: opts.threadId,
+      });
+      sessionFile = resolvedSessionFile.sessionFile;
+      sessionEntry = resolvedSessionFile.sessionEntry;
+    }
+    if (!sessionFile) {
+      const resolvedSessionFile = await resolveSessionTranscriptFile({
+        sessionId,
+        sessionKey: sessionKey ?? sessionId,
+        sessionEntry,
+        agentId: sessionAgentId,
+        threadId: opts.threadId,
       });
       sessionFile = resolvedSessionFile.sessionFile;
       sessionEntry = resolvedSessionFile.sessionEntry;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../acp/policy.js";
 import { toAcpRuntimeError } from "../acp/runtime/errors.js";
@@ -33,6 +35,7 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
+import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
@@ -86,6 +89,7 @@ import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
+import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
@@ -231,6 +235,131 @@ function createAcpVisibleTextAccumulator() {
       return visibleText.trim();
     },
   };
+}
+
+const ACP_TRANSCRIPT_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+} as const;
+
+async function resolveAcpTranscriptSessionFile(params: {
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  sessionAgentId: string;
+  threadId?: string | number;
+}): Promise<{ sessionFile: string; sessionEntry: SessionEntry | undefined }> {
+  const sessionPathOpts = resolveSessionFilePathOptions({
+    agentId: params.sessionAgentId,
+    storePath: params.storePath,
+  });
+  let sessionFile = resolveSessionFilePath(params.sessionId, params.sessionEntry, sessionPathOpts);
+  let sessionEntry = params.sessionEntry;
+
+  if (params.sessionStore && params.storePath) {
+    const threadIdFromSessionKey = parseSessionThreadInfo(params.sessionKey).threadId;
+    const fallbackSessionFile = !sessionEntry?.sessionFile
+      ? resolveSessionTranscriptPath(
+          params.sessionId,
+          params.sessionAgentId,
+          params.threadId ?? threadIdFromSessionKey,
+        )
+      : undefined;
+    const resolvedSessionFile = await resolveAndPersistSessionFile({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionStore: params.sessionStore,
+      storePath: params.storePath,
+      sessionEntry,
+      agentId: sessionPathOpts?.agentId,
+      sessionsDir: sessionPathOpts?.sessionsDir,
+      fallbackSessionFile,
+    });
+    sessionFile = resolvedSessionFile.sessionFile;
+    sessionEntry = resolvedSessionFile.sessionEntry;
+  }
+
+  return {
+    sessionFile,
+    sessionEntry,
+  };
+}
+
+async function persistAcpTurnTranscript(params: {
+  body: string;
+  finalText: string;
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  sessionAgentId: string;
+  threadId?: string | number;
+  workspaceDir: string;
+}): Promise<SessionEntry | undefined> {
+  const promptText = params.body.trim();
+  const replyText = params.finalText.trim();
+  if (!promptText && !replyText) {
+    return params.sessionEntry;
+  }
+
+  const { sessionFile, sessionEntry } = await resolveAcpTranscriptSessionFile({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+    storePath: params.storePath,
+    sessionAgentId: params.sessionAgentId,
+    threadId: params.threadId,
+  });
+  const hadSessionFile = await fs
+    .access(sessionFile)
+    .then(() => true)
+    .catch(() => false);
+  const sessionManager = SessionManager.open(sessionFile);
+  await prepareSessionManagerForRun({
+    sessionManager,
+    sessionFile,
+    hadSessionFile,
+    sessionId: params.sessionId,
+    cwd: params.workspaceDir,
+  });
+
+  if (promptText) {
+    sessionManager.appendMessage({
+      role: "user",
+      content: promptText,
+      timestamp: Date.now(),
+    });
+  }
+
+  if (replyText) {
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: replyText }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "acp-runtime",
+      usage: ACP_TRANSCRIPT_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+  }
+
+  emitSessionTranscriptUpdate(sessionFile);
+  return sessionEntry;
 }
 
 function runAgentAttempt(params: {
@@ -732,8 +861,28 @@ async function agentCommandInternal(
         },
       });
 
+      const finalText = visibleTextAccumulator.finalize();
+      try {
+        sessionEntry = await persistAcpTurnTranscript({
+          body,
+          finalText,
+          sessionId,
+          sessionKey,
+          sessionEntry,
+          sessionStore,
+          storePath,
+          sessionAgentId,
+          threadId: opts.threadId,
+          workspaceDir,
+        });
+      } catch (error) {
+        log.warn(
+          `ACP transcript persistence failed for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
       const normalizedFinalPayload = normalizeReplyPayload({
-        text: visibleTextAccumulator.finalize(),
+        text: finalText,
       });
       const payloads = normalizedFinalPayload ? [normalizedFinalPayload] : [];
       const result = {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { resolveDefaultSessionStorePath } from "./paths.js";
+import { parseSessionThreadInfo } from "./delivery-info.js";
+import {
+  resolveDefaultSessionStorePath,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPath,
+} from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
@@ -77,6 +83,51 @@ async function ensureSessionHeader(params: {
     encoding: "utf-8",
     mode: 0o600,
   });
+}
+
+export async function resolveSessionTranscriptFile(params: {
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  agentId: string;
+  threadId?: string | number;
+}): Promise<{ sessionFile: string; sessionEntry: SessionEntry | undefined }> {
+  const sessionPathOpts = resolveSessionFilePathOptions({
+    agentId: params.agentId,
+    storePath: params.storePath,
+  });
+  let sessionFile = resolveSessionFilePath(params.sessionId, params.sessionEntry, sessionPathOpts);
+  let sessionEntry = params.sessionEntry;
+
+  if (params.sessionStore && params.storePath) {
+    const threadIdFromSessionKey = parseSessionThreadInfo(params.sessionKey).threadId;
+    const fallbackSessionFile = !sessionEntry?.sessionFile
+      ? resolveSessionTranscriptPath(
+          params.sessionId,
+          params.agentId,
+          params.threadId ?? threadIdFromSessionKey,
+        )
+      : undefined;
+    const resolvedSessionFile = await resolveAndPersistSessionFile({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionStore: params.sessionStore,
+      storePath: params.storePath,
+      sessionEntry,
+      agentId: sessionPathOpts?.agentId,
+      sessionsDir: sessionPathOpts?.sessionsDir,
+      fallbackSessionFile,
+    });
+    sessionFile = resolvedSessionFile.sessionFile;
+    sessionEntry = resolvedSessionFile.sessionEntry;
+  }
+
+  return {
+    sessionFile,
+    sessionEntry,
+  };
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {


### PR DESCRIPTION
## Summary

- Problem: ACP spawned child sessions could execute and emit output, but their transcripts were not reliably persisted, so `sessions_history` could come back empty.
- Why it matters: successful ACP runs looked broken to callers because follow-up tooling could not read child history, and ACP children also did not participate correctly in spawned-session tree visibility.
- What changed: persist ACP child turn transcripts, preserve exact transcript text, record `spawnedBy` for ACP children, and share transcript-path/session-file resolution with best-effort spawn-time persistence.
- What did NOT change (scope boundary): ACP execution/runtime behavior, delivery routing beyond the existing oneshot fix, and non-ACP session persistence.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage
- [x] API / contracts

## Linked Issue/PR

- Closes #38565
- Related #38614

## User-visible / Behavior Changes

- `sessions_history` for successful ACP child runs now returns persisted transcript history instead of an empty result.
- ACP child sessions now participate in spawned-session lineage via `spawnedBy`.
- ACP transcript history preserves exact leading/trailing whitespace from the initiating prompt and final assistant reply.
- Spawn-time transcript-path persistence failures no longer block ACP execution; the run still starts and logs a warning.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS locally; Ubuntu on `mb-server`
- Runtime/container: Node via `pnpm`
- Model/provider: ACP runtime tests with mocked ACP manager
- Integration/channel (if any): ACP spawn + session history paths
- Relevant config (redacted): default test config with `acp.enabled=true`, `backend="acpx"`

### Steps

1. Spawn an ACP child run.
2. Let the task complete successfully.
3. Query `sessions_history` for the child session.

### Expected

- Child history is persisted and readable.
- ACP children are visible as spawned children.
- Transcript text matches the exact prompt/reply content.

### Actual

- Before this fix, child history could be empty even when the task ran successfully.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Local: `pnpm exec vitest run src/commands/agent.acp.test.ts src/agents/acp-spawn.test.ts src/agents/tools/sessions-spawn-tool.test.ts --maxWorkers=1`
  - Local: `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit`
  - `mb-server`: `pnpm exec vitest run src/commands/agent.acp.test.ts src/agents/acp-spawn.test.ts src/agents/tools/sessions-spawn-tool.test.ts --maxWorkers=3`
  - `mb-server`: `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit`
- Edge cases checked:
  - ACP spawn still succeeds when spawn-time session-file persistence fails.
  - Thread-bound ACP sessions resolve a thread-specific transcript path.
  - Exact whitespace is preserved in ACP transcript history.
- What you did **not** verify:
  - Full end-to-end Telegram/Discord manual flow in CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the three ACP commits in this PR.
- Files/config to restore: `src/commands/agent.ts`, `src/agents/acp-spawn.ts`, `src/config/sessions/transcript.ts`
- Known bad symptoms reviewers should watch for: ACP children missing from spawned-session trees, empty `sessions_history`, or ACP spawn unexpectedly failing on transcript-path storage issues.

## Risks and Mitigations

- Risk: best-effort spawn-time transcript persistence could mask storage-path problems until later transcript writes.
  - Mitigation: it emits a warning and keeps execution available; runtime transcript persistence still exercises the same path and tests cover the degraded case.
