### PR TITLE
fix(session): preserve modelOverride for subagent sessions

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1388,6 +1388,50 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("preserves modelOverride for new sessions without reset trigger (subagent spawn)", async () => {
+    const storePath = await createStorePath("openclaw-subagent-model-");
+    const sessionKey = "agent:main:telegram:dm:user-subagent-model";
+    const existingSessionId = "pre-populated-session";
+    // Simulate sessions.patch writing modelOverride before first message
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: {
+        modelOverride: "anthropic/claude-sonnet-4-6",
+        providerOverride: "anthropic",
+        // Set updatedAt far in the past so the session is stale (not fresh),
+        // which is what happens for subagent sessions on their first message.
+        updatedAt: 0,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 1 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "do something",
+        RawBody: "do something",
+        CommandBody: "do something",
+        From: "user-subagent-model",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionEntry.modelOverride).toBe("anthropic/claude-sonnet-4-6");
+    expect(result.sessionEntry.providerOverride).toBe("anthropic");
+  });
+
   it("archives the old session store entry on /new", async () => {
     const storePath = await createStorePath("openclaw-archive-old-");
     const sessionKey = "agent:main:telegram:dm:user-archive";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -381,12 +381,19 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
       persistedAuthProfileOverride = entry.authProfileOverride;
       persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
       persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
       persistedLabel = entry.label;
+    }
+    // Always preserve modelOverride/providerOverride from the session entry
+    // when it exists, even without a reset trigger.  sessions.patch writes
+    // these overrides for subagent sessions *before* the first message
+    // arrives, so gating on resetTriggered (which is always false for
+    // subagent first-runs) would silently discard the configured model.
+    if (entry) {
+      persistedModelOverride = entry.modelOverride;
+      persistedProviderOverride = entry.providerOverride;
     }
   }
 


### PR DESCRIPTION
\`initSessionState()\` discards \`modelOverride\`/\`providerOverride\` for subagent sessions because those fields are only read when \`resetTriggered\` is true — which never happens for subagents.

\`sessions.patch\` correctly writes the override before the first message, but \`initSessionState()\` ignores it and the subagent ends up running on the parent model.

The fix moves the model/provider override reads out of the \`resetTriggered\` guard so they're always picked up when an entry exists. The reset-only fields (thinking, verbose, reasoning, ttsAuto, label) stay gated behind \`resetTriggered\` as before.

Fixes #40159