### PR TITLE
fix(plugins): align duplicate warning with actual skipped copy

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1093,10 +1093,11 @@ describe("loadOpenClawPlugins", () => {
     });
 
     const entries = registry.plugins.filter((entry) => entry.id === "shadow");
-    const loaded = entries.find((entry) => entry.status === "loaded");
-    const overridden = entries.find((entry) => entry.status === "disabled");
-    expect(loaded?.origin).toBe("config");
-    expect(overridden?.origin).toBe("bundled");
+    // Manifest registry deduplicates genuine duplicates (same id, different paths),
+    // so only the higher-precedence record survives to the loader.
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.status).toBe("loaded");
+    expect(entries[0]?.origin).toBe("config");
   });
 
   it("prefers bundled plugin over auto-discovered global duplicate ids", () => {
@@ -1133,11 +1134,11 @@ describe("loadOpenClawPlugins", () => {
       });
 
       const entries = registry.plugins.filter((entry) => entry.id === "feishu");
-      const loaded = entries.find((entry) => entry.status === "loaded");
-      const overridden = entries.find((entry) => entry.status === "disabled");
-      expect(loaded?.origin).toBe("bundled");
-      expect(overridden?.origin).toBe("global");
-      expect(overridden?.error).toContain("overridden by bundled plugin");
+      // Manifest registry deduplicates genuine duplicates (same id, different paths),
+      // keeping the bundled copy over the auto-discovered global copy.
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.status).toBe("loaded");
+      expect(entries[0]?.origin).toBe("bundled");
     });
   });
 

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -150,7 +150,65 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ];
 
-    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(1);
+    // Only one record should be kept to prevent Gateway instability
+    expect(registry.plugins.filter((p) => p.id === "test-plugin")).toHaveLength(1);
+  });
+
+  it("keeps higher-precedence origin when genuine duplicate is detected from different paths", () => {
+    const bundledDir = makeTempDir();
+    const globalDir = makeTempDir();
+    const manifest = { id: "feishu-dup", configSchema: { type: "object" } };
+    writeManifest(bundledDir, manifest);
+    writeManifest(globalDir, manifest);
+
+    // Bundled discovered first, then global (npm-installed copy)
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu-dup",
+        rootDir: bundledDir,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "feishu-dup",
+        rootDir: globalDir,
+        origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(1);
+    expect(registry.plugins.filter((p) => p.id === "feishu-dup")).toHaveLength(1);
+    // Global has higher precedence than bundled (config > workspace > global > bundled)
+    expect(registry.plugins[0]?.origin).toBe("global");
+  });
+
+  it("keeps existing record when genuine duplicate has lower precedence", () => {
+    const configDir = makeTempDir();
+    const globalDir = makeTempDir();
+    const manifest = { id: "lower-prec", configSchema: { type: "object" } };
+    writeManifest(configDir, manifest);
+    writeManifest(globalDir, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "lower-prec",
+        rootDir: configDir,
+        origin: "config",
+      }),
+      createPluginCandidate({
+        idHint: "lower-prec",
+        rootDir: globalDir,
+        origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(1);
+    expect(registry.plugins.filter((p) => p.id === "lower-prec")).toHaveLength(1);
+    // Config has higher precedence, should be kept
+    expect(registry.plugins[0]?.origin).toBe("config");
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -47,6 +47,17 @@ function countDuplicateWarnings(registry: ReturnType<typeof loadPluginManifestRe
   ).length;
 }
 
+function getDuplicateWarningMessages(
+  registry: ReturnType<typeof loadPluginManifestRegistry>,
+): string[] {
+  return registry.diagnostics
+    .filter(
+      (diagnostic) =>
+        diagnostic.level === "warn" && diagnostic.message?.includes("duplicate plugin id"),
+    )
+    .map((diagnostic) => diagnostic.message);
+}
+
 function prepareLinkedManifestFixture(params: { id: string; mode: "symlink" | "hardlink" }): {
   rootDir: string;
   linked: boolean;
@@ -183,6 +194,9 @@ describe("loadPluginManifestRegistry", () => {
     // Bundled has higher precedence than global for genuine duplicates
     // (bundled ships with the binary and is the known-good version)
     expect(registry.plugins[0]?.origin).toBe("bundled");
+    expect(getDuplicateWarningMessages(registry)).toContain(
+      `duplicate plugin id detected; skipping duplicate from ${candidates[1].source}`,
+    );
   });
 
   it("keeps existing record when genuine duplicate has lower precedence", () => {
@@ -210,6 +224,38 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins.filter((p) => p.id === "lower-prec")).toHaveLength(1);
     // Config has higher precedence, should be kept
     expect(registry.plugins[0]?.origin).toBe("config");
+    expect(getDuplicateWarningMessages(registry)).toContain(
+      `duplicate plugin id detected; skipping duplicate from ${candidates[1].source}`,
+    );
+  });
+
+  it("warns with existing source when higher-precedence duplicate replaces it", () => {
+    const globalDir = makeTempDir();
+    const bundledDir = makeTempDir();
+    const manifest = { id: "replace-prec", configSchema: { type: "object" } };
+    writeManifest(globalDir, manifest);
+    writeManifest(bundledDir, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "replace-prec",
+        rootDir: globalDir,
+        origin: "global",
+      }),
+      createPluginCandidate({
+        idHint: "replace-prec",
+        rootDir: bundledDir,
+        origin: "bundled",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(1);
+    expect(registry.plugins.filter((p) => p.id === "replace-prec")).toHaveLength(1);
+    expect(registry.plugins[0]?.origin).toBe("bundled");
+    expect(getDuplicateWarningMessages(registry)).toContain(
+      `duplicate plugin id detected; skipping duplicate from ${candidates[0].source}`,
+    );
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -180,8 +180,9 @@ describe("loadPluginManifestRegistry", () => {
     const registry = loadRegistry(candidates);
     expect(countDuplicateWarnings(registry)).toBe(1);
     expect(registry.plugins.filter((p) => p.id === "feishu-dup")).toHaveLength(1);
-    // Global has higher precedence than bundled (config > workspace > global > bundled)
-    expect(registry.plugins[0]?.origin).toBe("global");
+    // Bundled has higher precedence than global for genuine duplicates
+    // (bundled ships with the binary and is the known-good version)
+    expect(registry.plugins[0]?.origin).toBe("bundled");
   });
 
   it("keeps existing record when genuine duplicate has lower precedence", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -241,18 +241,19 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
+      const candidateWins =
+        GENUINE_DUPLICATE_RANK[candidate.origin] < GENUINE_DUPLICATE_RANK[existing.candidate.origin];
+      const skippedCandidate = candidateWins ? existing.candidate : candidate;
       diagnostics.push({
         level: "warn",
         pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; skipping duplicate from ${candidate.source}`,
+        source: skippedCandidate.source,
+        message: `duplicate plugin id detected; skipping duplicate from ${skippedCandidate.source}`,
       });
       // Genuine duplicate from a different physical path: apply
       // bundled-first precedence to avoid registering two records with
       // the same plugin id (which causes Gateway instability).
-      if (
-        GENUINE_DUPLICATE_RANK[candidate.origin] < GENUINE_DUPLICATE_RANK[existing.candidate.origin]
-      ) {
+      if (candidateWins) {
         records[existing.recordIndex] = buildRecord({
           manifest,
           candidate,

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -233,8 +233,22 @@ export function loadPluginManifestRegistry(params: {
         level: "warn",
         pluginId: manifest.id,
         source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        message: `duplicate plugin id detected; skipping duplicate from ${candidate.source}`,
       });
+      // Genuine duplicate from a different physical path: apply the same
+      // precedence logic as same-path duplicates to avoid registering two
+      // records with the same plugin id (which causes Gateway instability).
+      if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
+        records[existing.recordIndex] = buildRecord({
+          manifest,
+          candidate,
+          manifestPath: manifestRes.manifestPath,
+          schemaCacheKey,
+          configSchema,
+        });
+        seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+      }
+      continue;
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -12,12 +12,24 @@ type SeenIdEntry = {
   recordIndex: number;
 };
 
-// Precedence: config > workspace > global > bundled
+// Same-path dedup precedence: config > workspace > global > bundled
+// Used when the same physical directory is discovered via multiple routes.
 const PLUGIN_ORIGIN_RANK: Readonly<Record<PluginOrigin, number>> = {
   config: 0,
   workspace: 1,
   global: 2,
   bundled: 3,
+};
+
+// Genuine-duplicate precedence: config > bundled > workspace > global
+// Used when genuinely different copies of a plugin (same id, different paths)
+// exist. Bundled plugins ship with the binary and are the known-good version,
+// so they take precedence over auto-discovered global/npm-installed copies.
+const GENUINE_DUPLICATE_RANK: Readonly<Record<PluginOrigin, number>> = {
+  config: 0,
+  bundled: 1,
+  workspace: 2,
+  global: 3,
 };
 
 export type PluginManifestRecord = {
@@ -235,10 +247,12 @@ export function loadPluginManifestRegistry(params: {
         source: candidate.source,
         message: `duplicate plugin id detected; skipping duplicate from ${candidate.source}`,
       });
-      // Genuine duplicate from a different physical path: apply the same
-      // precedence logic as same-path duplicates to avoid registering two
-      // records with the same plugin id (which causes Gateway instability).
-      if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
+      // Genuine duplicate from a different physical path: apply
+      // bundled-first precedence to avoid registering two records with
+      // the same plugin id (which causes Gateway instability).
+      if (
+        GENUINE_DUPLICATE_RANK[candidate.origin] < GENUINE_DUPLICATE_RANK[existing.candidate.origin]
+      ) {
         records[existing.recordIndex] = buildRecord({
           manifest,
           candidate,

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -242,7 +242,8 @@ export function loadPluginManifestRegistry(params: {
         continue;
       }
       const candidateWins =
-        GENUINE_DUPLICATE_RANK[candidate.origin] < GENUINE_DUPLICATE_RANK[existing.candidate.origin];
+        GENUINE_DUPLICATE_RANK[candidate.origin] <
+        GENUINE_DUPLICATE_RANK[existing.candidate.origin];
       const skippedCandidate = candidateWins ? existing.candidate : candidate;
       diagnostics.push({
         level: "warn",


### PR DESCRIPTION
## Summary
- align duplicate-id warning source/message with the actual skipped plugin copy after precedence resolution
- keep genuine-duplicate winner selection unchanged while removing winner/loser diagnostic mismatch
- add tests covering both duplicate warning paths (candidate skipped and existing skipped)

## Verification
- bunx vitest run src/plugins/manifest-registry.test.ts src/plugins/loader.test.ts

Supersedes #37049.