### PR TITLE
docs: remove broken navigation entries for missing install pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -876,10 +876,7 @@
                   "install/hetzner",
                   "install/gcp",
                   "install/macos-vm",
-                  "install/exe-dev",
-                  "install/railway",
-                  "install/render",
-                  "install/northflank"
+                  "install/exe-dev"
                 ]
               },
               {
@@ -1475,10 +1472,7 @@
                   "zh-CN/install/hetzner",
                   "zh-CN/install/gcp",
                   "zh-CN/install/macos-vm",
-                  "zh-CN/install/exe-dev",
-                  "zh-CN/install/railway",
-                  "zh-CN/install/render",
-                  "zh-CN/install/northflank"
+                  "zh-CN/install/exe-dev"
                 ]
               },
               {


### PR DESCRIPTION
## Summary

Removes three navigation entries from `docs/docs.json` that reference pages which do not exist:

- `install/railway` (no `docs/install/railway.md`)
- `install/render` (no `docs/install/render.md`)
- `install/northflank` (no `docs/install/northflank.md`)

Also removes the corresponding `zh-CN/install/` entries.

These broken references cause Mintlify to display empty/broken navigation links in the "Hosting and deployment" section.

## Test plan

- [ ] Verify docs build succeeds without warnings for missing pages
- [ ] Confirm the "Hosting and deployment" nav section renders correctly with remaining entries (fly, hetzner, gcp, macos-vm, exe-dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)