### PR TITLE
fix(ui): show model errors inline in web chat

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -143,6 +143,24 @@ img.chat-avatar {
   padding-right: 36px;
 }
 
+.chat-bubble--error {
+  border-color: color-mix(in srgb, var(--danger) 36%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, var(--card));
+}
+
+.chat-bubble--error:hover {
+  background: color-mix(in srgb, var(--danger) 16%, var(--card));
+}
+
+.chat-error-label {
+  margin-bottom: 6px;
+  color: var(--danger);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .chat-copy-btn {
   position: absolute;
   top: 6px;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -267,7 +267,7 @@ function renderGroupedMessage(
     return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
   }
 
-  if (!markdown && !hasToolCards && !hasImages) {
+  if (!markdown && !hasToolCards && !hasImages && !hasAssistantError) {
     return nothing;
   }
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -229,6 +229,10 @@ function renderGroupedMessage(
 ) {
   const m = message as Record<string, unknown>;
   const role = typeof m.role === "string" ? m.role : "unknown";
+  const hasAssistantError =
+    role.toLowerCase() === "assistant" &&
+    ((typeof m.stopReason === "string" && m.stopReason === "error") ||
+      (typeof m.errorMessage === "string" && Boolean(m.errorMessage.trim())));
   const isToolResult =
     isToolResultMessage(message) ||
     role.toLowerCase() === "toolresult" ||
@@ -251,6 +255,7 @@ function renderGroupedMessage(
 
   const bubbleClasses = [
     "chat-bubble",
+    hasAssistantError ? "chat-bubble--error" : "",
     canCopyMarkdown ? "has-copy" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
@@ -270,6 +275,13 @@ function renderGroupedMessage(
     <div class="${bubbleClasses}">
       ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
       ${renderMessageImages(images)}
+      ${
+        hasAssistantError
+          ? html`
+              <div class="chat-error-label">Model error</div>
+            `
+          : nothing
+      }
       ${
         reasoningMarkdown
           ? html`<div class="chat-thinking">${unsafeHTML(

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -52,12 +52,18 @@ describe("extractTextCached", () => {
       errorMessage: "401 unauthorized",
       content: [],
     };
-    expect(extractText(message)).toBe(
-      "Model error (anthropic/claude-sonnet-4-5): 401 unauthorized",
-    );
-    expect(extractTextCached(message)).toBe(
-      "Model error (anthropic/claude-sonnet-4-5): 401 unauthorized",
-    );
+    expect(extractText(message)).toBe("anthropic/claude-sonnet-4-5: 401 unauthorized");
+    expect(extractTextCached(message)).toBe("anthropic/claude-sonnet-4-5: 401 unauthorized");
+  });
+
+  it("renders a generic fallback when assistant stopReason is error but details are empty", () => {
+    const message = {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "",
+      content: [],
+    };
+    expect(extractText(message)).toBe("No error details were provided by the model.");
   });
 });
 

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -42,6 +42,23 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBe("Final user answer");
     expect(extractTextCached(message)).toBe("Final user answer");
   });
+
+  it("falls back to assistant errorMessage when no text blocks exist", () => {
+    const message = {
+      role: "assistant",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      stopReason: "error",
+      errorMessage: "401 unauthorized",
+      content: [],
+    };
+    expect(extractText(message)).toBe(
+      "Model error (anthropic/claude-sonnet-4-5): 401 unauthorized",
+    );
+    expect(extractTextCached(message)).toBe(
+      "Model error (anthropic/claude-sonnet-4-5): 401 unauthorized",
+    );
+  });
 });
 
 describe("extractThinkingCached", () => {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -31,14 +31,16 @@ function extractAssistantErrorText(message: unknown): string | null {
   if (role !== "assistant") {
     return null;
   }
+  const stopReason = typeof m.stopReason === "string" ? m.stopReason.toLowerCase() : "";
   const errorMessage = typeof m.errorMessage === "string" ? m.errorMessage.trim() : "";
-  if (!errorMessage) {
+  if (!errorMessage && stopReason !== "error") {
     return null;
   }
   const provider = typeof m.provider === "string" ? m.provider.trim() : "";
   const model = typeof m.model === "string" ? m.model.trim() : "";
   const modelRef = provider && model ? `${provider}/${model}` : model || provider;
-  return modelRef ? `Model error (${modelRef}): ${errorMessage}` : `Model error: ${errorMessage}`;
+  const detail = errorMessage || "No error details were provided by the model.";
+  return modelRef ? `${modelRef}: ${detail}` : detail;
 }
 
 export function extractTextCached(message: unknown): string | null {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -25,6 +25,22 @@ export function extractText(message: unknown): string | null {
   return processMessageText(raw, role);
 }
 
+function extractAssistantErrorText(message: unknown): string | null {
+  const m = message as Record<string, unknown>;
+  const role = typeof m.role === "string" ? m.role.toLowerCase() : "";
+  if (role !== "assistant") {
+    return null;
+  }
+  const errorMessage = typeof m.errorMessage === "string" ? m.errorMessage.trim() : "";
+  if (!errorMessage) {
+    return null;
+  }
+  const provider = typeof m.provider === "string" ? m.provider.trim() : "";
+  const model = typeof m.model === "string" ? m.model.trim() : "";
+  const modelRef = provider && model ? `${provider}/${model}` : model || provider;
+  return modelRef ? `Model error (${modelRef}): ${errorMessage}` : `Model error: ${errorMessage}`;
+}
+
 export function extractTextCached(message: unknown): string | null {
   if (!message || typeof message !== "object") {
     return extractText(message);
@@ -105,7 +121,7 @@ export function extractRawText(message: unknown): string | null {
   if (typeof m.text === "string") {
     return m.text;
   }
-  return null;
+  return extractAssistantErrorText(message);
 }
 
 export function formatReasoningMarkdown(text: string): string {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -534,6 +534,30 @@ describe("loadChatHistory", () => {
     // text takes precedence — "real reply" is NOT silent, so message is kept.
     expect(state.chatMessages).toHaveLength(1);
   });
+
+  it("keeps assistant error-only history entries visible", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.2",
+        stopReason: "error",
+        errorMessage: "rate limit reached",
+        content: [],
+      },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual(messages);
+  });
 });
 
 describe("loadChatHistory", () => {
@@ -564,5 +588,33 @@ describe("loadChatHistory", () => {
     expect(state.chatThinkingLevel).toBe("low");
     expect(state.chatLoading).toBe(false);
     expect(state.lastError).toBeNull();
+  });
+});
+
+describe("handleChatEvent errors", () => {
+  it("appends an inline assistant error message for own-run failures", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "partial",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "HTTP 401: invalid model binding",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.lastError).toBe("HTTP 401: invalid model binding");
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatMessages[0]).toMatchObject({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "HTTP 401: invalid model binding",
+    });
   });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -149,6 +149,46 @@ function normalizeFinalAssistantMessage(message: unknown): Record<string, unknow
   });
 }
 
+function normalizeErrorMessage(error: unknown, fallback = "chat error"): string {
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
+    return String(error);
+  }
+  if (typeof error === "object" && error !== null) {
+    try {
+      const serialized = JSON.stringify(error);
+      if (serialized && serialized !== "{}") {
+        return serialized;
+      }
+    } catch {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function appendAssistantErrorMessage(
+  state: ChatState,
+  errorMessage: string,
+  timestamp = Date.now(),
+) {
+  state.chatMessages = [
+    ...state.chatMessages,
+    {
+      role: "assistant",
+      content: [],
+      errorMessage,
+      stopReason: "error",
+      timestamp,
+    },
+  ];
+}
+
 export async function sendChatMessage(
   state: ChatState,
   message: string,
@@ -223,19 +263,12 @@ export async function sendChatMessage(
     });
     return runId;
   } catch (err) {
-    const error = String(err);
+    const error = normalizeErrorMessage(err);
     state.chatRunId = null;
     state.chatStream = null;
     state.chatStreamStartedAt = null;
     state.lastError = error;
-    state.chatMessages = [
-      ...state.chatMessages,
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Error: " + error }],
-        timestamp: Date.now(),
-      },
-    ];
+    appendAssistantErrorMessage(state, error);
     return null;
   } finally {
     state.chatSending = false;
@@ -327,10 +360,12 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
+    const errorMessage = normalizeErrorMessage(payload.errorMessage);
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
-    state.lastError = payload.errorMessage ?? "chat error";
+    state.lastError = errorMessage;
+    appendAssistantErrorMessage(state, errorMessage);
   }
   return payload.state;
 }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -308,6 +308,31 @@ describe("chat view", () => {
     const bubble = container.querySelector(".chat-bubble--error");
     expect(bubble).not.toBeNull();
     expect(container.textContent).toContain("Model error");
+    expect(container.textContent).toContain("anthropic/claude-sonnet-4-5");
     expect(container.textContent).toContain("401 unauthorized");
+  });
+
+  it("keeps error bubbles visible even when the model returns no details", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "assistant",
+              stopReason: "error",
+              errorMessage: "",
+              content: [],
+              timestamp: 1000,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-bubble--error")).not.toBeNull();
+    expect(container.textContent).toContain("Model error");
+    expect(container.textContent).toContain("No error details were provided by the model.");
   });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -283,4 +283,31 @@ describe("chat view", () => {
     expect(senderLabels).toContain("Iris");
     expect(senderLabels).toContain("Joaquin De Rojas");
   });
+
+  it("renders assistant model errors as highlighted chat bubbles", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "assistant",
+              provider: "anthropic",
+              model: "claude-sonnet-4-5",
+              stopReason: "error",
+              errorMessage: "401 unauthorized",
+              content: [],
+              timestamp: 1000,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const bubble = container.querySelector(".chat-bubble--error");
+    expect(bubble).not.toBeNull();
+    expect(container.textContent).toContain("Model error");
+    expect(container.textContent).toContain("401 unauthorized");
+  });
 });


### PR DESCRIPTION
## Summary

- Render assistant error-only messages from session history so failed runs stay visible after refresh.
- Append an inline assistant error bubble when a live chat run ends with an error event.
- Highlight model failures in the chat UI and cover the behavior with UI tests.

## Testing

- `npm test -- --run src/ui/controllers/chat.test.ts src/ui/chat/message-extract.test.ts src/ui/views/chat.test.ts`
- `npm run build`
- `npm test -- --run src/gateway/server-chat.agent-events.test.ts`