### PR TITLE
feat(web-search): expose Brave Goggles for custom search filtering and ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@ Docs: https://docs.openclaw.ai
 - LLM Task/Lobster: add an optional `thinking` override so workflow calls can explicitly set embedded reasoning level with shared validation for invalid values and unsupported `xhigh` modes. (#15606) Thanks @xadenryan and @ImLukeF.
 - Mattermost/reply threading: add `channels.mattermost.replyToMode` for channel and group messages so top-level posts can start thread-scoped sessions without the manual reply-then-thread workaround. (#29587) Thanks @teconomix.
 - iOS/push relay: add relay-backed official-build push delivery with App Attest + receipt verification, gateway-bound send delegation, and config-based relay URL setup on the gateway. (#43369) Thanks @ngutman.
+- Tools/Brave web search: add `goggles` parameter so `web_search` can apply [Brave Goggles](https://search.brave.com/help/goggles) custom filtering and ranking rules (inline or hosted URL) in both web and llm-context modes.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Docs: https://docs.openclaw.ai
 - Models/plugins: move Ollama, vLLM, and SGLang onto the provider-plugin architecture, with provider-owned onboarding, discovery, model-picker setup, and post-selection hooks so core provider wiring is more modular.
 - Docs/Kubernetes: Add a starter K8s install path with raw manifests, Kind setup, and deployment docs. Thanks @sallyom @dzianisv @egkristi
 - Agents/subagents: add `sessions_yield` so orchestrators can end the current turn immediately, skip queued tool work, and carry a hidden follow-up payload into the next session turn. (#36537) thanks @jriff
+- Tools/Brave web search: add `goggles` parameter so `web_search` can apply [Brave Goggles](https://search.brave.com/help/goggles) custom filtering and ranking rules (inline or hosted URL) in both web and llm-context modes.
 - Slack/agent replies: support `channelData.slack.blocks` in the shared reply delivery path so agents can send Block Kit messages through standard Slack outbound delivery. (#44592) Thanks @vincentkoc.
 - Slack/interactive replies: add opt-in Slack button and select reply directives behind `channels.slack.capabilities.interactiveReplies`, disabled by default unless explicitly enabled. (#44607) Thanks @vincentkoc.
 
@@ -253,7 +254,6 @@ Docs: https://docs.openclaw.ai
 - LLM Task/Lobster: add an optional `thinking` override so workflow calls can explicitly set embedded reasoning level with shared validation for invalid values and unsupported `xhigh` modes. (#15606) Thanks @xadenryan and @ImLukeF.
 - Mattermost/reply threading: add `channels.mattermost.replyToMode` for channel and group messages so top-level posts can start thread-scoped sessions without the manual reply-then-thread workaround. (#29587) Thanks @teconomix.
 - iOS/push relay: add relay-backed official-build push delivery with App Attest + receipt verification, gateway-bound send delegation, and config-based relay URL setup on the gateway. (#43369) Thanks @ngutman.
-- Tools/Brave web search: add `goggles` parameter so `web_search` can apply [Brave Goggles](https://search.brave.com/help/goggles) custom filtering and ranking rules (inline or hosted URL) in both web and llm-context modes.
 
 ### Breaking
 

--- a/docs/brave-search.md
+++ b/docs/brave-search.md
@@ -35,16 +35,17 @@ OpenClaw supports Brave Search API as a `web_search` provider.
 
 ## Tool parameters
 
-| Parameter     | Description                                                         |
-| ------------- | ------------------------------------------------------------------- |
-| `query`       | Search query (required)                                             |
-| `count`       | Number of results to return (1-10, default: 5)                      |
-| `country`     | 2-letter ISO country code (e.g., "US", "DE")                        |
-| `language`    | ISO 639-1 language code for search results (e.g., "en", "de", "fr") |
-| `ui_lang`     | ISO language code for UI elements                                   |
-| `freshness`   | Time filter: `day` (24h), `week`, `month`, or `year`                |
-| `date_after`  | Only results published after this date (YYYY-MM-DD)                 |
-| `date_before` | Only results published before this date (YYYY-MM-DD)                |
+| Parameter     | Description                                                                                                |
+| ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `query`       | Search query (required)                                                                                    |
+| `count`       | Number of results to return (1-10, default: 5)                                                             |
+| `country`     | 2-letter ISO country code (e.g., "US", "DE")                                                               |
+| `language`    | ISO 639-1 language code for search results (e.g., "en", "de", "fr")                                        |
+| `ui_lang`     | ISO language code for UI elements                                                                          |
+| `freshness`   | Time filter: `day` (24h), `week`, `month`, or `year`                                                       |
+| `date_after`  | Only results published after this date (YYYY-MM-DD)                                                        |
+| `date_before` | Only results published before this date (YYYY-MM-DD)                                                       |
+| `goggles`     | [Brave Goggle](https://search.brave.com/help/goggles) URL or inline rules for custom filtering and ranking |
 
 **Examples:**
 
@@ -68,6 +69,25 @@ await web_search({
   date_after: "2024-01-01",
   date_before: "2024-06-30",
 });
+
+// Restrict to trusted sources with inline Goggle rules
+await web_search({
+  query: "transformer architecture",
+  goggles: "$discard\n$site=arxiv.org\n$site=*.edu\n$site=huggingface.co",
+});
+
+// Boost docs over blog posts
+await web_search({
+  query: "react server components",
+  goggles: "/docs/*$boost=5\n/blog/*$downrank=5",
+});
+
+// Use the Tech Blogs community Goggle to boost developer blog content
+await web_search({
+  query: "javascript frameworks",
+  goggles:
+    "https://raw.githubusercontent.com/brave/goggles-quickstart/main/goggles/tech_blogs.goggle",
+});
 ```
 
 ## Notes
@@ -75,6 +95,7 @@ await web_search({
 - OpenClaw uses the Brave **Search** plan. If you have a legacy subscription (e.g. the original Free plan with 2,000 queries/month), it remains valid but does not include newer features like LLM Context or higher rate limits.
 - Each Brave plan includes **\$5/month in free credit** (renewing). The Search plan costs \$5 per 1,000 requests, so the credit covers 1,000 queries/month. Set your usage limit in the Brave dashboard to avoid unexpected charges. See the [Brave API portal](https://brave.com/search/api/) for current plans.
 - The Search plan includes the LLM Context endpoint and AI inference rights. Storing results to train or tune models requires a plan with explicit storage rights. See the Brave [Terms of Service](https://api-dashboard.search.brave.com/terms-of-service).
+- Brave [Goggles](https://search.brave.com/help/goggles) let you filter, boost, or downrank results using community-authored rules — restrict to trusted sources, suppress SEO spam, or surface niche content. Goggles work in both `web` and `llm-context` modes. Pass inline rules directly via `goggles` (no registration needed) or a hosted Goggle URL (must be registered at [search.brave.com/goggles/create](https://search.brave.com/goggles/create)). See the [Goggles quickstart](https://github.com/brave/goggles-quickstart) for the full DSL syntax.
 - Results are cached for 15 minutes by default (configurable via `cacheTtlMinutes`).
 
 See [Web tools](/tools/web) for the full web_search configuration.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -29,13 +29,13 @@ See [Brave Search setup](/brave-search) and [Perplexity Search setup](/perplexit
 
 ## Choosing a search provider
 
-| Provider                  | Result shape                       | Provider-specific filters                    | Notes                                                                          | API key                                     |
-| ------------------------- | ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------- |
-| **Brave Search API**      | Structured results with snippets   | `country`, `language`, `ui_lang`, time       | Supports Brave `llm-context` mode                                              | `BRAVE_API_KEY`                             |
-| **Gemini**                | AI-synthesized answers + citations | —                                            | Uses Google Search grounding                                                   | `GEMINI_API_KEY`                            |
-| **Grok**                  | AI-synthesized answers + citations | —                                            | Uses xAI web-grounded responses                                                | `XAI_API_KEY`                               |
-| **Kimi**                  | AI-synthesized answers + citations | —                                            | Uses Moonshot web search                                                       | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
-| **Perplexity Search API** | Structured results with snippets   | `country`, `language`, time, `domain_filter` | Supports content extraction controls; OpenRouter uses Sonar compatibility path | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
+| Provider                  | Result shape                       | Provider-specific filters                    | Notes                                                                                  | API key                                     |
+| ------------------------- | ---------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Brave Search API**      | Structured results with snippets   | `country`, `language`, `ui_lang`, time       | Supports Brave `llm-context` mode and [Goggles](https://search.brave.com/help/goggles) | `BRAVE_API_KEY`                             |
+| **Gemini**                | AI-synthesized answers + citations | —                                            | Uses Google Search grounding                                                           | `GEMINI_API_KEY`                            |
+| **Grok**                  | AI-synthesized answers + citations | —                                            | Uses xAI web-grounded responses                                                        | `XAI_API_KEY`                               |
+| **Kimi**                  | AI-synthesized answers + citations | —                                            | Uses Moonshot web search                                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
+| **Perplexity Search API** | Structured results with snippets   | `country`, `language`, time, `domain_filter` | Supports content extraction controls; OpenRouter uses Sonar compatibility path         | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
 
 ### Auto-detection
 
@@ -265,19 +265,20 @@ All parameters work for Brave and for native Perplexity Search API unless noted.
 Perplexity's OpenRouter / Sonar compatibility path supports only `query` and `freshness`.
 If you set `tools.web.search.perplexity.baseUrl` / `model`, use `OPENROUTER_API_KEY`, or configure an `sk-or-...` key, Search API-only filters return explicit errors.
 
-| Parameter             | Description                                           |
-| --------------------- | ----------------------------------------------------- |
-| `query`               | Search query (required)                               |
-| `count`               | Results to return (1-10, default: 5)                  |
-| `country`             | 2-letter ISO country code (e.g., "US", "DE")          |
-| `language`            | ISO 639-1 language code (e.g., "en", "de")            |
-| `freshness`           | Time filter: `day`, `week`, `month`, or `year`        |
-| `date_after`          | Results after this date (YYYY-MM-DD)                  |
-| `date_before`         | Results before this date (YYYY-MM-DD)                 |
-| `ui_lang`             | UI language code (Brave only)                         |
-| `domain_filter`       | Domain allowlist/denylist array (Perplexity only)     |
-| `max_tokens`          | Total content budget, default 25000 (Perplexity only) |
-| `max_tokens_per_page` | Per-page token limit, default 2048 (Perplexity only)  |
+| Parameter             | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `query`               | Search query (required)                                                  |
+| `count`               | Results to return (1-10, default: 5)                                     |
+| `country`             | 2-letter ISO country code (e.g., "US", "DE")                             |
+| `language`            | ISO 639-1 language code (e.g., "en", "de")                               |
+| `freshness`           | Time filter: `day`, `week`, `month`, or `year`                           |
+| `date_after`          | Results after this date (YYYY-MM-DD)                                     |
+| `date_before`         | Results before this date (YYYY-MM-DD)                                    |
+| `ui_lang`             | UI language code (Brave only)                                            |
+| `goggles`             | Goggle URL or inline rules for custom filtering and ranking (Brave only) |
+| `domain_filter`       | Domain allowlist/denylist array (Perplexity only)                        |
+| `max_tokens`          | Total content budget, default 25000 (Perplexity only)                    |
+| `max_tokens_per_page` | Per-page token limit, default 2048 (Perplexity only)                     |
 
 **Examples:**
 
@@ -302,16 +303,40 @@ await web_search({
   date_before: "2024-06-30",
 });
 
-// Domain filtering (Perplexity only)
+// Boost docs over blog posts (Brave Goggles)
 await web_search({
-  query: "climate research",
-  domain_filter: ["nature.com", "science.org", ".edu"],
+  query: "react server components",
+  goggles: "/docs/*$boost=5\n/blog/*$downrank=5",
 });
 
-// Exclude domains (Perplexity only)
+// Boost GitHub source code (Brave Goggles)
 await web_search({
-  query: "product reviews",
-  domain_filter: ["-reddit.com", "-pinterest.com"],
+  query: "openai streaming api",
+  goggles: "$boost=5,site=github.com,inurl=/blob/",
+});
+
+// Domain allowlist — Brave Goggles
+await web_search({
+  query: "transformer architecture",
+  goggles: "$discard\n$site=arxiv.org\n$site=*.edu\n$site=huggingface.co",
+});
+
+// Domain allowlist — Perplexity domain_filter
+await web_search({
+  query: "transformer architecture",
+  domain_filter: ["arxiv.org", ".edu", "huggingface.co"],
+});
+
+// Domain denylist — Brave Goggles
+await web_search({
+  query: "LLM fine-tuning guide",
+  goggles: "$discard,site=reddit.com\n$discard,site=medium.com",
+});
+
+// Domain denylist — Perplexity domain_filter
+await web_search({
+  query: "LLM fine-tuning guide",
+  domain_filter: ["-reddit.com", "-medium.com"],
 });
 
 // More content extraction (Perplexity only)
@@ -323,7 +348,7 @@ await web_search({
 ```
 
 When Brave `llm-context` mode is enabled, `ui_lang`, `freshness`, `date_after`, and
-`date_before` are not supported. Use Brave `web` mode for those filters.
+`date_before` are not supported; use Brave `web` mode for those filters. `goggles`, `country`, and `language` work in both modes.
 
 ## web_fetch
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -29,13 +29,13 @@ See [Brave Search setup](/brave-search) and [Perplexity Search setup](/perplexit
 
 ## Choosing a search provider
 
-| Provider                  | Result shape                       | Provider-specific filters                    | Notes                                                                                  | API key                                     |
-| ------------------------- | ---------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------- |
-| **Brave Search API**      | Structured results with snippets   | `country`, `language`, `ui_lang`, time       | Supports Brave `llm-context` mode and [Goggles](https://search.brave.com/help/goggles) | `BRAVE_API_KEY`                             |
-| **Gemini**                | AI-synthesized answers + citations | —                                            | Uses Google Search grounding                                                           | `GEMINI_API_KEY`                            |
-| **Grok**                  | AI-synthesized answers + citations | —                                            | Uses xAI web-grounded responses                                                        | `XAI_API_KEY`                               |
-| **Kimi**                  | AI-synthesized answers + citations | —                                            | Uses Moonshot web search                                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
-| **Perplexity Search API** | Structured results with snippets   | `country`, `language`, time, `domain_filter` | Supports content extraction controls; OpenRouter uses Sonar compatibility path         | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
+| Provider                  | Result shape                       | Provider-specific filters                         | Notes                                                                                  | API key                                     |
+| ------------------------- | ---------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Brave Search API**      | Structured results with snippets   | `country`, `language`, `ui_lang`, time, `goggles` | Supports Brave `llm-context` mode and [Goggles](https://search.brave.com/help/goggles) | `BRAVE_API_KEY`                             |
+| **Gemini**                | AI-synthesized answers + citations | —                                                 | Uses Google Search grounding                                                           | `GEMINI_API_KEY`                            |
+| **Grok**                  | AI-synthesized answers + citations | —                                                 | Uses xAI web-grounded responses                                                        | `XAI_API_KEY`                               |
+| **Kimi**                  | AI-synthesized answers + citations | —                                                 | Uses Moonshot web search                                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
+| **Perplexity Search API** | Structured results with snippets   | `country`, `language`, time, `domain_filter`      | Supports content extraction controls; OpenRouter uses Sonar compatibility path         | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
 
 ### Auto-detection
 

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -25,8 +25,6 @@ const {
   resolveBraveMode,
   mapBraveLlmContextResults,
   createWebSearchSchema,
-  buildBraveWebSearchUrl,
-  buildBraveLlmContextUrl,
 } = __testing;
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
@@ -495,28 +493,5 @@ describe("web_search goggles schema", () => {
     });
     const props = schema.properties as Record<string, unknown>;
     expect(props.goggles).toBeUndefined();
-  });
-});
-
-describe("web_search goggles URL construction", () => {
-  it("appends goggles to Brave web search URL", () => {
-    const url = buildBraveWebSearchUrl({
-      query: "test",
-      count: 5,
-      goggles: "$discard,site=example.com",
-    });
-    expect(url.searchParams.get("goggles")).toBe("$discard,site=example.com");
-  });
-
-  it("appends goggles to Brave llm-context URL", () => {
-    const url = buildBraveLlmContextUrl({ query: "test", goggles: "$site=arxiv.org" });
-    expect(url.searchParams.get("goggles")).toBe("$site=arxiv.org");
-  });
-
-  it("omits goggles from URL when not provided", () => {
-    const webUrl = buildBraveWebSearchUrl({ query: "test", count: 5 });
-    expect(webUrl.searchParams.has("goggles")).toBe(false);
-    const llmUrl = buildBraveLlmContextUrl({ query: "test" });
-    expect(llmUrl.searchParams.has("goggles")).toBe(false);
   });
 });

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -24,6 +24,7 @@ const {
   extractKimiCitations,
   resolveBraveMode,
   mapBraveLlmContextResults,
+  createWebSearchSchema,
 } = __testing;
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
@@ -466,5 +467,31 @@ describe("mapBraveLlmContextResults", () => {
       },
     });
     expect(results[0].siteName).toBeUndefined();
+  });
+});
+
+describe("web_search goggles schema", () => {
+  it("includes goggles as optional string for Brave provider", () => {
+    const schema = createWebSearchSchema({ provider: "brave" });
+    const props = schema.properties as Record<string, { type?: string }>;
+    expect(props.goggles).toBeDefined();
+    expect(props.goggles.type).toBe("string");
+  });
+
+  it("does not include goggles for Perplexity provider", () => {
+    const schema = createWebSearchSchema({
+      provider: "perplexity",
+      perplexityTransport: "search_api",
+    });
+    const props = schema.properties as Record<string, unknown>;
+    expect(props.goggles).toBeUndefined();
+  });
+
+  it("does not include goggles for non-Brave provider", () => {
+    const schema = createWebSearchSchema({
+      provider: "gemini",
+    });
+    const props = schema.properties as Record<string, unknown>;
+    expect(props.goggles).toBeUndefined();
   });
 });

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -25,6 +25,8 @@ const {
   resolveBraveMode,
   mapBraveLlmContextResults,
   createWebSearchSchema,
+  buildBraveWebSearchUrl,
+  buildBraveLlmContextUrl,
 } = __testing;
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
@@ -493,5 +495,28 @@ describe("web_search goggles schema", () => {
     });
     const props = schema.properties as Record<string, unknown>;
     expect(props.goggles).toBeUndefined();
+  });
+});
+
+describe("web_search goggles URL construction", () => {
+  it("appends goggles to Brave web search URL", () => {
+    const url = buildBraveWebSearchUrl({
+      query: "test",
+      count: 5,
+      goggles: "$discard,site=example.com",
+    });
+    expect(url.searchParams.get("goggles")).toBe("$discard,site=example.com");
+  });
+
+  it("appends goggles to Brave llm-context URL", () => {
+    const url = buildBraveLlmContextUrl({ query: "test", goggles: "$site=arxiv.org" });
+    expect(url.searchParams.get("goggles")).toBe("$site=arxiv.org");
+  });
+
+  it("omits goggles from URL when not provided", () => {
+    const webUrl = buildBraveWebSearchUrl({ query: "test", count: 5 });
+    expect(webUrl.searchParams.has("goggles")).toBe(false);
+    const llmUrl = buildBraveLlmContextUrl({ query: "test" });
+    expect(llmUrl.searchParams.has("goggles")).toBe(false);
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1632,7 +1632,7 @@ async function runWebSearch(params: {
       params.provider === "brave" && effectiveBraveMode === "llm-context"
         ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
         : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
-    ) + `:${(params.goggles || "default").trim()}`;
+    ) + `:${(params.goggles || "\0").trim()}`;
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -237,6 +237,12 @@ function createWebSearchSchema(params: {
             "Locale code for UI elements in language-region format (e.g., 'en-US', 'de-DE', 'fr-FR', 'tr-TR'). Must include region subtag.",
         }),
       ),
+      goggles: Type.Optional(
+        Type.String({
+          description:
+            "Brave Goggles — index-level result filtering and ranking. Inline rules (\\n-separated) or hosted URL. Syntax: [url_pattern]$[options] — site=DOMAIN|*.TLD, inurl=PATH, boost=N, downrank=N, discard; URL wildcards go before $. Examples: '$discard\\n$site=arxiv.org\\n$site=*.edu' (trusted sources only); '/docs/*$boost=5\\n/blog/*$downrank=5' (prioritize docs over blog posts); '$boost=5,site=github.com,inurl=/blob/' (boost source code).",
+        }),
+      ),
     });
   }
 
@@ -1529,6 +1535,7 @@ async function runBraveLlmContextSearch(params: {
   country?: string;
   search_lang?: string;
   freshness?: string;
+  goggles?: string;
 }): Promise<{
   results: Array<{
     url: string;
@@ -1548,6 +1555,9 @@ async function runBraveLlmContextSearch(params: {
   }
   if (params.freshness) {
     url.searchParams.set("freshness", params.freshness);
+  }
+  if (params.goggles) {
+    url.searchParams.set("goggles", params.goggles);
   }
 
   return withTrustedWebSearchEndpoint(
@@ -1603,6 +1613,7 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  goggles?: string;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
@@ -1617,8 +1628,8 @@ async function runWebSearch(params: {
             : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
-      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
-      : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
+      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}:${params.goggles || "default"}`
+      : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}:${params.goggles || "default"}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
@@ -1781,6 +1792,7 @@ async function runWebSearch(params: {
       country: params.country,
       search_lang: params.search_lang,
       freshness: params.freshness,
+      goggles: params.goggles,
     });
 
     const mapped = llmResults.map((entry) => ({
@@ -1832,6 +1844,9 @@ async function runWebSearch(params: {
     );
   } else if (params.dateBefore) {
     url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
+  }
+  if (params.goggles) {
+    url.searchParams.set("goggles", params.goggles);
   }
 
   const mapped = await withTrustedWebSearchEndpoint(
@@ -2030,6 +2045,14 @@ export function createWebSearchTool(options?: {
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
+      const goggles = readStringParam(params, "goggles");
+      if (goggles && provider !== "brave") {
+        return jsonResult({
+          error: "unsupported_goggles",
+          message: `goggles is not supported by the ${provider} provider. Goggles are only available with Brave Search.`,
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
       const rawFreshness = readStringParam(params, "freshness");
       if (rawFreshness && provider !== "brave" && provider !== "perplexity") {
         return jsonResult({
@@ -2186,6 +2209,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        goggles,
       });
       return jsonResult(result);
     },
@@ -2219,4 +2243,5 @@ export const __testing = {
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
   mapBraveLlmContextResults,
+  createWebSearchSchema,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1679,11 +1679,12 @@ async function runWebSearch(params: {
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
             : "";
-  const cacheKey = normalizeCacheKey(
-    params.provider === "brave" && effectiveBraveMode === "llm-context"
-      ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}:${params.goggles || "default"}`
-      : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}:${params.goggles || "default"}`,
-  );
+  const cacheKey =
+    normalizeCacheKey(
+      params.provider === "brave" && effectiveBraveMode === "llm-context"
+        ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
+        : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
+    ) + `:${(params.goggles || "default").trim()}`;
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1528,71 +1528,6 @@ function mapBraveLlmContextResults(
   }));
 }
 
-function buildBraveWebSearchUrl(params: {
-  query: string;
-  count: number;
-  country?: string;
-  language?: string;
-  search_lang?: string;
-  ui_lang?: string;
-  freshness?: string;
-  dateAfter?: string;
-  dateBefore?: string;
-  goggles?: string;
-}): URL {
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
-  url.searchParams.set("q", params.query);
-  url.searchParams.set("count", String(params.count));
-  if (params.country) {
-    url.searchParams.set("country", params.country);
-  }
-  if (params.search_lang || params.language) {
-    url.searchParams.set("search_lang", (params.search_lang || params.language)!);
-  }
-  if (params.ui_lang) {
-    url.searchParams.set("ui_lang", params.ui_lang);
-  }
-  if (params.freshness) {
-    url.searchParams.set("freshness", params.freshness);
-  } else if (params.dateAfter && params.dateBefore) {
-    url.searchParams.set("freshness", `${params.dateAfter}to${params.dateBefore}`);
-  } else if (params.dateAfter) {
-    url.searchParams.set(
-      "freshness",
-      `${params.dateAfter}to${new Date().toISOString().slice(0, 10)}`,
-    );
-  } else if (params.dateBefore) {
-    url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
-  }
-  if (params.goggles) {
-    url.searchParams.set("goggles", params.goggles);
-  }
-  return url;
-}
-
-function buildBraveLlmContextUrl(params: {
-  query: string;
-  country?: string;
-  search_lang?: string;
-  freshness?: string;
-  goggles?: string;
-}): URL {
-  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
-  url.searchParams.set("q", params.query);
-  if (params.country) {
-    url.searchParams.set("country", params.country);
-  }
-  if (params.search_lang) {
-    url.searchParams.set("search_lang", params.search_lang);
-  }
-  if (params.freshness) {
-    url.searchParams.set("freshness", params.freshness);
-  }
-  if (params.goggles) {
-    url.searchParams.set("goggles", params.goggles);
-  }
-  return url;
-}
 
 async function runBraveLlmContextSearch(params: {
   query: string;
@@ -1611,7 +1546,20 @@ async function runBraveLlmContextSearch(params: {
   }>;
   sources?: BraveLlmContextResponse["sources"];
 }> {
-  const url = buildBraveLlmContextUrl(params);
+  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
+  url.searchParams.set("q", params.query);
+  if (params.country) {
+    url.searchParams.set("country", params.country);
+  }
+  if (params.search_lang) {
+    url.searchParams.set("search_lang", params.search_lang);
+  }
+  if (params.freshness) {
+    url.searchParams.set("freshness", params.freshness);
+  }
+  if (params.goggles) {
+    url.searchParams.set("goggles", params.goggles);
+  }
 
   return withTrustedWebSearchEndpoint(
     {
@@ -1875,7 +1823,33 @@ async function runWebSearch(params: {
     return payload;
   }
 
-  const url = buildBraveWebSearchUrl(params);
+  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  url.searchParams.set("q", params.query);
+  url.searchParams.set("count", String(params.count));
+  if (params.country) {
+    url.searchParams.set("country", params.country);
+  }
+  if (params.search_lang || params.language) {
+    url.searchParams.set("search_lang", (params.search_lang || params.language)!);
+  }
+  if (params.ui_lang) {
+    url.searchParams.set("ui_lang", params.ui_lang);
+  }
+  if (params.freshness) {
+    url.searchParams.set("freshness", params.freshness);
+  } else if (params.dateAfter && params.dateBefore) {
+    url.searchParams.set("freshness", `${params.dateAfter}to${params.dateBefore}`);
+  } else if (params.dateAfter) {
+    url.searchParams.set(
+      "freshness",
+      `${params.dateAfter}to${new Date().toISOString().slice(0, 10)}`,
+    );
+  } else if (params.dateBefore) {
+    url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
+  }
+  if (params.goggles) {
+    url.searchParams.set("goggles", params.goggles);
+  }
 
   const mapped = await withTrustedWebSearchEndpoint(
     {
@@ -2275,6 +2249,4 @@ export const __testing = {
   resolveBraveMode,
   mapBraveLlmContextResults,
   createWebSearchSchema,
-  buildBraveWebSearchUrl,
-  buildBraveLlmContextUrl,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2046,6 +2046,9 @@ export function createWebSearchTool(options?: {
         });
       }
       const goggles = readStringParam(params, "goggles");
+      // Defense-in-depth: goggles is not in the schema for non-Brave providers, so
+      // schema validation strips it before reaching here. This guard catches any
+      // caller that bypasses schema validation (e.g. raw programmatic invocation).
       if (goggles && provider !== "brave") {
         return jsonResult({
           error: "unsupported_goggles",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1528,7 +1528,6 @@ function mapBraveLlmContextResults(
   }));
 }
 
-
 async function runBraveLlmContextSearch(params: {
   query: string;
   apiKey: string;
@@ -1626,7 +1625,7 @@ async function runWebSearch(params: {
   const cacheKey =
     normalizeCacheKey(
       params.provider === "brave" && effectiveBraveMode === "llm-context"
-        ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
+        ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}`
         : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
     ) + (params.goggles ? `:${params.goggles}` : "");
   const cached = readCache(SEARCH_CACHE, cacheKey);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1528,6 +1528,72 @@ function mapBraveLlmContextResults(
   }));
 }
 
+function buildBraveWebSearchUrl(params: {
+  query: string;
+  count: number;
+  country?: string;
+  language?: string;
+  search_lang?: string;
+  ui_lang?: string;
+  freshness?: string;
+  dateAfter?: string;
+  dateBefore?: string;
+  goggles?: string;
+}): URL {
+  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  url.searchParams.set("q", params.query);
+  url.searchParams.set("count", String(params.count));
+  if (params.country) {
+    url.searchParams.set("country", params.country);
+  }
+  if (params.search_lang || params.language) {
+    url.searchParams.set("search_lang", (params.search_lang || params.language)!);
+  }
+  if (params.ui_lang) {
+    url.searchParams.set("ui_lang", params.ui_lang);
+  }
+  if (params.freshness) {
+    url.searchParams.set("freshness", params.freshness);
+  } else if (params.dateAfter && params.dateBefore) {
+    url.searchParams.set("freshness", `${params.dateAfter}to${params.dateBefore}`);
+  } else if (params.dateAfter) {
+    url.searchParams.set(
+      "freshness",
+      `${params.dateAfter}to${new Date().toISOString().slice(0, 10)}`,
+    );
+  } else if (params.dateBefore) {
+    url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
+  }
+  if (params.goggles) {
+    url.searchParams.set("goggles", params.goggles);
+  }
+  return url;
+}
+
+function buildBraveLlmContextUrl(params: {
+  query: string;
+  country?: string;
+  search_lang?: string;
+  freshness?: string;
+  goggles?: string;
+}): URL {
+  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
+  url.searchParams.set("q", params.query);
+  if (params.country) {
+    url.searchParams.set("country", params.country);
+  }
+  if (params.search_lang) {
+    url.searchParams.set("search_lang", params.search_lang);
+  }
+  if (params.freshness) {
+    url.searchParams.set("freshness", params.freshness);
+  }
+  if (params.goggles) {
+    url.searchParams.set("goggles", params.goggles);
+  }
+  return url;
+}
+
 async function runBraveLlmContextSearch(params: {
   query: string;
   apiKey: string;
@@ -1545,20 +1611,7 @@ async function runBraveLlmContextSearch(params: {
   }>;
   sources?: BraveLlmContextResponse["sources"];
 }> {
-  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
-  url.searchParams.set("q", params.query);
-  if (params.country) {
-    url.searchParams.set("country", params.country);
-  }
-  if (params.search_lang) {
-    url.searchParams.set("search_lang", params.search_lang);
-  }
-  if (params.freshness) {
-    url.searchParams.set("freshness", params.freshness);
-  }
-  if (params.goggles) {
-    url.searchParams.set("goggles", params.goggles);
-  }
+  const url = buildBraveLlmContextUrl(params);
 
   return withTrustedWebSearchEndpoint(
     {
@@ -1821,33 +1874,7 @@ async function runWebSearch(params: {
     return payload;
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
-  url.searchParams.set("q", params.query);
-  url.searchParams.set("count", String(params.count));
-  if (params.country) {
-    url.searchParams.set("country", params.country);
-  }
-  if (params.search_lang || params.language) {
-    url.searchParams.set("search_lang", (params.search_lang || params.language)!);
-  }
-  if (params.ui_lang) {
-    url.searchParams.set("ui_lang", params.ui_lang);
-  }
-  if (params.freshness) {
-    url.searchParams.set("freshness", params.freshness);
-  } else if (params.dateAfter && params.dateBefore) {
-    url.searchParams.set("freshness", `${params.dateAfter}to${params.dateBefore}`);
-  } else if (params.dateAfter) {
-    url.searchParams.set(
-      "freshness",
-      `${params.dateAfter}to${new Date().toISOString().slice(0, 10)}`,
-    );
-  } else if (params.dateBefore) {
-    url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
-  }
-  if (params.goggles) {
-    url.searchParams.set("goggles", params.goggles);
-  }
+  const url = buildBraveWebSearchUrl(params);
 
   const mapped = await withTrustedWebSearchEndpoint(
     {
@@ -2247,4 +2274,6 @@ export const __testing = {
   resolveBraveMode,
   mapBraveLlmContextResults,
   createWebSearchSchema,
+  buildBraveWebSearchUrl,
+  buildBraveLlmContextUrl,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1535,7 +1535,6 @@ async function runBraveLlmContextSearch(params: {
   timeoutSeconds: number;
   country?: string;
   search_lang?: string;
-  freshness?: string;
   goggles?: string;
 }): Promise<{
   results: Array<{
@@ -1553,9 +1552,6 @@ async function runBraveLlmContextSearch(params: {
   }
   if (params.search_lang) {
     url.searchParams.set("search_lang", params.search_lang);
-  }
-  if (params.freshness) {
-    url.searchParams.set("freshness", params.freshness);
   }
   if (params.goggles) {
     url.searchParams.set("goggles", params.goggles);
@@ -1632,7 +1628,7 @@ async function runWebSearch(params: {
       params.provider === "brave" && effectiveBraveMode === "llm-context"
         ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
         : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
-    ) + `:${(params.goggles || "\0").trim()}`;
+    ) + (params.goggles ? `:${params.goggles}` : "");
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };
@@ -1793,7 +1789,6 @@ async function runWebSearch(params: {
       timeoutSeconds: params.timeoutSeconds,
       country: params.country,
       search_lang: params.search_lang,
-      freshness: params.freshness,
       goggles: params.goggles,
     });
 

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -222,6 +222,7 @@ describe("web_search country and language parameters", () => {
       search_lang: string;
       ui_lang: string;
       freshness: string;
+      goggles: string;
     }>,
   ) {
     const mockFetch = installMockFetch({ web: { results: [] } });
@@ -236,6 +237,7 @@ describe("web_search country and language parameters", () => {
     { key: "country", value: "DE" },
     { key: "ui_lang", value: "de-DE" },
     { key: "freshness", value: "pw" },
+    { key: "goggles", value: "$site=example.com" },
   ])("passes $key parameter to Brave API", async ({ key, value }) => {
     const url = await runBraveSearchAndGetUrl({ [key]: value });
     expect(url.searchParams.get(key)).toBe(value);
@@ -878,6 +880,7 @@ describe("web_search external content wrapping", () => {
       query: "llm-context test",
       country: "DE",
       search_lang: "de",
+      goggles: "$site=arxiv.org",
     });
 
     const requestUrl = new URL(mockFetch.mock.calls[0]?.[0] as string);
@@ -885,6 +888,7 @@ describe("web_search external content wrapping", () => {
     expect(requestUrl.searchParams.get("q")).toBe("llm-context test");
     expect(requestUrl.searchParams.get("country")).toBe("DE");
     expect(requestUrl.searchParams.get("search_lang")).toBe("de");
+    expect(requestUrl.searchParams.get("goggles")).toBe("$site=arxiv.org");
 
     const details = result?.details as {
       mode?: string;


### PR DESCRIPTION
## Summary

- Problem: Brave Search supports [Goggles](https://search.brave.com/help/goggles), a [query-time DSL](https://brave.com/static-assets/files/goggles.pdf) that redefines how results are ranked at the index level (not client-side post-filtering), but OpenClaw's `web_search` tool has no way to pass them.
- Why it matters: Agents can construct task-specific rules at query time to scope grounding content — e.g. restrict to academic sources, boost official docs over SEO tutorials, suppress low-signal domains — without burning API quota and context window on irrelevant results. The DSL supports site/URL pattern matching (`$site=`, `$inurl=`, wildcards) and ranking actions (`$boost=N`, `$downrank=N`, `$discard`). Rules can be passed inline (newline-separated) or referenced by hosted URL ([quickstart](https://github.com/brave/goggles-quickstart)). Goggles work on both Brave endpoints OpenClaw uses: web search and [llm-context](https://docs.openclaw.ai/brave-search).
- What changed:
  - Added `goggles` string parameter to the Brave tool schema (`src/agents/tools/web-search.ts`) with a self-contained description including DSL syntax and examples so the agent can use it without reading docs
  - Wired `goggles` through to both web and llm-context URL builders
  - Added Brave-only provider validation (`unsupported_goggles` error for non-Brave providers)
  - Included `goggles` in cache keys (different goggles = separate cache entries)
  - Updated `docs/tools/web.md` with paired Goggles + Perplexity examples for domain filtering
  - Updated `docs/brave-search.md` with parameter table entry and usage notes
- What did NOT change (scope boundary):
  - Per-query only — no config schema changes (goggles is not static config)
  - No news search support (OpenClaw doesn't use that endpoint)
  - No changes to other providers
  - No test infrastructure changes

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

- `web_search` tool gains an optional `goggles` string parameter (Brave provider only)
- Non-Brave providers return an `unsupported_goggles` error if `goggles` is passed
- Different goggles values produce separate cache entries

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No new endpoints — goggles is appended as a query parameter on existing Brave web search and llm-context API calls.
- Command/tool execution surface changed? Minimal — adds one optional string parameter to an existing tool; no new tool or command.
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Model/provider: Brave Search API
- Integration/channel (if any): N/A
- Relevant config (redacted): Brave API key configured

### Steps

1. `pnpm build` — no TS errors
2. `pnpm test -- web-search.test` — all 40 tests pass
3. `pnpm check` — clean
4. Live API: inline goggles (`$discard\n$site=docs.rs\n$site=rust-lang.org`) returned only docs.rs and rust-lang.org results on both web search and llm-context endpoints

### Expected

- Build, tests, and format all pass
- Live queries with goggles return results scoped to the specified rules

### Actual

- All pass as expected

### Examples

```
// Restrict to trusted academic sources
goggles: "$discard\n$site=arxiv.org\n$site=*.edu\n$site=huggingface.co"

// Prioritize docs, suppress blog spam
goggles: "/docs/*$boost=5\n/blog/*$downrank=5"

// Boost actual source code on GitHub
goggles: "$boost=5,site=github.com,inurl=/blob/"
```

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: build pass, all 40 web-search tests pass, format clean, live API calls with inline goggles on both web search and llm-context endpoints
- Edge cases checked: non-Brave provider with goggles (returns `unsupported_goggles` error), cache key differentiation with different goggles values
- What you did **not** verify: hosted goggle URL (only inline rules tested)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes — new optional parameter, no breaking changes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commit; goggles parameter is additive-only
- Files/config to restore: none
- Known bad symptoms reviewers should watch for: `unsupported_goggles` errors appearing for Brave provider (would indicate provider detection issue)

## Risks and Mitigations

Low — additive optional parameter on existing Brave API calls; no behavior change when goggles is not supplied.