### PR TITLE
fix: suppress undici TLS session null-deref as transient uncaughtException

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -6,7 +6,10 @@ import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isTransientNetworkError,
+} from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
 import { getCommandPathWithRootOptions, getPrimaryCommand, hasHelpOrVersion } from "./argv.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
@@ -107,6 +110,15 @@ export async function runCli(argv: string[] = process.argv) {
     installUnhandledRejectionHandler();
 
     process.on("uncaughtException", (error) => {
+      // Transient network errors (e.g. undici TLS session null-deref on reconnect)
+      // should not take down the gateway — log and continue.
+      if (isTransientNetworkError(error)) {
+        console.warn(
+          "[openclaw] Suppressed transient uncaught exception:",
+          formatUncaughtError(error),
+        );
+        return;
+      }
       console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
       process.exit(1);
     });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -117,6 +117,9 @@ export async function runCli(argv: string[] = process.argv) {
           "[openclaw] Suppressed transient uncaught exception:",
           formatUncaughtError(error),
         );
+        // Ensure one-shot CLI commands still surface a non-zero status if the
+        // event loop drains; long-running gateway processes keep running normally.
+        process.exitCode = 1;
         return;
       }
       console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ import {
   PortInUseError,
 } from "./infra/ports.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isTransientNetworkError,
+} from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
 import { runCommandWithTimeout, runExec } from "./process/exec.js";
 import { assertWebChannel, normalizeE164, toWhatsappJid } from "./utils.js";
@@ -82,6 +85,15 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    // Transient network errors (e.g. undici TLS session null-deref on reconnect)
+    // should not take down the gateway — log and continue.
+    if (isTransientNetworkError(error)) {
+      console.warn(
+        "[openclaw] Suppressed transient uncaught exception:",
+        formatUncaughtError(error),
+      );
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,9 @@ if (isMain) {
         "[openclaw] Suppressed transient uncaught exception:",
         formatUncaughtError(error),
       );
+      // Ensure one-shot CLI commands still surface a non-zero status if the
+      // event loop drains; long-running gateway processes keep running normally.
+      process.exitCode = 1;
       return;
     }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAbortError, isTransientNetworkError } from "./unhandled-rejections.js";
+import {
+  isAbortError,
+  isTransientNetworkError,
+  isTlsSocketNullDeref,
+} from "./unhandled-rejections.js";
 
 describe("isAbortError", () => {
   it("returns true for error with name AbortError", () => {
@@ -178,5 +182,82 @@ describe("isTransientNetworkError", () => {
   it("returns false for AggregateError with only non-network errors", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
+  });
+
+  it("returns true for undici TLS session null-deref TypeError (Node 18+ message)", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+      "    at Client.connect (undici/lib/core/connect.js:70:20)",
+    ].join("\n");
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("returns true for undici TLS session null-deref TypeError (Node <18 message)", () => {
+    const err = new TypeError("Cannot read property 'setSession' of null");
+    err.stack = [
+      "TypeError: Cannot read property 'setSession' of null",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+    ].join("\n");
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("returns false for unrelated TypeErrors that mention null", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'toString')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'toString')",
+      "    at someAppCode (/app/src/foo.ts:10:5)",
+    ].join("\n");
+    expect(isTransientNetworkError(err)).toBe(false);
+  });
+});
+
+describe("isTlsSocketNullDeref", () => {
+  it("returns true for Node 18+ TLS setSession null-deref", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+    ].join("\n");
+    expect(isTlsSocketNullDeref(err)).toBe(true);
+  });
+
+  it("returns true for Node <18 TLS setSession null-deref", () => {
+    const err = new TypeError("Cannot read property 'setSession' of null");
+    err.stack = [
+      "TypeError: Cannot read property 'setSession' of null",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+    ].join("\n");
+    expect(isTlsSocketNullDeref(err)).toBe(true);
+  });
+
+  it("returns false when stack has no _tls_wrap or TLSSocket reference", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at someApp (/app/src/foo.ts:5:1)",
+    ].join("\n");
+    expect(isTlsSocketNullDeref(err)).toBe(false);
+  });
+
+  it("returns false for non-TypeError errors", () => {
+    const err = new Error("Cannot read properties of null (reading 'setSession')");
+    (err as unknown as { stack: string }).stack =
+      "Error\n    at TLSSocket.setSession (node:_tls_wrap:1132:16)";
+    expect(isTlsSocketNullDeref(err)).toBe(false);
+  });
+
+  it("returns false for TypeErrors unrelated to setSession", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'length')");
+    err.stack = "TypeError\n    at TLSSocket.foo (node:_tls_wrap:10:1)";
+    expect(isTlsSocketNullDeref(err)).toBe(false);
+  });
+
+  it.each([null, undefined, "string", 42])("returns false for non-Error input %#", (value) => {
+    expect(isTlsSocketNullDeref(value)).toBe(false);
   });
 });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -251,6 +251,16 @@ describe("isTlsSocketNullDeref", () => {
     expect(isTlsSocketNullDeref(err)).toBe(false);
   });
 
+  it("returns true when stack contains only node:_tls_wrap (no TLSSocket.setSession frame)", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+      "    at Client.connect (undici/lib/core/connect.js:70:20)",
+    ].join("\n");
+    expect(isTlsSocketNullDeref(err)).toBe(true);
+  });
+
   it("returns false for TypeErrors unrelated to setSession", () => {
     const err = new TypeError("Cannot read properties of null (reading 'length')");
     err.stack = "TypeError\n    at TLSSocket.foo (node:_tls_wrap:10:1)";

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -77,6 +77,32 @@ function isWrappedFetchFailedMessage(message: string): boolean {
   return /:\s*fetch failed$/.test(message);
 }
 
+/**
+ * Detects the undici TLS session null-dereference crash that occurs when undici's
+ * reconnect path calls tls.connect() with a stale WeakRef-cached session whose
+ * internal _handle has already been destroyed.
+ *
+ * Stack: TLSSocket.setSession (node:_tls_wrap) ← Object.connect ← undici connect.js
+ *
+ * This is a transient condition — the session cache entry becomes invalid after
+ * a socket close under concurrent load; the next request will succeed without
+ * a cached session. Exiting the process is unnecessary and causes crash-loops
+ * when the network is still unstable at restart.
+ */
+export function isTlsSocketNullDeref(err: unknown): boolean {
+  if (!(err instanceof TypeError)) {
+    return false;
+  }
+  const msg = err.message ?? "";
+  // Node 18+: "Cannot read properties of null (reading 'setSession')"
+  // Node <18:  "Cannot read property 'setSession' of null"
+  if (!msg.includes("setSession")) {
+    return false;
+  }
+  const stack = err.stack ?? "";
+  return stack.includes("TLSSocket.setSession") || stack.includes("_tls_wrap");
+}
+
 function getErrorCause(err: unknown): unknown {
   if (!err || typeof err !== "object") {
     return undefined;
@@ -168,6 +194,11 @@ export function isTransientNetworkError(err: unknown): boolean {
 
     const name = readErrorName(candidate);
     if (name && TRANSIENT_NETWORK_ERROR_NAMES.has(name)) {
+      return true;
+    }
+
+    // undici TLS session null dereference during socket reconnect — transient
+    if (isTlsSocketNullDeref(candidate)) {
       return true;
     }
 

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -100,7 +100,7 @@ export function isTlsSocketNullDeref(err: unknown): boolean {
     return false;
   }
   const stack = err.stack ?? "";
-  return stack.includes("TLSSocket.setSession") || stack.includes("_tls_wrap");
+  return stack.includes("TLSSocket.setSession") || stack.includes("node:_tls_wrap");
 }
 
 function getErrorCause(err: unknown): unknown {


### PR DESCRIPTION
## Summary

Fixes #36585 — Gateway crashes with `TypeError: Cannot read properties of null (reading 'setSession')` when undici's reconnect path calls `tls.connect()` with a stale WeakRef-cached TLS session whose internal `_handle` has already been destroyed.

**Root cause:** Node's `TLSSocket.setSession` dereferences `this._handle` without a null guard. Under concurrent subagent load, a socket close can race with undici's reconnect, leaving the cached session handle invalid by the time `setSession` runs. The resulting `TypeError` is an `uncaughtException` that hits the global handler → `process.exit(1)` → crash loop when the network is still unstable.

**Fix — three cooperating changes:**

1. `src/infra/unhandled-rejections.ts` — export `isTlsSocketNullDeref(err)`, a narrow detector for this specific error: must be a `TypeError`, message must include `setSession`, stack must include `TLSSocket.setSession` or `_tls_wrap`. Wire it into `isTransientNetworkError` so it is also swallowed as a transient unhandled rejection.

2. `src/cli/run-main.ts` and `src/index.ts` — update the `uncaughtException` handler to call `isTransientNetworkError(error)` before exiting. Transient errors (including the TLS deref) are logged as warnings and do not exit the process.

3. `src/infra/unhandled-rejections.test.ts` — 10 new test cases covering `isTlsSocketNullDeref` (positive/negative) and the two message variants (`Cannot read properties of null` / `Cannot read property ... of null`).

## Test plan

- [x] `pnpm test src/infra/unhandled-rejections.test.ts` — all 41 tests pass (10 new)
- [x] Lint/format clean

## Notes

The fix is intentionally narrow — the detector requires the stack fingerprint from Node internals (`_tls_wrap`/`TLSSocket.setSession`) so that unrelated `setSession` calls in application code are not silently swallowed. The undici TODO in `connect.js` ("Can a session become invalid once established?") confirms this is a known upstream gap; this handler is the correct defensive layer until undici adds its own null guard.

**Note:** This is a resubmission of #36588 (auto-closed due to PR queue limit). This PR was submitted first for issue #36585 on Mar 5 at 18:58 UTC — 4 other PRs were submitted after.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
