### PR TITLE
[AI-assisted] Fix remote auth fields, bootstrap reuse, and zsh completion

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -213,6 +213,14 @@ final class AppState {
         didSet { self.syncGatewayConfigIfNeeded() }
     }
 
+    var remoteToken: String {
+        didSet { self.syncGatewayConfigIfNeeded() }
+    }
+
+    var remotePassword: String {
+        didSet { self.syncGatewayConfigIfNeeded() }
+    }
+
     var remoteIdentity: String {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) } }
     }
@@ -281,6 +289,8 @@ final class AppState {
 
         let configRoot = OpenClawConfigFile.loadDict()
         let configRemoteUrl = GatewayRemoteConfig.resolveUrlString(root: configRoot)
+        let configRemoteToken = GatewayRemoteConfig.resolveTokenString(root: configRoot)
+        let configRemotePassword = GatewayRemoteConfig.resolvePasswordString(root: configRoot)
         let configRemoteTransport = GatewayRemoteConfig.resolveTransport(root: configRoot)
         let resolvedConnectionMode = ConnectionModeResolver.resolve(root: configRoot).mode
         self.remoteTransport = configRemoteTransport
@@ -297,6 +307,8 @@ final class AppState {
             self.remoteTarget = storedRemoteTarget
         }
         self.remoteUrl = configRemoteUrl ?? ""
+        self.remoteToken = configRemoteToken ?? ""
+        self.remotePassword = configRemotePassword ?? ""
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey) ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey) ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey) ?? ""
@@ -378,12 +390,17 @@ final class AppState {
         current: [String: Any],
         transport: RemoteTransport,
         remoteUrl: String,
+        remoteToken: String,
+        remotePassword: String,
         remoteHost: String?,
         remoteTarget: String,
         remoteIdentity: String) -> (remote: [String: Any], changed: Bool)
     {
         var remote = current
         var changed = false
+
+        changed = Self.updateGatewayString(&remote, key: "token", value: remoteToken) || changed
+        changed = Self.updateGatewayString(&remote, key: "password", value: remotePassword) || changed
 
         switch transport {
         case .direct:
@@ -439,6 +456,8 @@ final class AppState {
         let gateway = root["gateway"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let remoteUrl = GatewayRemoteConfig.resolveUrlString(root: root)
+        let remoteToken = GatewayRemoteConfig.resolveTokenString(root: root)
+        let remotePassword = GatewayRemoteConfig.resolvePasswordString(root: root)
         let hasRemoteUrl = !(remoteUrl?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
@@ -469,6 +488,14 @@ final class AppState {
         let remoteUrlText = remoteUrl ?? ""
         if remoteUrlText != self.remoteUrl {
             self.remoteUrl = remoteUrlText
+        }
+        let remoteTokenText = remoteToken ?? ""
+        if remoteTokenText != self.remoteToken {
+            self.remoteToken = remoteTokenText
+        }
+        let remotePasswordText = remotePassword ?? ""
+        if remotePasswordText != self.remotePassword {
+            self.remotePassword = remotePasswordText
         }
 
         let targetMode = desiredMode ?? self.connectionMode
@@ -504,6 +531,8 @@ final class AppState {
         let remoteIdentity = self.remoteIdentity
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
+        let remoteToken = self.remoteToken
+        let remotePassword = self.remotePassword
         let desiredMode: String? = switch connectionMode {
         case .local:
             "local"
@@ -539,6 +568,8 @@ final class AppState {
                     current: currentRemote,
                     transport: remoteTransport,
                     remoteUrl: remoteUrl,
+                    remoteToken: remoteToken,
+                    remotePassword: remotePassword,
                     remoteHost: remoteHost,
                     remoteTarget: remoteTarget,
                     remoteIdentity: remoteIdentity)

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -2,6 +2,28 @@ import Foundation
 import OpenClawKit
 
 enum GatewayRemoteConfig {
+    static func resolveTokenString(root: [String: Any]) -> String? {
+        guard let gateway = root["gateway"] as? [String: Any],
+              let remote = gateway["remote"] as? [String: Any],
+              let tokenRaw = remote["token"] as? String
+        else {
+            return nil
+        }
+        let trimmed = tokenRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func resolvePasswordString(root: [String: Any]) -> String? {
+        guard let gateway = root["gateway"] as? [String: Any],
+              let remote = gateway["remote"] as? [String: Any],
+              let passwordRaw = remote["password"] as? String
+        else {
+            return nil
+        }
+        let trimmed = passwordRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     static func resolveTransport(root: [String: Any]) -> AppState.RemoteTransport {
         guard let gateway = root["gateway"] as? [String: Any],
               let remote = gateway["remote"] as? [String: Any],

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -150,6 +150,8 @@ struct GeneralSettings: View {
                 self.remoteDirectRow
             }
 
+            self.remoteAuthRows
+
             GatewayDiscoveryInlineList(
                 discovery: self.gatewayDiscovery,
                 currentTarget: self.state.remoteTarget,
@@ -285,6 +287,31 @@ struct GeneralSettings: View {
             }
             Text(
                 "Direct mode requires wss:// for remote hosts. ws:// is only allowed for localhost/127.0.0.1.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, self.remoteLabelWidth + 10)
+        }
+    }
+
+    private var remoteAuthRows: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 10) {
+                Text("Auth token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("gateway.remote.token", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
+            HStack(alignment: .center, spacing: 10) {
+                Text("Password")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("gateway.remote.password", text: self.$state.remotePassword)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
+            Text("Set the one that matches the remote gateway auth mode.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.leading, self.remoteLabelWidth + 10)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -209,6 +209,22 @@ extension OnboardingView {
                                 .frame(width: fieldWidth)
                         }
                     }
+                    GridRow {
+                        Text("Auth token")
+                            .font(.callout.weight(.semibold))
+                            .frame(width: labelWidth, alignment: .leading)
+                        SecureField("gateway.remote.token", text: self.$state.remoteToken)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: fieldWidth)
+                    }
+                    GridRow {
+                        Text("Password")
+                            .font(.callout.weight(.semibold))
+                            .frame(width: labelWidth, alignment: .leading)
+                        SecureField("gateway.remote.password", text: self.$state.remotePassword)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: fieldWidth)
+                    }
                     if self.state.remoteTransport == .ssh {
                         GridRow {
                             Text("SSH target")

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -61,6 +61,21 @@ struct GatewayEndpointStoreTests {
         #expect(token == nil)
     }
 
+    @Test func `resolve gateway token reads remote config in remote mode`() {
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: true,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "token": "remote-token",
+                    ],
+                ],
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(token == "remote-token")
+    }
+
     @Test func `resolve gateway password falls back to launchd`() {
         let snapshot = self.makeLaunchAgentSnapshot(
             env: ["OPENCLAW_GATEWAY_PASSWORD": "launchd-pass"],
@@ -73,6 +88,21 @@ struct GatewayEndpointStoreTests {
             env: [:],
             launchdSnapshot: snapshot)
         #expect(password == "launchd-pass")
+    }
+
+    @Test func `resolve gateway password reads remote config in remote mode`() {
+        let password = GatewayEndpointStore._testResolveGatewayPassword(
+            isRemote: true,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "password": "remote-pass",
+                    ],
+                ],
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(password == "remote-pass")
     }
 
     @Test func `connection mode resolver prefers config mode over defaults`() {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -111,7 +111,10 @@ import {
 } from "../runs.js";
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
-import { prepareSessionManagerForRun } from "../session-manager-init.js";
+import {
+  prepareSessionManagerForRun,
+  shouldInjectBootstrapContext,
+} from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
@@ -796,16 +799,18 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-      });
+    const injectBootstrapContext = await shouldInjectBootstrapContext(params.sessionFile);
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } = injectBootstrapContext
+      ? await resolveBootstrapContextForRun({
+          workspaceDir: effectiveWorkspace,
+          config: params.config,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          contextMode: params.bootstrapContextMode,
+          runKind: params.bootstrapContextRunKind,
+        })
+      : { bootstrapFiles: [], contextFiles: [] };
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { shouldInjectBootstrapContext } from "./session-manager-init.js";
+
+const tempRoots: string[] = [];
+
+async function makeSessionFile(content?: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-bootstrap-"));
+  tempRoots.push(root);
+  const sessionFile = path.join(root, "session.jsonl");
+  if (content !== undefined) {
+    await fs.writeFile(sessionFile, content, "utf-8");
+  }
+  return sessionFile;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("shouldInjectBootstrapContext", () => {
+  it("injects bootstrap context when the transcript does not exist yet", async () => {
+    const sessionFile = await makeSessionFile();
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("injects bootstrap context when the transcript only has a session header", async () => {
+    const sessionFile = await makeSessionFile(
+      `${JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" })}\n`,
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("skips bootstrap context after the transcript already has messages", async () => {
+    const sessionFile = await makeSessionFile(
+      [
+        JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      ].join("\n"),
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(false);
+  });
+
+  it("falls back to injecting bootstrap context when the transcript is malformed", async () => {
+    const sessionFile = await makeSessionFile("{not-json}\n");
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -3,6 +3,33 @@ import fs from "node:fs/promises";
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
+export async function shouldInjectBootstrapContext(sessionFile: string): Promise<boolean> {
+  let content: string;
+  try {
+    content = await fs.readFile(sessionFile, "utf-8");
+  } catch {
+    return true;
+  }
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line) as { type?: string };
+      if (entry.type === "message") {
+        return false;
+      }
+    } catch {
+      // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly yet.
+      return true;
+    }
+  }
+
+  return true;
+}
+
 /**
  * pi-coding-agent SessionManager persistence quirk:
  * - If the file exists but has no assistant message, SessionManager marks itself `flushed=true`

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { generateZshCompletion } from "./completion-cli.js";
+
+describe("generateZshCompletion", () => {
+  it("initializes compinit before calling compdef", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("status").description("show status");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain("autoload -Uz compinit");
+    expect(script).toContain("if ! (( $+functions[compdef] )); then");
+    expect(script).toContain("compinit");
+    expect(script).toContain("compdef _openclaw_root_completion openclaw");
+  });
+});

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -376,10 +376,15 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 }
 
-function generateZshCompletion(program: Command): string {
+export function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
 #compdef ${rootCmd}
+
+autoload -Uz compinit
+if ! (( $+functions[compdef] )); then
+  compinit
+fi
 
 _${rootCmd}_root_completion() {
   local -a commands


### PR DESCRIPTION
## Summary

- Problem: Remote macOS connections supported `gateway.remote.token/password` in config, but the app exposed no UI for them, so SSH/direct remote setups failed with missing auth.
- Why it matters: Users could not connect to authenticated remote gateways without manually editing `~/.openclaw/openclaw.json`, and onboarding hid the required inputs entirely.
- What changed: Added remote auth token/password fields to macOS settings + onboarding, persisted them into `gateway.remote.*`, skipped bootstrap prompt injection once a session already has transcript messages, and made generated zsh completion self-initialize `compinit` before `compdef`.
- What did NOT change (scope boundary): I did not implement WhatsApp phone-number pairing / pairing-code login from #4686; that is a larger protocol-level feature path, not a safe bugfix-sized change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #9157
- Closes #13552
- Closes #14289
- Related #4686

## User-visible / Behavior Changes

- macOS Remote mode now exposes auth token/password inputs in both Settings and onboarding.
- Existing sessions stop re-injecting workspace bootstrap files on every turn once transcript messages already exist.
- `source <(openclaw completion --shell zsh)` now initializes `compinit` automatically when needed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  Remote auth secrets are now editable from the macOS UI, but they are still persisted to the same `gateway.remote.token/password` config keys already used by the app. No new secret sink was introduced.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: mocked unit tests only
- Integration/channel (if any): macOS remote gateway UI, embedded agent bootstrap, zsh completion
- Relevant config (redacted): `gateway.remote.{url,token,password,sshTarget}`

### Steps

1. Configure macOS app for Remote mode with SSH tunnel or direct transport.
2. Enter remote auth token/password in the app instead of hand-editing config.
3. Reuse an existing embedded-agent session and run another message.
4. Source generated zsh completion in a shell without pre-running `compinit`.

### Expected

- Remote gateway auth is supplied from app-managed config.
- Existing sessions do not re-inject bootstrap prompt files every turn.
- zsh completion loads without `command not found: compdef`.

### Actual

- Verified by targeted unit tests plus manual code-path review.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  `pnpm exec vitest run src/agents/pi-embedded-runner/session-manager-init.test.ts src/cli/completion-cli.test.ts`
- Edge cases checked:
  session file missing, session header only, existing transcript messages, malformed JSONL transcript, zsh completion without preloaded `compdef`, remote config token/password resolution in Swift tests by code inspection.
- What you did **not** verify:
  I could not complete `swift test --package-path apps/macos --filter GatewayEndpointStoreTests` in this environment because SwiftPM hung while downloading Sparkle's binary artifact.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  Revert commit efa6495c4.
- Files/config to restore:
  macOS remote config fields under `gateway.remote.*`; embedded runner bootstrap behavior; generated zsh completion script.
- Known bad symptoms reviewers should watch for:
  Remote mode no longer reading saved token/password, missing AGENTS bootstrap on first turn, zsh completion double-running `compinit` unexpectedly.

## Risks and Mitigations

- Risk:
  Existing users with both remote token and password configured may enter mismatched credentials in UI.
  - Mitigation:
    The UI labels both fields explicitly and preserves the existing config-key behavior; only the gateway-selected auth mode is used.
- Risk:
  Bootstrap context skipping could suppress bootstrap files too early for pre-created transcripts.
  - Mitigation:
    The new gate checks for actual `message` entries, not mere file existence, and falls back to injection on malformed transcripts.
