### PR TITLE
fix(loop-detection): clear stale toolCallHistory across heartbeat cycles

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -591,4 +591,27 @@ describe("tool-loop-detection", () => {
       expect(stats.mostFrequent?.count).toBe(7);
     });
   });
+
+  describe("stale history clearing", () => {
+    it("clears history when last call is older than 2 minutes", () => {
+      const state = createState();
+      recordToolCall(state, "read", { path: "/a.txt" }, "call-1");
+      expect(state.toolCallHistory).toHaveLength(1);
+
+      // Simulate time passing (>2 minutes)
+      state.toolCallHistory![0].timestamp = Date.now() - 130_000;
+
+      recordToolCall(state, "read", { path: "/b.txt" }, "call-2");
+      // History should have been cleared before adding new call
+      expect(state.toolCallHistory).toHaveLength(1);
+      expect(state.toolCallHistory![0].toolCallId).toBe("call-2");
+    });
+
+    it("preserves history when last call is recent", () => {
+      const state = createState();
+      recordToolCall(state, "read", { path: "/a.txt" }, "call-1");
+      recordToolCall(state, "read", { path: "/b.txt" }, "call-2");
+      expect(state.toolCallHistory).toHaveLength(2);
+    });
+  });
 });

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -495,8 +495,17 @@ export function detectToolCallLoop(
 }
 
 /**
+ * If the most recent recorded tool call is older than this threshold,
+ * the history is considered stale (e.g. from a previous heartbeat cycle)
+ * and is cleared to prevent false-positive loop detection.
+ */
+const STALE_HISTORY_THRESHOLD_MS = 120_000; // 2 minutes
+
+/**
  * Record a tool call in the session's history for loop detection.
  * Maintains sliding window of last N calls.
+ * Clears stale history when there is a significant time gap between calls
+ * (e.g. across separate heartbeat cycles).
  */
 export function recordToolCall(
   state: SessionState,
@@ -507,6 +516,12 @@ export function recordToolCall(
 ): void {
   const resolvedConfig = resolveLoopDetectionConfig(config);
   if (!state.toolCallHistory) {
+    state.toolCallHistory = [];
+  }
+
+  // Clear stale history from previous heartbeat/session cycles
+  const lastCall = state.toolCallHistory.at(-1);
+  if (lastCall?.timestamp && Date.now() - lastCall.timestamp > STALE_HISTORY_THRESHOLD_MS) {
     state.toolCallHistory = [];
   }
 


### PR DESCRIPTION
## Summary

Fixes #40144.

`toolCallHistory` in session state persists across heartbeat cycles. When a heartbeat runs every 5 minutes, tool calls from the previous cycle accumulate in the history array. If the next heartbeat calls similar tools (which heartbeats often do), the loop detector counts them against the accumulated total and fires a false positive.

**Before:** `recordToolCall()` never checks whether existing history entries are stale. A heartbeat that ran 5 minutes ago is a completely separate logical turn, but the detector treats it as a continuation.

**After:** Added a staleness check in `recordToolCall()`. When the most recent history entry is older than 2 minutes, the history is cleared before recording the new call. This ensures separate heartbeat cycles are evaluated independently while preserving detection within a single continuous session.

The 2-minute threshold is conservative — heartbeat intervals are typically 5+ minutes, and normal tool call sequences within a single turn happen within seconds.

## Test plan

- [x] Added unit tests for stale history clearing behavior
- [x] All 31 existing loop detection tests pass
- [ ] Manual: configure a heartbeat with 5m interval and verify no false-positive loop detection after 2-3 cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)