### PR TITLE
ci(secrets): ensure base commit is available before PR diff scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pre-commit
 
+      - name: Ensure base commit (PRs)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Detect secrets
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Fixes #40141.

The `secrets` CI job falls back to a full-repo `detect-secrets` scan when the PR base SHA is unavailable in a shallow checkout. This causes unrelated PRs to fail on longstanding false positives outside the PR's changeset.

**Before:** The `secrets` job does a shallow checkout and immediately tries `git rev-parse --verify "$BASE^{commit}"`. In shallow clones, the base SHA is often missing, so the job falls back to `pre-commit run --all-files detect-secrets`.

**After:** Added the existing `ensure-base-commit` composite action (already used by `docs-scope`, `changed-scope`, and `build-artifacts` jobs) before the detect-secrets step. This progressively deepens the checkout until the base SHA is available, ensuring the diff-based scan works reliably.

## Test plan

- [ ] Open a PR with no secret-related changes and verify the `secrets` job runs only on changed files (no "Falling back to full detect-secrets scan" message)
- [ ] Verify `push` events still run the full scan as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)