### PR TITLE
fix(heartbeat): normalize system event session keys to lowercase

### DIFF
--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -68,6 +68,38 @@ describe("system events (session routing)", () => {
     expect(() => enqueueSystemEvent("Node: Mac Studio", { sessionKey: " " })).toThrow("sessionKey");
   });
 
+  it("normalizes session key case so channel sessions match", () => {
+    // Plugins may pass mixed-case keys (Slack channel IDs are uppercase),
+    // but the heartbeat runner normalizes to lowercase via parseAgentSessionKey.
+    // Without case normalization, events enqueued with mixed case are invisible
+    // to peek/drain calls using the canonical lowercase key. (#34338)
+    enqueueSystemEvent("CI passed on PR #365", {
+      sessionKey: "agent:main:slack:channel:C0AKA9RBSAU",
+    });
+
+    // Lookup with lowercase (as the heartbeat runner does) must find the event
+    expect(peekSystemEvents("agent:main:slack:channel:c0aka9rbsau")).toEqual([
+      "CI passed on PR #365",
+    ]);
+
+    // Lookup with original mixed case must also find the event
+    expect(peekSystemEvents("agent:main:slack:channel:C0AKA9RBSAU")).toEqual([
+      "CI passed on PR #365",
+    ]);
+  });
+
+  it("deduplicates across case variants of the same session key", () => {
+    enqueueSystemEvent("event one", {
+      sessionKey: "agent:main:slack:channel:C0XX",
+    });
+    enqueueSystemEvent("event two", {
+      sessionKey: "agent:main:slack:channel:c0xx",
+    });
+
+    // Both events should be in the same queue
+    expect(peekSystemEvents("agent:main:slack:channel:c0xx")).toEqual(["event one", "event two"]);
+  });
+
   it("returns false for consecutive duplicate events", () => {
     const first = enqueueSystemEvent("Node connected", { sessionKey: "agent:main:main" });
     const second = enqueueSystemEvent("Node connected", { sessionKey: "agent:main:main" });

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -41,7 +41,15 @@ function requireSessionKey(key?: string | null): string {
   if (!trimmed) {
     throw new Error("system events require a sessionKey");
   }
-  return trimmed;
+  // Normalize to lowercase for case-insensitive matching.
+  // Session keys are canonicalized to lowercase by parseAgentSessionKey()
+  // throughout the codebase, but callers (e.g. plugins) may pass keys with
+  // mixed case (Slack channel IDs like C0AKA9RBSAU). Without normalization,
+  // enqueueSystemEvent("...", {sessionKey: "agent:main:slack:channel:C0XX"})
+  // stores under the mixed-case key while peekSystemEventEntries() and
+  // drainSystemEventEntries() look up the lowercase canonical form — causing
+  // events to silently disappear for channel sessions.
+  return trimmed.toLowerCase();
 }
 
 function normalizeContextKey(key?: string | null): string | null {


### PR DESCRIPTION
## Summary

- **Problem:** `requestHeartbeatNow({ sessionKey })` silently produces no visible output for channel sessions (`agent:main:slack:channel:*`) while working correctly for main/thread sessions.
- **Why it matters:** Plugins (like event bridges) that use `requestHeartbeatNow` to wake channel sessions cannot reliably deliver system events — the events sit in the queue indefinitely and the heartbeat turn is pruned as if nothing happened.
- **What changed:** `requireSessionKey()` in `system-events.ts` now lowercases the key, matching the canonical form used by `parseAgentSessionKey()` throughout the codebase. Two new tests verify cross-case enqueue/peek and deduplication.
- **What did NOT change:** No changes to the heartbeat runner, wake mechanism, or session resolution. The fix is scoped entirely to the system events in-memory queue.

## Change Type

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no behavior change)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## Scope

- [x] Core functionality
- [ ] Channel (Slack, Telegram, etc.)
- [ ] CLI
- [ ] UI (Control Panel / Settings)
- [ ] Documentation
- [ ] Infrastructure / CI

## Linked Issue/PR

Closes #34338

## User-visible / Behavior Changes

System events enqueued with mixed-case session keys (e.g., Slack channel IDs like `C0AKA9RBSAU`) are now correctly found by the heartbeat runner's peek/drain calls. Previously, the heartbeat runner normalized session keys to lowercase via `parseAgentSessionKey()` but the system events queue stored them verbatim — causing a key mismatch for any session key containing uppercase characters.

**Before:** Plugin enqueues event → heartbeat fires → event not found (case mismatch) → model responds HEARTBEAT_OK → turn pruned → appears as "no heartbeat turn ran"

**After:** Plugin enqueues event → key normalized to lowercase → heartbeat finds event → model acts on it → visible output

## Security Impact

1. Does this change handle user input? **No**
2. Does it affect authentication or authorization? **No**
3. Does it introduce new API endpoints? **No**
4. Does it change data storage or handling? **No** (in-memory map only)
5. Does it affect cryptographic operations? **No**

## Repro + Verification

**Environment:** Any setup with a plugin calling `requestHeartbeatNow` for a channel session.

**Steps to reproduce (before fix):**
1. Enqueue a system event targeting a channel session: `enqueueSystemEvent("test", { sessionKey: "agent:main:slack:channel:C0XX" })`
2. Peek with the canonical lowercase key: `peekSystemEvents("agent:main:slack:channel:c0xx")`
3. Returns `[]` — event is invisible

**Expected:** Event should be found regardless of key casing.

**Actual (after fix):** `peekSystemEvents("agent:main:slack:channel:c0xx")` returns `["test"]` ✅

## Evidence

New tests added to `src/infra/system-events.test.ts`:

- `normalizes session key case so channel sessions match` — enqueues with uppercase Slack ID, peeks with lowercase, verifies match
- `deduplicates across case variants of the same session key` — enqueues from two case variants, verifies both land in the same queue

```
 ✓ src/infra/system-events.test.ts (13 tests) 20ms
 ✓ src/infra/heartbeat-runner.scheduler.test.ts (8 tests) 31ms
 ✓ src/infra/heartbeat-wake.test.ts (13 tests) 25ms
```

All 34 tests pass across system-events, heartbeat-runner scheduler, and heartbeat-wake.

## Human Verification

- Traced the full call chain from `requestHeartbeatNow()` → heartbeat-wake → heartbeat-runner → `runHeartbeatOnce()` → `resolveHeartbeatSession()` → `peekSystemEventEntries()` → `getReplyFromConfig()` → `drainSystemEventEntries()`
- Confirmed that `parseAgentSessionKey()` (used by `resolveHeartbeatSession`) lowercases all keys, while `requireSessionKey()` (used by system events) did not
- Verified that main/thread session keys are already lowercase, explaining why only channel sessions are affected
- Did NOT verify with a live Hermes plugin end-to-end (would require a multi-container test setup)

## Compatibility / Migration

Fully backward compatible. The only behavioral change is that system event keys are now case-insensitive. Any code already passing lowercase keys sees no change. Code passing mixed-case keys now works correctly instead of silently failing.

## Failure Recovery

One-line revert in `requireSessionKey()` (change `return trimmed.toLowerCase()` back to `return trimmed`). No data migration — system events are ephemeral (in-memory only).

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Existing code relies on case-sensitive system event keys | Extremely unlikely — all session key generation normalizes to lowercase. The mixed-case path was a bug, not a feature. |
| Performance impact of `.toLowerCase()` on every system event call | Negligible — called at most ~20 times per session per heartbeat cycle on short strings |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) · AI-assisted: fully tested with existing + new unit tests, code traced end-to-end through the heartbeat pipeline.
