### PR TITLE
feat(ui/agents): per-agent session restart button

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -587,6 +587,8 @@ export function renderApp(state: AppViewState) {
                 toolsCatalogError: state.toolsCatalogError,
                 toolsCatalogResult: state.toolsCatalogResult,
                 skillsFilter: state.skillsFilter,
+                agentSessionResetLoading: state.agentSessionResetLoading,
+                agentSessionResetError: state.agentSessionResetError,
                 onRefresh: async () => {
                   await loadAgents(state);
                   const nextSelected =
@@ -846,6 +848,20 @@ export function renderApp(state: AppViewState) {
                     return;
                   }
                   updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
+                },
+                onSessionReset: async (agentId) => {
+                  state.agentSessionResetLoading = true;
+                  state.agentSessionResetError = null;
+                  try {
+                    await state.client?.request("sessions.reset", {
+                      key: `agent:${agentId}:main`,
+                      reason: "reset",
+                    });
+                  } catch (err) {
+                    state.agentSessionResetError = String(err);
+                  } finally {
+                    state.agentSessionResetLoading = false;
+                  }
                 },
               })
             : nothing

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -240,6 +240,8 @@ export class OpenClawApp extends LitElement {
   @state() agentSkillsError: string | null = null;
   @state() agentSkillsReport: SkillStatusReport | null = null;
   @state() agentSkillsAgentId: string | null = null;
+  @state() agentSessionResetLoading = false;
+  @state() agentSessionResetError: string | null = null;
 
   @state() sessionsLoading = false;
   @state() sessionsResult: SessionsListResult | null = null;

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -88,6 +88,9 @@ export type AgentsProps = {
   onAgentSkillToggle: (agentId: string, skillName: string, enabled: boolean) => void;
   onAgentSkillsClear: (agentId: string) => void;
   onAgentSkillsDisableAll: (agentId: string) => void;
+  agentSessionResetLoading: boolean;
+  agentSessionResetError: string | null;
+  onSessionReset: (agentId: string) => void;
 };
 
 export type AgentContext = {
@@ -184,6 +187,9 @@ export function renderAgents(props: AgentsProps) {
                         onConfigSave: props.onConfigSave,
                         onModelChange: props.onModelChange,
                         onModelFallbacksChange: props.onModelFallbacksChange,
+                        agentSessionResetLoading: props.agentSessionResetLoading,
+                        agentSessionResetError: props.agentSessionResetError,
+                        onSessionReset: props.onSessionReset,
                       })
                     : nothing
                 }
@@ -359,6 +365,9 @@ function renderAgentOverview(params: {
   onConfigSave: () => void;
   onModelChange: (agentId: string, modelId: string | null) => void;
   onModelFallbacksChange: (agentId: string, fallbacks: string[]) => void;
+  agentSessionResetLoading: boolean;
+  agentSessionResetError: string | null;
+  onSessionReset: (agentId: string) => void;
 }) {
   const {
     agent,
@@ -374,6 +383,9 @@ function renderAgentOverview(params: {
     onConfigSave,
     onModelChange,
     onModelFallbacksChange,
+    agentSessionResetLoading,
+    agentSessionResetError,
+    onSessionReset,
   } = params;
   const config = resolveAgentConfig(configForm, agent.id);
   const workspaceFromFiles =
@@ -491,6 +503,24 @@ function renderAgentOverview(params: {
             @click=${onConfigSave}
           >
             ${configSaving ? "Saving…" : "Save"}
+          </button>
+        </div>
+        ${agentSessionResetError ? html`<div class="callout danger" style="margin-top: 8px;">${agentSessionResetError}</div>` : nothing}
+      </div>
+      <div style="margin-top: 16px; border-top: 1px solid var(--border); padding-top: 16px;">
+        <div class="row" style="justify-content: space-between; align-items: center;">
+          <div>
+            <div class="label">Session</div>
+            <div class="card-sub" style="margin-top: 2px;">
+              Reset to pick up model changes immediately. Clears active session history.
+            </div>
+          </div>
+          <button
+            class="btn btn--sm"
+            ?disabled=${agentSessionResetLoading}
+            @click=${() => onSessionReset(agent.id)}
+          >
+            ${agentSessionResetLoading ? "Restarting…" : "Restart Session"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds a **Restart Session** button to the agent overview panel in the dashboard.

## Problem

When you change an agent's model in the dashboard and save, the config is updated — but the existing session entry has the old model cached. The agent doesn't pick up the new model until its session is cleared. Previously the only way to do this was a full gateway restart (which clears all sessions, not just the one you care about).

## Solution

- Calls `sessions.reset` with the agent's main session key (`agent:<agentId>:main`)
- This creates a fresh session entry that reads the model from config on next invocation
- Other agents are unaffected

## Changes

- `ui/src/ui/app.ts` — Add `agentSessionResetLoading` and `agentSessionResetError` reactive state
- `ui/src/ui/views/agents.ts` — Add props + "Restart Session" button + error callout in the overview panel (below the model save row, separated by a divider)
- `ui/src/ui/app-render.ts` — Pass new state props and wire `onSessionReset` handler that calls `sessions.reset`

## UX

The button lives in the Overview tab, below the model selection / save controls, separated by a thin border:

```
Session
Reset to pick up model changes immediately. Clears active session history.   [Restart Session]
```

Button is disabled while the request is in-flight. Errors surface as a danger callout.