### PR TITLE
fix: allow spawnedBy/spawnDepth for ACP sessions

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -259,6 +259,26 @@ describe("gateway sessions patch", () => {
     expectPatchError(result, "spawnDepth is only supported");
   });
 
+  test("sets spawnDepth for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: "agent:main:acp:run-123",
+        patch: { key: "agent:main:acp:run-123", spawnDepth: 1 },
+      }),
+    );
+    expect(entry.spawnDepth).toBe(1);
+  });
+
+  test("sets spawnedBy for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: "agent:main:acp:run-456",
+        patch: { key: "agent:main:acp:run-456", spawnedBy: "agent:main" },
+      }),
+    );
+    expect(entry.spawnedBy).toBe("agent:main");
+  });
+
   test("normalizes exec/send/group patches", async () => {
     const entry = expectPatchOk(
       await runPatch({

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -19,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
+  isAcpSessionKey,
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
@@ -97,8 +98,8 @@ export async function applySessionsPatchToStore(params: {
       if (!trimmed) {
         return invalid("invalid spawnedBy: empty");
       }
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnedBy is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnedBy is only supported for subagent:* and acp:* sessions");
       }
       if (existing?.spawnedBy && existing.spawnedBy !== trimmed) {
         return invalid("spawnedBy cannot be changed once set");
@@ -114,8 +115,8 @@ export async function applySessionsPatchToStore(params: {
         return invalid("spawnDepth cannot be cleared once set");
       }
     } else if (raw !== undefined) {
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnDepth is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnDepth is only supported for subagent:* and acp:* sessions");
       }
       const numeric = Number(raw);
       if (!Number.isInteger(numeric) || numeric < 0) {


### PR DESCRIPTION
## Summary

- Fixes validation in `sessions-patch.ts` to allow `spawnedBy` and `spawnDepth` fields for ACP sessions
- PR #40137 added `spawnedBy` to ACP session spawn but validation only allowed these fields for `subagent:*` sessions
- This caused errors when spawning ACP sessions: `"spawnedBy is only supported for subagent:* sessions"`

## Test plan

- [x] Verify `sessions_spawn(runtime="acp", ...)` no longer returns validation error
- [x] Verify ACP container starts and executes task successfully

🤖 Generated with [Claude Code](https://claude.ai/code)