### PR TITLE
feat(infra): add structured observability events system

### DIFF
--- a/src/config/types.observability.ts
+++ b/src/config/types.observability.ts
@@ -1,0 +1,71 @@
+/**
+ * Observability domain identifiers — the high-level subsystems that emit
+ * structured runtime events via the observability-events module.
+ */
+export type ObservabilityDomain =
+  | "llm"
+  | "tool"
+  | "run"
+  | "queue"
+  | "session"
+  | (string & Record<never, never>); // allow extension without widening to plain string
+
+/**
+ * Runtime observability configuration.
+ *
+ * Controls the structured observability-events system: domain filtering and
+ * optional file-based log mirroring useful for debugging and integration.
+ */
+export type ObservabilityConfig = {
+  /**
+   * Master toggle. When false, no events are emitted or mirrored.
+   * Defaults to true (enabled).
+   */
+  enabled?: boolean;
+
+  /** Structured event emission settings. */
+  events?: {
+    /**
+     * Enable or disable the events subsystem entirely.
+     * When false, emitObservabilityEvent becomes a no-op.
+     */
+    enabled?: boolean;
+
+    /**
+     * Per-domain enable/disable flags. All domains are enabled by default.
+     * Set a domain key to `false` to suppress its events.
+     *
+     * @example
+     * { domains: { tool: false } }  // suppress tool-call events
+     */
+    domains?: Partial<Record<string, boolean>>;
+  };
+
+  /** File-based log mirroring (useful for local debugging and auditing). */
+  logs?: {
+    /**
+     * Enable file mirroring. When true, every emitted event is appended to
+     * `filePath` (default: `<tmpDir>/openclaw-observability.log`).
+     */
+    enabled?: boolean;
+
+    /**
+     * Log line format:
+     * - `"tail"` (default): compact logfmt-style lines suited for `tail -f`
+     * - `"json"`: one JSON object per line (NDJSON)
+     */
+    format?: "tail" | "json";
+
+    /**
+     * Absolute path for the log file. Falls back to a platform temp directory
+     * when omitted.
+     */
+    filePath?: string;
+
+    /**
+     * When true, include the event `id` and `seq` fields in each log line.
+     * Defaults to false to keep logs concise.
+     */
+    includeEventIds?: boolean;
+  };
+};

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -23,6 +23,7 @@ import type {
 } from "./types.messages.js";
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
+import type { ObservabilityConfig } from "./types.observability.js";
 import type { PluginsConfig } from "./types.plugins.js";
 import type { SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
@@ -62,6 +63,7 @@ export type OpenClawConfig = {
   };
   diagnostics?: DiagnosticsConfig;
   logging?: LoggingConfig;
+  observability?: ObservabilityConfig;
   cli?: CliConfig;
   update?: {
     /** Update channel for git + npm installs ("stable", "beta", or "dev"). */

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -9,6 +9,7 @@ export * from "./types.base.js";
 export * from "./types.browser.js";
 export * from "./types.channels.js";
 export * from "./types.cli.js";
+export * from "./types.observability.js";
 export * from "./types.openclaw.js";
 export * from "./types.cron.js";
 export * from "./types.discord.js";

--- a/src/infra/observability-events.ts
+++ b/src/infra/observability-events.ts
@@ -1,0 +1,441 @@
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ObservabilityDomain } from "../config/types.observability.js";
+import { formatLocalIsoWithOffset } from "../logging/timestamps.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
+
+export type ObservabilityStatus = "ok" | "error" | "timeout" | "aborted";
+
+export type ObservabilityEventPayload = {
+  id: string;
+  ts: number;
+  seq: number;
+  domain: ObservabilityDomain;
+  event: string;
+  phase?: string;
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  agentId?: string;
+  status?: ObservabilityStatus;
+  durationMs?: number;
+  error?: string;
+  data?: Record<string, unknown>;
+};
+
+export type ObservabilityEventInput = Omit<ObservabilityEventPayload, "id" | "seq" | "ts">;
+
+type ObservabilityEventsGlobalState = {
+  seq: number;
+  listeners: Set<(evt: ObservabilityEventPayload) => void>;
+  dispatchDepth: number;
+  mirrorInstalled: boolean;
+  configOverrideForTest?: OpenClawConfig;
+};
+
+function getObservabilityEventsState(): ObservabilityEventsGlobalState {
+  const globalStore = globalThis as typeof globalThis & {
+    __openclawObservabilityEventsState?: ObservabilityEventsGlobalState;
+  };
+  if (!globalStore.__openclawObservabilityEventsState) {
+    globalStore.__openclawObservabilityEventsState = {
+      seq: 0,
+      listeners: new Set<(evt: ObservabilityEventPayload) => void>(),
+      dispatchDepth: 0,
+      mirrorInstalled: false,
+      configOverrideForTest: undefined,
+    };
+  }
+  return globalStore.__openclawObservabilityEventsState;
+}
+
+export function isObservabilityDomainEnabled(
+  config: OpenClawConfig | undefined,
+  domain: ObservabilityDomain,
+): boolean {
+  const observability = config?.observability;
+  if (observability?.enabled === false) {
+    return false;
+  }
+  if (observability?.events?.enabled === false) {
+    return false;
+  }
+  return observability?.events?.domains?.[domain] !== false;
+}
+
+function shouldMirrorObservabilityLogs(config?: OpenClawConfig): boolean {
+  if (config?.observability?.enabled === false) {
+    return false;
+  }
+  return config?.observability?.logs?.enabled === true;
+}
+
+function defaultObservabilityLogPath(): string {
+  return path.join(resolvePreferredOpenClawTmpDir(), "openclaw-observability.log");
+}
+
+function appendObservabilityLogLine(filePath: string, line: string): void {
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.appendFileSync(filePath, `${line}\n`, "utf8");
+  } catch {
+    // never block runtime activity on observability log writes
+  }
+}
+
+function sanitizeToken(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return '""';
+  }
+  if (/^[A-Za-z0-9_./:@%-]+$/.test(trimmed)) {
+    return trimmed;
+  }
+  return JSON.stringify(trimmed);
+}
+
+function flattenData(
+  value: Record<string, unknown> | undefined,
+  prefix = "",
+  out: Array<[string, string]> = [],
+): Array<[string, string]> {
+  if (!value) {
+    return out;
+  }
+  for (const [key, item] of Object.entries(value)) {
+    const nextKey = prefix ? `${prefix}.${key}` : key;
+    if (item == null) {
+      continue;
+    }
+    if (typeof item === "string") {
+      out.push([nextKey, sanitizeToken(item)]);
+      continue;
+    }
+    if (typeof item === "number" || typeof item === "boolean") {
+      out.push([nextKey, String(item)]);
+      continue;
+    }
+    if (Array.isArray(item)) {
+      out.push([nextKey, sanitizeToken(JSON.stringify(item))]);
+      continue;
+    }
+    if (typeof item === "object") {
+      flattenData(item as Record<string, unknown>, nextKey, out);
+      continue;
+    }
+  }
+  return out;
+}
+
+function pushPart(parts: string[], key: string, value: unknown): void {
+  if (value == null) {
+    return;
+  }
+  if (typeof value === "string") {
+    parts.push(`${key}=${sanitizeToken(value)}`);
+    return;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    parts.push(`${key}=${value}`);
+    return;
+  }
+  parts.push(`${key}=${sanitizeToken(JSON.stringify(value))}`);
+}
+
+function getDataRecord(event: ObservabilityEventPayload): Record<string, unknown> {
+  return event.data ?? {};
+}
+
+function formatCommonParts(
+  event: ObservabilityEventPayload,
+  includeEventIds: boolean,
+  activity: string,
+): string[] {
+  const parts = [formatLocalIsoWithOffset(new Date(event.ts)), activity];
+  if (includeEventIds) {
+    parts.push(`id=${event.id}`);
+    parts.push(`seq=${event.seq}`);
+  }
+  pushPart(parts, "run", event.runId);
+  pushPart(parts, "sess", event.sessionId);
+  pushPart(parts, "skey", event.sessionKey);
+  pushPart(parts, "agent", event.agentId);
+  pushPart(parts, "status", event.status);
+  if (typeof event.durationMs === "number") {
+    parts.push(`dur=${event.durationMs}ms`);
+  }
+  pushPart(parts, "err", event.error);
+  return parts;
+}
+
+function formatTailLlmEvent(event: ObservabilityEventPayload, includeEventIds: boolean): string {
+  const data = getDataRecord(event);
+  const parts = formatCommonParts(event, includeEventIds, `llm.${event.phase ?? event.event}`);
+  pushPart(parts, "prov", data.provider);
+  pushPart(parts, "model", data.model);
+  pushPart(parts, "attempt", data.attempt);
+  pushPart(parts, "profile", data.authProfileId);
+  if (typeof data.stopReason === "string") {
+    pushPart(parts, "stop", data.stopReason);
+  }
+  if (typeof data.timedOut === "boolean" && data.timedOut) {
+    parts.push("timedOut=true");
+  }
+  if (typeof data.aborted === "boolean" && data.aborted) {
+    parts.push("aborted=true");
+  }
+  const prompt =
+    data.prompt && typeof data.prompt === "object"
+      ? (data.prompt as Record<string, unknown>)
+      : undefined;
+  if (prompt) {
+    pushPart(parts, "prompt.chars", prompt.chars);
+    pushPart(parts, "imgs", prompt.images);
+  }
+  const usage =
+    data.usage && typeof data.usage === "object"
+      ? (data.usage as Record<string, unknown>)
+      : undefined;
+  if (usage) {
+    pushPart(parts, "tok.in", usage.input);
+    pushPart(parts, "tok.out", usage.output);
+    pushPart(parts, "tok.total", usage.total);
+    pushPart(parts, "tok.cacheRead", usage.cacheRead);
+    pushPart(parts, "tok.cacheWrite", usage.cacheWrite);
+  }
+  pushPart(parts, "compact", data.compactionCount);
+  return parts.join(" ");
+}
+
+function formatTailToolEvent(event: ObservabilityEventPayload, includeEventIds: boolean): string {
+  const data = getDataRecord(event);
+  const parts = formatCommonParts(event, includeEventIds, `tool.${event.phase ?? event.event}`);
+  pushPart(parts, "tool", data.toolName);
+  pushPart(parts, "call", data.toolCallId);
+  pushPart(parts, "meta", data.meta);
+  const argsSummary =
+    data.argsSummary && typeof data.argsSummary === "object"
+      ? (data.argsSummary as Record<string, unknown>)
+      : undefined;
+  const resultSummary =
+    data.resultSummary && typeof data.resultSummary === "object"
+      ? (data.resultSummary as Record<string, unknown>)
+      : undefined;
+  if (argsSummary) {
+    pushPart(parts, "args.kind", argsSummary.kind);
+    pushPart(parts, "action", argsSummary.action);
+    pushPart(parts, "path", argsSummary.path ?? argsSummary.file_path);
+    pushPart(parts, "cmd", argsSummary.command ?? argsSummary.cmd);
+    pushPart(parts, "query", argsSummary.query);
+    pushPart(parts, "url", argsSummary.url);
+  }
+  if (resultSummary) {
+    pushPart(parts, "result.kind", resultSummary.kind);
+    pushPart(parts, "result.keys", resultSummary.keys);
+  }
+  return parts.join(" ");
+}
+
+function formatTailRunEvent(event: ObservabilityEventPayload, includeEventIds: boolean): string {
+  const data = getDataRecord(event);
+  const parts = formatCommonParts(
+    event,
+    includeEventIds,
+    `run.${event.event}${event.phase ? `.${event.phase}` : ""}`,
+  );
+  pushPart(parts, "attempt", data.attempt);
+  return parts.join(" ");
+}
+
+function formatTailQueueEvent(event: ObservabilityEventPayload, includeEventIds: boolean): string {
+  const data = getDataRecord(event);
+  const parts = formatCommonParts(event, includeEventIds, `queue.${event.phase ?? event.event}`);
+  pushPart(parts, "lane", data.lane);
+  pushPart(parts, "q", data.queueSize);
+  if (typeof data.waitMs === "number") {
+    parts.push(`wait=${data.waitMs}ms`);
+  }
+  return parts.join(" ");
+}
+
+function formatTailSessionEvent(
+  event: ObservabilityEventPayload,
+  includeEventIds: boolean,
+): string {
+  const data = getDataRecord(event);
+  const parts = formatCommonParts(
+    event,
+    includeEventIds,
+    `session.${event.event}${event.phase ? `.${event.phase}` : ""}`,
+  );
+  pushPart(parts, "state", data.state);
+  pushPart(parts, "prev", data.prevState);
+  pushPart(parts, "reason", data.reason);
+  pushPart(parts, "q", data.queueDepth);
+  if (typeof data.ageMs === "number") {
+    parts.push(`age=${data.ageMs}ms`);
+  }
+  return parts.join(" ");
+}
+
+function formatTailLogLine(event: ObservabilityEventPayload, includeEventIds: boolean): string {
+  if (event.domain === "llm" && event.event === "call") {
+    return formatTailLlmEvent(event, includeEventIds);
+  }
+  if (event.domain === "tool" && event.event === "call") {
+    return formatTailToolEvent(event, includeEventIds);
+  }
+  if (event.domain === "run") {
+    return formatTailRunEvent(event, includeEventIds);
+  }
+  if (event.domain === "queue") {
+    return formatTailQueueEvent(event, includeEventIds);
+  }
+  if (event.domain === "session") {
+    return formatTailSessionEvent(event, includeEventIds);
+  }
+
+  const parts = [
+    formatLocalIsoWithOffset(new Date(event.ts)),
+    `${event.domain}.${event.event}${event.phase ? `.${event.phase}` : ""}`,
+  ];
+  if (includeEventIds) {
+    parts.push(`eventId=${event.id}`);
+    parts.push(`seq=${event.seq}`);
+  }
+  if (event.runId) {
+    parts.push(`runId=${sanitizeToken(event.runId)}`);
+  }
+  if (event.sessionId) {
+    parts.push(`sessionId=${sanitizeToken(event.sessionId)}`);
+  }
+  if (event.sessionKey) {
+    parts.push(`sessionKey=${sanitizeToken(event.sessionKey)}`);
+  }
+  if (event.agentId) {
+    parts.push(`agentId=${sanitizeToken(event.agentId)}`);
+  }
+  if (event.status) {
+    parts.push(`status=${event.status}`);
+  }
+  if (typeof event.durationMs === "number") {
+    parts.push(`durationMs=${event.durationMs}`);
+  }
+  if (event.error) {
+    parts.push(`error=${sanitizeToken(event.error)}`);
+  }
+  for (const [key, item] of flattenData(event.data)) {
+    parts.push(`${key}=${item}`);
+  }
+  return parts.join(" ");
+}
+
+function ensureObservabilityLogMirrorInstalled(): void {
+  const state = getObservabilityEventsState();
+  if (state.mirrorInstalled) {
+    return;
+  }
+  state.mirrorInstalled = true;
+  state.listeners.add((event) => {
+    let config: OpenClawConfig | undefined;
+    try {
+      config = state.configOverrideForTest ?? loadConfig();
+    } catch {
+      config = undefined;
+    }
+    if (!shouldMirrorObservabilityLogs(config)) {
+      return;
+    }
+    const includeEventIds = config?.observability?.logs?.includeEventIds === true;
+    const format = config?.observability?.logs?.format ?? "tail";
+    const filePath = config?.observability?.logs?.filePath ?? defaultObservabilityLogPath();
+    if (format === "json") {
+      appendObservabilityLogLine(
+        filePath,
+        JSON.stringify({
+          ts: formatLocalIsoWithOffset(new Date(event.ts)),
+          ...(includeEventIds ? { id: event.id, seq: event.seq } : {}),
+          domain: event.domain,
+          event: event.event,
+          phase: event.phase,
+          runId: event.runId,
+          sessionId: event.sessionId,
+          sessionKey: event.sessionKey,
+          agentId: event.agentId,
+          status: event.status,
+          durationMs: event.durationMs,
+          error: event.error,
+          data: event.data,
+        }),
+      );
+      return;
+    }
+    appendObservabilityLogLine(filePath, formatTailLogLine(event, includeEventIds));
+  });
+}
+
+export function emitObservabilityEvent(event: ObservabilityEventInput): void {
+  const state = getObservabilityEventsState();
+  ensureObservabilityLogMirrorInstalled();
+  if (state.dispatchDepth > 100) {
+    console.error(
+      `[observability-events] recursion guard tripped at depth=${state.dispatchDepth}, dropping domain=${event.domain} event=${event.event}`,
+    );
+    return;
+  }
+
+  const seq = (state.seq += 1);
+  const enriched = {
+    ...event,
+    id: `obs_${Date.now()}_${seq}`,
+    seq,
+    ts: Date.now(),
+  } satisfies ObservabilityEventPayload;
+  state.dispatchDepth += 1;
+  for (const listener of state.listeners) {
+    try {
+      listener(enriched);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error
+          ? (err.stack ?? err.message)
+          : typeof err === "string"
+            ? err
+            : String(err);
+      console.error(
+        `[observability-events] listener error domain=${enriched.domain} seq=${enriched.seq}: ${errorMessage}`,
+      );
+    }
+  }
+  state.dispatchDepth -= 1;
+}
+
+export function emitRuntimeEvent(event: ObservabilityEventInput): void {
+  emitObservabilityEvent(event);
+}
+
+export function onObservabilityEvent(
+  listener: (evt: ObservabilityEventPayload) => void,
+): () => void {
+  const state = getObservabilityEventsState();
+  state.listeners.add(listener);
+  return () => {
+    state.listeners.delete(listener);
+  };
+}
+
+export function resetObservabilityEventsForTest(): void {
+  const state = getObservabilityEventsState();
+  state.seq = 0;
+  state.listeners.clear();
+  state.dispatchDepth = 0;
+  state.mirrorInstalled = false;
+  state.configOverrideForTest = undefined;
+}
+
+export function setObservabilityConfigOverrideForTest(config?: OpenClawConfig): void {
+  const state = getObservabilityEventsState();
+  state.configOverrideForTest = config;
+}


### PR DESCRIPTION
## Summary

Adds a domain-typed, sequence-numbered event bus for structured runtime observability across the gateway. This is a standalone, additive module with no impact on existing behaviour — all writes fail-safe (errors are caught and logged) and all config paths are optional/guarded.

---

## What's in this PR

### `src/infra/observability-events.ts` (new)

Core event bus module:

- **Typed event payloads** — `ObservabilityEventPayload` carries: `id`, `ts`, `seq`, `domain`, `event`, `phase?`, `runId?`, `sessionId?`, `sessionKey?`, `agentId?`, `status?`, `durationMs?`, `error?`, `data?`
- **Global sequence counter** — monotonic `seq` number for event ordering/correlation across async code paths
- **globalThis state isolation** — singleton state keyed on `__openclawObservabilityEventsState` survives module re-imports without double-counting
- **Listener pattern** — `onObservabilityEvent(fn)` registers a listener and returns a cleanup function; `emitObservabilityEvent(input)` dispatches to all listeners
- **Recursion guard** — dispatch depth >100 drops the event and logs to stderr, never throws or crashes the runtime
- **File-based log mirror** — optional auto-installed listener that appends events to a log file; supports:
  - `tail` format (compact logfmt-style, good for `tail -f`)
  - `json` format (NDJSON, one object per line)
  - Per-domain formatter functions for llm, tool, run, queue, and session events
- **Test helpers** — `resetObservabilityEventsForTest()` and `setObservabilityConfigOverrideForTest(config)` for unit test isolation

### `src/config/types.observability.ts` (new)

Config types required by the events module:

```ts
export type ObservabilityDomain = 'llm' | 'tool' | 'run' | 'queue' | 'session' | (string & {});

export type ObservabilityConfig = {
  enabled?: boolean;           // master toggle (default: true)
  events?: {
    enabled?: boolean;
    domains?: Partial<Record<string, boolean>>;  // per-domain on/off
  };
  logs?: {
    enabled?: boolean;
    format?: 'tail' | 'json';  // default: 'tail'
    filePath?: string;         // default: <tmpDir>/openclaw-observability.log
    includeEventIds?: boolean; // include id + seq in each line
  };
};
```

### `src/config/types.openclaw.ts` (modified)

Adds `observability?: ObservabilityConfig` to `OpenClawConfig`.

### `src/config/types.ts` (modified)

Re-exports the new `types.observability` module.

---

## Design notes

- **No mandatory config required** — works with zero config; all defaults are sensible (events enabled, file mirror disabled)
- **Zero impact on existing code paths** — nothing in this PR changes any existing behaviour; the module must be explicitly imported and called
- **Fail-safe throughout** — listener errors are caught individually, file writes swallow all errors, recursion is bounded
- **Extensible domain set** — `ObservabilityDomain` is an open-ish union; new domains can be added without breaking existing listeners
- **Singleton pattern across re-imports** — safe in ESM environments where multiple module instances may coexist (e.g. in test runners or dynamic imports)

---

## Usage example

```ts
import { emitObservabilityEvent, onObservabilityEvent } from './infra/observability-events.js';

// Register a listener
const off = onObservabilityEvent((evt) => {
  console.log(evt.domain, evt.event, evt.durationMs);
});

// Emit an event
emitObservabilityEvent({
  domain: 'llm',
  event: 'call',
  phase: 'complete',
  sessionId: 'sess_123',
  status: 'ok',
  durationMs: 1420,
  data: { model: 'claude-sonnet-4-6', usage: { input: 800, output: 250 } },
});

// Cleanup
off();
```
