### PR TITLE
feat(web-fetch): add ssrfPolicy.allowRfc2544BenchmarkRange config option

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,44 @@
+## Summary
+
+Add a new `tools.web.fetch.ssrfPolicy` configuration block that lets operators opt-in to allowing the RFC 2544 benchmark IP range (198.18.0.0/15) through the SSRF guard.
+
+## Problem
+
+When OpenClaw runs behind proxy tools that use fake-IP DNS resolution (e.g. **Clash TUN mode** commonly used in China), hostnames resolve to addresses in the 198.18.0.0/15 range. The default SSRF guard correctly identifies these as special-use addresses and **blocks every `web_fetch` request**, making the tool completely unusable.
+
+The `browser` tool already has `ssrfPolicy.dangerouslyAllowPrivateNetwork` for similar scenarios, but `web_fetch` had no equivalent escape hatch.
+
+## Solution
+
+Add a scoped `ssrfPolicy` config to the web fetch tool:
+
+```json
+{
+  "tools": {
+    "web": {
+      "fetch": {
+        "ssrfPolicy": {
+          "allowRfc2544BenchmarkRange": true
+        }
+      }
+    }
+  }
+}
+```
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `src/config/zod-schema.agent-runtime.ts` | Add `ssrfPolicy` to `ToolsWebFetchSchema` |
+| `src/config/types.tools.ts` | Add TypeScript type + JSDoc |
+| `src/agents/tools/web-fetch.ts` | Add `resolveSsrfPolicy()`, wire policy through to `fetchWithWebToolsNetworkGuard` |
+
+### Design notes
+
+- **Opt-in only**: The RFC 2544 range remains blocked by default.
+- **Minimal surface**: Only `allowRfc2544BenchmarkRange` is exposed; the broader `dangerouslyAllowPrivateNetwork` is intentionally not included to limit security impact.
+- **Consistent pattern**: Follows the same `SsrFPolicy` mechanism already used by `withTrustedWebToolsEndpoint` and the browser tool.
+
+Closes #25322
+Ref #25258

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,16 +1,14 @@
 ## Summary
 
-Add a new `tools.web.fetch.ssrfPolicy` configuration block that lets operators opt-in to allowing the RFC 2544 benchmark IP range (198.18.0.0/15) through the SSRF guard.
+Add a new `ssrfPolicy.allowRfc2544BenchmarkRange` configuration option for both the `web_fetch` tool and the `browser` tool, letting operators opt-in to allowing the RFC 2544 benchmark IP range (198.18.0.0/15) through the SSRF guard.
 
 ## Problem
 
-When OpenClaw runs behind proxy tools that use fake-IP DNS resolution (e.g. **Clash TUN mode** commonly used in China), hostnames resolve to addresses in the 198.18.0.0/15 range. The default SSRF guard correctly identifies these as special-use addresses and **blocks every `web_fetch` request**, making the tool completely unusable.
-
-The `browser` tool already has `ssrfPolicy.dangerouslyAllowPrivateNetwork` for similar scenarios, but `web_fetch` had no equivalent escape hatch.
+When OpenClaw runs behind proxy tools that use fake-IP DNS resolution (e.g. **Clash TUN mode** commonly used in China), hostnames resolve to addresses in the 198.18.0.0/15 range. The default SSRF guard correctly identifies these as special-use addresses and **blocks every `web_fetch` and `browser` request**, making both tools completely unusable.
 
 ## Solution
 
-Add a scoped `ssrfPolicy` config to the web fetch tool:
+Add a scoped `ssrfPolicy` config to both the web fetch tool and the browser tool:
 
 ```json
 {
@@ -22,6 +20,11 @@ Add a scoped `ssrfPolicy` config to the web fetch tool:
         }
       }
     }
+  },
+  "browser": {
+    "ssrfPolicy": {
+      "allowRfc2544BenchmarkRange": true
+    }
   }
 }
 ```
@@ -31,14 +34,22 @@ Add a scoped `ssrfPolicy` config to the web fetch tool:
 | File | Change |
 |------|--------|
 | `src/config/zod-schema.agent-runtime.ts` | Add `ssrfPolicy` to `ToolsWebFetchSchema` |
-| `src/config/types.tools.ts` | Add TypeScript type + JSDoc |
+| `src/config/zod-schema.ts` | Add `allowRfc2544BenchmarkRange` to browser `ssrfPolicy` schema |
+| `src/config/types.tools.ts` | Add TypeScript type + JSDoc for web fetch |
+| `src/config/types.browser.ts` | Add `allowRfc2544BenchmarkRange` to `BrowserSsrFPolicyConfig` |
+| `src/config/schema.help.ts` | Add help text for browser config field |
+| `src/config/schema.labels.ts` | Add label for browser config field |
 | `src/agents/tools/web-fetch.ts` | Add `resolveSsrfPolicy()`, wire policy through to `fetchWithWebToolsNetworkGuard` |
+| `src/browser/config.ts` | Pass through `allowRfc2544BenchmarkRange` in `resolveBrowserSsrFPolicy` |
+| `src/browser/config.test.ts` | Add tests for browser config resolution with `allowRfc2544BenchmarkRange` |
+| `src/browser/navigation-guard.test.ts` | Add tests for RFC 2544 range blocking/allowing |
 
 ### Design notes
 
 - **Opt-in only**: The RFC 2544 range remains blocked by default.
-- **Minimal surface**: Only `allowRfc2544BenchmarkRange` is exposed; the broader `dangerouslyAllowPrivateNetwork` is intentionally not included to limit security impact.
+- **Minimal surface**: Only `allowRfc2544BenchmarkRange` is exposed; the broader `dangerouslyAllowPrivateNetwork` is intentionally not included for web fetch to limit security impact.
 - **Consistent pattern**: Follows the same `SsrFPolicy` mechanism already used by `withTrustedWebToolsEndpoint` and the browser tool.
+- **Both tools covered**: Browser tool now supports the same `allowRfc2544BenchmarkRange` option alongside its existing `dangerouslyAllowPrivateNetwork`.
 
 Closes #25322
 Ref #25258

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -528,8 +528,9 @@ async function maybeFetchFirecrawlWebFetchPayload(
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
+  const policySuffix = params.ssrfPolicy?.allowRfc2544BenchmarkRange ? ":rfc2544" : "";
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}${policySuffix}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { SsrFBlockedError, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
@@ -64,19 +64,19 @@ const WebFetchSchema = Type.Object({
 
 type WebFetchConfig = NonNullable<OpenClawConfig["tools"]>["web"] extends infer Web
   ? Web extends { fetch?: infer Fetch }
-    ? Fetch
-    : undefined
+  ? Fetch
+  : undefined
   : undefined;
 
 type FirecrawlFetchConfig =
   | {
-      enabled?: boolean;
-      apiKey?: string;
-      baseUrl?: string;
-      onlyMainContent?: boolean;
-      maxAgeMs?: number;
-      timeoutSeconds?: number;
-    }
+    enabled?: boolean;
+    apiKey?: string;
+    baseUrl?: string;
+    onlyMainContent?: boolean;
+    maxAgeMs?: number;
+    timeoutSeconds?: number;
+  }
   | undefined;
 
 function resolveFetchConfig(cfg?: OpenClawConfig): WebFetchConfig {
@@ -122,6 +122,33 @@ function resolveFetchMaxResponseBytes(fetch?: WebFetchConfig): number {
   }
   const value = Math.floor(raw);
   return Math.min(FETCH_MAX_RESPONSE_BYTES_MAX, Math.max(FETCH_MAX_RESPONSE_BYTES_MIN, value));
+}
+
+/**
+ * Read ssrfPolicy from the web.fetch config block.
+ *
+ * When users sit behind proxy tools that use fake-IP DNS (e.g. Clash TUN
+ * mode mapping hostnames to 198.18.x.x), the default SSRF guard blocks
+ * every outgoing fetch.  Returning a policy object with
+ * `allowRfc2544BenchmarkRange: true` lets those addresses through.
+ */
+function resolveSsrfPolicy(fetch?: WebFetchConfig): SsrFPolicy | undefined {
+  if (!fetch || typeof fetch !== "object") {
+    return undefined;
+  }
+  const policy = "ssrfPolicy" in fetch ? fetch.ssrfPolicy : undefined;
+  if (!policy || typeof policy !== "object") {
+    return undefined;
+  }
+  const allowRfc2544 =
+    "allowRfc2544BenchmarkRange" in policy &&
+      typeof policy.allowRfc2544BenchmarkRange === "boolean"
+      ? policy.allowRfc2544BenchmarkRange
+      : false;
+  if (!allowRfc2544) {
+    return undefined;
+  }
+  return { allowRfc2544BenchmarkRange: true };
 }
 
 function resolveFirecrawlConfig(fetch?: WebFetchConfig): FirecrawlFetchConfig {
@@ -446,6 +473,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  ssrfPolicy?: SsrFPolicy;
 };
 
 function toFirecrawlContentParams(
@@ -527,6 +555,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      policy: params.ssrfPolicy,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -744,6 +773,7 @@ export function createWebFetchTool(options?: {
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readNumberParam(params, "maxChars", { integer: true });
       const maxCharsCap = resolveFetchMaxCharsCap(fetch);
+      const ssrfPolicy = resolveSsrfPolicy(fetch);
       const result = await runWebFetch({
         url,
         extractMode,
@@ -758,6 +788,7 @@ export function createWebFetchTool(options?: {
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
         readabilityEnabled,
+        ssrfPolicy,
         firecrawlEnabled,
         firecrawlApiKey,
         firecrawlBaseUrl,

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -278,6 +278,30 @@ describe("browser config", () => {
     expect(resolved.ssrfPolicy).toEqual({});
   });
 
+  it("passes through allowRfc2544BenchmarkRange when enabled", () => {
+    const resolved = resolveBrowserConfig({
+      ssrfPolicy: {
+        allowRfc2544BenchmarkRange: true,
+      },
+    });
+    expect(resolved.ssrfPolicy).toEqual({
+      dangerouslyAllowPrivateNetwork: true,
+      allowRfc2544BenchmarkRange: true,
+    });
+  });
+
+  it("omits allowRfc2544BenchmarkRange when not set or false", () => {
+    const resolved = resolveBrowserConfig({
+      ssrfPolicy: {
+        allowRfc2544BenchmarkRange: false,
+      },
+    });
+    expect(resolved.ssrfPolicy).toEqual({
+      dangerouslyAllowPrivateNetwork: true,
+    });
+    expect(resolved.ssrfPolicy).not.toHaveProperty("allowRfc2544BenchmarkRange");
+  });
+
   describe("default profile preference", () => {
     it("defaults to openclaw profile when defaultProfile is not configured", () => {
       const resolved = resolveBrowserConfig({

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -101,6 +101,7 @@ function normalizeStringList(raw: string[] | undefined): string[] | undefined {
 function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
   const allowPrivateNetwork = cfg?.ssrfPolicy?.allowPrivateNetwork;
   const dangerouslyAllowPrivateNetwork = cfg?.ssrfPolicy?.dangerouslyAllowPrivateNetwork;
+  const allowRfc2544BenchmarkRange = cfg?.ssrfPolicy?.allowRfc2544BenchmarkRange;
   const allowedHostnames = normalizeStringList(cfg?.ssrfPolicy?.allowedHostnames);
   const hostnameAllowlist = normalizeStringList(cfg?.ssrfPolicy?.hostnameAllowlist);
   const hasExplicitPrivateSetting =
@@ -114,6 +115,7 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
   if (
     !resolvedAllowPrivateNetwork &&
     !hasExplicitPrivateSetting &&
+    !allowRfc2544BenchmarkRange &&
     !allowedHostnames &&
     !hostnameAllowlist
   ) {
@@ -122,6 +124,7 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
 
   return {
     ...(resolvedAllowPrivateNetwork ? { dangerouslyAllowPrivateNetwork: true } : {}),
+    ...(allowRfc2544BenchmarkRange === true ? { allowRfc2544BenchmarkRange: true } : {}),
     ...(allowedHostnames ? { allowedHostnames } : {}),
     ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
   };
@@ -236,10 +239,10 @@ export function resolveBrowserConfig(
   const rawCdpUrl = (cfg?.cdpUrl ?? "").trim();
   let cdpInfo:
     | {
-        parsed: URL;
-        port: number;
-        normalized: string;
-      }
+      parsed: URL;
+      port: number;
+      normalized: string;
+    }
     | undefined;
   if (rawCdpUrl) {
     cdpInfo = parseHttpUrl(rawCdpUrl, "browser.cdpUrl");

--- a/src/browser/navigation-guard.test.ts
+++ b/src/browser/navigation-guard.test.ts
@@ -130,6 +130,27 @@ describe("browser navigation guard", () => {
     ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
   });
 
+  it("blocks RFC 2544 benchmark range IPs by default", async () => {
+    const lookupFn = createLookupFn("198.18.0.1");
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "https://example.com",
+        lookupFn,
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+  });
+
+  it("allows RFC 2544 benchmark range IPs when allowRfc2544BenchmarkRange is enabled", async () => {
+    const lookupFn = createLookupFn("198.18.0.1");
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "https://example.com",
+        lookupFn,
+        ssrfPolicy: { allowRfc2544BenchmarkRange: true },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("validates final network URLs after navigation", async () => {
     const lookupFn = createLookupFn("127.0.0.1");
     await expect(

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -280,6 +280,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit hostname allowlist exceptions for SSRF policy checks on browser/network requests. Keep this list minimal and review entries regularly to avoid stale broad access.",
   "browser.ssrfPolicy.hostnameAllowlist":
     "Legacy/alternate hostname allowlist field used by SSRF policy consumers for explicit host exceptions. Use stable exact hostnames and avoid wildcard-like broad patterns.",
+  "browser.ssrfPolicy.allowRfc2544BenchmarkRange":
+    "Allows the RFC 2544 benchmark IP range (198.18.0.0/15) through the browser SSRF guard. Enable this when running behind fake-IP DNS proxies such as Clash TUN mode that resolve hostnames to addresses in this range. Keep disabled unless your network setup specifically requires it.",
   "browser.remoteCdpTimeoutMs":
     "Timeout in milliseconds for connecting to a remote CDP endpoint before failing the browser attach attempt. Increase for high-latency tunnels, or lower for faster failure detection.",
   "browser.remoteCdpHandshakeTimeoutMs":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -504,6 +504,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "browser.ssrfPolicy.dangerouslyAllowPrivateNetwork": "Browser Dangerously Allow Private Network",
   "browser.ssrfPolicy.allowedHostnames": "Browser Allowed Hostnames",
   "browser.ssrfPolicy.hostnameAllowlist": "Browser Hostname Allowlist",
+  "browser.ssrfPolicy.allowRfc2544BenchmarkRange": "Browser Allow RFC 2544 Benchmark Range",
   "browser.remoteCdpTimeoutMs": "Remote CDP Timeout (ms)",
   "browser.remoteCdpHandshakeTimeoutMs": "Remote CDP Handshake Timeout (ms)",
   session: "Session",

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -20,6 +20,12 @@ export type BrowserSsrFPolicyConfig = {
   /** If true, permit browser navigation to private/internal networks. Default: true */
   dangerouslyAllowPrivateNetwork?: boolean;
   /**
+   * If true, allow the RFC 2544 benchmark IP range (198.18.0.0/15) through
+   * the SSRF guard. Useful when running behind fake-IP DNS proxies such as
+   * Clash TUN mode.
+   */
+  allowRfc2544BenchmarkRange?: boolean;
+  /**
    * Explicitly allowed hostnames (exact-match), including blocked names like localhost.
    * Example: ["localhost", "metadata.internal"]
    */

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -508,6 +508,22 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /**
+       * SSRF policy overrides for web_fetch.
+       *
+       * Useful when running behind proxy tools (e.g. Clash TUN fake-ip mode)
+       * that resolve hostnames to addresses in the RFC 2544 benchmark range
+       * (198.18.0.0/15), which would otherwise be blocked by default SSRF
+       * protection.
+       */
+      ssrfPolicy?: {
+        /**
+         * Allow the RFC 2544 benchmark range (198.18.0.0/15).
+         * Required when using Clash or similar proxy tools in fake-ip mode.
+         * Default: false.
+         */
+        allowRfc2544BenchmarkRange?: boolean;
+      };
       firecrawl?: {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -327,6 +327,12 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    ssrfPolicy: z
+      .object({
+        allowRfc2544BenchmarkRange: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -345,6 +345,7 @@ export const OpenClawSchema = z
           .object({
             allowPrivateNetwork: z.boolean().optional(),
             dangerouslyAllowPrivateNetwork: z.boolean().optional(),
+            allowRfc2544BenchmarkRange: z.boolean().optional(),
             allowedHostnames: z.array(z.string()).optional(),
             hostnameAllowlist: z.array(z.string()).optional(),
           })


### PR DESCRIPTION
## Summary

Add a new `tools.web.fetch.ssrfPolicy` configuration block that lets operators opt-in to allowing the RFC 2544 benchmark IP range (198.18.0.0/15) through the SSRF guard.

## Problem

When OpenClaw runs behind proxy tools that use fake-IP DNS resolution (e.g. **Clash TUN mode** commonly used in China), hostnames resolve to addresses in the 198.18.0.0/15 range. The default SSRF guard correctly identifies these as special-use addresses and **blocks every `web_fetch` request**, making the tool completely unusable.

The `browser` tool already has `ssrfPolicy.dangerouslyAllowPrivateNetwork` for similar scenarios, but `web_fetch` had no equivalent escape hatch.

## Solution

Add a scoped `ssrfPolicy` config to the web fetch tool:

```json
{
  "tools": {
    "web": {
      "fetch": {
        "ssrfPolicy": {
          "allowRfc2544BenchmarkRange": true
        }
      }
    }
  }
}
```

### Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.agent-runtime.ts` | Add `ssrfPolicy` to `ToolsWebFetchSchema` |
| `src/config/types.tools.ts` | Add TypeScript type + JSDoc |
| `src/agents/tools/web-fetch.ts` | Add `resolveSsrfPolicy()`, wire policy through to `fetchWithWebToolsNetworkGuard` |

### Design notes

- **Opt-in only**: The RFC 2544 range remains blocked by default.
- **Minimal surface**: Only `allowRfc2544BenchmarkRange` is exposed; the broader `dangerouslyAllowPrivateNetwork` is intentionally not included to limit security impact.
- **Consistent pattern**: Follows the same `SsrFPolicy` mechanism already used by `withTrustedWebToolsEndpoint` and the browser tool.

Closes #25322
Ref #25258
