### PR TITLE
iOS: auto-load the scoped gateway canvas with safe fallback

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
+++ b/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
@@ -1,9 +1,17 @@
 import Foundation
-import Network
 import OpenClawKit
-import os
 
 extension NodeAppModel {
+    func resolveCanvasHostURL() async -> String? {
+        guard let raw = await self.gatewaySession.currentCanvasHostUrl() else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let base = URL(string: trimmed) else { return nil }
+        if let host = base.host, LoopbackHost.isLoopback(host) {
+            return nil
+        }
+        return base.appendingPathComponent("__openclaw__/canvas/").absoluteString
+    }
+
     func _test_resolveA2UIHostURL() async -> String? {
         await self.resolveA2UIHostURL()
     }
@@ -19,22 +27,11 @@ extension NodeAppModel {
     }
 
     func showA2UIOnConnectIfNeeded() async {
-        guard let a2uiUrl = await self.resolveA2UIHostURL() else {
-            await MainActor.run {
-                self.lastAutoA2uiURL = nil
-                self.screen.showDefaultCanvas()
-            }
-            return
-        }
         let current = self.screen.urlString.trimmingCharacters(in: .whitespacesAndNewlines)
         if current.isEmpty || current == self.lastAutoA2uiURL {
-            // Avoid navigating the WKWebView to an unreachable host: it leaves a persistent
-            // "could not connect to the server" overlay even when the gateway is connected.
-            if let url = URL(string: a2uiUrl),
-               await Self.probeTCP(url: url, timeoutSeconds: 2.5)
-            {
-                self.screen.navigate(to: a2uiUrl)
-                self.lastAutoA2uiURL = a2uiUrl
+            if let canvasUrl = await self.resolveCanvasHostURLWithCapabilityRefresh() {
+                self.screen.navigate(to: canvasUrl)
+                self.lastAutoA2uiURL = canvasUrl
             } else {
                 self.lastAutoA2uiURL = nil
                 self.screen.showDefaultCanvas()
@@ -42,18 +39,41 @@ extension NodeAppModel {
         }
     }
 
+    func ensureA2UIReadyWithCapabilityRefresh(timeoutMs: Int = 5000) async -> String? {
+        guard let initialUrl = await self.resolveA2UIHostURLWithCapabilityRefresh() else { return nil }
+        self.screen.navigate(to: initialUrl)
+        if await self.screen.waitForA2UIReady(timeoutMs: timeoutMs) {
+            return initialUrl
+        }
+
+        // First render can fail when scoped capability rotates between reconnects.
+        guard await self.gatewaySession.refreshNodeCanvasCapability() else { return nil }
+        guard let refreshedUrl = await self.resolveA2UIHostURL() else { return nil }
+        self.screen.navigate(to: refreshedUrl)
+        if await self.screen.waitForA2UIReady(timeoutMs: timeoutMs) {
+            return refreshedUrl
+        }
+        return nil
+    }
+
     func showLocalCanvasOnDisconnect() {
         self.lastAutoA2uiURL = nil
         self.screen.showDefaultCanvas()
     }
 
-    private static func probeTCP(url: URL, timeoutSeconds: Double) async -> Bool {
-        guard let host = url.host, !host.isEmpty else { return false }
-        let portInt = url.port ?? ((url.scheme ?? "").lowercased() == "wss" ? 443 : 80)
-        return await TCPProbe.probe(
-            host: host,
-            port: portInt,
-            timeoutSeconds: timeoutSeconds,
-            queueLabel: "a2ui.preflight")
+    private func resolveA2UIHostURLWithCapabilityRefresh() async -> String? {
+        if let url = await self.resolveA2UIHostURL() {
+            return url
+        }
+        guard await self.gatewaySession.refreshNodeCanvasCapability() else { return nil }
+        return await self.resolveA2UIHostURL()
+    }
+
+    private func resolveCanvasHostURLWithCapabilityRefresh() async -> String? {
+        if let url = await self.resolveCanvasHostURL() {
+            return url
+        }
+        guard await self.gatewaySession.refreshNodeCanvasCapability() else { return nil }
+        return await self.resolveCanvasHostURL()
     }
 }

--- a/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
+++ b/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
@@ -1,5 +1,12 @@
 import Foundation
+import Network
 import OpenClawKit
+
+enum A2UIReadyState {
+    case ready(String)
+    case hostNotConfigured
+    case hostUnavailable
+}
 
 extension NodeAppModel {
     func resolveCanvasHostURL() async -> String? {
@@ -29,7 +36,10 @@ extension NodeAppModel {
     func showA2UIOnConnectIfNeeded() async {
         let current = self.screen.urlString.trimmingCharacters(in: .whitespacesAndNewlines)
         if current.isEmpty || current == self.lastAutoA2uiURL {
-            if let canvasUrl = await self.resolveCanvasHostURLWithCapabilityRefresh() {
+            if let canvasUrl = await self.resolveCanvasHostURLWithCapabilityRefresh(),
+               let url = URL(string: canvasUrl),
+               await Self.probeTCP(url: url, timeoutSeconds: 2.5)
+            {
                 self.screen.navigate(to: canvasUrl)
                 self.lastAutoA2uiURL = canvasUrl
             } else {
@@ -39,21 +49,23 @@ extension NodeAppModel {
         }
     }
 
-    func ensureA2UIReadyWithCapabilityRefresh(timeoutMs: Int = 5000) async -> String? {
-        guard let initialUrl = await self.resolveA2UIHostURLWithCapabilityRefresh() else { return nil }
+    func ensureA2UIReadyWithCapabilityRefresh(timeoutMs: Int = 5000) async -> A2UIReadyState {
+        guard let initialUrl = await self.resolveA2UIHostURLWithCapabilityRefresh() else {
+            return .hostNotConfigured
+        }
         self.screen.navigate(to: initialUrl)
         if await self.screen.waitForA2UIReady(timeoutMs: timeoutMs) {
-            return initialUrl
+            return .ready(initialUrl)
         }
 
         // First render can fail when scoped capability rotates between reconnects.
-        guard await self.gatewaySession.refreshNodeCanvasCapability() else { return nil }
-        guard let refreshedUrl = await self.resolveA2UIHostURL() else { return nil }
+        guard await self.gatewaySession.refreshNodeCanvasCapability() else { return .hostUnavailable }
+        guard let refreshedUrl = await self.resolveA2UIHostURL() else { return .hostUnavailable }
         self.screen.navigate(to: refreshedUrl)
         if await self.screen.waitForA2UIReady(timeoutMs: timeoutMs) {
-            return refreshedUrl
+            return .ready(refreshedUrl)
         }
-        return nil
+        return .hostUnavailable
     }
 
     func showLocalCanvasOnDisconnect() {
@@ -75,5 +87,15 @@ extension NodeAppModel {
         }
         guard await self.gatewaySession.refreshNodeCanvasCapability() else { return nil }
         return await self.resolveCanvasHostURL()
+    }
+
+    private static func probeTCP(url: URL, timeoutSeconds: Double) async -> Bool {
+        guard let host = url.host, !host.isEmpty else { return false }
+        let portInt = url.port ?? ((url.scheme ?? "").lowercased() == "wss" ? 443 : 80)
+        return await TCPProbe.probe(
+            host: host,
+            port: portInt,
+            timeoutSeconds: timeoutSeconds,
+            queueLabel: "a2ui.preflight")
     }
 }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -877,16 +877,7 @@ final class NodeAppModel {
         let command = req.command
         switch command {
         case OpenClawCanvasA2UICommand.reset.rawValue:
-            guard let a2uiUrl = await self.resolveA2UIHostURL() else {
-                return BridgeInvokeResponse(
-                    id: req.id,
-                    ok: false,
-                    error: OpenClawNodeError(
-                        code: .unavailable,
-                        message: "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host"))
-            }
-            self.screen.navigate(to: a2uiUrl)
-            if await !self.screen.waitForA2UIReady(timeoutMs: 5000) {
+            guard await self.ensureA2UIReadyWithCapabilityRefresh(timeoutMs: 5000) != nil else {
                 return BridgeInvokeResponse(
                     id: req.id,
                     ok: false,
@@ -919,16 +910,7 @@ final class NodeAppModel {
                 }
             }
 
-            guard let a2uiUrl = await self.resolveA2UIHostURL() else {
-                return BridgeInvokeResponse(
-                    id: req.id,
-                    ok: false,
-                    error: OpenClawNodeError(
-                        code: .unavailable,
-                        message: "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host"))
-            }
-            self.screen.navigate(to: a2uiUrl)
-            if await !self.screen.waitForA2UIReady(timeoutMs: 5000) {
+            guard await self.ensureA2UIReadyWithCapabilityRefresh(timeoutMs: 5000) != nil else {
                 return BridgeInvokeResponse(
                     id: req.id,
                     ok: false,

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -877,7 +877,17 @@ final class NodeAppModel {
         let command = req.command
         switch command {
         case OpenClawCanvasA2UICommand.reset.rawValue:
-            guard await self.ensureA2UIReadyWithCapabilityRefresh(timeoutMs: 5000) != nil else {
+            switch await self.ensureA2UIReadyWithCapabilityRefresh(timeoutMs: 5000) {
+            case .ready:
+                break
+            case .hostNotConfigured:
+                return BridgeInvokeResponse(
+                    id: req.id,
+                    ok: false,
+                    error: OpenClawNodeError(
+                        code: .unavailable,
+                        message: "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host"))
+            case .hostUnavailable:
                 return BridgeInvokeResponse(
                     id: req.id,
                     ok: false,
@@ -885,7 +895,6 @@ final class NodeAppModel {
                         code: .unavailable,
                         message: "A2UI_HOST_UNAVAILABLE: A2UI host not reachable"))
             }
-
             let json = try await self.screen.eval(javaScript: """
             (() => {
               const host = globalThis.openclawA2UI;
@@ -894,6 +903,7 @@ final class NodeAppModel {
             })()
             """)
             return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: json)
+
         case OpenClawCanvasA2UICommand.push.rawValue, OpenClawCanvasA2UICommand.pushJSONL.rawValue:
             let messages: [OpenClawKit.AnyCodable]
             if command == OpenClawCanvasA2UICommand.pushJSONL.rawValue {
@@ -910,7 +920,17 @@ final class NodeAppModel {
                 }
             }
 
-            guard await self.ensureA2UIReadyWithCapabilityRefresh(timeoutMs: 5000) != nil else {
+            switch await self.ensureA2UIReadyWithCapabilityRefresh(timeoutMs: 5000) {
+            case .ready:
+                break
+            case .hostNotConfigured:
+                return BridgeInvokeResponse(
+                    id: req.id,
+                    ok: false,
+                    error: OpenClawNodeError(
+                        code: .unavailable,
+                        message: "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host"))
+            case .hostUnavailable:
                 return BridgeInvokeResponse(
                     id: req.id,
                     ok: false,

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -85,7 +85,19 @@ struct RootCanvas: View {
 
     var body: some View {
         ZStack {
-            RootTabs()
+            CanvasContent(
+                systemColorScheme: self.systemColorScheme,
+                gatewayStatus: self.gatewayStatus,
+                voiceWakeEnabled: self.voiceWakeEnabled,
+                voiceWakeToastText: self.voiceWakeToastText,
+                cameraHUDText: self.appModel.cameraHUDText,
+                cameraHUDKind: self.appModel.cameraHUDKind,
+                openChat: {
+                    self.presentedSheet = .chat
+                },
+                openSettings: {
+                    self.presentedSheet = .settings
+                })
                 .preferredColorScheme(.dark)
 
             if self.appModel.cameraFlashNonce != 0 {

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -85,19 +85,7 @@ struct RootCanvas: View {
 
     var body: some View {
         ZStack {
-            CanvasContent(
-                systemColorScheme: self.systemColorScheme,
-                gatewayStatus: self.gatewayStatus,
-                voiceWakeEnabled: self.voiceWakeEnabled,
-                voiceWakeToastText: self.voiceWakeToastText,
-                cameraHUDText: self.appModel.cameraHUDText,
-                cameraHUDKind: self.appModel.cameraHUDKind,
-                openChat: {
-                    self.presentedSheet = .chat
-                },
-                openSettings: {
-                    self.presentedSheet = .settings
-                })
+            RootTabs()
                 .preferredColorScheme(.dark)
 
             if self.appModel.cameraFlashNonce != 0 {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -260,14 +260,18 @@ public actor GatewayNodeSession {
                 self.logger.warning("node.canvas.capability.refresh missing local canvasHostUrl")
                 return false
             }
-            guard let refreshed = replaceCanvasCapabilityInScopedHostUrl(scopedUrl: scopedUrl, capability: capability) else {
+            guard let refreshed = replaceCanvasCapabilityInScopedHostUrl(
+                scopedUrl: scopedUrl,
+                capability: capability)
+            else {
                 self.logger.warning("node.canvas.capability.refresh could not rewrite scoped canvas URL")
                 return false
             }
             self.canvasHostUrl = refreshed
             return true
         } catch {
-            self.logger.warning("node.canvas.capability.refresh failed: \(error.localizedDescription, privacy: .public)")
+            self.logger.warning(
+                "node.canvas.capability.refresh failed: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -428,16 +432,23 @@ public actor GatewayNodeSession {
         do {
             let request = try self.decodeInvokeRequest(from: payload)
             let timeoutLabel = request.timeoutMs.map(String.init) ?? "none"
-            self.logger.info("node invoke request decoded id=\(request.id, privacy: .public) command=\(request.command, privacy: .public) timeoutMs=\(timeoutLabel, privacy: .public)")
+            self.logger.info(
+                "node invoke request decoded id=\(request.id, privacy: .public) "
+                    + "command=\(request.command, privacy: .public) "
+                    + "timeoutMs=\(timeoutLabel, privacy: .public)")
             guard let onInvoke else { return }
-            let req = BridgeInvokeRequest(id: request.id, command: request.command, paramsJSON: request.paramsJSON)
+            let req = BridgeInvokeRequest(
+                id: request.id,
+                command: request.command,
+                paramsJSON: request.paramsJSON)
             self.logger.info("node invoke executing id=\(request.id, privacy: .public)")
             let response = await Self.invokeWithTimeout(
                 request: req,
                 timeoutMs: request.timeoutMs,
                 onInvoke: onInvoke
             )
-            self.logger.info("node invoke completed id=\(request.id, privacy: .public) ok=\(response.ok, privacy: .public)")
+            self.logger.info(
+                "node invoke completed id=\(request.id, privacy: .public) ok=\(response.ok, privacy: .public)")
             await self.sendInvokeResult(request: request, response: response)
         } catch {
             self.logger.error("node invoke decode failed: \(error.localizedDescription, privacy: .public)")
@@ -458,7 +469,8 @@ public actor GatewayNodeSession {
 
     private func sendInvokeResult(request: NodeInvokeRequestPayload, response: BridgeInvokeResponse) async {
         guard let channel = self.channel else { return }
-        self.logger.info("node invoke result sending id=\(request.id, privacy: .public) ok=\(response.ok, privacy: .public)")
+        self.logger.info(
+            "node invoke result sending id=\(request.id, privacy: .public) ok=\(response.ok, privacy: .public)")
         var params: [String: AnyCodable] = [
             "id": AnyCodable(request.id),
             "nodeId": AnyCodable(request.nodeId),
@@ -476,7 +488,9 @@ public actor GatewayNodeSession {
         do {
             try await channel.send(method: "node.invoke.result", params: params)
         } catch {
-            self.logger.error("node invoke result failed id=\(request.id, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            self.logger.error(
+                "node invoke result failed id=\(request.id, privacy: .public) "
+                    + "error=\(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -24,6 +24,37 @@ private func replaceCanvasCapabilityInScopedHostUrl(scopedUrl: String, capabilit
     return String(scopedUrl[..<capabilityStart]) + capability + String(scopedUrl[capabilityEnd...])
 }
 
+func canonicalizeCanvasHostUrl(raw: String?, activeURL: URL?) -> String? {
+    let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !trimmed.isEmpty else { return nil }
+    guard var parsed = URLComponents(string: trimmed) else { return trimmed }
+
+    let parsedHost = parsed.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let parsedIsLoopback = !parsedHost.isEmpty && LoopbackHost.isLoopback(parsedHost)
+
+    if !parsedHost.isEmpty, !parsedIsLoopback {
+        guard let activeURL else { return trimmed }
+        let isTLS = activeURL.scheme?.lowercased() == "wss"
+        guard isTLS else { return trimmed }
+        parsed.scheme = "https"
+        if parsed.port == nil {
+            let tlsPort = activeURL.port ?? 443
+            parsed.port = (tlsPort == 443) ? nil : tlsPort
+        }
+        return parsed.string ?? trimmed
+    }
+
+    guard let activeURL, let fallbackHost = activeURL.host, !LoopbackHost.isLoopback(fallbackHost) else {
+        return trimmed
+    }
+    let isTLS = activeURL.scheme?.lowercased() == "wss"
+    parsed.scheme = isTLS ? "https" : "http"
+    parsed.host = fallbackHost
+    let fallbackPort = activeURL.port ?? (isTLS ? 443 : 80)
+    parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
+    return parsed.string ?? trimmed
+}
+
 
 public actor GatewayNodeSession {
     private let logger = Logger(subsystem: "ai.openclaw", category: "node.gateway")
@@ -396,32 +427,7 @@ public actor GatewayNodeSession {
     }
 
     private func normalizeCanvasHostUrl(_ raw: String?) -> String? {
-        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !trimmed.isEmpty else { return nil }
-        guard var parsed = URLComponents(string: trimmed) else { return trimmed }
-
-        let parsedHost = parsed.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let parsedIsLoopback = !parsedHost.isEmpty && LoopbackHost.isLoopback(parsedHost)
-
-        if !parsedHost.isEmpty, !parsedIsLoopback {
-            guard let activeURL else { return trimmed }
-            let isTLS = activeURL.scheme?.lowercased() == "wss"
-            guard isTLS else { return trimmed }
-            parsed.scheme = "https"
-            let tlsPort = activeURL.port ?? 443
-            parsed.port = (tlsPort == 443) ? nil : tlsPort
-            return parsed.string ?? trimmed
-        }
-
-        guard let activeURL, let fallbackHost = activeURL.host, !LoopbackHost.isLoopback(fallbackHost) else {
-            return trimmed
-        }
-        let isTLS = activeURL.scheme?.lowercased() == "wss"
-        parsed.scheme = isTLS ? "https" : "http"
-        parsed.host = fallbackHost
-        let fallbackPort = activeURL.port ?? (isTLS ? 443 : 80)
-        parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
-        return parsed.string ?? trimmed
+        canonicalizeCanvasHostUrl(raw: raw, activeURL: self.activeURL)
     }
 
     private func handleEvent(_ evt: EventFrame) async {
@@ -433,9 +439,7 @@ public actor GatewayNodeSession {
             let request = try self.decodeInvokeRequest(from: payload)
             let timeoutLabel = request.timeoutMs.map(String.init) ?? "none"
             self.logger.info(
-                "node invoke request decoded id=\(request.id, privacy: .public) "
-                    + "command=\(request.command, privacy: .public) "
-                    + "timeoutMs=\(timeoutLabel, privacy: .public)")
+                "node invoke request decoded id=\(request.id, privacy: .public) command=\(request.command, privacy: .public) timeoutMs=\(timeoutLabel, privacy: .public)")
             guard let onInvoke else { return }
             let req = BridgeInvokeRequest(
                 id: request.id,
@@ -489,8 +493,7 @@ public actor GatewayNodeSession {
             try await channel.send(method: "node.invoke.result", params: params)
         } catch {
             self.logger.error(
-                "node invoke result failed id=\(request.id, privacy: .public) "
-                    + "error=\(error.localizedDescription, privacy: .public)")
+                "node invoke result failed id=\(request.id, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -11,6 +11,19 @@ private struct NodeInvokeRequestPayload: Codable, Sendable {
     var idempotencyKey: String?
 }
 
+private func replaceCanvasCapabilityInScopedHostUrl(scopedUrl: String, capability: String) -> String? {
+    let marker = "/__openclaw__/cap/"
+    guard let markerRange = scopedUrl.range(of: marker) else { return nil }
+    let capabilityStart = markerRange.upperBound
+    let suffix = scopedUrl[capabilityStart...]
+    let nextSlash = suffix.firstIndex(of: "/")
+    let nextQuery = suffix.firstIndex(of: "?")
+    let nextFragment = suffix.firstIndex(of: "#")
+    let capabilityEnd = [nextSlash, nextQuery, nextFragment].compactMap { $0 }.min() ?? scopedUrl.endIndex
+    guard capabilityStart < capabilityEnd else { return nil }
+    return String(scopedUrl[..<capabilityStart]) + capability + String(scopedUrl[capabilityEnd...])
+}
+
 
 public actor GatewayNodeSession {
     private let logger = Logger(subsystem: "ai.openclaw", category: "node.gateway")
@@ -223,6 +236,42 @@ public actor GatewayNodeSession {
         self.canvasHostUrl
     }
 
+    public func refreshNodeCanvasCapability(timeoutMs: Int = 8_000) async -> Bool {
+        guard let channel = self.channel else { return false }
+        do {
+            let data = try await channel.request(
+                method: "node.canvas.capability.refresh",
+                params: [:],
+                timeoutMs: Double(max(timeoutMs, 1)))
+            guard
+                let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let rawCapability = payload["canvasCapability"] as? String
+            else {
+                self.logger.warning("node.canvas.capability.refresh missing canvasCapability")
+                return false
+            }
+            let capability = rawCapability.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !capability.isEmpty else {
+                self.logger.warning("node.canvas.capability.refresh returned empty capability")
+                return false
+            }
+            let scopedUrl = self.canvasHostUrl?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !scopedUrl.isEmpty else {
+                self.logger.warning("node.canvas.capability.refresh missing local canvasHostUrl")
+                return false
+            }
+            guard let refreshed = replaceCanvasCapabilityInScopedHostUrl(scopedUrl: scopedUrl, capability: capability) else {
+                self.logger.warning("node.canvas.capability.refresh could not rewrite scoped canvas URL")
+                return false
+            }
+            self.canvasHostUrl = refreshed
+            return true
+        } catch {
+            self.logger.warning("node.canvas.capability.refresh failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
     public func currentRemoteAddress() -> String? {
         guard let url = self.activeURL else { return nil }
         guard let host = url.host else { return url.absoluteString }
@@ -275,7 +324,7 @@ public actor GatewayNodeSession {
         switch push {
         case let .snapshot(ok):
             let raw = ok.canvashosturl?.trimmingCharacters(in: .whitespacesAndNewlines)
-            self.canvasHostUrl = (raw?.isEmpty == false) ? raw : nil
+            self.canvasHostUrl = self.normalizeCanvasHostUrl(raw)
             if self.hasEverConnected {
                 self.broadcastServerEvent(
                     EventFrame(type: "event", event: "seqGap", payload: nil, seq: nil, stateversion: nil))
@@ -340,6 +389,35 @@ public actor GatewayNodeSession {
         guard !self.hasNotifiedConnected else { return }
         self.hasNotifiedConnected = true
         await self.onConnected?()
+    }
+
+    private func normalizeCanvasHostUrl(_ raw: String?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        guard var parsed = URLComponents(string: trimmed) else { return trimmed }
+
+        let parsedHost = parsed.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let parsedIsLoopback = !parsedHost.isEmpty && LoopbackHost.isLoopback(parsedHost)
+
+        if !parsedHost.isEmpty, !parsedIsLoopback {
+            guard let activeURL else { return trimmed }
+            let isTLS = activeURL.scheme?.lowercased() == "wss"
+            guard isTLS else { return trimmed }
+            parsed.scheme = "https"
+            let tlsPort = activeURL.port ?? 443
+            parsed.port = (tlsPort == 443) ? nil : tlsPort
+            return parsed.string ?? trimmed
+        }
+
+        guard let activeURL, let fallbackHost = activeURL.host, !LoopbackHost.isLoopback(fallbackHost) else {
+            return trimmed
+        }
+        let isTLS = activeURL.scheme?.lowercased() == "wss"
+        parsed.scheme = isTLS ? "https" : "http"
+        parsed.host = fallbackHost
+        let fallbackPort = activeURL.port ?? (isTLS ? 443 : 80)
+        parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
+        return parsed.string ?? trimmed
     }
 
     private func handleEvent(_ evt: EventFrame) async {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -170,6 +170,24 @@ private actor SeqGapProbe {
 
 struct GatewayNodeSessionTests {
     @Test
+    func normalizeCanvasHostUrlPreservesExplicitSecureCanvasPort() {
+        let normalized = canonicalizeCanvasHostUrl(
+            raw: "https://canvas.example.com:9443/__openclaw__/cap/token",
+            activeURL: URL(string: "wss://gateway.example.com")!)
+
+        #expect(normalized == "https://canvas.example.com:9443/__openclaw__/cap/token")
+    }
+
+    @Test
+    func normalizeCanvasHostUrlBackfillsGatewayHostForLoopbackCanvas() {
+        let normalized = canonicalizeCanvasHostUrl(
+            raw: "http://127.0.0.1:18789/__openclaw__/cap/token",
+            activeURL: URL(string: "wss://gateway.example.com:7443")!)
+
+        #expect(normalized == "https://gateway.example.com:7443/__openclaw__/cap/token")
+    }
+
+    @Test
     func invokeWithTimeoutReturnsUnderlyingResponseBeforeTimeout() async {
         let request = BridgeInvokeRequest(id: "1", command: "x", paramsJSON: nil)
         let response = await GatewayNodeSession.invokeWithTimeout(


### PR DESCRIPTION
## Summary
- auto-load the scoped gateway canvas on iOS connect, while falling back to the local scaffold when the host is missing or unreachable
- refresh scoped canvas capability before A2UI reset/push retries so reconnects survive rotated capability tokens
- preserve explicitly advertised secure canvas ports instead of rewriting them to the websocket port
- add shared-kit tests for canvas host normalization

## Testing
- on `mb-server`: `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests`
- on `mb-server`: `pnpm build`

## Notes
- the earlier `RootTabs` shell swap was intentionally removed from this PR to keep the slice focused on canvas connectivity behavior
- full iOS app-target tests on `mb-server` are still blocked by the missing watchOS simulator runtime for the embedded Watch app target
