### PR TITLE
macOS: add remote gateway token UI without clobbering config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 - Talk mode: add top-level `talk.silenceTimeoutMs` config so Talk waits a configurable amount of silence before auto-sending the current transcript, while keeping each platform's existing default pause window when unset. (#39607) Thanks @danodoesdesign. Fixes #17147.
 - CLI/install: include the short git commit hash in `openclaw --version` output when metadata is available, and keep installer version checks compatible with the decorated format. (#39712) thanks @sourman.
 - Docs/Web search: restore $5/month free-credit details, replace defunct "Data for Search"/"Data for AI" plan names with current "Search" plan, and note legacy subscription validity in Brave setup docs. Follows up on #26860. (#40111) Thanks @remusao.
-- macOS/onboarding: add a remote gateway token field for remote mode, preserve existing non-plaintext `gateway.remote.token` config values until explicitly replaced, and warn when the loaded token shape cannot be used directly from the macOS app. (#34614)
+- macOS/onboarding: add a remote gateway token field for remote mode, preserve existing non-plaintext `gateway.remote.token` config values until explicitly replaced, and warn when the loaded token shape cannot be used directly from the macOS app. (#40187, supersedes #34614) Thanks @cgdusek.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Talk mode: add top-level `talk.silenceTimeoutMs` config so Talk waits a configurable amount of silence before auto-sending the current transcript, while keeping each platform's existing default pause window when unset. (#39607) Thanks @danodoesdesign. Fixes #17147.
 - CLI/install: include the short git commit hash in `openclaw --version` output when metadata is available, and keep installer version checks compatible with the decorated format. (#39712) thanks @sourman.
 - Docs/Web search: restore $5/month free-credit details, replace defunct "Data for Search"/"Data for AI" plan names with current "Search" plan, and note legacy subscription validity in Brave setup docs. Follows up on #26860. (#40111) Thanks @remusao.
+- macOS/onboarding: add a remote gateway token field for remote mode, preserve existing non-plaintext `gateway.remote.token` config values until explicitly replaced, and warn when the loaded token shape cannot be used directly from the macOS app. (#34614)
 
 ### Fixes
 

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -9,6 +9,7 @@ import SwiftUI
 final class AppState {
     private let isPreview: Bool
     private var isInitializing = true
+    private var isApplyingRemoteTokenConfig = false
     private var configWatcher: ConfigFileWatcher?
     private var suppressVoiceWakeGlobalSync = false
     private var voiceWakeGlobalSyncTask: Task<Void, Never>?
@@ -214,8 +215,16 @@ final class AppState {
     }
 
     var remoteToken: String {
-        didSet { self.syncGatewayConfigIfNeeded() }
+        didSet {
+            guard !self.isApplyingRemoteTokenConfig else { return }
+            self.remoteTokenDirty = true
+            self.remoteTokenUnsupported = false
+            self.syncGatewayConfigIfNeeded()
+        }
     }
+
+    private(set) var remoteTokenDirty = false
+    private(set) var remoteTokenUnsupported = false
 
     var remoteIdentity: String {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) } }
@@ -285,6 +294,7 @@ final class AppState {
 
         let configRoot = OpenClawConfigFile.loadDict()
         let configRemoteUrl = GatewayRemoteConfig.resolveUrlString(root: configRoot)
+        let configRemoteToken = GatewayRemoteConfig.resolveTokenValue(root: configRoot)
         let configRemoteTransport = GatewayRemoteConfig.resolveTransport(root: configRoot)
         let resolvedConnectionMode = ConnectionModeResolver.resolve(root: configRoot).mode
         self.remoteTransport = configRemoteTransport
@@ -301,7 +311,9 @@ final class AppState {
             self.remoteTarget = storedRemoteTarget
         }
         self.remoteUrl = configRemoteUrl ?? ""
-        self.remoteToken = GatewayRemoteConfig.resolveTokenString(root: configRoot) ?? ""
+        self.remoteToken = configRemoteToken.textFieldValue
+        self.remoteTokenDirty = false
+        self.remoteTokenUnsupported = configRemoteToken.isUnsupportedNonString
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey) ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey) ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey) ?? ""
@@ -379,6 +391,20 @@ final class AppState {
         return false
     }
 
+    private func applyRemoteTokenState(_ tokenValue: GatewayRemoteConfig.TokenValue) {
+        let nextToken = tokenValue.textFieldValue
+        let unsupported = tokenValue.isUnsupportedNonString
+        guard self.remoteToken != nextToken || self.remoteTokenDirty || self.remoteTokenUnsupported != unsupported
+        else {
+            return
+        }
+        self.isApplyingRemoteTokenConfig = true
+        self.remoteToken = nextToken
+        self.isApplyingRemoteTokenConfig = false
+        self.remoteTokenDirty = false
+        self.remoteTokenUnsupported = unsupported
+    }
+
     private static func updatedRemoteGatewayConfig(
         current: [String: Any],
         transport: RemoteTransport,
@@ -386,7 +412,8 @@ final class AppState {
         remoteHost: String?,
         remoteTarget: String,
         remoteIdentity: String,
-        remoteToken: String) -> (remote: [String: Any], changed: Bool)
+        remoteToken: String,
+        remoteTokenDirty: Bool) -> (remote: [String: Any], changed: Bool)
     {
         var remote = current
         var changed = false
@@ -423,7 +450,9 @@ final class AppState {
             changed = Self.updateGatewayString(&remote, key: "sshIdentity", value: remoteIdentity) || changed
         }
 
-        changed = Self.updateGatewayString(&remote, key: "token", value: remoteToken) || changed
+        if remoteTokenDirty {
+            changed = Self.updateGatewayString(&remote, key: "token", value: remoteToken) || changed
+        }
 
         return (remote, changed)
     }
@@ -447,7 +476,7 @@ final class AppState {
         let gateway = root["gateway"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let remoteUrl = GatewayRemoteConfig.resolveUrlString(root: root)
-        let remoteToken = GatewayRemoteConfig.resolveTokenString(root: root) ?? ""
+        let remoteToken = GatewayRemoteConfig.resolveTokenValue(root: root)
         let hasRemoteUrl = !(remoteUrl?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
@@ -479,9 +508,7 @@ final class AppState {
         if remoteUrlText != self.remoteUrl {
             self.remoteUrl = remoteUrlText
         }
-        if remoteToken != self.remoteToken {
-            self.remoteToken = remoteToken
-        }
+        self.applyRemoteTokenState(remoteToken)
 
         let targetMode = desiredMode ?? self.connectionMode
         if targetMode == .remote,
@@ -515,7 +542,8 @@ final class AppState {
         remoteTarget: String,
         remoteIdentity: String,
         remoteUrl: String,
-        remoteToken: String) -> (root: [String: Any], changed: Bool)
+        remoteToken: String,
+        remoteTokenDirty: Bool) -> (root: [String: Any], changed: Bool)
     {
         var root = currentRoot
         var gateway = root["gateway"] as? [String: Any] ?? [:]
@@ -551,7 +579,8 @@ final class AppState {
                 remoteHost: remoteHost,
                 remoteTarget: remoteTarget,
                 remoteIdentity: remoteIdentity,
-                remoteToken: remoteToken)
+                remoteToken: remoteToken,
+                remoteTokenDirty: remoteTokenDirty)
             if updated.changed {
                 gateway["remote"] = updated.remote
                 changed = true
@@ -577,6 +606,7 @@ final class AppState {
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
         let remoteToken = self.remoteToken
+        let remoteTokenDirty = self.remoteTokenDirty
 
         Task { @MainActor in
             // Keep app-only connection settings local to avoid overwriting remote gateway config.
@@ -587,7 +617,8 @@ final class AppState {
                 remoteTarget: remoteTarget,
                 remoteIdentity: remoteIdentity,
                 remoteUrl: remoteUrl,
-                remoteToken: remoteToken)
+                remoteToken: remoteToken,
+                remoteTokenDirty: remoteTokenDirty)
             guard synced.changed else { return }
             OpenClawConfigFile.saveDict(synced.root)
         }
@@ -750,7 +781,8 @@ extension AppState {
         remoteHost: String?,
         remoteTarget: String,
         remoteIdentity: String,
-        remoteToken: String) -> [String: Any]
+        remoteToken: String,
+        remoteTokenDirty: Bool) -> [String: Any]
     {
         Self.updatedRemoteGatewayConfig(
             current: current,
@@ -759,7 +791,8 @@ extension AppState {
             remoteHost: remoteHost,
             remoteTarget: remoteTarget,
             remoteIdentity: remoteIdentity,
-            remoteToken: remoteToken).remote
+            remoteToken: remoteToken,
+            remoteTokenDirty: remoteTokenDirty).remote
     }
 
     static func _testSyncedGatewayRoot(
@@ -769,7 +802,8 @@ extension AppState {
         remoteTarget: String,
         remoteIdentity: String,
         remoteUrl: String,
-        remoteToken: String) -> [String: Any]
+        remoteToken: String,
+        remoteTokenDirty: Bool) -> [String: Any]
     {
         Self.syncedGatewayRoot(
             currentRoot: currentRoot,
@@ -778,7 +812,8 @@ extension AppState {
             remoteTarget: remoteTarget,
             remoteIdentity: remoteIdentity,
             remoteUrl: remoteUrl,
-            remoteToken: remoteToken).root
+            remoteToken: remoteToken,
+            remoteTokenDirty: remoteTokenDirty).root
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -213,6 +213,10 @@ final class AppState {
         didSet { self.syncGatewayConfigIfNeeded() }
     }
 
+    var remoteToken: String {
+        didSet { self.syncGatewayConfigIfNeeded() }
+    }
+
     var remoteIdentity: String {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) } }
     }
@@ -297,6 +301,7 @@ final class AppState {
             self.remoteTarget = storedRemoteTarget
         }
         self.remoteUrl = configRemoteUrl ?? ""
+        self.remoteToken = GatewayRemoteConfig.resolveTokenString(root: configRoot) ?? ""
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey) ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey) ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey) ?? ""
@@ -380,7 +385,8 @@ final class AppState {
         remoteUrl: String,
         remoteHost: String?,
         remoteTarget: String,
-        remoteIdentity: String) -> (remote: [String: Any], changed: Bool)
+        remoteIdentity: String,
+        remoteToken: String) -> (remote: [String: Any], changed: Bool)
     {
         var remote = current
         var changed = false
@@ -417,6 +423,8 @@ final class AppState {
             changed = Self.updateGatewayString(&remote, key: "sshIdentity", value: remoteIdentity) || changed
         }
 
+        changed = Self.updateGatewayString(&remote, key: "token", value: remoteToken) || changed
+
         return (remote, changed)
     }
 
@@ -439,6 +447,7 @@ final class AppState {
         let gateway = root["gateway"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let remoteUrl = GatewayRemoteConfig.resolveUrlString(root: root)
+        let remoteToken = GatewayRemoteConfig.resolveTokenString(root: root) ?? ""
         let hasRemoteUrl = !(remoteUrl?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
@@ -469,6 +478,9 @@ final class AppState {
         let remoteUrlText = remoteUrl ?? ""
         if remoteUrlText != self.remoteUrl {
             self.remoteUrl = remoteUrlText
+        }
+        if remoteToken != self.remoteToken {
+            self.remoteToken = remoteToken
         }
 
         let targetMode = desiredMode ?? self.connectionMode
@@ -504,6 +516,7 @@ final class AppState {
         let remoteIdentity = self.remoteIdentity
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
+        let remoteToken = self.remoteToken
         let desiredMode: String? = switch connectionMode {
         case .local:
             "local"
@@ -541,7 +554,8 @@ final class AppState {
                     remoteUrl: remoteUrl,
                     remoteHost: remoteHost,
                     remoteTarget: remoteTarget,
-                    remoteIdentity: remoteIdentity)
+                    remoteIdentity: remoteIdentity,
+                    remoteToken: remoteToken)
                 if updated.changed {
                     gateway["remote"] = updated.remote
                     changed = true
@@ -697,12 +711,37 @@ extension AppState {
         state.canvasEnabled = true
         state.remoteTarget = "user@example.com"
         state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "example-token"
         state.remoteIdentity = "~/.ssh/id_ed25519"
         state.remoteProjectRoot = "~/Projects/openclaw"
         state.remoteCliPath = ""
         return state
     }
 }
+
+#if DEBUG
+@MainActor
+extension AppState {
+    static func _testUpdatedRemoteGatewayConfig(
+        current: [String: Any],
+        transport: RemoteTransport,
+        remoteUrl: String,
+        remoteHost: String?,
+        remoteTarget: String,
+        remoteIdentity: String,
+        remoteToken: String) -> [String: Any]
+    {
+        Self.updatedRemoteGatewayConfig(
+            current: current,
+            transport: transport,
+            remoteUrl: remoteUrl,
+            remoteHost: remoteHost,
+            remoteTarget: remoteTarget,
+            remoteIdentity: remoteIdentity,
+            remoteToken: remoteToken).remote
+    }
+}
+#endif
 
 @MainActor
 enum AppStateStore {

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -508,6 +508,66 @@ final class AppState {
         }
     }
 
+    private static func syncedGatewayRoot(
+        currentRoot: [String: Any],
+        connectionMode: ConnectionMode,
+        remoteTransport: RemoteTransport,
+        remoteTarget: String,
+        remoteIdentity: String,
+        remoteUrl: String,
+        remoteToken: String) -> (root: [String: Any], changed: Bool)
+    {
+        var root = currentRoot
+        var gateway = root["gateway"] as? [String: Any] ?? [:]
+        var changed = false
+
+        let desiredMode: String? = switch connectionMode {
+        case .local:
+            "local"
+        case .remote:
+            "remote"
+        case .unconfigured:
+            nil
+        }
+
+        let currentMode = (gateway["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let desiredMode {
+            if currentMode != desiredMode {
+                gateway["mode"] = desiredMode
+                changed = true
+            }
+        } else if currentMode != nil {
+            gateway.removeValue(forKey: "mode")
+            changed = true
+        }
+
+        if connectionMode == .remote {
+            let remoteHost = CommandResolver.parseSSHTarget(remoteTarget)?.host
+            let currentRemote = gateway["remote"] as? [String: Any] ?? [:]
+            let updated = Self.updatedRemoteGatewayConfig(
+                current: currentRemote,
+                transport: remoteTransport,
+                remoteUrl: remoteUrl,
+                remoteHost: remoteHost,
+                remoteTarget: remoteTarget,
+                remoteIdentity: remoteIdentity,
+                remoteToken: remoteToken)
+            if updated.changed {
+                gateway["remote"] = updated.remote
+                changed = true
+            }
+        }
+
+        guard changed else { return (currentRoot, false) }
+
+        if gateway.isEmpty {
+            root.removeValue(forKey: "gateway")
+        } else {
+            root["gateway"] = gateway
+        }
+        return (root, true)
+    }
+
     private func syncGatewayConfigIfNeeded() {
         guard !self.isPreview, !self.isInitializing else { return }
 
@@ -517,58 +577,19 @@ final class AppState {
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
         let remoteToken = self.remoteToken
-        let desiredMode: String? = switch connectionMode {
-        case .local:
-            "local"
-        case .remote:
-            "remote"
-        case .unconfigured:
-            nil
-        }
-        let remoteHost = connectionMode == .remote
-            ? CommandResolver.parseSSHTarget(remoteTarget)?.host
-            : nil
 
         Task { @MainActor in
             // Keep app-only connection settings local to avoid overwriting remote gateway config.
-            var root = OpenClawConfigFile.loadDict()
-            var gateway = root["gateway"] as? [String: Any] ?? [:]
-            var changed = false
-
-            let currentMode = (gateway["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let desiredMode {
-                if currentMode != desiredMode {
-                    gateway["mode"] = desiredMode
-                    changed = true
-                }
-            } else if currentMode != nil {
-                gateway.removeValue(forKey: "mode")
-                changed = true
-            }
-
-            if connectionMode == .remote {
-                let currentRemote = gateway["remote"] as? [String: Any] ?? [:]
-                let updated = Self.updatedRemoteGatewayConfig(
-                    current: currentRemote,
-                    transport: remoteTransport,
-                    remoteUrl: remoteUrl,
-                    remoteHost: remoteHost,
-                    remoteTarget: remoteTarget,
-                    remoteIdentity: remoteIdentity,
-                    remoteToken: remoteToken)
-                if updated.changed {
-                    gateway["remote"] = updated.remote
-                    changed = true
-                }
-            }
-
-            guard changed else { return }
-            if gateway.isEmpty {
-                root.removeValue(forKey: "gateway")
-            } else {
-                root["gateway"] = gateway
-            }
-            OpenClawConfigFile.saveDict(root)
+            let synced = Self.syncedGatewayRoot(
+                currentRoot: OpenClawConfigFile.loadDict(),
+                connectionMode: connectionMode,
+                remoteTransport: remoteTransport,
+                remoteTarget: remoteTarget,
+                remoteIdentity: remoteIdentity,
+                remoteUrl: remoteUrl,
+                remoteToken: remoteToken)
+            guard synced.changed else { return }
+            OpenClawConfigFile.saveDict(synced.root)
         }
     }
 
@@ -739,6 +760,25 @@ extension AppState {
             remoteTarget: remoteTarget,
             remoteIdentity: remoteIdentity,
             remoteToken: remoteToken).remote
+    }
+
+    static func _testSyncedGatewayRoot(
+        currentRoot: [String: Any],
+        connectionMode: ConnectionMode,
+        remoteTransport: RemoteTransport,
+        remoteTarget: String,
+        remoteIdentity: String,
+        remoteUrl: String,
+        remoteToken: String) -> [String: Any]
+    {
+        Self.syncedGatewayRoot(
+            currentRoot: currentRoot,
+            connectionMode: connectionMode,
+            remoteTransport: remoteTransport,
+            remoteTarget: remoteTarget,
+            remoteIdentity: remoteIdentity,
+            remoteUrl: remoteUrl,
+            remoteToken: remoteToken).root
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -188,13 +188,7 @@ actor GatewayEndpointStore {
 
     private static func resolveConfigToken(isRemote: Bool, root: [String: Any]) -> String? {
         if isRemote {
-            if let gateway = root["gateway"] as? [String: Any],
-               let remote = gateway["remote"] as? [String: Any],
-               let token = remote["token"] as? String
-            {
-                return token.trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return nil
+            return GatewayRemoteConfig.resolveTokenString(root: root)
         }
 
         if let gateway = root["gateway"] as? [String: Any],

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -2,6 +2,28 @@ import Foundation
 import OpenClawKit
 
 enum GatewayRemoteConfig {
+    enum TokenValue: Equatable {
+        case missing
+        case plaintext(String)
+        case unsupportedNonString
+
+        var textFieldValue: String {
+            switch self {
+            case let .plaintext(token):
+                token
+            case .missing, .unsupportedNonString:
+                ""
+            }
+        }
+
+        var isUnsupportedNonString: Bool {
+            if case .unsupportedNonString = self {
+                return true
+            }
+            return false
+        }
+    }
+
     static func resolveTransport(root: [String: Any]) -> AppState.RemoteTransport {
         guard let gateway = root["gateway"] as? [String: Any],
               let remote = gateway["remote"] as? [String: Any],
@@ -24,15 +46,27 @@ enum GatewayRemoteConfig {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    static func resolveTokenString(root: [String: Any]) -> String? {
+    static func resolveTokenValue(root: [String: Any]) -> TokenValue {
         guard let gateway = root["gateway"] as? [String: Any],
               let remote = gateway["remote"] as? [String: Any],
-              let tokenRaw = remote["token"] as? String
+              let tokenRaw = remote["token"]
         else {
-            return nil
+            return .missing
         }
-        let trimmed = tokenRaw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        guard let tokenString = tokenRaw as? String else {
+            return .unsupportedNonString
+        }
+        let trimmed = tokenString.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? .missing : .plaintext(trimmed)
+    }
+
+    static func resolveTokenString(root: [String: Any]) -> String? {
+        switch self.resolveTokenValue(root: root) {
+        case let .plaintext(token):
+            token
+        case .missing, .unsupportedNonString:
+            nil
+        }
     }
 
     static func resolveGatewayUrl(root: [String: Any]) -> URL? {

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -24,6 +24,17 @@ enum GatewayRemoteConfig {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    static func resolveTokenString(root: [String: Any]) -> String? {
+        guard let gateway = root["gateway"] as? [String: Any],
+              let remote = gateway["remote"] as? [String: Any],
+              let tokenRaw = remote["token"] as? String
+        else {
+            return nil
+        }
+        let trimmed = tokenRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     static func resolveGatewayUrl(root: [String: Any]) -> URL? {
         guard let raw = self.resolveUrlString(root: root) else { return nil }
         return self.normalizeGatewayUrl(raw)

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -298,7 +298,7 @@ struct GeneralSettings: View {
                 Text("Gateway token")
                     .font(.callout.weight(.semibold))
                     .frame(width: self.remoteLabelWidth, alignment: .leading)
-                SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                SecureField("remote gateway auth token (gateway.auth.token)", text: self.$state.remoteToken)
                     .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: .infinity)
             }

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -149,6 +149,7 @@ struct GeneralSettings: View {
             } else {
                 self.remoteDirectRow
             }
+            self.remoteTokenRow
 
             GatewayDiscoveryInlineList(
                 discovery: self.gatewayDiscovery,
@@ -285,6 +286,23 @@ struct GeneralSettings: View {
             }
             Text(
                 "Direct mode requires wss:// for remote hosts. ws:// is only allowed for localhost/127.0.0.1.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, self.remoteLabelWidth + 10)
+        }
+    }
+
+    private var remoteTokenRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 10) {
+                Text("Gateway token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
+            Text("Used when the remote gateway requires token auth.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.leading, self.remoteLabelWidth + 10)
@@ -692,6 +710,7 @@ extension GeneralSettings {
         state.remoteTransport = .ssh
         state.remoteTarget = "user@host:2222"
         state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "example-token"
         state.remoteIdentity = "/tmp/id_ed25519"
         state.remoteProjectRoot = "/tmp/openclaw"
         state.remoteCliPath = "/tmp/openclaw"

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -298,7 +298,7 @@ struct GeneralSettings: View {
                 Text("Gateway token")
                     .font(.callout.weight(.semibold))
                     .frame(width: self.remoteLabelWidth, alignment: .leading)
-                SecureField("remote gateway auth token (gateway.auth.token)", text: self.$state.remoteToken)
+                SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
                     .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: .infinity)
             }
@@ -306,6 +306,13 @@ struct GeneralSettings: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.leading, self.remoteLabelWidth + 10)
+            if self.state.remoteTokenUnsupported {
+                Text(
+                    "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .padding(.leading, self.remoteLabelWidth + 10)
+            }
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -203,7 +203,7 @@ extension OnboardingView {
                         Text("Gateway token")
                             .font(.callout.weight(.semibold))
                             .frame(width: labelWidth, alignment: .leading)
-                        SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                        SecureField("remote gateway auth token (gateway.auth.token)", text: self.$state.remoteToken)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: fieldWidth)
                     }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -203,9 +203,20 @@ extension OnboardingView {
                         Text("Gateway token")
                             .font(.callout.weight(.semibold))
                             .frame(width: labelWidth, alignment: .leading)
-                        SecureField("remote gateway auth token (gateway.auth.token)", text: self.$state.remoteToken)
+                        SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: fieldWidth)
+                    }
+                    if self.state.remoteTokenUnsupported {
+                        GridRow {
+                            Text("")
+                                .frame(width: labelWidth, alignment: .leading)
+                            Text(
+                                "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
+                                .frame(width: fieldWidth, alignment: .leading)
+                        }
                     }
                     if self.state.remoteTransport == .direct {
                         GridRow {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -199,6 +199,14 @@ extension OnboardingView {
                         .pickerStyle(.segmented)
                         .frame(width: fieldWidth)
                     }
+                    GridRow {
+                        Text("Gateway token")
+                            .font(.callout.weight(.semibold))
+                            .frame(width: labelWidth, alignment: .leading)
+                        SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: fieldWidth)
+                    }
                     if self.state.remoteTransport == .direct {
                         GridRow {
                             Text("Gateway URL")

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -57,6 +57,7 @@ struct AppStateRemoteConfigTests {
             remoteToken: "")
         let localGateway = localRoot["gateway"] as? [String: Any]
         let localRemoteConfig = localGateway?["remote"] as? [String: Any]
+        // Local mode should not discard remote token state; users can return to remote mode later.
         #expect(localGateway?["mode"] as? String == "local")
         #expect(localRemoteConfig?["token"] as? String == "persisted-token")
 

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -13,7 +13,8 @@ struct AppStateRemoteConfigTests {
             remoteHost: "gateway.example",
             remoteTarget: "alice@gateway.example",
             remoteIdentity: "/tmp/id_ed25519",
-            remoteToken: "  secret-token  ")
+            remoteToken: "  secret-token  ",
+            remoteTokenDirty: true)
 
         #expect(remote["token"] as? String == "secret-token")
     }
@@ -27,49 +28,101 @@ struct AppStateRemoteConfigTests {
             remoteHost: nil,
             remoteTarget: "",
             remoteIdentity: "",
-            remoteToken: "   ")
+            remoteToken: "   ",
+            remoteTokenDirty: true)
 
         #expect((remote["token"] as? String) == nil)
     }
 
     @Test
-    func syncedGatewayRootPreservesTokenAcrossModeToggleAndClearsOnBlankRemoteToken() {
-        let remoteRoot = AppState._testSyncedGatewayRoot(
-            currentRoot: [:],
+    func syncedGatewayRootPreservesObjectTokenAcrossModeAndTransportChangesWhenUntouched() {
+        let initialRoot: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://old-gateway.example",
+                    "token": [
+                        "$secretRef": "gateway-token",
+                    ],
+                ],
+            ],
+        ]
+
+        let sshRoot = AppState._testSyncedGatewayRoot(
+            currentRoot: initialRoot,
             connectionMode: .remote,
-            remoteTransport: .direct,
-            remoteTarget: "",
+            remoteTransport: .ssh,
+            remoteTarget: "alice@gateway.example",
             remoteIdentity: "",
-            remoteUrl: "wss://gateway.example",
-            remoteToken: "  persisted-token  ")
-        let remoteGateway = remoteRoot["gateway"] as? [String: Any]
-        let remoteConfig = remoteGateway?["remote"] as? [String: Any]
-        #expect(remoteGateway?["mode"] as? String == "remote")
-        #expect(remoteConfig?["token"] as? String == "persisted-token")
+            remoteUrl: "",
+            remoteToken: "",
+            remoteTokenDirty: false)
+        let sshRemote = (sshRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
+        #expect((sshRemote?["token"] as? [String: String])?["$secretRef"] == "gateway-token")
 
         let localRoot = AppState._testSyncedGatewayRoot(
-            currentRoot: remoteRoot,
+            currentRoot: sshRoot,
             connectionMode: .local,
-            remoteTransport: .direct,
+            remoteTransport: .ssh,
             remoteTarget: "",
             remoteIdentity: "",
             remoteUrl: "",
-            remoteToken: "")
+            remoteToken: "",
+            remoteTokenDirty: false)
         let localGateway = localRoot["gateway"] as? [String: Any]
-        let localRemoteConfig = localGateway?["remote"] as? [String: Any]
-        // Local mode should not discard remote token state; users can return to remote mode later.
+        let localRemote = localGateway?["remote"] as? [String: Any]
         #expect(localGateway?["mode"] as? String == "local")
-        #expect(localRemoteConfig?["token"] as? String == "persisted-token")
+        #expect((localRemote?["token"] as? [String: String])?["$secretRef"] == "gateway-token")
+    }
 
-        let clearedRoot = AppState._testSyncedGatewayRoot(
-            currentRoot: localRoot,
-            connectionMode: .remote,
-            remoteTransport: .direct,
+    @Test
+    func updatedRemoteGatewayConfigReplacesObjectTokenWhenUserEntersPlaintext() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: [
+                "token": [
+                    "$secretRef": "gateway-token",
+                ],
+            ],
+            transport: .direct,
+            remoteUrl: "wss://gateway.example",
+            remoteHost: nil,
             remoteTarget: "",
             remoteIdentity: "",
+            remoteToken: "  fresh-token  ",
+            remoteTokenDirty: true)
+
+        #expect(remote["token"] as? String == "fresh-token")
+    }
+
+    @Test
+    func updatedRemoteGatewayConfigClearsObjectTokenOnlyAfterExplicitEdit() {
+        let current: [String: Any] = [
+            "token": [
+                "$secretRef": "gateway-token",
+            ],
+        ]
+
+        let preserved = AppState._testUpdatedRemoteGatewayConfig(
+            current: current,
+            transport: .direct,
             remoteUrl: "wss://gateway.example",
-            remoteToken: "   ")
-        let clearedRemote = (clearedRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
-        #expect((clearedRemote?["token"] as? String) == nil)
+            remoteHost: nil,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteToken: "",
+            remoteTokenDirty: false)
+        #expect((preserved["token"] as? [String: String])?["$secretRef"] == "gateway-token")
+
+        let cleared = AppState._testUpdatedRemoteGatewayConfig(
+            current: current,
+            transport: .direct,
+            remoteUrl: "wss://gateway.example",
+            remoteHost: nil,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteToken: "   ",
+            remoteTokenDirty: true)
+        #expect((cleared["token"] as? String) == nil)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct AppStateRemoteConfigTests {
+    @Test
+    func updatedRemoteGatewayConfigSetsTrimmedToken() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: [:],
+            transport: .ssh,
+            remoteUrl: "",
+            remoteHost: "gateway.example",
+            remoteTarget: "alice@gateway.example",
+            remoteIdentity: "/tmp/id_ed25519",
+            remoteToken: "  secret-token  ")
+
+        #expect(remote["token"] as? String == "secret-token")
+    }
+
+    @Test
+    func updatedRemoteGatewayConfigClearsTokenWhenBlank() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: ["token": "old-token"],
+            transport: .direct,
+            remoteUrl: "wss://gateway.example",
+            remoteHost: nil,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteToken: "   ")
+
+        #expect((remote["token"] as? String) == nil)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -31,4 +31,44 @@ struct AppStateRemoteConfigTests {
 
         #expect((remote["token"] as? String) == nil)
     }
+
+    @Test
+    func syncedGatewayRootPreservesTokenAcrossModeToggleAndClearsOnBlankRemoteToken() {
+        let remoteRoot = AppState._testSyncedGatewayRoot(
+            currentRoot: [:],
+            connectionMode: .remote,
+            remoteTransport: .direct,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteUrl: "wss://gateway.example",
+            remoteToken: "  persisted-token  ")
+        let remoteGateway = remoteRoot["gateway"] as? [String: Any]
+        let remoteConfig = remoteGateway?["remote"] as? [String: Any]
+        #expect(remoteGateway?["mode"] as? String == "remote")
+        #expect(remoteConfig?["token"] as? String == "persisted-token")
+
+        let localRoot = AppState._testSyncedGatewayRoot(
+            currentRoot: remoteRoot,
+            connectionMode: .local,
+            remoteTransport: .direct,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteUrl: "",
+            remoteToken: "")
+        let localGateway = localRoot["gateway"] as? [String: Any]
+        let localRemoteConfig = localGateway?["remote"] as? [String: Any]
+        #expect(localGateway?["mode"] as? String == "local")
+        #expect(localRemoteConfig?["token"] as? String == "persisted-token")
+
+        let clearedRoot = AppState._testSyncedGatewayRoot(
+            currentRoot: localRoot,
+            connectionMode: .remote,
+            remoteTransport: .direct,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteUrl: "wss://gateway.example",
+            remoteToken: "   ")
+        let clearedRemote = (clearedRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
+        #expect((clearedRemote?["token"] as? String) == nil)
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -61,7 +61,22 @@ struct GatewayEndpointStoreTests {
         #expect(token == nil)
     }
 
-    @Test func `resolve gateway password falls back to launchd`() {
+    @Test func resolveGatewayTokenUsesRemoteConfigToken() {
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: true,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "token": "  remote-token  ",
+                    ],
+                ],
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(token == "remote-token")
+    }
+
+    @Test func resolveGatewayPasswordFallsBackToLaunchd() {
         let snapshot = self.makeLaunchAgentSnapshot(
             env: ["OPENCLAW_GATEWAY_PASSWORD": "launchd-pass"],
             token: nil,


### PR DESCRIPTION
## Summary

- Supersedes #34614 and carries forward the original macOS remote token UI work from @cgdusek.
- Add a remote gateway token field to macOS Settings and onboarding advanced remote setup for `gateway.remote.token`.
- Preserve existing non-plaintext `gateway.remote.token` values unless the user explicitly edits the field, instead of silently clobbering them during app-state sync.
- Warn when the loaded remote token value is not plaintext, while keeping the macOS app plaintext-only for remote token auth.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #13552
- Related #8545
- Supersedes #34614

## User-visible / Behavior Changes

- macOS Settings > General > Remote now includes a `Gateway token` field.
- Onboarding advanced remote setup now includes a `Gateway token` field.
- Existing unsupported non-plaintext `gateway.remote.token` config values are preserved until explicitly replaced.
- The UI now warns when the loaded `gateway.remote.token` value is not plaintext and cannot be used directly by the macOS app.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: token input in UI could accidentally store whitespace or clear config unexpectedly.
  - Mitigation: token input is trimmed, blank values only remove `gateway.remote.token` after explicit user edit, and unsupported existing token shapes are preserved when untouched.

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Swift Package (`apps/macos`)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `gateway.mode=remote`, `gateway.remote.*`

### Steps

1. Open macOS Settings in Remote mode or onboarding advanced remote setup.
2. Enter a plaintext gateway token or load a config containing a non-string `gateway.remote.token`.
3. Confirm plaintext tokens persist correctly and unsupported non-string values are preserved until explicitly replaced.

### Expected

- Remote token can be set without manual config edits.
- Existing unsupported token shapes are not silently removed by unrelated remote config changes.

### Actual

- Implemented and covered by updated tests below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `swift test --package-path apps/macos --filter AppStateRemoteConfigTests`
  - `swift test --package-path apps/macos --filter GatewayEndpointStoreTests`
  - `swift test --package-path apps/macos --filter SettingsViewSmokeTests`
  - `swift test --package-path apps/macos --filter OnboardingViewSmokeTests`
- Edge cases checked:
  - Token is trimmed before persistence.
  - Blank plaintext tokens remove `gateway.remote.token`.
  - Object-valued `gateway.remote.token` is preserved unless the user explicitly edits the field.
- What you did **not** verify:
  - Full `swift test --package-path apps/macos` run is not currently stable on this host due unrelated baseline failures/flakes (`ExecAllowlistTests` fixture mismatch; `LowCoverageViewSmokeTests` exclusivity crash).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `gateway.remote.token` from config and/or revert this PR.
- Files/config to restore:
  - `apps/macos/Sources/OpenClaw/AppState.swift`
  - `apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift`
  - `apps/macos/Sources/OpenClaw/GeneralSettings.swift`
  - `apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift`
- Known bad symptoms reviewers should watch for:
  - Remote token field appears but does not persist to config.
  - Existing non-string `gateway.remote.token` values disappear after unrelated remote config edits.

## Risks and Mitigations

- Risk: Exposing token input in UI could increase accidental shoulder-surfing.
  - Mitigation: Uses `SecureField` and keeps scope limited to remote gateway token entry.
