### PR TITLE
fix(signal): extract inbound reply/quote context from webhook payload

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -235,6 +235,91 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
   });
 
+  it("extracts reply/quote context into ReplyTo fields", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "what about this?",
+          attachments: [],
+          quote: {
+            id: 1700000099000,
+            text: "the original message",
+            authorNumber: "+15550003333",
+          },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ReplyToId).toBe("1700000099000");
+    expect(capture.ctx?.ReplyToBody).toBe("the original message");
+    expect(capture.ctx?.ReplyToSender).toBe("+15550003333");
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
+  it("extracts quote context with UUID author when no phone number", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "replying here",
+          attachments: [],
+          quote: {
+            id: 1700000088000,
+            text: "quoted text",
+            authorUuid: "abc-def-123",
+          },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ReplyToId).toBe("1700000088000");
+    expect(capture.ctx?.ReplyToBody).toBe("quoted text");
+    expect(capture.ctx?.ReplyToSender).toBe("abc-def-123");
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
+  it("does not set ReplyTo fields when no quote is present", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "plain message",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ReplyToId).toBeUndefined();
+    expect(capture.ctx?.ReplyToBody).toBeUndefined();
+    expect(capture.ctx?.ReplyToSender).toBeUndefined();
+    expect(capture.ctx?.ReplyToIsQuote).toBeUndefined();
+  });
+
   it("drops sync envelopes when syncMessage is present but null", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -114,6 +114,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    replyToId?: string;
+    replyToBody?: string;
+    replyToSender?: string;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -214,6 +217,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
+      ReplyToId: entry.replyToId,
+      ReplyToBody: entry.replyToBody,
+      ReplyToSender: entry.replyToSender,
+      ReplyToIsQuote: entry.replyToId || entry.replyToBody ? true : undefined,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });
@@ -778,6 +785,18 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const senderName = envelope.sourceName ?? senderDisplay;
     const messageId =
       typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
+
+    // Extract reply/quote context from Signal's quote field.
+    // signal-cli provides id (timestamp of quoted msg), text, and author identifiers.
+    const quote = dataMessage.quote;
+    const replyToId = typeof quote?.id === "number" ? String(quote.id) : undefined;
+    const replyToBody = quote?.text?.trim() || undefined;
+    const replyToSender =
+      quote?.authorNumber?.trim() ||
+      quote?.authorUuid?.trim() ||
+      quote?.author?.trim() ||
+      undefined;
+
     await inboundDebouncer.enqueue({
       senderName,
       senderDisplay,
@@ -796,6 +815,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      replyToId,
+      replyToBody,
+      replyToSender,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -37,7 +37,13 @@ export type SignalDataMessage = {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
-  quote?: { text?: string | null } | null;
+  quote?: {
+    id?: number | null;
+    text?: string | null;
+    author?: string | null;
+    authorNumber?: string | null;
+    authorUuid?: string | null;
+  } | null;
   reaction?: SignalReactionMessage | null;
 };
 


### PR DESCRIPTION
## Summary
- Extracts reply/quote context from Signal `dataMessage.quote` webhook payload fields (`id`, `text`, `author`/`authorNumber`/`authorUuid`)
- Wires quote data into the agent context as `ReplyToId`, `ReplyToBody`, `ReplyToSender`, and `ReplyToIsQuote` — matching the same context fields already used by Telegram and other channels
- Expands `SignalDataMessage.quote` type to include the full set of fields signal-cli-rest-api provides

## Change Type
Bug fix

## Linked Issue
Closes #10637

## Security Impact
None — reads existing webhook payload fields, no auth/data changes.

## Test Plan
- [x] Added test: quote with phone-number author populates all ReplyTo fields
- [x] Added test: quote with UUID-only author falls back to `authorUuid`
- [x] Added test: no ReplyTo fields when no quote present
- [x] `pnpm tsgo` and `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted contribution*

---

### AI-Assisted PR Checklist
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested (pnpm build + check + test gates passed)
- [x] Code reviewed by LLM committee (Claude Opus + Codex dual-model review with consensus gate — equivalent to codex review)
- [x] I understand what the code does
- [x] Bot review conversations addressed and resolved