### PR TITLE
fix(agents): show env var hint when provider API key is missing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11451,7 +11451,7 @@
         "filename": "src/agents/model-auth.ts",
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 25
       }
     ],
     "src/agents/models-config.e2e-harness.ts": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - ACP/sessions.patch: allow `spawnedBy` and `spawnDepth` lineage fields on ACP session keys so `sessions_spawn` with `runtime: "acp"` no longer fails during child-session setup. Fixes #40971. (#40995) thanks @xaeon2026.
 - ACP/stop reason mapping: resolve gateway chat `state: "error"` completions as ACP `end_turn` instead of `refusal` so transient backend failures are not surfaced as deliberate refusals. (#41187) thanks @pejmanjohn.
 - ACP/setSessionMode: propagate gateway `sessions.patch` failures back to ACP clients so rejected mode changes no longer return silent success. (#41185) thanks @pejmanjohn.
+- Agents/auth errors: show the provider-specific env var name (e.g. `ANTHROPIC_API_KEY`) in the missing-key error instead of dumping internal auth-store paths. (#40338) Thanks @ademczuk.
 
 ## 2026.3.8
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -257,15 +256,14 @@ export async function resolveApiKeyForProvider(params: {
     }
   }
 
-  const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
-  const resolvedAgentDir = path.dirname(authStorePath);
-  throw new Error(
-    [
-      `No API key found for provider "${provider}".`,
-      `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
-      `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
-    ].join(" "),
-  );
+  const envCandidates = PROVIDER_ENV_API_KEY_CANDIDATES[normalized];
+  const envHint = envCandidates?.[0];
+  const parts = [
+    `No API key found for provider "${provider}".`,
+    envHint ? `Set ${envHint} or run` : "Run",
+    `${formatCliCommand("openclaw models auth add")} to configure it.`,
+  ];
+  throw new Error(parts.join(" "));
 }
 
 export type EnvApiKeyResult = { apiKey: string; source: string };

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -13,7 +13,6 @@ import {
   listProfilesForProvider,
   resolveApiKeyForProfile,
   resolveAuthProfileOrder,
-  resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
 import { PROVIDER_ENV_API_KEY_CANDIDATES } from "./model-auth-env-vars.js";
 import { OLLAMA_LOCAL_AUTH_MARKER } from "./model-auth-markers.js";

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -612,7 +612,7 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("no api key found")).toBe("auth");
     expect(
       classifyFailoverReason(
-        'No API key found for provider "openai". Auth store: /tmp/openclaw-agent-abc/auth-profiles.json (agentDir: /tmp/openclaw-agent-abc).',
+        'No API key found for provider "openai". Set OPENAI_API_KEY or run `openclaw models auth add` to configure it.',
       ),
     ).toBe("auth");
     expect(classifyFailoverReason("You have insufficient permissions for this operation.")).toBe(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: When no API key is configured for a provider, the auth-missing error shows internal filesystem paths (`auth-store`, `agentDir`) instead of the actionable env var name the user needs to set.
- Why it matters: Users hitting this error get no indication of which env var to export. The internal paths are noise — they don't help, and they expose implementation details.
- What changed: `src/agents/model-auth.ts` now builds the error message using `PROVIDER_ENV_API_KEY_CANDIDATES` (already in scope) to surface the correct env var name (e.g. `ANTHROPIC_API_KEY`) and a short `openclaw models auth add` fallback for unknown providers. Dropped the unused `path` import. Updated one test in `pi-embedded-helpers.isbillingerrormessage.test.ts` to match the new format.
- What did NOT change (scope boundary): No changes to how auth credentials are loaded, stored, or validated. No changes to the `PROVIDER_ENV_API_KEY_CANDIDATES` map itself or to any other error classification path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544

## User-visible / Behavior Changes

The auth-missing error now reads: `No API key found for provider "anthropic". Set ANTHROPIC_API_KEY or run \`openclaw models auth add\` to configure it.` Previously it showed internal paths including auth-store location and agentDir.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No — error message display only, no change to how keys are stored or read)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Linux / macOS / Windows
- Runtime/container: Node 22 / bun
- Model/provider: Any model whose provider has no configured key (e.g. `anthropic` with no `ANTHROPIC_API_KEY` set)
- Integration/channel (if any): Any
- Relevant config (redacted): no `ANTHROPIC_API_KEY` in environment

### Steps

1. Start an agent with a model whose provider has no API key configured.
2. Observe the error message in the terminal / log output.

### Expected

- `No API key found for provider "anthropic". Set ANTHROPIC_API_KEY or run \`openclaw models auth add\` to configure it.`

### Actual

- Before fix: verbose message including internal `auth-store` path, `agentDir`, and instructions to copy JSON files.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after — `pi-embedded-helpers.isbillingerrormessage.test.ts` `classifyFailoverReason` test updated to match new error format; 55/55 pass.
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: provider in `PROVIDER_ENV_API_KEY_CANDIDATES` (e.g. `anthropic` → `ANTHROPIC_API_KEY`), provider not in map (fallback `openclaw models auth add` hint), `classifyFailoverReason` regex correctly classifies new message format as `"auth"`.
- Edge cases checked: providers absent from `PROVIDER_ENV_API_KEY_CANDIDATES` fall back gracefully; no auth logic changed — only the error string.
- What you did **not** verify: end-to-end test with every provider key variant; tested representative cases only.

## Compatibility / Migration

- Backward compatible? (Yes — error message text change only, not a programmatic contract)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <sha>` or revert the PR.
- Files/config to restore: `src/agents/model-auth.ts`
- Known bad symptoms reviewers should watch for: auth errors reverting to showing internal paths — no functional regression, only UX regression.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Downstream scripts or monitoring that parsed the old error message format (specifically matching the path-containing string) will no longer match.
  - Mitigation: Searched for string matches in the codebase — only one test matched, updated in this PR. No production code parses the error string programmatically.