### PR TITLE
fix(gateway): drain supervisor child runs before restart

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGatewayCloseHandler } from "./server-close.js";
+
+function createHttpServerStub() {
+  return {
+    closeIdleConnections: vi.fn(),
+    close: vi.fn((cb: (err?: Error | null) => void) => cb(null)),
+  };
+}
+
+describe("gateway close handler", () => {
+  it("terminates active supervisor runs before closing sockets", async () => {
+    const terminateAll = vi.fn(async () => {});
+    const httpServer = createHttpServerStub();
+    const tickInterval = setInterval(() => {}, 60_000);
+    const healthInterval = setInterval(() => {}, 60_000);
+    const dedupeCleanup = setInterval(() => {}, 60_000);
+    const handler = createGatewayCloseHandler({
+      bonjourStop: null,
+      tailscaleCleanup: null,
+      canvasHost: null,
+      canvasHostServer: null,
+      stopChannel: async () => {},
+      pluginServices: null,
+      cron: { stop: vi.fn() },
+      heartbeatRunner: { stop: vi.fn() } as never,
+      updateCheckStop: null,
+      nodePresenceTimers: new Map(),
+      broadcast: vi.fn(),
+      tickInterval,
+      healthInterval,
+      dedupeCleanup,
+      mediaCleanup: null,
+      agentUnsub: null,
+      heartbeatUnsub: null,
+      chatRunState: { clear: vi.fn() },
+      clients: new Set(),
+      configReloader: { stop: vi.fn(async () => {}) },
+      browserControl: null,
+      processSupervisor: { terminateAll },
+      wss: { close: (cb: () => void) => cb() } as never,
+      httpServer: httpServer as never,
+    });
+
+    try {
+      await handler({ reason: "test restart", restartExpectedMs: 1_500 });
+    } finally {
+      clearInterval(tickInterval);
+      clearInterval(healthInterval);
+      clearInterval(dedupeCleanup);
+    }
+
+    expect(terminateAll).toHaveBeenCalledWith({
+      reason: "manual-cancel",
+      timeoutMs: 5_000,
+    });
+    expect(httpServer.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -5,6 +5,7 @@ import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import type { ProcessSupervisor } from "../process/supervisor/index.js";
 
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
@@ -28,6 +29,7 @@ export function createGatewayCloseHandler(params: {
   clients: Set<{ socket: { close: (code: number, reason: string) => void } }>;
   configReloader: { stop: () => Promise<void> };
   browserControl: { stop: () => Promise<void> } | null;
+  processSupervisor: Pick<ProcessSupervisor, "terminateAll">;
   wss: WebSocketServer;
   httpServer: HttpServer;
   httpServers?: HttpServer[];
@@ -106,6 +108,12 @@ export function createGatewayCloseHandler(params: {
       }
     }
     params.chatRunState.clear();
+    await params.processSupervisor
+      .terminateAll({
+        reason: "manual-cancel",
+        timeoutMs: 5_000,
+      })
+      .catch(() => {});
     for (const c of params.clients) {
       try {
         c.socket.close(1012, "service restart");

--- a/src/gateway/server-reload-handlers.supervisor.test.ts
+++ b/src/gateway/server-reload-handlers.supervisor.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
+
+const deferGatewayRestartUntilIdle = vi.fn();
+const emitGatewayRestart = vi.fn(() => true);
+const setGatewaySigusr1RestartPolicy = vi.fn();
+const setCommandLaneConcurrency = vi.fn();
+
+let totalQueueSize = 0;
+let totalPendingReplies = 0;
+let activeEmbeddedRuns = 0;
+let activeSupervisorRuns = 0;
+
+vi.mock("../infra/restart.js", () => ({
+  deferGatewayRestartUntilIdle: (...args: unknown[]) => deferGatewayRestartUntilIdle(...args),
+  emitGatewayRestart: (...args: unknown[]) => emitGatewayRestart(...args),
+  setGatewaySigusr1RestartPolicy: (...args: unknown[]) => setGatewaySigusr1RestartPolicy(...args),
+}));
+
+vi.mock("../process/command-queue.js", () => ({
+  getTotalQueueSize: () => totalQueueSize,
+  setCommandLaneConcurrency: (...args: unknown[]) => setCommandLaneConcurrency(...args),
+}));
+
+vi.mock("../auto-reply/reply/dispatcher-registry.js", () => ({
+  getTotalPendingReplies: () => totalPendingReplies,
+}));
+
+vi.mock("../agents/pi-embedded-runner/runs.js", () => ({
+  getActiveEmbeddedRunCount: () => activeEmbeddedRuns,
+}));
+
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({
+    getActiveCount: () => activeSupervisorRuns,
+  }),
+}));
+
+describe("gateway reload handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    totalQueueSize = 0;
+    totalPendingReplies = 0;
+    activeEmbeddedRuns = 0;
+    activeSupervisorRuns = 0;
+  });
+
+  it("defers restart when only supervisor child runs are active", () => {
+    const handlers = createGatewayReloadHandlers({
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () =>
+        ({
+          hooksConfig: {},
+          heartbeatRunner: { updateConfig: vi.fn() },
+          cronState: { cron: { stop: vi.fn(), start: vi.fn() } },
+          browserControl: null,
+          channelHealthMonitor: null,
+        }) as never,
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logBrowser: { error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn() },
+      createHealthMonitor: vi.fn(),
+    });
+    const onSigusr1 = () => {};
+    process.on("SIGUSR1", onSigusr1);
+    activeSupervisorRuns = 1;
+
+    try {
+      handlers.requestGatewayRestart(
+        {
+          changedPaths: ["gateway.auth"],
+          restartGateway: true,
+          restartReasons: ["gateway.auth"],
+          hotReasons: [],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartBrowserControl: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartHealthMonitor: false,
+          restartChannels: new Set(),
+          noopPaths: [],
+        },
+        {},
+      );
+    } finally {
+      process.off("SIGUSR1", onSigusr1);
+    }
+
+    expect(deferGatewayRestartUntilIdle).toHaveBeenCalledTimes(1);
+    expect(emitGatewayRestart).not.toHaveBeenCalled();
+    const [params] = deferGatewayRestartUntilIdle.mock.calls[0] ?? [];
+    expect(params.getPendingCount()).toBe(1);
+  });
+});

--- a/src/gateway/server-reload-handlers.supervisor.test.ts
+++ b/src/gateway/server-reload-handlers.supervisor.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
 
-const deferGatewayRestartUntilIdle = vi.fn();
-const emitGatewayRestart = vi.fn(() => true);
-const setGatewaySigusr1RestartPolicy = vi.fn();
-const setCommandLaneConcurrency = vi.fn();
+const {
+  deferGatewayRestartUntilIdle,
+  emitGatewayRestart,
+  setGatewaySigusr1RestartPolicy,
+  setCommandLaneConcurrency,
+} = vi.hoisted(() => ({
+  deferGatewayRestartUntilIdle: vi.fn(),
+  emitGatewayRestart: vi.fn(() => true),
+  setGatewaySigusr1RestartPolicy: vi.fn(),
+  setCommandLaneConcurrency: vi.fn(),
+}));
 
 let totalQueueSize = 0;
 let totalPendingReplies = 0;
@@ -12,14 +19,14 @@ let activeEmbeddedRuns = 0;
 let activeSupervisorRuns = 0;
 
 vi.mock("../infra/restart.js", () => ({
-  deferGatewayRestartUntilIdle: (...args: unknown[]) => deferGatewayRestartUntilIdle(...args),
-  emitGatewayRestart: (...args: unknown[]) => emitGatewayRestart(...args),
-  setGatewaySigusr1RestartPolicy: (...args: unknown[]) => setGatewaySigusr1RestartPolicy(...args),
+  deferGatewayRestartUntilIdle,
+  emitGatewayRestart,
+  setGatewaySigusr1RestartPolicy,
 }));
 
 vi.mock("../process/command-queue.js", () => ({
   getTotalQueueSize: () => totalQueueSize,
-  setCommandLaneConcurrency: (...args: unknown[]) => setCommandLaneConcurrency(...args),
+  setCommandLaneConcurrency,
 }));
 
 vi.mock("../auto-reply/reply/dispatcher-registry.js", () => ({

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -16,6 +16,7 @@ import {
 } from "../infra/restart.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
+import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelKind } from "./config-reload-plan.js";
 import type { GatewayReloadPlan } from "./config-reload.js";
@@ -164,11 +165,13 @@ export function createGatewayReloadHandlers(params: {
       const queueSize = getTotalQueueSize();
       const pendingReplies = getTotalPendingReplies();
       const embeddedRuns = getActiveEmbeddedRunCount();
+      const supervisorRuns = getProcessSupervisor().getActiveCount();
       return {
         queueSize,
         pendingReplies,
         embeddedRuns,
-        totalActive: queueSize + pendingReplies + embeddedRuns,
+        supervisorRuns,
+        totalActive: queueSize + pendingReplies + embeddedRuns + supervisorRuns,
       };
     };
     const formatActiveDetails = (counts: ReturnType<typeof getActiveCounts>) => {
@@ -181,6 +184,9 @@ export function createGatewayReloadHandlers(params: {
       }
       if (counts.embeddedRuns > 0) {
         details.push(`${counts.embeddedRuns} embedded run(s)`);
+      }
+      if (counts.supervisorRuns > 0) {
+        details.push(`${counts.supervisorRuns} child run(s)`);
       }
       return details;
     };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -49,6 +49,7 @@ import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
+import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { CommandSecretAssignment } from "../secrets/command-config.js";
 import {
@@ -451,7 +452,11 @@ export async function startGatewayServer(
   }
   setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
   setPreRestartDeferralCheck(
-    () => getTotalQueueSize() + getTotalPendingReplies() + getActiveEmbeddedRunCount(),
+    () =>
+      getTotalQueueSize() +
+      getTotalPendingReplies() +
+      getActiveEmbeddedRunCount() +
+      getProcessSupervisor().getActiveCount(),
   );
   // Unconditional startup migration: seed gateway.controlUi.allowedOrigins for existing
   // non-loopback installs that upgraded to v2026.2.26+ without required origins.
@@ -1024,6 +1029,7 @@ export async function startGatewayServer(
     clients,
     configReloader,
     browserControl,
+    processSupervisor: getProcessSupervisor(),
     wss,
     httpServer,
     httpServers,

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -106,4 +106,22 @@ describe("process supervisor", () => {
     expect(streamed).toBe("streamed");
     expect(exit.stdout).toBe("");
   });
+
+  it("tracks active runs and terminates them on demand", async () => {
+    const supervisor = createProcessSupervisor();
+    const run = await spawnChild(supervisor, {
+      sessionId: "s-active",
+      argv: [process.execPath, "-e", "setTimeout(() => {}, 10_000)"],
+      timeoutMs: 20_000,
+      stdinMode: "pipe-closed",
+    });
+
+    expect(supervisor.getActiveCount()).toBe(1);
+
+    await supervisor.terminateAll({ timeoutMs: 4_000 });
+    const exit = await run.wait();
+
+    expect(supervisor.getActiveCount()).toBe(0);
+    expect(exit.reason).toBe("manual-cancel");
+  });
 });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -31,6 +31,33 @@ function isTimeoutReason(reason: TerminationReason) {
   return reason === "overall-timeout" || reason === "no-output-timeout";
 }
 
+async function waitForManagedRuns(params: {
+  runs: ManagedRun[];
+  timeoutMs?: number;
+}): Promise<void> {
+  if (params.runs.length === 0) {
+    return;
+  }
+  const waits = Promise.allSettled(params.runs.map((run) => run.wait())).then(() => undefined);
+  const timeoutMs =
+    typeof params.timeoutMs === "number" &&
+    Number.isFinite(params.timeoutMs) &&
+    params.timeoutMs > 0
+      ? Math.floor(params.timeoutMs)
+      : undefined;
+  if (!timeoutMs) {
+    await waits;
+    return;
+  }
+  await Promise.race([
+    waits,
+    new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs);
+      timer.unref();
+    }),
+  ]);
+}
+
 export function createProcessSupervisor(): ProcessSupervisor {
   const registry = createRunRegistry();
   const active = new Map<string, ActiveRun>();
@@ -56,6 +83,18 @@ export function createProcessSupervisor(): ProcessSupervisor {
       }
       cancel(runId, reason);
     }
+  };
+
+  const terminateAll = async (opts?: {
+    reason?: TerminationReason;
+    timeoutMs?: number;
+  }): Promise<void> => {
+    const reason = opts?.reason ?? "manual-cancel";
+    const runs = [...active.values()].map((entry) => entry.run);
+    for (const run of runs) {
+      run.cancel(reason);
+    }
+    await waitForManagedRuns({ runs, timeoutMs: opts?.timeoutMs });
   };
 
   const spawn = async (input: SpawnInput): Promise<ManagedRun> => {
@@ -273,6 +312,8 @@ export function createProcessSupervisor(): ProcessSupervisor {
     spawn,
     cancel,
     cancelScope,
+    terminateAll,
+    getActiveCount: () => active.size,
     reconcileOrphans: async () => {
       // Deliberate no-op: this supervisor uses in-memory ownership only.
       // Active runs are not recovered after process restart in the current model.

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -101,6 +101,8 @@ export interface ProcessSupervisor {
   spawn(input: SpawnInput): Promise<ManagedRun>;
   cancel(runId: string, reason?: TerminationReason): void;
   cancelScope(scopeKey: string, reason?: TerminationReason): void;
+  terminateAll(opts?: { reason?: TerminationReason; timeoutMs?: number }): Promise<void>;
+  getActiveCount(): number;
   reconcileOrphans(): Promise<void>;
   getRecord(runId: string): RunRecord | undefined;
 }


### PR DESCRIPTION
## Summary
- count active process-supervisor child runs when deciding whether a gateway restart can proceed
- terminate and wait for active supervised child runs during gateway shutdown so restart does not strand them as orphans
- add focused regression coverage for supervisor-run restart deferral and shutdown cleanup

## Root cause
The gateway restart path only deferred on queued operations, pending replies, and embedded runs. It did not account for active process-supervisor child runs.

When a restart proceeded while those child runs were still active, the gateway shutdown path also did not explicitly cancel and wait for them. In service-managed environments, that could leave spawned `openclaw` / `openclaw-nodes` children behind after restart, contributing to stale runtime state and memory pressure.

## Scope
This PR targets the gateway child-run restart/shutdown leak path.

Related issues:
- #36793
- #24151
- #39074

This PR does not claim to fix unrelated launchd supervision-marker issues or browser-specific orphaning paths.

## Testing
- `pnpm exec vitest run src/process/supervisor/supervisor.test.ts src/gateway/server-close.test.ts src/gateway/server-reload-handlers.supervisor.test.ts`
- `pnpm build`

## Notes
- AI-assisted
- Repo-wide `pnpm check` is currently blocked by an unrelated pre-existing formatting failure in `src/cli/daemon-cli/lifecycle.test.ts`
