### PR TITLE
fix(codex-usage): normalize OAuth token before Authorization header

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -27,6 +27,7 @@ describe("fetchCodexUsage", () => {
     const mockFetch = createProviderUsageFetch(async (_url, init) => {
       const headers = (init?.headers as Record<string, string> | undefined) ?? {};
       expect(headers["ChatGPT-Account-Id"]).toBe("acct-1");
+      expect(headers.Authorization).toBe("Bearer token");
       return makeResponse(200, {
         rate_limit: {
           primary_window: {
@@ -45,7 +46,7 @@ describe("fetchCodexUsage", () => {
       });
     });
 
-    const result = await fetchCodexUsage("token", "acct-1", 5000, mockFetch);
+    const result = await fetchCodexUsage("token\n", "acct-1", 5000, mockFetch);
 
     expect(result.provider).toBe("openai-codex");
     expect(result.plan).toBe("Plus ($12.50)");

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -1,3 +1,4 @@
+import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import { buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
@@ -50,8 +51,9 @@ export async function fetchCodexUsage(
   timeoutMs: number,
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
+  const normalizedToken = normalizeSecretInput(token);
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
+    Authorization: `Bearer ${normalizedToken}`,
     "User-Agent": "CodexBar",
     Accept: "application/json",
   };


### PR DESCRIPTION
Some Codex OAuth tokens can include trailing newlines/whitespace which results in a malformed `Authorization` header and HTTP 400 responses.

This normalizes (trims) the token before constructing the `Authorization: Bearer ...` header, and adds a regression test.

Tests:
- `pnpm test src/infra/provider-usage.fetch.codex.test.ts`