### PR TITLE
fix(voice-call): add speed and instructions to OpenAI TTS config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Podman/SELinux: auto-detect SELinux enforcing/permissive mode and add `:Z` relabel to bind mounts in `run-openclaw-podman.sh` and the Quadlet template, fixing `EACCES` on Fedora/RHEL hosts. Supports `OPENCLAW_BIND_MOUNT_OPTIONS` override. (#39449) Thanks @langdon and @githubbzxs.
 - TUI/theme: detect light terminal backgrounds via `COLORFGBG` and pick a WCAG AA-compliant light palette, with `OPENCLAW_THEME=light|dark` override for terminals without auto-detection. (#38636) Thanks @ademczuk and @vincentkoc.
 - Agents/context-engine plugins: bootstrap runtime plugins once at embedded-run, compaction, and subagent boundaries so plugin-provided context engines and hooks load from the active workspace before runtime resolution. (#40232)
+- Voice-call/OpenAI TTS: add `speed` (0.25–4.0) and `instructions` fields to the plugin JSON schema and core Zod schema so config validation accepts parameters already supported by the OpenAI TTS runtime. (#39226)
 
 ## 2026.3.7
 

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -527,6 +527,14 @@
               },
               "voice": {
                 "type": "string"
+              },
+              "speed": {
+                "type": "number",
+                "minimum": 0.25,
+                "maximum": 4
+              },
+              "instructions": {
+                "type": "string"
               }
             }
           },

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -335,4 +335,28 @@ describe("config plugin validation", () => {
       ).toBe(true);
     }
   });
-});
+
+  it("accepts voice-call OpenAI TTS speed and instructions config fields", async () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: true,
+        load: { paths: [voiceCallSchemaPluginDir] },
+        entries: {
+          "voice-call-schema-fixture": {
+            config: {
+              tts: {
+                provider: "openai",
+                openai: {
+                  voice: "alloy",
+                  speed: 1.5,
+                  instructions: "Speak in a cheerful tone",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -360,3 +360,4 @@ describe("config plugin validation", () => {
     });
     expect(res.ok).toBe(true);
   });
+});

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -405,6 +405,8 @@ export const TtsConfigSchema = z
         baseUrl: z.string().optional(),
         model: z.string().optional(),
         voice: z.string().optional(),
+        speed: z.number().min(0.25).max(4).optional(),
+        instructions: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Fixes #39226

## Summary

The voice-call extension's `OpenAITTSProvider` already supports `speed` (0.25-4.0 multiplier) and `instructions` (style directives for gpt-4o-mini-tts), but both the plugin JSON schema (`additionalProperties: false`) and the core Zod `TtsConfigSchema` (`.strict()`) reject them.

## Changes

- Add `speed` and `instructions` to OpenAI TTS JSON schema
- Add matching fields to core Zod TTS openai schema
- Add validation test for OpenAI TTS speed/instructions config fields
- Update CHANGELOG.md

## Test Plan

- [x] All unit tests passed
- [x] Schema validation tests passed
- [x] Existing voice-call tests still pass