### PR TITLE
fix(imessage): stop sending <media:image> placeholder as visible text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.
 - Context engine/tests: add bundled-registry regression coverage for cross-chunk resolution, plugin-sdk re-exports, and concurrent chunk registration. (#40460) thanks @dsantoreis.
 - Agents/embedded runner: bound compaction retry waiting and drain embedded runs during SIGUSR1 restart so session lanes recover instead of staying blocked behind compaction. (#40324) thanks @cgdusek.
+- iMessage/media: stop injecting `<media:image>` placeholder text into media-only sends, which was delivered to the recipient as visible message text. (#40252)
 
 ## 2026.3.8
 

--- a/src/imessage/send.test.ts
+++ b/src/imessage/send.test.ts
@@ -58,7 +58,7 @@ describe("sendMessageIMessage", () => {
     expect(params.to).toBe("+1555");
   });
 
-  it("adds file attachment with placeholder text", async () => {
+  it("sends file attachment without placeholder text", async () => {
     await sendWithDefaults("chat_id:7", "", {
       mediaUrl: "http://x/y.jpg",
       resolveAttachmentImpl: async () => ({
@@ -68,10 +68,10 @@ describe("sendMessageIMessage", () => {
     });
     const params = getSentParams();
     expect(params.file).toBe("/tmp/imessage-media.jpg");
-    expect(params.text).toBe("<media:image>");
+    expect(params.text).toBe("");
   });
 
-  it("normalizes mixed-case parameterized MIME for attachment placeholder text", async () => {
+  it("sends audio attachment without placeholder text", async () => {
     await sendWithDefaults("chat_id:7", "", {
       mediaUrl: "http://x/voice",
       resolveAttachmentImpl: async () => ({
@@ -81,7 +81,7 @@ describe("sendMessageIMessage", () => {
     });
     const params = getSentParams();
     expect(params.file).toBe("/tmp/imessage-media.ogg");
-    expect(params.text).toBe("<media:audio>");
+    expect(params.text).toBe("");
   });
 
   it("returns message id when rpc provides one", async () => {

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -1,7 +1,6 @@
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { convertMarkdownTables } from "../markdown/tables.js";
-import { kindFromMime } from "../media/mime.js";
 import { resolveOutboundAttachmentFromUrl } from "../media/outbound-attachment.js";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
@@ -128,12 +127,6 @@ export async function sendMessageIMessage(
       localRoots: opts.mediaLocalRoots,
     });
     filePath = resolved.path;
-    if (!message.trim()) {
-      const kind = kindFromMime(resolved.contentType ?? undefined);
-      if (kind) {
-        message = kind === "image" ? "<media:image>" : `<media:${kind}>`;
-      }
-    }
   }
 
   if (!message.trim() && !filePath) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: When sending a media-only iMessage (image, audio, video), the send function injected a synthetic `<media:image>` / `<media:audio>` placeholder as the `text` field of the outbound message. Unlike Telegram and Discord, iMessage/BlueBubbles passes the `text` field verbatim to the recipient, so the placeholder arrived as visible text alongside the attachment.
- Why it matters: Every media-only send via iMessage delivered a broken-looking `<media:image>` string to the recipient. The message looked malformed on the recipient's device.
- What changed: Removed the 5-line placeholder-generation block from `src/imessage/send.ts` and dropped the now-unused `kindFromMime` import. Updated two tests in `src/imessage/send.test.ts` to assert empty text for media-only sends.
- What did NOT change (scope boundary): No changes to Telegram, Discord, or any other channel's send path. The guard that throws when neither text nor media is provided is unchanged. Text+media sends (where the user provides both) are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40252

## User-visible / Behavior Changes

iMessage media-only sends no longer include a visible `<media:image>` or `<media:audio>` string in the message text. The attachment arrives as the sole content.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: macOS (BlueBubbles host)
- Runtime/container: Node 22 / bun
- Model/provider: Any
- Integration/channel (if any): iMessage / BlueBubbles
- Relevant config (redacted): `channels.imessage` configured

### Steps

1. Send an image (no text) to a contact via the iMessage channel.
2. Observe the received message on the recipient's device.
3. Before fix: `<media:image>` visible as message text alongside the attachment.

### Expected

- Attachment arrives with no accompanying text string.

### Actual

- Before fix: `<media:image>` string visible to recipient as message text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after — two tests in `send.test.ts` updated: now assert `text: ""` for media-only sends instead of `text: "<media:image>"`.
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: media-only image send (empty text output), media-only audio send (empty text output), text+image send (user text preserved), empty text+empty media guard still throws.
- Edge cases checked: `kindFromMime` removal leaves no dangling references — it was only used for placeholder generation and had no other callers.
- What you did **not** verify: live iMessage device end-to-end test (requires a connected BlueBubbles instance and a test contact).

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <sha>` or revert the PR.
- Files/config to restore: `src/imessage/send.ts`
- Known bad symptoms reviewers should watch for: media-only iMessage sends silently failing if any downstream code expected a non-empty `text` field (none do in the current codebase).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: iMessage channels that depend on `text` being non-empty for downstream routing (e.g. custom webhooks reading the raw message object) will now receive an empty string for media-only sends.
  - Mitigation: Intentional fix — the prior value was a bug artefact, not a stable API. No OpenClaw code path checks for the `<media:image>` string.