### PR TITLE
fix(context-engine): load plugins before resolving engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Context engine registry/bundled builds: share the registry state through a `globalThis` singleton so duplicated bundled module copies can resolve engines registered by each other at runtime, with regression coverage for duplicate-module imports. (#40115) thanks @jalehman.
 - macOS/Tailscale gateway discovery: keep Tailscale Serve probing alive when other remote gateways are already discovered, prefer direct transport for resolved `.ts.net` and Tailscale Serve gateways, and set `TERM=dumb` for GUI-launched Tailscale CLI discovery. (#40167) thanks @ngutman.
 - Podman/setup: fix `cannot chdir: Permission denied` in `run_as_user` when `setup-podman.sh` is invoked from a directory the target user cannot access, by wrapping user-switch calls in a subshell that cd's to `/tmp` with `/` fallback. (#39435) Thanks @langdon and @jlcbk.
+- Agents/context engine plugins: load workspace-scoped plugins before resolving the context engine in runner, compaction, and subagent-end paths so engines from `<workspace>/.openclaw/extensions` register consistently. (#40234) thanks @dgarman194.
 
 ## 2026.3.7
 

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   hookRunner,
+  loadOpenClawPluginsMock,
+  ensureContextEnginesInitializedMock,
+  resolveContextEngineMock,
+  contextEngineCompactMock,
   resolveModelMock,
   sessionCompactImpl,
   triggerInternalHook,
@@ -12,6 +16,20 @@ const {
     runBeforeCompaction: vi.fn(),
     runAfterCompaction: vi.fn(),
   },
+  loadOpenClawPluginsMock: vi.fn(),
+  ensureContextEnginesInitializedMock: vi.fn(),
+  contextEngineCompactMock: vi.fn(async () => ({
+    ok: true,
+    compacted: true,
+    result: {
+      summary: "context summary",
+      firstKeptEntryId: "entry-1",
+      tokensBefore: 120,
+    },
+  })),
+  resolveContextEngineMock: vi.fn(async () => ({
+    compact: contextEngineCompactMock,
+  })),
   resolveModelMock: vi.fn(() => ({
     model: { provider: "openai", api: "responses", id: "fake", input: [] },
     error: null,
@@ -30,6 +48,15 @@ const {
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: () => hookRunner,
+}));
+
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: loadOpenClawPluginsMock,
+}));
+
+vi.mock("../../context-engine/index.js", () => ({
+  ensureContextEnginesInitialized: ensureContextEnginesInitializedMock,
+  resolveContextEngine: resolveContextEngineMock,
 }));
 
 vi.mock("../../hooks/internal-hooks.js", async () => {
@@ -245,7 +272,7 @@ vi.mock("./utils.js", () => ({
 
 import { getApiProvider, unregisterApiProviders } from "@mariozechner/pi-ai";
 import { getCustomApiRegistrySourceId } from "../custom-api-registry.js";
-import { compactEmbeddedPiSessionDirect } from "./compact.js";
+import { compactEmbeddedPiSession, compactEmbeddedPiSessionDirect } from "./compact.js";
 
 const sessionHook = (action: string) =>
   triggerInternalHook.mock.calls.find(
@@ -258,6 +285,22 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     hookRunner.hasHooks.mockReset();
     hookRunner.runBeforeCompaction.mockReset();
     hookRunner.runAfterCompaction.mockReset();
+    loadOpenClawPluginsMock.mockReset();
+    ensureContextEnginesInitializedMock.mockReset();
+    contextEngineCompactMock.mockReset();
+    contextEngineCompactMock.mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "context summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 120,
+      },
+    });
+    resolveContextEngineMock.mockReset();
+    resolveContextEngineMock.mockResolvedValue({
+      compact: contextEngineCompactMock,
+    });
     resolveModelMock.mockReset();
     resolveModelMock.mockReturnValue({
       model: { provider: "openai", api: "responses", id: "fake", input: [] },
@@ -277,6 +320,31 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       return params.messages;
     });
     unregisterApiProviders(getCustomApiRegistrySourceId("ollama"));
+  });
+
+  it("loads plugins from the workspace before resolving the context engine", async () => {
+    const result = await compactEmbeddedPiSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace-local-plugin",
+      customInstructions: "focus on decisions",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith({
+      config: undefined,
+      workspaceDir: "/tmp/workspace-local-plugin",
+    });
+    expect(ensureContextEnginesInitializedMock).toHaveBeenCalledTimes(1);
+    expect(resolveContextEngineMock).toHaveBeenCalledWith(undefined);
+    expect(contextEngineCompactMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeContext: expect.objectContaining({
+          workspaceDir: "/tmp/workspace-local-plugin",
+        }),
+      }),
+    );
   });
 
   it("emits internal + plugin compaction hooks with counts", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -19,6 +19,7 @@ import { createInternalHookEvent, triggerInternalHook } from "../../hooks/intern
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { loadOpenClawPlugins } from "../../plugins/loader.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
@@ -910,6 +911,10 @@ export async function compactEmbeddedPiSession(
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   return enqueueCommandInLane(sessionLane, () =>
     enqueueGlobal(async () => {
+      loadOpenClawPlugins({
+        config: params.config,
+        workspaceDir: params.agentDir,
+      });
       ensureContextEnginesInitialized();
       const contextEngine = await resolveContextEngine(params.config);
       try {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -907,13 +907,14 @@ export async function compactEmbeddedPiSession(
 ): Promise<EmbeddedPiCompactResult> {
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);
+  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   return enqueueCommandInLane(sessionLane, () =>
     enqueueGlobal(async () => {
       loadOpenClawPlugins({
         config: params.config,
-        workspaceDir: params.agentDir,
+        workspaceDir: resolvedWorkspace,
       });
       ensureContextEnginesInitialized();
       const contextEngine = await resolveContextEngine(params.config);

--- a/src/agents/pi-embedded-runner/run.context-engine-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run.context-engine-workspace.test.ts
@@ -89,7 +89,7 @@ vi.mock("../failover-error.js", () => ({
 vi.mock("../model-auth.js", () => ({
   ensureAuthProfileStore: vi.fn(() => ({})),
   getApiKeyForModel: vi.fn(async () => ({
-    apiKey: "test-key",
+    apiKey: "test",
     profileId: "test-profile",
     source: "test",
   })),

--- a/src/agents/pi-embedded-runner/run.context-engine-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run.context-engine-workspace.test.ts
@@ -89,7 +89,7 @@ vi.mock("../failover-error.js", () => ({
 vi.mock("../model-auth.js", () => ({
   ensureAuthProfileStore: vi.fn(() => ({})),
   getApiKeyForModel: vi.fn(async () => ({
-    apiKey: "test",
+    apiKey: "test", // pragma: allowlist secret
     profileId: "test-profile",
     source: "test",
   })),

--- a/src/agents/pi-embedded-runner/run.context-engine-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run.context-engine-workspace.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  loadOpenClawPluginsMock,
+  ensureContextEnginesInitializedMock,
+  resolveContextEngineMock,
+  runEmbeddedAttemptMock,
+} = vi.hoisted(() => ({
+  loadOpenClawPluginsMock: vi.fn(),
+  ensureContextEnginesInitializedMock: vi.fn(),
+  resolveContextEngineMock: vi.fn(async () => ({
+    compact: vi.fn(async () => ({
+      compacted: false,
+      reason: "not-needed",
+    })),
+  })),
+  runEmbeddedAttemptMock: vi.fn(async () => ({
+    aborted: false,
+    promptError: null,
+    timedOut: false,
+    sessionIdUsed: "test-session",
+    assistantTexts: ["ok"],
+  })),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => ({ hasHooks: vi.fn(() => false) })),
+}));
+
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: loadOpenClawPluginsMock,
+}));
+
+vi.mock("../../context-engine/index.js", () => ({
+  ensureContextEnginesInitialized: ensureContextEnginesInitializedMock,
+  resolveContextEngine: resolveContextEngineMock,
+}));
+
+vi.mock("../../process/command-queue.js", () => ({
+  enqueueCommandInLane: vi.fn((_lane: string, task: () => unknown) => task()),
+}));
+
+vi.mock("../../utils/message-channel.js", () => ({
+  isMarkdownCapableMessageChannel: vi.fn(() => true),
+}));
+
+vi.mock("../agent-paths.js", () => ({
+  resolveOpenClawAgentDir: vi.fn(() => "/tmp/agent-dir"),
+}));
+
+vi.mock("../agent-scope.js", () => ({
+  hasConfiguredModelFallbacks: vi.fn(() => false),
+}));
+
+vi.mock("../auth-profiles.js", () => ({
+  isProfileInCooldown: vi.fn(() => false),
+  markAuthProfileFailure: vi.fn(async () => {}),
+  markAuthProfileGood: vi.fn(async () => {}),
+  markAuthProfileUsed: vi.fn(async () => {}),
+  resolveProfilesUnavailableReason: vi.fn(() => null),
+}));
+
+vi.mock("../context-window-guard.js", () => ({
+  CONTEXT_WINDOW_HARD_MIN_TOKENS: 1_000,
+  CONTEXT_WINDOW_WARN_BELOW_TOKENS: 5_000,
+  evaluateContextWindowGuard: vi.fn(() => ({
+    shouldWarn: false,
+    shouldBlock: false,
+    tokens: 128_000,
+    source: "model",
+  })),
+  resolveContextWindowInfo: vi.fn(() => ({
+    tokens: 128_000,
+    source: "model",
+  })),
+}));
+
+vi.mock("../defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 128_000,
+  DEFAULT_MODEL: "test-model",
+  DEFAULT_PROVIDER: "anthropic",
+}));
+
+vi.mock("../failover-error.js", () => ({
+  FailoverError: class extends Error {},
+  resolveFailoverStatus: vi.fn(() => null),
+}));
+
+vi.mock("../model-auth.js", () => ({
+  ensureAuthProfileStore: vi.fn(() => ({})),
+  getApiKeyForModel: vi.fn(async () => ({
+    apiKey: "test-key",
+    profileId: "test-profile",
+    source: "test",
+  })),
+  resolveAuthProfileOrder: vi.fn(() => []),
+}));
+
+vi.mock("../model-selection.js", () => ({
+  normalizeProviderId: vi.fn((value: string) => value),
+}));
+
+vi.mock("../models-config.js", () => ({
+  ensureOpenClawModelsJson: vi.fn(async () => {}),
+}));
+
+vi.mock("../pi-embedded-helpers.js", () => ({
+  formatBillingErrorMessage: vi.fn(() => ""),
+  classifyFailoverReason: vi.fn(() => null),
+  formatAssistantErrorText: vi.fn(() => ""),
+  isAuthAssistantError: vi.fn(() => false),
+  isBillingAssistantError: vi.fn(() => false),
+  isCompactionFailureError: vi.fn(() => false),
+  isLikelyContextOverflowError: vi.fn(() => false),
+  isFailoverAssistantError: vi.fn(() => false),
+  isFailoverErrorMessage: vi.fn(() => false),
+  parseImageSizeError: vi.fn(() => null),
+  parseImageDimensionError: vi.fn(() => null),
+  isRateLimitAssistantError: vi.fn(() => false),
+  isTimeoutErrorMessage: vi.fn(() => false),
+  pickFallbackThinkingLevel: vi.fn(() => null),
+}));
+
+vi.mock("../usage.js", () => ({
+  derivePromptTokens: vi.fn(() => undefined),
+  normalizeUsage: vi.fn((value: unknown) => value),
+}));
+
+vi.mock("../workspace-run.js", () => ({
+  redactRunIdentifier: vi.fn((value?: string) => value ?? ""),
+  resolveRunWorkspaceDir: vi.fn((params: { workspaceDir: string; agentId?: string }) => ({
+    workspaceDir: params.workspaceDir,
+    usedFallback: false,
+    fallbackReason: undefined,
+    agentId: params.agentId ?? "main",
+  })),
+}));
+
+vi.mock("./compact.js", () => ({
+  compactEmbeddedPiSessionDirect: vi.fn(),
+}));
+
+vi.mock("./lanes.js", () => ({
+  resolveGlobalLane: vi.fn(() => "global-lane"),
+  resolveSessionLane: vi.fn(() => "session-lane"),
+}));
+
+vi.mock("./logger.js", () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    isEnabled: vi.fn(() => false),
+  },
+}));
+
+vi.mock("./model.js", () => ({
+  resolveModel: vi.fn(() => ({
+    model: {
+      id: "test-model",
+      provider: "anthropic",
+      contextWindow: 128_000,
+      api: "messages",
+    },
+    error: null,
+    authStorage: { setRuntimeApiKey: vi.fn() },
+    modelRegistry: {},
+  })),
+}));
+
+vi.mock("./run/attempt.js", () => ({
+  runEmbeddedAttempt: runEmbeddedAttemptMock,
+}));
+
+vi.mock("./run/payloads.js", () => ({
+  buildEmbeddedRunPayloads: vi.fn(() => []),
+}));
+
+vi.mock("./tool-result-truncation.js", () => ({
+  sessionLikelyHasOversizedToolResults: vi.fn(() => false),
+  truncateOversizedToolResultsInSession: vi.fn(async () => ({
+    truncated: false,
+    truncatedCount: 0,
+    reason: "none",
+  })),
+}));
+
+vi.mock("./utils.js", () => ({
+  describeUnknownError: vi.fn((err: unknown) => String(err)),
+}));
+
+import { runEmbeddedPiAgent } from "./run.js";
+
+describe("runEmbeddedPiAgent context-engine workspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads plugins from the resolved workspace before resolving the context engine", async () => {
+    await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace-local-plugin",
+      prompt: "hello",
+      timeoutMs: 30_000,
+      runId: "run-plugin-workspace",
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith({
+      config: undefined,
+      workspaceDir: "/tmp/workspace-local-plugin",
+    });
+    expect(ensureContextEnginesInitializedMock).toHaveBeenCalledTimes(1);
+    expect(resolveContextEngineMock).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
@@ -30,6 +30,10 @@ export const mockedGlobalHookRunner = {
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => mockedGlobalHookRunner),
+  getGlobalPluginRegistry: vi.fn(() => null),
+  hasGlobalHooks: vi.fn(() => false),
+  initializeGlobalHookRunner: vi.fn(),
+  resetGlobalHookRunner: vi.fn(),
 }));
 
 vi.mock("../auth-profiles.js", () => ({
@@ -142,7 +146,9 @@ vi.mock("../../process/command-queue.js", () => ({
 }));
 
 vi.mock("../../utils/message-channel.js", () => ({
+  INTERNAL_MESSAGE_CHANNEL: "webchat",
   isMarkdownCapableMessageChannel: vi.fn(() => true),
+  normalizeMessageChannel: vi.fn(() => undefined),
 }));
 
 vi.mock("../agent-paths.js", () => ({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -8,6 +8,7 @@ import {
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { loadOpenClawPlugins } from "../../plugins/loader.js";
 import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -789,6 +790,11 @@ export async function runEmbeddedPiAgent(
           throw err;
         }
       };
+      // Ensure plugin-provided context engines are registered before resolution.
+      loadOpenClawPlugins({
+        config: params.config,
+        workspaceDir: params.agentDir,
+      });
       // Resolve the context engine once and reuse across retries to avoid
       // repeated initialization/connection overhead per attempt.
       ensureContextEnginesInitialized();

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -793,7 +793,7 @@ export async function runEmbeddedPiAgent(
       // Ensure plugin-provided context engines are registered before resolution.
       loadOpenClawPlugins({
         config: params.config,
-        workspaceDir: params.agentDir,
+        workspaceDir: resolvedWorkspace,
       });
       // Resolve the context engine once and reuse across retries to avoid
       // repeated initialization/connection overhead per attempt.

--- a/src/agents/subagent-registry.context-engine-workspace.test.ts
+++ b/src/agents/subagent-registry.context-engine-workspace.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const noop = () => {};
+
+type LifecycleEvent = {
+  stream?: string;
+  runId: string;
+  sessionKey?: string;
+  data?: {
+    phase?: string;
+    endedAt?: number;
+    aborted?: boolean;
+  };
+};
+
+let lifecycleHandler: ((evt: LifecycleEvent) => void) | undefined;
+
+const loadOpenClawPluginsMock = vi.fn();
+const ensureContextEnginesInitializedMock = vi.fn();
+const onSubagentEndedMock = vi.fn(async () => {});
+const resolveContextEngineMock = vi.fn(async () => ({
+  onSubagentEnded: onSubagentEndedMock,
+}));
+const runSubagentAnnounceFlowMock = vi.fn(async () => true);
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async () => ({})),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((handler: typeof lifecycleHandler) => {
+    lifecycleHandler = handler;
+    return noop;
+  }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: {
+      defaults: {
+        subagents: { archiveAfterMinutes: 0 },
+      },
+      list: [
+        {
+          id: "child",
+          workspace: "/tmp/workspace-child",
+        },
+      ],
+    },
+  })),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({
+    "agent:child:subagent:child-1": {
+      sessionId: "sess-child-1",
+      updatedAt: 1,
+    },
+  })),
+  resolveAgentIdFromSessionKey: (key: string) => {
+    const match = key.match(/^agent:([^:]+)/);
+    return match?.[1] ?? "main";
+  },
+  resolveStorePath: vi.fn(() => "/tmp/test-session-store.json"),
+}));
+
+vi.mock("../context-engine/init.js", () => ({
+  ensureContextEnginesInitialized: ensureContextEnginesInitializedMock,
+}));
+
+vi.mock("../context-engine/registry.js", () => ({
+  resolveContextEngine: resolveContextEngineMock,
+}));
+
+vi.mock("../plugins/loader.js", () => ({
+  loadOpenClawPlugins: loadOpenClawPluginsMock,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
+  runSubagentAnnounceFlow: runSubagentAnnounceFlowMock,
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(() => {}),
+}));
+
+describe("subagent registry context-engine workspace", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeAll(async () => {
+    mod = await import("./subagent-registry.js");
+  });
+
+  beforeEach(() => {
+    lifecycleHandler = undefined;
+    loadOpenClawPluginsMock.mockReset();
+    ensureContextEnginesInitializedMock.mockReset();
+    onSubagentEndedMock.mockReset();
+    onSubagentEndedMock.mockResolvedValue(undefined);
+    resolveContextEngineMock.mockReset();
+    resolveContextEngineMock.mockResolvedValue({
+      onSubagentEnded: onSubagentEndedMock,
+    });
+    runSubagentAnnounceFlowMock.mockReset();
+    runSubagentAnnounceFlowMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  const flushAsync = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  };
+
+  const waitForPluginLoad = async () => {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (loadOpenClawPluginsMock.mock.calls.length > 0) {
+        return;
+      }
+      await flushAsync();
+    }
+    throw new Error("expected plugin loader call");
+  };
+
+  it("uses the child session workspace before onSubagentEnded resolves the engine", async () => {
+    mod.registerSubagentRun({
+      runId: "run-child-workspace",
+      childSessionKey: "agent:child:subagent:child-1",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "test subagent workspace plugin loading",
+      cleanup: "keep",
+    });
+
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-child-workspace",
+      sessionKey: "agent:child:subagent:child-1",
+      data: {
+        phase: "end",
+        endedAt: 1_000,
+      },
+    });
+
+    await waitForPluginLoad();
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/workspace-child",
+      }),
+    );
+    expect(ensureContextEnginesInitializedMock).toHaveBeenCalledTimes(1);
+    expect(resolveContextEngineMock).toHaveBeenCalledTimes(1);
+    expect(onSubagentEndedMock).toHaveBeenCalledWith({
+      childSessionKey: "agent:child:subagent:child-1",
+      reason: "completed",
+    });
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -14,6 +14,7 @@ import type { SubagentEndReason } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { defaultRuntime } from "../runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
@@ -315,8 +316,10 @@ async function notifyContextEngineSubagentEnded(params: {
   reason: SubagentEndReason;
 }) {
   try {
+    const cfg = loadConfig();
+    loadOpenClawPlugins({ config: cfg });
     ensureContextEnginesInitialized();
-    const engine = await resolveContextEngine(loadConfig());
+    const engine = await resolveContextEngine(cfg);
     if (!engine.onSubagentEnded) {
       return;
     }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -17,6 +17,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { defaultRuntime } from "../runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
+import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
   captureSubagentCompletionReply,
@@ -317,7 +318,9 @@ async function notifyContextEngineSubagentEnded(params: {
 }) {
   try {
     const cfg = loadConfig();
-    loadOpenClawPlugins({ config: cfg });
+    const childAgentId = resolveAgentIdFromSessionKey(params.childSessionKey);
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, childAgentId);
+    loadOpenClawPlugins({ config: cfg, workspaceDir });
     ensureContextEnginesInitialized();
     const engine = await resolveContextEngine(cfg);
     if (!engine.onSubagentEnded) {


### PR DESCRIPTION
## Summary
Fixes a plugin context-engine load-order issue where `resolveContextEngine(config)` can run before plugin-provided engines have registered, causing startup failures like:

```text
Context engine "lossless-claw" is not registered. Available engines: legacy
```

Closes #40232.

## What this changes
Ensures plugin loading occurs before context-engine resolution in the runtime paths that call `resolveContextEngine(...)`:

- `src/agents/pi-embedded-runner/run.ts`
- `src/agents/pi-embedded-runner/compact.ts`
- `src/agents/subagent-registry.ts`

## Why
Built-in `legacy` is registered eagerly, but plugin engines (like `lossless-claw`) are registered during plugin load via `api.registerContextEngine(...)`.

Without forcing plugin load first, the configured `contextEngine` slot can resolve while the registry still only contains `legacy`.

## Validation
Local isolated source-runtime testing showed the patched runtime now registers Lossless Claw into the context-engine registry:

```text
[context-engine] registered: lossless-claw; now available: lossless-claw
```

That signal did not appear before the patch.

## Notes
This PR intentionally contains only the functional fix. Temporary debug logging used during diagnosis was not included.
