### PR TITLE
feat: add local backup CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Docs: https://docs.openclaw.ai
 - CLI/install: include the short git commit hash in `openclaw --version` output when metadata is available, and keep installer version checks compatible with the decorated format. (#39712) thanks @sourman.
 - Docs/Web search: restore $5/month free-credit details, replace defunct "Data for Search"/"Data for AI" plan names with current "Search" plan, and note legacy subscription validity in Brave setup docs. Follows up on #26860. (#40111) Thanks @remusao.
 - macOS/onboarding: add a remote gateway token field for remote mode, preserve existing non-plaintext `gateway.remote.token` config values until explicitly replaced, and warn when the loaded token shape cannot be used directly from the macOS app. (#40187, supersedes #34614) Thanks @cgdusek.
-- CLI/backup: add `openclaw backup create` and `openclaw backup verify` for local state archives, with manifest/payload validation and backup guidance in destructive flows. (#40163) thanks @shichangs.
+- CLI/backup: add `openclaw backup create` and `openclaw backup verify` for local state archives, including `--only-config`, `--no-include-workspace`, manifest/payload validation, and backup guidance in destructive flows. (#40163) thanks @shichangs.
+- CLI/backup: improve archive naming for date sorting, add config-only backup mode, and harden backup planning, publication, and verification edge cases. (#40163) Thanks @gumadeiras.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - CLI/install: include the short git commit hash in `openclaw --version` output when metadata is available, and keep installer version checks compatible with the decorated format. (#39712) thanks @sourman.
 - Docs/Web search: restore $5/month free-credit details, replace defunct "Data for Search"/"Data for AI" plan names with current "Search" plan, and note legacy subscription validity in Brave setup docs. Follows up on #26860. (#40111) Thanks @remusao.
 - macOS/onboarding: add a remote gateway token field for remote mode, preserve existing non-plaintext `gateway.remote.token` config values until explicitly replaced, and warn when the loaded token shape cannot be used directly from the macOS app. (#40187, supersedes #34614) Thanks @cgdusek.
+- CLI/backup: add `openclaw backup create` and `openclaw backup verify` for local state archives, with manifest/payload validation and backup guidance in destructive flows. (#40163) thanks @shichangs.
 
 ### Fixes
 

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -14,7 +14,9 @@ Create a local backup archive for OpenClaw state, config, credentials, sessions,
 openclaw backup create
 openclaw backup create --output ~/Backups
 openclaw backup create --dry-run --json
+openclaw backup create --verify
 openclaw backup create --no-include-workspace
+openclaw backup verify ./openclaw-backup-2026-03-09T00-00-00.000Z.tar.gz
 ```
 
 ## Notes
@@ -24,3 +26,5 @@ openclaw backup create --no-include-workspace
 - If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten.
 - Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
+- `openclaw backup verify <archive>` validates that the archive contains exactly one manifest and that every manifest-declared payload exists in the tarball.
+- `openclaw backup create --verify` runs that validation immediately after writing the archive.

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -16,7 +16,7 @@ openclaw backup create --output ~/Backups
 openclaw backup create --dry-run --json
 openclaw backup create --verify
 openclaw backup create --no-include-workspace
-openclaw backup verify ./openclaw-backup-2026-03-09T00-00-00.000Z.tar.gz
+openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz
 ```
 
 ## Notes

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -26,5 +26,43 @@ openclaw backup verify ./openclaw-backup-2026-03-09T00-00-00.000Z.tar.gz
 - If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten.
 - Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
-- `openclaw backup verify <archive>` validates that the archive contains exactly one manifest and that every manifest-declared payload exists in the tarball.
+- `openclaw backup verify <archive>` validates that the archive contains exactly one root manifest, rejects traversal-style archive paths, and checks that every manifest-declared payload exists in the tarball.
 - `openclaw backup create --verify` runs that validation immediately after writing the archive.
+
+## What gets backed up
+
+`openclaw backup create` plans backup sources from your local OpenClaw install:
+
+- The state directory returned by OpenClaw's local state resolver, usually `~/.openclaw`
+- The active config file path
+- The OAuth / credentials directory
+- Workspace directories discovered from the current config, unless you pass `--no-include-workspace`
+
+OpenClaw canonicalizes paths before building the archive. If config, credentials, or a workspace already live inside the state directory, they are not duplicated as separate top-level backup sources. Missing paths are skipped.
+
+The archive payload stores file contents from those source trees, and the embedded `manifest.json` records the resolved absolute source paths plus the archive layout used for each asset.
+
+## Invalid config behavior
+
+`openclaw backup` intentionally bypasses the normal config preflight so it can still help during recovery. Because workspace discovery depends on a valid config, `openclaw backup create` now fails fast when the config file exists but is invalid and workspace backup is still enabled.
+
+If you still want a partial backup in that situation, rerun:
+
+```bash
+openclaw backup create --no-include-workspace
+```
+
+That keeps state, config, and credentials in scope while skipping workspace discovery entirely.
+
+## Size and performance
+
+OpenClaw does not enforce a built-in maximum backup size or per-file size limit.
+
+Practical limits come from the local machine and destination filesystem:
+
+- Available space for the temporary archive write plus the final archive
+- Time to walk large workspace trees and compress them into a `.tar.gz`
+- Time to rescan the archive if you use `openclaw backup create --verify` or run `openclaw backup verify`
+- Filesystem behavior at the destination path. OpenClaw prefers a no-overwrite hard-link publish step and falls back to exclusive copy when hard links are unsupported
+
+Large workspaces are usually the main driver of archive size. If you want a smaller or faster backup, use `--no-include-workspace`.

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -1,0 +1,25 @@
+---
+summary: "CLI reference for `openclaw backup` (create local backup archives)"
+read_when:
+  - You want a first-class backup archive for local OpenClaw state
+  - You want to preview which paths would be included before reset or uninstall
+title: "backup"
+---
+
+# `openclaw backup`
+
+Create a local backup archive for OpenClaw state, config, credentials, sessions, and optionally workspaces.
+
+```bash
+openclaw backup create
+openclaw backup create --output ~/Backups
+openclaw backup create --dry-run --json
+openclaw backup create --no-include-workspace
+```
+
+## Notes
+
+- The archive includes a `manifest.json` file with the resolved source paths and archive layout.
+- Default output is a timestamped `.tar.gz` archive in the current working directory.
+- Existing archive files are never overwritten.
+- Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -16,6 +16,7 @@ openclaw backup create --output ~/Backups
 openclaw backup create --dry-run --json
 openclaw backup create --verify
 openclaw backup create --no-include-workspace
+openclaw backup create --only-config
 openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz
 ```
 
@@ -28,6 +29,7 @@ openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz
 - Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
 - `openclaw backup verify <archive>` validates that the archive contains exactly one root manifest, rejects traversal-style archive paths, and checks that every manifest-declared payload exists in the tarball.
 - `openclaw backup create --verify` runs that validation immediately after writing the archive.
+- `openclaw backup create --only-config` backs up just the active JSON config file.
 
 ## What gets backed up
 
@@ -37,6 +39,8 @@ openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz
 - The active config file path
 - The OAuth / credentials directory
 - Workspace directories discovered from the current config, unless you pass `--no-include-workspace`
+
+If you use `--only-config`, OpenClaw skips state, credentials, and workspace discovery and archives only the active config file path.
 
 OpenClaw canonicalizes paths before building the archive. If config, credentials, or a workspace already live inside the state directory, they are not duplicated as separate top-level backup sources. Missing paths are skipped.
 
@@ -54,6 +58,8 @@ openclaw backup create --no-include-workspace
 
 That keeps state, config, and credentials in scope while skipping workspace discovery entirely.
 
+If you only need a copy of the config file itself, `--only-config` also works when the config is malformed because it does not rely on parsing the config for workspace discovery.
+
 ## Size and performance
 
 OpenClaw does not enforce a built-in maximum backup size or per-file size limit.
@@ -66,3 +72,5 @@ Practical limits come from the local machine and destination filesystem:
 - Filesystem behavior at the destination path. OpenClaw prefers a no-overwrite hard-link publish step and falls back to exclusive copy when hard links are unsupported
 
 Large workspaces are usually the main driver of archive size. If you want a smaller or faster backup, use `--no-include-workspace`.
+
+For the smallest archive, use `--only-config`.

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -21,5 +21,6 @@ openclaw backup create --no-include-workspace
 
 - The archive includes a `manifest.json` file with the resolved source paths and archive layout.
 - Default output is a timestamped `.tar.gz` archive in the current working directory.
+- If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten.
 - Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -106,6 +106,7 @@ openclaw [--dev] [--profile <name>] <command>
   dashboard
   backup
     create
+    verify
   security
     audit
   secrets

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -19,6 +19,7 @@ This page describes the current CLI behavior. If commands change, update this do
 - [`completion`](/cli/completion)
 - [`doctor`](/cli/doctor)
 - [`dashboard`](/cli/dashboard)
+- [`backup`](/cli/backup)
 - [`reset`](/cli/reset)
 - [`uninstall`](/cli/uninstall)
 - [`update`](/cli/update)
@@ -103,6 +104,8 @@ openclaw [--dev] [--profile <name>] <command>
   completion
   doctor
   dashboard
+  backup
+    create
   security
     audit
   secrets

--- a/docs/cli/reset.md
+++ b/docs/cli/reset.md
@@ -11,7 +11,10 @@ title: "reset"
 Reset local config/state (keeps the CLI installed).
 
 ```bash
+openclaw backup create
 openclaw reset
 openclaw reset --dry-run
 openclaw reset --scope config+creds+sessions --yes --non-interactive
 ```
+
+Run `openclaw backup create` first if you want a restorable snapshot before removing local state.

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -11,7 +11,10 @@ title: "uninstall"
 Uninstall the gateway service + local data (CLI remains).
 
 ```bash
+openclaw backup create
 openclaw uninstall
 openclaw uninstall --all --yes
 openclaw uninstall --dry-run
 ```
+
+Run `openclaw backup create` first if you want a restorable snapshot before removing state or workspaces.

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -273,22 +273,17 @@ describe("resolveCommandSecretRefsViaGateway", () => {
   });
 
   it("fails when configured refs remain unresolved after gateway assignments are applied", async () => {
+    const envKey = "TALK_API_KEY_STRICT_UNRESOLVED";
     callGateway.mockResolvedValueOnce({
       assignments: [],
       diagnostics: [],
     });
 
-    await expect(
-      resolveCommandSecretRefsViaGateway({
-        config: {
-          talk: {
-            apiKey: { source: "env", provider: "default", id: "TALK_API_KEY" },
-          },
-        } as OpenClawConfig,
-        commandName: "memory status",
-        targetIds: new Set(["talk.apiKey"]),
-      }),
-    ).rejects.toThrow(/talk\.apiKey is unresolved in the active runtime snapshot/i);
+    await withEnvValue(envKey, undefined, async () => {
+      await expect(resolveTalkApiKey({ envKey })).rejects.toThrow(
+        /talk\.apiKey is unresolved in the active runtime snapshot/i,
+      );
+    });
   });
 
   it("allows unresolved refs when gateway diagnostics mark the target as inactive", async () => {

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -11,6 +11,13 @@ vi.mock("./register.agent.js", () => ({
   },
 }));
 
+vi.mock("./register.backup.js", () => ({
+  registerBackupCommand: (program: Command) => {
+    const backup = program.command("backup");
+    backup.command("create");
+  },
+}));
+
 vi.mock("./register.maintenance.js", () => ({
   registerMaintenanceCommands: (program: Command) => {
     program.command("doctor");
@@ -67,6 +74,7 @@ describe("command-registry", () => {
     expect(names).toContain("config");
     expect(names).toContain("memory");
     expect(names).toContain("agents");
+    expect(names).toContain("backup");
     expect(names).toContain("browser");
     expect(names).toContain("sessions");
     expect(names).not.toContain("agent");

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -96,7 +96,7 @@ const coreEntries: CoreCliEntry[] = [
     commands: [
       {
         name: "backup",
-        description: "Create local backup archives for OpenClaw state",
+        description: "Create and verify local backup archives for OpenClaw state",
         hasSubcommands: true,
       },
     ],

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -95,6 +95,19 @@ const coreEntries: CoreCliEntry[] = [
   {
     commands: [
       {
+        name: "backup",
+        description: "Create local backup archives for OpenClaw state",
+        hasSubcommands: true,
+      },
+    ],
+    register: async ({ program }) => {
+      const mod = await import("./register.backup.js");
+      mod.registerBackupCommand(program);
+    },
+  },
+  {
+    commands: [
+      {
         name: "doctor",
         description: "Health checks + quick fixes for the gateway and channels",
         hasSubcommands: false,

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -80,6 +80,11 @@ describe("registerPreActionHooks", () => {
   function buildProgram() {
     const program = new Command().name("openclaw");
     program.command("status").action(() => {});
+    program
+      .command("backup")
+      .command("create")
+      .option("--json")
+      .action(() => {});
     program.command("doctor").action(() => {});
     program.command("completion").action(() => {});
     program.command("secrets").action(() => {});
@@ -221,6 +226,15 @@ describe("registerPreActionHooks", () => {
     await runPreAction({
       parseArgv: ["config", "validate"],
       processArgv: ["node", "openclaw", "--profile", "work", "config", "validate"],
+    });
+
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("bypasses config guard for backup create", async () => {
+    await runPreAction({
+      parseArgv: ["backup", "create"],
+      processArgv: ["node", "openclaw", "backup", "create", "--json"],
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -36,7 +36,7 @@ const PLUGIN_REQUIRED_COMMANDS = new Set([
   "status",
   "health",
 ]);
-const CONFIG_GUARD_BYPASS_COMMANDS = new Set(["doctor", "completion", "secrets"]);
+const CONFIG_GUARD_BYPASS_COMMANDS = new Set(["backup", "doctor", "completion", "secrets"]);
 const JSON_PARSE_ONLY_COMMANDS = new Set(["config set"]);
 let configGuardModulePromise: Promise<typeof import("./config-guard.js")> | undefined;
 let pluginRegistryModulePromise: Promise<typeof import("../plugin-registry.js")> | undefined;

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const backupCreateCommand = vi.fn();
+const backupVerifyCommand = vi.fn();
 
 const runtime = {
   log: vi.fn(),
@@ -11,6 +12,10 @@ const runtime = {
 
 vi.mock("../../commands/backup.js", () => ({
   backupCreateCommand,
+}));
+
+vi.mock("../../commands/backup-verify.js", () => ({
+  backupVerifyCommand,
 }));
 
 vi.mock("../../runtime.js", () => ({
@@ -33,6 +38,7 @@ describe("registerBackupCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     backupCreateCommand.mockResolvedValue(undefined);
+    backupVerifyCommand.mockResolvedValue(undefined);
   });
 
   it("runs backup create with forwarded options", async () => {
@@ -44,6 +50,7 @@ describe("registerBackupCommand", () => {
         output: "/tmp/backups",
         json: true,
         dryRun: true,
+        verify: false,
         includeWorkspace: true,
       }),
     );
@@ -56,6 +63,29 @@ describe("registerBackupCommand", () => {
       runtime,
       expect.objectContaining({
         includeWorkspace: false,
+      }),
+    );
+  });
+
+  it("forwards --verify to backup create", async () => {
+    await runCli(["backup", "create", "--verify"]);
+
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        verify: true,
+      }),
+    );
+  });
+
+  it("runs backup verify with forwarded options", async () => {
+    await runCli(["backup", "verify", "/tmp/openclaw-backup.tar.gz", "--json"]);
+
+    expect(backupVerifyCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        archive: "/tmp/openclaw-backup.tar.gz",
+        json: true,
       }),
     );
   });

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -1,0 +1,62 @@
+import { Command } from "commander";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const backupCreateCommand = vi.fn();
+
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+vi.mock("../../commands/backup.js", () => ({
+  backupCreateCommand,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: runtime,
+}));
+
+let registerBackupCommand: typeof import("./register.backup.js").registerBackupCommand;
+
+beforeAll(async () => {
+  ({ registerBackupCommand } = await import("./register.backup.js"));
+});
+
+describe("registerBackupCommand", () => {
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerBackupCommand(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backupCreateCommand.mockResolvedValue(undefined);
+  });
+
+  it("runs backup create with forwarded options", async () => {
+    await runCli(["backup", "create", "--output", "/tmp/backups", "--json", "--dry-run"]);
+
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        output: "/tmp/backups",
+        json: true,
+        dryRun: true,
+        includeWorkspace: true,
+      }),
+    );
+  });
+
+  it("honors --no-include-workspace", async () => {
+    await runCli(["backup", "create", "--no-include-workspace"]);
+
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        includeWorkspace: false,
+      }),
+    );
+  });
+});

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -51,6 +51,7 @@ describe("registerBackupCommand", () => {
         json: true,
         dryRun: true,
         verify: false,
+        onlyConfig: false,
         includeWorkspace: true,
       }),
     );
@@ -74,6 +75,17 @@ describe("registerBackupCommand", () => {
       runtime,
       expect.objectContaining({
         verify: true,
+      }),
+    );
+  });
+
+  it("forwards --only-config to backup create", async () => {
+    await runCli(["backup", "create", "--only-config"]);
+
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        onlyConfig: true,
       }),
     );
   });

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { backupVerifyCommand } from "../../commands/backup-verify.js";
 import { backupCreateCommand } from "../../commands/backup.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
@@ -9,7 +10,7 @@ import { formatHelpExamples } from "../help-format.js";
 export function registerBackupCommand(program: Command) {
   const backup = program
     .command("backup")
-    .description("Create local backup archives for OpenClaw state")
+    .description("Create and verify local backup archives for OpenClaw state")
     .addHelpText(
       "after",
       () =>
@@ -22,6 +23,7 @@ export function registerBackupCommand(program: Command) {
     .option("--output <path>", "Archive path or destination directory")
     .option("--json", "Output JSON", false)
     .option("--dry-run", "Print the backup plan without writing the archive", false)
+    .option("--verify", "Verify the archive after writing it", false)
     .option("--no-include-workspace", "Exclude workspace directories from the backup")
     .addHelpText(
       "after",
@@ -37,6 +39,10 @@ export function registerBackupCommand(program: Command) {
             "Preview the archive plan without writing any files.",
           ],
           [
+            "openclaw backup create --verify",
+            "Create the archive and immediately validate its manifest and payload layout.",
+          ],
+          [
             "openclaw backup create --no-include-workspace",
             "Back up state/config without agent workspace files.",
           ],
@@ -48,7 +54,35 @@ export function registerBackupCommand(program: Command) {
           output: opts.output as string | undefined,
           json: Boolean(opts.json),
           dryRun: Boolean(opts.dryRun),
+          verify: Boolean(opts.verify),
           includeWorkspace: opts.includeWorkspace as boolean,
+        });
+      });
+    });
+
+  backup
+    .command("verify <archive>")
+    .description("Validate a backup archive and its embedded manifest")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw backup verify ./openclaw-backup-2026-03-09T00-00-00.000Z.tar.gz",
+            "Check that the archive structure and manifest are intact.",
+          ],
+          [
+            "openclaw backup verify ~/Backups/latest.tar.gz --json",
+            "Emit machine-readable verification output.",
+          ],
+        ])}`,
+    )
+    .action(async (archive, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await backupVerifyCommand(defaultRuntime, {
+          archive: archive as string,
+          json: Boolean(opts.json),
         });
       });
     });

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -24,6 +24,7 @@ export function registerBackupCommand(program: Command) {
     .option("--json", "Output JSON", false)
     .option("--dry-run", "Print the backup plan without writing the archive", false)
     .option("--verify", "Verify the archive after writing it", false)
+    .option("--only-config", "Back up only the active JSON config file", false)
     .option("--no-include-workspace", "Exclude workspace directories from the backup")
     .addHelpText(
       "after",
@@ -46,6 +47,7 @@ export function registerBackupCommand(program: Command) {
             "openclaw backup create --no-include-workspace",
             "Back up state/config without agent workspace files.",
           ],
+          ["openclaw backup create --only-config", "Back up only the active JSON config file."],
         ])}`,
     )
     .action(async (opts) => {
@@ -55,6 +57,7 @@ export function registerBackupCommand(program: Command) {
           json: Boolean(opts.json),
           dryRun: Boolean(opts.dryRun),
           verify: Boolean(opts.verify),
+          onlyConfig: Boolean(opts.onlyConfig),
           includeWorkspace: opts.includeWorkspace as boolean,
         });
       });

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -1,0 +1,55 @@
+import type { Command } from "commander";
+import { backupCreateCommand } from "../../commands/backup.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+import { formatHelpExamples } from "../help-format.js";
+
+export function registerBackupCommand(program: Command) {
+  const backup = program
+    .command("backup")
+    .description("Create local backup archives for OpenClaw state")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/backup", "docs.openclaw.ai/cli/backup")}\n`,
+    );
+
+  backup
+    .command("create")
+    .description("Write a backup archive for config, credentials, sessions, and workspaces")
+    .option("--output <path>", "Archive path or destination directory")
+    .option("--json", "Output JSON", false)
+    .option("--dry-run", "Print the backup plan without writing the archive", false)
+    .option("--no-include-workspace", "Exclude workspace directories from the backup")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw backup create", "Create a timestamped backup in the current directory."],
+          [
+            "openclaw backup create --output ~/Backups",
+            "Write the archive into an existing backup directory.",
+          ],
+          [
+            "openclaw backup create --dry-run --json",
+            "Preview the archive plan without writing any files.",
+          ],
+          [
+            "openclaw backup create --no-include-workspace",
+            "Back up state/config without agent workspace files.",
+          ],
+        ])}`,
+    )
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await backupCreateCommand(defaultRuntime, {
+          output: opts.output as string | undefined,
+          json: Boolean(opts.json),
+          dryRun: Boolean(opts.dryRun),
+          includeWorkspace: opts.includeWorkspace as boolean,
+        });
+      });
+    });
+}

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -69,7 +69,7 @@ export function registerBackupCommand(program: Command) {
       () =>
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           [
-            "openclaw backup verify ./openclaw-backup-2026-03-09T00-00-00.000Z.tar.gz",
+            "openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz",
             "Check that the archive structure and manifest are intact.",
           ],
           [

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -106,14 +106,56 @@ async function canonicalizeExistingPath(targetPath: string): Promise<string> {
 export async function resolveBackupPlanFromDisk(
   params: {
     includeWorkspace?: boolean;
+    onlyConfig?: boolean;
     nowMs?: number;
   } = {},
 ): Promise<BackupPlan> {
   const includeWorkspace = params.includeWorkspace ?? true;
-  const configSnapshot = await readConfigFileSnapshot();
+  const onlyConfig = params.onlyConfig ?? false;
   const stateDir = resolveStateDir();
   const configPath = resolveConfigPath();
   const oauthDir = resolveOAuthDir();
+  const archiveRoot = buildBackupArchiveRoot(params.nowMs);
+
+  if (onlyConfig) {
+    const resolvedConfigPath = path.resolve(configPath);
+    if (!(await pathExists(resolvedConfigPath))) {
+      return {
+        stateDir,
+        configPath,
+        oauthDir,
+        workspaceDirs: [],
+        included: [],
+        skipped: [
+          {
+            kind: "config",
+            sourcePath: resolvedConfigPath,
+            displayPath: shortenHomePath(resolvedConfigPath),
+            reason: "missing",
+          },
+        ],
+      };
+    }
+
+    const canonicalConfigPath = await canonicalizeExistingPath(resolvedConfigPath);
+    return {
+      stateDir,
+      configPath,
+      oauthDir,
+      workspaceDirs: [],
+      included: [
+        {
+          kind: "config",
+          sourcePath: canonicalConfigPath,
+          displayPath: shortenHomePath(canonicalConfigPath),
+          archivePath: buildBackupArchivePath(archiveRoot, canonicalConfigPath),
+        },
+      ],
+      skipped: [],
+    };
+  }
+
+  const configSnapshot = await readConfigFileSnapshot();
   if (includeWorkspace && configSnapshot.exists && !configSnapshot.valid) {
     throw new Error(
       `Config invalid at ${shortenHomePath(configSnapshot.path)}. OpenClaw cannot reliably discover custom workspaces for backup. Fix the config or rerun with --no-include-workspace for a partial backup.`,
@@ -165,8 +207,6 @@ export async function resolveBackupPlanFromDisk(
     seenCanonicalPaths.add(candidate.canonicalPath);
     uniqueCandidates.push(candidate);
   }
-  const archiveRoot = buildBackupArchiveRoot(params.nowMs);
-
   const included: BackupAsset[] = [];
   const skipped: SkippedBackupAsset[] = [];
 

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -58,7 +58,7 @@ function backupAssetPriority(kind: BackupAssetKind): number {
 }
 
 export function buildBackupArchiveRoot(nowMs = Date.now()): string {
-  return `openclaw-backup-${formatSessionArchiveTimestamp(nowMs)}`;
+  return `${formatSessionArchiveTimestamp(nowMs)}-openclaw-backup`;
 }
 
 export function buildBackupArchiveBasename(nowMs = Date.now()): string {

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -40,6 +40,8 @@ export type BackupPlan = {
 type BackupAssetCandidate = {
   kind: BackupAssetKind;
   sourcePath: string;
+  canonicalPath: string;
+  exists: boolean;
 };
 
 function backupAssetPriority(kind: BackupAssetKind): number {
@@ -82,7 +84,7 @@ export function buildBackupArchivePath(archiveRoot: string, sourcePath: string):
 }
 
 function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandidate): number {
-  const depthDelta = left.sourcePath.length - right.sourcePath.length;
+  const depthDelta = left.canonicalPath.length - right.canonicalPath.length;
   if (depthDelta !== 0) {
     return depthDelta;
   }
@@ -90,7 +92,7 @@ function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandida
   if (priorityDelta !== 0) {
     return priorityDelta;
   }
-  return left.sourcePath.localeCompare(right.sourcePath);
+  return left.canonicalPath.localeCompare(right.canonicalPath);
 }
 
 async function canonicalizeExistingPath(targetPath: string): Promise<string> {
@@ -125,7 +127,7 @@ export async function resolveBackupPlanFromDisk(
   });
   const workspaceDirs = includeWorkspace ? cleanupPlan.workspaceDirs : [];
 
-  const candidates: BackupAssetCandidate[] = [
+  const rawCandidates = [
     { kind: "state", sourcePath: path.resolve(stateDir) },
     ...(cleanupPlan.configInsideState
       ? []
@@ -141,16 +143,35 @@ export async function resolveBackupPlanFromDisk(
       : []),
   ];
 
-  const uniqueCandidates = [
-    ...new Map(candidates.map((candidate) => [candidate.sourcePath, candidate])).values(),
-  ].toSorted(compareCandidates);
+  const candidates: BackupAssetCandidate[] = await Promise.all(
+    rawCandidates.map(async (candidate) => {
+      const exists = await pathExists(candidate.sourcePath);
+      return {
+        ...candidate,
+        exists,
+        canonicalPath: exists
+          ? await canonicalizeExistingPath(candidate.sourcePath)
+          : path.resolve(candidate.sourcePath),
+      };
+    }),
+  );
+
+  const uniqueCandidates: BackupAssetCandidate[] = [];
+  const seenCanonicalPaths = new Set<string>();
+  for (const candidate of [...candidates].toSorted(compareCandidates)) {
+    if (seenCanonicalPaths.has(candidate.canonicalPath)) {
+      continue;
+    }
+    seenCanonicalPaths.add(candidate.canonicalPath);
+    uniqueCandidates.push(candidate);
+  }
   const archiveRoot = buildBackupArchiveRoot(params.nowMs);
 
   const included: BackupAsset[] = [];
   const skipped: SkippedBackupAsset[] = [];
 
   for (const candidate of uniqueCandidates) {
-    if (!(await pathExists(candidate.sourcePath))) {
+    if (!candidate.exists) {
       skipped.push({
         kind: candidate.kind,
         sourcePath: candidate.sourcePath,
@@ -160,13 +181,14 @@ export async function resolveBackupPlanFromDisk(
       continue;
     }
 
-    const canonicalPath = await canonicalizeExistingPath(candidate.sourcePath);
-    const coveredBy = included.find((asset) => isPathWithin(canonicalPath, asset.sourcePath));
+    const coveredBy = included.find((asset) =>
+      isPathWithin(candidate.canonicalPath, asset.sourcePath),
+    );
     if (coveredBy) {
       skipped.push({
         kind: candidate.kind,
-        sourcePath: canonicalPath,
-        displayPath: shortenHomePath(canonicalPath),
+        sourcePath: candidate.canonicalPath,
+        displayPath: shortenHomePath(candidate.canonicalPath),
         reason: "covered",
         coveredBy: coveredBy.displayPath,
       });
@@ -175,9 +197,9 @@ export async function resolveBackupPlanFromDisk(
 
     included.push({
       kind: candidate.kind,
-      sourcePath: canonicalPath,
-      displayPath: shortenHomePath(canonicalPath),
-      archivePath: buildBackupArchivePath(archiveRoot, canonicalPath),
+      sourcePath: candidate.canonicalPath,
+      displayPath: shortenHomePath(candidate.canonicalPath),
+      archivePath: buildBackupArchivePath(archiveRoot, candidate.canonicalPath),
     });
   }
 

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -127,7 +127,7 @@ export async function resolveBackupPlanFromDisk(
   });
   const workspaceDirs = includeWorkspace ? cleanupPlan.workspaceDirs : [];
 
-  const rawCandidates = [
+  const rawCandidates: Array<Pick<BackupAssetCandidate, "kind" | "sourcePath">> = [
     { kind: "state", sourcePath: path.resolve(stateDir) },
     ...(cleanupPlan.configInsideState
       ? []

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -1,0 +1,172 @@
+import path from "node:path";
+import {
+  readBestEffortConfig,
+  resolveConfigPath,
+  resolveOAuthDir,
+  resolveStateDir,
+} from "../config/config.js";
+import { formatSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
+import { pathExists, shortenHomePath } from "../utils.js";
+import { buildCleanupPlan, isPathWithin } from "./cleanup-utils.js";
+
+export type BackupAssetKind = "state" | "config" | "credentials" | "workspace";
+export type BackupSkipReason = "covered" | "missing";
+
+export type BackupAsset = {
+  kind: BackupAssetKind;
+  sourcePath: string;
+  displayPath: string;
+  archivePath: string;
+};
+
+export type SkippedBackupAsset = {
+  kind: BackupAssetKind;
+  sourcePath: string;
+  displayPath: string;
+  reason: BackupSkipReason;
+  coveredBy?: string;
+};
+
+export type BackupPlan = {
+  stateDir: string;
+  configPath: string;
+  oauthDir: string;
+  workspaceDirs: string[];
+  included: BackupAsset[];
+  skipped: SkippedBackupAsset[];
+};
+
+type BackupAssetCandidate = {
+  kind: BackupAssetKind;
+  sourcePath: string;
+};
+
+function backupAssetPriority(kind: BackupAssetKind): number {
+  switch (kind) {
+    case "state":
+      return 0;
+    case "config":
+      return 1;
+    case "credentials":
+      return 2;
+    case "workspace":
+      return 3;
+  }
+}
+
+export function buildBackupArchiveRoot(nowMs = Date.now()): string {
+  return `openclaw-backup-${formatSessionArchiveTimestamp(nowMs)}`;
+}
+
+export function buildBackupArchiveBasename(nowMs = Date.now()): string {
+  return `${buildBackupArchiveRoot(nowMs)}.tar.gz`;
+}
+
+export function encodeAbsolutePathForBackupArchive(sourcePath: string): string {
+  const normalized = sourcePath.replaceAll("\\", "/");
+  const windowsMatch = normalized.match(/^([A-Za-z]):\/(.*)$/);
+  if (windowsMatch) {
+    const drive = windowsMatch[1]?.toUpperCase() ?? "UNKNOWN";
+    const rest = windowsMatch[2] ?? "";
+    return path.posix.join("windows", drive, rest);
+  }
+  if (normalized.startsWith("/")) {
+    return path.posix.join("posix", normalized.slice(1));
+  }
+  return path.posix.join("relative", normalized);
+}
+
+export function buildBackupArchivePath(archiveRoot: string, sourcePath: string): string {
+  return path.posix.join(archiveRoot, "payload", encodeAbsolutePathForBackupArchive(sourcePath));
+}
+
+function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandidate): number {
+  const depthDelta = left.sourcePath.length - right.sourcePath.length;
+  if (depthDelta !== 0) {
+    return depthDelta;
+  }
+  const priorityDelta = backupAssetPriority(left.kind) - backupAssetPriority(right.kind);
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+  return left.sourcePath.localeCompare(right.sourcePath);
+}
+
+export async function resolveBackupPlanFromDisk(
+  params: {
+    includeWorkspace?: boolean;
+    nowMs?: number;
+  } = {},
+): Promise<BackupPlan> {
+  const cfg = await readBestEffortConfig();
+  const stateDir = resolveStateDir();
+  const configPath = resolveConfigPath();
+  const oauthDir = resolveOAuthDir();
+  const cleanupPlan = buildCleanupPlan({ cfg, stateDir, configPath, oauthDir });
+
+  const candidates: BackupAssetCandidate[] = [
+    { kind: "state", sourcePath: path.resolve(stateDir) },
+    ...(cleanupPlan.configInsideState
+      ? []
+      : [{ kind: "config" as const, sourcePath: path.resolve(configPath) }]),
+    ...(cleanupPlan.oauthInsideState
+      ? []
+      : [{ kind: "credentials" as const, sourcePath: path.resolve(oauthDir) }]),
+    ...((params.includeWorkspace ?? true)
+      ? cleanupPlan.workspaceDirs.map((workspaceDir) => ({
+          kind: "workspace" as const,
+          sourcePath: path.resolve(workspaceDir),
+        }))
+      : []),
+  ];
+
+  const uniqueCandidates = [
+    ...new Map(candidates.map((candidate) => [candidate.sourcePath, candidate])).values(),
+  ].sort(compareCandidates);
+  const archiveRoot = buildBackupArchiveRoot(params.nowMs);
+
+  const included: BackupAsset[] = [];
+  const skipped: SkippedBackupAsset[] = [];
+
+  for (const candidate of uniqueCandidates) {
+    if (!(await pathExists(candidate.sourcePath))) {
+      skipped.push({
+        kind: candidate.kind,
+        sourcePath: candidate.sourcePath,
+        displayPath: shortenHomePath(candidate.sourcePath),
+        reason: "missing",
+      });
+      continue;
+    }
+
+    const coveredBy = included.find((asset) =>
+      isPathWithin(candidate.sourcePath, asset.sourcePath),
+    );
+    if (coveredBy) {
+      skipped.push({
+        kind: candidate.kind,
+        sourcePath: candidate.sourcePath,
+        displayPath: shortenHomePath(candidate.sourcePath),
+        reason: "covered",
+        coveredBy: coveredBy.displayPath,
+      });
+      continue;
+    }
+
+    included.push({
+      kind: candidate.kind,
+      sourcePath: candidate.sourcePath,
+      displayPath: shortenHomePath(candidate.sourcePath),
+      archivePath: buildBackupArchivePath(archiveRoot, candidate.sourcePath),
+    });
+  }
+
+  return {
+    stateDir,
+    configPath,
+    oauthDir,
+    workspaceDirs: cleanupPlan.workspaceDirs.map((entry) => path.resolve(entry)),
+    included,
+    skipped,
+  };
+}

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import {
   readBestEffortConfig,
@@ -92,6 +93,14 @@ function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandida
   return left.sourcePath.localeCompare(right.sourcePath);
 }
 
+async function canonicalizeExistingPath(targetPath: string): Promise<string> {
+  try {
+    return await fs.realpath(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
 export async function resolveBackupPlanFromDisk(
   params: {
     includeWorkspace?: boolean;
@@ -139,14 +148,13 @@ export async function resolveBackupPlanFromDisk(
       continue;
     }
 
-    const coveredBy = included.find((asset) =>
-      isPathWithin(candidate.sourcePath, asset.sourcePath),
-    );
+    const canonicalPath = await canonicalizeExistingPath(candidate.sourcePath);
+    const coveredBy = included.find((asset) => isPathWithin(canonicalPath, asset.sourcePath));
     if (coveredBy) {
       skipped.push({
         kind: candidate.kind,
-        sourcePath: candidate.sourcePath,
-        displayPath: shortenHomePath(candidate.sourcePath),
+        sourcePath: canonicalPath,
+        displayPath: shortenHomePath(canonicalPath),
         reason: "covered",
         coveredBy: coveredBy.displayPath,
       });
@@ -155,9 +163,9 @@ export async function resolveBackupPlanFromDisk(
 
     included.push({
       kind: candidate.kind,
-      sourcePath: candidate.sourcePath,
-      displayPath: shortenHomePath(candidate.sourcePath),
-      archivePath: buildBackupArchivePath(archiveRoot, candidate.sourcePath),
+      sourcePath: canonicalPath,
+      displayPath: shortenHomePath(canonicalPath),
+      archivePath: buildBackupArchivePath(archiveRoot, canonicalPath),
     });
   }
 

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
-  readBestEffortConfig,
+  readConfigFileSnapshot,
   resolveConfigPath,
   resolveOAuthDir,
   resolveStateDir,
@@ -107,11 +107,23 @@ export async function resolveBackupPlanFromDisk(
     nowMs?: number;
   } = {},
 ): Promise<BackupPlan> {
-  const cfg = await readBestEffortConfig();
+  const includeWorkspace = params.includeWorkspace ?? true;
+  const configSnapshot = await readConfigFileSnapshot();
   const stateDir = resolveStateDir();
   const configPath = resolveConfigPath();
   const oauthDir = resolveOAuthDir();
-  const cleanupPlan = buildCleanupPlan({ cfg, stateDir, configPath, oauthDir });
+  if (includeWorkspace && configSnapshot.exists && !configSnapshot.valid) {
+    throw new Error(
+      `Config invalid at ${shortenHomePath(configSnapshot.path)}. OpenClaw cannot reliably discover custom workspaces for backup. Fix the config or rerun with --no-include-workspace for a partial backup.`,
+    );
+  }
+  const cleanupPlan = buildCleanupPlan({
+    cfg: configSnapshot.config,
+    stateDir,
+    configPath,
+    oauthDir,
+  });
+  const workspaceDirs = includeWorkspace ? cleanupPlan.workspaceDirs : [];
 
   const candidates: BackupAssetCandidate[] = [
     { kind: "state", sourcePath: path.resolve(stateDir) },
@@ -121,8 +133,8 @@ export async function resolveBackupPlanFromDisk(
     ...(cleanupPlan.oauthInsideState
       ? []
       : [{ kind: "credentials" as const, sourcePath: path.resolve(oauthDir) }]),
-    ...((params.includeWorkspace ?? true)
-      ? cleanupPlan.workspaceDirs.map((workspaceDir) => ({
+    ...(includeWorkspace
+      ? workspaceDirs.map((workspaceDir) => ({
           kind: "workspace" as const,
           sourcePath: path.resolve(workspaceDir),
         }))
@@ -131,7 +143,7 @@ export async function resolveBackupPlanFromDisk(
 
   const uniqueCandidates = [
     ...new Map(candidates.map((candidate) => [candidate.sourcePath, candidate])).values(),
-  ].sort(compareCandidates);
+  ].toSorted(compareCandidates);
   const archiveRoot = buildBackupArchiveRoot(params.nowMs);
 
   const included: BackupAsset[] = [];
@@ -173,7 +185,7 @@ export async function resolveBackupPlanFromDisk(
     stateDir,
     configPath,
     oauthDir,
-    workspaceDirs: cleanupPlan.workspaceDirs.map((entry) => path.resolve(entry)),
+    workspaceDirs: workspaceDirs.map((entry) => path.resolve(entry)),
     included,
     skipped,
   };

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { buildBackupArchiveRoot } from "./backup-shared.js";
+import { backupVerifyCommand } from "./backup-verify.js";
+import { backupCreateCommand } from "./backup.js";
+
+describe("backupVerifyCommand", () => {
+  let tempHome: TempHomeEnv;
+
+  beforeEach(async () => {
+    tempHome = await createTempHomeEnv("openclaw-backup-verify-test-");
+  });
+
+  afterEach(async () => {
+    await tempHome.restore();
+  });
+
+  it("verifies an archive created by backup create", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-verify-out-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "hello\n", "utf8");
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const nowMs = Date.UTC(2026, 2, 9, 0, 0, 0);
+      const created = await backupCreateCommand(runtime, { output: archiveDir, nowMs });
+      const verified = await backupVerifyCommand(runtime, { archive: created.archivePath });
+
+      expect(verified.ok).toBe(true);
+      expect(verified.archiveRoot).toBe(buildBackupArchiveRoot(nowMs));
+      expect(verified.assetCount).toBeGreaterThan(0);
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when the archive does not contain a manifest", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-no-manifest-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    try {
+      const root = path.join(tempDir, "root");
+      await fs.mkdir(path.join(root, "payload"), { recursive: true });
+      await fs.writeFile(path.join(root, "payload", "data.txt"), "x\n", "utf8");
+      await tar.c({ file: archivePath, gzip: true, cwd: tempDir }, ["root"]);
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /expected exactly one backup manifest entry/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when the manifest references a missing asset payload", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-missing-asset-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    try {
+      const rootName = "openclaw-backup-2026-03-09T00-00-00.000Z";
+      const root = path.join(tempDir, rootName);
+      await fs.mkdir(root, { recursive: true });
+      const manifest = {
+        schemaVersion: 1,
+        createdAt: "2026-03-09T00:00:00.000Z",
+        archiveRoot: rootName,
+        runtimeVersion: "test",
+        platform: process.platform,
+        nodeVersion: process.version,
+        assets: [
+          {
+            kind: "state",
+            sourcePath: "/tmp/.openclaw",
+            archivePath: `${rootName}/payload/posix/tmp/.openclaw`,
+          },
+        ],
+      };
+      await fs.writeFile(
+        path.join(root, "manifest.json"),
+        `${JSON.stringify(manifest, null, 2)}\n`,
+      );
+      await tar.c({ file: archivePath, gzip: true, cwd: tempDir }, [rootName]);
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /missing payload for manifest asset/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -71,7 +71,7 @@ describe("backupVerifyCommand", () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-missing-asset-"));
     const archivePath = path.join(tempDir, "broken.tar.gz");
     try {
-      const rootName = "openclaw-backup-2026-03-09T00-00-00.000Z";
+      const rootName = "2026-03-09T00-00-00.000Z-openclaw-backup";
       const root = path.join(tempDir, rootName);
       await fs.mkdir(root, { recursive: true });
       const manifest = {
@@ -115,7 +115,7 @@ describe("backupVerifyCommand", () => {
     const manifestPath = path.join(tempDir, "manifest.json");
     const payloadPath = path.join(tempDir, "payload.txt");
     try {
-      const rootName = "openclaw-backup-2026-03-09T00-00-00.000Z";
+      const rootName = "2026-03-09T00-00-00.000Z-openclaw-backup";
       const traversalPath = `${rootName}/payload/../escaped.txt`;
       const manifest = {
         schemaVersion: 1,
@@ -221,7 +221,7 @@ describe("backupVerifyCommand", () => {
     const manifestPath = path.join(tempDir, "manifest.json");
     const payloadPath = path.join(tempDir, "payload.txt");
     try {
-      const rootName = "openclaw-backup-2026-03-09T00-00-00.000Z";
+      const rootName = "2026-03-09T00-00-00.000Z-openclaw-backup";
       const manifest = {
         schemaVersion: 1,
         createdAt: "2026-03-09T00:00:00.000Z",

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -166,4 +166,52 @@ describe("backupVerifyCommand", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("ignores payload manifest.json files when locating the backup manifest", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const configPath = path.join(tempHome.home, "custom-config.json");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-verify-out-"));
+    try {
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: externalWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "hello\n", "utf8");
+      await fs.writeFile(
+        path.join(externalWorkspace, "manifest.json"),
+        JSON.stringify({ name: "workspace-payload" }),
+        "utf8",
+      );
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: true,
+        nowMs: Date.UTC(2026, 2, 9, 2, 0, 0),
+      });
+      const verified = await backupVerifyCommand(runtime, { archive: created.archivePath });
+
+      expect(verified.ok).toBe(true);
+      expect(verified.assetCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -108,4 +108,62 @@ describe("backupVerifyCommand", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("fails when archive paths contain traversal segments", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-traversal-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    const manifestPath = path.join(tempDir, "manifest.json");
+    const payloadPath = path.join(tempDir, "payload.txt");
+    try {
+      const rootName = "openclaw-backup-2026-03-09T00-00-00.000Z";
+      const traversalPath = `${rootName}/payload/../escaped.txt`;
+      const manifest = {
+        schemaVersion: 1,
+        createdAt: "2026-03-09T00:00:00.000Z",
+        archiveRoot: rootName,
+        runtimeVersion: "test",
+        platform: process.platform,
+        nodeVersion: process.version,
+        assets: [
+          {
+            kind: "state",
+            sourcePath: "/tmp/.openclaw",
+            archivePath: traversalPath,
+          },
+        ],
+      };
+      await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+      await fs.writeFile(payloadPath, "payload\n", "utf8");
+      await tar.c(
+        {
+          file: archivePath,
+          gzip: true,
+          portable: true,
+          preservePaths: true,
+          onWriteEntry: (entry) => {
+            if (entry.path === manifestPath) {
+              entry.path = `${rootName}/manifest.json`;
+              return;
+            }
+            if (entry.path === payloadPath) {
+              entry.path = traversalPath;
+            }
+          },
+        },
+        [manifestPath, payloadPath],
+      );
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /path traversal segments/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -214,4 +214,61 @@ describe("backupVerifyCommand", () => {
       await fs.rm(archiveDir, { recursive: true, force: true });
     }
   });
+
+  it("fails when the archive contains duplicate root manifest entries", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-duplicate-manifest-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    const manifestPath = path.join(tempDir, "manifest.json");
+    const payloadPath = path.join(tempDir, "payload.txt");
+    try {
+      const rootName = "openclaw-backup-2026-03-09T00-00-00.000Z";
+      const manifest = {
+        schemaVersion: 1,
+        createdAt: "2026-03-09T00:00:00.000Z",
+        archiveRoot: rootName,
+        runtimeVersion: "test",
+        platform: process.platform,
+        nodeVersion: process.version,
+        assets: [
+          {
+            kind: "state",
+            sourcePath: "/tmp/.openclaw",
+            archivePath: `${rootName}/payload/posix/tmp/.openclaw/payload.txt`,
+          },
+        ],
+      };
+      await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+      await fs.writeFile(payloadPath, "payload\n", "utf8");
+      await tar.c(
+        {
+          file: archivePath,
+          gzip: true,
+          portable: true,
+          preservePaths: true,
+          onWriteEntry: (entry) => {
+            if (entry.path === manifestPath) {
+              entry.path = `${rootName}/manifest.json`;
+              return;
+            }
+            if (entry.path === payloadPath) {
+              entry.path = `${rootName}/payload/posix/tmp/.openclaw/payload.txt`;
+            }
+          },
+        },
+        [manifestPath, manifestPath, payloadPath],
+      );
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /expected exactly one backup manifest entry, found 2/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
 import type { RuntimeEnv } from "../runtime.js";
@@ -185,22 +183,38 @@ async function extractManifest(params: {
   archivePath: string;
   manifestEntryPath: string;
 }): Promise<string> {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-verify-"));
-  try {
-    await tar.x(
-      {
-        file: params.archivePath,
-        gzip: true,
-        cwd: tempDir,
-        preservePaths: false,
-      },
-      [params.manifestEntryPath],
-    );
-    const manifestPath = path.join(tempDir, params.manifestEntryPath);
-    return await fs.readFile(manifestPath, "utf8");
-  } finally {
-    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  let manifestContentPromise: Promise<string> | undefined;
+  await tar.t({
+    file: params.archivePath,
+    gzip: true,
+    onentry: (entry) => {
+      if (entry.path !== params.manifestEntryPath) {
+        entry.resume();
+        return;
+      }
+
+      manifestContentPromise = new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        entry.on("data", (chunk: Buffer | string) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        entry.on("error", reject);
+        entry.on("end", () => {
+          resolve(Buffer.concat(chunks).toString("utf8"));
+        });
+      });
+    },
+  });
+
+  if (!manifestContentPromise) {
+    throw new Error(`Archive is missing manifest entry: ${params.manifestEntryPath}`);
   }
+  return await manifestContentPromise;
+}
+
+function isRootManifestEntry(entryPath: string): boolean {
+  const parts = entryPath.split("/");
+  return parts.length === 2 && parts[0] !== "" && parts[1] === "manifest.json";
 }
 
 function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<string>): void {
@@ -263,7 +277,7 @@ export async function backupVerifyCommand(
       raw: entry,
       normalized: normalizeArchivePath(entry, "Archive entry"),
     }))
-    .filter((entry) => entry.normalized.endsWith("/manifest.json"));
+    .filter((entry) => isRootManifestEntry(entry.normalized));
   if (manifestMatches.length !== 1) {
     throw new Error(`Expected exactly one backup manifest entry, found ${manifestMatches.length}.`);
   }

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
+
+type BackupManifestAsset = {
+  kind: string;
+  sourcePath: string;
+  archivePath: string;
+};
+
+type BackupManifest = {
+  schemaVersion: number;
+  createdAt: string;
+  archiveRoot: string;
+  runtimeVersion: string;
+  platform: string;
+  nodeVersion: string;
+  options?: {
+    includeWorkspace?: boolean;
+  };
+  paths?: {
+    stateDir?: string;
+    configPath?: string;
+    oauthDir?: string;
+    workspaceDirs?: string[];
+  };
+  assets: BackupManifestAsset[];
+  skipped?: Array<{
+    kind?: string;
+    sourcePath?: string;
+    reason?: string;
+    coveredBy?: string;
+  }>;
+};
+
+export type BackupVerifyOptions = {
+  archive: string;
+  json?: boolean;
+};
+
+export type BackupVerifyResult = {
+  ok: true;
+  archivePath: string;
+  archiveRoot: string;
+  createdAt: string;
+  runtimeVersion: string;
+  assetCount: number;
+  entryCount: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseManifest(raw: string): BackupManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Backup manifest is not valid JSON: ${String(err)}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("Backup manifest must be an object.");
+  }
+  if (parsed.schemaVersion !== 1) {
+    throw new Error(`Unsupported backup manifest schemaVersion: ${String(parsed.schemaVersion)}`);
+  }
+  if (typeof parsed.archiveRoot !== "string" || !parsed.archiveRoot.trim()) {
+    throw new Error("Backup manifest is missing archiveRoot.");
+  }
+  if (typeof parsed.createdAt !== "string" || !parsed.createdAt.trim()) {
+    throw new Error("Backup manifest is missing createdAt.");
+  }
+  if (!Array.isArray(parsed.assets)) {
+    throw new Error("Backup manifest is missing assets.");
+  }
+
+  const assets: BackupManifestAsset[] = [];
+  for (const asset of parsed.assets) {
+    if (!isRecord(asset)) {
+      throw new Error("Backup manifest contains a non-object asset.");
+    }
+    if (typeof asset.kind !== "string" || !asset.kind.trim()) {
+      throw new Error("Backup manifest asset is missing kind.");
+    }
+    if (typeof asset.sourcePath !== "string" || !asset.sourcePath.trim()) {
+      throw new Error("Backup manifest asset is missing sourcePath.");
+    }
+    if (typeof asset.archivePath !== "string" || !asset.archivePath.trim()) {
+      throw new Error("Backup manifest asset is missing archivePath.");
+    }
+    assets.push({
+      kind: asset.kind,
+      sourcePath: asset.sourcePath,
+      archivePath: asset.archivePath,
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    archiveRoot: parsed.archiveRoot,
+    createdAt: parsed.createdAt,
+    runtimeVersion:
+      typeof parsed.runtimeVersion === "string" && parsed.runtimeVersion.trim()
+        ? parsed.runtimeVersion
+        : "unknown",
+    platform: typeof parsed.platform === "string" ? parsed.platform : "unknown",
+    nodeVersion: typeof parsed.nodeVersion === "string" ? parsed.nodeVersion : "unknown",
+    options: isRecord(parsed.options)
+      ? { includeWorkspace: parsed.options.includeWorkspace as boolean | undefined }
+      : undefined,
+    paths: isRecord(parsed.paths)
+      ? {
+          stateDir: typeof parsed.paths.stateDir === "string" ? parsed.paths.stateDir : undefined,
+          configPath:
+            typeof parsed.paths.configPath === "string" ? parsed.paths.configPath : undefined,
+          oauthDir: typeof parsed.paths.oauthDir === "string" ? parsed.paths.oauthDir : undefined,
+          workspaceDirs: Array.isArray(parsed.paths.workspaceDirs)
+            ? parsed.paths.workspaceDirs.filter(
+                (entry): entry is string => typeof entry === "string",
+              )
+            : undefined,
+        }
+      : undefined,
+    assets,
+    skipped: Array.isArray(parsed.skipped) ? parsed.skipped : undefined,
+  };
+}
+
+async function listArchiveEntries(archivePath: string): Promise<Set<string>> {
+  const entries = new Set<string>();
+  await tar.t({
+    file: archivePath,
+    gzip: true,
+    onentry: (entry) => {
+      entries.add(entry.path);
+    },
+  });
+  return entries;
+}
+
+async function extractManifest(params: {
+  archivePath: string;
+  manifestEntryPath: string;
+}): Promise<string> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-verify-"));
+  try {
+    await tar.x({
+      file: params.archivePath,
+      gzip: true,
+      cwd: tempDir,
+      preservePaths: false,
+      entries: [params.manifestEntryPath],
+    });
+    const manifestPath = path.join(tempDir, params.manifestEntryPath);
+    return await fs.readFile(manifestPath, "utf8");
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<string>): void {
+  const manifestEntryPath = path.posix.join(manifest.archiveRoot, "manifest.json");
+  if (!entries.has(manifestEntryPath)) {
+    throw new Error(`Archive is missing manifest entry: ${manifestEntryPath}`);
+  }
+
+  for (const entry of entries) {
+    if (!entry.startsWith(`${manifest.archiveRoot}/`)) {
+      throw new Error(`Archive entry is outside the declared archive root: ${entry}`);
+    }
+  }
+
+  for (const asset of manifest.assets) {
+    if (!asset.archivePath.startsWith(`${manifest.archiveRoot}/payload/`)) {
+      throw new Error(`Manifest asset path is outside payload root: ${asset.archivePath}`);
+    }
+    const exact = entries.has(asset.archivePath);
+    const nested = [...entries].some((entry) => entry.startsWith(`${asset.archivePath}/`));
+    if (!exact && !nested) {
+      throw new Error(`Archive is missing payload for manifest asset: ${asset.archivePath}`);
+    }
+  }
+}
+
+function formatResult(result: BackupVerifyResult): string {
+  return [
+    `Backup archive OK: ${result.archivePath}`,
+    `Archive root: ${result.archiveRoot}`,
+    `Created at: ${result.createdAt}`,
+    `Runtime version: ${result.runtimeVersion}`,
+    `Assets verified: ${result.assetCount}`,
+    `Archive entries scanned: ${result.entryCount}`,
+  ].join("\n");
+}
+
+export async function backupVerifyCommand(
+  runtime: RuntimeEnv,
+  opts: BackupVerifyOptions,
+): Promise<BackupVerifyResult> {
+  const archivePath = resolveUserPath(opts.archive);
+  const entries = await listArchiveEntries(archivePath);
+  if (entries.size === 0) {
+    throw new Error("Backup archive is empty.");
+  }
+
+  const manifestMatches = [...entries].filter((entry) => entry.endsWith("/manifest.json"));
+  if (manifestMatches.length !== 1) {
+    throw new Error(`Expected exactly one backup manifest entry, found ${manifestMatches.length}.`);
+  }
+  const manifestEntryPath = manifestMatches[0];
+  if (!manifestEntryPath) {
+    throw new Error("Backup archive manifest entry could not be resolved.");
+  }
+
+  const manifestRaw = await extractManifest({ archivePath, manifestEntryPath });
+  const manifest = parseManifest(manifestRaw);
+  verifyManifestAgainstEntries(manifest, entries);
+
+  const result: BackupVerifyResult = {
+    ok: true,
+    archivePath,
+    archiveRoot: manifest.archiveRoot,
+    createdAt: manifest.createdAt,
+    runtimeVersion: manifest.runtimeVersion,
+    assetCount: manifest.assets.length,
+    entryCount: entries.size,
+  };
+
+  runtime.log(opts.json ? JSON.stringify(result, null, 2) : formatResult(result));
+  return result;
+}

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -187,13 +187,15 @@ async function extractManifest(params: {
 }): Promise<string> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-verify-"));
   try {
-    await tar.x({
-      file: params.archivePath,
-      gzip: true,
-      cwd: tempDir,
-      preservePaths: false,
-      entries: [params.manifestEntryPath],
-    });
+    await tar.x(
+      {
+        file: params.archivePath,
+        gzip: true,
+        cwd: tempDir,
+        preservePaths: false,
+      },
+      [params.manifestEntryPath],
+    );
     const manifestPath = path.join(tempDir, params.manifestEntryPath);
     return await fs.readFile(manifestPath, "utf8");
   } finally {

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -5,6 +5,8 @@ import * as tar from "tar";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 
+const WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
+
 type BackupManifestAsset = {
   kind: string;
   sourcePath: string;
@@ -55,12 +57,48 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/u, "");
+}
+
+function normalizeArchivePath(entryPath: string, label: string): string {
+  const trimmed = stripTrailingSlashes(entryPath.trim());
+  if (!trimmed) {
+    throw new Error(`${label} is empty.`);
+  }
+  if (trimmed.startsWith("/") || WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE.test(trimmed)) {
+    throw new Error(`${label} must be relative: ${entryPath}`);
+  }
+  if (trimmed.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new Error(`${label} contains path traversal segments: ${entryPath}`);
+  }
+
+  const normalized = stripTrailingSlashes(path.posix.normalize(trimmed));
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(`${label} resolves outside the archive root: ${entryPath}`);
+  }
+  return normalized;
+}
+
+function normalizeArchiveRoot(rootName: string): string {
+  const normalized = normalizeArchivePath(rootName, "Backup manifest archiveRoot");
+  if (normalized.includes("/")) {
+    throw new Error(`Backup manifest archiveRoot must be a single path segment: ${rootName}`);
+  }
+  return normalized;
+}
+
+function isArchivePathWithin(child: string, parent: string): boolean {
+  const relative = path.posix.relative(parent, child);
+  return relative === "" || (!relative.startsWith("../") && relative !== "..");
+}
+
 function parseManifest(raw: string): BackupManifest {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    throw new Error(`Backup manifest is not valid JSON: ${String(err)}`);
+    throw new Error(`Backup manifest is not valid JSON: ${String(err)}`, { cause: err });
   }
 
   if (!isRecord(parsed)) {
@@ -164,25 +202,35 @@ async function extractManifest(params: {
 }
 
 function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<string>): void {
-  const manifestEntryPath = path.posix.join(manifest.archiveRoot, "manifest.json");
-  if (!entries.has(manifestEntryPath)) {
+  const archiveRoot = normalizeArchiveRoot(manifest.archiveRoot);
+  const manifestEntryPath = path.posix.join(archiveRoot, "manifest.json");
+  const normalizedEntries = [...entries].map((entry) =>
+    normalizeArchivePath(entry, "Archive entry"),
+  );
+  const normalizedEntrySet = new Set(normalizedEntries);
+
+  if (!normalizedEntrySet.has(manifestEntryPath)) {
     throw new Error(`Archive is missing manifest entry: ${manifestEntryPath}`);
   }
 
-  for (const entry of entries) {
-    if (!entry.startsWith(`${manifest.archiveRoot}/`)) {
+  for (const entry of normalizedEntries) {
+    if (!isArchivePathWithin(entry, archiveRoot)) {
       throw new Error(`Archive entry is outside the declared archive root: ${entry}`);
     }
   }
 
+  const payloadRoot = path.posix.join(archiveRoot, "payload");
   for (const asset of manifest.assets) {
-    if (!asset.archivePath.startsWith(`${manifest.archiveRoot}/payload/`)) {
+    const assetArchivePath = normalizeArchivePath(asset.archivePath, "Backup manifest asset path");
+    if (!isArchivePathWithin(assetArchivePath, payloadRoot)) {
       throw new Error(`Manifest asset path is outside payload root: ${asset.archivePath}`);
     }
-    const exact = entries.has(asset.archivePath);
-    const nested = [...entries].some((entry) => entry.startsWith(`${asset.archivePath}/`));
+    const exact = normalizedEntrySet.has(assetArchivePath);
+    const nested = normalizedEntries.some(
+      (entry) => entry !== assetArchivePath && isArchivePathWithin(entry, assetArchivePath),
+    );
     if (!exact && !nested) {
-      throw new Error(`Archive is missing payload for manifest asset: ${asset.archivePath}`);
+      throw new Error(`Archive is missing payload for manifest asset: ${assetArchivePath}`);
     }
   }
 }
@@ -208,11 +256,16 @@ export async function backupVerifyCommand(
     throw new Error("Backup archive is empty.");
   }
 
-  const manifestMatches = [...entries].filter((entry) => entry.endsWith("/manifest.json"));
+  const manifestMatches = [...entries]
+    .map((entry) => ({
+      raw: entry,
+      normalized: normalizeArchivePath(entry, "Archive entry"),
+    }))
+    .filter((entry) => entry.normalized.endsWith("/manifest.json"));
   if (manifestMatches.length !== 1) {
     throw new Error(`Expected exactly one backup manifest entry, found ${manifestMatches.length}.`);
   }
-  const manifestEntryPath = manifestMatches[0];
+  const manifestEntryPath = manifestMatches[0]?.raw;
   if (!manifestEntryPath) {
     throw new Error("Backup archive manifest entry could not be resolved.");
   }

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -167,13 +167,13 @@ function parseManifest(raw: string): BackupManifest {
   };
 }
 
-async function listArchiveEntries(archivePath: string): Promise<Set<string>> {
-  const entries = new Set<string>();
+async function listArchiveEntries(archivePath: string): Promise<string[]> {
+  const entries: string[] = [];
   await tar.t({
     file: archivePath,
     gzip: true,
     onentry: (entry) => {
-      entries.add(entry.path);
+      entries.push(entry.path);
     },
   });
   return entries;
@@ -220,9 +220,7 @@ function isRootManifestEntry(entryPath: string): boolean {
 function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<string>): void {
   const archiveRoot = normalizeArchiveRoot(manifest.archiveRoot);
   const manifestEntryPath = path.posix.join(archiveRoot, "manifest.json");
-  const normalizedEntries = [...entries].map((entry) =>
-    normalizeArchivePath(entry, "Archive entry"),
-  );
+  const normalizedEntries = [...entries];
   const normalizedEntrySet = new Set(normalizedEntries);
 
   if (!normalizedEntrySet.has(manifestEntryPath)) {
@@ -267,17 +265,18 @@ export async function backupVerifyCommand(
   opts: BackupVerifyOptions,
 ): Promise<BackupVerifyResult> {
   const archivePath = resolveUserPath(opts.archive);
-  const entries = await listArchiveEntries(archivePath);
-  if (entries.size === 0) {
+  const rawEntries = await listArchiveEntries(archivePath);
+  if (rawEntries.length === 0) {
     throw new Error("Backup archive is empty.");
   }
 
-  const manifestMatches = [...entries]
-    .map((entry) => ({
-      raw: entry,
-      normalized: normalizeArchivePath(entry, "Archive entry"),
-    }))
-    .filter((entry) => isRootManifestEntry(entry.normalized));
+  const entries = rawEntries.map((entry) => ({
+    raw: entry,
+    normalized: normalizeArchivePath(entry, "Archive entry"),
+  }));
+  const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
+
+  const manifestMatches = entries.filter((entry) => isRootManifestEntry(entry.normalized));
   if (manifestMatches.length !== 1) {
     throw new Error(`Expected exactly one backup manifest entry, found ${manifestMatches.length}.`);
   }
@@ -288,7 +287,7 @@ export async function backupVerifyCommand(
 
   const manifestRaw = await extractManifest({ archivePath, manifestEntryPath });
   const manifest = parseManifest(manifestRaw);
-  verifyManifestAgainstEntries(manifest, entries);
+  verifyManifestAgainstEntries(manifest, normalizedEntrySet);
 
   const result: BackupVerifyResult = {
     ok: true,
@@ -297,7 +296,7 @@ export async function backupVerifyCommand(
     createdAt: manifest.createdAt,
     runtimeVersion: manifest.runtimeVersion,
     assetCount: manifest.assets.length,
-    entryCount: entries.size,
+    entryCount: rawEntries.length,
   };
 
   runtime.log(opts.json ? JSON.stringify(result, null, 2) : formatResult(result));

--- a/src/commands/backup.atomic.test.ts
+++ b/src/commands/backup.atomic.test.ts
@@ -59,4 +59,41 @@ describe("backupCreateCommand atomic archive write", () => {
       await fs.rm(archiveDir, { recursive: true, force: true });
     }
   });
+
+  it("does not overwrite an archive created after readiness checks complete", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-race-"));
+    const realLink = fs.link.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link");
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+
+      tarCreateMock.mockImplementationOnce(async ({ file }: { file: string }) => {
+        await fs.writeFile(file, "archive-bytes", "utf8");
+      });
+      linkSpy.mockImplementationOnce(async (existingPath, newPath) => {
+        await fs.writeFile(newPath, "concurrent-archive", "utf8");
+        return await realLink(existingPath, newPath);
+      });
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      const outputPath = path.join(archiveDir, "backup.tar.gz");
+
+      await expect(
+        backupCreateCommand(runtime, {
+          output: outputPath,
+        }),
+      ).rejects.toThrow(/refusing to overwrite existing backup archive/i);
+
+      expect(await fs.readFile(outputPath, "utf8")).toBe("concurrent-archive");
+    } finally {
+      linkSpy.mockRestore();
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup.atomic.test.ts
+++ b/src/commands/backup.atomic.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+
+const tarCreateMock = vi.hoisted(() => vi.fn());
+const backupVerifyCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock("tar", () => ({
+  c: tarCreateMock,
+}));
+
+vi.mock("./backup-verify.js", () => ({
+  backupVerifyCommand: backupVerifyCommandMock,
+}));
+
+const { backupCreateCommand } = await import("./backup.js");
+
+describe("backupCreateCommand atomic archive write", () => {
+  let tempHome: TempHomeEnv;
+
+  beforeEach(async () => {
+    tempHome = await createTempHomeEnv("openclaw-backup-atomic-test-");
+    tarCreateMock.mockReset();
+    backupVerifyCommandMock.mockReset();
+  });
+
+  afterEach(async () => {
+    await tempHome.restore();
+  });
+
+  it("does not leave a partial final archive behind when tar creation fails", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-failure-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+
+      tarCreateMock.mockRejectedValueOnce(new Error("disk full"));
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      const outputPath = path.join(archiveDir, "backup.tar.gz");
+
+      await expect(
+        backupCreateCommand(runtime, {
+          output: outputPath,
+        }),
+      ).rejects.toThrow(/disk full/i);
+
+      await expect(fs.access(outputPath)).rejects.toThrow();
+      const remaining = await fs.readdir(archiveDir);
+      expect(remaining).toEqual([]);
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/backup.atomic.test.ts
+++ b/src/commands/backup.atomic.test.ts
@@ -96,4 +96,38 @@ describe("backupCreateCommand atomic archive write", () => {
       await fs.rm(archiveDir, { recursive: true, force: true });
     }
   });
+
+  it("falls back to exclusive copy when hard-link publication is unsupported", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-copy-fallback-"));
+    const linkSpy = vi.spyOn(fs, "link");
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+
+      tarCreateMock.mockImplementationOnce(async ({ file }: { file: string }) => {
+        await fs.writeFile(file, "archive-bytes", "utf8");
+      });
+      linkSpy.mockRejectedValueOnce(
+        Object.assign(new Error("hard links not supported"), { code: "EOPNOTSUPP" }),
+      );
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      const outputPath = path.join(archiveDir, "backup.tar.gz");
+
+      const result = await backupCreateCommand(runtime, {
+        output: outputPath,
+      });
+
+      expect(result.archivePath).toBe(outputPath);
+      expect(await fs.readFile(outputPath, "utf8")).toBe("archive-bytes");
+    } finally {
+      linkSpy.mockRestore();
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import {
+  buildBackupArchiveRoot,
+  encodeAbsolutePathForBackupArchive,
+  resolveBackupPlanFromDisk,
+} from "./backup-shared.js";
+import { backupCreateCommand } from "./backup.js";
+
+describe("backup commands", () => {
+  let tempHome: TempHomeEnv;
+
+  beforeEach(async () => {
+    tempHome = await createTempHomeEnv("openclaw-backup-test-");
+  });
+
+  afterEach(async () => {
+    await tempHome.restore();
+  });
+
+  it("collapses default config, credentials, and workspace into the state backup root", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    await fs.mkdir(path.join(stateDir, "credentials"), { recursive: true });
+    await fs.writeFile(path.join(stateDir, "credentials", "oauth.json"), "{}", "utf8");
+    await fs.mkdir(path.join(stateDir, "workspace"), { recursive: true });
+    await fs.writeFile(path.join(stateDir, "workspace", "SOUL.md"), "# soul\n", "utf8");
+
+    const plan = await resolveBackupPlanFromDisk({ includeWorkspace: true, nowMs: 123 });
+
+    expect(plan.included).toHaveLength(1);
+    expect(plan.included[0]?.kind).toBe("state");
+    expect(plan.skipped).toEqual(
+      expect.arrayContaining([expect.objectContaining({ kind: "workspace", reason: "covered" })]),
+    );
+  });
+
+  it("creates an archive with a manifest and external workspace payload", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const configPath = path.join(tempHome.home, "custom-config.json");
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-"));
+    try {
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: externalWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      await fs.writeFile(path.join(externalWorkspace, "SOUL.md"), "# external\n", "utf8");
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const nowMs = Date.UTC(2026, 2, 9, 0, 0, 0);
+      const result = await backupCreateCommand(runtime, {
+        output: backupDir,
+        includeWorkspace: true,
+        nowMs,
+      });
+
+      expect(result.archivePath).toBe(
+        path.join(backupDir, `${buildBackupArchiveRoot(nowMs)}.tar.gz`),
+      );
+
+      const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-extract-"));
+      try {
+        await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = path.join(extractDir, buildBackupArchiveRoot(nowMs));
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(archiveRoot, "manifest.json"), "utf8"),
+        ) as {
+          assets: Array<{ kind: string; archivePath: string }>;
+        };
+
+        expect(manifest.assets).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ kind: "state" }),
+            expect.objectContaining({ kind: "config" }),
+            expect.objectContaining({ kind: "workspace" }),
+          ]),
+        );
+
+        const encodedStatePath = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(stateDir),
+          "state.txt",
+        );
+        const encodedWorkspacePath = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(externalWorkspace),
+          "SOUL.md",
+        );
+        expect(await fs.readFile(encodedStatePath, "utf8")).toBe("state\n");
+        expect(await fs.readFile(encodedWorkspacePath, "utf8")).toBe("# external\n");
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(backupDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects output paths that would be created inside a backed-up directory", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    await expect(
+      backupCreateCommand(runtime, {
+        output: path.join(stateDir, "backups"),
+      }),
+    ).rejects.toThrow(/must not be written inside a source path/i);
+  });
+});

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -11,6 +11,12 @@ import {
 } from "./backup-shared.js";
 import { backupCreateCommand } from "./backup.js";
 
+const backupVerifyCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./backup-verify.js", () => ({
+  backupVerifyCommand: backupVerifyCommandMock,
+}));
+
 describe("backup commands", () => {
   let tempHome: TempHomeEnv;
   let previousCwd: string;
@@ -18,6 +24,16 @@ describe("backup commands", () => {
   beforeEach(async () => {
     tempHome = await createTempHomeEnv("openclaw-backup-test-");
     previousCwd = process.cwd();
+    backupVerifyCommandMock.mockReset();
+    backupVerifyCommandMock.mockResolvedValue({
+      ok: true,
+      archivePath: "/tmp/fake.tar.gz",
+      archiveRoot: "fake",
+      createdAt: new Date().toISOString(),
+      runtimeVersion: "test",
+      assetCount: 1,
+      entryCount: 2,
+    });
   });
 
   afterEach(async () => {
@@ -127,6 +143,36 @@ describe("backup commands", () => {
     }
   });
 
+  it("optionally verifies the archive after writing it", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-backup-verify-on-create-"),
+    );
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const result = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        verify: true,
+      });
+
+      expect(result.verified).toBe(true);
+      expect(backupVerifyCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({ log: expect.any(Function) }),
+        expect.objectContaining({ archive: result.archivePath, json: false }),
+      );
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects output paths that would be created inside a backed-up directory", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
@@ -185,6 +231,7 @@ describe("backup commands", () => {
     });
 
     expect(result.dryRun).toBe(true);
+    expect(result.verified).toBe(false);
     expect(result.archivePath).toBe(existingArchive);
     expect(await fs.readFile(existingArchive, "utf8")).toBe("already here");
   });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -348,4 +348,53 @@ describe("backup commands", () => {
       delete process.env.OPENCLAW_CONFIG_PATH;
     }
   });
+
+  it("backs up only the active config file when --only-config is requested", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.mkdir(path.join(stateDir, "credentials"), { recursive: true });
+    await fs.writeFile(configPath, JSON.stringify({ theme: "config-only" }), "utf8");
+    await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+    await fs.writeFile(path.join(stateDir, "credentials", "oauth.json"), "{}", "utf8");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const result = await backupCreateCommand(runtime, {
+      dryRun: true,
+      onlyConfig: true,
+    });
+
+    expect(result.onlyConfig).toBe(true);
+    expect(result.includeWorkspace).toBe(false);
+    expect(result.assets).toHaveLength(1);
+    expect(result.assets[0]?.kind).toBe("config");
+  });
+
+  it("allows config-only backups even when the config file is invalid", async () => {
+    const configPath = path.join(tempHome.home, "custom-config.json");
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    await fs.writeFile(configPath, '{"agents": { defaults: { workspace: ', "utf8");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    try {
+      const result = await backupCreateCommand(runtime, {
+        dryRun: true,
+        onlyConfig: true,
+      });
+
+      expect(result.assets).toHaveLength(1);
+      expect(result.assets[0]?.kind).toBe("config");
+    } finally {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    }
+  });
 });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -58,6 +58,43 @@ describe("backup commands", () => {
     );
   });
 
+  it("orders coverage checks by canonical path so symlinked workspaces do not duplicate state", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const symlinkDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-link-"));
+    const workspaceLink = path.join(symlinkDir, "ws-link");
+    try {
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
+      await fs.symlink(workspaceDir, workspaceLink);
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: workspaceLink,
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      const plan = await resolveBackupPlanFromDisk({ includeWorkspace: true, nowMs: 123 });
+
+      expect(plan.included).toHaveLength(1);
+      expect(plan.included[0]?.kind).toBe("state");
+      expect(plan.skipped).toEqual(
+        expect.arrayContaining([expect.objectContaining({ kind: "workspace", reason: "covered" })]),
+      );
+    } finally {
+      await fs.rm(symlinkDir, { recursive: true, force: true });
+    }
+  });
+
   it("creates an archive with a manifest and external workspace payload", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
@@ -188,6 +225,34 @@ describe("backup commands", () => {
         output: path.join(stateDir, "backups"),
       }),
     ).rejects.toThrow(/must not be written inside a source path/i);
+  });
+
+  it("rejects symlinked output paths even when intermediate directories do not exist yet", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const symlinkDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-link-"));
+    const symlinkPath = path.join(symlinkDir, "linked-state");
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.symlink(stateDir, symlinkPath);
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(
+        backupCreateCommand(runtime, {
+          output: path.join(symlinkPath, "new", "subdir", "backup.tar.gz"),
+        }),
+      ).rejects.toThrow(/must not be written inside a source path/i);
+    } finally {
+      await fs.rm(symlinkDir, { recursive: true, force: true });
+    }
   });
 
   it("falls back to the home directory when cwd is inside a backed-up source tree", async () => {

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -235,4 +235,52 @@ describe("backup commands", () => {
     expect(result.archivePath).toBe(existingArchive);
     expect(await fs.readFile(existingArchive, "utf8")).toBe("already here");
   });
+
+  it("fails fast when config is invalid and workspace backup is enabled", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const configPath = path.join(tempHome.home, "custom-config.json");
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    await fs.writeFile(configPath, '{"agents": { defaults: { workspace: ', "utf8");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    try {
+      await expect(backupCreateCommand(runtime, { dryRun: true })).rejects.toThrow(
+        /--no-include-workspace/i,
+      );
+    } finally {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    }
+  });
+
+  it("allows explicit partial backups when config is invalid", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const configPath = path.join(tempHome.home, "custom-config.json");
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    await fs.writeFile(configPath, '{"agents": { defaults: { workspace: ', "utf8");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    try {
+      const result = await backupCreateCommand(runtime, {
+        dryRun: true,
+        includeWorkspace: false,
+      });
+
+      expect(result.includeWorkspace).toBe(false);
+      expect(result.assets.some((asset) => asset.kind === "workspace")).toBe(false);
+    } finally {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    }
+  });
 });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -278,6 +278,40 @@ describe("backup commands", () => {
     await fs.rm(result.archivePath, { force: true });
   });
 
+  it("falls back to the home directory when cwd is a symlink into a backed-up source tree", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const linkParent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-cwd-link-"));
+    const workspaceLink = path.join(linkParent, "workspace-link");
+    try {
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
+      await fs.symlink(workspaceDir, workspaceLink);
+      process.chdir(workspaceLink);
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const nowMs = Date.UTC(2026, 2, 9, 1, 3, 4);
+      const result = await backupCreateCommand(runtime, { nowMs });
+
+      expect(result.archivePath).toBe(
+        path.join(tempHome.home, `${buildBackupArchiveRoot(nowMs)}.tar.gz`),
+      );
+      await fs.rm(result.archivePath, { force: true });
+    } finally {
+      await fs.rm(linkParent, { recursive: true, force: true });
+    }
+  });
+
   it("allows dry-run preview even when the target archive already exists", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const existingArchive = path.join(tempHome.home, "existing-backup.tar.gz");

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -13,12 +13,15 @@ import { backupCreateCommand } from "./backup.js";
 
 describe("backup commands", () => {
   let tempHome: TempHomeEnv;
+  let previousCwd: string;
 
   beforeEach(async () => {
     tempHome = await createTempHomeEnv("openclaw-backup-test-");
+    previousCwd = process.cwd();
   });
 
   afterEach(async () => {
+    process.chdir(previousCwd);
     await tempHome.restore();
   });
 
@@ -95,16 +98,21 @@ describe("backup commands", () => {
           ]),
         );
 
+        const stateAsset = result.assets.find((asset) => asset.kind === "state");
+        const workspaceAsset = result.assets.find((asset) => asset.kind === "workspace");
+        expect(stateAsset).toBeDefined();
+        expect(workspaceAsset).toBeDefined();
+
         const encodedStatePath = path.join(
           archiveRoot,
           "payload",
-          encodeAbsolutePathForBackupArchive(stateDir),
+          encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
           "state.txt",
         );
         const encodedWorkspacePath = path.join(
           archiveRoot,
           "payload",
-          encodeAbsolutePathForBackupArchive(externalWorkspace),
+          encodeAbsolutePathForBackupArchive(workspaceAsset!.sourcePath),
           "SOUL.md",
         );
         expect(await fs.readFile(encodedStatePath, "utf8")).toBe("state\n");
@@ -134,5 +142,50 @@ describe("backup commands", () => {
         output: path.join(stateDir, "backups"),
       }),
     ).rejects.toThrow(/must not be written inside a source path/i);
+  });
+
+  it("falls back to the home directory when cwd is inside a backed-up source tree", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
+    process.chdir(workspaceDir);
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const nowMs = Date.UTC(2026, 2, 9, 1, 2, 3);
+    const result = await backupCreateCommand(runtime, { nowMs });
+
+    expect(result.archivePath).toBe(
+      path.join(tempHome.home, `${buildBackupArchiveRoot(nowMs)}.tar.gz`),
+    );
+    await fs.rm(result.archivePath, { force: true });
+  });
+
+  it("allows dry-run preview even when the target archive already exists", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const existingArchive = path.join(tempHome.home, "existing-backup.tar.gz");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    await fs.writeFile(existingArchive, "already here", "utf8");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const result = await backupCreateCommand(runtime, {
+      output: existingArchive,
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.archivePath).toBe(existingArchive);
+    expect(await fs.readFile(existingArchive, "utf8")).toBe("already here");
   });
 });

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -21,6 +21,7 @@ export type BackupCreateOptions = {
   output?: string;
   dryRun?: boolean;
   includeWorkspace?: boolean;
+  onlyConfig?: boolean;
   verify?: boolean;
   json?: boolean;
   nowMs?: number;
@@ -41,6 +42,7 @@ type BackupManifest = {
   nodeVersion: string;
   options: {
     includeWorkspace: boolean;
+    onlyConfig?: boolean;
   };
   paths: {
     stateDir: string;
@@ -63,6 +65,7 @@ export type BackupCreateResult = {
   archivePath: string;
   dryRun: boolean;
   includeWorkspace: boolean;
+  onlyConfig: boolean;
   verified: boolean;
   assets: BackupAsset[];
   skipped: Array<{
@@ -189,6 +192,7 @@ function buildManifest(params: {
   createdAt: string;
   archiveRoot: string;
   includeWorkspace: boolean;
+  onlyConfig: boolean;
   assets: BackupAsset[];
   skipped: BackupCreateResult["skipped"];
   stateDir: string;
@@ -205,6 +209,7 @@ function buildManifest(params: {
     nodeVersion: process.version,
     options: {
       includeWorkspace: params.includeWorkspace,
+      onlyConfig: params.onlyConfig,
     },
     paths: {
       stateDir: params.stateDir,
@@ -271,8 +276,9 @@ export async function backupCreateCommand(
 ): Promise<BackupCreateResult> {
   const nowMs = opts.nowMs ?? Date.now();
   const archiveRoot = buildBackupArchiveRoot(nowMs);
-  const includeWorkspace = opts.includeWorkspace ?? true;
-  const plan = await resolveBackupPlanFromDisk({ includeWorkspace, nowMs });
+  const onlyConfig = Boolean(opts.onlyConfig);
+  const includeWorkspace = onlyConfig ? false : (opts.includeWorkspace ?? true);
+  const plan = await resolveBackupPlanFromDisk({ includeWorkspace, onlyConfig, nowMs });
   const outputPath = await resolveOutputPath({
     output: opts.output,
     nowMs,
@@ -281,7 +287,11 @@ export async function backupCreateCommand(
   });
 
   if (plan.included.length === 0) {
-    throw new Error("No local OpenClaw state was found to back up.");
+    throw new Error(
+      onlyConfig
+        ? "No OpenClaw config file was found to back up."
+        : "No local OpenClaw state was found to back up.",
+    );
   }
 
   const canonicalOutputPath = await canonicalizePathForContainment(outputPath);
@@ -305,6 +315,7 @@ export async function backupCreateCommand(
     archivePath: outputPath,
     dryRun: Boolean(opts.dryRun),
     includeWorkspace,
+    onlyConfig,
     verified: false,
     assets: plan.included,
     skipped: plan.skipped,
@@ -320,6 +331,7 @@ export async function backupCreateCommand(
         createdAt,
         archiveRoot,
         includeWorkspace,
+        onlyConfig,
         assets: result.assets,
         skipped: result.skipped,
         stateDir: plan.stateDir,

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
+import { resolveRuntimeServiceVersion } from "../version.js";
+import {
+  buildBackupArchiveBasename,
+  buildBackupArchiveRoot,
+  buildBackupArchivePath,
+  type BackupAsset,
+  resolveBackupPlanFromDisk,
+} from "./backup-shared.js";
+import { isPathWithin } from "./cleanup-utils.js";
+
+export type BackupCreateOptions = {
+  output?: string;
+  dryRun?: boolean;
+  includeWorkspace?: boolean;
+  json?: boolean;
+  nowMs?: number;
+};
+
+type BackupManifestAsset = {
+  kind: BackupAsset["kind"];
+  sourcePath: string;
+  archivePath: string;
+};
+
+type BackupManifest = {
+  schemaVersion: 1;
+  createdAt: string;
+  archiveRoot: string;
+  runtimeVersion: string;
+  platform: NodeJS.Platform;
+  nodeVersion: string;
+  options: {
+    includeWorkspace: boolean;
+  };
+  paths: {
+    stateDir: string;
+    configPath: string;
+    oauthDir: string;
+    workspaceDirs: string[];
+  };
+  assets: BackupManifestAsset[];
+  skipped: Array<{
+    kind: string;
+    sourcePath: string;
+    reason: string;
+    coveredBy?: string;
+  }>;
+};
+
+export type BackupCreateResult = {
+  createdAt: string;
+  archiveRoot: string;
+  archivePath: string;
+  dryRun: boolean;
+  includeWorkspace: boolean;
+  assets: BackupAsset[];
+  skipped: Array<{
+    kind: string;
+    sourcePath: string;
+    displayPath: string;
+    reason: string;
+    coveredBy?: string;
+  }>;
+};
+
+async function resolveOutputPath(params: { output?: string; nowMs: number }): Promise<string> {
+  const basename = buildBackupArchiveBasename(params.nowMs);
+  const rawOutput = params.output?.trim();
+  if (!rawOutput) {
+    return path.resolve(process.cwd(), basename);
+  }
+
+  const resolved = resolveUserPath(rawOutput);
+  if (rawOutput.endsWith("/") || rawOutput.endsWith("\\")) {
+    return path.join(resolved, basename);
+  }
+
+  try {
+    const stat = await fs.stat(resolved);
+    if (stat.isDirectory()) {
+      return path.join(resolved, basename);
+    }
+  } catch {
+    // Treat as a file path when the target does not exist yet.
+  }
+
+  return resolved;
+}
+
+async function assertOutputPathReady(outputPath: string): Promise<void> {
+  try {
+    await fs.access(outputPath);
+    throw new Error(`Refusing to overwrite existing backup archive: ${outputPath}`);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+}
+
+function buildManifest(params: {
+  createdAt: string;
+  archiveRoot: string;
+  includeWorkspace: boolean;
+  assets: BackupAsset[];
+  skipped: BackupCreateResult["skipped"];
+  stateDir: string;
+  configPath: string;
+  oauthDir: string;
+  workspaceDirs: string[];
+}): BackupManifest {
+  return {
+    schemaVersion: 1,
+    createdAt: params.createdAt,
+    archiveRoot: params.archiveRoot,
+    runtimeVersion: resolveRuntimeServiceVersion(),
+    platform: process.platform,
+    nodeVersion: process.version,
+    options: {
+      includeWorkspace: params.includeWorkspace,
+    },
+    paths: {
+      stateDir: params.stateDir,
+      configPath: params.configPath,
+      oauthDir: params.oauthDir,
+      workspaceDirs: params.workspaceDirs,
+    },
+    assets: params.assets.map((asset) => ({
+      kind: asset.kind,
+      sourcePath: asset.sourcePath,
+      archivePath: asset.archivePath,
+    })),
+    skipped: params.skipped.map((entry) => ({
+      kind: entry.kind,
+      sourcePath: entry.sourcePath,
+      reason: entry.reason,
+      coveredBy: entry.coveredBy,
+    })),
+  };
+}
+
+function formatTextSummary(result: BackupCreateResult): string[] {
+  const lines = [`Backup archive: ${result.archivePath}`];
+  lines.push(`Included ${result.assets.length} path${result.assets.length === 1 ? "" : "s"}:`);
+  for (const asset of result.assets) {
+    lines.push(`- ${asset.kind}: ${asset.displayPath}`);
+  }
+  if (result.skipped.length > 0) {
+    lines.push(`Skipped ${result.skipped.length} path${result.skipped.length === 1 ? "" : "s"}:`);
+    for (const entry of result.skipped) {
+      if (entry.reason === "covered" && entry.coveredBy) {
+        lines.push(`- ${entry.kind}: ${entry.displayPath} (${entry.reason} by ${entry.coveredBy})`);
+      } else {
+        lines.push(`- ${entry.kind}: ${entry.displayPath} (${entry.reason})`);
+      }
+    }
+  }
+  if (result.dryRun) {
+    lines.push("Dry run only; archive was not written.");
+  } else {
+    lines.push(`Created ${result.archivePath}`);
+  }
+  return lines;
+}
+
+function remapArchiveEntryPath(params: {
+  entryPath: string;
+  manifestPath: string;
+  archiveRoot: string;
+}): string {
+  const normalizedEntry = path.resolve(params.entryPath);
+  if (normalizedEntry === params.manifestPath) {
+    return path.posix.join(params.archiveRoot, "manifest.json");
+  }
+  return buildBackupArchivePath(params.archiveRoot, normalizedEntry);
+}
+
+export async function backupCreateCommand(
+  runtime: RuntimeEnv,
+  opts: BackupCreateOptions = {},
+): Promise<BackupCreateResult> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const archiveRoot = buildBackupArchiveRoot(nowMs);
+  const outputPath = await resolveOutputPath({ output: opts.output, nowMs });
+  const includeWorkspace = opts.includeWorkspace ?? true;
+  const plan = await resolveBackupPlanFromDisk({ includeWorkspace, nowMs });
+
+  if (plan.included.length === 0) {
+    throw new Error("No local OpenClaw state was found to back up.");
+  }
+
+  const overlappingAsset = plan.included.find((asset) =>
+    isPathWithin(outputPath, asset.sourcePath),
+  );
+  if (overlappingAsset) {
+    throw new Error(
+      `Backup output must not be written inside a source path: ${outputPath} is inside ${overlappingAsset.sourcePath}`,
+    );
+  }
+
+  await assertOutputPathReady(outputPath);
+
+  const createdAt = new Date(nowMs).toISOString();
+  const result: BackupCreateResult = {
+    createdAt,
+    archiveRoot,
+    archivePath: outputPath,
+    dryRun: Boolean(opts.dryRun),
+    includeWorkspace,
+    assets: plan.included,
+    skipped: plan.skipped,
+  };
+
+  if (!opts.dryRun) {
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-"));
+    const manifestPath = path.join(tempDir, "manifest.json");
+    try {
+      const manifest = buildManifest({
+        createdAt,
+        archiveRoot,
+        includeWorkspace,
+        assets: result.assets,
+        skipped: result.skipped,
+        stateDir: plan.stateDir,
+        configPath: plan.configPath,
+        oauthDir: plan.oauthDir,
+        workspaceDirs: plan.workspaceDirs,
+      });
+      await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+      await tar.c(
+        {
+          file: outputPath,
+          gzip: true,
+          portable: true,
+          preservePaths: true,
+          onWriteEntry: (entry) => {
+            entry.path = remapArchiveEntryPath({
+              entryPath: entry.path,
+              manifestPath,
+              archiveRoot,
+            });
+          },
+        },
+        [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  const output = opts.json ? JSON.stringify(result, null, 2) : formatTextSummary(result).join("\n");
+  runtime.log(output);
+  return result;
+}

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -12,12 +12,14 @@ import {
   type BackupAsset,
   resolveBackupPlanFromDisk,
 } from "./backup-shared.js";
+import { backupVerifyCommand } from "./backup-verify.js";
 import { isPathWithin } from "./cleanup-utils.js";
 
 export type BackupCreateOptions = {
   output?: string;
   dryRun?: boolean;
   includeWorkspace?: boolean;
+  verify?: boolean;
   json?: boolean;
   nowMs?: number;
 };
@@ -59,6 +61,7 @@ export type BackupCreateResult = {
   archivePath: string;
   dryRun: boolean;
   includeWorkspace: boolean;
+  verified: boolean;
   assets: BackupAsset[];
   skipped: Array<{
     kind: string;
@@ -194,6 +197,9 @@ function formatTextSummary(result: BackupCreateResult): string[] {
     lines.push("Dry run only; archive was not written.");
   } else {
     lines.push(`Created ${result.archivePath}`);
+    if (result.verified) {
+      lines.push("Archive verification: passed");
+    }
   }
   return lines;
 }
@@ -250,6 +256,7 @@ export async function backupCreateCommand(
     archivePath: outputPath,
     dryRun: Boolean(opts.dryRun),
     includeWorkspace,
+    verified: false,
     assets: plan.included,
     skipped: plan.skipped,
   };
@@ -290,6 +297,17 @@ export async function backupCreateCommand(
       );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+
+    if (opts.verify) {
+      await backupVerifyCommand(
+        {
+          ...runtime,
+          log: () => {},
+        },
+        { archive: outputPath, json: false },
+      );
+      result.verified = true;
     }
   }
 

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -117,6 +118,10 @@ async function assertOutputPathReady(outputPath: string): Promise<void> {
     }
     throw err;
   }
+}
+
+function buildTempArchivePath(outputPath: string): string {
+  return `${outputPath}.${randomUUID()}.tmp`;
 }
 
 async function canonicalizePathForContainment(targetPath: string): Promise<string> {
@@ -265,6 +270,7 @@ export async function backupCreateCommand(
     await fs.mkdir(path.dirname(outputPath), { recursive: true });
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-"));
     const manifestPath = path.join(tempDir, "manifest.json");
+    const tempArchivePath = buildTempArchivePath(outputPath);
     try {
       const manifest = buildManifest({
         createdAt,
@@ -281,7 +287,7 @@ export async function backupCreateCommand(
 
       await tar.c(
         {
-          file: outputPath,
+          file: tempArchivePath,
           gzip: true,
           portable: true,
           preservePaths: true,
@@ -295,7 +301,9 @@ export async function backupCreateCommand(
         },
         [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
       );
+      await fs.rename(tempArchivePath, outputPath);
     } finally {
+      await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
     }
 

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -124,20 +124,41 @@ function buildTempArchivePath(outputPath: string): string {
   return `${outputPath}.${randomUUID()}.tmp`;
 }
 
+async function publishTempArchive(params: {
+  tempArchivePath: string;
+  outputPath: string;
+}): Promise<void> {
+  try {
+    await fs.link(params.tempArchivePath, params.outputPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EEXIST") {
+      throw new Error(`Refusing to overwrite existing backup archive: ${params.outputPath}`, {
+        cause: err,
+      });
+    }
+    throw err;
+  }
+  await fs.rm(params.tempArchivePath, { force: true });
+}
+
 async function canonicalizePathForContainment(targetPath: string): Promise<string> {
   const resolved = path.resolve(targetPath);
-  try {
-    return await fs.realpath(resolved);
-  } catch {
-    // Fall through to canonicalizing the nearest existing parent directory.
-  }
+  const suffix: string[] = [];
+  let probe = resolved;
 
-  const parent = path.dirname(resolved);
-  try {
-    const realParent = await fs.realpath(parent);
-    return path.join(realParent, path.basename(resolved));
-  } catch {
-    return resolved;
+  while (true) {
+    try {
+      const realProbe = await fs.realpath(probe);
+      return suffix.length === 0 ? realProbe : path.join(realProbe, ...suffix.toReversed());
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) {
+        return resolved;
+      }
+      suffix.push(path.basename(probe));
+      probe = parent;
+    }
   }
 }
 
@@ -301,7 +322,7 @@ export async function backupCreateCommand(
         },
         [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
       );
-      await fs.rename(tempArchivePath, outputPath);
+      await publishTempArchive({ tempArchivePath, outputPath });
     } finally {
       await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -87,8 +87,9 @@ async function resolveOutputPath(params: {
   const rawOutput = params.output?.trim();
   if (!rawOutput) {
     const cwd = path.resolve(process.cwd());
+    const canonicalCwd = await fs.realpath(cwd).catch(() => cwd);
     const cwdInsideSource = params.includedAssets.some((asset) =>
-      isPathWithin(cwd, asset.sourcePath),
+      isPathWithin(canonicalCwd, asset.sourcePath),
     );
     const defaultDir = cwdInsideSource ? (resolveHomeDir() ?? path.dirname(params.stateDir)) : cwd;
     return path.resolve(defaultDir, basename);

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
 import type { RuntimeEnv } from "../runtime.js";
-import { resolveUserPath } from "../utils.js";
+import { resolveHomeDir, resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import {
   buildBackupArchiveBasename,
@@ -69,11 +69,21 @@ export type BackupCreateResult = {
   }>;
 };
 
-async function resolveOutputPath(params: { output?: string; nowMs: number }): Promise<string> {
+async function resolveOutputPath(params: {
+  output?: string;
+  nowMs: number;
+  includedAssets: BackupAsset[];
+  stateDir: string;
+}): Promise<string> {
   const basename = buildBackupArchiveBasename(params.nowMs);
   const rawOutput = params.output?.trim();
   if (!rawOutput) {
-    return path.resolve(process.cwd(), basename);
+    const cwd = path.resolve(process.cwd());
+    const cwdInsideSource = params.includedAssets.some((asset) =>
+      isPathWithin(cwd, asset.sourcePath),
+    );
+    const defaultDir = cwdInsideSource ? (resolveHomeDir() ?? path.dirname(params.stateDir)) : cwd;
+    return path.resolve(defaultDir, basename);
   }
 
   const resolved = resolveUserPath(rawOutput);
@@ -103,6 +113,23 @@ async function assertOutputPathReady(outputPath: string): Promise<void> {
       return;
     }
     throw err;
+  }
+}
+
+async function canonicalizePathForContainment(targetPath: string): Promise<string> {
+  const resolved = path.resolve(targetPath);
+  try {
+    return await fs.realpath(resolved);
+  } catch {
+    // Fall through to canonicalizing the nearest existing parent directory.
+  }
+
+  const parent = path.dirname(resolved);
+  try {
+    const realParent = await fs.realpath(parent);
+    return path.join(realParent, path.basename(resolved));
+  } catch {
+    return resolved;
   }
 }
 
@@ -189,16 +216,22 @@ export async function backupCreateCommand(
 ): Promise<BackupCreateResult> {
   const nowMs = opts.nowMs ?? Date.now();
   const archiveRoot = buildBackupArchiveRoot(nowMs);
-  const outputPath = await resolveOutputPath({ output: opts.output, nowMs });
   const includeWorkspace = opts.includeWorkspace ?? true;
   const plan = await resolveBackupPlanFromDisk({ includeWorkspace, nowMs });
+  const outputPath = await resolveOutputPath({
+    output: opts.output,
+    nowMs,
+    includedAssets: plan.included,
+    stateDir: plan.stateDir,
+  });
 
   if (plan.included.length === 0) {
     throw new Error("No local OpenClaw state was found to back up.");
   }
 
+  const canonicalOutputPath = await canonicalizePathForContainment(outputPath);
   const overlappingAsset = plan.included.find((asset) =>
-    isPathWithin(outputPath, asset.sourcePath),
+    isPathWithin(canonicalOutputPath, asset.sourcePath),
   );
   if (overlappingAsset) {
     throw new Error(
@@ -206,7 +239,9 @@ export async function backupCreateCommand(
     );
   }
 
-  await assertOutputPathReady(outputPath);
+  if (!opts.dryRun) {
+    await assertOutputPathReady(outputPath);
+  }
 
   const createdAt = new Date(nowMs).toISOString();
   const result: BackupCreateResult = {

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -124,6 +125,10 @@ function buildTempArchivePath(outputPath: string): string {
   return `${outputPath}.${randomUUID()}.tmp`;
 }
 
+function isLinkUnsupportedError(code: string | undefined): boolean {
+  return code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EPERM";
+}
+
 async function publishTempArchive(params: {
   tempArchivePath: string;
   outputPath: string;
@@ -137,7 +142,25 @@ async function publishTempArchive(params: {
         cause: err,
       });
     }
-    throw err;
+    if (!isLinkUnsupportedError(code)) {
+      throw err;
+    }
+
+    try {
+      // Some backup targets support ordinary files but not hard links.
+      await fs.copyFile(params.tempArchivePath, params.outputPath, fsConstants.COPYFILE_EXCL);
+    } catch (copyErr) {
+      const copyCode = (copyErr as NodeJS.ErrnoException | undefined)?.code;
+      if (copyCode !== "EEXIST") {
+        await fs.rm(params.outputPath, { force: true }).catch(() => undefined);
+      }
+      if (copyCode === "EEXIST") {
+        throw new Error(`Refusing to overwrite existing backup archive: ${params.outputPath}`, {
+          cause: copyErr,
+        });
+      }
+      throw copyErr;
+    }
   }
   await fs.rm(params.tempArchivePath, { force: true });
 }

--- a/src/commands/reset.test.ts
+++ b/src/commands/reset.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNonExitingRuntime } from "../runtime.js";
+
+const resolveCleanupPlanFromDisk = vi.fn();
+const removePath = vi.fn();
+const listAgentSessionDirs = vi.fn();
+const removeStateAndLinkedPaths = vi.fn();
+const removeWorkspaceDirs = vi.fn();
+
+vi.mock("../config/config.js", () => ({
+  isNixMode: false,
+}));
+
+vi.mock("./cleanup-plan.js", () => ({
+  resolveCleanupPlanFromDisk,
+}));
+
+vi.mock("./cleanup-utils.js", () => ({
+  removePath,
+  listAgentSessionDirs,
+  removeStateAndLinkedPaths,
+  removeWorkspaceDirs,
+}));
+
+const { resetCommand } = await import("./reset.js");
+
+describe("resetCommand", () => {
+  const runtime = createNonExitingRuntime();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveCleanupPlanFromDisk.mockReturnValue({
+      stateDir: "/tmp/.openclaw",
+      configPath: "/tmp/.openclaw/openclaw.json",
+      oauthDir: "/tmp/.openclaw/credentials",
+      configInsideState: true,
+      oauthInsideState: true,
+      workspaceDirs: ["/tmp/.openclaw/workspace"],
+    });
+    removePath.mockResolvedValue({ ok: true });
+    listAgentSessionDirs.mockResolvedValue(["/tmp/.openclaw/agents/main/sessions"]);
+    removeStateAndLinkedPaths.mockResolvedValue(undefined);
+    removeWorkspaceDirs.mockResolvedValue(undefined);
+    vi.spyOn(runtime, "log").mockImplementation(() => {});
+    vi.spyOn(runtime, "error").mockImplementation(() => {});
+  });
+
+  it("recommends creating a backup before state-destructive reset scopes", async () => {
+    await resetCommand(runtime, {
+      scope: "config+creds+sessions",
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+  });
+
+  it("does not recommend backup for config-only reset", async () => {
+    await resetCommand(runtime, {
+      scope: "config",
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+  });
+});

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -44,6 +44,10 @@ async function stopGatewayIfRunning(runtime: RuntimeEnv) {
   }
 }
 
+function logBackupRecommendation(runtime: RuntimeEnv) {
+  runtime.log(`Recommended first: ${formatCliCommand("openclaw backup create")}`);
+}
+
 export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {
   const interactive = !opts.nonInteractive;
   if (!interactive && !opts.yes) {
@@ -110,6 +114,7 @@ export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {
     resolveCleanupPlanFromDisk();
 
   if (scope !== "config") {
+    logBackupRecommendation(runtime);
     if (dryRun) {
       runtime.log("[dry-run] stop gateway service");
     } else {

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNonExitingRuntime } from "../runtime.js";
+
+const resolveCleanupPlanFromDisk = vi.fn();
+const removePath = vi.fn();
+const removeStateAndLinkedPaths = vi.fn();
+const removeWorkspaceDirs = vi.fn();
+
+vi.mock("../config/config.js", () => ({
+  isNixMode: false,
+}));
+
+vi.mock("./cleanup-plan.js", () => ({
+  resolveCleanupPlanFromDisk,
+}));
+
+vi.mock("./cleanup-utils.js", () => ({
+  removePath,
+  removeStateAndLinkedPaths,
+  removeWorkspaceDirs,
+}));
+
+const { uninstallCommand } = await import("./uninstall.js");
+
+describe("uninstallCommand", () => {
+  const runtime = createNonExitingRuntime();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveCleanupPlanFromDisk.mockReturnValue({
+      stateDir: "/tmp/.openclaw",
+      configPath: "/tmp/.openclaw/openclaw.json",
+      oauthDir: "/tmp/.openclaw/credentials",
+      configInsideState: true,
+      oauthInsideState: true,
+      workspaceDirs: ["/tmp/.openclaw/workspace"],
+    });
+    removePath.mockResolvedValue({ ok: true });
+    removeStateAndLinkedPaths.mockResolvedValue(undefined);
+    removeWorkspaceDirs.mockResolvedValue(undefined);
+    vi.spyOn(runtime, "log").mockImplementation(() => {});
+    vi.spyOn(runtime, "error").mockImplementation(() => {});
+  });
+
+  it("recommends creating a backup before removing state or workspaces", async () => {
+    await uninstallCommand(runtime, {
+      state: true,
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+  });
+
+  it("does not recommend backup for service-only uninstall", async () => {
+    await uninstallCommand(runtime, {
+      service: true,
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+  });
+});

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { cancel, confirm, isCancel, multiselect } from "@clack/prompts";
+import { formatCliCommand } from "../cli/command-format.js";
 import { isNixMode } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -92,6 +93,10 @@ async function removeMacApp(runtime: RuntimeEnv, dryRun?: boolean) {
   });
 }
 
+function logBackupRecommendation(runtime: RuntimeEnv) {
+  runtime.log(`Recommended first: ${formatCliCommand("openclaw backup create")}`);
+}
+
 export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptions) {
   const { scopes, hadExplicit } = buildScopeSelection(opts);
   const interactive = !opts.nonInteractive;
@@ -154,6 +159,10 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
   const dryRun = Boolean(opts.dryRun);
   const { stateDir, configPath, oauthDir, configInsideState, oauthInsideState, workspaceDirs } =
     resolveCleanupPlanFromDisk();
+
+  if (scopes.has("state") || scopes.has("workspace")) {
+    logBackupRecommendation(runtime);
+  }
 
   if (scopes.has("service")) {
     if (dryRun) {


### PR DESCRIPTION
## Summary

- Problem: OpenClaw had only ad-hoc documentation for backups, but no first-class CLI backup workflow.
- Why it matters: `reset` and `uninstall` can remove local state, credentials, sessions, and workspaces, so recoverability depended on manual operator steps.
- What changed: added `openclaw backup create`, `openclaw backup verify`, optional `openclaw backup create --verify`, docs, archive manifest validation, atomic archive writes, and backup guidance in destructive flows.
- What did NOT change (scope boundary): this PR does not add `backup restore` yet.

## Change Type (select all)

- [x] Feature
- [x] Docs
- [ ] Bug fix
- [ ] Refactor
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Memory / storage
- [x] UI / DX
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New `openclaw backup create` command to archive local state/config/credentials/workspace into a timestamped `.tar.gz`.
- New `openclaw backup verify <archive>` command to validate backup structure and embedded `manifest.json`.
- New `openclaw backup create --verify` option to self-check an archive immediately after writing it.
- Backup archives are now written atomically through a temp file + rename, so failed runs do not strand partial final archives.
- `reset` and `uninstall` now recommend running `openclaw backup create` before state-destructive flows.
- Default backup output now falls back out of the source tree when the current working directory is inside backed-up state.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:

This adds a local CLI capability that reads user state/config/workspace paths and writes a backup tarball. Mitigations:
- output paths inside backed-up source trees are rejected
- symlink/canonical-path containment is checked before writing
- final archive writes are atomic via temp file + rename
- existing archive files are never overwritten
- archive contents are rooted under a generated backup root and described by a manifest
- `backup verify` validates manifest/payload consistency

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temp home/state dirs in tests; custom config path for external-workspace coverage

### Steps

1. Run `openclaw backup create --output <dir>`.
2. Inspect the generated `.tar.gz` and embedded `manifest.json`.
3. Run `openclaw backup verify <archive>`.
4. Run `openclaw reset --dry-run` or `openclaw uninstall --dry-run` and confirm backup guidance is shown for state-destructive scopes.

### Expected

- Backup archive is created with canonicalized payload paths and manifest metadata.
- Verification succeeds for valid archives and fails for malformed archives.
- Failed writes do not leave a final partial archive behind.
- Destructive flows point users at the backup command first.

### Actual

- Matches expected in targeted test coverage.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - backup archive creation for default state layout
  - backup archive creation when workspace is outside state
  - backup archive verification for valid and malformed archives
  - backup guidance emitted by `reset` and `uninstall` for state-destructive flows
  - create-time verification via `--verify`
  - failed archive creation does not leave a final partial archive behind
- Edge cases checked:
  - cwd inside backed-up source tree
  - dry-run with an already-existing target path
  - manifest references missing payload
  - archive missing manifest
  - symlink/canonical-path containment on macOS temp paths
  - temp archive cleanup on failure
- What you did **not** verify:
  - restore flow, because it is intentionally out of scope
  - full repo `tsc`, due to unrelated existing failures outside this PR

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - do not use the new `backup` commands
  - revert this PR to restore previous behavior
- Files/config to restore:
  - none required; this feature is additive
- Known bad symptoms reviewers should watch for:
  - backup output path accidentally resolving inside state/workspace trees
  - verify passing malformed archives
  - destructive-flow guidance showing for non-destructive scopes
  - partial final archives left behind after failed writes

## Risks and Mitigations

- Risk: archive verification only validates manifest/payload structure, not file-level checksums.
  - Mitigation: keep restore out of scope for now; follow up with stronger integrity metadata if maintainers want it.
- Risk: backup now surfaces a larger local-data packaging capability.
  - Mitigation: keep it explicit CLI-only, local-only, non-overwriting, atomically written, and guarded against self-inclusion.

## Testing

- [x] AI-assisted
- [x] `pnpm exec vitest run src/commands/backup.atomic.test.ts src/commands/backup.test.ts src/commands/backup-verify.test.ts src/commands/reset.test.ts src/commands/uninstall.test.ts src/cli/program/register.backup.test.ts src/cli/program/command-registry.test.ts src/cli/program/preaction.test.ts src/cli/program/register.maintenance.test.ts`
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` was attempted earlier, but the repo currently fails on unrelated pre-existing errors in `extensions/tlon` and existing agent/provider tests
