### PR TITLE
docs(changelog): mark 2026.3.8 as unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Docs: https://docs.openclaw.ai
 
-## 2026.3.8
+## Unreleased
 
 ### Changes
 


### PR DESCRIPTION
## Summary

- Problem: `CHANGELOG.md` labels the current top section as `2026.3.8`, but GitHub does not have a published `v2026.3.8` release.
- Why it matters: readers can mistake unreleased `main` changes for a shipped release.
- What changed: renamed the top changelog heading from `2026.3.8` to `Unreleased`.
- What did NOT change (scope boundary): no changelog entries were reordered, edited, or removed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`CHANGELOG.md` now correctly presents unreleased `main` changes under `Unreleased` instead of implying a shipped `2026.3.8` release.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local git checkout
- Model/provider: N/A
- Integration/channel (if any): GitHub releases + local git history
- Relevant config (redacted): N/A

### Steps

1. Run `gh release list --repo openclaw/openclaw --limit 20`.
2. Observe the latest published release is `v2026.3.7` and there is no `v2026.3.8` release.
3. Open `CHANGELOG.md` and verify the top section is now `Unreleased`.

### Expected

- Unreleased changes on `main` are labeled `Unreleased` until a `v2026.3.8` release exists.

### Actual

- Before this change, the changelog implied `2026.3.8` was already released.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked `gh release list` for published releases and compared it with the top-level `CHANGELOG.md` heading.
- Edge cases checked: confirmed there is no `v2026.3.8` release object, so the fix should be a heading-only change rather than content movement.
- What you did **not** verify: no build/test runs; docs-only change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `5074b6b6f4`.
- Files/config to restore: `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: none beyond incorrect release labeling.

## Risks and Mitigations

- Risk: the project intended to pre-stage the next release under a date heading before publishing.
  - Mitigation: current GitHub release metadata still shows `v2026.3.7` as latest, so `Unreleased` is the accurate public-facing label until `v2026.3.8` exists.
