### PR TITLE
fix(memory): sanitize durable memory metadata

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -203,6 +203,15 @@
         "line_number": 723
       }
     ],
+    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
+        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
+        "is_verified": false,
+        "line_number": 58
+      }
+    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
@@ -219,6 +228,22 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1763
+      }
+    ],
+    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
+        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
+        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
+        "is_verified": false,
+        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -2134,7 +2159,7 @@
         "filename": "docs/.i18n/zh-CN.tm.jsonl",
         "hashed_secret": "becd47f7a933263c4029eb3298bdf67e64166b72",
         "is_verified": false,
-        "line_number": 267
+        "line_number": 331
       },
       {
         "type": "Hex High Entropy String",
@@ -10987,6 +11012,15 @@
         "line_number": 74
       }
     ],
+    "extensions/google-antigravity-auth/index.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/google-antigravity-auth/index.ts",
+        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11355,6 +11389,84 @@
         "line_number": 22
       }
     ],
+    "src/agents/compaction.tool-result-details.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    "src/agents/memory-search.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/memory-search.e2e.test.ts",
+        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
+        "is_verified": false,
+        "line_number": 189
+      }
+    ],
+    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
+        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "src/agents/model-auth.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.e2e.test.ts",
+        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
+        "is_verified": false,
+        "line_number": 228
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.e2e.test.ts",
+        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.e2e.test.ts",
+        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
+        "is_verified": false,
+        "line_number": 275
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.e2e.test.ts",
+        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.e2e.test.ts",
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_verified": false,
+        "line_number": 319
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.e2e.test.ts",
+        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
+        "is_verified": false,
+        "line_number": 374
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.e2e.test.ts",
+        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
+        "is_verified": false,
+        "line_number": 395
+      }
+    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11373,6 +11485,31 @@
         "line_number": 157
       }
     ],
+    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
+        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
+        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ],
+    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
+        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
     "src/agents/models-config.providers.nvidia.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11387,6 +11524,40 @@
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
         "line_number": 23
+      }
+    ],
+    "src/agents/models-config.providers.ollama.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
+        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
+        "is_verified": false,
+        "line_number": 100
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
+        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
+        "is_verified": false,
+        "line_number": 113
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11425,6 +11596,15 @@
         "line_number": 114
       }
     ],
+    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
+        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11434,6 +11614,67 @@
         "line_number": 28
       }
     ],
+    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
+        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
+        "is_verified": false,
+        "line_number": 103
+      }
+    ],
+    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 147
+      }
+    ],
+    "src/agents/skills.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.e2e.test.ts",
+        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
+        "is_verified": false,
+        "line_number": 250
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.e2e.test.ts",
+        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
+        "is_verified": false,
+        "line_number": 277
+      }
+    ],
+    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
+        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
+        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ],
+    "src/agents/tools/web-search.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-search.e2e.test.ts",
+        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
+        "is_verified": false,
+        "line_number": 129
+      }
+    ],
     "src/agents/tools/web-search.ts": [
       {
         "type": "Secret Keyword",
@@ -11441,6 +11682,63 @@
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
         "line_number": 292
+      }
+    ],
+    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
+        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
+        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
+        "is_verified": false,
+        "line_number": 187
+      }
+    ],
+    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
+        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
+        "is_verified": false,
+        "line_number": 246
+      }
+    ],
+    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
+        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
+        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
+        "is_verified": false,
+        "line_number": 149
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11495,6 +11793,15 @@
         "line_number": 64
       }
     ],
+    "src/cli/program.smoke.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/program.smoke.e2e.test.ts",
+        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
+        "is_verified": false,
+        "line_number": 215
+      }
+    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11502,6 +11809,50 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
+      }
+    ],
+    "src/commands/auth-choice.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.e2e.test.ts",
+        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
+        "is_verified": false,
+        "line_number": 454
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.e2e.test.ts",
+        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
+        "is_verified": false,
+        "line_number": 487
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.e2e.test.ts",
+        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "is_verified": false,
+        "line_number": 549
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.e2e.test.ts",
+        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
+        "is_verified": false,
+        "line_number": 584
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.e2e.test.ts",
+        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
+        "is_verified": false,
+        "line_number": 726
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.e2e.test.ts",
+        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
+        "is_verified": false,
+        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11513,6 +11864,31 @@
         "line_number": 8
       }
     ],
+    "src/commands/configure.gateway-auth.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
+        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "src/commands/daemon-install-helpers.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 128
+      }
+    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11520,6 +11896,52 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
+      }
+    ],
+    "src/commands/model-picker.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/model-picker.e2e.test.ts",
+        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
+        "is_verified": false,
+        "line_number": 127
+      }
+    ],
+    "src/commands/models/list.status.e2e.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
+        "is_verified": false,
+        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11536,6 +11958,96 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
+      }
+    ],
+    "src/commands/onboard-auth.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.e2e.test.ts",
+        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
+        "is_verified": false,
+        "line_number": 272
+      }
+    ],
+    "src/commands/onboard-custom.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-custom.e2e.test.ts",
+        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
+        "is_verified": false,
+        "line_number": 238
+      }
+    ],
+    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "is_verified": false,
+        "line_number": 153
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
+        "is_verified": false,
+        "line_number": 191
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "is_verified": false,
+        "line_number": 234
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
+        "is_verified": false,
+        "line_number": 304
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
+        "is_verified": false,
+        "line_number": 338
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
+        "is_verified": false,
+        "line_number": 366
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
+        "is_verified": false,
+        "line_number": 383
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
+        "is_verified": false,
+        "line_number": 402
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
+        "is_verified": false,
+        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -11563,6 +12075,15 @@
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
         "line_number": 60
+      }
+    ],
+    "src/commands/zai-endpoint-detect.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "is_verified": false,
+        "line_number": 24
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -11889,6 +12410,15 @@
         "line_number": 10
       }
     ],
+    "src/docker-setup.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/docker-setup.test.ts",
+        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
+        "is_verified": false,
+        "line_number": 131
+      }
+    ],
     "src/gateway/auth-rate-limit.ts": [
       {
         "type": "Secret Keyword",
@@ -11972,6 +12502,15 @@
         "line_number": 704
       }
     ],
+    "src/gateway/client.e2e.test.ts": [
+      {
+        "type": "Private Key",
+        "filename": "src/gateway/client.e2e.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12006,6 +12545,40 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
+      }
+    ],
+    "src/gateway/server.auth.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.auth.e2e.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 460
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.auth.e2e.test.ts",
+        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
+        "is_verified": false,
+        "line_number": 478
+      }
+    ],
+    "src/gateway/server.skills-status.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.skills-status.e2e.test.ts",
+        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "src/gateway/server.talk-config.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.talk-config.e2e.test.ts",
+        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
+        "is_verified": false,
+        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12218,6 +12791,15 @@
         "hashed_secret": "063995ecb4fa5afe2460397d322925cd867b7d74",
         "is_verified": false,
         "line_number": 88
+      }
+    ],
+    "src/media-understanding/apply.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/apply.e2e.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 12
       }
     ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
@@ -12453,5 +13035,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T23:45:26Z"
+  "generated_at": "2026-03-08T23:41:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -203,15 +203,6 @@
         "line_number": 723
       }
     ],
-    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
-        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
-        "is_verified": false,
-        "line_number": 58
-      }
-    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
@@ -228,22 +219,6 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1763
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -2159,7 +2134,7 @@
         "filename": "docs/.i18n/zh-CN.tm.jsonl",
         "hashed_secret": "becd47f7a933263c4029eb3298bdf67e64166b72",
         "is_verified": false,
-        "line_number": 331
+        "line_number": 267
       },
       {
         "type": "Hex High Entropy String",
@@ -11012,15 +10987,6 @@
         "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
-        "is_verified": false,
-        "line_number": 14
-      }
-    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11389,84 +11355,6 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "src/agents/memory-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
-        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    "src/agents/model-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 228
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 275
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
-        "is_verified": false,
-        "line_number": 374
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
-        "is_verified": false,
-        "line_number": 395
-      }
-    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11485,31 +11373,6 @@
         "line_number": 157
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
-        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
-        "is_verified": false,
-        "line_number": 20
-      }
-    ],
     "src/agents/models-config.providers.nvidia.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11524,40 +11387,6 @@
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
         "line_number": 23
-      }
-    ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
-        "is_verified": false,
-        "line_number": 113
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11584,7 +11413,7 @@
         "filename": "src/agents/pi-embedded-runner/model.ts",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 267
+        "line_number": 331
       }
     ],
     "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts": [
@@ -11596,15 +11425,6 @@
         "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
-        "is_verified": false,
-        "line_number": 126
-      }
-    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11614,67 +11434,6 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
-        "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
-        "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/tools/web-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
-        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
-        "is_verified": false,
-        "line_number": 129
-      }
-    ],
     "src/agents/tools/web-search.ts": [
       {
         "type": "Secret Keyword",
@@ -11682,63 +11441,6 @@
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
         "line_number": 292
-      }
-    ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
-        "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
-        "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 246
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11793,15 +11495,6 @@
         "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
-        "is_verified": false,
-        "line_number": 215
-      }
-    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11809,50 +11502,6 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
-      }
-    ],
-    "src/commands/auth-choice.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
-        "is_verified": false,
-        "line_number": 454
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 584
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
-        "is_verified": false,
-        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11864,31 +11513,6 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 128
-      }
-    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11896,52 +11520,6 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
-        "is_verified": false,
-        "line_number": 127
-      }
-    ],
-    "src/commands/models/list.status.e2e.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11958,96 +11536,6 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
-      }
-    ],
-    "src/commands/onboard-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
-        "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12075,15 +11563,6 @@
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
         "line_number": 60
-      }
-    ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 24
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12410,15 +11889,6 @@
         "line_number": 10
       }
     ],
-    "src/docker-setup.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
-        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
-        "is_verified": false,
-        "line_number": 131
-      }
-    ],
     "src/gateway/auth-rate-limit.ts": [
       {
         "type": "Secret Keyword",
@@ -12502,15 +11972,6 @@
         "line_number": 704
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
-      {
-        "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12545,40 +12006,6 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
-      }
-    ],
-    "src/gateway/server.auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
-      }
-    ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
-        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
-        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
-        "is_verified": false,
-        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12791,15 +12218,6 @@
         "hashed_secret": "063995ecb4fa5afe2460397d322925cd867b7d74",
         "is_verified": false,
         "line_number": 88
-      }
-    ],
-    "src/media-understanding/apply.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
       }
     ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
@@ -13035,5 +12453,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T23:41:46Z"
+  "generated_at": "2026-03-08T23:51:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -203,15 +203,6 @@
         "line_number": 723
       }
     ],
-    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
-        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
-        "is_verified": false,
-        "line_number": 58
-      }
-    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
@@ -228,22 +219,6 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1763
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -11012,15 +10987,6 @@
         "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
-        "is_verified": false,
-        "line_number": 14
-      }
-    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11389,84 +11355,6 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "src/agents/memory-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
-        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    "src/agents/model-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 228
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 275
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
-        "is_verified": false,
-        "line_number": 374
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
-        "is_verified": false,
-        "line_number": 395
-      }
-    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11485,31 +11373,6 @@
         "line_number": 157
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
-        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
-        "is_verified": false,
-        "line_number": 20
-      }
-    ],
     "src/agents/models-config.providers.nvidia.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11524,40 +11387,6 @@
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
         "line_number": 23
-      }
-    ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
-        "is_verified": false,
-        "line_number": 113
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11596,15 +11425,6 @@
         "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
-        "is_verified": false,
-        "line_number": 126
-      }
-    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11614,67 +11434,6 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
-        "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
-        "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/tools/web-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
-        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
-        "is_verified": false,
-        "line_number": 129
-      }
-    ],
     "src/agents/tools/web-search.ts": [
       {
         "type": "Secret Keyword",
@@ -11682,63 +11441,6 @@
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
         "line_number": 292
-      }
-    ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
-        "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
-        "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 246
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11793,15 +11495,6 @@
         "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
-        "is_verified": false,
-        "line_number": 215
-      }
-    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11809,50 +11502,6 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
-      }
-    ],
-    "src/commands/auth-choice.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
-        "is_verified": false,
-        "line_number": 454
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 584
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
-        "is_verified": false,
-        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11864,31 +11513,6 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 128
-      }
-    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11896,52 +11520,6 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
-        "is_verified": false,
-        "line_number": 127
-      }
-    ],
-    "src/commands/models/list.status.e2e.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11958,96 +11536,6 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
-      }
-    ],
-    "src/commands/onboard-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
-        "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12075,15 +11563,6 @@
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
         "line_number": 60
-      }
-    ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 24
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12410,15 +11889,6 @@
         "line_number": 10
       }
     ],
-    "src/docker-setup.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
-        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
-        "is_verified": false,
-        "line_number": 131
-      }
-    ],
     "src/gateway/auth-rate-limit.ts": [
       {
         "type": "Secret Keyword",
@@ -12502,15 +11972,6 @@
         "line_number": 704
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
-      {
-        "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12545,40 +12006,6 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
-      }
-    ],
-    "src/gateway/server.auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
-      }
-    ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
-        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
-        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
-        "is_verified": false,
-        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12791,15 +12218,6 @@
         "hashed_secret": "063995ecb4fa5afe2460397d322925cd867b7d74",
         "is_verified": false,
         "line_number": 88
-      }
-    ],
-    "src/media-understanding/apply.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
       }
     ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
@@ -13035,5 +12453,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T23:02:48Z"
+  "generated_at": "2026-03-08T23:45:26Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -227,7 +227,7 @@
         "filename": "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1749
+        "line_number": 1763
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
@@ -288,7 +288,7 @@
         "filename": "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1749
+        "line_number": 1763
       }
     ],
     "docs/.i18n/zh-CN.tm.jsonl": [
@@ -9720,7 +9720,7 @@
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "b9f640d6095b9f6b5a65983f7b76dbbb254e0044",
         "is_verified": false,
-        "line_number": 726
+        "line_number": 730
       }
     ],
     "docs/concepts/model-providers.md": [
@@ -13035,5 +13035,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T20:41:38Z"
+  "generated_at": "2026-03-08T23:02:48Z"
 }

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -376,6 +376,8 @@ Tools:
 
 - `memory_search` — returns snippets with file + line ranges.
 - `memory_get` — read memory file content by path.
+- `memory_write` — append a durable memory line to daily (`memory/YYYY-MM-DD.md`) or long-term (`MEMORY.md`) memory.
+- `memory_upsert` — keyed update/insert for durable memory entries to avoid duplicates.
 
 Local mode:
 
@@ -387,7 +389,9 @@ Local mode:
 
 - `memory_search` semantically searches Markdown chunks (~400 token target, 80-token overlap) from `MEMORY.md` + `memory/**/*.md`. It returns snippet text (capped ~700 chars), file path, line range, score, provider/model, and whether we fell back from local → remote embeddings. No full file payload is returned.
 - `memory_get` reads a specific memory Markdown file (workspace-relative), optionally from a starting line and for N lines. Paths outside `MEMORY.md` / `memory/` are rejected.
-- Both tools are enabled only when `memorySearch.enabled` resolves true for the agent.
+- `memory_write` appends one normalized Markdown bullet to daily or long-term memory files.
+- `memory_upsert` writes a keyed bullet (`[key:<id>]`) and updates existing entries that share the same key.
+- Search tools require `memorySearch.enabled`; write tools require memory plugin availability and a writable workspace.
 
 ### What gets indexed (and when)
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1697,7 +1697,7 @@ Local onboarding defaults new local configs to `tools.profile: "coding"` when un
 | `group:runtime`    | `exec`, `process` (`bash` is accepted as an alias for `exec`)                            |
 | `group:fs`         | `read`, `write`, `edit`, `apply_patch`                                                   |
 | `group:sessions`   | `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status` |
-| `group:memory`     | `memory_search`, `memory_get`                                                            |
+| `group:memory`     | `memory_search`, `memory_get`, `memory_write`, `memory_upsert`                           |
 | `group:web`        | `web_search`, `web_fetch`                                                                |
 | `group:ui`         | `browser`, `canvas`                                                                      |
 | `group:automation` | `cron`, `gateway`                                                                        |

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -88,7 +88,7 @@ Available groups:
 - `group:runtime`: `exec`, `bash`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
-- `group:memory`: `memory_search`, `memory_get`
+- `group:memory`: `memory_search`, `memory_get`, `memory_write`, `memory_upsert`
 - `group:ui`: `browser`, `canvas`
 - `group:automation`: `cron`, `gateway`
 - `group:messaging`: `message`

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -145,7 +145,7 @@ Available groups:
 - `group:runtime`: `exec`, `bash`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
-- `group:memory`: `memory_search`, `memory_get`
+- `group:memory`: `memory_search`, `memory_get`, `memory_write`, `memory_upsert`
 - `group:web`: `web_search`, `web_fetch`
 - `group:ui`: `browser`, `canvas`
 - `group:automation`: `cron`, `gateway`

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -229,7 +229,7 @@ Tool policies (global, agent, sandbox) support `group:*` entries that expand to 
 - `group:runtime`: `exec`, `bash`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
-- `group:memory`: `memory_search`, `memory_get`
+- `group:memory`: `memory_search`, `memory_get`, `memory_write`, `memory_upsert`
 - `group:ui`: `browser`, `canvas`
 - `group:automation`: `cron`, `gateway`
 - `group:messaging`: `message`

--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -1,5 +1,8 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/bluebubbles";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { z } from "zod";
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
 

--- a/extensions/bluebubbles/src/runtime.ts
+++ b/extensions/bluebubbles/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 
 const runtimeStore = createPluginRuntimeStore<PluginRuntime>("BlueBubbles runtime not initialized");
 type LegacyRuntimeLogShape = { log?: (message: string) => void };

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/discord";
 
 const { setRuntime: setDiscordRuntime, getRuntime: getDiscordRuntime } =

--- a/extensions/feishu/src/runtime.ts
+++ b/extensions/feishu/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/feishu";
 
 const { setRuntime: setFeishuRuntime, getRuntime: getFeishuRuntime } =

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
   buildOpenGroupPolicyConfigureRouteAllowlistWarning,

--- a/extensions/googlechat/src/runtime.ts
+++ b/extensions/googlechat/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/googlechat";
 
 const { setRuntime: setGoogleChatRuntime, getRuntime: getGoogleChatRuntime } =

--- a/extensions/imessage/src/runtime.ts
+++ b/extensions/imessage/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/imessage";
 
 const { setRuntime: setIMessageRuntime, getRuntime: getIMessageRuntime } =

--- a/extensions/irc/src/runtime.ts
+++ b/extensions/irc/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/irc";
 
 const { setRuntime: setIrcRuntime, getRuntime: getIrcRuntime } =

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/line";
 
 const { setRuntime: setLineRuntime, getRuntime: getLineRuntime } =

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
 
 const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/mattermost";
 
 const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -18,12 +18,20 @@ const memoryCorePlugin = {
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
         });
-        if (!memorySearchTool || !memoryGetTool) {
-          return null;
-        }
-        return [memorySearchTool, memoryGetTool];
+        const memoryWriteTool = api.runtime.tools.createMemoryWriteTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        const memoryUpsertTool = api.runtime.tools.createMemoryUpsertTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        const tools = [memorySearchTool, memoryGetTool, memoryWriteTool, memoryUpsertTool].filter(
+          (tool): tool is NonNullable<typeof tool> => Boolean(tool),
+        );
+        return tools.length > 0 ? tools : null;
       },
-      { names: ["memory_search", "memory_get"] },
+      { names: ["memory_search", "memory_get", "memory_write", "memory_upsert"] },
     );
 
     api.registerCli(

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/msteams";
 
 const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =

--- a/extensions/nextcloud-talk/src/runtime.ts
+++ b/extensions/nextcloud-talk/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nextcloud-talk";
 
 const { setRuntime: setNextcloudTalkRuntime, getRuntime: getNextcloudTalkRuntime } =

--- a/extensions/nostr/src/runtime.ts
+++ b/extensions/nostr/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nostr";
 
 const { setRuntime: setNostrRuntime, getRuntime: getNostrRuntime } =

--- a/extensions/signal/src/runtime.ts
+++ b/extensions/signal/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/signal";
 
 const { setRuntime: setSignalRuntime, getRuntime: getSignalRuntime } =

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,

--- a/extensions/slack/src/runtime.ts
+++ b/extensions/slack/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/slack";
 
 const { setRuntime: setSlackRuntime, getRuntime: getSlackRuntime } =

--- a/extensions/synology-chat/src/runtime.ts
+++ b/extensions/synology-chat/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/synology-chat";
 
 const { setRuntime: setSynologyRuntime, getRuntime: getSynologyRuntime } =

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   collectAllowlistProviderGroupPolicyWarnings,
   buildAccountScopedDmSecurityPolicy,

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/telegram";
 
 const { setRuntime: setTelegramRuntime, getRuntime: getTelegramRuntime } =

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -66,6 +66,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       createMemoryGetTool: vi.fn() as unknown as PluginRuntime["tools"]["createMemoryGetTool"],
       createMemorySearchTool:
         vi.fn() as unknown as PluginRuntime["tools"]["createMemorySearchTool"],
+      createMemoryWriteTool: vi.fn() as unknown as PluginRuntime["tools"]["createMemoryWriteTool"],
+      createMemoryUpsertTool:
+        vi.fn() as unknown as PluginRuntime["tools"]["createMemoryUpsertTool"],
       registerMemoryCli: vi.fn() as unknown as PluginRuntime["tools"]["registerMemoryCli"],
     },
     channel: {

--- a/extensions/tlon/src/runtime.ts
+++ b/extensions/tlon/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/tlon";
 
 const { setRuntime: setTlonRuntime, getRuntime: getTlonRuntime } =

--- a/extensions/twitch/src/runtime.ts
+++ b/extensions/twitch/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/twitch";
 
 const { setRuntime: setTwitchRuntime, getRuntime: getTwitchRuntime } =

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/whatsapp";
 
 const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =

--- a/extensions/zalo/src/config-schema.ts
+++ b/extensions/zalo/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { MarkdownConfigSchema } from "openclaw/plugin-sdk/zalo";
 import { z } from "zod";
 import { buildSecretInputSchema } from "./secret-input.js";

--- a/extensions/zalo/src/runtime.ts
+++ b/extensions/zalo/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalo";
 
 const { setRuntime: setZaloRuntime, getRuntime: getZaloRuntime } =

--- a/extensions/zalouser/src/config-schema.ts
+++ b/extensions/zalouser/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/zalouser";
 import { z } from "zod";
 

--- a/extensions/zalouser/src/runtime.ts
+++ b/extensions/zalouser/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalouser";
 
 const { setRuntime: setZalouserRuntime, getRuntime: getZalouserRuntime } =

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -126,6 +126,8 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("cron", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_write", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_upsert", policy)).toBe(false);
   });
 
   it("depth-2 leaf denies sessions_spawn", () => {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -55,6 +55,8 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   // Memory - pass relevant info in spawn prompt instead
   "memory_search",
   "memory_get",
+  "memory_write",
+  "memory_upsert",
   // Direct session sends - subagents communicate through announce chain
   "sessions_send",
 ];

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -325,7 +325,6 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain('`runtime: "acp"`');
     expect(prompt).toContain('Use `runtime: "subagent"` instead.');
   });
-
   it("preserves tool casing in the prompt", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -240,6 +240,21 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("sessions_send");
   });
 
+  it("includes memory write guidance when only write tools are available", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["memory_write"],
+    });
+
+    expect(prompt).toContain("## Memory Recall");
+    expect(prompt).toContain(
+      "When the user explicitly asks to remember/update something, use memory_write (append) or memory_upsert (keyed update) so durable memory is saved to disk.",
+    );
+    expect(prompt).not.toContain(
+      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
+    );
+  });
+
   it("documents ACP sessions_spawn agent targeting requirements", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -248,11 +248,25 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## Memory Recall");
     expect(prompt).toContain(
-      "When the user explicitly asks to remember/update something, use memory_write (append) or memory_upsert (keyed update) so durable memory is saved to disk.",
+      "When the user explicitly asks to remember/update something, use memory_write (append) so durable memory is saved to disk.",
     );
     expect(prompt).not.toContain(
       "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
     );
+    expect(prompt).not.toContain("memory_upsert (keyed update)");
+  });
+
+  it("includes memory upsert guidance when only upsert is available", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["memory_upsert"],
+    });
+
+    expect(prompt).toContain("## Memory Recall");
+    expect(prompt).toContain(
+      "When the user explicitly asks to remember/update something, use memory_upsert (keyed update) so durable memory is saved to disk.",
+    );
+    expect(prompt).not.toContain("memory_write (append)");
   });
 
   it("documents ACP sessions_spawn agent targeting requirements", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -57,8 +57,14 @@ function buildMemorySection(params: {
     );
   }
   if (canWrite) {
+    const writeGuidance = [
+      params.availableTools.has("memory_write") ? "memory_write (append)" : null,
+      params.availableTools.has("memory_upsert") ? "memory_upsert (keyed update)" : null,
+    ].filter(Boolean);
+    const writeTools =
+      writeGuidance.length === 2 ? `${writeGuidance[0]} or ${writeGuidance[1]}` : writeGuidance[0];
     lines.push(
-      "When the user explicitly asks to remember/update something, use memory_write (append) or memory_upsert (keyed update) so durable memory is saved to disk.",
+      `When the user explicitly asks to remember/update something, use ${writeTools} so durable memory is saved to disk.`,
     );
   }
   if (canRecall) {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -43,26 +43,34 @@ function buildMemorySection(params: {
   if (params.isMinimal) {
     return [];
   }
-  if (!params.availableTools.has("memory_search") && !params.availableTools.has("memory_get")) {
+  const canRecall =
+    params.availableTools.has("memory_search") || params.availableTools.has("memory_get");
+  const canWrite =
+    params.availableTools.has("memory_write") || params.availableTools.has("memory_upsert");
+  if (!canRecall && !canWrite) {
     return [];
   }
-  const lines = [
-    "## Memory Recall",
-    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
-  ];
-  if (params.availableTools.has("memory_write") || params.availableTools.has("memory_upsert")) {
+  const lines = ["## Memory Recall"];
+  if (canRecall) {
+    lines.push(
+      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
+    );
+  }
+  if (canWrite) {
     lines.push(
       "When the user explicitly asks to remember/update something, use memory_write (append) or memory_upsert (keyed update) so durable memory is saved to disk.",
     );
   }
-  if (params.citationsMode === "off") {
-    lines.push(
-      "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
-    );
-  } else {
-    lines.push(
-      "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
-    );
+  if (canRecall) {
+    if (params.citationsMode === "off") {
+      lines.push(
+        "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
+      );
+    } else {
+      lines.push(
+        "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
+      );
+    }
   }
   lines.push("");
   return lines;

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -50,6 +50,11 @@ function buildMemorySection(params: {
     "## Memory Recall",
     "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
   ];
+  if (params.availableTools.has("memory_write") || params.availableTools.has("memory_upsert")) {
+    lines.push(
+      "When the user explicitly asks to remember/update something, use memory_write (append) or memory_upsert (keyed update) so durable memory is saved to disk.",
+    );
+  }
   if (params.citationsMode === "off") {
     lines.push(
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -114,6 +114,22 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "memory_write",
+    label: "memory_write",
+    description: "Append durable notes",
+    sectionId: "memory",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
+    id: "memory_upsert",
+    label: "memory_upsert",
+    description: "Update keyed memory",
+    sectionId: "memory",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "sessions_list",
     label: "sessions_list",
     description: "List sessions",

--- a/src/agents/tool-display-overrides.json
+++ b/src/agents/tool-display-overrides.json
@@ -82,6 +82,16 @@
       "title": "Memory Get",
       "detailKeys": ["path", "from", "lines"]
     },
+    "memory_write": {
+      "emoji": "📝",
+      "title": "Memory Write",
+      "detailKeys": ["target", "date", "kind"]
+    },
+    "memory_upsert": {
+      "emoji": "🧷",
+      "title": "Memory Upsert",
+      "detailKeys": ["key", "target", "date", "kind"]
+    },
     "web_search": {
       "emoji": "🔎",
       "title": "Web Search",

--- a/src/agents/tools/memory-tool.test.ts
+++ b/src/agents/tools/memory-tool.test.ts
@@ -8,6 +8,7 @@ import {
   setMemorySearchImpl,
 } from "../../../test/helpers/memory-tool-manager-mock.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { ToolInputError } from "./common.js";
 import {
   createMemoryGetTool,
   createMemorySearchTool,
@@ -302,5 +303,90 @@ describe("memory write tools", () => {
 
     const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
     expect(content).toBe("- \\[key:favorite-food] do not treat this as an upsert entry\n");
+  });
+
+  it("memory_write surfaces invalid target/date as ToolInputError", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-invalid-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryWriteTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await expect(
+      tool.execute("call_write_invalid_target", {
+        text: "remember this",
+        target: "weekly",
+      }),
+    ).rejects.toMatchObject({
+      name: "ToolInputError",
+      message: 'target must be "daily" or "longterm"',
+    } satisfies Partial<ToolInputError>);
+
+    await expect(
+      tool.execute("call_write_invalid_date", {
+        text: "remember this",
+        target: "daily",
+        date: "03-08-2026",
+      }),
+    ).rejects.toMatchObject({
+      name: "ToolInputError",
+      message: "date must be YYYY-MM-DD",
+    } satisfies Partial<ToolInputError>);
+  });
+
+  it("memory_upsert surfaces invalid normalized keys as ToolInputError", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-upsert-invalid-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryUpsertTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await expect(
+      tool.execute("call_upsert_invalid_key", {
+        key: "!!!",
+        text: "remember this",
+      }),
+    ).rejects.toMatchObject({
+      name: "ToolInputError",
+      message: "key is required",
+    } satisfies Partial<ToolInputError>);
+  });
+
+  it("ignores incidental date values for longterm memory writes and upserts", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-longterm-date-"));
+    const cfg = configWithWorkspace(workspace);
+    const writeTool = createMemoryWriteTool({ config: cfg });
+    const upsertTool = createMemoryUpsertTool({ config: cfg });
+    expect(writeTool).not.toBeNull();
+    expect(upsertTool).not.toBeNull();
+    if (!writeTool || !upsertTool) {
+      throw new Error("tool missing");
+    }
+
+    await expect(
+      writeTool.execute("call_write_longterm_date", {
+        text: "remember this",
+        target: "longterm",
+        date: "next week",
+      }),
+    ).resolves.toBeDefined();
+
+    await expect(
+      upsertTool.execute("call_upsert_longterm_date", {
+        key: "favorite-food",
+        text: "sushi",
+        target: "longterm",
+        date: "next week",
+      }),
+    ).resolves.toBeDefined();
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    expect(content).toContain("remember this");
+    expect(content).toContain("[key:favorite-food]");
+    expect(content).toContain("sushi");
   });
 });

--- a/src/agents/tools/memory-tool.test.ts
+++ b/src/agents/tools/memory-tool.test.ts
@@ -1,9 +1,47 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   resetMemoryToolMockState,
+  setMemoryReadFileImpl,
   setMemorySearchImpl,
 } from "../../../test/helpers/memory-tool-manager-mock.js";
-import { createMemorySearchTool } from "./memory-tool.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  createMemoryGetTool,
+  createMemorySearchTool,
+  createMemoryUpsertTool,
+  createMemoryWriteTool,
+} from "./memory-tool.js";
+
+function asOpenClawConfig(config: Partial<OpenClawConfig>): OpenClawConfig {
+  return config as OpenClawConfig;
+}
+
+function createToolConfig() {
+  return asOpenClawConfig({ agents: { list: [{ id: "main", default: true }] } });
+}
+
+function createMemoryGetToolOrThrow(config: OpenClawConfig = createToolConfig()) {
+  const tool = createMemoryGetTool({ config });
+  if (!tool) {
+    throw new Error("tool missing");
+  }
+  return tool;
+}
+
+function configWithWorkspace(workspace: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        workspace,
+        memorySearch: { enabled: true },
+      },
+      list: [{ id: "main", default: true }],
+    },
+  } as unknown as OpenClawConfig;
+}
 
 describe("memory_search unavailable payloads", () => {
   beforeEach(() => {
@@ -54,5 +92,215 @@ describe("memory_search unavailable payloads", () => {
       warning: "Memory search is unavailable due to an embedding/provider error.",
       action: "Check embedding provider configuration and retry memory_search.",
     });
+  });
+});
+
+describe("memory tools", () => {
+  it("does not throw when memory_get fails", async () => {
+    setMemoryReadFileImpl(async () => {
+      throw new Error("path required");
+    });
+
+    const tool = createMemoryGetToolOrThrow();
+
+    const result = await tool.execute("call_2", { path: "memory/NOPE.md" });
+    expect(result.details).toEqual({
+      path: "memory/NOPE.md",
+      text: "",
+      disabled: true,
+      error: "path required",
+    });
+  });
+});
+
+describe("memory write tools", () => {
+  it("memory_write appends to daily memory file", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryWriteTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const result = await tool.execute("call_write", {
+      text: "remember this",
+      date: "2026-02-18",
+      kind: "preference",
+    });
+    const details = result.details as { path: string; target: string };
+    expect(details.path).toBe("memory/2026-02-18.md");
+    expect(details.target).toBe("daily");
+
+    const content = await fs.readFile(path.join(workspace, "memory", "2026-02-18.md"), "utf-8");
+    expect(content).toContain("remember this");
+    expect(content).toContain("kind:preference");
+  });
+
+  it("memory_write inserts a separator when the file lacks a trailing newline", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-separator-"));
+    await fs.mkdir(path.join(workspace, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace, "memory", "2026-02-18.md"),
+      "- existing entry without newline",
+      "utf-8",
+    );
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryWriteTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_write_separator", {
+      text: "remember this",
+      date: "2026-02-18",
+    });
+
+    const content = await fs.readFile(path.join(workspace, "memory", "2026-02-18.md"), "utf-8");
+    expect(content).toBe("- existing entry without newline\n- remember this\n");
+  });
+
+  it("memory_upsert updates existing keyed entries", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-upsert-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryUpsertTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_upsert_1", {
+      key: "favorite-food",
+      text: "pizza",
+      target: "longterm",
+    });
+    await tool.execute("call_upsert_2", {
+      key: "favorite-food",
+      text: "sushi",
+      target: "longterm",
+    });
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    expect(content).toContain("[key:favorite-food]");
+    expect(content).toContain("sushi");
+    expect(content).not.toContain("pizza");
+    expect(content.match(/\[key:favorite-food\]/g)?.length).toBe(1);
+  });
+
+  it("memory_upsert collapses duplicate keyed entries down to one line", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-upsert-dedupe-"));
+    await fs.writeFile(
+      path.join(workspace, "MEMORY.md"),
+      "- [key:favorite-food] pizza\n- [key:favorite-food] tacos\n",
+      "utf-8",
+    );
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryUpsertTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_upsert_dedupe", {
+      key: "favorite-food",
+      text: "sushi",
+      target: "longterm",
+    });
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    expect(content).toBe("- [key:favorite-food] sushi\n");
+  });
+
+  it("memory_upsert preserves all concurrent keyed writes to the same file", async () => {
+    const workspace = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-memory-upsert-concurrent-"),
+    );
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryUpsertTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const count = 20;
+    await Promise.all(
+      Array.from({ length: count }, (_, index) =>
+        tool.execute(`call_upsert_concurrent_${index}`, {
+          key: `pref-${index}`,
+          text: `value-${index}`,
+          target: "longterm",
+        }),
+      ),
+    );
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    for (let index = 0; index < count; index += 1) {
+      expect(content).toContain(`[key:pref-${index}]`);
+      expect(content).toContain(`value-${index}`);
+    }
+  });
+
+  it("memory_write normalizes metadata into a single delimiter-safe line", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-meta-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryWriteTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_write_meta", {
+      text: "remember this",
+      date: "2026-02-18",
+      kind: "preference,\nprimary",
+      source: "user)\n- [key:evil] injected",
+    });
+
+    const content = await fs.readFile(path.join(workspace, "memory", "2026-02-18.md"), "utf-8");
+    expect(content.split(/\r?\n/).filter(Boolean)).toHaveLength(1);
+    expect(content).toContain("kind:preference primary");
+    expect(content).toContain("source:user - key:evil injected");
+    expect(content).not.toContain("[key:evil]");
+  });
+
+  it("memory_upsert does not allow metadata to inject extra keyed entries", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-upsert-meta-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryUpsertTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_upsert_meta", {
+      key: "favorite-food",
+      text: "pizza",
+      target: "longterm",
+      source: "user)\n- [key:evil] injected",
+    });
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    expect(content.split(/\r?\n/).filter(Boolean)).toHaveLength(1);
+    expect(content).toContain("[key:favorite-food]");
+    expect(content).not.toContain("\n- [key:evil]");
+  });
+
+  it("memory_write escapes a leading key marker in freeform text", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-text-"));
+    const cfg = configWithWorkspace(workspace);
+    const tool = createMemoryWriteTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("call_write_text_marker", {
+      text: "[key:favorite-food] do not treat this as an upsert entry",
+      target: "longterm",
+    });
+
+    const content = await fs.readFile(path.join(workspace, "MEMORY.md"), "utf-8");
+    expect(content).toBe("- \\[key:favorite-food] do not treat this as an upsert entry\n");
   });
 });

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -237,7 +237,8 @@ export function createMemoryWriteTool(options: {
       });
       await withMemoryFileLock(absPath, async () => {
         await ensureMemoryFile(absPath);
-        await fs.appendFile(absPath, `${entry}\n`, "utf-8");
+        const separator = await resolveMemoryAppendSeparator(absPath);
+        await fs.appendFile(absPath, `${separator}${entry}\n`, "utf-8");
       });
       return jsonResult({
         ok: true,
@@ -302,14 +303,21 @@ export function createMemoryUpsertTool(options: {
           lines.pop();
         }
         const prefix = `- [key:${key}] `;
-        const existingIndex = lines.findIndex((line) => line.startsWith(prefix));
-        const alreadyExists = existingIndex >= 0;
+        const existingIndexes = lines.flatMap((line, index) =>
+          line.startsWith(prefix) ? [index] : [],
+        );
+        const alreadyExists = existingIndexes.length > 0;
+        const nextLines = lines.filter((line) => !line.startsWith(prefix));
         if (alreadyExists) {
-          lines[existingIndex] = entry;
+          nextLines.splice(
+            Math.min(existingIndexes[0] ?? nextLines.length, nextLines.length),
+            0,
+            entry,
+          );
         } else {
-          lines.push(entry);
+          nextLines.push(entry);
         }
-        await fs.writeFile(absPath, `${lines.join("\n")}\n`, "utf-8");
+        await fs.writeFile(absPath, `${nextLines.join("\n")}\n`, "utf-8");
         return alreadyExists;
       });
       return jsonResult({
@@ -352,10 +360,14 @@ function normalizeMemoryDate(raw?: string): string {
 }
 
 function normalizeMemoryText(raw: string): string {
-  return raw
+  const normalized = raw
     .replace(/\s*\n+\s*/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+  if (!normalized) {
+    return "";
+  }
+  return /^\[key:/i.test(normalized) ? `\\${normalized}` : normalized;
 }
 
 function normalizeMemoryKey(raw: string): string {
@@ -366,6 +378,18 @@ function normalizeMemoryKey(raw: string): string {
     .toLowerCase();
 }
 
+function normalizeMemoryMetaValue(raw?: string): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw
+    .replace(/\s*\n+\s*/g, " ")
+    .replace(/[()[\],]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized || undefined;
+}
+
 function formatMemoryEntry(params: {
   text: string;
   kind?: string;
@@ -373,11 +397,11 @@ function formatMemoryEntry(params: {
   confidence?: number;
 }): string {
   const meta: string[] = [];
-  const kind = params.kind?.trim();
+  const kind = normalizeMemoryMetaValue(params.kind);
   if (kind) {
     meta.push(`kind:${kind}`);
   }
-  const source = params.source?.trim();
+  const source = normalizeMemoryMetaValue(params.source);
   if (source) {
     meta.push(`source:${source}`);
   }
@@ -407,6 +431,11 @@ async function ensureMemoryFile(absPath: string) {
   } catch {
     await fs.writeFile(absPath, "", "utf-8");
   }
+}
+
+async function resolveMemoryAppendSeparator(absPath: string): Promise<string> {
+  const current = await fs.readFile(absPath, "utf-8");
+  return current.length > 0 && !current.endsWith("\n") ? "\n" : "";
 }
 
 function asWorkspaceRelativePath(absPath: string, workspaceDir: string): string {

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -11,7 +11,7 @@ import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../agent-scope.
 import { resolveMemorySearchConfig } from "../memory-search.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
-import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+import { ToolInputError, jsonResult, readNumberParam, readStringParam } from "./common.js";
 
 const MemorySearchSchema = Type.Object({
   query: Type.String(),
@@ -223,7 +223,7 @@ export function createMemoryWriteTool(options: {
       }
       const target = readMemoryTarget(params, "target", "daily");
       const requestedDate = readStringParam(params, "date");
-      const date = normalizeMemoryDate(requestedDate);
+      const date = resolveMemoryWriteDate(target, requestedDate);
       const entry = formatMemoryEntry({
         text,
         kind: readStringParam(params, "kind"),
@@ -269,7 +269,7 @@ export function createMemoryUpsertTool(options: {
       const keyRaw = readStringParam(params, "key", { required: true });
       const key = normalizeMemoryKey(keyRaw);
       if (!key) {
-        throw new Error("key is required");
+        throw new ToolInputError("key is required");
       }
       const text = normalizeMemoryText(readStringParam(params, "text", { required: true }));
       if (!text) {
@@ -277,7 +277,7 @@ export function createMemoryUpsertTool(options: {
       }
       const target = readMemoryTarget(params, "target", "longterm");
       const requestedDate = readStringParam(params, "date");
-      const date = normalizeMemoryDate(requestedDate);
+      const date = resolveMemoryWriteDate(target, requestedDate);
       const body = formatMemoryEntry({
         text,
         kind: readStringParam(params, "kind"),
@@ -345,7 +345,7 @@ function readMemoryTarget(
   if (raw === "daily" || raw === "longterm") {
     return raw;
   }
-  throw new Error(`${field} must be "daily" or "longterm"`);
+  throw new ToolInputError(`${field} must be "daily" or "longterm"`);
 }
 
 function normalizeMemoryDate(raw?: string): string {
@@ -354,9 +354,16 @@ function normalizeMemoryDate(raw?: string): string {
   }
   const trimmed = raw.trim();
   if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
-    throw new Error(`date must be YYYY-MM-DD`);
+    throw new ToolInputError(`date must be YYYY-MM-DD`);
   }
   return trimmed;
+}
+
+function resolveMemoryWriteDate(target: "daily" | "longterm", raw?: string): string | undefined {
+  if (target !== "daily") {
+    return undefined;
+  }
+  return normalizeMemoryDate(raw);
 }
 
 function normalizeMemoryText(raw: string): string {
@@ -416,10 +423,13 @@ function formatMemoryEntry(params: {
 function resolveMemoryWritePath(params: {
   workspaceDir: string;
   target: "daily" | "longterm";
-  date: string;
+  date?: string;
 }): string {
   if (params.target === "longterm") {
     return path.join(params.workspaceDir, "MEMORY.md");
+  }
+  if (!params.date) {
+    throw new ToolInputError("date must be YYYY-MM-DD");
   }
   return path.join(params.workspaceDir, "memory", `${params.date}.md`);
 }

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -55,8 +55,8 @@ async function withMemoryFileLock<T>(absPath: string, action: () => Promise<T>):
   });
   const queued = previous.then(() => current);
   memoryFileLocks.set(lockKey, queued);
-  await previous;
   try {
+    await previous;
     return await action();
   } finally {
     releaseCurrent?.();

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+type ProbeGatewayFn = (opts: {
+  url: string;
+  auth?: { token?: string; password?: string };
+  timeoutMs: number;
+}) => Promise<{
+  ok: boolean;
+  configSnapshot: unknown;
+}>;
+
+const probeGateway = vi.fn<ProbeGatewayFn>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/plugins/runtime/runtime-tools.ts
+++ b/src/plugins/runtime/runtime-tools.ts
@@ -1,4 +1,9 @@
-import { createMemoryGetTool, createMemorySearchTool } from "../../agents/tools/memory-tool.js";
+import {
+  createMemoryGetTool,
+  createMemorySearchTool,
+  createMemoryUpsertTool,
+  createMemoryWriteTool,
+} from "../../agents/tools/memory-tool.js";
 import { registerMemoryCli } from "../../cli/memory-cli.js";
 import type { PluginRuntime } from "./types.js";
 
@@ -6,6 +11,8 @@ export function createRuntimeTools(): PluginRuntime["tools"] {
   return {
     createMemoryGetTool,
     createMemorySearchTool,
+    createMemoryWriteTool,
+    createMemoryUpsertTool,
     registerMemoryCli,
   };
 }

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -36,6 +36,8 @@ export type PluginRuntimeCore = {
   tools: {
     createMemoryGetTool: typeof import("../../agents/tools/memory-tool.js").createMemoryGetTool;
     createMemorySearchTool: typeof import("../../agents/tools/memory-tool.js").createMemorySearchTool;
+    createMemoryWriteTool: typeof import("../../agents/tools/memory-tool.js").createMemoryWriteTool;
+    createMemoryUpsertTool: typeof import("../../agents/tools/memory-tool.js").createMemoryUpsertTool;
     registerMemoryCli: typeof import("../../cli/memory-cli.js").registerMemoryCli;
   };
   events: {


### PR DESCRIPTION
## Summary
- normalize `kind` and `source` metadata into single-line delimiter-safe values before writing Markdown memory entries
- add regression tests covering newline and delimiter injection for both `memory_write` and `memory_upsert`

## Why
`text` was already normalized to a single line, but `kind` and `source` were interpolated into Markdown metadata after only `trim()`. A single tool call could therefore inject extra lines and create additional apparent memory entries.

## Validation
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/tools/memory-tool.e2e.test.ts`
- `pnpm exec oxfmt --check src/agents/tools/memory-tool.ts src/agents/tools/memory-tool.e2e.test.ts`
- `pnpm exec oxlint src/agents/tools/memory-tool.ts src/agents/tools/memory-tool.e2e.test.ts`

## Stacking / review notes
- This is intentionally stacked on top of #21003.
- Until #21003 lands, this PR includes the durable-memory foundation from that branch.
- After #21003 merges, this should collapse to the metadata sanitization delta.
