### PR TITLE
fix(ci): restore branch-scoped secrets scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,12 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,8 @@ repos:
           - '"ap[i]Key": "xxxxx"(,)?'
           - --exclude-lines
           - 'ap[i]Key: "A[I]za\.\.\.",'
+          - --exclude-lines
+          - '"ap[i]Key": "(resolved|normalized|legacy)-key"(,)?'
   # Shell script linting
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -152,7 +152,8 @@
         "grep -q 'N[O]DE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache' ~/.bashrc \\|\\| cat >> ~/.bashrc <<'EOF'",
         "env: \\{ MISTRAL_API_K[E]Y: \"sk-\\.\\.\\.\" \\},",
         "\"ap[i]Key\": \"xxxxx\"(,)?",
-        "ap[i]Key: \"A[I]za\\.\\.\\.\","
+        "ap[i]Key: \"A[I]za\\.\\.\\.\",",
+        "\"ap[i]Key\": \"(resolved|normalized|legacy)-key\"(,)?"
       ]
     },
     {
@@ -11515,14 +11516,14 @@
         "filename": "src/agents/models-config.providers.nvidia.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       },
       {
         "type": "Secret Keyword",
         "filename": "src/agents/models-config.providers.nvidia.test.ts",
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 23
       }
     ],
     "src/agents/models-config.providers.ollama.e2e.test.ts": [
@@ -13034,5 +13035,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T18:30:57Z"
+  "generated_at": "2026-03-08T20:08:19Z"
 }

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -43,7 +43,7 @@ struct AppStateRemoteConfigTests {
                     "transport": "direct",
                     "url": "wss://old-gateway.example",
                     "token": [
-                        "$secretRef": "gateway-token",
+                        "$secretRef": "gateway-token", // pragma: allowlist secret
                     ],
                 ],
             ],
@@ -59,7 +59,7 @@ struct AppStateRemoteConfigTests {
             remoteToken: "",
             remoteTokenDirty: false)
         let sshRemote = (sshRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
-        #expect((sshRemote?["token"] as? [String: String])?["$secretRef"] == "gateway-token")
+        #expect((sshRemote?["token"] as? [String: String])?["$secretRef"] == "gateway-token") // pragma: allowlist secret
 
         let localRoot = AppState._testSyncedGatewayRoot(
             currentRoot: sshRoot,
@@ -73,7 +73,7 @@ struct AppStateRemoteConfigTests {
         let localGateway = localRoot["gateway"] as? [String: Any]
         let localRemote = localGateway?["remote"] as? [String: Any]
         #expect(localGateway?["mode"] as? String == "local")
-        #expect((localRemote?["token"] as? [String: String])?["$secretRef"] == "gateway-token")
+        #expect((localRemote?["token"] as? [String: String])?["$secretRef"] == "gateway-token") // pragma: allowlist secret
     }
 
     @Test
@@ -81,7 +81,7 @@ struct AppStateRemoteConfigTests {
         let remote = AppState._testUpdatedRemoteGatewayConfig(
             current: [
                 "token": [
-                    "$secretRef": "gateway-token",
+                    "$secretRef": "gateway-token", // pragma: allowlist secret
                 ],
             ],
             transport: .direct,
@@ -99,7 +99,7 @@ struct AppStateRemoteConfigTests {
     func updatedRemoteGatewayConfigClearsObjectTokenOnlyAfterExplicitEdit() {
         let current: [String: Any] = [
             "token": [
-                "$secretRef": "gateway-token",
+                "$secretRef": "gateway-token", // pragma: allowlist secret
             ],
         ]
 
@@ -112,7 +112,7 @@ struct AppStateRemoteConfigTests {
             remoteIdentity: "",
             remoteToken: "",
             remoteTokenDirty: false)
-        #expect((preserved["token"] as? [String: String])?["$secretRef"] == "gateway-token")
+        #expect((preserved["token"] as? [String: String])?["$secretRef"] == "gateway-token") // pragma: allowlist secret
 
         let cleared = AppState._testUpdatedRemoteGatewayConfig(
             current: current,

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -22,7 +22,7 @@ describe("models-config", () => {
           models: { providers: {} },
           env: {
             vars: {
-              OPENROUTER_API_KEY: "from-config",
+              OPENROUTER_API_KEY: "from-config", // pragma: allowlist secret
               [TEST_ENV_VAR]: "from-config",
             },
           },
@@ -44,13 +44,13 @@ describe("models-config", () => {
   it("does not overwrite already-set host env vars while ensuring models.json", async () => {
     await withTempHome(async () => {
       await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
-        process.env.OPENROUTER_API_KEY = "from-host";
+        process.env.OPENROUTER_API_KEY = "from-host"; // pragma: allowlist secret
         process.env[TEST_ENV_VAR] = "from-host";
         const cfg: OpenClawConfig = {
           models: { providers: {} },
           env: {
             vars: {
-              OPENROUTER_API_KEY: "from-config",
+              OPENROUTER_API_KEY: "from-config", // pragma: allowlist secret
               [TEST_ENV_VAR]: "from-config",
             },
           },

--- a/src/agents/models-config.providers.matrix.test.ts
+++ b/src/agents/models-config.providers.matrix.test.ts
@@ -39,7 +39,7 @@ async function writeAuthProfiles(
 const MATRIX_CASES: MatrixCase[] = [
   {
     name: "env api key injects a simple provider",
-    env: { NVIDIA_API_KEY: "test-nvidia-key" },
+    env: { NVIDIA_API_KEY: "test-nvidia-key" }, // pragma: allowlist secret
     assertProviders(providers) {
       expect(providers?.nvidia?.apiKey).toBe("NVIDIA_API_KEY");
       expect(providers?.nvidia?.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
@@ -48,7 +48,7 @@ const MATRIX_CASES: MatrixCase[] = [
   },
   {
     name: "env api key injects paired plan providers",
-    env: { VOLCANO_ENGINE_API_KEY: "test-volcengine-key" },
+    env: { VOLCANO_ENGINE_API_KEY: "test-volcengine-key" }, // pragma: allowlist secret
     assertProviders(providers) {
       expect(providers?.volcengine?.apiKey).toBe("VOLCANO_ENGINE_API_KEY");
       expect(providers?.["volcengine-plan"]?.apiKey).toBe("VOLCANO_ENGINE_API_KEY");
@@ -116,7 +116,7 @@ const MATRIX_CASES: MatrixCase[] = [
   },
   {
     name: "explicit vllm config suppresses implicit vllm injection",
-    env: { VLLM_API_KEY: "test-vllm-key" },
+    env: { VLLM_API_KEY: "test-vllm-key" }, // pragma: allowlist secret
     explicitProviders: {
       vllm: {
         baseUrl: "http://127.0.0.1:8000/v1",


### PR DESCRIPTION
## Summary

- Problem: the `secrets` job used a shallow checkout on PR branches without fetching `github.event.pull_request.base.sha`, so branch runs frequently fell back to a full `detect-secrets` scan.
- Why it matters: branch PRs were failing on unrelated repo-wide false positives instead of scanning touched files, while `main` still had separate full-scan baseline churn.
- What changed: added the same base-commit fetch step used by other scoped jobs, added narrow false-positive allowlists for the current fixtures, and refreshed `.secrets.baseline` line-number metadata.
- What did NOT change (scope boundary): push-to-`main` still runs the full `detect-secrets` scan, and no runtime secret-handling behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

None.

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  CI secret scanning now reliably uses the PR base commit on branch runs, while `main` continues to run the existing full-repo scan. The fixture allowlists are intentionally narrow and limited to test-only false positives.

## Repro + Verification

### Environment

- OS: macOS 15.4.1
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions CI
- Relevant config (redacted): default repo CI config

### Steps

1. Inspect recent failing `CI` runs for the `secrets` job.
2. Verify that PR jobs fall back to `pre-commit run --all-files detect-secrets` when the PR base SHA is missing from the shallow checkout.
3. Patch the workflow to fetch the base commit and narrow the false-positive fixture allowlists.
4. Re-run the relevant local checks.

### Expected

- PR branches scan touched files against the fetched base commit.
- Pushes to `main` keep the full scan.
- The current fixture false positives no longer fail `detect-secrets`.

### Actual

- Verified locally with:
  - `pre-commit run detect-secrets --files .github/workflows/ci.yml .pre-commit-config.yaml apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.providers.matrix.test.ts test-fixtures/talk-config-contract.json`
  - `pre-commit run actionlint --files .github/workflows/ci.yml`
- Verified prior CI failure mode from:
  - https://github.com/openclaw/openclaw/actions/runs/22828673445
  - https://github.com/openclaw/openclaw/actions/runs/22828590894

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed the PR-path fallback to full `detect-secrets` in GitHub Actions logs.
  - Confirmed the scoped `detect-secrets` run passes locally after the fixture allowlists and baseline refresh.
  - Confirmed `actionlint` passes for the updated workflow.
- Edge cases checked:
  - PR branch path still scopes to changed files.
  - Push path remains full-scan by design.
- What you did **not** verify:
  - I did not wait for a fresh GitHub Actions run on this branch to complete end-to-end.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  Revert this PR to restore the prior `secrets` job behavior.
- Files/config to restore:
  `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `.secrets.baseline`
- Known bad symptoms reviewers should watch for:
  PR `secrets` jobs still falling back to full scans, or full-scan `detect-secrets` failures resurfacing on the known test fixtures.

## Risks and Mitigations

- Risk:
  A too-broad allowlist could hide a real finding.
  - Mitigation:
    The new exclusions target only the exact fixture patterns currently failing and keep `main` on the full scan.
