### PR TITLE
fix(gateway): bind to loopback alongside tailnet/custom IPs for internal calls

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -283,7 +283,7 @@ describe("resolveGatewayListenHosts", () => {
   it("resolves listen hosts for non-loopback and loopback variants", async () => {
     const cases = [
       {
-        name: "non-loopback host passthrough",
+        name: "LAN mode (0.0.0.0) passthrough - already binds all interfaces",
         host: "0.0.0.0",
         canBindToHost: async () => {
           throw new Error("should not be called");
@@ -301,6 +301,24 @@ describe("resolveGatewayListenHosts", () => {
         host: "127.0.0.1",
         canBindToHost: async () => false,
         expected: ["127.0.0.1"],
+      },
+      {
+        name: "tailnet IP also binds loopback for internal calls",
+        host: "100.64.0.1",
+        canBindToHost: async () => true,
+        expected: ["100.64.0.1", "127.0.0.1"],
+      },
+      {
+        name: "custom IP also binds loopback for internal calls",
+        host: "192.168.1.100",
+        canBindToHost: async () => true,
+        expected: ["192.168.1.100", "127.0.0.1"],
+      },
+      {
+        name: "specific IP without loopback available",
+        host: "100.64.0.1",
+        canBindToHost: async () => false,
+        expected: ["100.64.0.1"],
       },
     ] as const;
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -312,12 +312,26 @@ export async function resolveGatewayListenHosts(
   bindHost: string,
   opts?: { canBindToHost?: (host: string) => Promise<boolean> },
 ): Promise<string[]> {
-  if (bindHost !== "127.0.0.1") {
+  const canBind = opts?.canBindToHost ?? canBindToHost;
+
+  if (bindHost === "127.0.0.1") {
+    // Loopback mode: also try IPv6 loopback
+    if (await canBind("::1")) {
+      return [bindHost, "::1"];
+    }
     return [bindHost];
   }
-  const canBind = opts?.canBindToHost ?? canBindToHost;
-  if (await canBind("::1")) {
-    return [bindHost, "::1"];
+
+  if (bindHost === "0.0.0.0") {
+    // LAN mode: already binds all interfaces including loopback
+    return [bindHost];
+  }
+
+  // Non-loopback specific IP (tailnet, custom): also bind loopback for internal calls
+  // This ensures sessions_spawn and other internal gateway calls work when gateway
+  // is bound to a specific IP like a Tailscale address.
+  if (await canBind("127.0.0.1")) {
+    return [bindHost, "127.0.0.1"];
   }
   return [bindHost];
 }


### PR DESCRIPTION
## Summary

- **Problem:** When using `--bind tailnet` or a custom IP, the gateway only listens on that specific address. Internal operations (`sessions_spawn`, CLI probes, subagent RPC) hardcode connections to `wss://127.0.0.1:18789`, which fails because nothing is listening on loopback.
- **Why it matters:** Users running OpenClaw headless/remote with Tailscale cannot use subagents or session spawning — core orchestration features break silently. Multiple users have reported this as a regression affecting real deployments.
- **What changed:** `resolveGatewayListenHosts()` now returns both the specified IP and `127.0.0.1` when the bind host is a specific IP (not `0.0.0.0` which already binds all interfaces). The `canBind()` helper is hoisted for reuse across all branches.
- **What did NOT change (scope boundary):** No auth policy changes. No changes to how `0.0.0.0` (LAN mode) or `127.0.0.1` (loopback mode) behave. No client-side RPC target changes.

Fixes #24011
Fixes #30589
Fixes #50607

## Related

- #29871 — alternative approach (client-side forceLoopback), superseded by this fix
- #30618 — related tailnet RPC target fix
- #50751 — related CLI gateway host resolution

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Verification

Ran:

```bash
pnpm test src/gateway/net.test.ts
```

Passed: `6/6` tests covering loopback, LAN, and specific-IP modes with various bindability scenarios.

Live verification:
- Gateway listens on both Tailscale IP and localhost
- `openclaw channels status --probe` succeeds with tailnet binding
- `sessions_spawn` no longer fails with connection refused

## Why this approach over client-side fixes

An alternative approach (#29871) forces every internal `callGateway()` callsite to use loopback. That requires threading `forceLoopback` through multiple files and call paths. This PR fixes the problem at the source — the gateway simply binds to both addresses — which is simpler, less invasive, and requires no client-side changes.

🤖 Generated with [Claude Code](https://claude.ai/code)