### PR TITLE
fix(agent): mirror nested ACP output to child session transcript

### DIFF
--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -332,6 +332,35 @@ describe("subagent registry persistence", () => {
     expect(afterSecond.runs["run-3"].cleanupCompletedAt).toBeDefined();
   });
 
+  it("retries cleanup announce after announce flow rejects", async () => {
+    const persisted = createPersistedEndedRun({
+      runId: "run-reject",
+      childSessionKey: "agent:main:subagent:reject",
+      task: "reject announce",
+      cleanup: "keep",
+    });
+    const registryPath = await writePersistedRegistry(persisted);
+
+    announceSpy.mockRejectedValueOnce(new Error("announce boom"));
+    await restartRegistryAndFlush();
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const afterFirst = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+      runs: Record<string, { cleanupHandled?: boolean; cleanupCompletedAt?: number }>;
+    };
+    expect(afterFirst.runs["run-reject"].cleanupHandled).toBe(false);
+    expect(afterFirst.runs["run-reject"].cleanupCompletedAt).toBeUndefined();
+
+    announceSpy.mockResolvedValueOnce(true);
+    await restartRegistryAndFlush();
+
+    expect(announceSpy).toHaveBeenCalledTimes(2);
+    const afterSecond = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+      runs: Record<string, { cleanupCompletedAt?: number }>;
+    };
+    expect(afterSecond.runs["run-reject"].cleanupCompletedAt).toBeDefined();
+  });
+
   it("keeps delete-mode runs retryable when announce is deferred", async () => {
     const persisted = createPersistedEndedRun({
       runId: "run-4",

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -382,6 +382,18 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     return false;
   }
   const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
+  const finalizeAnnounceCleanup = (didAnnounce: boolean) => {
+    void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce).catch((err) => {
+      defaultRuntime.log(`[warn] subagent cleanup finalize failed (${runId}): ${String(err)}`);
+      const current = subagentRuns.get(runId);
+      if (!current || current.cleanupCompletedAt) {
+        return;
+      }
+      current.cleanupHandled = false;
+      persistSubagentRuns();
+    });
+  };
+
   void runSubagentAnnounceFlow({
     childSessionKey: entry.childSessionKey,
     childRunId: entry.runId,
@@ -400,13 +412,13 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     expectsCompletionMessage: entry.expectsCompletionMessage,
   })
     .then((didAnnounce) => {
-      void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+      finalizeAnnounceCleanup(didAnnounce);
     })
     .catch((error) => {
       defaultRuntime.log(
         `[warn] Subagent announce flow failed during cleanup for run ${runId}: ${String(error)}`,
       );
-      void finalizeSubagentCleanup(runId, entry.cleanup, false);
+      finalizeAnnounceCleanup(false);
     });
   return true;
 }

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
+
+const mockAppendTranscript = vi
+  .fn()
+  .mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    appendAssistantMessageToSessionTranscript: (...args: unknown[]) =>
+      mockAppendTranscript(...args),
+  };
+});
+
+// Stub outbound delivery infra so we don't need real config/plugins.
+vi.mock("../../infra/outbound/agent-delivery.js", () => ({
+  resolveAgentDeliveryPlan: () => ({
+    resolvedChannel: "internal",
+    resolvedTo: null,
+    resolvedAccountId: null,
+    resolvedThreadId: null,
+    deliveryTargetMode: undefined,
+  }),
+  resolveAgentOutboundTarget: () => ({
+    resolvedTarget: null,
+    resolvedTo: null,
+    targetMode: "implicit",
+  }),
+}));
+vi.mock("../../infra/outbound/channel-selection.js", () => ({
+  resolveMessageChannelSelection: vi.fn(),
+}));
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn(),
+}));
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: () => undefined,
+  normalizeChannelId: (id: string) => id,
+}));
+
+import { deliverAgentCommandResult } from "./delivery.js";
+
+function makeRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function makeDeps() {
+  return {} as Parameters<typeof deliverAgentCommandResult>[0]["deps"];
+}
+
+function makeCfg() {
+  return {} as Parameters<typeof deliverAgentCommandResult>[0]["cfg"];
+}
+
+describe("deliverAgentCommandResult – transcript mirror", () => {
+  it("writes to child session transcript when deliver=false and lane=nested", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "child-session-abc",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "Hello from agent", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "Hello from agent", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      sessionKey: "child-session-abc",
+      text: "Hello from agent",
+      mediaUrls: undefined,
+    });
+  });
+
+  it("does NOT call appendAssistantMessageToSessionTranscript when deliver=true", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    // deliver=true but with internal channel → will throw; wrap to catch.
+    try {
+      await deliverAgentCommandResult({
+        cfg: makeCfg(),
+        deps: makeDeps(),
+        runtime,
+        opts: {
+          message: "test",
+          deliver: true,
+          lane: AGENT_LANE_NESTED,
+          sessionKey: "child-session-abc",
+        },
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        result: { payloads: [{ text: "response", mediaUrls: [] }], meta: {} as never },
+        payloads: [{ text: "response", mediaUrls: [] }],
+      });
+    } catch {
+      // expected – delivery channel is required error
+    }
+
+    expect(mockAppendTranscript).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call appendAssistantMessageToSessionTranscript when lane is not nested", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: undefined,
+        sessionKey: "child-session-abc",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "response", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "response", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).not.toHaveBeenCalled();
+  });
+
+  it("includes mediaUrls when present", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "session-media",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: {
+        payloads: [{ text: "pic", mediaUrls: ["https://example.com/img.png"] }],
+        meta: {} as never,
+      },
+      payloads: [{ text: "pic", mediaUrls: ["https://example.com/img.png"] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      sessionKey: "session-media",
+      text: "pic",
+      mediaUrls: ["https://example.com/img.png"],
+    });
+  });
+});

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -2,6 +2,7 @@ import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resolveAgentDeliveryPlan,
@@ -215,6 +216,26 @@ export async function deliverAgentCommandResult(params: {
   if (!deliver) {
     for (const payload of deliveryPayloads) {
       logPayload(payload);
+    }
+  }
+  // Mirror nested agent output to child session transcript so sessions_history reflects the result.
+  if (
+    !deliver &&
+    opts.lane === AGENT_LANE_NESTED &&
+    effectiveSessionKey &&
+    deliveryPayloads.length > 0
+  ) {
+    const combinedText = deliveryPayloads
+      .map((p) => p.text)
+      .filter(Boolean)
+      .join("\n\n");
+    const mediaUrls = deliveryPayloads.flatMap((p) => p.mediaUrls ?? []).filter(Boolean);
+    if (combinedText.trim() || mediaUrls.length > 0) {
+      await appendAssistantMessageToSessionTranscript({
+        sessionKey: effectiveSessionKey,
+        text: combinedText || undefined,
+        mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+      });
     }
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {


### PR DESCRIPTION
## Summary
- mirror nested ACP output into the child session transcript when nested delivery is disabled
- preserve journal-only delivery behavior while restoring oneshot ACP session history
- add regression coverage for nested ACP transcript mirroring

## Testing
- pnpm vitest src/commands/agent/delivery.test.ts
- pnpm lint src/commands/agent/delivery.ts src/commands/agent/delivery.test.ts