### PR TITLE
Docker: improve build cache reuse

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -109,6 +109,8 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
+          cache-from: type=gha,scope=docker-release-amd64
+          cache-to: type=gha,mode=max,scope=docker-release-amd64
 
       - name: Build and push amd64 slim image
         id: build-slim
@@ -122,6 +124,8 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
+          cache-from: type=gha,scope=docker-release-amd64
+          cache-to: type=gha,mode=max,scope=docker-release-amd64
 
   # Build arm64 images (default + slim share the build stage cache)
   build-arm64:
@@ -210,6 +214,8 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
+          cache-from: type=gha,scope=docker-release-arm64
+          cache-to: type=gha,mode=max,scope=docker-release-arm64
 
       - name: Build and push arm64 slim image
         id: build-slim
@@ -223,6 +229,8 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
+          cache-from: type=gha,scope=docker-release-arm64
+          cache-to: type=gha,mode=max,scope=docker-release-arm64
 
   # Create multi-platform manifests
   create-manifest:

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -51,19 +51,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          docker buildx build \
-            --load \
-            --tag openclaw-sandbox-common-smoke:bookworm-slim \
-            --file Dockerfile.sandbox-common \
-            --build-arg BASE_IMAGE=openclaw-sandbox-smoke-base:bookworm-slim \
-            --build-arg PACKAGES=ca-certificates \
-            --build-arg INSTALL_PNPM=0 \
-            --build-arg INSTALL_BUN=0 \
-            --build-arg INSTALL_BREW=0 \
-            --build-arg FINAL_USER=sandbox \
-            --cache-from type=gha,scope=sandbox-common-smoke \
-            --cache-to type=gha,mode=max,scope=sandbox-common-smoke \
-            .
+          BASE_IMAGE="openclaw-sandbox-smoke-base:bookworm-slim" \
+            TARGET_IMAGE="openclaw-sandbox-common-smoke:bookworm-slim" \
+            PACKAGES="ca-certificates" \
+            INSTALL_PNPM=0 \
+            INSTALL_BUN=0 \
+            INSTALL_BREW=0 \
+            FINAL_USER=sandbox \
+            OPENCLAW_DOCKER_BUILD_USE_BUILDX=1 \
+            OPENCLAW_DOCKER_BUILD_CACHE_FROM="type=gha,scope=sandbox-common-smoke" \
+            OPENCLAW_DOCKER_BUILD_CACHE_TO="type=gha,mode=max,scope=sandbox-common-smoke" \
+            scripts/sandbox-common-setup.sh
 
           u="$(docker run --rm openclaw-sandbox-common-smoke:bookworm-slim sh -lc 'id -un')"
           test "$u" = "sandbox"

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -34,7 +34,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          docker build -t openclaw-sandbox-smoke-base:bookworm-slim - <<'EOF'
+          docker buildx build \
+            --load \
+            --tag openclaw-sandbox-smoke-base:bookworm-slim \
+            --cache-from type=gha,scope=sandbox-common-smoke-base \
+            --cache-to type=gha,mode=max,scope=sandbox-common-smoke-base \
+            - <<'EOF'
           FROM debian:bookworm-slim
           RUN useradd --create-home --shell /bin/bash sandbox
           USER sandbox
@@ -46,14 +51,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          BASE_IMAGE="openclaw-sandbox-smoke-base:bookworm-slim" \
-            TARGET_IMAGE="openclaw-sandbox-common-smoke:bookworm-slim" \
-            PACKAGES="ca-certificates" \
-            INSTALL_PNPM=0 \
-            INSTALL_BUN=0 \
-            INSTALL_BREW=0 \
-            FINAL_USER=sandbox \
-            scripts/sandbox-common-setup.sh
+          docker buildx build \
+            --load \
+            --tag openclaw-sandbox-common-smoke:bookworm-slim \
+            --file Dockerfile.sandbox-common \
+            --build-arg BASE_IMAGE=openclaw-sandbox-smoke-base:bookworm-slim \
+            --build-arg PACKAGES=ca-certificates \
+            --build-arg INSTALL_PNPM=0 \
+            --build-arg INSTALL_BUN=0 \
+            --build-arg INSTALL_BREW=0 \
+            --build-arg FINAL_USER=sandbox \
+            --cache-from type=gha,scope=sandbox-common-smoke \
+            --cache-to type=gha,mode=max,scope=sandbox-common-smoke \
+            .
 
           u="$(docker run --rm openclaw-sandbox-common-smoke:bookworm-slim sh -lc 'id -un')"
           test "$u" = "sandbox"

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -34,12 +34,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          docker buildx build \
-            --load \
-            --tag openclaw-sandbox-smoke-base:bookworm-slim \
-            --cache-from type=gha,scope=sandbox-common-smoke-base \
-            --cache-to type=gha,mode=max,scope=sandbox-common-smoke-base \
-            - <<'EOF'
+          docker build -t openclaw-sandbox-smoke-base:bookworm-slim - <<'EOF'
           FROM debian:bookworm-slim
           RUN useradd --create-home --shell /bin/bash sandbox
           USER sandbox
@@ -58,9 +53,6 @@ jobs:
             INSTALL_BUN=0 \
             INSTALL_BREW=0 \
             FINAL_USER=sandbox \
-            OPENCLAW_DOCKER_BUILD_USE_BUILDX=1 \
-            OPENCLAW_DOCKER_BUILD_CACHE_FROM="type=gha,scope=sandbox-common-smoke" \
-            OPENCLAW_DOCKER_BUILD_CACHE_TO="type=gha,mode=max,scope=sandbox-common-smoke" \
             scripts/sandbox-common-setup.sh
 
           u="$(docker run --rm openclaw-sandbox-common-smoke:bookworm-slim sh -lc 'id -un')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Opt-in extension dependencies at build time (space-separated directory names).
 # Example: docker build --build-arg OPENCLAW_EXTENSIONS="diagnostics-otel matrix" .
 #
@@ -48,13 +50,13 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
-COPY scripts ./scripts
 
 COPY --from=ext-deps /out/ ./extensions/
 
 # Reduce OOM risk on low-memory hosts during dependency installation.
 # Docker builds on small VMs may otherwise fail with "Killed" (exit 137).
-RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
+    NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -117,11 +119,11 @@ WORKDIR /app
 
 # Install system utilities present in bookworm but missing in bookworm-slim.
 # On the full bookworm image these are already installed (apt-get is a no-op).
-RUN apt-get update && \
+RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      procps hostname curl git openssl && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+      procps hostname curl git openssl
 
 RUN chown node:node /app
 
@@ -145,11 +147,11 @@ RUN install -d -m 0755 "$COREPACK_HOME" && \
 # Install additional system packages needed by your skills or extensions.
 # Example: docker build --build-arg OPENCLAW_DOCKER_APT_PACKAGES="python3 wget" .
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
-RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
+RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+    if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES && \
-      apt-get clean && \
-      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES; \
     fi
 
 # Optionally install Chromium and Xvfb for browser automation.
@@ -157,15 +159,15 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after node_modules COPY so playwright-core is available.
 ARG OPENCLAW_INSTALL_BROWSER=""
-RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
+RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+    if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
       mkdir -p /home/node/.cache/ms-playwright && \
       PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      chown -R node:node /home/node/.cache/ms-playwright && \
-      apt-get clean && \
-      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+      chown -R node:node /home/node/.cache/ms-playwright; \
     fi
 
 # Optionally install Docker CLI for sandbox container management.
@@ -174,7 +176,9 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
 # Required for agents.defaults.sandbox to function in Docker deployments.
 ARG OPENCLAW_INSTALL_DOCKER_CLI=""
 ARG OPENCLAW_DOCKER_GPG_FINGERPRINT="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-RUN if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
+RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+    if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates curl gnupg && \
@@ -195,9 +199,7 @@ RUN if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
         "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/docker.list && \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        docker-ce-cli docker-compose-plugin && \
-      apt-get clean && \
-      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+        docker-ce-cli docker-compose-plugin; \
     fi
 
 # Expose the CLI binary without requiring npm global writes as non-root.

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -14,7 +14,7 @@ RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/
     git \
     jq \
     python3 \
-    ripgrep \
+    ripgrep
 
 RUN useradd --create-home --shell /bin/bash sandbox
 USER sandbox

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,8 +1,12 @@
+# syntax=docker/dockerfile:1.7
+
 FROM debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
+RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=openclaw-sandbox-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+  apt-get update \
   && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
@@ -11,7 +15,6 @@ RUN apt-get update \
     jq \
     python3 \
     ripgrep \
-  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash sandbox
 USER sandbox

--- a/Dockerfile.sandbox-browser
+++ b/Dockerfile.sandbox-browser
@@ -1,8 +1,12 @@
+# syntax=docker/dockerfile:1.7
+
 FROM debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
+RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=openclaw-sandbox-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+  apt-get update \
   && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
@@ -17,8 +21,7 @@ RUN apt-get update \
     socat \
     websockify \
     x11vnc \
-    xvfb \
-  && rm -rf /var/lib/apt/lists/*
+    xvfb
 
 COPY --chmod=755 scripts/sandbox-browser-entrypoint.sh /usr/local/bin/openclaw-sandbox-browser
 

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 ARG BASE_IMAGE=openclaw-sandbox:bookworm-slim
 FROM ${BASE_IMAGE}
 
@@ -19,9 +21,10 @@ ENV HOMEBREW_CELLAR=${BREW_INSTALL_DIR}/Cellar
 ENV HOMEBREW_REPOSITORY=${BREW_INSTALL_DIR}/Homebrew
 ENV PATH=${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin:${PATH}
 
-RUN apt-get update \
+RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=openclaw-sandbox-common-apt-lists,target=/var/lib/apt,sharing=locked \
+  apt-get update \
   && apt-get install -y --no-install-recommends ${PACKAGES} \
-  && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
 
@@ -42,4 +45,3 @@ fi
 
 # Default is sandbox, but allow BASE_IMAGE overrides to select another final user.
 USER ${FINAL_USER}
-

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -24,7 +24,7 @@ ENV PATH=${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin
 RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-sandbox-common-apt-lists,target=/var/lib/apt,sharing=locked \
   apt-get update \
-  && apt-get install -y --no-install-recommends ${PACKAGES} \
+  && apt-get install -y --no-install-recommends ${PACKAGES}
 
 RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
 

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,id=openclaw-cleanup-smoke-apt-cache,target=/var/cache/apt
   && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
-    git \
+    git
 
 WORKDIR /repo
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1.7
+
 FROM node:22-bookworm-slim@sha256:3cfe526ec8dd62013b8843e8e5d4877e297b886e5aace4a59fec25dc20736e45
 
-RUN apt-get update \
+RUN --mount=type=cache,id=openclaw-cleanup-smoke-apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=openclaw-cleanup-smoke-apt-lists,target=/var/lib/apt,sharing=locked \
+  apt-get update \
   && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
     git \
-  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /repo
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN corepack enable \
+RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
+  corepack enable \
   && pnpm install --frozen-lockfile
 
 COPY . .

--- a/scripts/docker/install-sh-e2e/Dockerfile
+++ b/scripts/docker/install-sh-e2e/Dockerfile
@@ -1,12 +1,15 @@
+# syntax=docker/dockerfile:1.7
+
 FROM node:22-bookworm-slim@sha256:3cfe526ec8dd62013b8843e8e5d4877e297b886e5aace4a59fec25dc20736e45
 
-RUN apt-get update \
+RUN --mount=type=cache,id=openclaw-install-sh-e2e-apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=openclaw-install-sh-e2e-apt-lists,target=/var/lib/apt,sharing=locked \
+  apt-get update \
   && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
     curl \
-    git \
-  && rm -rf /var/lib/apt/lists/*
+    git
 
 COPY install-sh-common/version-parse.sh /usr/local/install-sh-common/version-parse.sh
 COPY --chmod=755 run.sh /usr/local/bin/openclaw-install-e2e

--- a/scripts/docker/install-sh-nonroot/Dockerfile
+++ b/scripts/docker/install-sh-nonroot/Dockerfile
@@ -1,6 +1,10 @@
+# syntax=docker/dockerfile:1.7
+
 FROM ubuntu:24.04@sha256:cd1dba651b3080c3686ecf4e3c4220f026b521fb76978881737d24f200828b2b
 
-RUN set -eux; \
+RUN --mount=type=cache,id=openclaw-install-sh-nonroot-apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=openclaw-install-sh-nonroot-apt-lists,target=/var/lib/apt,sharing=locked \
+  set -eux; \
   for attempt in 1 2 3; do \
     if apt-get update -o Acquire::Retries=3; then break; fi; \
     echo "apt-get update failed (attempt ${attempt})" >&2; \
@@ -14,8 +18,7 @@ RUN set -eux; \
     g++ \
     make \
     python3 \
-    sudo \
-  && rm -rf /var/lib/apt/lists/*
+    sudo
 
 RUN useradd -m -s /bin/bash app \
   && echo "app ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/app

--- a/scripts/docker/install-sh-smoke/Dockerfile
+++ b/scripts/docker/install-sh-smoke/Dockerfile
@@ -1,6 +1,10 @@
+# syntax=docker/dockerfile:1.7
+
 FROM node:22-bookworm-slim@sha256:3cfe526ec8dd62013b8843e8e5d4877e297b886e5aace4a59fec25dc20736e45
 
-RUN set -eux; \
+RUN --mount=type=cache,id=openclaw-install-sh-smoke-apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=openclaw-install-sh-smoke-apt-lists,target=/var/lib/apt,sharing=locked \
+  set -eux; \
   for attempt in 1 2 3; do \
     if apt-get update -o Acquire::Retries=3; then break; fi; \
     echo "apt-get update failed (attempt ${attempt})" >&2; \
@@ -15,8 +19,7 @@ RUN set -eux; \
     g++ \
     make \
     python3 \
-    sudo \
-  && rm -rf /var/lib/apt/lists/*
+    sudo
 
 COPY install-sh-common/cli-verify.sh /usr/local/install-sh-common/cli-verify.sh
 COPY install-sh-common/version-parse.sh /usr/local/install-sh-common/version-parse.sh

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
 RUN corepack enable
@@ -7,19 +9,24 @@ WORKDIR /app
 ENV NODE_OPTIONS="--disable-warning=ExperimentalWarning"
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.plugin-sdk.dts.json tsdown.config.ts vitest.config.ts vitest.e2e.config.ts openclaw.mjs ./
+COPY ui/package.json ./ui/package.json
+COPY extensions/memory-core/package.json ./extensions/memory-core/package.json
+COPY patches ./patches
+
+RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
+    pnpm install --frozen-lockfile
+
 COPY src ./src
 COPY test ./test
 COPY scripts ./scripts
 COPY docs ./docs
 COPY skills ./skills
-COPY patches ./patches
 COPY ui ./ui
 COPY extensions/memory-core ./extensions/memory-core
 COPY vendor/a2ui/renderers/lit ./vendor/a2ui/renderers/lit
 COPY apps/shared/OpenClawKit/Sources/OpenClawKit/Resources ./apps/shared/OpenClawKit/Sources/OpenClawKit/Resources
 COPY apps/shared/OpenClawKit/Tools/CanvasA2UI ./apps/shared/OpenClawKit/Tools/CanvasA2UI
 
-RUN pnpm install --frozen-lockfile
 RUN pnpm build
 RUN pnpm ui:build
 

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 ENV NODE_OPTIONS="--disable-warning=ExperimentalWarning"
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.plugin-sdk.dts.json tsdown.config.ts vitest.config.ts vitest.e2e.config.ts openclaw.mjs ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY ui/package.json ./ui/package.json
 COPY extensions/memory-core/package.json ./extensions/memory-core/package.json
 COPY patches ./patches
@@ -16,6 +16,7 @@ COPY patches ./patches
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile
 
+COPY tsconfig.json tsconfig.plugin-sdk.dts.json tsdown.config.ts vitest.config.ts vitest.e2e.config.ts openclaw.mjs ./
 COPY src ./src
 COPY test ./test
 COPY scripts ./scripts

--- a/scripts/e2e/Dockerfile.qr-import
+++ b/scripts/e2e/Dockerfile.qr-import
@@ -10,6 +10,9 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
 
+# This image only exercises the root qrcode-terminal dependency path.
+# Keep the pre-install copy set limited to the manifests needed for root
+# workspace resolution so unrelated extension edits do not bust the layer.
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile
 

--- a/scripts/e2e/Dockerfile.qr-import
+++ b/scripts/e2e/Dockerfile.qr-import
@@ -1,12 +1,19 @@
+# syntax=docker/dockerfile:1.7
+
 FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
 RUN corepack enable
 
 WORKDIR /app
 
-COPY . .
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
 
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
+    pnpm install --frozen-lockfile
+
+COPY . .
 
 RUN useradd --create-home --shell /bin/bash appuser \
   && chown -R appuser:appuser /app

--- a/scripts/sandbox-common-setup.sh
+++ b/scripts/sandbox-common-setup.sh
@@ -10,6 +10,9 @@ BUN_INSTALL_DIR="${BUN_INSTALL_DIR:-/opt/bun}"
 INSTALL_BREW="${INSTALL_BREW:-1}"
 BREW_INSTALL_DIR="${BREW_INSTALL_DIR:-/home/linuxbrew/.linuxbrew}"
 FINAL_USER="${FINAL_USER:-sandbox}"
+OPENCLAW_DOCKER_BUILD_USE_BUILDX="${OPENCLAW_DOCKER_BUILD_USE_BUILDX:-0}"
+OPENCLAW_DOCKER_BUILD_CACHE_FROM="${OPENCLAW_DOCKER_BUILD_CACHE_FROM:-}"
+OPENCLAW_DOCKER_BUILD_CACHE_TO="${OPENCLAW_DOCKER_BUILD_CACHE_TO:-}"
 
 if ! docker image inspect "${BASE_IMAGE}" >/dev/null 2>&1; then
   echo "Base image missing: ${BASE_IMAGE}"
@@ -19,7 +22,18 @@ fi
 
 echo "Building ${TARGET_IMAGE} with: ${PACKAGES}"
 
-docker build \
+build_cmd=(docker build)
+if [ "${OPENCLAW_DOCKER_BUILD_USE_BUILDX}" = "1" ]; then
+  build_cmd=(docker buildx build --load)
+  if [ -n "${OPENCLAW_DOCKER_BUILD_CACHE_FROM}" ]; then
+    build_cmd+=(--cache-from "${OPENCLAW_DOCKER_BUILD_CACHE_FROM}")
+  fi
+  if [ -n "${OPENCLAW_DOCKER_BUILD_CACHE_TO}" ]; then
+    build_cmd+=(--cache-to "${OPENCLAW_DOCKER_BUILD_CACHE_TO}")
+  fi
+fi
+
+"${build_cmd[@]}" \
   -t "${TARGET_IMAGE}" \
   -f Dockerfile.sandbox-common \
   --build-arg BASE_IMAGE="${BASE_IMAGE}" \

--- a/src/docker-build-cache.test.ts
+++ b/src/docker-build-cache.test.ts
@@ -106,6 +106,14 @@ describe("docker build cache layout", () => {
       dockerfile.indexOf("COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./"),
     ).toBeLessThan(installIndex);
     expect(dockerfile.indexOf("COPY ui/package.json ./ui/package.json")).toBeLessThan(installIndex);
+    expect(dockerfile).toContain(
+      "This image only exercises the root qrcode-terminal dependency path.",
+    );
+    expect(
+      dockerfile.indexOf(
+        "COPY extensions/memory-core/package.json ./extensions/memory-core/package.json",
+      ),
+    ).toBe(-1);
     expect(dockerfile.indexOf("COPY . .")).toBeGreaterThan(installIndex);
   });
 });

--- a/src/docker-build-cache.test.ts
+++ b/src/docker-build-cache.test.ts
@@ -1,0 +1,85 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+async function readRepoFile(path: string): Promise<string> {
+  return readFile(resolve(repoRoot, path), "utf8");
+}
+
+describe("docker build cache layout", () => {
+  it("keeps the root dependency layer independent from scripts changes", async () => {
+    const dockerfile = await readRepoFile("Dockerfile");
+    const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
+    const copyAllIndex = dockerfile.indexOf("COPY . .");
+    const scriptsCopyIndex = dockerfile.indexOf("COPY scripts ./scripts");
+
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(copyAllIndex).toBeGreaterThan(installIndex);
+    expect(scriptsCopyIndex === -1 || scriptsCopyIndex > installIndex).toBe(true);
+  });
+
+  it("uses pnpm cache mounts in Dockerfiles that install repo dependencies", async () => {
+    for (const path of [
+      "Dockerfile",
+      "scripts/e2e/Dockerfile",
+      "scripts/e2e/Dockerfile.qr-import",
+      "scripts/docker/cleanup-smoke/Dockerfile",
+    ]) {
+      const dockerfile = await readRepoFile(path);
+      expect(dockerfile, `${path} should use a shared pnpm store cache`).toContain(
+        "--mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked",
+      );
+    }
+  });
+
+  it("uses apt cache mounts in Dockerfiles that install system packages", async () => {
+    for (const path of [
+      "Dockerfile",
+      "Dockerfile.sandbox",
+      "Dockerfile.sandbox-browser",
+      "Dockerfile.sandbox-common",
+      "scripts/docker/cleanup-smoke/Dockerfile",
+      "scripts/docker/install-sh-smoke/Dockerfile",
+      "scripts/docker/install-sh-e2e/Dockerfile",
+      "scripts/docker/install-sh-nonroot/Dockerfile",
+    ]) {
+      const dockerfile = await readRepoFile(path);
+      expect(dockerfile, `${path} should cache apt package archives`).toContain(
+        "target=/var/cache/apt,sharing=locked",
+      );
+      expect(dockerfile, `${path} should cache apt metadata`).toContain(
+        "target=/var/lib/apt,sharing=locked",
+      );
+    }
+  });
+
+  it("copies only install inputs before pnpm install in the e2e image", async () => {
+    const dockerfile = await readRepoFile("scripts/e2e/Dockerfile");
+    const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
+
+    expect(dockerfile.indexOf("COPY ui/package.json ./ui/package.json")).toBeLessThan(installIndex);
+    expect(
+      dockerfile.indexOf(
+        "COPY extensions/memory-core/package.json ./extensions/memory-core/package.json",
+      ),
+    ).toBeLessThan(installIndex);
+    expect(dockerfile.indexOf("COPY src ./src")).toBeGreaterThan(installIndex);
+    expect(dockerfile.indexOf("COPY test ./test")).toBeGreaterThan(installIndex);
+    expect(dockerfile.indexOf("COPY scripts ./scripts")).toBeGreaterThan(installIndex);
+    expect(dockerfile.indexOf("COPY ui ./ui")).toBeGreaterThan(installIndex);
+  });
+
+  it("copies manifests before install in the qr-import image", async () => {
+    const dockerfile = await readRepoFile("scripts/e2e/Dockerfile.qr-import");
+    const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
+
+    expect(
+      dockerfile.indexOf("COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./"),
+    ).toBeLessThan(installIndex);
+    expect(dockerfile.indexOf("COPY ui/package.json ./ui/package.json")).toBeLessThan(installIndex);
+    expect(dockerfile.indexOf("COPY . .")).toBeGreaterThan(installIndex);
+  });
+});

--- a/src/docker-build-cache.test.ts
+++ b/src/docker-build-cache.test.ts
@@ -56,6 +56,32 @@ describe("docker build cache layout", () => {
     }
   });
 
+  it("does not leave empty shell continuation lines in sandbox-common", async () => {
+    const dockerfile = await readRepoFile("Dockerfile.sandbox-common");
+    expect(dockerfile).not.toContain("apt-get install -y --no-install-recommends ${PACKAGES} \\");
+    expect(dockerfile).toContain(
+      'RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi',
+    );
+  });
+
+  it("does not leave blank lines after shell continuation markers", async () => {
+    for (const path of [
+      "Dockerfile.sandbox",
+      "Dockerfile.sandbox-browser",
+      "Dockerfile.sandbox-common",
+      "scripts/docker/cleanup-smoke/Dockerfile",
+      "scripts/docker/install-sh-smoke/Dockerfile",
+      "scripts/docker/install-sh-e2e/Dockerfile",
+      "scripts/docker/install-sh-nonroot/Dockerfile",
+    ]) {
+      const dockerfile = await readRepoFile(path);
+      expect(
+        dockerfile,
+        `${path} should not have blank lines after a trailing backslash`,
+      ).not.toMatch(/\\\n\s*\n/);
+    }
+  });
+
   it("copies only install inputs before pnpm install in the e2e image", async () => {
     const dockerfile = await readRepoFile("scripts/e2e/Dockerfile");
     const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");

--- a/src/docker-build-cache.test.ts
+++ b/src/docker-build-cache.test.ts
@@ -86,12 +86,20 @@ describe("docker build cache layout", () => {
     const dockerfile = await readRepoFile("scripts/e2e/Dockerfile");
     const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
 
+    expect(
+      dockerfile.indexOf("COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./"),
+    ).toBeLessThan(installIndex);
     expect(dockerfile.indexOf("COPY ui/package.json ./ui/package.json")).toBeLessThan(installIndex);
     expect(
       dockerfile.indexOf(
         "COPY extensions/memory-core/package.json ./extensions/memory-core/package.json",
       ),
     ).toBeLessThan(installIndex);
+    expect(
+      dockerfile.indexOf(
+        "COPY tsconfig.json tsconfig.plugin-sdk.dts.json tsdown.config.ts vitest.config.ts vitest.e2e.config.ts openclaw.mjs ./",
+      ),
+    ).toBeGreaterThan(installIndex);
     expect(dockerfile.indexOf("COPY src ./src")).toBeGreaterThan(installIndex);
     expect(dockerfile.indexOf("COPY test ./test")).toBeGreaterThan(installIndex);
     expect(dockerfile.indexOf("COPY scripts ./scripts")).toBeGreaterThan(installIndex);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: several Docker images were invalidating dependency and apt layers too often because they copied broad source trees before install steps and did not cache package-manager metadata between builds.
- Why it matters: rebuilds were slower than necessary for the root image, e2e images, and helper images used by Docker-based smoke tests.
- What changed: added BuildKit cache mounts for pnpm and apt where those layers are built, moved root and e2e dependency installation to manifest-first copy order, fixed the sandbox/helper Dockerfiles to avoid broken empty continuation lines, and added regression coverage for the cache layout.
- What did NOT change (scope boundary): left the more invasive `ext-deps` manifest collection redesign out of this PR.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #40307

## User-visible / Behavior Changes

- None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  None.

## Repro + Verification

### Environment

- OS: macOS 15.4.1
- Runtime/container: Docker Desktop (`docker` driver)
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): local Docker image builds

### Steps

1. `pnpm install`
2. `pnpm test -- src/dockerfile.test.ts src/docker-build-cache.test.ts src/docker-image-digests.test.ts`
3. `pnpm format`
4. `docker build -t openclaw-cache-test -f Dockerfile .`
5. `docker build -t openclaw-cache-test -f Dockerfile .`
6. `docker build -t openclaw-qr-cache-test -f scripts/e2e/Dockerfile.qr-import .`
7. `docker build -t openclaw-sandbox-smoke-base:bookworm-slim - <<'EOF' ... EOF`
8. `BASE_IMAGE="openclaw-sandbox-smoke-base:bookworm-slim" TARGET_IMAGE="openclaw-sandbox-common-smoke:bookworm-slim" PACKAGES="ca-certificates" INSTALL_PNPM=0 INSTALL_BUN=0 INSTALL_BREW=0 FINAL_USER=sandbox scripts/sandbox-common-setup.sh`
9. `docker run --rm openclaw-sandbox-common-smoke:bookworm-slim sh -lc 'id -un'`

### Expected

- Targeted Dockerfile tests pass.
- The root Docker image still builds successfully.
- The QR-import image still builds successfully after switching to manifest-first dependency installation.
- A second root image build reuses cached pnpm and apt layers.
- The sandbox-common smoke path still builds and runs as the `sandbox` user.

### Actual

- Tests passed.
- The root Docker image built successfully twice.
- The second root build showed cache hits for the pnpm install and apt install layers.
- The QR-import image built successfully after the copy-order change.
- The sandbox-common smoke build completed successfully and `id -un` returned `sandbox`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Dockerfile tests, root Docker build, repeat root Docker build for cache reuse, QR-import Docker build, and the sandbox-common smoke workflow path.
- Edge cases checked: root image cache mounts work with optional apt steps left disabled; the QR-import image still resolves workspace installs when only manifests are copied before `pnpm install`; sandbox-common still returns to the `sandbox` user at runtime.
- What you did **not** verify: Podman compatibility for the new `RUN --mount=type=cache` usage, the full install-sh-e2e smoke path, and a redesign of the root `ext-deps` stage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commits in this PR or remove the BuildKit cache mounts and manifest-first copy-order changes from the touched Dockerfiles.
- Files/config to restore: `Dockerfile`, `Dockerfile.sandbox`, `Dockerfile.sandbox-common`, `scripts/e2e/Dockerfile`, `scripts/e2e/Dockerfile.qr-import`, `scripts/docker/*/Dockerfile`
- Known bad symptoms reviewers should watch for: Docker builds failing on engines without `RUN --mount=type=cache` support, unexpected dependency reinstall/cache misses after source-only edits, or Dockerfiles accidentally concatenating adjacent `RUN` instructions due to a dangling continuation.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some Docker engines may not support the added cache-mount syntax consistently.
  - Mitigation: verified on Docker Desktop and called out Podman compatibility as an unverified area for reviewers.
- Risk: a manifest needed for workspace dependency resolution was omitted from the pre-install copy set.
  - Mitigation: kept the required root, UI, patch, and `extensions/memory-core` manifests in place and verified root and QR-import builds.
- Risk: Dockerfile line continuations can accidentally merge adjacent instructions when cleanup commands are removed.
  - Mitigation: added regression coverage that fails on blank lines after trailing `\` markers and verified the sandbox-common smoke path that caught the bug.
