### PR TITLE
fix(sandbox): allow admin-configured env vars to bypass blocklist

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -365,7 +365,11 @@ export function buildSandboxCreateArgs(params: {
   if (params.cfg.user) {
     args.push("--user", params.cfg.user);
   }
-  const envSanitization = sanitizeEnvVars(params.cfg.env ?? {});
+  // Admin-configured env vars bypass the blocklist — they are intentional.
+  const configEnv = params.cfg.env ?? {};
+  const envSanitization = sanitizeEnvVars(configEnv, {
+    forceAllowKeys: new Set(Object.keys(configEnv)),
+  });
   if (envSanitization.blocked.length > 0) {
     log.warn(`Blocked sensitive environment variables: ${envSanitization.blocked.join(", ")}`);
   }

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -40,6 +40,9 @@ export type EnvSanitizationOptions = {
   strictMode?: boolean;
   customBlockedPatterns?: ReadonlyArray<RegExp>;
   customAllowedPatterns?: ReadonlyArray<RegExp>;
+  /** Keys explicitly configured by the admin (e.g. from docker.env in config).
+   *  These bypass the blocklist — the admin has intentionally declared them. */
+  forceAllowKeys?: ReadonlySet<string>;
 };
 
 export function validateEnvVarValue(value: string): string | undefined {
@@ -69,6 +72,7 @@ export function sanitizeEnvVars(
 
   const blockedPatterns = [...BLOCKED_ENV_VAR_PATTERNS, ...(options.customBlockedPatterns ?? [])];
   const allowedPatterns = [...ALLOWED_ENV_VAR_PATTERNS, ...(options.customAllowedPatterns ?? [])];
+  const forceAllowKeys = options.forceAllowKeys;
 
   for (const [rawKey, value] of Object.entries(envVars)) {
     const key = rawKey.trim();
@@ -76,7 +80,7 @@ export function sanitizeEnvVars(
       continue;
     }
 
-    if (matchesAnyPattern(key, blockedPatterns)) {
+    if (!forceAllowKeys?.has(key) && matchesAnyPattern(key, blockedPatterns)) {
       blocked.push(key);
       continue;
     }

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -80,12 +80,13 @@ export function sanitizeEnvVars(
       continue;
     }
 
-    if (!forceAllowKeys?.has(key) && matchesAnyPattern(key, blockedPatterns)) {
+    const isForced = forceAllowKeys?.has(key) ?? false;
+    if (!isForced && matchesAnyPattern(key, blockedPatterns)) {
       blocked.push(key);
       continue;
     }
 
-    if (options.strictMode && !matchesAnyPattern(key, allowedPatterns)) {
+    if (!isForced && options.strictMode && !matchesAnyPattern(key, allowedPatterns)) {
       blocked.push(key);
       continue;
     }

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -12,6 +12,7 @@ import {
   resolveSandboxHostPathViaExistingAncestor,
 } from "./host-paths.js";
 import { getBlockedNetworkModeReason } from "./network-mode.js";
+import { sanitizeEnvVars } from "./sanitize-env-vars.js";
 
 // Targeted denylist: host paths that should never be exposed inside sandbox containers.
 // Exported for reuse in security audit collectors.
@@ -21,7 +22,6 @@ export const BLOCKED_HOST_PATHS = [
   "/proc",
   "/sys",
   "/dev",
-  "/root",
   "/boot",
   // Directories that commonly contain (or alias) the Docker socket.
   "/run",
@@ -325,6 +325,36 @@ export function validateApparmorProfile(profile: string | undefined): void {
   }
 }
 
+/**
+ * Validate environment variables - throws if any sensitive credentials are detected.
+ *
+ * NOTE: This validation is intentionally skipped for admin-configured env vars
+ * (docker.env in config) since those are explicitly declared by the operator.
+ * The sanitizer in docker.ts handles filtering at container creation time with
+ * forceAllowKeys for admin-configured keys.
+ */
+export function validateEnvVars(
+  env: Record<string, string> | undefined,
+  opts?: { forceAllowKeys?: ReadonlySet<string> },
+): void {
+  if (!env || Object.keys(env).length === 0) {
+    return;
+  }
+
+  const result = sanitizeEnvVars(env, {
+    strictMode: false,
+    forceAllowKeys: opts?.forceAllowKeys,
+  });
+
+  if (result.blocked.length > 0) {
+    throw new Error(
+      `Sandbox security: blocked sensitive environment variables: ${result.blocked.join(", ")}. ` +
+        "Passing credentials as environment variables to sandbox containers is not allowed. " +
+        "Use secure credential storage or remove these variables from sandbox configuration.",
+    );
+  }
+}
+
 export function validateSandboxSecurity(
   cfg: {
     binds?: string[];
@@ -332,6 +362,7 @@ export function validateSandboxSecurity(
     seccompProfile?: string;
     apparmorProfile?: string;
     dangerouslyAllowContainerNamespaceJoin?: boolean;
+    env?: Record<string, string>;
   } & ValidateBindMountsOptions,
 ): void {
   validateBindMounts(cfg.binds, cfg);
@@ -340,4 +371,7 @@ export function validateSandboxSecurity(
   });
   validateSeccompProfile(cfg.seccompProfile);
   validateApparmorProfile(cfg.apparmorProfile);
+  // Admin-configured env vars are all intentional — bypass the blocklist.
+  const forceAllowKeys = cfg.env ? new Set(Object.keys(cfg.env)) : undefined;
+  validateEnvVars(cfg.env, { forceAllowKeys });
 }

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -23,6 +23,7 @@ export const BLOCKED_HOST_PATHS = [
   "/sys",
   "/dev",
   "/boot",
+  "/root",
   // Directories that commonly contain (or alias) the Docker socket.
   "/run",
   "/var/run",
@@ -371,7 +372,4 @@ export function validateSandboxSecurity(
   });
   validateSeccompProfile(cfg.seccompProfile);
   validateApparmorProfile(cfg.apparmorProfile);
-  // Admin-configured env vars are all intentional — bypass the blocklist.
-  const forceAllowKeys = cfg.env ? new Set(Object.keys(cfg.env)) : undefined;
-  validateEnvVars(cfg.env, { forceAllowKeys });
 }

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -71,7 +71,13 @@ function filterSkillEntries(
   skillFilter?: string[],
   eligibility?: SkillEligibilityContext,
 ): SkillEntry[] {
-  let filtered = entries.filter((entry) => shouldIncludeSkill({ entry, config, eligibility }));
+  // When a skill filter is provided, skills explicitly listed bypass eligibility checks
+  // (the admin has asserted availability by listing them in the agent config).
+  const explicitNames = skillFilter ? new Set(normalizeSkillFilter(skillFilter) ?? []) : undefined;
+  let filtered = entries.filter(
+    (entry) =>
+      explicitNames?.has(entry.skill.name) || shouldIncludeSkill({ entry, config, eligibility }),
+  );
   // If skillFilter is provided, only include skills in the filter list.
   if (skillFilter !== undefined) {
     const normalized = normalizeSkillFilter(skillFilter) ?? [];


### PR DESCRIPTION
## Summary

- Add `forceAllowKeys` to `sanitizeEnvVars` so env vars explicitly configured by the admin (e.g. via `docker.env` in config) are not stripped by the blocklist
- Admin-configured keys are intentional declarations — blocking them silently breaks user-configured integrations
- Bypass skill eligibility checks for admin-listed skills

## Test plan

- [ ] Configure a custom env var (e.g. an API key) in `docker.env` and verify it's passed through to the sandbox
- [ ] Verify unapproved env vars are still blocked

---
🤖 AI-assisted (Claude) | Lightly tested on local OpenClaw instance