### PR TITLE
WhatsApp: Add account/group systemPrompt hierarchy & fix group policy gating

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -36471,6 +36471,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.accounts.*.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.accounts.*.groups.*.tools",
       "kind": "channel",
       "type": "object",
@@ -36769,6 +36779,16 @@
       "path": "channels.whatsapp.accounts.*.sendReadReceipts",
       "kind": "channel",
       "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.accounts.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -37168,6 +37188,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.groups.*.tools",
       "kind": "channel",
       "type": "object",
@@ -37462,6 +37492,16 @@
       "path": "channels.whatsapp.sendReadReceipts",
       "kind": "channel",
       "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.systemPrompt",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5628}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5632}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3290,6 +3290,7 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3320,6 +3321,7 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.selfChatMode","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.sendReadReceipts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.ackReaction","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.ackReaction.direct","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3355,6 +3357,7 @@
 {"recordType":"path","path":"channels.whatsapp.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3384,6 +3387,7 @@
 {"recordType":"path","path":"channels.whatsapp.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.selfChatMode","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"WhatsApp Self-Phone Mode","help":"Same-phone setup (bot uses your personal WhatsApp number).","hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.sendReadReceipts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Zalo","help":"Vietnam-focused messaging platform with Bot API.","hasChildren":true}
 {"recordType":"path","path":"channels.zalo.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -23,8 +23,8 @@ Translation: allowlisted senders can trigger OpenClaw by mentioning it.
 
 > TL;DR
 >
-> - **DM access** is controlled by `*.allowFrom`.
-> - **Group access** is controlled by `*.groupPolicy` + allowlists (`*.groups`, `*.groupAllowFrom`).
+> - **DM access** is controlled by `*.allowFrom` (root or account-level).
+> - **Group access** is controlled by `*.groupPolicy` + allowlists (`*.groups`, `*.groupAllowFrom`), including account-level `groupAllowFrom`/`allowFrom`.
 > - **Reply triggering** is controlled by mention gating (`requireMention`, `/activation`).
 
 Quick flow (what happens to a group message):
@@ -40,12 +40,12 @@ otherwise -> reply
 
 If you want...
 
-| Goal                                         | What to set                                                |
-| -------------------------------------------- | ---------------------------------------------------------- |
-| Allow all groups but only reply on @mentions | `groups: { "*": { requireMention: true } }`                |
-| Disable all group replies                    | `groupPolicy: "disabled"`                                  |
-| Only specific groups                         | `groups: { "<group-id>": { ... } }` (no `"*"` key)         |
-| Only you can trigger in groups               | `groupPolicy: "allowlist"`, `groupAllowFrom: ["+1555..."]` |
+| Goal                                         | What to set                                                                        |
+| -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Allow all groups but only reply on @mentions | `groups: { "*": { requireMention: true } }`                                        |
+| Disable all group replies                    | `groupPolicy: "disabled"`                                                          |
+| Only specific groups                         | `groups: { "<group-id>": { ... } }` (no `"*"` key)                                 |
+| Only you can trigger in groups               | `groupPolicy: "allowlist"`, `groupAllowFrom: ["+1555..."]` (root or account-level) |
 
 ## Session keys
 
@@ -127,7 +127,7 @@ Related:
 
 ## Group policy
 
-Control how group/room messages are handled per channel:
+Control how group/room messages are handled per channel (root or account-level):
 
 ```json5
 {

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -374,6 +374,45 @@ The agent system prompt includes a group intro on the first turn of a new group 
 - List chats: `imsg chats --limit 20`.
 - Group replies always go back to the same `chat_id`.
 
+## WhatsApp system prompts for groups
+
+WhatsApp supports per-account and per-group system prompts. For group messages, the final prompt delivered to the agent is the account prompt and group prompt joined with a blank line (either part is omitted if not set).
+
+Resolution hierarchy:
+
+1. **Account system prompt** (`channels.whatsapp.systemPrompt` or `accounts.<id>.systemPrompt`): the root value applies to all accounts; an account-level value overrides it for that account.
+2. **Group system prompt** (`groups["<groupId>"].systemPrompt` or `groups["*"].systemPrompt`): the specific group entry is used if it defines a `systemPrompt`; falls back to `groups["*"].systemPrompt` for groups with no specific entry. Account `groups` fully overrides root `groups` (same override semantics as Telegram). This means root `groups["*"]` applies automatically when an account defines no `groups` of its own, but is replaced entirely once an account defines any `groups` entry.
+
+Example:
+
+```json5
+{
+  channels: {
+    whatsapp: {
+      systemPrompt: "Respond in English only.",
+      groups: {
+        // Applies to all accounts that do not define their own groups map.
+        "*": { systemPrompt: "Default prompt for all groups." },
+      },
+      accounts: {
+        work: {
+          systemPrompt: "You are a work assistant.",
+          groups: {
+            // This account defines its own groups, so root groups are fully
+            // replaced. To keep a wildcard, define "*" explicitly here too.
+            "120363406415684625@g.us": {
+              requireMention: false,
+              systemPrompt: "Focus on project management.",
+            },
+            "*": { systemPrompt: "Default prompt for work groups." },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
 ## WhatsApp specifics
 
 See [Group messages](/channels/group-messages) for WhatsApp-only behavior (history injection, mention handling details).

--- a/extensions/whatsapp/src/accounts.test.ts
+++ b/extensions/whatsapp/src/accounts.test.ts
@@ -71,4 +71,33 @@ describe("resolveWhatsAppAuthDir", () => {
     expect(resolved.messagePrefix).toBe("[root]");
     expect(resolved.debounceMs).toBe(250);
   });
+
+  it("account groups override root groups (no deep merge)", () => {
+    // An account setting groups: {} or a subset must fully override root.groups
+    // so that routing/gating and prompt surfaces see a consistent picture.
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            groups: {
+              "*": { systemPrompt: "Root wildcard prompt" },
+              "120363406415684625@g.us": { requireMention: true },
+            },
+            accounts: {
+              work: {
+                groups: {
+                  "120363406415684625@g.us": { requireMention: false },
+                },
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    // Account groups replace root groups entirely — root "*" must not bleed in.
+    expect(resolved.groups?.["*"]).toBeUndefined();
+    expect(resolved.groups?.["120363406415684625@g.us"]).toEqual({ requireMention: false });
+  });
 });

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -34,6 +34,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  systemPrompt?: string;
 };
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_MB = 50;
@@ -156,6 +157,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: merged.ackReaction,
     groups: merged.groups,
     debounceMs: merged.debounceMs,
+    systemPrompt: merged.systemPrompt,
   };
 }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
@@ -34,6 +34,7 @@ export function maybeSendAckReaction(params: {
           agentId: params.agentId,
           sessionKey: params.sessionKey,
           conversationId: conversationIdForCheck,
+          accountId: params.accountId,
         })
       : null;
   const shouldSendReaction = () =>

--- a/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
@@ -9,23 +9,45 @@ import {
   resolveStorePath,
 } from "openclaw/plugin-sdk/config-runtime";
 import { normalizeGroupActivation } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
 
-export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conversationId: string) {
+export function resolveGroupPolicyFor(
+  cfg: ReturnType<typeof loadConfig>,
+  conversationId: string,
+  accountId?: string | null,
+) {
   const groupId = resolveGroupSessionKey({
     From: conversationId,
     ChatType: "group",
     Provider: "whatsapp",
   })?.id;
+  let hasGroupAllowFrom = false;
   const whatsappCfg = cfg.channels?.whatsapp as
-    | { groupAllowFrom?: string[]; allowFrom?: string[] }
+    | {
+        groupAllowFrom?: string[];
+        allowFrom?: string[];
+        accounts?: Record<string, { groupAllowFrom?: string[]; allowFrom?: string[] }>;
+      }
     | undefined;
-  const hasGroupAllowFrom = Boolean(
-    whatsappCfg?.groupAllowFrom?.length || whatsappCfg?.allowFrom?.length,
-  );
+  if (whatsappCfg) {
+    // Root-level
+    hasGroupAllowFrom = Boolean(
+      whatsappCfg.groupAllowFrom?.length || whatsappCfg.allowFrom?.length,
+    );
+    // Account-level (case-insensitive lookup — accountId is normalized to lowercase by routing)
+    if (accountId && whatsappCfg.accounts) {
+      const acctCfg = resolveAccountEntry(whatsappCfg.accounts, accountId);
+      if (acctCfg) {
+        hasGroupAllowFrom =
+          hasGroupAllowFrom || Boolean(acctCfg.groupAllowFrom?.length || acctCfg.allowFrom?.length);
+      }
+    }
+  }
   return resolveChannelGroupPolicy({
     cfg,
     channel: "whatsapp",
     groupId: groupId ?? conversationId,
+    accountId,
     hasGroupAllowFrom,
   });
 }
@@ -33,6 +55,7 @@ export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conver
 export function resolveGroupRequireMentionFor(
   cfg: ReturnType<typeof loadConfig>,
   conversationId: string,
+  accountId?: string | null,
 ) {
   const groupId = resolveGroupSessionKey({
     From: conversationId,
@@ -43,6 +66,7 @@ export function resolveGroupRequireMentionFor(
     cfg,
     channel: "whatsapp",
     groupId: groupId ?? conversationId,
+    accountId,
   });
 }
 
@@ -51,13 +75,18 @@ export function resolveGroupActivationFor(params: {
   agentId: string;
   sessionKey: string;
   conversationId: string;
+  accountId?: string | null;
 }) {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.agentId,
   });
   const store = loadSessionStore(storePath);
   const entry = store[params.sessionKey];
-  const requireMention = resolveGroupRequireMentionFor(params.cfg, params.conversationId);
+  const requireMention = resolveGroupRequireMentionFor(
+    params.cfg,
+    params.conversationId,
+    params.accountId,
+  );
   const defaultActivation = !requireMention ? "always" : "mention";
   return normalizeGroupActivation(entry?.groupActivation) ?? defaultActivation;
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -26,6 +26,7 @@ type ApplyGroupGatingParams = {
   groupHistoryKey: string;
   agentId: string;
   sessionKey: string;
+  accountId?: string | null;
   baseMentionConfig: MentionConfig;
   authDir?: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
@@ -80,7 +81,7 @@ function skipGroupMessageAndStoreHistory(params: ApplyGroupGatingParams, verbose
 }
 
 export function applyGroupGating(params: ApplyGroupGatingParams) {
-  const groupPolicy = resolveGroupPolicyFor(params.cfg, params.conversationId);
+  const groupPolicy = resolveGroupPolicyFor(params.cfg, params.conversationId, params.accountId);
   if (groupPolicy.allowlistEnabled && !groupPolicy.allowed) {
     params.logVerbose(`Skipping group message ${params.conversationId} (not in allowlist)`);
     return { shouldProcess: false };
@@ -125,6 +126,7 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     conversationId: params.conversationId,
+    accountId: params.accountId,
   });
   const requireMention = activation !== "always";
   const selfJid = params.msg.selfJid?.replace(/:\\d+/, "");

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -131,6 +131,7 @@ export function createWebOnMessageHandler(params: {
         groupHistoryKey,
         agentId: route.agentId,
         sessionKey: route.sessionKey,
+        accountId: route.accountId,
         baseMentionConfig: params.baseMentionConfig,
         authDir: params.account.authDir,
         groupHistories: params.groupHistories,

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -32,6 +32,7 @@ import {
   resolveDmGroupAccessWithCommandGate,
 } from "openclaw/plugin-sdk/security-runtime";
 import { jidToE164, normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
+import { resolveWhatsAppGroupSystemPrompt } from "openclaw/plugin-sdk/whatsapp-shared";
 import { resolveWhatsAppAccount } from "../../accounts.js";
 import { newConnectionId } from "../../reconnect.js";
 import { formatError } from "../../session.js";
@@ -299,6 +300,16 @@ export async function processMessage(params: {
         )
       : undefined;
 
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.route.accountId });
+  // Resolve combined system prompt (account-level + group-level if applicable)
+  const groupSystemPrompt =
+    params.msg.chatType === "group"
+      ? resolveWhatsAppGroupSystemPrompt({
+          accountConfig: account,
+          groupId: conversationId,
+        })
+      : undefined;
+
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     BodyForAgent: params.msg.body,
@@ -329,6 +340,7 @@ export async function processMessage(params: {
     SenderE164: params.msg.senderE164,
     CommandAuthorized: commandAuthorized,
     WasMentioned: params.msg.wasMentioned,
+    GroupSystemPrompt: groupSystemPrompt,
     ...(params.msg.location ? toLocationContext(params.msg.location) : {}),
     Provider: "whatsapp",
     Surface: "whatsapp",

--- a/src/channels/plugins/whatsapp-shared.test.ts
+++ b/src/channels/plugins/whatsapp-shared.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { resolveWhatsAppGroupSystemPrompt } from "./whatsapp-shared.js";
+
+describe("resolveWhatsAppGroupSystemPrompt", () => {
+  it("returns undefined when no systemPrompt is configured", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {},
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns account-level systemPrompt when only account systemPrompt is set", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: { systemPrompt: "You are a helpful assistant for this WhatsApp account." },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are a helpful assistant for this WhatsApp account.");
+  });
+
+  it("returns account-level systemPrompt from specific account config", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: { systemPrompt: "You are my personal assistant." },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are my personal assistant.");
+  });
+
+  it("returns group-level systemPrompt when only group systemPrompt is set", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "123@g.us": { systemPrompt: "You are helping with group discussions." } },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are helping with group discussions.");
+  });
+
+  it("combines account and group systemPrompts with double newlines", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are a helpful assistant for this WhatsApp account.",
+        groups: {
+          "123@g.us": { systemPrompt: "This is a work group, keep responses professional." },
+        },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe(
+      "You are a helpful assistant for this WhatsApp account.\n\nThis is a work group, keep responses professional.",
+    );
+  });
+
+  it("combines account-specific and group systemPrompts", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are a work assistant.",
+        groups: { "456@g.us": { systemPrompt: "Focus on project management topics." } },
+      },
+      groupId: "456@g.us",
+    });
+
+    expect(result).toBe("You are a work assistant.\n\nFocus on project management topics.");
+  });
+
+  it("trims whitespace from systemPrompts", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "  You are helpful  ",
+        groups: { "123@g.us": { systemPrompt: "  Keep it brief  " } },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are helpful\n\nKeep it brief");
+  });
+
+  it("ignores empty systemPrompts after trimming", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are helpful",
+        groups: { "123@g.us": { systemPrompt: "   " } }, // Only whitespace
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are helpful");
+  });
+
+  it("returns account-level systemPrompt when groupId is not provided", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are helpful",
+        groups: { "123@g.us": { systemPrompt: "Group specific prompt" } },
+      },
+      groupId: undefined,
+    });
+
+    expect(result).toBe("You are helpful");
+  });
+
+  it("returns account systemPrompt when group doesn't exist", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are helpful",
+        groups: { "123@g.us": { systemPrompt: "Group specific prompt" } },
+      },
+      groupId: "999@g.us", // Non-existent group
+    });
+
+    expect(result).toBe("You are helpful");
+  });
+
+  it("handles pre-resolved account configs with group entries", () => {
+    // Account with its own systemPrompt (as resolved by the caller)
+    const personalResult = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "Personal assistant",
+        groups: { "123@g.us": { systemPrompt: "Family group" } },
+      },
+      groupId: "123@g.us",
+    });
+    expect(personalResult).toBe("Personal assistant\n\nFamily group");
+
+    // Account with systemPrompt inherited from root (already resolved by caller)
+    const workResult = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "Root assistant",
+        groups: { "456@g.us": { systemPrompt: "Work group" } },
+      },
+      groupId: "456@g.us",
+    });
+    expect(workResult).toBe("Root assistant\n\nWork group");
+  });
+
+  it("falls back to wildcard '*' group when specific group is not configured", () => {
+    const accountConfig = {
+      systemPrompt: "Root prompt",
+      groups: {
+        "*": { systemPrompt: "Default group prompt" },
+        "123@g.us": { systemPrompt: "Specific group prompt" },
+      },
+    };
+
+    // Specific group config takes precedence
+    expect(resolveWhatsAppGroupSystemPrompt({ accountConfig, groupId: "123@g.us" })).toBe(
+      "Root prompt\n\nSpecific group prompt",
+    );
+
+    // Unknown group falls back to "*"
+    expect(resolveWhatsAppGroupSystemPrompt({ accountConfig, groupId: "999@g.us" })).toBe(
+      "Root prompt\n\nDefault group prompt",
+    );
+  });
+
+  it("falls back to wildcard '*' in account-level groups", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        accountConfig: {
+          systemPrompt: "Work assistant",
+          groups: { "*": { systemPrompt: "Default work group prompt" } },
+        },
+        groupId: "456@g.us",
+      }),
+    ).toBe("Work assistant\n\nDefault work group prompt");
+  });
+
+  it("uses wildcard systemPrompt when specific group entry has no systemPrompt", () => {
+    // Should still get wildcard's systemPrompt even though group entry exists
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        accountConfig: {
+          systemPrompt: "Root prompt",
+          groups: {
+            "*": { systemPrompt: "Default group prompt" },
+            "123@g.us": {}, // Group entry exists but only sets non-prompt fields (e.g. requireMention)
+          },
+        },
+        groupId: "123@g.us",
+      }),
+    ).toBe("Root prompt\n\nDefault group prompt");
+  });
+});

--- a/src/channels/plugins/whatsapp-shared.ts
+++ b/src/channels/plugins/whatsapp-shared.ts
@@ -7,6 +7,68 @@ import type { ChannelOutboundAdapter } from "./types.js";
 export const WHATSAPP_GROUP_INTRO_HINT =
   "WhatsApp IDs: SenderId is the participant JID (group participant id).";
 
+export type WhatsAppGroupSystemPromptParams = {
+  /** Pre-resolved merged account config (systemPrompt + groups). Mirrors Telegram's groupConfig param style. */
+  accountConfig?: {
+    systemPrompt?: string;
+    groups?: Record<string, { systemPrompt?: string }>;
+  } | null;
+  groupId?: string | null;
+};
+
+/**
+ * Resolves and combines WhatsApp system prompts from a pre-resolved account config slice.
+ * Follows the same pattern as Telegram's resolveTelegramGroupPromptSettings: the caller
+ * resolves the account config first, then passes the relevant slice here.
+ *
+ * Resolution hierarchy for group messages:
+ *
+ * 1. Account system prompt (channels.whatsapp.systemPrompt or
+ *    accounts.<id>.systemPrompt):
+ *    - Root value applies to all accounts.
+ *    - Account-level value overrides root for that account.
+ *
+ * 2. Group system prompt (groups["<groupId>"].systemPrompt or
+ *    groups["*"].systemPrompt):
+ *    - The specific group entry is used if it defines a systemPrompt.
+ *    - Falls back to groups["*"].systemPrompt for groups with no specific entry.
+ *    - resolveWhatsAppAccount uses the same override semantics as the shared
+ *      resolveChannelGroups helper: account groups replace root groups entirely
+ *      (no deep merge). The resolved account config therefore already contains
+ *      root groups (including "*") whenever the account defines no groups of its
+ *      own, mirroring Telegram's resolveTelegramGroupPromptSettings pattern.
+ *
+ * 3. Final prompt delivered to the agent for group messages:
+ *    accountSystemPrompt + "\n\n" + groupSystemPrompt
+ *    (either part is omitted if not configured)
+ */
+export function resolveWhatsAppGroupSystemPrompt(
+  params: WhatsAppGroupSystemPromptParams,
+): string | undefined {
+  const accountSystemPrompt = params.accountConfig?.systemPrompt?.trim() || undefined;
+
+  // Get group-level systemPrompt if groupId is provided.
+  // Resolve per-field: use the specific group's systemPrompt if set, otherwise
+  // fall back to the wildcard "*" entry so default prompts still apply even when
+  // the specific group entry only defines non-prompt settings (e.g. requireMention).
+  let groupSystemPrompt: string | undefined;
+  if (params.groupId) {
+    const groups = params.accountConfig?.groups;
+    // Resolution order: specific group entry → wildcard "*" entry.
+    // Root groups naturally reach here when the account defines no groups of its
+    // own (resolveWhatsAppAccount uses override-not-merge semantics, same as
+    // resolveChannelGroups: accountGroups ?? rootGroups).
+    groupSystemPrompt =
+      groups?.[params.groupId]?.systemPrompt?.trim() ||
+      groups?.["*"]?.systemPrompt?.trim() ||
+      undefined;
+  }
+
+  // Combine prompts following Telegram's pattern
+  const systemPrompts = [accountSystemPrompt, groupSystemPrompt].filter(Boolean);
+  return systemPrompts.length > 0 ? systemPrompts.join("\n\n") : undefined;
+}
+
 export function resolveWhatsAppGroupIntroHint(): string {
   return WHATSAPP_GROUP_INTRO_HINT;
 }

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -3,6 +3,32 @@ import type { OpenClawConfig } from "./config.js";
 import { resolveChannelGroupPolicy, resolveToolsBySender } from "./group-policy.js";
 
 describe("resolveChannelGroupPolicy", () => {
+  it("allows groups when account-level groupPolicy=allowlist and account groupAllowFrom is set (senderFilterBypass)", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          accounts: {
+            test: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+1234"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      accountId: "test",
+      groupId: "123@g.us",
+      hasGroupAllowFrom: true,
+    });
+
+    expect(policy.allowlistEnabled).toBe(true);
+    expect(policy.allowed).toBe(true);
+  });
   it("fails closed when groupPolicy=allowlist and groups are missing", () => {
     const cfg = {
       channels: {
@@ -128,6 +154,133 @@ describe("resolveChannelGroupPolicy", () => {
 
     expect(policy.allowlistEnabled).toBe(true);
     expect(policy.allowed).toBe(false);
+  });
+
+  it("account-level groups override root-level groups", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groups: {
+            "root-group@g.us": { requireMention: false },
+          },
+          accounts: {
+            work: {
+              groups: {
+                "account-group@g.us": { requireMention: true },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // Account group is allowed
+    const accountGroup = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      accountId: "work",
+      groupId: "account-group@g.us",
+    });
+    expect(accountGroup.allowed).toBe(true);
+    expect(accountGroup.groupConfig).toEqual({ requireMention: true });
+
+    // Root group is NOT visible when account defines its own groups
+    const rootGroupViaAccount = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      accountId: "work",
+      groupId: "root-group@g.us",
+    });
+    expect(rootGroupViaAccount.allowed).toBe(false);
+
+    // Root group is still visible without accountId
+    const rootGroupDirect = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      groupId: "root-group@g.us",
+    });
+    expect(rootGroupDirect.allowed).toBe(true);
+  });
+
+  it("falls back to root-level groups when account defines no groups", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groups: {
+            "shared-group@g.us": { requireMention: false },
+          },
+          accounts: {
+            personal: {
+              groupPolicy: "allowlist",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      accountId: "personal",
+      groupId: "shared-group@g.us",
+    });
+    expect(policy.allowed).toBe(true);
+    expect(policy.groupConfig).toEqual({ requireMention: false });
+  });
+
+  it("allows groups when account-level groupPolicy=allowlist and account groupAllowFrom is set, with no root policy", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            test: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+1234"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      accountId: "test",
+      groupId: "123@g.us",
+      hasGroupAllowFrom: true,
+    });
+
+    expect(policy.allowlistEnabled).toBe(true);
+    expect(policy.allowed).toBe(true);
+  });
+
+  it("allows groups when account-level groupPolicy=allowlist and account groupAllowFrom is set, overriding root policy", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "disabled",
+          accounts: {
+            test: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+1234"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      accountId: "test",
+      groupId: "123@g.us",
+      hasGroupAllowFrom: true,
+    });
+
+    expect(policy.allowlistEnabled).toBe(true);
+    expect(policy.allowed).toBe(true);
   });
 });
 

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -21,6 +21,8 @@ export type WhatsAppGroupConfig = {
   requireMention?: boolean;
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
+  /** Optional system prompt for this group. */
+  systemPrompt?: string;
 };
 
 export type WhatsAppAckReactionConfig = {
@@ -108,6 +110,8 @@ export type WhatsAppConfig = WhatsAppConfigCore &
     defaultAccount?: string;
     /** Per-action tool gating (default: true for all). */
     actions?: WhatsAppActionConfig;
+    /** Optional system prompt for all accounts (global default). */
+    systemPrompt?: string;
   };
 
 export type WhatsAppAccountConfig = WhatsAppConfigCore &
@@ -118,4 +122,6 @@ export type WhatsAppAccountConfig = WhatsAppConfigCore &
     enabled?: boolean;
     /** Override auth directory (Baileys multi-file auth state). */
     authDir?: string;
+    /** Optional system prompt for this account (global for all groups). */
+    systemPrompt?: string;
   };

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { WhatsAppConfigSchema, WhatsAppAccountSchema } from "./zod-schema.providers-whatsapp.js";
+
+describe("WhatsApp systemPrompt Zod validation", () => {
+  it("validates root-level systemPrompt", () => {
+    const config = {
+      systemPrompt: "You are a helpful assistant",
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.systemPrompt).toBe("You are a helpful assistant");
+    }
+  });
+
+  it("validates account-level systemPrompt", () => {
+    const config = {
+      accounts: {
+        personal: {
+          systemPrompt: "You are my personal assistant",
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accounts?.personal?.systemPrompt).toBe("You are my personal assistant");
+    }
+  });
+
+  it("validates group-level systemPrompt", () => {
+    const config = {
+      groups: {
+        "123@g.us": {
+          systemPrompt: "This is a work group",
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.groups?.["123@g.us"]?.systemPrompt).toBe("This is a work group");
+    }
+  });
+
+  it("validates combined account and group systemPrompts", () => {
+    const config = {
+      systemPrompt: "Global assistant",
+      accounts: {
+        work: {
+          systemPrompt: "Work assistant",
+          groups: {
+            "456@g.us": {
+              systemPrompt: "Project team",
+            },
+          },
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.systemPrompt).toBe("Global assistant");
+      expect(result.data.accounts?.work?.systemPrompt).toBe("Work assistant");
+      expect(result.data.accounts?.work?.groups?.["456@g.us"]?.systemPrompt).toBe("Project team");
+    }
+  });
+
+  it("validates WhatsAppAccountSchema directly", () => {
+    const accountConfig = {
+      name: "Personal Account",
+      systemPrompt: "You are my personal WhatsApp assistant",
+      groups: {
+        "family@g.us": {
+          systemPrompt: "Keep responses family-friendly",
+        },
+      },
+    };
+
+    const result = WhatsAppAccountSchema.safeParse(accountConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.systemPrompt).toBe("You are my personal WhatsApp assistant");
+      expect(result.data.groups?.["family@g.us"]?.systemPrompt).toBe(
+        "Keep responses family-friendly",
+      );
+    }
+  });
+});

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -19,6 +19,7 @@ const WhatsAppGroupEntrySchema = z
     requireMention: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
+    systemPrompt: z.string().optional(),
   })
   .strict()
   .optional();
@@ -60,6 +61,7 @@ const WhatsAppSharedSchema = z.object({
   debounceMs: z.number().int().nonnegative().optional().default(0),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   healthMonitor: ChannelHealthMonitorSchema,
+  systemPrompt: z.string().optional(),
 });
 
 function enforceOpenDmPolicyAllowFromStar(params: {

--- a/src/plugin-sdk/whatsapp-shared.ts
+++ b/src/plugin-sdk/whatsapp-shared.ts
@@ -3,8 +3,10 @@ export type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/typ
 export {
   createWhatsAppOutboundBase,
   resolveWhatsAppGroupIntroHint,
+  resolveWhatsAppGroupSystemPrompt,
   resolveWhatsAppMentionStripRegexes,
 } from "../channels/plugins/whatsapp-shared.js";
+export type { WhatsAppGroupSystemPromptParams } from "../channels/plugins/whatsapp-shared.js";
 export {
   looksLikeWhatsAppTargetId,
   normalizeWhatsAppAllowFromEntries,


### PR DESCRIPTION
## Summary

 **Feature:** Extends WhatsApp `systemPrompt` support from root to account and group levels, enabling fine-grained prompt customization for group conversations.

## Commits

- `0ecdbe1cc` feat(whatsapp): add systemPrompt support for accounts and groups
- `b87bcfda9` fix(whatsapp): respect per-account group policy and allowlists

## Hierarchy of systemPrompt resolution

- **Root-level:** `channels.whatsapp.systemPrompt` applies to all accounts/groups unless overridden.
- **Account-level:** `channels.whatsapp.accounts.<accountId>.systemPrompt` overrides root for that account.
- **Group-level:** `channels.whatsapp.accounts.<accountId>.groups.<groupId>.systemPrompt` is added (concatenated) to the account/root prompt for that group.
- **Resolution:** The final prompt is a concatenation of account-level (if present) and group-level (if present), joined with `\n\n`. If account-level is missing, root-level is used instead. If group-level is missing, only account/root is used.

## Similarity with Telegram design

- Telegram also supports hierarchical prompt resolution and per-account group policy configuration. The WhatsApp implementation mirrors Telegram’s pattern, allowing group-specific and account-specific prompt customization, and full override at each level.

## Bug Explanation

- **Previous behavior:** WhatsApp group policy gating only checked root-level allowlists and group policies, ignoring account-level settings. This meant that even if an account had its own allowlist or group policy, it was not respected for group messages.
- **Fix:** The bug was resolved by threading account-level allowlists and group policies into group gating logic, so group messages now correctly honor per-account settings. This enables configuring different group policies per account, matching Telegram's implementation, and ensures group access and prompt customization work as intended for each account.

## Change Type

- [x] Feature
- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Integrations
- [x] API / contracts
- [x] Memory / storage

## Linked Issue/PR

- Addresses (in part) [#7011](https://github.com/openclaw/openclaw/issues/7011) (WhatsApp group prompt enhancement)

## User-visible / Behavior Changes

- WhatsApp config now supports `systemPrompt` at root, account, and group levels.
- Group policy gating now respects account-level allowlists.
- No breaking changes; backward compatible.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime: Node 22+, pnpm
- Model/provider: Google Gemini 3.1-pro-preview
- Integration/channel: WhatsApp (Baileys)
- Relevant config: `~/.openclaw-dev/openclaw.json` (root/account/group systemPrompt, allowlists)

### Example configuration (actual test)

```
{
  "channels": {
    "whatsapp": {
      "enabled": true,
      "dmPolicy": "pairing",
      "groupPolicy": "allowlist",
      "debounceMs": 0,
      "systemPrompt": "Please respond in English even if you are being communicated with in another language. If the message to you in not in English, add a thumbs up emoji at the end of your response to indicate that you understood the message but can only respond in English.",
      "accounts": {
        "test": {
          "dmPolicy": "allowlist",
          "allowFrom": ["+xxxxxxxxxxxx", "+yyyyyyyyyyy"],
          "groupAllowFrom": ["*"],
          "groupPolicy": "allowlist",
          "groups": {
            "120363406415684625@g.us": {
              "requireMention": false,
              "systemPrompt": "Please add the word GHH! once in a while at the end of the sentences to confirm that the group-specific prompt is being included in your responses."
            }
          },
          "debounceMs": 0,
          "systemPrompt": "Please add the word MOO-BOO once in a while at the end of the sentences to confirm that the account-specific prompt is being included in your responses.",
          "name": "Test Account"
        },
        "default": {
          "dmPolicy": "pairing",
          "groupPolicy": "allowlist",
          "debounceMs": 0
        }
      },
      "mediaMaxMb": 50
    }
  }
}
```

### Steps

1. Built and tested (`pnpm install`, `pnpm build`, `pnpm check`, `pnpm test`) — all passing (860 files, 6983 tests).
2. Live-tested dev gateway (`pnpm openclaw --dev gateway run --verbose`) with WhatsApp test account.
3. Verified systemPrompt resolution for root, account, and group.
4. Confirmed bug fix: account-level group allowlists now respected.
5. Changed config and restarted gateway to verify prompt changes.
6. Confirmed prompt behavior in live WhatsApp group messages.

### Example message exchange (human testing)

- **Sent:** `/new` to WhatsApp group
- **Bot replied:**

```
Hey folks, I'm online and ready to help. What are we working on today MOO-BOO? Let me know what you need me to do GHH!
```

- **Removed account-level prompt, restarted gateway, sent message in Hebrew asking how things are going**
- **Bot replied:**

```
Everything is going great here! How can I help you today, GHH! 👍
```

*Note: The first message includes both the account-specific prompt (MOO-BOO) and the group-specific prompt (GHH!). The second message includes the group-specific prompt (GHH!) and a thumbs up emoji, indicating the bot responded in English to a Hebrew message, as per the root-level prompt.*

## Evidence

- [x] Passing tests before/after
- [x] Live logs showing correct prompt resolution
- [x] Message transcript (see above)

## Human Verification

- Verified scenarios: root/account/group prompt, allowlist gating, config changes.
- Edge cases checked: account prompt removal, group prompt override, fallback logic.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes (new fields, but optional)
- Migration needed? No

## Failure Recovery

- To disable: remove new config fields, restart gateway.
- Files/config to restore: `openclaw.json`

---

**Note:** Developed with the help of GitHub Copilot. All lint, format, and test checks passed.
