### PR TITLE
fix(feishu): recover group peer routing on named accounts

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1709,6 +1709,79 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("falls back to default-account peer bindings for group routes on named accounts", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    mockResolveAgentRoute
+      .mockReturnValueOnce({
+        agentId: "main-agent",
+        channel: "feishu",
+        accountId: "router-d",
+        sessionKey: "agent:main-agent:feishu:group:oc-group-fallback",
+        mainSessionKey: "agent:main-agent:main",
+        matchedBy: "default",
+      })
+      .mockReturnValueOnce({
+        agentId: "hr-agent",
+        channel: "feishu",
+        accountId: "default",
+        sessionKey: "agent:hr-agent:feishu:group:oc-group-fallback",
+        mainSessionKey: "agent:hr-agent:main",
+        matchedBy: "binding.peer",
+      });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group-fallback": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-group-fallback" } },
+      message: {
+        message_id: "msg-group-fallback",
+        chat_id: "oc-group-fallback",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      accountId: "router-d",
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockResolveAgentRoute).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ channel: "feishu", accountId: "router-d" }),
+    );
+    expect(mockResolveAgentRoute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ channel: "feishu", accountId: "default" }),
+    );
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SessionKey: "agent:hr-agent:feishu:group:oc-group-fallback",
+        AccountId: "router-d",
+      }),
+    );
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "hr-agent",
+      }),
+    );
+  });
+
   it("does not dispatch twice for the same image message_id (concurrent dedupe)", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -4,6 +4,7 @@ import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
   createScopedPairingAccess,
+  DEFAULT_ACCOUNT_ID,
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
   issuePairingChallenge,
@@ -1165,16 +1166,37 @@ export async function handleFeishuMessage(params: {
       );
     }
 
-    let route = core.channel.routing.resolveAgentRoute({
-      cfg,
+    const routeInput = {
       channel: "feishu",
-      accountId: account.accountId,
       peer: {
         kind: isGroup ? "group" : "direct",
         id: peerId,
       },
       parentPeer,
+    } as const;
+
+    let route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      ...routeInput,
+      accountId: account.accountId,
     });
+
+    if (isGroup && route.matchedBy === "default" && account.accountId !== DEFAULT_ACCOUNT_ID) {
+      const fallbackRoute = core.channel.routing.resolveAgentRoute({
+        cfg,
+        ...routeInput,
+        accountId: DEFAULT_ACCOUNT_ID,
+      });
+      if (fallbackRoute.matchedBy === "binding.peer" || fallbackRoute.matchedBy === "binding.peer.parent") {
+        route = {
+          ...fallbackRoute,
+          accountId: account.accountId,
+        };
+        log(
+          `feishu[${account.accountId}]: recovered group route via default-account peer binding (peer=${peerId}, agent=${route.agentId})`,
+        );
+      }
+    }
 
     // Dynamic agent creation for DM users
     // When enabled, creates a unique agent instance with its own workspace for each DM user.


### PR DESCRIPTION
## Summary
- add a Feishu group-route fallback for named accounts: when routing on the active account falls back to the default agent, retry route resolution against default-account bindings
- apply the fallback only for group traffic and only when the fallback result is a peer-scoped match (binding.peer / binding.peer.parent)
- preserve the active runtime account id in the finalized dispatch context so tool/account routing still uses the live account
- add a regression test covering named-account group routing fallback behavior

## Testing
- bash /Users/newdldewdl/.openclaw/workspace/skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /tmp/openclaw-issue-40337-1773012292 ✅

Closes #40337
