### PR TITLE
fix(heartbeat): don't inject workspace path hint into user-configured prompts

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1107,11 +1107,7 @@ describe("runHeartbeatOnce", () => {
     const storePath = path.join(tmpDir, "sessions.json");
     const workspaceDir = path.join(tmpDir, "workspace");
     await fs.mkdir(workspaceDir, { recursive: true });
-    await fs.writeFile(
-      path.join(workspaceDir, "HEARTBEAT.md"),
-      "- Check server logs\n",
-      "utf-8",
-    );
+    await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "- Check server logs\n", "utf-8");
     const customPrompt = "Read heartbeat.md and summarise what's pending.";
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1102,6 +1102,62 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("does not append workspace path hint to user-configured heartbeat prompts", async () => {
+    const tmpDir = await createCaseDir("hb-custom-prompt-no-hint");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const workspaceDir = path.join(tmpDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "HEARTBEAT.md"),
+      "- Check server logs\n",
+      "utf-8",
+    );
+    const customPrompt = "Read heartbeat.md and summarise what's pending.";
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          heartbeat: { every: "5m", target: "whatsapp", prompt: customPrompt },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "120363401234567890@g.us",
+        },
+      }),
+    );
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    replySpy.mockResolvedValue({ text: "Checked logs" });
+    const sendWhatsApp = vi
+      .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "interval",
+        deps: createHeartbeatDeps(sendWhatsApp),
+      });
+      expect(res.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      // Custom prompt should be used as-is — no workspace path hint injected.
+      expect(calledCtx.Body).toContain(customPrompt);
+      expect(calledCtx.Body).not.toContain("use workspace file");
+      expect(calledCtx.Body).not.toContain("Do not read docs/heartbeat.md");
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("applies HEARTBEAT.md gating rules across file states and triggers", async () => {
     const cases: Array<{
       name: string;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -12,6 +12,7 @@ import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payl
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   DEFAULT_HEARTBEAT_EVERY,
+  HEARTBEAT_PROMPT,
   isHeartbeatContentEffectivelyEmpty,
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
   stripHeartbeatToken,
@@ -592,20 +593,18 @@ function resolveHeartbeatRunPrompt(params: {
     .map((event) => event.text);
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
   const hasCronEvents = cronEvents.length > 0;
+  const effectiveHeartbeatPrompt = resolveHeartbeatPrompt(params.cfg, params.heartbeat);
   const basePrompt = hasExecCompletion
     ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
-      : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
-  // Only append the workspace path hint when using the built-in default prompt.
-  // User-configured prompts should not be modified — they reference their own files.
-  const isCustomPrompt = !!(
-    params.heartbeat?.prompt?.trim() ||
-    params.cfg.agents?.defaults?.heartbeat?.prompt?.trim()
-  );
-  const prompt = isCustomPrompt
-    ? basePrompt
-    : appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
+      : effectiveHeartbeatPrompt;
+  // Only append the workspace path hint when the built-in default prompt is in use.
+  // User-configured prompts already express user intent and must not be modified.
+  const prompt =
+    !hasExecCompletion && !hasCronEvents && effectiveHeartbeatPrompt === HEARTBEAT_PROMPT
+      ? appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir)
+      : basePrompt;
 
   return { prompt, hasExecCompletion, hasCronEvents };
 }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -597,7 +597,15 @@ function resolveHeartbeatRunPrompt(params: {
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
-  const prompt = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
+  // Only append the workspace path hint when using the built-in default prompt.
+  // User-configured prompts should not be modified — they reference their own files.
+  const isCustomPrompt = !!(
+    params.heartbeat?.prompt?.trim() ||
+    params.cfg.agents?.defaults?.heartbeat?.prompt?.trim()
+  );
+  const prompt = isCustomPrompt
+    ? basePrompt
+    : appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
 
   return { prompt, hasExecCompletion, hasCronEvents };
 }


### PR DESCRIPTION
## What

`appendHeartbeatWorkspacePathHint` was called unconditionally inside
`resolveHeartbeatRunPrompt`, so any user-configured heartbeat prompt
that happened to mention `heartbeat.md` would silently get the
path-hint sentence appended:

```
When reading HEARTBEAT.md, use workspace file /path/HEARTBEAT.md (exact case). Do not read docs/heartbeat.md.
```

This regression was introduced in 604f22c (issue #40255).

## Root cause

The hint is only meaningful for the **built-in default prompt** — it
tells the model which exact file to open.  A custom prompt already
says what the user wants; injecting extra instructions corrupts it.

## Fix

In `resolveHeartbeatRunPrompt`, check whether a custom prompt is
configured (via `heartbeat.prompt` or
`agents.defaults.heartbeat.prompt`).  Only call
`appendHeartbeatWorkspacePathHint` when neither is set, i.e. when the
default prompt is in use.

```typescript
const isCustomPrompt = !!(
  params.heartbeat?.prompt?.trim() ||
  params.cfg.agents?.defaults?.heartbeat?.prompt?.trim()
);
const prompt = isCustomPrompt
  ? basePrompt
  : appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
```

## Test

Added a regression test in
`heartbeat-runner.returns-default-unset.test.ts` that sets a custom
prompt containing `"heartbeat.md"` and asserts the injected hint
strings are absent from the prompt forwarded to the LLM.

Fixes #40255