### PR TITLE
fix(hooks): deliver internal message hook replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks: deliver internal message hook replies with bound session context and keep hook-loop suppression intact across queued retry/recovery. Fixes #39688; carries forward #40314. Thanks @stablegenius49.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/Anthropic: cancel stalled Anthropic Messages SSE body reads when abort signals fire, so active-memory timeouts release transport resources instead of leaving hidden recall runs parked on `reader.read()`. Refs #72965 and #73120. Thanks @wdeveloper16.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -63,7 +63,7 @@ const hookMocks = vi.hoisted(() => ({
 }));
 const internalHookMocks = vi.hoisted(() => ({
   createInternalHookEvent: vi.fn(),
-  triggerInternalHook: vi.fn(async () => {}),
+  triggerInternalHook: vi.fn<(event: unknown) => Promise<void>>(async () => {}),
 }));
 const acpMocks = vi.hoisted(() => ({
   listAcpSessionEntries: vi.fn(async () => []),
@@ -2819,11 +2819,10 @@ describe("dispatchReplyFromConfig", () => {
       SessionKey: "agent:main:main",
       CommandBody: "/help",
     });
-    internalHookMocks.triggerInternalHook.mockImplementationOnce(
-      async (event: { messages: string[] }) => {
-        event.messages.push("Hook echo");
-      },
-    );
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(async (event: unknown) => {
+      const hookEvent = event as { messages: string[] };
+      hookEvent.messages.push("Hook echo");
+    });
 
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
@@ -2835,6 +2834,62 @@ describe("dispatchReplyFromConfig", () => {
         to: "feishu:ou_123",
         accountId: "acc-1",
         mirror: false,
+        skipMessageHooks: true,
+      }),
+    );
+  });
+
+  it("uses bound ACP session context for internal message:received hook replies", async () => {
+    setNoAbort();
+    const boundSessionKey = "agent:opencode:acp:bound-session";
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-acp-hook",
+      targetSessionKey: boundSessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "slack",
+        accountId: "default",
+        conversationId: "C123",
+      },
+      status: "active",
+      boundAt: Date.now(),
+    } satisfies SessionBindingRecord);
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(async (event: unknown) => {
+      const hookEvent = event as { messages: string[] };
+      hookEvent.messages.push("Bound hook echo");
+    });
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "slack",
+      OriginatingTo: "slack:C123",
+      To: "slack:C123",
+      AccountId: "default",
+      SessionKey: "agent:main:slack:C123",
+      CommandBody: "/help",
+      MessageThreadId: "thread-1",
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "received",
+      boundSessionKey,
+      expect.any(Object),
+    );
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "Bound hook echo" },
+        channel: "slack",
+        to: "slack:C123",
+        sessionKey: boundSessionKey,
+        policySessionKey: boundSessionKey,
+        accountId: "default",
+        threadId: "thread-1",
         skipMessageHooks: true,
       }),
     );

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2839,6 +2839,75 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("suppresses internal message:received hook message delivery when sendPolicy is deny", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "feishu:ou_123",
+      AccountId: "acc-1",
+      SessionKey: "agent:main:main",
+      CommandBody: "/help",
+    });
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(async (event: unknown) => {
+      const hookEvent = event as { messages: string[] };
+      hookEvent.messages.push("Hook echo");
+    });
+
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) satisfies ReplyPayload);
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses internal message:received hook message delivery in message-tool-only mode", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "feishu:ou_123",
+      AccountId: "acc-1",
+      SessionKey: "agent:main:main",
+      CommandBody: "/help",
+    });
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(async (event: unknown) => {
+      const hookEvent = event as { messages: string[] };
+      hookEvent.messages.push("Hook echo");
+    });
+
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) satisfies ReplyPayload);
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("uses bound ACP session context for internal message:received hook replies", async () => {
     setNoAbort();
     const boundSessionKey = "agent:opencode:acp:bound-session";

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2806,6 +2806,40 @@ describe("dispatchReplyFromConfig", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
+  it("routes internal message:received hook messages back to the user", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "feishu:ou_123",
+      AccountId: "acc-1",
+      SessionKey: "agent:main:main",
+      CommandBody: "/help",
+    });
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(
+      async (event: { messages: string[] }) => {
+        event.messages.push("Hook echo");
+      },
+    );
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "Hook echo" },
+        channel: "feishu",
+        to: "feishu:ou_123",
+        accountId: "acc-1",
+        mirror: false,
+        skipMessageHooks: true,
+      }),
+    );
+  });
+
   it("skips internal message:received hook when session key is unavailable", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -723,8 +723,9 @@ export async function dispatchReplyFromConfig(
   }
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
-  if (sessionKey) {
-    const hookEvent = createInternalHookEvent("message", "received", sessionKey, {
+  const internalHookSessionKey = acpDispatchSessionKey;
+  if (internalHookSessionKey) {
+    const hookEvent = createInternalHookEvent("message", "received", internalHookSessionKey, {
       ...toInternalMessageReceivedContext(hookContext),
       timestamp,
     });
@@ -733,9 +734,9 @@ export async function dispatchReplyFromConfig(
         await triggerInternalHook(hookEvent);
         const hookReplyText = hookEvent.messages.join("\n\n").trim();
         const hookReplyChannel = normalizeMessageChannel(
-          ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider,
+          replyRoute.channel ?? ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider,
         );
-        const hookReplyTo = ctx.OriginatingTo ?? ctx.From ?? ctx.To;
+        const hookReplyTo = replyRoute.to ?? ctx.OriginatingTo ?? ctx.From ?? ctx.To;
         const hookReplyRuntime = routeReplyRuntime ?? (await loadRouteReplyRuntime());
         if (
           !hookReplyText ||
@@ -749,18 +750,18 @@ export async function dispatchReplyFromConfig(
           payload: { text: hookReplyText },
           channel: hookReplyChannel,
           to: hookReplyTo,
-          sessionKey: ctx.SessionKey,
+          sessionKey: internalHookSessionKey,
           policySessionKey:
             ctx.CommandSource === "native"
-              ? (ctx.CommandTargetSessionKey ?? ctx.SessionKey)
-              : ctx.SessionKey,
+              ? (ctx.CommandTargetSessionKey ?? internalHookSessionKey)
+              : internalHookSessionKey,
           policyConversationType: resolveRoutedPolicyConversationType(ctx),
-          accountId: ctx.AccountId,
+          accountId: replyRoute.accountId ?? ctx.AccountId,
           requesterSenderId: ctx.SenderId,
           requesterSenderName: ctx.SenderName,
           requesterSenderUsername: ctx.SenderUsername,
           requesterSenderE164: ctx.SenderE164,
-          threadId: ctx.MessageThreadId,
+          threadId: routeThreadId,
           cfg,
           mirror: false,
           isGroup,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -732,6 +732,9 @@ export async function dispatchReplyFromConfig(
     fireAndForgetHook(
       (async () => {
         await triggerInternalHook(hookEvent);
+        if (suppressHookUserDelivery) {
+          return;
+        }
         const hookReplyText = hookEvent.messages.join("\n\n").trim();
         const hookReplyChannel = normalizeMessageChannel(
           replyRoute.channel ?? ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -724,13 +724,50 @@ export async function dispatchReplyFromConfig(
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
   if (sessionKey) {
+    const hookEvent = createInternalHookEvent("message", "received", sessionKey, {
+      ...toInternalMessageReceivedContext(hookContext),
+      timestamp,
+    });
     fireAndForgetHook(
-      triggerInternalHook(
-        createInternalHookEvent("message", "received", sessionKey, {
-          ...toInternalMessageReceivedContext(hookContext),
-          timestamp,
-        }),
-      ),
+      (async () => {
+        await triggerInternalHook(hookEvent);
+        const hookReplyText = hookEvent.messages.join("\n\n").trim();
+        const hookReplyChannel = normalizeMessageChannel(
+          ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider,
+        );
+        const hookReplyTo = ctx.OriginatingTo ?? ctx.From ?? ctx.To;
+        const hookReplyRuntime = routeReplyRuntime ?? (await loadRouteReplyRuntime());
+        if (
+          !hookReplyText ||
+          !hookReplyChannel ||
+          !hookReplyTo ||
+          !hookReplyRuntime.isRoutableChannel(hookReplyChannel as never)
+        ) {
+          return;
+        }
+        await hookReplyRuntime.routeReply({
+          payload: { text: hookReplyText },
+          channel: hookReplyChannel,
+          to: hookReplyTo,
+          sessionKey: ctx.SessionKey,
+          policySessionKey:
+            ctx.CommandSource === "native"
+              ? (ctx.CommandTargetSessionKey ?? ctx.SessionKey)
+              : ctx.SessionKey,
+          policyConversationType: resolveRoutedPolicyConversationType(ctx),
+          accountId: ctx.AccountId,
+          requesterSenderId: ctx.SenderId,
+          requesterSenderName: ctx.SenderName,
+          requesterSenderUsername: ctx.SenderUsername,
+          requesterSenderE164: ctx.SenderE164,
+          threadId: ctx.MessageThreadId,
+          cfg,
+          mirror: false,
+          isGroup,
+          groupId,
+          skipMessageHooks: true,
+        });
+      })(),
       "dispatch-from-config: message_received internal hook failed",
     );
   }

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -69,6 +69,8 @@ export type RouteReplyParams = {
   abortSignal?: AbortSignal;
   /** Mirror reply into session transcript (default: true when sessionKey is set). */
   mirror?: boolean;
+  /** Suppress message:* hook emission for this routed send. */
+  skipMessageHooks?: boolean;
   /** Whether this message is being sent in a group/channel context */
   isGroup?: boolean;
   /** Group or channel identifier for correlation with received events */
@@ -235,6 +237,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       threadId: resolvedThreadId,
       session: outboundSession,
       abortSignal,
+      skipMessageHooks: params.skipMessageHooks,
       mirror:
         params.mirror !== false && params.sessionKey
           ? {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1348,6 +1348,38 @@ describe("deliverOutboundPayloads", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
+  it("delivers internal message:sent hook messages without re-emitting hooks", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(
+      async (event: { messages: string[] }) => {
+        event.messages.push("Hook echo");
+      },
+    );
+
+    await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      deps: { matrix: sendMatrix },
+      session: { key: "agent:main:main" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sendMatrix).toHaveBeenCalledTimes(2);
+    expect(sendMatrix).toHaveBeenNthCalledWith(
+      2,
+      "!room:example",
+      "Hook echo",
+      expect.objectContaining({ cfg: matrixChunkConfig }),
+    );
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledTimes(1);
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+  });
+
   it("warns when session.agentId is set without a session key", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
     hookMocks.runner.hasHooks.mockReturnValue(true);
@@ -1396,6 +1428,7 @@ describe("deliverOutboundPayloads", () => {
       to: "!room:example",
       payloads: rawPayloads,
       deps: { matrix: sendMatrix },
+      skipMessageHooks: true,
     });
 
     expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(1);
@@ -1407,6 +1440,7 @@ describe("deliverOutboundPayloads", () => {
           { text: "caption\nMEDIA:https://x.test/a.png" },
           { text: "NO_REPLY", mediaUrl: " https://x.test/b.png " },
         ],
+        skipMessageHooks: true,
       }),
     );
   });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -35,7 +35,7 @@ const hookMocks = vi.hoisted(() => ({
 }));
 const internalHookMocks = vi.hoisted(() => ({
   createInternalHookEvent: vi.fn(),
-  triggerInternalHook: vi.fn(async () => {}),
+  triggerInternalHook: vi.fn<(event: unknown) => Promise<void>>(async () => {}),
 }));
 const queueMocks = vi.hoisted(() => ({
   enqueueDelivery: vi.fn(async () => "mock-queue-id"),
@@ -1353,11 +1353,10 @@ describe("deliverOutboundPayloads", () => {
       .fn()
       .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
       .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
-    internalHookMocks.triggerInternalHook.mockImplementationOnce(
-      async (event: { messages: string[] }) => {
-        event.messages.push("Hook echo");
-      },
-    );
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(async (event: unknown) => {
+      const hookEvent = event as { messages: string[] };
+      hookEvent.messages.push("Hook echo");
+    });
 
     await deliverOutboundPayloads({
       cfg: matrixChunkConfig,
@@ -1370,6 +1369,15 @@ describe("deliverOutboundPayloads", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(sendMatrix).toHaveBeenCalledTimes(2);
+    expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(2);
+    expect(queueMocks.enqueueDelivery).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        payloads: [{ text: "Hook echo" }],
+        session: { key: "agent:main:main" },
+        skipMessageHooks: true,
+      }),
+    );
     expect(sendMatrix).toHaveBeenNthCalledWith(
       2,
       "!room:example",

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -371,6 +371,8 @@ type DeliverOutboundPayloadsCoreParams = {
   mirror?: DeliveryMirror;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  /** Suppress message:* hook emission for this send (used for hook-generated replies). */
+  skipMessageHooks?: boolean;
 };
 
 function collectPayloadMediaSources(plan: readonly OutboundPayloadPlan[]): string[] {
@@ -622,14 +624,26 @@ async function renderPresentationForDelivery(
 }
 
 function createMessageSentEmitter(params: {
+  cfg: OpenClawConfig;
+  deps?: OutboundSendDeps;
+  mediaAccess?: OutboundMediaAccess;
+  session?: OutboundSessionContext;
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  threadId?: string | number | null;
+  silent?: boolean;
+  gatewayClientScopes?: readonly string[];
+  skipMessageHooks?: boolean;
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
 }): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
+  if (params.skipMessageHooks) {
+    return { emitMessageSent: () => {}, hasMessageSentHooks: false };
+  }
+
   const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
   const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
   const emitMessageSent = (event: MessageSentEvent) => {
@@ -663,15 +677,35 @@ function createMessageSentEmitter(params: {
     if (!canEmitInternalHook) {
       return;
     }
+    const hookEvent = createInternalHookEvent(
+      "message",
+      "sent",
+      params.sessionKeyForInternalHooks!,
+      toInternalMessageSentContext(canonical),
+    );
     fireAndForgetHook(
-      triggerInternalHook(
-        createInternalHookEvent(
-          "message",
-          "sent",
-          params.sessionKeyForInternalHooks!,
-          toInternalMessageSentContext(canonical),
-        ),
-      ),
+      (async () => {
+        await triggerInternalHook(hookEvent);
+        const text = hookEvent.messages.join("\n\n").trim();
+        if (!text) {
+          return;
+        }
+        await deliverOutboundPayloads({
+          cfg: params.cfg,
+          channel: params.channel,
+          to: params.to,
+          accountId: params.accountId,
+          payloads: [{ text }],
+          threadId: params.threadId,
+          deps: params.deps,
+          mediaAccess: params.mediaAccess,
+          session: params.session,
+          silent: params.silent,
+          gatewayClientScopes: params.gatewayClientScopes,
+          skipQueue: true,
+          skipMessageHooks: true,
+        });
+      })(),
       "deliverOutboundPayloads: message:sent internal hook failed",
       (message) => {
         log.warn(message);
@@ -796,6 +830,7 @@ export async function deliverOutboundPayloads(
         mirror: params.mirror,
         session: params.session,
         gatewayClientScopes: params.gatewayClientScopes,
+        skipMessageHooks: params.skipMessageHooks,
       }).catch(() => null); // Best-effort — don't block delivery if queue write fails.
 
   if (!queueId) {
@@ -951,10 +986,18 @@ async function deliverOutboundPayloadsCore(
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
   const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
+    cfg,
+    deps,
+    mediaAccess,
+    session: params.session,
     hookRunner,
     channel,
     to,
     accountId,
+    threadId: params.threadId,
+    silent: params.silent,
+    gatewayClientScopes: params.gatewayClientScopes,
+    skipMessageHooks: params.skipMessageHooks,
     sessionKeyForInternalHooks,
     mirrorIsGroup,
     mirrorGroupId,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -702,7 +702,6 @@ function createMessageSentEmitter(params: {
           session: params.session,
           silent: params.silent,
           gatewayClientScopes: params.gatewayClientScopes,
-          skipQueue: true,
           skipMessageHooks: true,
         });
       })(),

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -127,6 +127,7 @@ function buildRecoveryDeliverParams(entry: QueuedDelivery, cfg: OpenClawConfig) 
     mirror: entry.mirror,
     session: entry.session,
     gatewayClientScopes: entry.gatewayClientScopes,
+    skipMessageHooks: entry.skipMessageHooks,
     skipQueue: true, // Prevent re-enqueueing during recovery.
   } satisfies Parameters<DeliverFn>[0];
 }

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -35,6 +35,8 @@ export type QueuedDeliveryPayload = {
   session?: OutboundSessionContext;
   /** Gateway caller scopes at enqueue time, preserved for recovery replay. */
   gatewayClientScopes?: readonly string[];
+  /** Suppress message:* hook emission when this queued send is replayed. */
+  skipMessageHooks?: boolean;
 };
 
 export interface QueuedDelivery extends QueuedDeliveryPayload {
@@ -155,6 +157,7 @@ export async function enqueueDelivery(
     mirror: params.mirror,
     session: params.session,
     gatewayClientScopes: params.gatewayClientScopes,
+    skipMessageHooks: params.skipMessageHooks,
     retryCount: 0,
   });
   return id;

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -168,6 +168,7 @@ describe("delivery-queue recovery", () => {
         gifPlayback: true,
         silent: true,
         gatewayClientScopes: ["operator.write"],
+        skipMessageHooks: true,
         mirror: {
           sessionKey: "agent:main:main",
           text: "a",
@@ -194,6 +195,7 @@ describe("delivery-queue recovery", () => {
         bestEffort: true,
         gifPlayback: true,
         silent: true,
+        skipMessageHooks: true,
         replyToId: "root-message",
         replyToMode: "first",
         formatting: {

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -28,6 +28,7 @@ describe("delivery-queue storage", () => {
           gifPlayback: true,
           silent: true,
           gatewayClientScopes: ["operator.write"],
+          skipMessageHooks: true,
           mirror: {
             sessionKey: "agent:main:main",
             text: "hello",
@@ -54,6 +55,7 @@ describe("delivery-queue storage", () => {
         gifPlayback: true,
         silent: true,
         gatewayClientScopes: ["operator.write"],
+        skipMessageHooks: true,
         mirror: {
           sessionKey: "agent:main:main",
           text: "hello",
@@ -179,6 +181,21 @@ describe("delivery-queue storage", () => {
 
       const entry = readQueuedEntry(tmpDir(), id);
       expect(entry.gatewayClientScopes).toEqual(["operator.write"]);
+    });
+
+    it("persists hook suppression for recovery replay", async () => {
+      const id = await enqueueTextDelivery(
+        {
+          channel: "forum",
+          to: "2",
+          payloads: [{ text: "b" }],
+          skipMessageHooks: true,
+        },
+        tmpDir(),
+      );
+
+      const entry = readQueuedEntry(tmpDir(), id);
+      expect(entry.skipMessageHooks).toBe(true);
     });
 
     it("persists session context for recovery replay", async () => {


### PR DESCRIPTION
## Summary
- deliver `message:received` internal hook replies back to the originating user
- deliver `message:sent` internal hook replies through outbound delivery
- suppress `message:*` hook re-emission for hook-generated replies to avoid loops

## Testing
- `corepack pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts`
- `corepack pnpm exec vitest run src/infra/outbound/deliver.test.ts`
- `corepack pnpm exec oxlint src/auto-reply/reply/dispatch-from-config.ts src/infra/outbound/deliver.ts src/auto-reply/reply/route-reply.ts src/auto-reply/reply/dispatch-from-config.test.ts src/infra/outbound/deliver.test.ts`

Closes #39688.
