### PR TITLE
fix(heartbeat): respect user-configured prompt without appending workspace path hint

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1173,6 +1173,66 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("respects user-configured heartbeat prompt without appending workspace path hint", async () => {
+    const tmpDir = await createCaseDir("openclaw-hb-custom");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const workspaceDir = path.join(tmpDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "HEARTBEAT.md"),
+      "# HEARTBEAT.md\n\n- Check logs\n",
+      "utf-8",
+    );
+
+    const customPrompt =
+      "Read HEARTBEAT.md from the system prompt injection. Do not use the read tool.";
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          heartbeat: { every: "5m", target: "whatsapp", prompt: customPrompt },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "120363401234567890@g.us",
+        },
+      }),
+    );
+
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    replySpy.mockResolvedValue({ text: "Custom heartbeat response" });
+    const sendWhatsApp = vi
+      .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "interval",
+        deps: createHeartbeatDeps(sendWhatsApp),
+      });
+      expect(res.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      // Custom prompt should be used as-is without the workspace path hint
+      expect(calledCtx.Body).toContain(customPrompt);
+      expect(calledCtx.Body).not.toContain("use workspace file");
+      expect(calledCtx.Body).not.toContain("Do not read docs/heartbeat.md.");
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("applies HEARTBEAT.md gating rules across file states and triggers", async () => {
     const cases: Array<{
       name: string;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -509,9 +509,9 @@ function resolveHeartbeatRunPrompt(params: {
   // Only append workspace path hint for internal prompts (exec/cron) or when using the
   // default heartbeat prompt. User-configured prompts are left unchanged to respect
   // custom instructions (e.g., using HEARTBEAT.md from system prompt instead of workspace).
-  const hasCustomHeartbeatPrompt =
-    typeof (params.heartbeat?.prompt ?? params.cfg.agents?.defaults?.heartbeat?.prompt) ===
-    "string";
+  const resolvedHeartbeatPrompt =
+    params.heartbeat?.prompt ?? params.cfg.agents?.defaults?.heartbeat?.prompt;
+  const hasCustomHeartbeatPrompt = typeof resolvedHeartbeatPrompt === "string";
   const basePrompt = hasExecCompletion
     ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
     : hasCronEvents

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -506,12 +506,21 @@ function resolveHeartbeatRunPrompt(params: {
     .map((event) => event.text);
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
   const hasCronEvents = cronEvents.length > 0;
+  // Only append workspace path hint for internal prompts (exec/cron) or when using the
+  // default heartbeat prompt. User-configured prompts are left unchanged to respect
+  // custom instructions (e.g., using HEARTBEAT.md from system prompt instead of workspace).
+  const hasCustomHeartbeatPrompt =
+    typeof (params.heartbeat?.prompt ?? params.cfg.agents?.defaults?.heartbeat?.prompt) ===
+    "string";
   const basePrompt = hasExecCompletion
     ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
-  const prompt = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
+  const shouldAppendWorkspaceHint = hasExecCompletion || hasCronEvents || !hasCustomHeartbeatPrompt;
+  const prompt = shouldAppendWorkspaceHint
+    ? appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir)
+    : basePrompt;
 
   return { prompt, hasExecCompletion, hasCronEvents };
 }


### PR DESCRIPTION
## Summary
When a user configures a custom heartbeat prompt, the workspace path hint ('When reading HEARTBEAT.md, use workspace file ... Do not read docs/heartbeat.md.') was being appended unconditionally. This modified user prompts in ways that could contradict their intended behavior (e.g., using HEARTBEAT.md from system prompt injection instead of reading from workspace).

## Changes
Now the workspace path hint is only appended when:
1. Using internal prompts (exec completion or cron events)
2. Using the default heartbeat prompt (no custom prompt configured)

## Testing
Added test case: "respects user-configured heartbeat prompt without appending workspace path hint"

Fixes #40255