### PR TITLE
fix(daemon): guard stdout.write against EPIPE in stopLaunchAgent

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,6 +11,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -333,6 +334,35 @@ describe("launchd install", () => {
         programArguments: defaultProgramArguments,
       }),
     ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
+  });
+});
+
+describe("launchd stop", () => {
+  it("swallows EPIPE when stdout pipe is already closed", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const broken = new PassThrough();
+    broken.write = () => {
+      const err = new Error("write EPIPE") as NodeJS.ErrnoException;
+      err.code = "EPIPE";
+      throw err;
+    };
+    // Should not throw — EPIPE is silently swallowed
+    await stopLaunchAgent({ env, stdout: broken });
+  });
+
+  it("rethrows non-EPIPE write errors", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const broken = new PassThrough();
+    broken.write = () => {
+      throw new Error("disk full");
+    };
+    await expect(stopLaunchAgent({ env, stdout: broken })).rejects.toThrow("disk full");
   });
 });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -367,7 +367,13 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
     throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  try {
+    stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+      throw err;
+    }
+  }
 }
 
 export async function installLaunchAgent({


### PR DESCRIPTION
## Summary
- `stopLaunchAgent` calls `stdout.write()` without EPIPE protection
- `restartLaunchAgent` in the same file already has the exact guard (lines 489-495)
- When stop is triggered from agent/tool automation (#40306), the parent pipe may be closed → uncaught EPIPE crash
- Apply the same try/catch pattern so stop completes gracefully

## Test plan
- [x] Added test: `stopLaunchAgent` with a stdout that throws EPIPE → completes without error
- [x] Added test: non-EPIPE write errors (e.g. "disk full") are still rethrown
- [x] All existing launchd tests pass (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)