### PR TITLE
Fix one-shot exit hangs by tearing down cached memory managers

### DIFF
--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -1,5 +1,8 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/bluebubbles";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { z } from "zod";
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
 

--- a/extensions/bluebubbles/src/runtime.ts
+++ b/extensions/bluebubbles/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 
 const runtimeStore = createPluginRuntimeStore<PluginRuntime>("BlueBubbles runtime not initialized");
 type LegacyRuntimeLogShape = { log?: (message: string) => void };

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/discord";
 
 const { setRuntime: setDiscordRuntime, getRuntime: getDiscordRuntime } =

--- a/extensions/feishu/src/runtime.ts
+++ b/extensions/feishu/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/feishu";
 
 const { setRuntime: setFeishuRuntime, getRuntime: getFeishuRuntime } =

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
   buildOpenGroupPolicyConfigureRouteAllowlistWarning,

--- a/extensions/googlechat/src/runtime.ts
+++ b/extensions/googlechat/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/googlechat";
 
 const { setRuntime: setGoogleChatRuntime, getRuntime: getGoogleChatRuntime } =

--- a/extensions/imessage/src/runtime.ts
+++ b/extensions/imessage/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/imessage";
 
 const { setRuntime: setIMessageRuntime, getRuntime: getIMessageRuntime } =

--- a/extensions/irc/src/runtime.ts
+++ b/extensions/irc/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/irc";
 
 const { setRuntime: setIrcRuntime, getRuntime: getIrcRuntime } =

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/line";
 
 const { setRuntime: setLineRuntime, getRuntime: getLineRuntime } =

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
 
 const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/mattermost";
 
 const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/msteams";
 
 const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =

--- a/extensions/nextcloud-talk/src/runtime.ts
+++ b/extensions/nextcloud-talk/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nextcloud-talk";
 
 const { setRuntime: setNextcloudTalkRuntime, getRuntime: getNextcloudTalkRuntime } =

--- a/extensions/nostr/src/runtime.ts
+++ b/extensions/nostr/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nostr";
 
 const { setRuntime: setNostrRuntime, getRuntime: getNostrRuntime } =

--- a/extensions/signal/src/runtime.ts
+++ b/extensions/signal/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/signal";
 
 const { setRuntime: setSignalRuntime, getRuntime: getSignalRuntime } =

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,

--- a/extensions/slack/src/runtime.ts
+++ b/extensions/slack/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/slack";
 
 const { setRuntime: setSlackRuntime, getRuntime: getSlackRuntime } =

--- a/extensions/synology-chat/src/runtime.ts
+++ b/extensions/synology-chat/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/synology-chat";
 
 const { setRuntime: setSynologyRuntime, getRuntime: getSynologyRuntime } =

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
 import {
   collectAllowlistProviderGroupPolicyWarnings,
   buildAccountScopedDmSecurityPolicy,

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/telegram";
 
 const { setRuntime: setTelegramRuntime, getRuntime: getTelegramRuntime } =

--- a/extensions/tlon/src/runtime.ts
+++ b/extensions/tlon/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/tlon";
 
 const { setRuntime: setTlonRuntime, getRuntime: getTlonRuntime } =

--- a/extensions/twitch/src/runtime.ts
+++ b/extensions/twitch/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/twitch";
 
 const { setRuntime: setTwitchRuntime, getRuntime: getTwitchRuntime } =

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/whatsapp";
 
 const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =

--- a/extensions/zalo/src/config-schema.ts
+++ b/extensions/zalo/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { MarkdownConfigSchema } from "openclaw/plugin-sdk/zalo";
 import { z } from "zod";
 import { buildSecretInputSchema } from "./secret-input.js";

--- a/extensions/zalo/src/runtime.ts
+++ b/extensions/zalo/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalo";
 
 const { setRuntime: setZaloRuntime, getRuntime: getZaloRuntime } =

--- a/extensions/zalouser/src/config-schema.ts
+++ b/extensions/zalouser/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/compat";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/zalouser";
 import { z } from "zod";
 

--- a/extensions/zalouser/src/runtime.ts
+++ b/extensions/zalouser/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalouser";
 
 const { setRuntime: setZalouserRuntime, getRuntime: getZalouserRuntime } =

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -6,6 +6,7 @@ const loadDotEnvMock = vi.hoisted(() => vi.fn());
 const normalizeEnvMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
+const closeAllMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("./route.js", () => ({
   tryRouteCli: tryRouteCliMock,
@@ -27,6 +28,10 @@ vi.mock("../infra/runtime-guard.js", () => ({
   assertSupportedRuntime: assertRuntimeMock,
 }));
 
+vi.mock("../memory/index.js", () => ({
+  closeAllMemorySearchManagers: closeAllMemorySearchManagersMock,
+}));
+
 const { runCli } = await import("./run-main.js");
 
 describe("runCli exit behavior", () => {
@@ -43,6 +48,7 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "status"]);
 
     expect(tryRouteCliMock).toHaveBeenCalledWith(["node", "openclaw", "status"]);
+    expect(closeAllMemorySearchManagersMock).toHaveBeenCalledTimes(1);
     expect(exitSpy).not.toHaveBeenCalled();
     exitSpy.mockRestore();
   });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -13,6 +13,15 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { tryRouteCli } from "./route.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
+async function closeCliMemoryManagers(): Promise<void> {
+  try {
+    const { closeAllMemorySearchManagers } = await import("../memory/index.js");
+    await closeAllMemorySearchManagers();
+  } catch {
+    // Best-effort teardown for short-lived CLI processes.
+  }
+}
+
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
   const index = argv.indexOf("--update");
   if (index === -1) {
@@ -82,59 +91,63 @@ export async function runCli(argv: string[] = process.argv) {
   // Enforce the minimum supported runtime before doing any work.
   assertSupportedRuntime();
 
-  if (await tryRouteCli(normalizedArgv)) {
-    return;
-  }
-
-  // Capture all console output into structured logs while keeping stdout/stderr behavior.
-  enableConsoleCapture();
-
-  const { buildProgram } = await import("./program.js");
-  const program = buildProgram();
-
-  // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
-  // These log the error and exit gracefully instead of crashing without trace.
-  installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
-
-  const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
-  // Register the primary command (builtin or subcli) so help and command parsing
-  // are correct even with lazy command registration.
-  const primary = getPrimaryCommand(parseArgv);
-  if (primary) {
-    const { getProgramContext } = await import("./program/program-context.js");
-    const ctx = getProgramContext(program);
-    if (ctx) {
-      const { registerCoreCliByName } = await import("./program/command-registry.js");
-      await registerCoreCliByName(program, ctx, primary, parseArgv);
+  try {
+    if (await tryRouteCli(normalizedArgv)) {
+      return;
     }
-    const { registerSubCliByName } = await import("./program/register.subclis.js");
-    await registerSubCliByName(program, primary);
-  }
 
-  const hasBuiltinPrimary =
-    primary !== null && program.commands.some((command) => command.name() === primary);
-  const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
-    argv: parseArgv,
-    primary,
-    hasBuiltinPrimary,
-  });
-  if (!shouldSkipPluginRegistration) {
-    // Register plugin CLI commands before parsing
-    const { registerPluginCliCommands } = await import("../plugins/cli.js");
-    const { loadValidatedConfigForPluginRegistration } =
-      await import("./program/register.subclis.js");
-    const config = await loadValidatedConfigForPluginRegistration();
-    if (config) {
-      registerPluginCliCommands(program, config);
+    // Capture all console output into structured logs while keeping stdout/stderr behavior.
+    enableConsoleCapture();
+
+    const { buildProgram } = await import("./program.js");
+    const program = buildProgram();
+
+    // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
+    // These log the error and exit gracefully instead of crashing without trace.
+    installUnhandledRejectionHandler();
+
+    process.on("uncaughtException", (error) => {
+      console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
+      process.exit(1);
+    });
+
+    const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
+    // Register the primary command (builtin or subcli) so help and command parsing
+    // are correct even with lazy command registration.
+    const primary = getPrimaryCommand(parseArgv);
+    if (primary) {
+      const { getProgramContext } = await import("./program/program-context.js");
+      const ctx = getProgramContext(program);
+      if (ctx) {
+        const { registerCoreCliByName } = await import("./program/command-registry.js");
+        await registerCoreCliByName(program, ctx, primary, parseArgv);
+      }
+      const { registerSubCliByName } = await import("./program/register.subclis.js");
+      await registerSubCliByName(program, primary);
     }
-  }
 
-  await program.parseAsync(parseArgv);
+    const hasBuiltinPrimary =
+      primary !== null && program.commands.some((command) => command.name() === primary);
+    const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
+      argv: parseArgv,
+      primary,
+      hasBuiltinPrimary,
+    });
+    if (!shouldSkipPluginRegistration) {
+      // Register plugin CLI commands before parsing
+      const { registerPluginCliCommands } = await import("../plugins/cli.js");
+      const { loadValidatedConfigForPluginRegistration } =
+        await import("./program/register.subclis.js");
+      const config = await loadValidatedConfigForPluginRegistration();
+      if (config) {
+        registerPluginCliCommands(program, config);
+      }
+    }
+
+    await program.parseAsync(parseArgv);
+  } finally {
+    await closeCliMemoryManagers();
+  }
 }
 
 export function isCliMainModule(): boolean {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,4 +4,8 @@ export type {
   MemorySearchManager,
   MemorySearchResult,
 } from "./types.js";
-export { getMemorySearchManager, type MemorySearchManagerResult } from "./search-manager.js";
+export {
+  closeAllMemorySearchManagers,
+  getMemorySearchManager,
+  type MemorySearchManagerResult,
+} from "./search-manager.js";

--- a/src/memory/manager-runtime.ts
+++ b/src/memory/manager-runtime.ts
@@ -1,1 +1,1 @@
-export { MemoryIndexManager } from "./manager.js";
+export { closeAllMemoryIndexManagers, MemoryIndexManager } from "./manager.js";

--- a/src/memory/manager.get-concurrency.test.ts
+++ b/src/memory/manager.get-concurrency.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
+import {
+  closeAllMemoryIndexManagers,
+  MemoryIndexManager as RawMemoryIndexManager,
+} from "./manager.js";
 import "./test-runtime-mocks.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -77,5 +81,38 @@ describe("memory manager cache hydration", () => {
     expect(hoisted.providerCreateCalls).toBe(1);
 
     await managers[0].close();
+  });
+
+  it("drains in-flight manager creation during global teardown", async () => {
+    const indexPath = path.join(workspaceDir, "index.sqlite");
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath, vector: { enabled: false } },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    hoisted.providerDelayMs = 100;
+
+    const pendingResult = RawMemoryIndexManager.get({ cfg, agentId: "main" });
+    await closeAllMemoryIndexManagers();
+    const firstManager = await pendingResult;
+
+    const secondManager = await RawMemoryIndexManager.get({ cfg, agentId: "main" });
+
+    expect(firstManager).toBeTruthy();
+    expect(secondManager).toBeTruthy();
+    expect(Object.is(secondManager, firstManager)).toBe(false);
+    expect(hoisted.providerCreateCalls).toBe(2);
+
+    await secondManager?.close?.();
   });
 });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -42,6 +42,21 @@ const log = createSubsystemLogger("memory");
 const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 const INDEX_CACHE_PENDING = new Map<string, Promise<MemoryIndexManager>>();
 
+export async function closeAllMemoryIndexManagers(): Promise<void> {
+  const managers = Array.from(INDEX_CACHE.values());
+  if (managers.length === 0) {
+    return;
+  }
+  for (const manager of managers) {
+    try {
+      await manager.close();
+    } catch (err) {
+      log.warn(`failed to close memory index manager: ${String(err)}`);
+    }
+  }
+  INDEX_CACHE.clear();
+}
+
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
   protected readonly cfg: OpenClawConfig;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -43,10 +43,12 @@ const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 const INDEX_CACHE_PENDING = new Map<string, Promise<MemoryIndexManager>>();
 
 export async function closeAllMemoryIndexManagers(): Promise<void> {
-  const managers = Array.from(INDEX_CACHE.values());
-  if (managers.length === 0) {
-    return;
+  const pending = Array.from(INDEX_CACHE_PENDING.values());
+  if (pending.length > 0) {
+    await Promise.allSettled(pending);
   }
+  const managers = Array.from(INDEX_CACHE.values());
+  INDEX_CACHE.clear();
   for (const manager of managers) {
     try {
       await manager.close();
@@ -54,7 +56,6 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
       log.warn(`failed to close memory index manager: ${String(err)}`);
     }
   }
-  INDEX_CACHE.clear();
 }
 
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -29,53 +29,53 @@ function createManagerStatus(params: {
   };
 }
 
-const qmdManagerStatus = createManagerStatus({
-  backend: "qmd",
-  provider: "qmd",
-  model: "qmd",
-  requestedProvider: "qmd",
-  withMemorySourceCounts: true,
-});
-
-const fallbackManagerStatus = createManagerStatus({
-  backend: "builtin",
-  provider: "openai",
-  model: "text-embedding-3-small",
-  requestedProvider: "openai",
-});
-
-const mockPrimary = {
+const mockPrimary = vi.hoisted(() => ({
   search: vi.fn(async () => []),
   readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
-  status: vi.fn(() => qmdManagerStatus),
+  status: vi.fn(() =>
+    createManagerStatus({
+      backend: "qmd",
+      provider: "qmd",
+      model: "qmd",
+      requestedProvider: "qmd",
+      withMemorySourceCounts: true,
+    }),
+  ),
   sync: vi.fn(async () => {}),
   probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
   probeVectorAvailability: vi.fn(async () => true),
   close: vi.fn(async () => {}),
-};
+}));
 
-const fallbackSearch = vi.fn(async () => [
-  {
-    path: "MEMORY.md",
-    startLine: 1,
-    endLine: 1,
-    score: 1,
-    snippet: "fallback",
-    source: "memory" as const,
-  },
-]);
-
-const fallbackManager = {
-  search: fallbackSearch,
+const fallbackManager = vi.hoisted(() => ({
+  search: vi.fn(async () => [
+    {
+      path: "MEMORY.md",
+      startLine: 1,
+      endLine: 1,
+      score: 1,
+      snippet: "fallback",
+      source: "memory" as const,
+    },
+  ]),
   readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
-  status: vi.fn(() => fallbackManagerStatus),
+  status: vi.fn(() =>
+    createManagerStatus({
+      backend: "builtin",
+      provider: "openai",
+      model: "text-embedding-3-small",
+      requestedProvider: "openai",
+    }),
+  ),
   sync: vi.fn(async () => {}),
   probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
   probeVectorAvailability: vi.fn(async () => true),
   close: vi.fn(async () => {}),
-};
+}));
 
-const mockMemoryIndexGet = vi.fn(async () => fallbackManager);
+const fallbackSearch = fallbackManager.search;
+const mockMemoryIndexGet = vi.hoisted(() => vi.fn(async () => fallbackManager));
+const mockCloseAllMemoryIndexManagers = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("./qmd-manager.js", () => ({
   QmdMemoryManager: {
@@ -87,10 +87,11 @@ vi.mock("./manager.js", () => ({
   MemoryIndexManager: {
     get: mockMemoryIndexGet,
   },
+  closeAllMemoryIndexManagers: mockCloseAllMemoryIndexManagers,
 }));
 
 import { QmdMemoryManager } from "./qmd-manager.js";
-import { getMemorySearchManager } from "./search-manager.js";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./search-manager.js";
 // eslint-disable-next-line @typescript-eslint/unbound-method -- mocked static function
 const createQmdManagerMock = vi.mocked(QmdMemoryManager.create);
 
@@ -119,7 +120,8 @@ async function createFailedQmdSearchHarness(params: { agentId: string; errorMess
   return { cfg, manager: requireManager(first), firstResult: first };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await closeAllMemorySearchManagers();
   mockPrimary.search.mockClear();
   mockPrimary.readFile.mockClear();
   mockPrimary.status.mockClear();
@@ -134,6 +136,7 @@ beforeEach(() => {
   fallbackManager.probeEmbeddingAvailability.mockClear();
   fallbackManager.probeVectorAvailability.mockClear();
   fallbackManager.close.mockClear();
+  mockCloseAllMemoryIndexManagers.mockClear();
   mockMemoryIndexGet.mockClear();
   mockMemoryIndexGet.mockResolvedValue(fallbackManager);
   createQmdManagerMock.mockClear();
@@ -242,5 +245,22 @@ describe("getMemorySearchManager caching", () => {
     mockMemoryIndexGet.mockRejectedValueOnce(new Error("No API key found for provider openai"));
 
     await expect(firstManager.search("hello")).rejects.toThrow("qmd query failed");
+  });
+
+  it("closes cached managers on global teardown", async () => {
+    const cfg = createQmdCfg("teardown-agent");
+    const first = await getMemorySearchManager({ cfg, agentId: "teardown-agent" });
+    const firstManager = requireManager(first);
+
+    await closeAllMemorySearchManagers();
+
+    expect(mockPrimary.close).toHaveBeenCalledTimes(1);
+    expect(mockCloseAllMemoryIndexManagers).toHaveBeenCalledTimes(1);
+
+    const second = await getMemorySearchManager({ cfg, agentId: "teardown-agent" });
+    expect(second.manager).toBeTruthy();
+    expect(second.manager).not.toBe(firstManager);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -83,7 +83,7 @@ vi.mock("./qmd-manager.js", () => ({
   },
 }));
 
-vi.mock("./manager.js", () => ({
+vi.mock("./manager-runtime.js", () => ({
   MemoryIndexManager: {
     get: mockMemoryIndexGet,
   },

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedQmdConfig } from "./backend-config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
+import { closeAllMemoryIndexManagers } from "./manager.js";
 import type {
   MemoryEmbeddingProbeResult,
   MemorySearchManager,
@@ -83,6 +84,19 @@ export async function getMemorySearchManager(params: {
     const message = err instanceof Error ? err.message : String(err);
     return { manager: null, error: message };
   }
+}
+
+export async function closeAllMemorySearchManagers(): Promise<void> {
+  const managers = Array.from(QMD_MANAGER_CACHE.values());
+  QMD_MANAGER_CACHE.clear();
+  for (const manager of managers) {
+    try {
+      await manager.close?.();
+    } catch (err) {
+      log.warn(`failed to close qmd memory manager: ${String(err)}`);
+    }
+  }
+  await closeAllMemoryIndexManagers();
 }
 
 class FallbackMemoryManager implements MemorySearchManager {

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -2,7 +2,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedQmdConfig } from "./backend-config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
-import { closeAllMemoryIndexManagers } from "./manager.js";
 import type {
   MemoryEmbeddingProbeResult,
   MemorySearchManager,
@@ -96,6 +95,7 @@ export async function closeAllMemorySearchManagers(): Promise<void> {
       log.warn(`failed to close qmd memory manager: ${String(err)}`);
     }
   }
+  const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
   await closeAllMemoryIndexManagers();
 }
 

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -567,7 +567,12 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: {
+                source: "file",
+                path: secretFile,
+                mode: "json",
+                ...(process.platform === "win32" ? { allowInsecurePath: true } : {}),
+              },
             },
           },
           models: {
@@ -658,7 +663,12 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: {
+                source: "file",
+                path: secretFile,
+                mode: "json",
+                ...(process.platform === "win32" ? { allowInsecurePath: true } : {}),
+              },
             },
           },
           models: {

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -622,7 +622,7 @@ describe("secrets runtime snapshot", () => {
       });
       await fs.writeFile(
         secretFile,
-        `${JSON.stringify({ providers: { openai: { apiKey: "sk-file-runtime" } } }, null, 2)}\n`,
+        `${JSON.stringify({ providers: { openai: { apiKey: "sk-file-runtime" } } }, null, 2)}\n`, // pragma: allowlist secret
         { encoding: "utf8", mode: 0o600 },
       );
       await fs.writeFile(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: One-shot CLI runs can complete (`message_end` / `agent_end`) but the process may hang instead of exiting.
- Why it matters: Short-lived automation/benchmark workflows can stall and timeout even when task execution succeeded.
- What changed: Added explicit teardown for globally cached memory managers (index + search) and invoked teardown in `runCli()` `finally`.
- What did NOT change (scope boundary): No changes to model logic, tool behavior, prompt flow, or memory retrieval semantics during normal execution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40365
- Related #

## User-visible / Behavior Changes

One-shot CLI commands now exit cleanly after completion in cases where cached memory manager watcher handles previously kept the process alive.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 14.0 (Sonoma, 23A344)
- Runtime/container: Node.js + pnpm (local dev)
- Model/provider: N/A (provider-independent; reproduced with successful one-shot completion)
- Integration/channel (if any): CLI one-shot run
- Relevant config (redacted): default memory settings (memory search enabled)

### Steps

1. Run OpenClaw `main` before this fix with default memory enabled.
2. Execute a one-shot CLI command that completes successfully.
3. Observe process state after completion event.

### Expected

- Process exits promptly after successful completion.

### Actual

- Process can remain alive due to active `FSWatcher` handles from cached memory managers.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced hang before fix on one-shot run.
  - Confirmed clean exit after fix.
  - Ran targeted tests:  
    `pnpm exec vitest run src/memory/search-manager.test.ts src/cli/run-main.exit.test.ts`
- Edge cases checked:
  - Cleanup path executed via `finally` (success/failure/interrupt paths).
  - Teardown is best-effort and does not crash CLI if cleanup throws.
- What you did **not** verify:
  - Full matrix across all OSes/containers/providers.
  - Long-duration stress testing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/cli/run-main.ts`, `src/memory/manager.ts`, `src/memory/search-manager.ts`, related test updates.
- Known bad symptoms reviewers should watch for: unexpected errors during shutdown/teardown path.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Teardown could run while some async cleanup is still in-flight.
  - Mitigation: Cleanup is called in CLI terminal lifecycle (`finally`) and is best-effort with error handling.
- Risk: Regressions in memory manager cache behavior.
  - Mitigation: Added/updated targeted tests for teardown and CLI exit behavior.
