### PR TITLE
fix(macos): stop relaunching the app after quit when launch-at-login is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Docs: https://docs.openclaw.ai
 - Agents/bootstrap warnings: move bootstrap truncation warnings out of the system prompt and into the per-turn prompt body so prompt-cache reuse stays stable when truncation warnings appear or disappear. (#48753) Thanks @scoootscooob and @obviyus.
 - Telegram/DM topic session keys: route named-account DM topics through the same per-account base session key across inbound messages, native commands, and session-state lookups so `/status` and thread recovery stop creating phantom `agent:main:main:thread:...` sessions. (#48204) Thanks @vincentkoc.
 - macOS/node service startup: use `openclaw node start/stop --json` from the Mac app instead of the removed `openclaw service node ...` command shape, so current CLI installs expose the full node exec surface again. (#46843) Fixes #43171. Thanks @Br1an67.
+- macOS/launch at login: stop emitting `KeepAlive` for the desktop app launch agent so OpenClaw no longer relaunches immediately after a manual quit while launch at login remains enabled. (#40213) Thanks @stablegenius49.
 
 ## 2026.3.13
 

--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -26,7 +26,12 @@ enum LaunchAgentManager {
     }
 
     private static func writePlist(bundlePath: String) {
-        let plist = """
+        let plist = self.plistContents(bundlePath: bundlePath)
+        try? plist.write(to: self.plistURL, atomically: true, encoding: .utf8)
+    }
+
+    static func plistContents(bundlePath: String) -> String {
+        """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">
@@ -41,8 +46,6 @@ enum LaunchAgentManager {
           <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>
           <key>RunAtLoad</key>
           <true/>
-          <key>KeepAlive</key>
-          <true/>
           <key>EnvironmentVariables</key>
           <dict>
             <key>PATH</key>
@@ -55,7 +58,6 @@ enum LaunchAgentManager {
         </dict>
         </plist>
         """
-        try? plist.write(to: self.plistURL, atomically: true, encoding: .utf8)
     }
 
     @discardableResult

--- a/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct LaunchAgentManagerTests {
+    @Test func `launch at login plist does not keep app alive after manual quit`() throws {
+        let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
+        let data = try #require(plist.data(using: .utf8))
+        let object = try #require(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        #expect(object["RunAtLoad"] as? Bool == true)
+        #expect(object["KeepAlive"] == nil)
+
+        let args = try #require(object["ProgramArguments"] as? [String])
+        #expect(args == ["/Applications/OpenClaw.app/Contents/MacOS/OpenClaw"])
+    }
+}


### PR DESCRIPTION
## Summary
- remove `KeepAlive` from the macOS app launch-at-login plist so launchd does not immediately restart OpenClaw after a manual quit
- factor plist generation into a testable helper
- add a regression test asserting the generated plist keeps `RunAtLoad` but does not emit `KeepAlive`

## Verification
- source-level verification: confirmed the generated launch-at-login plist no longer contains `KeepAlive`
- added regression test coverage for plist generation
- could not run `swift test` in this environment because the installed Command Line Tools Swift is 6.1.0 while `apps/macos/Package.swift` requires Swift tools 6.2.0

Closes #39868.
