### PR TITLE
fix(discord): include card text as context when button is clicked

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -144,7 +144,9 @@ function buildMessagingSection(params: {
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled
-            ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
+            ? params.runtimeChannel === "discord"
+              ? '- Inline buttons supported via Discord Components v2. Use `action=send` with `components`: `{"blocks":[{"type":"text","text":"…"},{"type":"actions","buttons":[{"label":"…","style":"primary|success|danger"}]}],"reusable":true}`. Set `reusable:true` to keep buttons active across clicks.'
+              : "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
             : params.runtimeChannel
               ? `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
               : "",

--- a/src/discord/components.ts
+++ b/src/discord/components.ts
@@ -167,6 +167,8 @@ export type DiscordComponentEntry = {
   messageId?: string;
   createdAt?: number;
   expiresAt?: number;
+  /** Text content of the card that contains this button, for context when dispatching. */
+  cardText?: string;
 };
 
 export type DiscordModalFieldDefinition = {
@@ -947,6 +949,25 @@ export function buildDiscordComponentMessage(params: {
     | File
   > = [];
 
+  // Collect all text content from the spec to attach as context to button entries.
+  const cardTextParts: string[] = [];
+  if (params.spec.text ?? params.fallbackText) {
+    cardTextParts.push((params.spec.text ?? params.fallbackText)!);
+  }
+  for (const block of params.spec.blocks ?? []) {
+    if (block.type === "text") {
+      cardTextParts.push(block.text);
+    } else if (block.type === "section") {
+      if (block.text) {
+        cardTextParts.push(block.text);
+      }
+      if (block.texts) {
+        cardTextParts.push(...block.texts);
+      }
+    }
+  }
+  const cardText = cardTextParts.length > 0 ? cardTextParts.join("\n") : undefined;
+
   const addEntry = (entry: DiscordComponentEntry) => {
     entries.push({
       ...entry,
@@ -954,6 +975,7 @@ export function buildDiscordComponentMessage(params: {
       agentId: params.agentId,
       accountId: params.accountId,
       reusable: entry.reusable ?? params.spec.reusable,
+      cardText: entry.cardText ?? cardText,
     });
   };
 
@@ -1137,13 +1159,20 @@ export function formatDiscordComponentEventText(params: {
   kind: "button" | "select";
   label: string;
   values?: string[];
+  cardText?: string;
 }): string {
+  let text: string;
   if (params.kind === "button") {
-    return `Clicked "${params.label}".`;
+    text = `Clicked "${params.label}".`;
+  } else {
+    const values = params.values ?? [];
+    text =
+      values.length === 0
+        ? `Updated "${params.label}".`
+        : `Selected ${values.join(", ")} from "${params.label}".`;
   }
-  const values = params.values ?? [];
-  if (values.length === 0) {
-    return `Updated "${params.label}".`;
+  if (params.cardText) {
+    text += `\n\nCard context:\n${params.cardText}`;
   }
-  return `Selected ${values.join(", ")} from "${params.label}".`;
+  return text;
 }

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -1155,6 +1155,7 @@ async function handleDiscordComponentEvent(params: {
     kind: consumed.kind === "select" ? "select" : "button",
     label: consumed.label,
     values,
+    cardText: consumed.cardText,
   });
 
   try {


### PR DESCRIPTION
## Summary

- Include the card/embed text content as context when a Discord button interaction is triggered
- Previously, the agent had no access to the message text when handling button clicks, causing it to respond without context

## Test plan

- [ ] Send a Discord message with buttons and card text, click a button, verify the agent response uses the card text as context

---
🤖 AI-assisted (Claude) | Lightly tested on local OpenClaw instance