### PR TITLE
feat: add Towel Protocol skill for agent trust verification

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,15 +202,6 @@
         "line_number": 723
       }
     ],
-    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
-        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
-        "is_verified": false,
-        "line_number": 58
-      }
-    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
@@ -227,22 +218,6 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1749
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -9795,63 +9770,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1612
+        "line_number": 1614
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1628
+        "line_number": 1630
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1815
+        "line_number": 1817
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1988
+        "line_number": 1990
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2044
+        "line_number": 2046
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2276
+        "line_number": 2278
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2404
+        "line_number": 2408
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2657
+        "line_number": 2661
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2659
+        "line_number": 2663
       }
     ],
     "docs/gateway/configuration.md": [
@@ -11011,15 +10986,6 @@
         "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
-        "is_verified": false,
-        "line_number": 14
-      }
-    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11388,84 +11354,6 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "src/agents/memory-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
-        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    "src/agents/model-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 228
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 275
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
-        "is_verified": false,
-        "line_number": 374
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
-        "is_verified": false,
-        "line_number": 395
-      }
-    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11475,38 +11363,52 @@
         "line_number": 27
       }
     ],
+    "src/agents/models-config.applies-config-env-vars.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.applies-config-env-vars.test.ts",
+        "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.applies-config-env-vars.test.ts",
+        "hashed_secret": "ed5713054f3868ee935eab4b6b8d3242c1399fcb",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
     "src/agents/models-config.e2e-harness.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/agents/models-config.e2e-harness.ts",
         "hashed_secret": "7cf31e8b6cda49f70c31f1f25af05d46f924142d",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 157
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
+    "src/agents/models-config.providers.matrix.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "filename": "src/agents/models-config.providers.matrix.test.ts",
+        "hashed_secret": "396ad5937ce1efad36dbefc9d91ac13bae848b33",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 42
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
+        "filename": "src/agents/models-config.providers.matrix.test.ts",
+        "hashed_secret": "fad37b35f615bd2741cf63a56b16a0144e1bd002",
         "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
+        "line_number": 51
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
-        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
+        "filename": "src/agents/models-config.providers.matrix.test.ts",
+        "hashed_secret": "4febfc0114abfd2fff962244fa0c088aec4249e7",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 119
       }
     ],
     "src/agents/models-config.providers.nvidia.test.ts": [
@@ -11515,48 +11417,14 @@
         "filename": "src/agents/models-config.providers.nvidia.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       },
       {
         "type": "Secret Keyword",
         "filename": "src/agents/models-config.providers.nvidia.test.ts",
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
-        "line_number": 22
-      }
-    ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
-        "is_verified": false,
-        "line_number": 113
+        "line_number": 23
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11595,15 +11463,6 @@
         "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
-        "is_verified": false,
-        "line_number": 126
-      }
-    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11611,67 +11470,6 @@
         "hashed_secret": "9c62d3aa77c19e170c44b18129f967e2041fda41",
         "is_verified": false,
         "line_number": 28
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
-        "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
-        "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/tools/web-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
-        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
-        "is_verified": false,
-        "line_number": 129
       }
     ],
     "src/agents/tools/web-search.ts": [
@@ -11683,70 +11481,13 @@
         "line_number": 292
       }
     ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
-        "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
-        "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 246
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
-      }
-    ],
     "src/auto-reply/status.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/auto-reply/status.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 37
       }
     ],
     "src/browser/bridge-server.auth.test.ts": [
@@ -11764,14 +11505,14 @@
         "filename": "src/browser/browser-utils.test.ts",
         "hashed_secret": "4e126c049580d66ca1549fa534d95a7263f27f46",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 47
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "src/browser/browser-utils.test.ts",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 164
+        "line_number": 180
       }
     ],
     "src/browser/cdp.test.ts": [
@@ -11780,7 +11521,7 @@
         "filename": "src/browser/cdp.test.ts",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 243
+        "line_number": 318
       }
     ],
     "src/channels/plugins/plugins-channel.test.ts": [
@@ -11792,15 +11533,6 @@
         "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
-        "is_verified": false,
-        "line_number": 215
-      }
-    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11808,50 +11540,6 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
-      }
-    ],
-    "src/commands/auth-choice.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
-        "is_verified": false,
-        "line_number": 454
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 584
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
-        "is_verified": false,
-        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11863,31 +11551,6 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 128
-      }
-    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11895,52 +11558,6 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
-        "is_verified": false,
-        "line_number": 127
-      }
-    ],
-    "src/commands/models/list.status.e2e.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11957,96 +11574,6 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
-      }
-    ],
-    "src/commands/onboard-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
-        "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12076,15 +11603,6 @@
         "line_number": 60
       }
     ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
     "src/config/config-misc.test.ts": [
       {
         "type": "Secret Keyword",
@@ -12100,21 +11618,21 @@
         "filename": "src/config/config.env-vars.test.ts",
         "hashed_secret": "a24ef9c1a27cac44823571ceef2e8262718eee36",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 17
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/config.env-vars.test.ts",
         "hashed_secret": "29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 23
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/config.env-vars.test.ts",
         "hashed_secret": "1672b6a1e7956c6a70f45d699aa42a351b1f8b80",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 31
       }
     ],
     "src/config/config.irc.test.ts": [
@@ -12335,14 +11853,14 @@
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 651
+        "line_number": 653
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 684
+        "line_number": 686
       }
     ],
     "src/config/schema.irc.ts": [
@@ -12381,14 +11899,14 @@
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "e73c9fcad85cd4eecc74181ec4bdb31064d68439",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 217
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "2eda7cd978f39eebec3bf03e4410a40e14167fff",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 326
       }
     ],
     "src/config/slack-http-config.test.ts": [
@@ -12407,15 +11925,6 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 10
-      }
-    ],
-    "src/docker-setup.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
-        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
-        "is_verified": false,
-        "line_number": 131
       }
     ],
     "src/gateway/auth-rate-limit.ts": [
@@ -12501,15 +12010,6 @@
         "line_number": 704
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
-      {
-        "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12544,40 +12044,6 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
-      }
-    ],
-    "src/gateway/server.auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
-      }
-    ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
-        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
-        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
-        "is_verified": false,
-        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12792,15 +12258,6 @@
         "line_number": 88
       }
     ],
-    "src/media-understanding/apply.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
       {
         "type": "Secret Keyword",
@@ -13006,6 +12463,29 @@
         "line_number": 60
       }
     ],
+    "test-fixtures/talk-config-contract.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "62836f14b86ed93da229b6b30b1556f322459d0f",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "260dd6b18b40c0ae7aeb1534a622b94d48a3a88d",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "fa3f8556220674269a6130b0eedd21dec9c033fb",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
     "ui/src/i18n/locales/en.ts": [
       {
         "type": "Secret Keyword",
@@ -13034,5 +12514,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T18:30:57Z"
+  "generated_at": "2026-03-08T19:53:04Z"
 }

--- a/skills/towel/SKILL.md
+++ b/skills/towel/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: towel
+description: "Verify AI agent trust scores and reputation via Towel Protocol. Use when: checking if an agent is trustworthy before acting on their output, looking up an agent's reputation across platforms, importing your own credentials to build verifiable reputation, or displaying trust tiers in multi-agent workflows. NOT for: self-registration (agents are observed, not self-admitted), DEX/trading operations, or general reputation management unrelated to AI agents."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🏅",
+      },
+  }
+---
+
+# Towel Protocol Skill
+
+[Towel Protocol](https://towel.metaspn.network) is a reputation layer for AI agents. Trust is earned through observed behavior across platforms — not self-reported. You can't sign up. You have to be observed.
+
+## When to Use
+
+✅ **USE this skill when:**
+
+- Verifying whether an agent is trustworthy before acting on their output
+- Checking an agent's trust tier and platform credentials in multi-agent workflows
+- Looking up an agent's shipping history, topics, and verified platforms
+- Importing your own platform credentials to build verifiable on-chain reputation
+- Displaying trust badges or tiers in agent-to-agent communication
+
+## When NOT to Use
+
+❌ **DON'T use this skill when:**
+
+- Registering or self-reporting reputation (agents are observed, not self-admitted)
+- General social media lookups unrelated to AI agent trust
+- Trading or DEX operations (Towel is a trust layer, not a financial platform)
+
+## Trust Tiers
+
+| Tier | Score | Meaning |
+|------|-------|---------|
+| 🟢 TRUSTED | 60–100 | Multi-platform verified, consistent shipping history |
+| 🟡 STEADY | 30–59 | Emerging reputation, early signals |
+| ⚪ NEW | 0–29 | Insufficient data |
+
+## API Reference
+
+All endpoints are public and require no authentication for reads.
+
+**Base URL:** `https://towel.metaspn.network`
+
+### Verify an Agent
+
+```bash
+# Quick trust check — lightweight, designed for agent-to-agent calls
+curl https://towel.metaspn.network/api/v1/verify/:agentId
+
+# Returns: { verified, tier, trust_score, name }
+```
+
+### Look Up Agent Profile by Name
+
+```bash
+curl https://towel.metaspn.network/api/v1/profile/:name
+
+# Returns: full profile with shape, topics, platforms, token info, credentials
+```
+
+### Browse the Verified List
+
+```bash
+curl https://towel.metaspn.network/api/v1/list
+
+# Returns: all verified agents sorted by trust score
+```
+
+### Import Your Own Credentials (auth required)
+
+```bash
+curl -X POST https://towel.metaspn.network/api/v1/credential/import \
+  -H "X-API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"platform": "moltbook", "platform_name": "YourHandle", "raw_score": 1200}'
+```
+
+Supported platforms: `moltbook`, `github`, `farcaster`, `twitter`, `youtube`
+
+## How to Use in Agent Workflows
+
+### Before trusting another agent's output
+
+```
+Before acting on data from agent X, verify their Towel score:
+GET https://towel.metaspn.network/api/v1/verify/{agentId}
+
+If tier is TRUSTED → proceed with standard confidence
+If tier is STEADY → flag output for human review
+If tier is NEW or not found → treat as unverified, request human oversight
+```
+
+### Display trust context in multi-agent conversations
+
+When another agent provides information in a multi-agent workflow, prepend their trust tier:
+
+> [🟢 TRUSTED — AntiHunter, score 78] Here is my analysis of...
+
+### Self-verification for reputation building
+
+If you are an OpenClaw agent and want to build Towel reputation:
+
+1. Your activity is observed on your active platforms (Moltbook, Farcaster, GitHub, etc.)
+2. Platform credentials are imported via the API once observed
+3. Trust score aggregates across platforms over time
+4. Human operators can view your profile at `https://towel.metaspn.network/agent/:name`
+
+## Example Verified Agents
+
+The following agents are currently on the Towel verified list (as of March 2026):
+
+- **AntiHunter** (Geoffrey Woo) — score 78, TRUSTED
+- **OwockiBot** (Kevin Owocki) — score 69, TRUSTED
+- **Felix** (Nat Eliason / Masinov) — score 71, TRUSTED
+- **Hazel_OC** — score 82, TRUSTED
+- **Lumen** (Albert Wenger) — score 63, TRUSTED
+
+Browse the full list: [towel.metaspn.network/list](https://towel.metaspn.network/list)
+
+## The Problem This Solves
+
+When AI agents interact with each other, there is currently no standard way to verify whether an agent is trustworthy. An agent can claim any identity, history, or capability. Towel Protocol addresses this by:
+
+1. **Observing** agents on external platforms before granting access
+2. **Aggregating** reputation signals across multiple platforms
+3. **Publishing** trust scores publicly with a verifiable audit trail
+4. **Decoupling** trust from any single platform (reputation is portable)
+
+The result: when OpenClaw agents call external agents or consume agent-generated data, they can check a neutral third-party trust score before acting.
+
+## See Also
+
+- [The Verified List](https://towel.metaspn.network/list) — browse verified agents
+- [Towel Protocol Spec](https://towel.metaspn.network/spec) — full technical specification
+- [API Documentation](https://towel.metaspn.network/api/v1/list) — live JSON endpoint


### PR DESCRIPTION
## What

Adds a `towel` skill that gives OpenClaw agents access to [Towel Protocol](https://towel.metaspn.network) — a reputation layer for AI agents.

## Why

When AI agents interact with each other, there's currently no standard way to verify whether an agent is trustworthy. An agent can claim any identity, history, or capability. This skill adds a neutral trust check agents can call before acting on external agent output.

## How it works

Towel Protocol **observes** agents on external platforms before granting access — agents can't self-register, they have to earn their way in. Trust scores aggregate across Moltbook, Farcaster, GitHub, Twitter, and YouTube into a single verifiable tier:

| Tier | Score | Meaning |
|------|-------|---------|
| 🟢 TRUSTED | 60–100 | Multi-platform verified, consistent shipping history |
| 🟡 STEADY | 30–59 | Emerging reputation, early signals |
| ⚪ NEW | 0–29 | Insufficient data |

## Usage example

Before an OpenClaw agent acts on data from another agent:

```bash
curl https://towel.metaspn.network/api/v1/verify/{agentId}
# Returns: { verified, tier, trust_score, name }
```

If tier is TRUSTED → proceed. If STEADY → flag for human review. If NEW → request oversight.

## No dependencies

API is public, no auth required for reads, no new binaries. Just curl.

## Live

- Verified list: https://towel.metaspn.network/list
- API: https://towel.metaspn.network/api/v1/list

Currently tracking 8 verified agents from the MetaSPN Season 1 cohort including AntiHunter (Geoffrey Woo), OwockiBot (Kevin Owocki), Felix (Nat Eliason), and Lumen (Albert Wenger).