### PR TITLE
fix(gateway): abort timed-out local browser requests

### DIFF
--- a/src/browser/pw-tools-core.interactions.abort.test.ts
+++ b/src/browser/pw-tools-core.interactions.abort.test.ts
@@ -1,0 +1,116 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let page: Record<string, unknown> | null = null;
+let locator: { click: ReturnType<typeof vi.fn> } | null = null;
+
+const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+const getPageForTargetId = vi.fn(async () => {
+  if (!page) {
+    throw new Error("test: page not set");
+  }
+  return page;
+});
+const ensurePageState = vi.fn(() => {});
+const restoreRoleRefsForTarget = vi.fn(() => {});
+const refLocator = vi.fn(() => {
+  if (!locator) {
+    throw new Error("test: locator not set");
+  }
+  return locator;
+});
+
+vi.mock("./pw-session.js", () => ({
+  ensurePageState,
+  forceDisconnectPlaywrightForTarget,
+  getPageForTargetId,
+  refLocator,
+  restoreRoleRefsForTarget,
+}));
+
+let clickViaPlaywright: typeof import("./pw-tools-core.interactions.js").clickViaPlaywright;
+
+describe("clickViaPlaywright (abort)", () => {
+  beforeAll(async () => {
+    ({ clickViaPlaywright } = await import("./pw-tools-core.interactions.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disconnects the target when a click is aborted after it starts", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingClick = new Promise<void>(() => {});
+
+    page = {};
+    locator = {
+      click: vi.fn(() => {
+        resolveStarted();
+        return pendingClick;
+      }),
+    };
+
+    const promise = clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      ref: "e1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("aborted by test"));
+
+    await expect(promise).rejects.toThrow("aborted by test");
+    expect(forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "page-1",
+      }),
+    );
+  });
+
+  it("rejects immediately on abort even if disconnect cleanup is still pending", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    let resolveClick!: () => void;
+    let resolveDisconnect!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingClick = new Promise<void>((resolve) => {
+      resolveClick = resolve;
+    });
+    forceDisconnectPlaywrightForTarget.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveDisconnect = resolve;
+        }),
+    );
+
+    page = {};
+    locator = {
+      click: vi.fn(() => {
+        resolveStarted();
+        return pendingClick;
+      }),
+    };
+
+    const promise = clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      ref: "e1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("abort should win"));
+    resolveClick();
+
+    await expect(promise).rejects.toThrow("abort should win");
+    resolveDisconnect();
+  });
+});

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -540,7 +540,9 @@ export async function waitForViaPlaywright(opts: {
     ensurePageState(page);
     const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
     if (typeof opts.timeMs === "number" && Number.isFinite(opts.timeMs)) {
-      await page.waitForTimeout(resolveBoundedDelayMs(opts.timeMs, "wait timeMs", MAX_WAIT_TIME_MS));
+      await page.waitForTimeout(
+        resolveBoundedDelayMs(opts.timeMs, "wait timeMs", MAX_WAIT_TIME_MS),
+      );
     }
     if (opts.text) {
       await page.getByText(opts.text).first().waitFor({

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -43,6 +43,67 @@ async function getRestoredPageForTarget(opts: TargetOpts) {
   return page;
 }
 
+async function runAbortablePlaywrightAction<T>(
+  opts: TargetOpts & { signal?: AbortSignal },
+  work: () => Promise<T>,
+): Promise<T> {
+  const signal = opts.signal;
+  if (!signal) {
+    return await work();
+  }
+
+  const abortReason = () => signal.reason ?? new Error("aborted");
+  const disconnect = () => {
+    void forceDisconnectPlaywrightForTarget({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      reason: "abort browser action",
+    }).catch(() => {});
+  };
+
+  if (signal.aborted) {
+    disconnect();
+    throw abortReason();
+  }
+
+  let completed = false;
+  let abortTriggered = false;
+  let abortListener: (() => void) | undefined;
+  const abortPromise: Promise<never> = new Promise((_, reject) => {
+    abortListener = () => {
+      if (completed || abortTriggered) {
+        return;
+      }
+      abortTriggered = true;
+      disconnect();
+      reject(abortReason());
+    };
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+
+  if (signal.aborted) {
+    abortListener?.();
+  }
+  if (abortTriggered) {
+    return await abortPromise;
+  }
+
+  const workPromise = work().finally(() => {
+    completed = true;
+  });
+
+  try {
+    return await Promise.race([workPromise, abortPromise]);
+  } catch (err) {
+    void workPromise.catch(() => {});
+    throw err;
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
 function resolveInteractionTimeoutMs(timeoutMs?: number): number {
   return Math.max(500, Math.min(60_000, Math.floor(timeoutMs ?? 8000)));
 }
@@ -87,36 +148,39 @@ export async function clickViaPlaywright(opts: {
   modifiers?: Array<"Alt" | "Control" | "ControlOrMeta" | "Meta" | "Shift">;
   delayMs?: number;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
-  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
-  try {
-    const delayMs = resolveBoundedDelayMs(opts.delayMs, "click delayMs", MAX_CLICK_DELAY_MS);
-    if (delayMs > 0) {
-      await locator.hover({ timeout });
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+  await runAbortablePlaywrightAction(opts, async () => {
+    const resolved = requireRefOrSelector(opts.ref, opts.selector);
+    const page = await getRestoredPageForTarget(opts);
+    const label = resolved.ref ?? resolved.selector!;
+    const locator = resolved.ref
+      ? refLocator(page, requireRef(resolved.ref))
+      : page.locator(resolved.selector!);
+    const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+    try {
+      const delayMs = resolveBoundedDelayMs(opts.delayMs, "click delayMs", MAX_CLICK_DELAY_MS);
+      if (delayMs > 0) {
+        await locator.hover({ timeout });
+        await new Promise((r) => setTimeout(r, delayMs));
+      }
+      if (opts.doubleClick) {
+        await locator.dblclick({
+          timeout,
+          button: opts.button,
+          modifiers: opts.modifiers,
+        });
+      } else {
+        await locator.click({
+          timeout,
+          button: opts.button,
+          modifiers: opts.modifiers,
+        });
+      }
+    } catch (err) {
+      throw toAIFriendlyError(err, label);
     }
-    if (opts.doubleClick) {
-      await locator.dblclick({
-        timeout,
-        button: opts.button,
-        modifiers: opts.modifiers,
-      });
-    } else {
-      await locator.click({
-        timeout,
-        button: opts.button,
-        modifiers: opts.modifiers,
-      });
-    }
-  } catch (err) {
-    throw toAIFriendlyError(err, label);
-  }
+  });
 }
 
 export async function hoverViaPlaywright(opts: {
@@ -125,20 +189,23 @@ export async function hoverViaPlaywright(opts: {
   ref?: string;
   selector?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
-  try {
-    await locator.hover({
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
-  } catch (err) {
-    throw toAIFriendlyError(err, label);
-  }
+  await runAbortablePlaywrightAction(opts, async () => {
+    const resolved = requireRefOrSelector(opts.ref, opts.selector);
+    const page = await getRestoredPageForTarget(opts);
+    const label = resolved.ref ?? resolved.selector!;
+    const locator = resolved.ref
+      ? refLocator(page, requireRef(resolved.ref))
+      : page.locator(resolved.selector!);
+    try {
+      await locator.hover({
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      });
+    } catch (err) {
+      throw toAIFriendlyError(err, label);
+    }
+  });
 }
 
 export async function dragViaPlaywright(opts: {
@@ -149,25 +216,28 @@ export async function dragViaPlaywright(opts: {
   endRef?: string;
   endSelector?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const resolvedStart = requireRefOrSelector(opts.startRef, opts.startSelector);
-  const resolvedEnd = requireRefOrSelector(opts.endRef, opts.endSelector);
-  const page = await getRestoredPageForTarget(opts);
-  const startLocator = resolvedStart.ref
-    ? refLocator(page, requireRef(resolvedStart.ref))
-    : page.locator(resolvedStart.selector!);
-  const endLocator = resolvedEnd.ref
-    ? refLocator(page, requireRef(resolvedEnd.ref))
-    : page.locator(resolvedEnd.selector!);
-  const startLabel = resolvedStart.ref ?? resolvedStart.selector!;
-  const endLabel = resolvedEnd.ref ?? resolvedEnd.selector!;
-  try {
-    await startLocator.dragTo(endLocator, {
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
-  } catch (err) {
-    throw toAIFriendlyError(err, `${startLabel} -> ${endLabel}`);
-  }
+  await runAbortablePlaywrightAction(opts, async () => {
+    const resolvedStart = requireRefOrSelector(opts.startRef, opts.startSelector);
+    const resolvedEnd = requireRefOrSelector(opts.endRef, opts.endSelector);
+    const page = await getRestoredPageForTarget(opts);
+    const startLocator = resolvedStart.ref
+      ? refLocator(page, requireRef(resolvedStart.ref))
+      : page.locator(resolvedStart.selector!);
+    const endLocator = resolvedEnd.ref
+      ? refLocator(page, requireRef(resolvedEnd.ref))
+      : page.locator(resolvedEnd.selector!);
+    const startLabel = resolvedStart.ref ?? resolvedStart.selector!;
+    const endLabel = resolvedEnd.ref ?? resolvedEnd.selector!;
+    try {
+      await startLocator.dragTo(endLocator, {
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      });
+    } catch (err) {
+      throw toAIFriendlyError(err, `${startLabel} -> ${endLabel}`);
+    }
+  });
 }
 
 export async function selectOptionViaPlaywright(opts: {
@@ -177,23 +247,26 @@ export async function selectOptionViaPlaywright(opts: {
   selector?: string;
   values: string[];
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  if (!opts.values?.length) {
-    throw new Error("values are required");
-  }
-  const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
-  try {
-    await locator.selectOption(opts.values, {
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
-  } catch (err) {
-    throw toAIFriendlyError(err, label);
-  }
+  await runAbortablePlaywrightAction(opts, async () => {
+    const resolved = requireRefOrSelector(opts.ref, opts.selector);
+    if (!opts.values?.length) {
+      throw new Error("values are required");
+    }
+    const page = await getRestoredPageForTarget(opts);
+    const label = resolved.ref ?? resolved.selector!;
+    const locator = resolved.ref
+      ? refLocator(page, requireRef(resolved.ref))
+      : page.locator(resolved.selector!);
+    try {
+      await locator.selectOption(opts.values, {
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      });
+    } catch (err) {
+      throw toAIFriendlyError(err, label);
+    }
+  });
 }
 
 export async function pressKeyViaPlaywright(opts: {
@@ -201,15 +274,18 @@ export async function pressKeyViaPlaywright(opts: {
   targetId?: string;
   key: string;
   delayMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const key = String(opts.key ?? "").trim();
-  if (!key) {
-    throw new Error("key is required");
-  }
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  await page.keyboard.press(key, {
-    delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
+  await runAbortablePlaywrightAction(opts, async () => {
+    const key = String(opts.key ?? "").trim();
+    if (!key) {
+      throw new Error("key is required");
+    }
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    await page.keyboard.press(key, {
+      delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
+    });
   });
 }
 
@@ -222,28 +298,31 @@ export async function typeViaPlaywright(opts: {
   submit?: boolean;
   slowly?: boolean;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  const text = String(opts.text ?? "");
-  const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
-  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
-  try {
-    if (opts.slowly) {
-      await locator.click({ timeout });
-      await locator.type(text, { timeout, delay: 75 });
-    } else {
-      await locator.fill(text, { timeout });
+  await runAbortablePlaywrightAction(opts, async () => {
+    const resolved = requireRefOrSelector(opts.ref, opts.selector);
+    const text = String(opts.text ?? "");
+    const page = await getRestoredPageForTarget(opts);
+    const label = resolved.ref ?? resolved.selector!;
+    const locator = resolved.ref
+      ? refLocator(page, requireRef(resolved.ref))
+      : page.locator(resolved.selector!);
+    const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+    try {
+      if (opts.slowly) {
+        await locator.click({ timeout });
+        await locator.type(text, { timeout, delay: 75 });
+      } else {
+        await locator.fill(text, { timeout });
+      }
+      if (opts.submit) {
+        await locator.press("Enter", { timeout });
+      }
+    } catch (err) {
+      throw toAIFriendlyError(err, label);
     }
-    if (opts.submit) {
-      await locator.press("Enter", { timeout });
-    }
-  } catch (err) {
-    throw toAIFriendlyError(err, label);
-  }
+  });
 }
 
 export async function fillFormViaPlaywright(opts: {
@@ -251,39 +330,42 @@ export async function fillFormViaPlaywright(opts: {
   targetId?: string;
   fields: BrowserFormField[];
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getRestoredPageForTarget(opts);
-  const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
-  for (const field of opts.fields) {
-    const ref = field.ref.trim();
-    const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
-    const rawValue = field.value;
-    const value =
-      typeof rawValue === "string"
-        ? rawValue
-        : typeof rawValue === "number" || typeof rawValue === "boolean"
-          ? String(rawValue)
-          : "";
-    if (!ref) {
-      continue;
-    }
-    const locator = refLocator(page, ref);
-    if (type === "checkbox" || type === "radio") {
-      const checked =
-        rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
+  await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getRestoredPageForTarget(opts);
+    const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+    for (const field of opts.fields) {
+      const ref = field.ref.trim();
+      const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
+      const rawValue = field.value;
+      const value =
+        typeof rawValue === "string"
+          ? rawValue
+          : typeof rawValue === "number" || typeof rawValue === "boolean"
+            ? String(rawValue)
+            : "";
+      if (!ref) {
+        continue;
+      }
+      const locator = refLocator(page, ref);
+      if (type === "checkbox" || type === "radio") {
+        const checked =
+          rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
+        try {
+          await locator.setChecked(checked, { timeout });
+        } catch (err) {
+          throw toAIFriendlyError(err, ref);
+        }
+        continue;
+      }
       try {
-        await locator.setChecked(checked, { timeout });
+        await locator.fill(value, { timeout });
       } catch (err) {
         throw toAIFriendlyError(err, ref);
       }
-      continue;
     }
-    try {
-      await locator.fill(value, { timeout });
-    } catch (err) {
-      throw toAIFriendlyError(err, ref);
-    }
-  }
+  });
 }
 
 export async function evaluateViaPlaywright(opts: {
@@ -422,20 +504,22 @@ export async function scrollIntoViewViaPlaywright(opts: {
   ref?: string;
   selector?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  const page = await getRestoredPageForTarget(opts);
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
-
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
-  try {
-    await locator.scrollIntoViewIfNeeded({ timeout });
-  } catch (err) {
-    throw toAIFriendlyError(err, label);
-  }
+  await runAbortablePlaywrightAction(opts, async () => {
+    const resolved = requireRefOrSelector(opts.ref, opts.selector);
+    const page = await getRestoredPageForTarget(opts);
+    const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
+    const label = resolved.ref ?? resolved.selector!;
+    const locator = resolved.ref
+      ? refLocator(page, requireRef(resolved.ref))
+      : page.locator(resolved.selector!);
+    try {
+      await locator.scrollIntoViewIfNeeded({ timeout });
+    } catch (err) {
+      throw toAIFriendlyError(err, label);
+    }
+  });
 }
 
 export async function waitForViaPlaywright(opts: {
@@ -449,47 +533,49 @@ export async function waitForViaPlaywright(opts: {
   loadState?: "load" | "domcontentloaded" | "networkidle";
   fn?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
-
-  if (typeof opts.timeMs === "number" && Number.isFinite(opts.timeMs)) {
-    await page.waitForTimeout(resolveBoundedDelayMs(opts.timeMs, "wait timeMs", MAX_WAIT_TIME_MS));
-  }
-  if (opts.text) {
-    await page.getByText(opts.text).first().waitFor({
-      state: "visible",
-      timeout,
-    });
-  }
-  if (opts.textGone) {
-    await page.getByText(opts.textGone).first().waitFor({
-      state: "hidden",
-      timeout,
-    });
-  }
-  if (opts.selector) {
-    const selector = String(opts.selector).trim();
-    if (selector) {
-      await page.locator(selector).first().waitFor({ state: "visible", timeout });
+  await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
+    if (typeof opts.timeMs === "number" && Number.isFinite(opts.timeMs)) {
+      await page.waitForTimeout(resolveBoundedDelayMs(opts.timeMs, "wait timeMs", MAX_WAIT_TIME_MS));
     }
-  }
-  if (opts.url) {
-    const url = String(opts.url).trim();
-    if (url) {
-      await page.waitForURL(url, { timeout });
+    if (opts.text) {
+      await page.getByText(opts.text).first().waitFor({
+        state: "visible",
+        timeout,
+      });
     }
-  }
-  if (opts.loadState) {
-    await page.waitForLoadState(opts.loadState, { timeout });
-  }
-  if (opts.fn) {
-    const fn = String(opts.fn).trim();
-    if (fn) {
-      await page.waitForFunction(fn, { timeout });
+    if (opts.textGone) {
+      await page.getByText(opts.textGone).first().waitFor({
+        state: "hidden",
+        timeout,
+      });
     }
-  }
+    if (opts.selector) {
+      const selector = String(opts.selector).trim();
+      if (selector) {
+        await page.locator(selector).first().waitFor({ state: "visible", timeout });
+      }
+    }
+    if (opts.url) {
+      const url = String(opts.url).trim();
+      if (url) {
+        await page.waitForURL(url, { timeout });
+      }
+    }
+    if (opts.loadState) {
+      await page.waitForLoadState(opts.loadState, { timeout });
+    }
+    if (opts.fn) {
+      const fn = String(opts.fn).trim();
+      if (fn) {
+        await page.waitForFunction(fn, { timeout });
+      }
+    }
+  });
 }
 
 export async function takeScreenshotViaPlaywright(opts: {
@@ -499,32 +585,35 @@ export async function takeScreenshotViaPlaywright(opts: {
   element?: string;
   fullPage?: boolean;
   type?: "png" | "jpeg";
+  signal?: AbortSignal;
 }): Promise<{ buffer: Buffer }> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
-  const type = opts.type ?? "png";
-  if (opts.ref) {
-    if (opts.fullPage) {
-      throw new Error("fullPage is not supported for element screenshots");
+  return await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+    const type = opts.type ?? "png";
+    if (opts.ref) {
+      if (opts.fullPage) {
+        throw new Error("fullPage is not supported for element screenshots");
+      }
+      const locator = refLocator(page, opts.ref);
+      const buffer = await locator.screenshot({ type });
+      return { buffer };
     }
-    const locator = refLocator(page, opts.ref);
-    const buffer = await locator.screenshot({ type });
-    return { buffer };
-  }
-  if (opts.element) {
-    if (opts.fullPage) {
-      throw new Error("fullPage is not supported for element screenshots");
+    if (opts.element) {
+      if (opts.fullPage) {
+        throw new Error("fullPage is not supported for element screenshots");
+      }
+      const locator = page.locator(opts.element).first();
+      const buffer = await locator.screenshot({ type });
+      return { buffer };
     }
-    const locator = page.locator(opts.element).first();
-    const buffer = await locator.screenshot({ type });
+    const buffer = await page.screenshot({
+      type,
+      fullPage: Boolean(opts.fullPage),
+    });
     return { buffer };
-  }
-  const buffer = await page.screenshot({
-    type,
-    fullPage: Boolean(opts.fullPage),
   });
-  return { buffer };
 }
 
 export async function screenshotWithLabelsViaPlaywright(opts: {
@@ -533,125 +622,128 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   refs: Record<string, { role: string; name?: string; nth?: number }>;
   maxLabels?: number;
   type?: "png" | "jpeg";
+  signal?: AbortSignal;
 }): Promise<{ buffer: Buffer; labels: number; skipped: number }> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
-  const type = opts.type ?? "png";
-  const maxLabels =
-    typeof opts.maxLabels === "number" && Number.isFinite(opts.maxLabels)
-      ? Math.max(1, Math.floor(opts.maxLabels))
-      : 150;
+  return await runAbortablePlaywrightAction(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+    const type = opts.type ?? "png";
+    const maxLabels =
+      typeof opts.maxLabels === "number" && Number.isFinite(opts.maxLabels)
+        ? Math.max(1, Math.floor(opts.maxLabels))
+        : 150;
 
-  const viewport = await page.evaluate(() => ({
-    scrollX: window.scrollX || 0,
-    scrollY: window.scrollY || 0,
-    width: window.innerWidth || 0,
-    height: window.innerHeight || 0,
-  }));
+    const viewport = await page.evaluate(() => ({
+      scrollX: window.scrollX || 0,
+      scrollY: window.scrollY || 0,
+      width: window.innerWidth || 0,
+      height: window.innerHeight || 0,
+    }));
 
-  const refs = Object.keys(opts.refs ?? {});
-  const boxes: Array<{ ref: string; x: number; y: number; w: number; h: number }> = [];
-  let skipped = 0;
+    const refs = Object.keys(opts.refs ?? {});
+    const boxes: Array<{ ref: string; x: number; y: number; w: number; h: number }> = [];
+    let skipped = 0;
 
-  for (const ref of refs) {
-    if (boxes.length >= maxLabels) {
-      skipped += 1;
-      continue;
-    }
-    try {
-      const box = await refLocator(page, ref).boundingBox();
-      if (!box) {
+    for (const ref of refs) {
+      if (boxes.length >= maxLabels) {
         skipped += 1;
         continue;
       }
-      const x0 = box.x;
-      const y0 = box.y;
-      const x1 = box.x + box.width;
-      const y1 = box.y + box.height;
-      const vx0 = viewport.scrollX;
-      const vy0 = viewport.scrollY;
-      const vx1 = viewport.scrollX + viewport.width;
-      const vy1 = viewport.scrollY + viewport.height;
-      if (x1 < vx0 || x0 > vx1 || y1 < vy0 || y0 > vy1) {
-        skipped += 1;
-        continue;
-      }
-      boxes.push({
-        ref,
-        x: x0 - viewport.scrollX,
-        y: y0 - viewport.scrollY,
-        w: Math.max(1, box.width),
-        h: Math.max(1, box.height),
-      });
-    } catch {
-      skipped += 1;
-    }
-  }
-
-  try {
-    if (boxes.length > 0) {
-      await page.evaluate((labels) => {
-        const existing = document.querySelectorAll("[data-openclaw-labels]");
-        existing.forEach((el) => el.remove());
-
-        const root = document.createElement("div");
-        root.setAttribute("data-openclaw-labels", "1");
-        root.style.position = "fixed";
-        root.style.left = "0";
-        root.style.top = "0";
-        root.style.zIndex = "2147483647";
-        root.style.pointerEvents = "none";
-        root.style.fontFamily =
-          '"SF Mono","SFMono-Regular",Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace';
-
-        const clamp = (value: number, min: number, max: number) =>
-          Math.min(max, Math.max(min, value));
-
-        for (const label of labels) {
-          const box = document.createElement("div");
-          box.setAttribute("data-openclaw-labels", "1");
-          box.style.position = "absolute";
-          box.style.left = `${label.x}px`;
-          box.style.top = `${label.y}px`;
-          box.style.width = `${label.w}px`;
-          box.style.height = `${label.h}px`;
-          box.style.border = "2px solid #ffb020";
-          box.style.boxSizing = "border-box";
-
-          const tag = document.createElement("div");
-          tag.setAttribute("data-openclaw-labels", "1");
-          tag.textContent = label.ref;
-          tag.style.position = "absolute";
-          tag.style.left = `${label.x}px`;
-          tag.style.top = `${clamp(label.y - 18, 0, 20000)}px`;
-          tag.style.background = "#ffb020";
-          tag.style.color = "#1a1a1a";
-          tag.style.fontSize = "12px";
-          tag.style.lineHeight = "14px";
-          tag.style.padding = "1px 4px";
-          tag.style.borderRadius = "3px";
-          tag.style.boxShadow = "0 1px 2px rgba(0,0,0,0.35)";
-          tag.style.whiteSpace = "nowrap";
-
-          root.appendChild(box);
-          root.appendChild(tag);
+      try {
+        const box = await refLocator(page, ref).boundingBox();
+        if (!box) {
+          skipped += 1;
+          continue;
         }
-
-        document.documentElement.appendChild(root);
-      }, boxes);
+        const x0 = box.x;
+        const y0 = box.y;
+        const x1 = box.x + box.width;
+        const y1 = box.y + box.height;
+        const vx0 = viewport.scrollX;
+        const vy0 = viewport.scrollY;
+        const vx1 = viewport.scrollX + viewport.width;
+        const vy1 = viewport.scrollY + viewport.height;
+        if (x1 < vx0 || x0 > vx1 || y1 < vy0 || y0 > vy1) {
+          skipped += 1;
+          continue;
+        }
+        boxes.push({
+          ref,
+          x: x0 - viewport.scrollX,
+          y: y0 - viewport.scrollY,
+          w: Math.max(1, box.width),
+          h: Math.max(1, box.height),
+        });
+      } catch {
+        skipped += 1;
+      }
     }
 
-    const buffer = await page.screenshot({ type });
-    return { buffer, labels: boxes.length, skipped };
-  } finally {
-    await page
-      .evaluate(() => {
-        const existing = document.querySelectorAll("[data-openclaw-labels]");
-        existing.forEach((el) => el.remove());
-      })
-      .catch(() => {});
-  }
+    try {
+      if (boxes.length > 0) {
+        await page.evaluate((labels) => {
+          const existing = document.querySelectorAll("[data-openclaw-labels]");
+          existing.forEach((el) => el.remove());
+
+          const root = document.createElement("div");
+          root.setAttribute("data-openclaw-labels", "1");
+          root.style.position = "fixed";
+          root.style.left = "0";
+          root.style.top = "0";
+          root.style.zIndex = "2147483647";
+          root.style.pointerEvents = "none";
+          root.style.fontFamily =
+            '"SF Mono","SFMono-Regular",Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace';
+
+          const clamp = (value: number, min: number, max: number) =>
+            Math.min(max, Math.max(min, value));
+
+          for (const label of labels) {
+            const box = document.createElement("div");
+            box.setAttribute("data-openclaw-labels", "1");
+            box.style.position = "absolute";
+            box.style.left = `${label.x}px`;
+            box.style.top = `${label.y}px`;
+            box.style.width = `${label.w}px`;
+            box.style.height = `${label.h}px`;
+            box.style.border = "2px solid #ffb020";
+            box.style.boxSizing = "border-box";
+
+            const tag = document.createElement("div");
+            tag.setAttribute("data-openclaw-labels", "1");
+            tag.textContent = label.ref;
+            tag.style.position = "absolute";
+            tag.style.left = `${label.x}px`;
+            tag.style.top = `${clamp(label.y - 18, 0, 20000)}px`;
+            tag.style.background = "#ffb020";
+            tag.style.color = "#1a1a1a";
+            tag.style.fontSize = "12px";
+            tag.style.lineHeight = "14px";
+            tag.style.padding = "1px 4px";
+            tag.style.borderRadius = "3px";
+            tag.style.boxShadow = "0 1px 2px rgba(0,0,0,0.35)";
+            tag.style.whiteSpace = "nowrap";
+
+            root.appendChild(box);
+            root.appendChild(tag);
+          }
+
+          document.documentElement.appendChild(root);
+        }, boxes);
+      }
+
+      const buffer = await page.screenshot({ type });
+      return { buffer, labels: boxes.length, skipped };
+    } finally {
+      await page
+        .evaluate(() => {
+          const existing = document.querySelectorAll("[data-openclaw-labels]");
+          existing.forEach((el) => el.remove());
+        })
+        .catch(() => {});
+    }
+  });
 }
 
 export async function setInputFilesViaPlaywright(opts: {

--- a/src/browser/pw-tools-core.snapshot.abort.test.ts
+++ b/src/browser/pw-tools-core.snapshot.abort.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let page: Record<string, unknown> | null = null;
+
+const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+const getPageForTargetId = vi.fn(async () => {
+  if (!page) {
+    throw new Error("test: page not set");
+  }
+  return page;
+});
+const ensurePageState = vi.fn(() => {});
+const storeRoleRefsForTarget = vi.fn(() => {});
+
+vi.mock("./pw-session.js", () => ({
+  ensurePageState,
+  forceDisconnectPlaywrightForTarget,
+  getPageForTargetId,
+  storeRoleRefsForTarget,
+}));
+
+let snapshotAiViaPlaywright: typeof import("./pw-tools-core.snapshot.js").snapshotAiViaPlaywright;
+
+describe("snapshotAiViaPlaywright (abort)", () => {
+  beforeAll(async () => {
+    ({ snapshotAiViaPlaywright } = await import("./pw-tools-core.snapshot.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disconnects the target when an AI snapshot is aborted after it starts", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingSnapshot = new Promise(() => {});
+
+    page = {
+      _snapshotForAI: vi.fn(() => {
+        resolveStarted();
+        return pendingSnapshot;
+      }),
+    };
+
+    const promise = snapshotAiViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("snapshot aborted"));
+
+    await expect(promise).rejects.toThrow("snapshot aborted");
+    expect(forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "page-1",
+      }),
+    );
+  });
+
+  it("rejects immediately on abort even if snapshot disconnect cleanup is still pending", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    let resolveSnapshot!: () => void;
+    let resolveDisconnect!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingSnapshot = new Promise<void>((resolve) => {
+      resolveSnapshot = resolve;
+    });
+    forceDisconnectPlaywrightForTarget.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveDisconnect = resolve;
+        }),
+    );
+
+    page = {
+      _snapshotForAI: vi.fn(() => {
+        resolveStarted();
+        return pendingSnapshot;
+      }),
+    };
+
+    const promise = snapshotAiViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("snapshot abort should win"));
+    resolveSnapshot();
+
+    await expect(promise).rejects.toThrow("snapshot abort should win");
+    resolveDisconnect();
+  });
+});

--- a/src/browser/pw-tools-core.snapshot.abort.test.ts
+++ b/src/browser/pw-tools-core.snapshot.abort.test.ts
@@ -20,10 +20,12 @@ vi.mock("./pw-session.js", () => ({
 }));
 
 let snapshotAiViaPlaywright: typeof import("./pw-tools-core.snapshot.js").snapshotAiViaPlaywright;
+let closePageViaPlaywright: typeof import("./pw-tools-core.snapshot.js").closePageViaPlaywright;
 
 describe("snapshotAiViaPlaywright (abort)", () => {
   beforeAll(async () => {
-    ({ snapshotAiViaPlaywright } = await import("./pw-tools-core.snapshot.js"));
+    ({ snapshotAiViaPlaywright, closePageViaPlaywright } =
+      await import("./pw-tools-core.snapshot.js"));
   });
 
   beforeEach(() => {
@@ -100,5 +102,38 @@ describe("snapshotAiViaPlaywright (abort)", () => {
 
     await expect(promise).rejects.toThrow("snapshot abort should win");
     resolveDisconnect();
+  });
+
+  it("disconnects the target when a close is aborted after it starts", async () => {
+    const ctrl = new AbortController();
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const pendingClose = new Promise<void>(() => {});
+
+    page = {
+      close: vi.fn(() => {
+        resolveStarted();
+        return pendingClose;
+      }),
+    };
+
+    const promise = closePageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "page-1",
+      signal: ctrl.signal,
+    });
+
+    await started;
+    ctrl.abort(new Error("close aborted"));
+
+    await expect(promise).rejects.toThrow("close aborted");
+    expect(forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "page-1",
+      }),
+    );
   });
 });

--- a/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -136,4 +136,28 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       reason: "retry navigate after detached frame",
     });
   });
+
+  it("does not start the first navigation once the request is already aborted", async () => {
+    const ctrl = new AbortController();
+    const goto = vi.fn(async () => {});
+    getPwToolsCoreSessionMocks().getPageForTargetId.mockImplementationOnce(async () => {
+      ctrl.abort(new Error("navigate aborted before goto"));
+      return {
+        goto,
+        url: vi.fn(() => "https://example.com/aborted"),
+      };
+    });
+
+    await expect(
+      mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        url: "https://example.com/aborted",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        signal: ctrl.signal,
+      }),
+    ).rejects.toThrow("navigate aborted before goto");
+
+    expect(goto).not.toHaveBeenCalled();
+  });
 });

--- a/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -104,4 +104,36 @@ describe("pw-tools-core.snapshot navigate guard", () => {
 
     expect(goto).toHaveBeenCalledTimes(1);
   });
+
+  it("does not retry navigation after the request aborts", async () => {
+    const ctrl = new AbortController();
+    const goto = vi.fn(async () => {
+      ctrl.abort(new Error("navigate aborted"));
+      throw new Error("Target page, context or browser has been closed");
+    });
+    setPwToolsCoreCurrentPage({
+      goto,
+      url: vi.fn(() => "https://example.com/aborted"),
+    });
+
+    await expect(
+      mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        url: "https://example.com/aborted",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        signal: ctrl.signal,
+      }),
+    ).rejects.toThrow("navigate aborted");
+
+    expect(goto).toHaveBeenCalledTimes(1);
+    expect(getPwToolsCoreSessionMocks().getPageForTargetId).toHaveBeenCalledTimes(1);
+    expect(
+      getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget,
+    ).not.toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      reason: "retry navigate after detached frame",
+    });
+  });
 });

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -22,32 +22,103 @@ import {
 } from "./pw-session.js";
 import { withPageScopedCdpClient } from "./pw-session.page-cdp.js";
 
+type SnapshotTargetOpts = {
+  cdpUrl: string;
+  targetId?: string;
+  signal?: AbortSignal;
+  disconnectReason?: string;
+};
+
+async function runAbortableSnapshotWork<T>(
+  opts: SnapshotTargetOpts,
+  work: () => Promise<T>,
+): Promise<T> {
+  const signal = opts.signal;
+  if (!signal) {
+    return await work();
+  }
+
+  const abortReason = () => signal.reason ?? new Error("aborted");
+  const disconnect = () => {
+    void forceDisconnectPlaywrightForTarget({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      reason: opts.disconnectReason ?? "abort browser snapshot",
+    }).catch(() => {});
+  };
+
+  if (signal.aborted) {
+    disconnect();
+    throw abortReason();
+  }
+
+  let completed = false;
+  let abortTriggered = false;
+  let abortListener: (() => void) | undefined;
+  const abortPromise: Promise<never> = new Promise((_, reject) => {
+    abortListener = () => {
+      if (completed || abortTriggered) {
+        return;
+      }
+      abortTriggered = true;
+      disconnect();
+      reject(abortReason());
+    };
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+
+  if (signal.aborted) {
+    abortListener?.();
+  }
+  if (abortTriggered) {
+    return await abortPromise;
+  }
+
+  const workPromise = work().finally(() => {
+    completed = true;
+  });
+
+  try {
+    return await Promise.race([workPromise, abortPromise]);
+  } catch (err) {
+    void workPromise.catch(() => {});
+    throw err;
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
 export async function snapshotAriaViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   limit?: number;
+  signal?: AbortSignal;
 }): Promise<{ nodes: AriaSnapshotNode[] }> {
-  const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
-  const page = await getPageForTargetId({
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
+  return await runAbortableSnapshotWork(opts, async () => {
+    const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
+    const page = await getPageForTargetId({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+    });
+    ensurePageState(page);
+    const res = (await withPageScopedCdpClient({
+      cdpUrl: opts.cdpUrl,
+      page,
+      targetId: opts.targetId,
+      fn: async (send) => {
+        await send("Accessibility.enable").catch(() => {});
+        return (await send("Accessibility.getFullAXTree")) as {
+          nodes?: RawAXNode[];
+        };
+      },
+    })) as {
+      nodes?: RawAXNode[];
+    };
+    const nodes = Array.isArray(res?.nodes) ? res.nodes : [];
+    return { nodes: formatAriaSnapshot(nodes, limit) };
   });
-  ensurePageState(page);
-  const res = (await withPageScopedCdpClient({
-    cdpUrl: opts.cdpUrl,
-    page,
-    targetId: opts.targetId,
-    fn: async (send) => {
-      await send("Accessibility.enable").catch(() => {});
-      return (await send("Accessibility.getFullAXTree")) as {
-        nodes?: RawAXNode[];
-      };
-    },
-  })) as {
-    nodes?: RawAXNode[];
-  };
-  const nodes = Array.isArray(res?.nodes) ? res.nodes : [];
-  return { nodes: formatAriaSnapshot(nodes, limit) };
 }
 
 export async function snapshotAiViaPlaywright(opts: {
@@ -55,43 +126,46 @@ export async function snapshotAiViaPlaywright(opts: {
   targetId?: string;
   timeoutMs?: number;
   maxChars?: number;
+  signal?: AbortSignal;
 }): Promise<{ snapshot: string; truncated?: boolean; refs: RoleRefMap }> {
-  const page = await getPageForTargetId({
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-  });
-  ensurePageState(page);
+  return await runAbortableSnapshotWork(opts, async () => {
+    const page = await getPageForTargetId({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+    });
+    ensurePageState(page);
 
-  const maybe = page as unknown as WithSnapshotForAI;
-  if (!maybe._snapshotForAI) {
-    throw new Error("Playwright _snapshotForAI is not available. Upgrade playwright-core.");
-  }
+    const maybe = page as unknown as WithSnapshotForAI;
+    if (!maybe._snapshotForAI) {
+      throw new Error("Playwright _snapshotForAI is not available. Upgrade playwright-core.");
+    }
 
-  const result = await maybe._snapshotForAI({
-    timeout: Math.max(500, Math.min(60_000, Math.floor(opts.timeoutMs ?? 5000))),
-    track: "response",
-  });
-  let snapshot = String(result?.full ?? "");
-  const maxChars = opts.maxChars;
-  const limit =
-    typeof maxChars === "number" && Number.isFinite(maxChars) && maxChars > 0
-      ? Math.floor(maxChars)
-      : undefined;
-  let truncated = false;
-  if (limit && snapshot.length > limit) {
-    snapshot = `${snapshot.slice(0, limit)}\n\n[...TRUNCATED - page too large]`;
-    truncated = true;
-  }
+    const result = await maybe._snapshotForAI({
+      timeout: Math.max(500, Math.min(60_000, Math.floor(opts.timeoutMs ?? 5000))),
+      track: "response",
+    });
+    let snapshot = String(result?.full ?? "");
+    const maxChars = opts.maxChars;
+    const limit =
+      typeof maxChars === "number" && Number.isFinite(maxChars) && maxChars > 0
+        ? Math.floor(maxChars)
+        : undefined;
+    let truncated = false;
+    if (limit && snapshot.length > limit) {
+      snapshot = `${snapshot.slice(0, limit)}\n\n[...TRUNCATED - page too large]`;
+      truncated = true;
+    }
 
-  const built = buildRoleSnapshotFromAiSnapshot(snapshot);
-  storeRoleRefsForTarget({
-    page,
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-    refs: built.refs,
-    mode: "aria",
+    const built = buildRoleSnapshotFromAiSnapshot(snapshot);
+    storeRoleRefsForTarget({
+      page,
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      refs: built.refs,
+      mode: "aria",
+    });
+    return truncated ? { snapshot, truncated, refs: built.refs } : { snapshot, refs: built.refs };
   });
-  return truncated ? { snapshot, truncated, refs: built.refs } : { snapshot, refs: built.refs };
 }
 
 export async function snapshotRoleViaPlaywright(opts: {
@@ -101,69 +175,72 @@ export async function snapshotRoleViaPlaywright(opts: {
   frameSelector?: string;
   refsMode?: "role" | "aria";
   options?: RoleSnapshotOptions;
+  signal?: AbortSignal;
 }): Promise<{
   snapshot: string;
   refs: Record<string, { role: string; name?: string; nth?: number }>;
   stats: { lines: number; chars: number; refs: number; interactive: number };
 }> {
-  const page = await getPageForTargetId({
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-  });
-  ensurePageState(page);
-
-  if (opts.refsMode === "aria") {
-    if (opts.selector?.trim() || opts.frameSelector?.trim()) {
-      throw new Error("refs=aria does not support selector/frame snapshots yet.");
-    }
-    const maybe = page as unknown as WithSnapshotForAI;
-    if (!maybe._snapshotForAI) {
-      throw new Error("refs=aria requires Playwright _snapshotForAI support.");
-    }
-    const result = await maybe._snapshotForAI({
-      timeout: 5000,
-      track: "response",
+  return await runAbortableSnapshotWork(opts, async () => {
+    const page = await getPageForTargetId({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
     });
-    const built = buildRoleSnapshotFromAiSnapshot(String(result?.full ?? ""), opts.options);
+    ensurePageState(page);
+
+    if (opts.refsMode === "aria") {
+      if (opts.selector?.trim() || opts.frameSelector?.trim()) {
+        throw new Error("refs=aria does not support selector/frame snapshots yet.");
+      }
+      const maybe = page as unknown as WithSnapshotForAI;
+      if (!maybe._snapshotForAI) {
+        throw new Error("refs=aria requires Playwright _snapshotForAI support.");
+      }
+      const result = await maybe._snapshotForAI({
+        timeout: 5000,
+        track: "response",
+      });
+      const built = buildRoleSnapshotFromAiSnapshot(String(result?.full ?? ""), opts.options);
+      storeRoleRefsForTarget({
+        page,
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        refs: built.refs,
+        mode: "aria",
+      });
+      return {
+        snapshot: built.snapshot,
+        refs: built.refs,
+        stats: getRoleSnapshotStats(built.snapshot, built.refs),
+      };
+    }
+
+    const frameSelector = opts.frameSelector?.trim() || "";
+    const selector = opts.selector?.trim() || "";
+    const locator = frameSelector
+      ? selector
+        ? page.frameLocator(frameSelector).locator(selector)
+        : page.frameLocator(frameSelector).locator(":root")
+      : selector
+        ? page.locator(selector)
+        : page.locator(":root");
+
+    const ariaSnapshot = await locator.ariaSnapshot();
+    const built = buildRoleSnapshotFromAriaSnapshot(String(ariaSnapshot ?? ""), opts.options);
     storeRoleRefsForTarget({
       page,
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
       refs: built.refs,
-      mode: "aria",
+      frameSelector: frameSelector || undefined,
+      mode: "role",
     });
     return {
       snapshot: built.snapshot,
       refs: built.refs,
       stats: getRoleSnapshotStats(built.snapshot, built.refs),
     };
-  }
-
-  const frameSelector = opts.frameSelector?.trim() || "";
-  const selector = opts.selector?.trim() || "";
-  const locator = frameSelector
-    ? selector
-      ? page.frameLocator(frameSelector).locator(selector)
-      : page.frameLocator(frameSelector).locator(":root")
-    : selector
-      ? page.locator(selector)
-      : page.locator(":root");
-
-  const ariaSnapshot = await locator.ariaSnapshot();
-  const built = buildRoleSnapshotFromAriaSnapshot(String(ariaSnapshot ?? ""), opts.options);
-  storeRoleRefsForTarget({
-    page,
-    cdpUrl: opts.cdpUrl,
-    targetId: opts.targetId,
-    refs: built.refs,
-    frameSelector: frameSelector || undefined,
-    mode: "role",
   });
-  return {
-    snapshot: built.snapshot,
-    refs: built.refs,
-    stats: getRoleSnapshotStats(built.snapshot, built.refs),
-  };
 }
 
 export async function navigateViaPlaywright(opts: {
@@ -172,6 +249,7 @@ export async function navigateViaPlaywright(opts: {
   url: string;
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<{ url: string }> {
   const isRetryableNavigateError = (err: unknown): boolean => {
     const msg =
@@ -185,47 +263,54 @@ export async function navigateViaPlaywright(opts: {
       msg.includes("target page, context or browser has been closed")
     );
   };
-
-  const url = String(opts.url ?? "").trim();
-  if (!url) {
-    throw new Error("url is required");
-  }
-  await assertBrowserNavigationAllowed({
-    url,
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
-  });
-  const timeout = Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000));
-  let page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  const navigate = async () => await page.goto(url, { timeout });
-  let response;
-  try {
-    response = await navigate();
-  } catch (err) {
-    if (!isRetryableNavigateError(err)) {
-      throw err;
+  return await runAbortableSnapshotWork(opts, async () => {
+    const url = String(opts.url ?? "").trim();
+    if (!url) {
+      throw new Error("url is required");
     }
-    // Extension relays can briefly drop CDP during renderer swaps/navigation.
-    // Force a clean reconnect, then retry once on the refreshed page handle.
-    await forceDisconnectPlaywrightForTarget({
-      cdpUrl: opts.cdpUrl,
-      targetId: opts.targetId,
-      reason: "retry navigate after detached frame",
-    }).catch(() => {});
-    page = await getPageForTargetId(opts);
+    await assertBrowserNavigationAllowed({
+      url,
+      ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+    });
+    const timeout = Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000));
+    let page = await getPageForTargetId(opts);
     ensurePageState(page);
-    response = await navigate();
-  }
-  await assertBrowserNavigationRedirectChainAllowed({
-    request: response?.request(),
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+    const navigate = async () => await page.goto(url, { timeout });
+    let response;
+    try {
+      response = await navigate();
+    } catch (err) {
+      if (!isRetryableNavigateError(err)) {
+        throw err;
+      }
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason ?? new Error("aborted");
+      }
+      // Extension relays can briefly drop CDP during renderer swaps/navigation.
+      // Force a clean reconnect, then retry once on the refreshed page handle.
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        reason: "retry navigate after detached frame",
+      }).catch(() => {});
+      if (opts.signal?.aborted) {
+        throw opts.signal.reason ?? new Error("aborted");
+      }
+      page = await getPageForTargetId(opts);
+      ensurePageState(page);
+      response = await navigate();
+    }
+    await assertBrowserNavigationRedirectChainAllowed({
+      request: response?.request(),
+      ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+    });
+    const finalUrl = page.url();
+    await assertBrowserNavigationResultAllowed({
+      url: finalUrl,
+      ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+    });
+    return { url: finalUrl };
   });
-  const finalUrl = page.url();
-  await assertBrowserNavigationResultAllowed({
-    url: finalUrl,
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
-  });
-  return { url: finalUrl };
 }
 
 export async function resizeViewportViaPlaywright(opts: {
@@ -233,30 +318,51 @@ export async function resizeViewportViaPlaywright(opts: {
   targetId?: string;
   width: number;
   height: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  await page.setViewportSize({
-    width: Math.max(1, Math.floor(opts.width)),
-    height: Math.max(1, Math.floor(opts.height)),
-  });
+  await runAbortableSnapshotWork(
+    {
+      ...opts,
+      disconnectReason: "abort browser action",
+    },
+    async () => {
+      const page = await getPageForTargetId(opts);
+      ensurePageState(page);
+      await page.setViewportSize({
+        width: Math.max(1, Math.floor(opts.width)),
+        height: Math.max(1, Math.floor(opts.height)),
+      });
+    },
+  );
 }
 
 export async function closePageViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  signal?: AbortSignal;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  await page.close();
+  await runAbortableSnapshotWork(
+    {
+      ...opts,
+      disconnectReason: "abort browser action",
+    },
+    async () => {
+      const page = await getPageForTargetId(opts);
+      ensurePageState(page);
+      await page.close();
+    },
+  );
 }
 
 export async function pdfViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  signal?: AbortSignal;
 }): Promise<{ buffer: Buffer }> {
-  const page = await getPageForTargetId(opts);
-  ensurePageState(page);
-  const buffer = await page.pdf({ printBackground: true });
-  return { buffer };
+  return await runAbortableSnapshotWork(opts, async () => {
+    const page = await getPageForTargetId(opts);
+    ensurePageState(page);
+    const buffer = await page.pdf({ printBackground: true });
+    return { buffer };
+  });
 }

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -29,6 +29,12 @@ type SnapshotTargetOpts = {
   disconnectReason?: string;
 };
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("aborted");
+  }
+}
+
 async function runAbortableSnapshotWork<T>(
   opts: SnapshotTargetOpts,
   work: () => Promise<T>,
@@ -268,13 +274,16 @@ export async function navigateViaPlaywright(opts: {
     if (!url) {
       throw new Error("url is required");
     }
+    throwIfAborted(opts.signal);
     await assertBrowserNavigationAllowed({
       url,
       ...withBrowserNavigationPolicy(opts.ssrfPolicy),
     });
+    throwIfAborted(opts.signal);
     const timeout = Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000));
     let page = await getPageForTargetId(opts);
     ensurePageState(page);
+    throwIfAborted(opts.signal);
     const navigate = async () => await page.goto(url, { timeout });
     let response;
     try {
@@ -283,9 +292,7 @@ export async function navigateViaPlaywright(opts: {
       if (!isRetryableNavigateError(err)) {
         throw err;
       }
-      if (opts.signal?.aborted) {
-        throw opts.signal.reason ?? new Error("aborted");
-      }
+      throwIfAborted(opts.signal);
       // Extension relays can briefly drop CDP during renderer swaps/navigation.
       // Force a clean reconnect, then retry once on the refreshed page handle.
       await forceDisconnectPlaywrightForTarget({
@@ -293,11 +300,10 @@ export async function navigateViaPlaywright(opts: {
         targetId: opts.targetId,
         reason: "retry navigate after detached frame",
       }).catch(() => {});
-      if (opts.signal?.aborted) {
-        throw opts.signal.reason ?? new Error("aborted");
-      }
+      throwIfAborted(opts.signal);
       page = await getPageForTargetId(opts);
       ensurePageState(page);
+      throwIfAborted(opts.signal);
       response = await navigate();
     }
     await assertBrowserNavigationRedirectChainAllowed({

--- a/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -283,7 +283,7 @@ describe("pw-tools-core", () => {
     expect(sessionMocks.refLocator).toHaveBeenCalledWith(page, "1");
     expect(scrollIntoViewIfNeeded).toHaveBeenCalledWith({ timeout: 20_000 });
   });
-  it("requires a ref for scrollIntoView", async () => {
+  it("requires a ref or selector for scrollIntoView", async () => {
     setPwToolsCoreCurrentRefLocator({ scrollIntoViewIfNeeded: vi.fn(async () => {}) });
     setPwToolsCoreCurrentPage({});
 

--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -538,6 +538,7 @@ export function registerBrowserAgentActRoutes(
               cdpUrl,
               targetId: tab.targetId,
               doubleClick,
+              signal: req.signal,
             };
             if (ref) {
               clickRequest.ref = ref;
@@ -615,6 +616,7 @@ export function registerBrowserAgentActRoutes(
               text,
               submit,
               slowly,
+              signal: req.signal,
             };
             if (ref) {
               typeRequest.ref = ref;
@@ -655,6 +657,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               key,
               delayMs: delayMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -698,6 +701,7 @@ export function registerBrowserAgentActRoutes(
               ref,
               selector,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -739,6 +743,7 @@ export function registerBrowserAgentActRoutes(
             const scrollRequest: Parameters<typeof pw.scrollIntoViewViaPlaywright>[0] = {
               cdpUrl,
               targetId: tab.targetId,
+              signal: req.signal,
             };
             if (ref) {
               scrollRequest.ref = ref;
@@ -800,6 +805,7 @@ export function registerBrowserAgentActRoutes(
               endRef,
               endSelector,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -853,6 +859,7 @@ export function registerBrowserAgentActRoutes(
               selector,
               values,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -898,6 +905,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               fields,
               timeoutMs: timeoutMs ?? undefined,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -926,6 +934,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               width,
               height,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId, url: tab.url });
           }
@@ -1000,6 +1009,7 @@ export function registerBrowserAgentActRoutes(
               loadState,
               fn,
               timeoutMs,
+              signal: req.signal,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }
@@ -1066,7 +1076,11 @@ export function registerBrowserAgentActRoutes(
             if (!pw) {
               return;
             }
-            await pw.closePageViaPlaywright({ cdpUrl, targetId: tab.targetId });
+            await pw.closePageViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              signal: req.signal,
+            });
             return res.json({ ok: true, targetId: tab.targetId });
           }
           case "batch": {

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -250,6 +250,7 @@ export function registerBrowserAgentSnapshotRoutes(
           cdpUrl,
           targetId: tab.targetId,
           url,
+          signal: req.signal,
           ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
         });
         const currentTargetId = await resolveTargetIdAfterNavigate({
@@ -286,6 +287,7 @@ export function registerBrowserAgentSnapshotRoutes(
         const pdf = await pw.pdfViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
+          signal: req.signal,
         });
         await saveBrowserMediaResponse({
           res,
@@ -362,6 +364,7 @@ export function registerBrowserAgentSnapshotRoutes(
             element,
             fullPage,
             type,
+            signal: req.signal,
           });
           buffer = snap.buffer;
         } else {
@@ -495,6 +498,7 @@ export function registerBrowserAgentSnapshotRoutes(
         const roleSnapshotArgs = {
           cdpUrl: profileCtx.profile.cdpUrl,
           targetId: tab.targetId,
+          signal: req.signal,
           selector: plan.selectorValue,
           frameSelector: plan.frameSelectorValue,
           refsMode: plan.refsMode,
@@ -511,6 +515,7 @@ export function registerBrowserAgentSnapshotRoutes(
               .snapshotAiViaPlaywright({
                 cdpUrl: profileCtx.profile.cdpUrl,
                 targetId: tab.targetId,
+                signal: req.signal,
                 ...(typeof plan.resolvedMaxChars === "number"
                   ? { maxChars: plan.resolvedMaxChars }
                   : {}),
@@ -528,6 +533,7 @@ export function registerBrowserAgentSnapshotRoutes(
             targetId: tab.targetId,
             refs: "refs" in snap ? snap.refs : {},
             type: "png",
+            signal: req.signal,
           });
           const normalized = await normalizeBrowserScreenshot(labeled.buffer, {
             maxSide: DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
@@ -579,6 +585,7 @@ export function registerBrowserAgentSnapshotRoutes(
                 cdpUrl: profileCtx.profile.cdpUrl,
                 targetId: tab.targetId,
                 limit: plan.limit,
+                signal: req.signal,
               });
             });
           })()

--- a/src/gateway/server-methods/browser.local-timeout.test.ts
+++ b/src/gateway/server-methods/browser.local-timeout.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  loadConfigMock,
+  dispatcherDispatchMock,
+  createBrowserRouteDispatcherMock,
+  createBrowserControlContextMock,
+  startBrowserControlServiceFromConfigMock,
+} = vi.hoisted(() => ({
+  loadConfigMock: vi.fn(),
+  dispatcherDispatchMock: vi.fn(),
+  createBrowserRouteDispatcherMock: vi.fn(() => ({
+    dispatch: dispatcherDispatchMock,
+  })),
+  createBrowserControlContextMock: vi.fn(() => ({})),
+  startBrowserControlServiceFromConfigMock: vi.fn(async () => true),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock("../node-command-policy.js", () => ({
+  isNodeCommandAllowed: vi.fn(),
+  resolveNodeCommandAllowlist: vi.fn(),
+}));
+
+vi.mock("../../browser/control-service.js", () => ({
+  createBrowserControlContext: createBrowserControlContextMock,
+  startBrowserControlServiceFromConfig: startBrowserControlServiceFromConfigMock,
+}));
+
+vi.mock("../../browser/routes/dispatcher.js", () => ({
+  createBrowserRouteDispatcher: createBrowserRouteDispatcherMock,
+}));
+
+import { browserHandlers } from "./browser.js";
+
+describe("browser.request local timeout forwarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfigMock.mockReturnValue({
+      gateway: { nodes: { browser: { mode: "off" } } },
+    });
+  });
+
+  it("passes an abort signal to local dispatch and times out cleanly", async () => {
+    let observedSignal: AbortSignal | undefined;
+    dispatcherDispatchMock.mockImplementationOnce(async ({ signal }: { signal?: AbortSignal }) => {
+      observedSignal = signal;
+      await new Promise<never>((_, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+
+    const respond = vi.fn();
+
+    await browserHandlers["browser.request"]({
+      params: {
+        method: "POST",
+        path: "/act",
+        body: { kind: "click", ref: "e1" },
+        timeoutMs: 5,
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          listConnected: () => [],
+        },
+      } as never,
+      client: null,
+      req: { type: "req", id: "req-1", method: "browser.request" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(createBrowserRouteDispatcherMock).toHaveBeenCalled();
+    expect(observedSignal).toBeDefined();
+    expect(observedSignal?.aborted).toBe(true);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("browser request timed out"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/browser.local-timeout.test.ts
+++ b/src/gateway/server-methods/browser.local-timeout.test.ts
@@ -116,4 +116,47 @@ describe("browser.request local timeout forwarding", () => {
     expect(observedSignal).toBeUndefined();
     expect(respond).toHaveBeenCalledWith(true, { ok: true });
   });
+
+  it("leaves existing-session profiles on the direct dispatch path", async () => {
+    loadConfigMock.mockReturnValue({
+      gateway: { nodes: { browser: { mode: "off" } } },
+      browser: {
+        defaultProfile: "existing",
+        profiles: {
+          existing: {
+            driver: "existing-session",
+          },
+        },
+      },
+    });
+
+    let observedSignal: AbortSignal | undefined;
+    dispatcherDispatchMock.mockImplementationOnce(async ({ signal }: { signal?: AbortSignal }) => {
+      observedSignal = signal;
+      return { status: 200, body: { ok: true } };
+    });
+
+    const respond = vi.fn();
+
+    await browserHandlers["browser.request"]({
+      params: {
+        method: "POST",
+        path: "/navigate",
+        body: { url: "https://example.com" },
+        timeoutMs: 5,
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          listConnected: () => [],
+        },
+      } as never,
+      client: null,
+      req: { type: "req", id: "req-3", method: "browser.request" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(observedSignal).toBeUndefined();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
 });

--- a/src/gateway/server-methods/browser.local-timeout.test.ts
+++ b/src/gateway/server-methods/browser.local-timeout.test.ts
@@ -159,4 +159,42 @@ describe("browser.request local timeout forwarding", () => {
     expect(observedSignal).toBeUndefined();
     expect(respond).toHaveBeenCalledWith(true, { ok: true });
   });
+
+  it("leaves the built-in user existing-session profile on the direct dispatch path", async () => {
+    loadConfigMock.mockReturnValue({
+      gateway: { nodes: { browser: { mode: "off" } } },
+      browser: {
+        defaultProfile: "user",
+      },
+    });
+
+    let observedSignal: AbortSignal | undefined;
+    dispatcherDispatchMock.mockImplementationOnce(async ({ signal }: { signal?: AbortSignal }) => {
+      observedSignal = signal;
+      return { status: 200, body: { ok: true } };
+    });
+
+    const respond = vi.fn();
+
+    await browserHandlers["browser.request"]({
+      params: {
+        method: "POST",
+        path: "/navigate",
+        body: { url: "https://example.com", profile: "user" },
+        timeoutMs: 5,
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          listConnected: () => [],
+        },
+      } as never,
+      client: null,
+      req: { type: "req", id: "req-4", method: "browser.request" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(observedSignal).toBeUndefined();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
 });

--- a/src/gateway/server-methods/browser.local-timeout.test.ts
+++ b/src/gateway/server-methods/browser.local-timeout.test.ts
@@ -85,4 +85,35 @@ describe("browser.request local timeout forwarding", () => {
       }),
     );
   });
+
+  it("leaves non-abort-aware local routes on the direct dispatch path", async () => {
+    let observedSignal: AbortSignal | undefined;
+    dispatcherDispatchMock.mockImplementationOnce(async ({ signal }: { signal?: AbortSignal }) => {
+      observedSignal = signal;
+      return { status: 200, body: { ok: true } };
+    });
+
+    const respond = vi.fn();
+
+    await browserHandlers["browser.request"]({
+      params: {
+        method: "POST",
+        path: "/highlight",
+        body: { ref: "e1" },
+        timeoutMs: 5,
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          listConnected: () => [],
+        },
+      } as never,
+      client: null,
+      req: { type: "req", id: "req-2", method: "browser.request" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(observedSignal).toBeUndefined();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
 });

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -241,20 +241,30 @@ export const browserHandlers: GatewayRequestHandlers = {
       return;
     }
 
+    const shouldApplyLocalTimeout =
+      timeoutMs !== undefined && shouldWrapLocalBrowserRequestWithTimeout({ path, body });
+
     let result;
     try {
-      result = await withTimeout(
-        async (signal) =>
-          await dispatcher.dispatch({
+      result = shouldApplyLocalTimeout
+        ? await withTimeout(
+            async (signal) =>
+              await dispatcher.dispatch({
+                method: methodRaw,
+                path,
+                query,
+                body,
+                signal,
+              }),
+            timeoutMs,
+            "browser request",
+          )
+        : await dispatcher.dispatch({
             method: methodRaw,
             path,
             query,
             body,
-            signal,
-          }),
-        timeoutMs,
-        "browser request",
-      );
+          });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
       return;

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { resolveBrowserConfig } from "../../browser/config.js";
 import {
   createBrowserControlContext,
   startBrowserControlServiceFromConfig,
@@ -10,7 +11,6 @@ import {
   resolveRequestedBrowserProfile,
 } from "../../browser/request-policy.js";
 import { createBrowserRouteDispatcher } from "../../browser/routes/dispatcher.js";
-import { resolveBrowserConfig } from "../../browser/config.js";
 import { loadConfig } from "../../config/config.js";
 import { withTimeout } from "../../node-host/with-timeout.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -6,9 +6,11 @@ import {
 import { applyBrowserProxyPaths, persistBrowserProxyFiles } from "../../browser/proxy-files.js";
 import {
   isPersistentBrowserProfileMutation,
+  normalizeBrowserRequestPath,
   resolveRequestedBrowserProfile,
 } from "../../browser/request-policy.js";
 import { createBrowserRouteDispatcher } from "../../browser/routes/dispatcher.js";
+import { resolveBrowserConfig } from "../../browser/config.js";
 import { loadConfig } from "../../config/config.js";
 import { withTimeout } from "../../node-host/with-timeout.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
@@ -25,6 +27,57 @@ type BrowserRequestParams = {
   timeoutMs?: number;
 };
 
+const ABORT_AWARE_LOCAL_ACT_KINDS = new Set([
+  "click",
+  "type",
+  "press",
+  "hover",
+  "scrollIntoView",
+  "drag",
+  "select",
+  "fill",
+  "resize",
+  "wait",
+  "evaluate",
+  "close",
+]);
+
+function resolveRequestedProfileDriver(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  query?: Record<string, unknown>;
+  body?: unknown;
+}): string | undefined {
+  const resolvedBrowser = resolveBrowserConfig(params.cfg.browser, params.cfg);
+  const profileName =
+    resolveRequestedBrowserProfile({ query: params.query, body: params.body }) ??
+    resolvedBrowser.defaultProfile;
+  if (!profileName) {
+    return undefined;
+  }
+  const profile = resolvedBrowser.profiles[profileName];
+  return typeof profile?.driver === "string" ? profile.driver : undefined;
+}
+
+function shouldWrapLocalBrowserRequestWithTimeout(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  path: string;
+  query?: Record<string, unknown>;
+  body?: unknown;
+}) {
+  if (resolveRequestedProfileDriver(params) === "existing-session") {
+    return false;
+  }
+  const path = normalizeBrowserRequestPath(params.path);
+  if (path === "/navigate" || path === "/pdf") {
+    return true;
+  }
+  if (path !== "/act" || !params.body || typeof params.body !== "object") {
+    return false;
+  }
+  const kind =
+    "kind" in params.body && typeof params.body.kind === "string" ? params.body.kind.trim() : "";
+  return ABORT_AWARE_LOCAL_ACT_KINDS.has(kind);
+}
 type BrowserProxyFile = {
   path: string;
   base64: string;
@@ -242,7 +295,8 @@ export const browserHandlers: GatewayRequestHandlers = {
     }
 
     const shouldApplyLocalTimeout =
-      timeoutMs !== undefined && shouldWrapLocalBrowserRequestWithTimeout({ path, body });
+      timeoutMs !== undefined &&
+      shouldWrapLocalBrowserRequestWithTimeout({ cfg, path, query, body });
 
     let result;
     try {

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -10,6 +10,7 @@ import {
 } from "../../browser/request-policy.js";
 import { createBrowserRouteDispatcher } from "../../browser/routes/dispatcher.js";
 import { loadConfig } from "../../config/config.js";
+import { withTimeout } from "../../node-host/with-timeout.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import type { NodeSession } from "../node-registry.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
@@ -240,12 +241,24 @@ export const browserHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const result = await dispatcher.dispatch({
-      method: methodRaw,
-      path,
-      query,
-      body,
-    });
+    let result;
+    try {
+      result = await withTimeout(
+        async (signal) =>
+          await dispatcher.dispatch({
+            method: methodRaw,
+            path,
+            query,
+            body,
+            signal,
+          }),
+        timeoutMs,
+        "browser request",
+      );
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+      return;
+    }
 
     if (result.status >= 400) {
       const message =


### PR DESCRIPTION
AI-assisted: yes (Codex).
Testing: focused regression tests + `pnpm build`.

## Summary

- This supersedes #39277. After `v2026.3.7` landed the overlapping `pw-session` refactor in `a075baba8` (`refactor(browser): scope CDP sessions and harden stale target recovery`), the old branch now conflicts heavily with `main`.
- The upstream refactor improved session scoping, but it did not finish the local timeout/abort path that triggered the original bug: local `browser.request` still timed out at the caller while in-process Playwright work could continue, and most non-`evaluate` browser actions/snapshots still did not honor request aborts.
- This PR re-submits only the remaining bugfix: wire local `browser.request` timeouts into in-process dispatch, pass route abort signals into action/snapshot Playwright helpers, make those helpers reject immediately on abort while disconnecting in the background, and avoid retrying navigation after the request is already aborted.
- Scope boundary: this intentionally does not re-touch the new `pw-session` structure from `v2026.3.7`, and it does not include the broader CLI timeout cleanups from #39277.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Supersedes #39277
- Related #39007
- Related #39090
- Related #38852
- Related #39144

## User-visible / Behavior Changes

- Timed-out local browser actions and snapshots now abort cleanly instead of leaving the attached Playwright/CDP target running in the background.
- Follow-up interactive requests against the same attached session are less likely to degrade into repeated timeouts after one aborted action.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux arm64 (original Raspberry Pi repro) and local Linux dev environment for source validation
- Runtime/container: Node.js workspace via `pnpm`
- Relevant config (redacted): attached Chromium session (`attachOnly: true`), persistent browser profile, local CDP endpoint, local gateway websocket

### Steps

1. Attach OpenClaw to a persistent Chromium/CDP session and confirm `browser status`, `browser tabs`, and `browser snapshot` succeed.
2. Run an interactive browser action such as `browser act kind=type ... --submit` or `browser act kind=click ...`.
3. Observe timeout/abort behavior and then retry follow-up browser actions against the same tab/session.

### Expected

- Timed-out browser work should abort cleanly, and follow-up actions should still be able to reuse the session.

### Actual

- Before this change, local request timeout could fire first while in-process Playwright work kept running, which left later interactive requests prone to more timeouts.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: the original runtime hotfix was exercised end-to-end against a live attached Chromium session on Raspberry Pi (Gemini `snapshot` + `type --submit`, plus `example.com` click flows), and this re-based source version was validated with focused regression tests plus `pnpm build`.
- Edge cases checked: local gateway timeout forwarding, route-level signal propagation for actions and snapshots, abort-triggered helper rejection, and navigation retry suppression after abort.
- What I did **not** verify: a fresh end-to-end attach-only browser run against `v2026.3.7` on Raspberry Pi after re-basing; verification here is source-level plus the already reproduced runtime behavior.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit; the behavior is isolated to local browser timeout/abort propagation.
- Files/config to restore: the touched browser gateway, route, and Playwright helper files.
- Known bad symptoms reviewers should watch for: aborted browser actions unexpectedly disconnecting healthy sessions too aggressively, or timed-out local browser requests continuing to mutate tab state afterward.

## Risks and Mitigations

- Risk: abort-triggered Playwright disconnect/recovery could still interrupt the current target's in-flight work.
  - Mitigation: this only happens on timeout/abort paths and is preferable to leaving the local session wedged for follow-up requests.
- Risk: this does not address every browser timeout behavior from #39277.
  - Mitigation: the PR is intentionally narrowed to the remaining user-visible bug after `v2026.3.7`; anything else can follow up separately without re-opening the old `pw-session` conflict set.
