### PR TITLE
fix: scope PR secrets scanning to changed files

### DIFF
--- a/.github/actions/ensure-base-commit/action.yml
+++ b/.github/actions/ensure-base-commit/action.yml
@@ -44,4 +44,5 @@ runs:
           exit 0
         fi
 
-        echo "Base commit still unavailable after fetch attempts: $BASE_SHA"
+        echo "::error::Base commit still unavailable after fetch attempts: $BASE_SHA"
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,10 +307,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          detect_secrets_exit=0
+          detect_private_key_exit=0
+
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "Running full detect-secrets scan on push."
-            pre-commit run --all-files detect-secrets
-            pre-commit run --all-files detect-private-key
+            pre-commit run --all-files detect-secrets || detect_secrets_exit=$?
+            pre-commit run --all-files detect-private-key || detect_private_key_exit=$?
+            test "$detect_secrets_exit" -eq 0 -a "$detect_private_key_exit" -eq 0
             exit 0
           fi
 
@@ -330,8 +334,9 @@ jobs:
 
           if [ "${#changed_files[@]}" -gt 0 ]; then
             echo "Running secret scans on ${#changed_files[@]} changed file(s)."
-            pre-commit run detect-secrets --files "${changed_files[@]}"
-            pre-commit run detect-private-key --files "${changed_files[@]}"
+            pre-commit run detect-secrets --files "${changed_files[@]}" || detect_secrets_exit=$?
+            pre-commit run detect-private-key --files "${changed_files[@]}" || detect_private_key_exit=$?
+            test "$detect_secrets_exit" -eq 0 -a "$detect_private_key_exit" -eq 0
           else
             echo "No added/copied/modified/renamed files to scan in this pull request."
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -296,36 +303,38 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pre-commit
 
-      - name: Detect secrets
+      - name: Detect secrets and private keys
         run: |
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
+            pre-commit run --all-files detect-private-key
             exit 0
           fi
 
           BASE="${{ github.event.pull_request.base.sha }}"
-          changed_files=()
-          if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
-            while IFS= read -r path; do
-              [ -n "$path" ] || continue
-              [ -f "$path" ] || continue
-              changed_files+=("$path")
-            done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+          if ! git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
+            echo "::error::PR base commit is unavailable after fetch attempts: $BASE"
+            echo "Refusing to fall back to a full-repo secrets scan for pull requests."
+            exit 1
           fi
+
+          changed_files=()
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            [ -f "$path" ] || continue
+            changed_files+=("$path")
+          done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
 
           if [ "${#changed_files[@]}" -gt 0 ]; then
-            echo "Running detect-secrets on ${#changed_files[@]} changed file(s)."
+            echo "Running secret scans on ${#changed_files[@]} changed file(s)."
             pre-commit run detect-secrets --files "${changed_files[@]}"
+            pre-commit run detect-private-key --files "${changed_files[@]}"
           else
-            echo "Falling back to full detect-secrets scan."
-            pre-commit run --all-files detect-secrets
+            echo "No added/copied/modified/renamed files to scan in this pull request."
           fi
-
-      - name: Detect committed private keys
-        run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
         run: |


### PR DESCRIPTION
## Summary

- Problem: PR `secrets` CI can fall back to full-repo secret scanning when the PR base SHA is missing from a shallow checkout.
- Why it matters: unrelated PRs fail on longstanding repo-wide detections, which destroys CI signal and blocks landing.
- What changed: the `secrets` job now ensures the base commit is available for PRs and scans only changed files for both `detect-secrets` and `detect-private-key`.
- What did NOT change (scope boundary): push builds still run full-repo secret scans, and this PR does not refresh `.secrets.baseline` or touch application runtime code.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #40141
- Related #40094

## User-visible / Behavior Changes

PR `secrets` CI now stays scoped to changed files and fails explicitly if the PR base commit cannot be resolved after fetch attempts. Push builds still do full-repo scans.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  PR scans now read only PR-changed files instead of the whole repo. Full-repo secret enforcement remains on push builds, and PRs fail explicitly if the base SHA cannot be resolved.

## Repro + Verification

### Environment

- OS: macOS 15.x locally, GitHub Actions Ubuntu 24.04 in CI
- Runtime/container: Node 22 / pnpm / pre-commit
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions CI
- Relevant config (redacted): `.github/workflows/ci.yml`, `.github/actions/ensure-base-commit/action.yml`, `.pre-commit-config.yaml`

### Steps

1. Inspect the `secrets` workflow path in `.github/workflows/ci.yml`.
2. Confirm the previous PR path could fall back to `pre-commit run --all-files detect-secrets` when the base SHA was unavailable.
3. Update the job to ensure the base SHA is fetched and keep PR scans restricted to changed files.
4. Verify the workflow diff and shell logic locally.

### Expected

- PR `secrets` scans run only on changed files.
- Missing PR base SHAs produce an explicit infra-style failure instead of a full-repo scan.
- Push builds continue full-repo secret scans.

### Actual

- Updated workflow now matches the expected behavior above.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the previous failing `secrets` log, confirmed the fallback-to-`--all-files` path, and checked the new workflow logic in the new worktree.
- Edge cases checked: PR with missing base SHA now errors explicitly; PR with zero `ACMR` files emits a no-op message; push path still runs full-repo scans.
- What you did **not** verify: live GitHub Actions execution on this branch yet.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the prior `secrets` job body in `.github/workflows/ci.yml`
- Files/config to restore: `.github/workflows/ci.yml`
- Known bad symptoms reviewers should watch for: PR `secrets` failing with `PR base commit is unavailable after fetch attempts` if `ensure-base-commit` cannot recover the base SHA

## Risks and Mitigations

- Risk: PRs with no changed `ACMR` files now skip secret scanning in this job.
  - Mitigation: push builds still run full-repo scans.
- Risk: missing base SHA now fails explicitly instead of surfacing repo-wide detections.
  - Mitigation: this is a cleaner infra signal and prevents unrelated PR failures.
