### PR TITLE
fix(acp): apply media understanding before ACP dispatch

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -84,6 +84,17 @@ vi.mock("../../infra/outbound/session-binding-service.js", () => ({
   }),
 }));
 
+vi.mock("../../media-understanding/apply.js", () => ({
+  applyMediaUnderstanding: vi.fn(async () => ({
+    outputs: [],
+    decisions: [],
+    appliedImage: false,
+    appliedAudio: false,
+    appliedVideo: false,
+    appliedFile: false,
+  })),
+}));
+
 const { tryDispatchAcpReply } = await import("./dispatch-acp.js");
 const sessionKey = "agent:codex-acp:session-1";
 

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -11,10 +11,10 @@ import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
-import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
+import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { maybeApplyTtsToPayload, resolveTtsConfig } from "../../tts/tts.js";
 import {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -11,6 +11,7 @@ import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
+import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
@@ -186,6 +187,14 @@ export async function tryDispatchAcpReply(params: {
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,
     onReplyStart: params.onReplyStart,
+  });
+
+  // Apply media understanding (audio transcription, image description, etc.)
+  // before resolving the prompt text. Without this, ACP agents receive raw
+  // <media:document> tags instead of transcribed/described content.
+  await applyMediaUnderstanding({
+    ctx: params.ctx,
+    cfg: params.cfg,
   });
 
   const promptText = resolveAcpPromptText(params.ctx);

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -189,15 +189,7 @@ export async function tryDispatchAcpReply(params: {
     onReplyStart: params.onReplyStart,
   });
 
-  // Apply media understanding (audio transcription, image description, etc.)
-  // before resolving the prompt text. Without this, ACP agents receive raw
-  // <media:document> tags instead of transcribed/described content.
-  await applyMediaUnderstanding({
-    ctx: params.ctx,
-    cfg: params.cfg,
-  });
-
-  const promptText = resolveAcpPromptText(params.ctx);
+  let promptText = resolveAcpPromptText(params.ctx);
   if (!promptText) {
     const counts = params.dispatcher.getQueuedCounts();
     delivery.applyRoutedCounts(counts);
@@ -246,6 +238,28 @@ export async function tryDispatchAcpReply(params: {
     const agentPolicyError = resolveAcpAgentPolicyError(params.cfg, resolvedAcpAgent);
     if (agentPolicyError) {
       throw agentPolicyError;
+    }
+
+    // Apply media understanding (audio transcription, image description, etc.)
+    // before resolving the prompt text. Without this, ACP agents receive raw
+    // <media:document> tags instead of transcribed/described content.
+    // Guarded against double processing for AcpDispatchTailAfterReset paths.
+    if (!params.ctx.MediaUnderstanding?.length) {
+      try {
+        await applyMediaUnderstanding({
+          ctx: params.ctx,
+          cfg: params.cfg,
+        });
+      } catch (err) {
+        logVerbose(
+          `dispatch-acp: media understanding failed, proceeding with raw content: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const mediaPromptText = resolveAcpPromptText(params.ctx);
+    if (mediaPromptText) {
+      promptText = mediaPromptText;
     }
 
     try {


### PR DESCRIPTION
## Summary

- ACP agents receive raw `<media:document>` tags instead of transcribed/described content for voice messages, images, and video
- Root cause: `tryDispatchAcpReply()` resolves prompt text **before** `applyMediaUnderstanding()` runs — media understanding only executes in the non-ACP path (`getReplyFromConfig`)
- Fix: call `applyMediaUnderstanding()` inside `tryDispatchAcpReply()` before `resolveAcpPromptText()`

## Root Cause

In `dispatch-from-config.ts`, the dispatch flow is:

1. `tryDispatchAcpReply()` → ACP path (early return if ACP session exists)
2. `getReplyFromConfig()` → non-ACP path (calls `applyMediaUnderstanding` internally)

For ACP sessions, step 1 returns before step 2 ever runs, so media understanding is skipped entirely.

## Test Plan

- [x] Validated locally with patched dist file — voice messages now transcribed and delivered as text to ACP agents
- [x] Confirmed `applyMediaUnderstanding()` accepts optional `agentDir` and `activeModel` params (both unused in ACP context)
- [x] Run existing `dispatch-acp.test.ts` tests — all 7 pass (added mock for `applyMediaUnderstanding`)
- [x] Verify non-ACP path is unaffected — `get-reply.ts` untouched, full CI suite green

Fixes #40161