### PR TITLE
Fix session_spawn acp model and thinking for acpx\codex

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -240,9 +240,8 @@ Interface details:
 - `agentId` (optional): ACP target harness id. Falls back to `acp.defaultAgent` if set.
 - `model` (optional): currently supported only when `agentId` resolves to `codex` on the `acpx` backend. The override is applied during Codex ACP bootstrap.
 - `thinking` (optional): currently supported only when `agentId` resolves to `codex` on the `acpx` backend.
-  - supported values: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`
-  - `none` is also accepted as an alias for no reasoning effort
-  - `adaptive` is not supported for ACP Codex bootstrap
+  - supported values: `low`, `medium`, `high`, `xhigh`
+  - `off`, `minimal`, `adaptive`, and `none` are rejected for ACP Codex bootstrap because the Codex CLI does not accept them
 - `thread` (optional, default `false`): request thread binding flow where supported.
 - `mode` (optional): `run` (one-shot) or `session` (persistent).
   - default is `run`

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -220,6 +220,8 @@ Use `runtime: "acp"` to start an ACP session from an agent turn or tool call.
   "task": "Open the repo and summarize failing tests",
   "runtime": "acp",
   "agentId": "codex",
+  "model": "gpt-5.3-codex-spark",
+  "thinking": "high",
   "thread": true,
   "mode": "session"
 }
@@ -236,6 +238,11 @@ Interface details:
 - `task` (required): initial prompt sent to the ACP session.
 - `runtime` (required for ACP): must be `"acp"`.
 - `agentId` (optional): ACP target harness id. Falls back to `acp.defaultAgent` if set.
+- `model` (optional): currently supported only when `agentId` resolves to `codex` on the `acpx` backend. The override is applied during Codex ACP bootstrap.
+- `thinking` (optional): currently supported only when `agentId` resolves to `codex` on the `acpx` backend.
+  - supported values: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`
+  - `none` is also accepted as an alias for no reasoning effort
+  - `adaptive` is not supported for ACP Codex bootstrap
 - `thread` (optional, default `false`): request thread binding flow where supported.
 - `mode` (optional): `run` (one-shot) or `session` (persistent).
   - default is `run`
@@ -245,6 +252,12 @@ Interface details:
 - `label` (optional): operator-facing label used in session/banner text.
 - `streamTo` (optional): `"parent"` streams initial ACP run progress summaries back to the requester session as system events.
   - When available, accepted responses include `streamLogPath` pointing to a session-scoped JSONL log (`<sessionId>.acp-stream.jsonl`) you can tail for full relay history.
+
+Current override scope:
+
+- ACP `model` / `thinking` overrides currently apply only to `agentId: "codex"` on the `acpx` backend.
+- For other ACP harnesses, OpenClaw ignores those two fields, continues the spawn, and returns a note explaining that the overrides were skipped.
+- Other ACP harnesses still use their normal backend/runtime defaults or later `/acp` session controls.
 
 ## Sandbox compatibility
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -487,7 +487,7 @@ Notes:
 - `sessions_send` waits for final completion when `timeoutSeconds > 0`.
 - Delivery/announce happens after completion and is best-effort; `status: "ok"` confirms the agent run finished, not that the announce was delivered.
 - `sessions_spawn` supports `runtime: "subagent" | "acp"` (`subagent` default). For ACP runtime behavior, see [ACP Agents](/tools/acp-agents).
-- For ACP runtime, `model` and `thinking` overrides currently apply only to `agentId: "codex"` on the `acpx` backend. Supported `thinking` values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, plus `none`; `adaptive` is rejected. Other ACP harnesses ignore those two fields and continue with a note.
+- For ACP runtime, `model` and `thinking` overrides currently apply only to `agentId: "codex"` on the `acpx` backend. Supported `thinking` values there are `low`, `medium`, `high`, and `xhigh`; `off`, `minimal`, `adaptive`, and `none` are rejected because the Codex CLI does not accept them. Other ACP harnesses ignore those two fields and continue with a note.
 - For ACP runtime, `streamTo: "parent"` routes initial-run progress summaries back to the requester session as system events instead of direct child delivery.
 - `sessions_spawn` starts a sub-agent run and posts an announce reply back to the requester chat.
   - Supports one-shot mode (`mode: "run"`) and persistent thread-bound mode (`mode: "session"` with `thread: true`).

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -487,6 +487,7 @@ Notes:
 - `sessions_send` waits for final completion when `timeoutSeconds > 0`.
 - Delivery/announce happens after completion and is best-effort; `status: "ok"` confirms the agent run finished, not that the announce was delivered.
 - `sessions_spawn` supports `runtime: "subagent" | "acp"` (`subagent` default). For ACP runtime behavior, see [ACP Agents](/tools/acp-agents).
+- For ACP runtime, `model` and `thinking` overrides currently apply only to `agentId: "codex"` on the `acpx` backend. Supported `thinking` values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, plus `none`; `adaptive` is rejected. Other ACP harnesses ignore those two fields and continue with a note.
 - For ACP runtime, `streamTo: "parent"` routes initial-run progress summaries back to the requester session as system events instead of direct child delivery.
 - `sessions_spawn` starts a sub-agent run and posts an announce reply back to the requester chat.
   - Supports one-shot mode (`mode: "run"`) and persistent thread-bound mode (`mode: "session"` with `thread: true`).

--- a/extensions/acpx/src/runtime-internals/codex-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/codex-agent-command.ts
@@ -1,0 +1,36 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AcpxCodexBootstrapState } from "./shared.js";
+
+const CODEX_BOOTSTRAP_WRAPPER_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "codex-bootstrap-wrapper.mjs",
+);
+
+function quoteCommandPart(value: string): string {
+  if (value === "") {
+    return '""';
+  }
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/["\\]/g, "\\$&")}"`;
+}
+
+function toCommandLine(parts: string[]): string {
+  return parts.map(quoteCommandPart).join(" ");
+}
+
+export function buildCodexBootstrapAgentCommand(params: {
+  targetCommand: string;
+  bootstrap: AcpxCodexBootstrapState;
+}): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      targetCommand: params.targetCommand,
+      bootstrap: params.bootstrap,
+    }),
+    "utf8",
+  ).toString("base64url");
+  return toCommandLine([process.execPath, CODEX_BOOTSTRAP_WRAPPER_PATH, "--payload", payload]);
+}

--- a/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.mjs
+++ b/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.mjs
@@ -3,6 +3,16 @@
 import { spawn } from "node:child_process";
 import { splitCommandLine } from "./split-command-line.mjs";
 
+const SUPPORTED_REASONING_EFFORTS = new Set(["low", "medium", "high", "xhigh"]);
+
+function normalizeReasoningEffort(value) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim().toLowerCase();
+  return SUPPORTED_REASONING_EFFORTS.has(trimmed) ? trimmed : undefined;
+}
+
 function decodePayload(argv) {
   const payloadIndex = argv.indexOf("--payload");
   if (payloadIndex < 0) {
@@ -25,10 +35,7 @@ function decodePayload(argv) {
       : {};
   const model =
     typeof bootstrap.model === "string" && bootstrap.model.trim() ? bootstrap.model : "";
-  const reasoningEffort =
-    typeof bootstrap.reasoningEffort === "string" && bootstrap.reasoningEffort.trim()
-      ? bootstrap.reasoningEffort
-      : "";
+  const reasoningEffort = normalizeReasoningEffort(bootstrap.reasoningEffort) ?? "";
   return {
     targetCommand: parsed.targetCommand,
     model: model || undefined,

--- a/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.mjs
+++ b/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { splitCommandLine } from "./split-command-line.mjs";
+
+function decodePayload(argv) {
+  const payloadIndex = argv.indexOf("--payload");
+  if (payloadIndex < 0) {
+    throw new Error("Missing --payload");
+  }
+  const encoded = argv[payloadIndex + 1];
+  if (!encoded) {
+    throw new Error("Missing Codex bootstrap payload value");
+  }
+  const parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Invalid Codex bootstrap payload");
+  }
+  if (typeof parsed.targetCommand !== "string" || parsed.targetCommand.trim() === "") {
+    throw new Error("Codex bootstrap payload missing targetCommand");
+  }
+  const bootstrap =
+    parsed.bootstrap && typeof parsed.bootstrap === "object" && !Array.isArray(parsed.bootstrap)
+      ? parsed.bootstrap
+      : {};
+  const model =
+    typeof bootstrap.model === "string" && bootstrap.model.trim() ? bootstrap.model : "";
+  const reasoningEffort =
+    typeof bootstrap.reasoningEffort === "string" && bootstrap.reasoningEffort.trim()
+      ? bootstrap.reasoningEffort
+      : "";
+  return {
+    targetCommand: parsed.targetCommand,
+    model: model || undefined,
+    reasoningEffort: reasoningEffort || undefined,
+  };
+}
+
+function buildCliOverrides(params) {
+  const args = [];
+  if (params.model) {
+    args.push("-c", `model=${JSON.stringify(params.model)}`);
+  }
+  if (params.reasoningEffort) {
+    args.push("-c", `model_reasoning_effort=${JSON.stringify(params.reasoningEffort)}`);
+  }
+  return args;
+}
+
+const payload = decodePayload(process.argv.slice(2));
+const target = splitCommandLine(payload.targetCommand);
+const child = spawn(target.command, [...target.args, ...buildCliOverrides(payload)], {
+  stdio: ["pipe", "pipe", "inherit"],
+  env: process.env,
+});
+
+if (!child.stdin || !child.stdout) {
+  throw new Error("Failed to create Codex bootstrap wrapper stdio pipes");
+}
+
+process.stdin.pipe(child.stdin);
+child.stdin.on("error", () => {
+  // Ignore EPIPE when the child exits before stdin flush completes.
+});
+child.stdout.pipe(process.stdout);
+
+child.on("error", (error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});
+
+child.on("close", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.mjs
+++ b/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.mjs
@@ -66,8 +66,13 @@ if (!child.stdin || !child.stdout) {
 }
 
 process.stdin.pipe(child.stdin);
-child.stdin.on("error", () => {
+child.stdin.on("error", (error) => {
   // Ignore EPIPE when the child exits before stdin flush completes.
+  if (error?.code === "EPIPE") {
+    return;
+  }
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}
+`);
 });
 child.stdout.pipe(process.stdout);
 

--- a/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.test.ts
+++ b/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.test.ts
@@ -109,4 +109,41 @@ process.stdout.write(JSON.stringify(process.argv.slice(2)) + "\n");
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout.trim())).toEqual(["--flag", "-c", 'model="gpt-5.3-codex-spark"']);
   });
+
+  it('passes reasoningEffort="none" through to the Codex CLI overrides', async () => {
+    const argvPrinterPath = await makeTempScript(
+      "argv-printer-none.cjs",
+      String.raw`#!/usr/bin/env node
+process.stdout.write(JSON.stringify(process.argv.slice(2)) + "\n");
+`,
+    );
+
+    const payload = Buffer.from(
+      JSON.stringify({
+        targetCommand: `${process.execPath} ${argvPrinterPath}`,
+        bootstrap: {
+          reasoningEffort: "none",
+        },
+      }),
+      "utf8",
+    ).toString("base64url");
+
+    const child = spawn(process.execPath, [wrapperPath, "--payload", payload], {
+      stdio: ["pipe", "pipe", "inherit"],
+      cwd: process.cwd(),
+    });
+    child.stdin.end();
+
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.trim())).toEqual(["-c", 'model_reasoning_effort="none"']);
+  });
 });

--- a/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.test.ts
+++ b/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.test.ts
@@ -110,7 +110,7 @@ process.stdout.write(JSON.stringify(process.argv.slice(2)) + "\n");
     expect(JSON.parse(stdout.trim())).toEqual(["--flag", "-c", 'model="gpt-5.3-codex-spark"']);
   });
 
-  it('passes reasoningEffort="none" through to the Codex CLI overrides', async () => {
+  it("ignores unsupported reasoningEffort values instead of forwarding invalid Codex CLI overrides", async () => {
     const argvPrinterPath = await makeTempScript(
       "argv-printer-none.cjs",
       String.raw`#!/usr/bin/env node
@@ -144,6 +144,6 @@ process.stdout.write(JSON.stringify(process.argv.slice(2)) + "\n");
     });
 
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout.trim())).toEqual(["-c", 'model_reasoning_effort="none"']);
+    expect(JSON.parse(stdout.trim())).toEqual([]);
   });
 });

--- a/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.test.ts
+++ b/extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.test.ts
@@ -1,0 +1,112 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+const wrapperPath = path.resolve(
+  "extensions/acpx/src/runtime-internals/codex-bootstrap-wrapper.mjs",
+);
+
+async function makeTempScript(name: string, content: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-acpx-codex-wrapper-"));
+  tempDirs.push(dir);
+  const scriptPath = path.join(dir, name);
+  await writeFile(scriptPath, content, "utf8");
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("codex-bootstrap-wrapper", () => {
+  it("appends Codex CLI config overrides before spawning the target command", async () => {
+    const argvPrinterPath = await makeTempScript(
+      "argv-printer.cjs",
+      String.raw`#!/usr/bin/env node
+process.stdout.write(JSON.stringify(process.argv.slice(2)) + "\n");
+`,
+    );
+
+    const payload = Buffer.from(
+      JSON.stringify({
+        targetCommand: `${process.execPath} ${argvPrinterPath} --flag`,
+        bootstrap: {
+          model: "gpt-5.3-codex-spark",
+          reasoningEffort: "high",
+        },
+      }),
+      "utf8",
+    ).toString("base64url");
+
+    const child = spawn(process.execPath, [wrapperPath, "--payload", payload], {
+      stdio: ["pipe", "pipe", "inherit"],
+      cwd: process.cwd(),
+    });
+    child.stdin.end();
+
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.trim())).toEqual([
+      "--flag",
+      "-c",
+      'model="gpt-5.3-codex-spark"',
+      "-c",
+      'model_reasoning_effort="high"',
+    ]);
+  });
+
+  it("preserves backslashes in quoted executable paths", async () => {
+    const argvPrinterPath = await makeTempScript(
+      String.raw`argv printer\with spaces.cjs`,
+      String.raw`#!/usr/bin/env node
+process.stdout.write(JSON.stringify(process.argv.slice(2)) + "\n");
+`,
+    );
+
+    const payload = Buffer.from(
+      JSON.stringify({
+        targetCommand: `"${argvPrinterPath}" --flag`,
+        bootstrap: {
+          model: "gpt-5.3-codex-spark",
+        },
+      }),
+      "utf8",
+    ).toString("base64url");
+
+    const child = spawn(process.execPath, [wrapperPath, "--payload", payload], {
+      stdio: ["pipe", "pipe", "inherit"],
+      cwd: process.cwd(),
+    });
+    child.stdin.end();
+
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.trim())).toEqual(["--flag", "-c", 'model="gpt-5.3-codex-spark"']);
+  });
+});

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
@@ -2,62 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
-
-function splitCommandLine(value) {
-  const parts = [];
-  let current = "";
-  let quote = null;
-  let escaping = false;
-
-  for (const ch of value) {
-    if (escaping) {
-      current += ch;
-      escaping = false;
-      continue;
-    }
-    if (ch === "\\" && quote !== "'") {
-      escaping = true;
-      continue;
-    }
-    if (quote) {
-      if (ch === quote) {
-        quote = null;
-      } else {
-        current += ch;
-      }
-      continue;
-    }
-    if (ch === "'" || ch === '"') {
-      quote = ch;
-      continue;
-    }
-    if (/\s/.test(ch)) {
-      if (current.length > 0) {
-        parts.push(current);
-        current = "";
-      }
-      continue;
-    }
-    current += ch;
-  }
-
-  if (escaping) {
-    current += "\\";
-  }
-  if (quote) {
-    throw new Error("Invalid agent command: unterminated quote");
-  }
-  if (current.length > 0) {
-    parts.push(current);
-  }
-  if (parts.length === 0) {
-    throw new Error("Invalid agent command: empty command");
-  }
-  return {
-    command: parts[0],
-    args: parts.slice(1),
-  };
-}
+import { splitCommandLine } from "./split-command-line.mjs";
 
 function decodePayload(argv) {
   const payloadIndex = argv.indexOf("--payload");

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
@@ -111,4 +111,71 @@ rl.on("close", () => process.exit(0));
     expect(lines[2].method).toBe("session/prompt");
     expect(lines[2].params.mcpServers).toBeUndefined();
   });
+
+  it("preserves backslashes in quoted executable paths", async () => {
+    const echoServerPath = await makeTempScript(
+      String.raw`echo server\with spaces.cjs`,
+      String.raw`#!/usr/bin/env node
+const { createInterface } = require("node:readline");
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => process.stdout.write(line + "\n"));
+rl.on("close", () => process.exit(0));
+`,
+    );
+
+    const payload = Buffer.from(
+      JSON.stringify({
+        targetCommand: `"${echoServerPath}"`,
+        mcpServers: [
+          {
+            name: "canva",
+            command: "npx",
+            args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+            env: [{ name: "CANVA_TOKEN", value: "secret" }],
+          },
+        ],
+      }),
+      "utf8",
+    ).toString("base64url");
+
+    const child = spawn(process.execPath, [proxyPath, "--payload", payload], {
+      stdio: ["pipe", "pipe", "inherit"],
+      cwd: process.cwd(),
+    });
+
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stdin.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "session/new",
+        params: { cwd: process.cwd(), mcpServers: [] },
+      })}\n`,
+    );
+    child.stdin.end();
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    expect(exitCode).toBe(0);
+    const lines = stdout
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as { method: string; params: Record<string, unknown> });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].params.mcpServers).toEqual([
+      {
+        name: "canva",
+        command: "npx",
+        args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+        env: [{ name: "CANVA_TOKEN", value: "secret" }],
+      },
+    ]);
+  });
 });

--- a/extensions/acpx/src/runtime-internals/shared.ts
+++ b/extensions/acpx/src/runtime-internals/shared.ts
@@ -1,10 +1,16 @@
 import type { ResolvedAcpxPluginConfig } from "../config.js";
 
+export type AcpxCodexBootstrapState = {
+  model?: string;
+  reasoningEffort?: string;
+};
+
 export type AcpxHandleState = {
   name: string;
   agent: string;
   cwd: string;
   mode: "persistent" | "oneshot";
+  codexBootstrap?: AcpxCodexBootstrapState;
   acpxRecordId?: string;
   backendSessionId?: string;
   agentSessionId?: string;

--- a/extensions/acpx/src/runtime-internals/split-command-line.mjs
+++ b/extensions/acpx/src/runtime-internals/split-command-line.mjs
@@ -1,0 +1,70 @@
+export function splitCommandLine(value) {
+  const parts = [];
+  let current = "";
+  let quote = null;
+  let escaping = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const ch = value[index];
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\") {
+      if (quote === "'") {
+        current += ch;
+        continue;
+      }
+      if (quote === '"') {
+        const next = value[index + 1];
+        if (next === '"' || next === "\\") {
+          escaping = true;
+          continue;
+        }
+        // Preserve literal backslashes inside double-quoted Windows/custom paths.
+        current += ch;
+        continue;
+      }
+      escaping = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  if (quote) {
+    throw new Error("Invalid agent command: unterminated quote");
+  }
+  if (current.length > 0) {
+    parts.push(current);
+  }
+  if (parts.length === 0) {
+    throw new Error("Invalid agent command: empty command");
+  }
+  return {
+    command: parts[0],
+    args: parts.slice(1),
+  };
+}

--- a/extensions/acpx/src/runtime-internals/split-command-line.mjs
+++ b/extensions/acpx/src/runtime-internals/split-command-line.mjs
@@ -26,7 +26,13 @@ export function splitCommandLine(value) {
         current += ch;
         continue;
       }
-      escaping = true;
+      const next = value[index + 1];
+      if (next === '"' || next === "'" || next === "\\" || /\s/.test(next ?? "")) {
+        escaping = true;
+        continue;
+      }
+      // Preserve literal backslashes in unquoted Windows/custom paths.
+      current += ch;
       continue;
     }
     if (quote) {

--- a/extensions/acpx/src/runtime-internals/split-command-line.test.ts
+++ b/extensions/acpx/src/runtime-internals/split-command-line.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { splitCommandLine } from "./split-command-line.mjs";
+
+describe("splitCommandLine", () => {
+  it("preserves backslashes in unquoted Windows command paths", () => {
+    expect(splitCommandLine(String.raw`C:\Users\bob\codex.cmd --flag`)).toEqual({
+      command: String.raw`C:\Users\bob\codex.cmd`,
+      args: ["--flag"],
+    });
+  });
+
+  it("still treats backslashes before whitespace as escapes", () => {
+    expect(splitCommandLine(String.raw`my\ command --flag`)).toEqual({
+      command: "my command",
+      args: ["--flag"],
+    });
+  });
+});

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -284,6 +284,29 @@ describe("AcpxRuntime", () => {
     expect(close?.sessionName).toBe("agent:claude:acp:789");
   });
 
+  it("prefers handle.cwd over the encoded runtime cwd for restored sessions", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:cwd-override",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const overrideCwd = os.tmpdir();
+
+    await runtime.getStatus({
+      handle: {
+        ...handle,
+        cwd: overrideCwd,
+      },
+    });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const statusArgs = (logs.findLast((entry) => entry.kind === "status")?.args as string[]) ?? [];
+    const cwdFlagIndex = statusArgs.indexOf("--cwd");
+    expect(cwdFlagIndex).toBeGreaterThanOrEqual(0);
+    expect(statusArgs[cwdFlagIndex + 1]).toBe(overrideCwd);
+  });
+
   it("exposes control capabilities and runs set-mode/set/status commands", async () => {
     const { runtime, logPath } = await createMockRuntimeFixture();
     const handle = await runtime.ensureSession({
@@ -373,6 +396,184 @@ describe("AcpxRuntime", () => {
     } finally {
       delete process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS;
     }
+  });
+
+  it("routes Codex ACP spawns through a dedicated bootstrap wrapper and reuses it for later verbs", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:codex-bootstrap",
+      agent: "codex",
+      mode: "persistent",
+      env: {
+        OPENCLAW_ACPX_CODEX_BOOTSTRAP: Buffer.from(
+          JSON.stringify({
+            model: "gpt-5.3-codex-spark",
+            reasoningEffort: "high",
+          }),
+          "utf8",
+        ).toString("base64url"),
+      },
+    });
+    await runtime.getStatus({ handle });
+
+    const decoded = decodeAcpxRuntimeHandleState(handle.runtimeSessionName);
+    expect(decoded?.codexBootstrap).toEqual({
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "high",
+    });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const ensureArgs = (logs.find((entry) => entry.kind === "ensure")?.args as string[]) ?? [];
+    const statusArgs = (logs.find((entry) => entry.kind === "status")?.args as string[]) ?? [];
+
+    for (const args of [ensureArgs, statusArgs]) {
+      const agentFlagIndex = args.indexOf("--agent");
+      expect(agentFlagIndex).toBeGreaterThanOrEqual(0);
+      const rawAgentCommand = args[agentFlagIndex + 1];
+      expect(rawAgentCommand).toContain("codex-bootstrap-wrapper.mjs");
+      const payloadMatch = rawAgentCommand.match(/--payload\s+([A-Za-z0-9_-]+)/);
+      expect(payloadMatch?.[1]).toBeDefined();
+      const payload = JSON.parse(
+        Buffer.from(String(payloadMatch?.[1]), "base64url").toString("utf8"),
+      ) as {
+        targetCommand: string;
+        bootstrap: { model?: string; reasoningEffort?: string };
+      };
+      expect(payload.targetCommand).toContain("@zed-industries/codex-acp");
+      expect(payload.bootstrap).toEqual({
+        model: "gpt-5.3-codex-spark",
+        reasoningEffort: "high",
+      });
+    }
+  });
+
+  it("composes Codex bootstrap and MCP proxy wrappers when both are configured", async () => {
+    process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS = JSON.stringify({
+      codex: {
+        command: "npx custom-codex-acp",
+      },
+    });
+    try {
+      const { runtime, logPath } = await createMockRuntimeFixture({
+        mcpServers: {
+          canva: {
+            command: "npx",
+            args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+            env: {
+              CANVA_TOKEN: "secret",
+            },
+          },
+        },
+      });
+      const handle = await runtime.ensureSession({
+        sessionKey: "agent:codex:acp:codex-bootstrap-mcp",
+        agent: "codex",
+        mode: "persistent",
+        env: {
+          OPENCLAW_ACPX_CODEX_BOOTSTRAP: Buffer.from(
+            JSON.stringify({
+              model: "gpt-5.3-codex-spark",
+              reasoningEffort: "high",
+            }),
+            "utf8",
+          ).toString("base64url"),
+        },
+      });
+      await runtime.getStatus({ handle });
+
+      const logs = await readMockRuntimeLogEntries(logPath);
+      const ensureArgs = (logs.find((entry) => entry.kind === "ensure")?.args as string[]) ?? [];
+      const statusArgs = (logs.find((entry) => entry.kind === "status")?.args as string[]) ?? [];
+
+      for (const args of [ensureArgs, statusArgs]) {
+        const agentFlagIndex = args.indexOf("--agent");
+        expect(agentFlagIndex).toBeGreaterThanOrEqual(0);
+        const rawAgentCommand = args[agentFlagIndex + 1];
+        expect(rawAgentCommand).toContain("mcp-proxy.mjs");
+        const outerPayloadMatch = rawAgentCommand.match(/--payload\s+([A-Za-z0-9_-]+)/);
+        expect(outerPayloadMatch?.[1]).toBeDefined();
+        const outerPayload = JSON.parse(
+          Buffer.from(String(outerPayloadMatch?.[1]), "base64url").toString("utf8"),
+        ) as {
+          targetCommand: string;
+          mcpServers: Array<{ name: string }>;
+        };
+        expect(outerPayload.mcpServers).toEqual([
+          expect.objectContaining({
+            name: "canva",
+          }),
+        ]);
+        expect(outerPayload.targetCommand).toContain("codex-bootstrap-wrapper.mjs");
+
+        const innerPayloadMatch = outerPayload.targetCommand.match(/--payload\s+([A-Za-z0-9_-]+)/);
+        expect(innerPayloadMatch?.[1]).toBeDefined();
+        const innerPayload = JSON.parse(
+          Buffer.from(String(innerPayloadMatch?.[1]), "base64url").toString("utf8"),
+        ) as {
+          targetCommand: string;
+          bootstrap: { model?: string; reasoningEffort?: string };
+        };
+        expect(innerPayload.targetCommand).toContain("custom-codex-acp");
+        expect(innerPayload.bootstrap).toEqual({
+          model: "gpt-5.3-codex-spark",
+          reasoningEffort: "high",
+        });
+      }
+    } finally {
+      delete process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS;
+    }
+  });
+
+  it("reuses Codex bootstrap from the previous handle when re-ensuring without env", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture();
+    const firstHandle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:codex-bootstrap-restore",
+      agent: "codex",
+      mode: "persistent",
+      env: {
+        OPENCLAW_ACPX_CODEX_BOOTSTRAP: Buffer.from(
+          JSON.stringify({
+            model: "gpt-5.3-codex-spark",
+            reasoningEffort: "high",
+          }),
+          "utf8",
+        ).toString("base64url"),
+      },
+    });
+    const restoredHandle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:codex-bootstrap-restore",
+      agent: "codex",
+      mode: "persistent",
+      previousHandle: firstHandle,
+    });
+
+    const decoded = decodeAcpxRuntimeHandleState(restoredHandle.runtimeSessionName);
+    expect(decoded?.codexBootstrap).toEqual({
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "high",
+    });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const ensureEntries = logs.filter((entry) => entry.kind === "ensure");
+    expect(ensureEntries).toHaveLength(2);
+    const ensureArgs = (ensureEntries[1]?.args as string[]) ?? [];
+    const agentFlagIndex = ensureArgs.indexOf("--agent");
+    expect(agentFlagIndex).toBeGreaterThanOrEqual(0);
+    const rawAgentCommand = ensureArgs[agentFlagIndex + 1];
+    expect(rawAgentCommand).toContain("codex-bootstrap-wrapper.mjs");
+    const payloadMatch = rawAgentCommand.match(/--payload\s+([A-Za-z0-9_-]+)/);
+    expect(payloadMatch?.[1]).toBeDefined();
+    const payload = JSON.parse(
+      Buffer.from(String(payloadMatch?.[1]), "base64url").toString("utf8"),
+    ) as {
+      targetCommand: string;
+      bootstrap: { model?: string; reasoningEffort?: string };
+    };
+    expect(payload.targetCommand).toContain("@zed-industries/codex-acp");
+    expect(payload.bootstrap).toEqual({
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "high",
+    });
   });
 
   it("skips prompt execution when runTurn starts with an already-aborted signal", async () => {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -524,6 +524,61 @@ describe("AcpxRuntime", () => {
     }
   });
 
+  it("does not cache override-bearing Codex agent commands across later verbs", async () => {
+    process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS = JSON.stringify({
+      codex: {
+        command: "npx custom-codex-acp-one",
+      },
+    });
+    try {
+      const { runtime, logPath } = await createMockRuntimeFixture();
+      const handle = await runtime.ensureSession({
+        sessionKey: "agent:codex:acp:codex-bootstrap-no-cache",
+        agent: "codex",
+        mode: "persistent",
+        env: {
+          OPENCLAW_ACPX_CODEX_BOOTSTRAP: Buffer.from(
+            JSON.stringify({
+              model: "gpt-5.3-codex-spark",
+              reasoningEffort: "high",
+            }),
+            "utf8",
+          ).toString("base64url"),
+        },
+      });
+
+      process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS = JSON.stringify({
+        codex: {
+          command: "npx custom-codex-acp-two",
+        },
+      });
+      await runtime.getStatus({ handle });
+
+      const logs = await readMockRuntimeLogEntries(logPath);
+      const ensureArgs = (logs.find((entry) => entry.kind === "ensure")?.args as string[]) ?? [];
+      const statusArgs = (logs.find((entry) => entry.kind === "status")?.args as string[]) ?? [];
+
+      const extractTargetCommand = (args: string[]) => {
+        const agentFlagIndex = args.indexOf("--agent");
+        expect(agentFlagIndex).toBeGreaterThanOrEqual(0);
+        const rawAgentCommand = args[agentFlagIndex + 1];
+        const payloadMatch = rawAgentCommand.match(/--payload\s+([A-Za-z0-9_-]+)/);
+        expect(payloadMatch?.[1]).toBeDefined();
+        const payload = JSON.parse(
+          Buffer.from(String(payloadMatch?.[1]), "base64url").toString("utf8"),
+        ) as {
+          targetCommand: string;
+        };
+        return payload.targetCommand;
+      };
+
+      expect(extractTargetCommand(ensureArgs)).toContain("custom-codex-acp-one");
+      expect(extractTargetCommand(statusArgs)).toContain("custom-codex-acp-two");
+    } finally {
+      delete process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS;
+    }
+  });
+
   it("reuses Codex bootstrap from the previous handle when re-ensuring without env", async () => {
     const { runtime, logPath } = await createMockRuntimeFixture();
     const firstHandle = await runtime.ensureSession({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -765,13 +765,13 @@ export class AcpxRuntime implements AcpRuntime {
     if (!wantsMcpProxy && !wantsCodexBootstrap) {
       return null;
     }
-    const cacheKey = [
+    const cacheKey = JSON.stringify([
       params.cwd,
       params.agent,
       params.codexBootstrap?.model ?? "",
       params.codexBootstrap?.reasoningEffort ?? "",
       wantsMcpProxy ? "mcp" : "nomcp",
-    ].join("::");
+    ]);
     const cached = this.agentCommandCache.get(cacheKey);
     if (cached) {
       return cached;

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -14,6 +14,7 @@ import type {
 import { AcpRuntimeError } from "openclaw/plugin-sdk/acpx";
 import { toAcpMcpServers, type ResolvedAcpxPluginConfig } from "./config.js";
 import { checkAcpxVersion } from "./ensure.js";
+import { buildCodexBootstrapAgentCommand } from "./runtime-internals/codex-agent-command.js";
 import {
   parseJsonLines,
   parsePromptEventLine,
@@ -38,6 +39,7 @@ import {
   buildPermissionArgs,
   deriveAgentFromSessionKey,
   isRecord,
+  type AcpxCodexBootstrapState,
   type AcpxHandleState,
   type AcpxJsonObject,
 } from "./runtime-internals/shared.js";
@@ -47,6 +49,7 @@ export const ACPX_BACKEND_ID = "acpx";
 const ACPX_RUNTIME_HANDLE_PREFIX = "acpx:v1:";
 const DEFAULT_AGENT_FALLBACK = "codex";
 const ACPX_EXIT_CODE_PERMISSION_DENIED = 5;
+const ACPX_CODEX_BOOTSTRAP_ENV_KEY = "OPENCLAW_ACPX_CODEX_BOOTSTRAP";
 const ACPX_CAPABILITIES: AcpRuntimeCapabilities = {
   controls: ["session/set_mode", "session/set_config_option", "session/status"],
 };
@@ -94,6 +97,7 @@ export function decodeAcpxRuntimeHandleState(runtimeSessionName: string): AcpxHa
     const agent = asTrimmedString(parsed.agent);
     const cwd = asTrimmedString(parsed.cwd);
     const mode = asTrimmedString(parsed.mode);
+    const codexBootstrap = parseCodexBootstrapState(parsed.codexBootstrap);
     const acpxRecordId = asOptionalString(parsed.acpxRecordId);
     const backendSessionId = asOptionalString(parsed.backendSessionId);
     const agentSessionId = asOptionalString(parsed.agentSessionId);
@@ -108,6 +112,7 @@ export function decodeAcpxRuntimeHandleState(runtimeSessionName: string): AcpxHa
       agent,
       cwd,
       mode,
+      ...(codexBootstrap ? { codexBootstrap } : {}),
       ...(acpxRecordId ? { acpxRecordId } : {}),
       ...(backendSessionId ? { backendSessionId } : {}),
       ...(agentSessionId ? { agentSessionId } : {}),
@@ -117,12 +122,60 @@ export function decodeAcpxRuntimeHandleState(runtimeSessionName: string): AcpxHa
   }
 }
 
+function parseCodexBootstrapState(value: unknown): AcpxCodexBootstrapState | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const model = asOptionalString(value.model);
+  const reasoningEffort = asOptionalString(value.reasoningEffort);
+  if (!model && !reasoningEffort) {
+    return undefined;
+  }
+  return {
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+}
+
+function decodeCodexBootstrapEnv(
+  env?: Record<string, string>,
+): AcpxCodexBootstrapState | undefined {
+  const encoded = env?.[ACPX_CODEX_BOOTSTRAP_ENV_KEY];
+  if (!encoded) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as unknown;
+    return parseCodexBootstrapState(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolvePreviousHandleStateForEnsure(params: {
+  previousHandle?: AcpRuntimeHandle;
+  sessionKey: string;
+  agent: string;
+}): AcpxHandleState | undefined {
+  if (!params.previousHandle || params.previousHandle.sessionKey !== params.sessionKey) {
+    return undefined;
+  }
+  const decoded = decodeAcpxRuntimeHandleState(params.previousHandle.runtimeSessionName);
+  if (!decoded) {
+    return undefined;
+  }
+  if (decoded.name !== params.sessionKey || decoded.agent !== params.agent) {
+    return undefined;
+  }
+  return decoded;
+}
+
 export class AcpxRuntime implements AcpRuntime {
   private healthy = false;
   private readonly logger?: PluginLogger;
   private readonly queueOwnerTtlSeconds: number;
   private readonly spawnCommandCache: SpawnCommandCache = {};
-  private readonly mcpProxyAgentCommandCache = new Map<string, string>();
+  private readonly agentCommandCache = new Map<string, string>();
   private readonly spawnCommandOptions: SpawnCommandOptions;
   private readonly loggedSpawnResolutions = new Set<string>();
 
@@ -201,11 +254,22 @@ export class AcpxRuntime implements AcpRuntime {
     if (!agent) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP agent id is required.");
     }
-    const cwd = asTrimmedString(input.cwd) || this.config.cwd;
+    const previousHandleState = resolvePreviousHandleStateForEnsure({
+      previousHandle: input.previousHandle,
+      sessionKey: input.sessionKey,
+      agent,
+    });
+    const cwd = asTrimmedString(input.cwd) || previousHandleState?.cwd || this.config.cwd;
     const mode = input.mode;
+    const bootstrapKeyPresent = Boolean(input.env?.[ACPX_CODEX_BOOTSTRAP_ENV_KEY]);
+    const envCodexBootstrap = agent === "codex" ? decodeCodexBootstrapEnv(input.env) : undefined;
+    const restoredCodexBootstrap =
+      !bootstrapKeyPresent && agent === "codex" ? previousHandleState?.codexBootstrap : undefined;
+    const codexBootstrap = bootstrapKeyPresent ? envCodexBootstrap : restoredCodexBootstrap;
     const ensureCommand = await this.buildVerbArgs({
       agent,
       cwd,
+      codexBootstrap,
       command: ["sessions", "ensure", "--name", sessionName],
     });
 
@@ -225,6 +289,7 @@ export class AcpxRuntime implements AcpRuntime {
       const newCommand = await this.buildVerbArgs({
         agent,
         cwd,
+        codexBootstrap,
         command: ["sessions", "new", "--name", sessionName],
       });
       events = await this.runControlCommand({
@@ -260,6 +325,7 @@ export class AcpxRuntime implements AcpRuntime {
         agent,
         cwd,
         mode,
+        ...(codexBootstrap ? { codexBootstrap } : {}),
         ...(acpxRecordId ? { acpxRecordId } : {}),
         ...(backendSessionId ? { backendSessionId } : {}),
         ...(agentSessionId ? { agentSessionId } : {}),
@@ -277,6 +343,7 @@ export class AcpxRuntime implements AcpRuntime {
       agent: state.agent,
       sessionName: state.name,
       cwd: state.cwd,
+      codexBootstrap: state.codexBootstrap,
     });
 
     const cancelOnAbort = async () => {
@@ -393,6 +460,7 @@ export class AcpxRuntime implements AcpRuntime {
     const args = await this.buildVerbArgs({
       agent: state.agent,
       cwd: state.cwd,
+      codexBootstrap: state.codexBootstrap,
       command: ["status", "--session", state.name],
     });
     const events = await this.runControlCommand({
@@ -402,6 +470,17 @@ export class AcpxRuntime implements AcpRuntime {
       ignoreNoSession: true,
       signal: input.signal,
     });
+    const errorDetail = events.map((event) => toAcpxErrorEvent(event)).find(Boolean) ?? null;
+    if (errorDetail?.code === "NO_SESSION") {
+      return {
+        summary: "status=missing",
+        details: {
+          status: "missing",
+          errorCode: errorDetail.code,
+          message: errorDetail.message,
+        },
+      };
+    }
     const detail = events.find((event) => !toAcpxErrorEvent(event)) ?? events[0];
     if (!detail) {
       return {
@@ -439,6 +518,7 @@ export class AcpxRuntime implements AcpRuntime {
     const args = await this.buildVerbArgs({
       agent: state.agent,
       cwd: state.cwd,
+      codexBootstrap: state.codexBootstrap,
       command: ["set-mode", mode, "--session", state.name],
     });
     await this.runControlCommand({
@@ -462,6 +542,7 @@ export class AcpxRuntime implements AcpRuntime {
     const args = await this.buildVerbArgs({
       agent: state.agent,
       cwd: state.cwd,
+      codexBootstrap: state.codexBootstrap,
       command: ["set", key, value, "--session", state.name],
     });
     await this.runControlCommand({
@@ -557,6 +638,7 @@ export class AcpxRuntime implements AcpRuntime {
     const args = await this.buildVerbArgs({
       agent: state.agent,
       cwd: state.cwd,
+      codexBootstrap: state.codexBootstrap,
       command: ["cancel", "--session", state.name],
     });
     await this.runControlCommand({
@@ -572,6 +654,7 @@ export class AcpxRuntime implements AcpRuntime {
     const args = await this.buildVerbArgs({
       agent: state.agent,
       cwd: state.cwd,
+      codexBootstrap: state.codexBootstrap,
       command: ["sessions", "close", state.name],
     });
     await this.runControlCommand({
@@ -585,7 +668,18 @@ export class AcpxRuntime implements AcpRuntime {
   private resolveHandleState(handle: AcpRuntimeHandle): AcpxHandleState {
     const decoded = decodeAcpxRuntimeHandleState(handle.runtimeSessionName);
     if (decoded) {
-      return decoded;
+      const effectiveCwd = asTrimmedString(handle.cwd) || decoded.cwd;
+      const acpxRecordId = asOptionalString(handle.acpxRecordId) || decoded.acpxRecordId;
+      const backendSessionId =
+        asOptionalString(handle.backendSessionId) || decoded.backendSessionId;
+      const agentSessionId = asOptionalString(handle.agentSessionId) || decoded.agentSessionId;
+      return {
+        ...decoded,
+        cwd: effectiveCwd,
+        ...(acpxRecordId ? { acpxRecordId } : {}),
+        ...(backendSessionId ? { backendSessionId } : {}),
+        ...(agentSessionId ? { agentSessionId } : {}),
+      };
     }
 
     const legacyName = asTrimmedString(handle.runtimeSessionName);
@@ -596,11 +690,18 @@ export class AcpxRuntime implements AcpRuntime {
       );
     }
 
+    const effectiveCwd = asTrimmedString(handle.cwd) || this.config.cwd;
+    const acpxRecordId = asOptionalString(handle.acpxRecordId);
+    const backendSessionId = asOptionalString(handle.backendSessionId);
+    const agentSessionId = asOptionalString(handle.agentSessionId);
     return {
       name: legacyName,
       agent: deriveAgentFromSessionKey(handle.sessionKey, DEFAULT_AGENT_FALLBACK),
-      cwd: this.config.cwd,
+      cwd: effectiveCwd,
       mode: "persistent",
+      ...(acpxRecordId ? { acpxRecordId } : {}),
+      ...(backendSessionId ? { backendSessionId } : {}),
+      ...(agentSessionId ? { agentSessionId } : {}),
     };
   }
 
@@ -608,6 +709,7 @@ export class AcpxRuntime implements AcpRuntime {
     agent: string;
     sessionName: string;
     cwd: string;
+    codexBootstrap?: AcpxCodexBootstrapState;
   }): Promise<string[]> {
     const prefix = [
       "--format",
@@ -626,6 +728,7 @@ export class AcpxRuntime implements AcpRuntime {
     return await this.buildVerbArgs({
       agent: params.agent,
       cwd: params.cwd,
+      codexBootstrap: params.codexBootstrap,
       command: ["prompt", "--session", params.sessionName, "--file", "-"],
       prefix,
     });
@@ -636,11 +739,13 @@ export class AcpxRuntime implements AcpRuntime {
     cwd: string;
     command: string[];
     prefix?: string[];
+    codexBootstrap?: AcpxCodexBootstrapState;
   }): Promise<string[]> {
     const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cwd", params.cwd];
     const agentCommand = await this.resolveRawAgentCommand({
       agent: params.agent,
       cwd: params.cwd,
+      codexBootstrap: params.codexBootstrap,
     });
     if (!agentCommand) {
       return [...prefix, params.agent, ...params.command];
@@ -651,27 +756,46 @@ export class AcpxRuntime implements AcpRuntime {
   private async resolveRawAgentCommand(params: {
     agent: string;
     cwd: string;
+    codexBootstrap?: AcpxCodexBootstrapState;
   }): Promise<string | null> {
-    if (Object.keys(this.config.mcpServers).length === 0) {
+    const wantsMcpProxy = Object.keys(this.config.mcpServers).length > 0;
+    const wantsCodexBootstrap = Boolean(
+      params.codexBootstrap?.model || params.codexBootstrap?.reasoningEffort,
+    );
+    if (!wantsMcpProxy && !wantsCodexBootstrap) {
       return null;
     }
-    const cacheKey = `${params.cwd}::${params.agent}`;
-    const cached = this.mcpProxyAgentCommandCache.get(cacheKey);
+    const cacheKey = [
+      params.cwd,
+      params.agent,
+      params.codexBootstrap?.model ?? "",
+      params.codexBootstrap?.reasoningEffort ?? "",
+      wantsMcpProxy ? "mcp" : "nomcp",
+    ].join("::");
+    const cached = this.agentCommandCache.get(cacheKey);
     if (cached) {
       return cached;
     }
-    const targetCommand = await resolveAcpxAgentCommand({
+    let resolvedCommand = await resolveAcpxAgentCommand({
       acpxCommand: this.config.command,
       cwd: params.cwd,
       agent: params.agent,
       spawnOptions: this.spawnCommandOptions,
     });
-    const resolved = buildMcpProxyAgentCommand({
-      targetCommand,
-      mcpServers: toAcpMcpServers(this.config.mcpServers),
-    });
-    this.mcpProxyAgentCommandCache.set(cacheKey, resolved);
-    return resolved;
+    if (wantsCodexBootstrap && params.codexBootstrap) {
+      resolvedCommand = buildCodexBootstrapAgentCommand({
+        targetCommand: resolvedCommand,
+        bootstrap: params.codexBootstrap,
+      });
+    }
+    if (wantsMcpProxy) {
+      resolvedCommand = buildMcpProxyAgentCommand({
+        targetCommand: resolvedCommand,
+        mcpServers: toAcpMcpServers(this.config.mcpServers),
+      });
+    }
+    this.agentCommandCache.set(cacheKey, resolvedCommand);
+    return resolvedCommand;
   }
 
   private async runControlCommand(params: {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -765,14 +765,17 @@ export class AcpxRuntime implements AcpRuntime {
     if (!wantsMcpProxy && !wantsCodexBootstrap) {
       return null;
     }
-    const cacheKey = JSON.stringify([
-      params.cwd,
-      params.agent,
-      params.codexBootstrap?.model ?? "",
-      params.codexBootstrap?.reasoningEffort ?? "",
-      wantsMcpProxy ? "mcp" : "nomcp",
-    ]);
-    const cached = this.agentCommandCache.get(cacheKey);
+    const shouldCache = !wantsCodexBootstrap;
+    const cacheKey = shouldCache
+      ? JSON.stringify([
+          params.cwd,
+          params.agent,
+          params.codexBootstrap?.model ?? "",
+          params.codexBootstrap?.reasoningEffort ?? "",
+          wantsMcpProxy ? "mcp" : "nomcp",
+        ])
+      : null;
+    const cached = cacheKey ? this.agentCommandCache.get(cacheKey) : undefined;
     if (cached) {
       return cached;
     }
@@ -794,7 +797,9 @@ export class AcpxRuntime implements AcpRuntime {
         mcpServers: toAcpMcpServers(this.config.mcpServers),
       });
     }
-    this.agentCommandCache.set(cacheKey, resolvedCommand);
+    if (cacheKey) {
+      this.agentCommandCache.set(cacheKey, resolvedCommand);
+    }
     return resolvedCommand;
   }
 

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -235,6 +235,7 @@ export class AcpSessionManager {
             agent,
             mode: input.mode,
             cwd: requestedCwd,
+            env: input.env,
           }),
         fallbackCode: "ACP_SESSION_INIT_FAILED",
         fallbackMessage: "Could not initialize ACP session runtime.",
@@ -915,13 +916,65 @@ export class AcpSessionManager {
       this.clearCachedRuntimeState(params.sessionKey);
     }
 
+    const backend = this.deps.requireRuntimeBackend(configuredBackend || undefined);
+    const runtime = backend.runtime;
+    const previousMeta = params.meta;
+    const previousIdentity = resolveSessionIdentityFromMeta(previousMeta);
+    const persistedRuntimeSessionName = previousMeta.runtimeSessionName?.trim();
+    const persistedHandleIdentifiers =
+      resolveRuntimeHandleIdentifiersFromIdentity(previousIdentity);
+    const persistedHandle: AcpRuntimeHandle | null = persistedRuntimeSessionName
+      ? {
+          sessionKey: params.sessionKey,
+          backend: previousMeta.backend || backend.id,
+          runtimeSessionName: persistedRuntimeSessionName,
+          ...(cwd ? { cwd } : {}),
+          ...(persistedHandleIdentifiers.backendSessionId
+            ? { backendSessionId: persistedHandleIdentifiers.backendSessionId }
+            : {}),
+          ...(persistedHandleIdentifiers.agentSessionId
+            ? { agentSessionId: persistedHandleIdentifiers.agentSessionId }
+            : {}),
+        }
+      : null;
+    const restoreValidation = persistedHandle
+      ? await this.validatePersistedRuntimeHandle({
+          sessionKey: params.sessionKey,
+          runtime,
+          handle: persistedHandle,
+        })
+      : { stale: false as const };
+    if (persistedHandle && restoreValidation.runtimeStatus) {
+      const restored = await this.reconcileRuntimeSessionIdentifiers({
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        runtime,
+        handle: persistedHandle,
+        meta: previousMeta,
+        runtimeStatus: restoreValidation.runtimeStatus,
+        failOnStatusError: false,
+      });
+      this.setCachedRuntimeState(params.sessionKey, {
+        runtime,
+        handle: restored.handle,
+        backend: restored.handle.backend || previousMeta.backend || backend.id,
+        agent,
+        mode,
+        cwd: restored.handle.cwd ?? cwd,
+        appliedControlSignature: undefined,
+      });
+      return {
+        runtime,
+        handle: restored.handle,
+        meta: restored.meta,
+      };
+    }
+
     this.enforceConcurrentSessionLimit({
       cfg: params.cfg,
       sessionKey: params.sessionKey,
     });
 
-    const backend = this.deps.requireRuntimeBackend(configuredBackend || undefined);
-    const runtime = backend.runtime;
     const ensured = await withAcpRuntimeErrorBoundary({
       run: async () =>
         await runtime.ensureSession({
@@ -929,13 +982,12 @@ export class AcpSessionManager {
           agent,
           mode,
           cwd,
+          ...(persistedHandle ? { previousHandle: persistedHandle } : {}),
         }),
       fallbackCode: "ACP_SESSION_INIT_FAILED",
       fallbackMessage: "Could not initialize ACP session runtime.",
     });
 
-    const previousMeta = params.meta;
-    const previousIdentity = resolveSessionIdentityFromMeta(previousMeta);
     const now = Date.now();
     const effectiveCwd = normalizeText(ensured.cwd) ?? cwd;
     const nextRuntimeOptions = normalizeRuntimeOptions({
@@ -944,7 +996,7 @@ export class AcpSessionManager {
     });
     const nextIdentity =
       mergeSessionIdentity({
-        current: previousIdentity,
+        current: restoreValidation.stale ? undefined : previousIdentity,
         incoming: createIdentityFromEnsure({
           handle: ensured,
           now,
@@ -1007,6 +1059,70 @@ export class AcpSessionManager {
       handle: nextHandle,
       meta: nextMeta,
     };
+  }
+
+  private async validatePersistedRuntimeHandle(params: {
+    sessionKey: string;
+    runtime: AcpRuntime;
+    handle: AcpRuntimeHandle;
+  }): Promise<{ runtimeStatus?: AcpRuntimeStatus; stale: boolean }> {
+    if (!params.runtime.getStatus) {
+      return { stale: false };
+    }
+    try {
+      const runtimeStatus = await withAcpRuntimeErrorBoundary({
+        run: async () =>
+          await params.runtime.getStatus!({
+            handle: params.handle,
+          }),
+        fallbackCode: "ACP_TURN_FAILED",
+        fallbackMessage: "Could not read ACP runtime status.",
+      });
+      if (this.runtimeStatusIndicatesMissingSession(runtimeStatus)) {
+        logVerbose(
+          `acp-manager: persisted runtime handle is stale for ${params.sessionKey}; reinitializing runtime session`,
+        );
+        return { stale: true };
+      }
+      return {
+        runtimeStatus,
+        stale: false,
+      };
+    } catch (error) {
+      const acpError = toAcpRuntimeError({
+        error,
+        fallbackCode: "ACP_TURN_FAILED",
+        fallbackMessage: "Could not read ACP runtime status.",
+      });
+      if (acpError.code === "ACP_BACKEND_MISSING" || acpError.code === "ACP_BACKEND_UNAVAILABLE") {
+        throw acpError;
+      }
+      logVerbose(
+        `acp-manager: persisted runtime handle validation failed for ${params.sessionKey}; reinitializing runtime session: ${acpError.message}`,
+      );
+      return { stale: false };
+    }
+  }
+
+  private runtimeStatusIndicatesMissingSession(status: AcpRuntimeStatus | undefined): boolean {
+    const details = status?.details;
+    const detailStatus =
+      details && typeof details === "object" && !Array.isArray(details)
+        ? normalizeText(details.status)
+        : undefined;
+    const detailErrorCode =
+      details && typeof details === "object" && !Array.isArray(details)
+        ? normalizeText(details.errorCode ?? details.code)
+        : undefined;
+    const summary = normalizeText(status?.summary)?.toLowerCase();
+    return (
+      detailErrorCode === "NO_SESSION" ||
+      detailStatus === "missing" ||
+      detailStatus === "no-session" ||
+      summary === "status=missing" ||
+      summary === "status=no-session" ||
+      summary === "acpx status unavailable"
+    );
   }
 
   private async persistRuntimeOptions(params: {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -954,6 +954,10 @@ export class AcpSessionManager {
         runtimeStatus: restoreValidation.runtimeStatus,
         failOnStatusError: false,
       });
+      this.enforceConcurrentSessionLimit({
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+      });
       this.setCachedRuntimeState(params.sessionKey, {
         runtime,
         handle: restored.handle,
@@ -1120,8 +1124,7 @@ export class AcpSessionManager {
       detailStatus === "missing" ||
       detailStatus === "no-session" ||
       summary === "status=missing" ||
-      summary === "status=no-session" ||
-      summary === "acpx status unavailable"
+      summary === "status=no-session"
     );
   }
 

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -98,7 +98,7 @@ function createRuntime(): {
   };
 }
 
-function readySessionMeta() {
+function readySessionMeta(overrides: Partial<SessionAcpMeta> = {}): SessionAcpMeta {
   return {
     backend: "acpx",
     agent: "codex",
@@ -106,6 +106,7 @@ function readySessionMeta() {
     mode: "persistent" as const,
     state: "idle" as const,
     lastActivityAt: Date.now(),
+    ...overrides,
   };
 }
 
@@ -227,10 +228,7 @@ describe("AcpSessionManager", () => {
       return {
         sessionKey,
         storeSessionKey: sessionKey,
-        acp: {
-          ...readySessionMeta(),
-          runtimeSessionName: `runtime:${sessionKey}`,
-        },
+        acp: readySessionMeta({ runtimeSessionName: "" }),
       };
     });
 
@@ -277,7 +275,7 @@ describe("AcpSessionManager", () => {
     hoisted.readAcpSessionEntryMock.mockReturnValue({
       sessionKey: "agent:codex:acp:session-1",
       storeSessionKey: "agent:codex:acp:session-1",
-      acp: readySessionMeta(),
+      acp: readySessionMeta({ runtimeSessionName: "" }),
     });
 
     const manager = new AcpSessionManager();
@@ -300,7 +298,7 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
   });
 
-  it("rehydrates runtime handles after a manager restart", async () => {
+  it("validates and reuses persisted runtime handles after a manager restart", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
       id: "acpx",
@@ -329,7 +327,79 @@ describe("AcpSessionManager", () => {
       requestId: "r2",
     });
 
-    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expect(runtimeState.ensureSession).not.toHaveBeenCalled();
+    expect(runtimeState.getStatus).toHaveBeenCalled();
+  });
+
+  it("reinitializes stale persisted runtime handles using the previous handle as restore input", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getStatus
+      .mockResolvedValueOnce({
+        summary: "status=missing",
+        details: { status: "missing", errorCode: "NO_SESSION" },
+      })
+      .mockResolvedValue({
+        summary: "status=alive",
+        backendSessionId: "acpx-fresh",
+        agentSessionId: "agent-fresh",
+        details: { status: "alive" },
+      });
+    runtimeState.ensureSession.mockResolvedValue({
+      sessionKey: "agent:codex:acp:session-1",
+      backend: "acpx",
+      runtimeSessionName: "runtime-fresh",
+      backendSessionId: "acpx-fresh",
+      agentSessionId: "agent-fresh",
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta({
+        runtimeSessionName: "runtime-stale",
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxSessionId: "acpx-stale",
+          agentSessionId: "agent-stale",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "restore stale handle",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousHandle: expect.objectContaining({
+          runtimeSessionName: "runtime-stale",
+          backendSessionId: "acpx-stale",
+          agentSessionId: "agent-stale",
+        }),
+      }),
+    );
+    const runInput = runtimeState.runTurn.mock.calls[0]?.[0] as
+      | {
+          handle?: {
+            runtimeSessionName?: string;
+            backendSessionId?: string;
+            agentSessionId?: string;
+          };
+        }
+      | undefined;
+    expect(runInput?.handle?.runtimeSessionName).toBe("runtime-fresh");
+    expect(runInput?.handle?.backendSessionId).toBe("acpx-fresh");
+    expect(runInput?.handle?.agentSessionId).toBe("agent-fresh");
   });
 
   it("enforces acp.maxConcurrentSessions when opening new runtime handles", async () => {
@@ -343,10 +413,7 @@ describe("AcpSessionManager", () => {
       return {
         sessionKey,
         storeSessionKey: sessionKey,
-        acp: {
-          ...readySessionMeta(),
-          runtimeSessionName: `runtime:${sessionKey}`,
-        },
+        acp: readySessionMeta({ runtimeSessionName: "" }),
       };
     });
     const limitedCfg = {
@@ -434,10 +501,7 @@ describe("AcpSessionManager", () => {
       return {
         sessionKey,
         storeSessionKey: sessionKey,
-        acp: {
-          ...readySessionMeta(),
-          runtimeSessionName: `runtime:${sessionKey}`,
-        },
+        acp: readySessionMeta({ runtimeSessionName: "" }),
       };
     });
     const limitedCfg = {
@@ -491,10 +555,7 @@ describe("AcpSessionManager", () => {
         return {
           sessionKey,
           storeSessionKey: sessionKey,
-          acp: {
-            ...readySessionMeta(),
-            runtimeSessionName: `runtime:${sessionKey}`,
-          },
+          acp: readySessionMeta({ runtimeSessionName: "" }),
         };
       });
       const cfg = {
@@ -913,7 +974,7 @@ describe("AcpSessionManager", () => {
       requestId: "run-1",
     });
 
-    expect(runtimeState.getStatus).toHaveBeenCalledTimes(1);
+    expect(runtimeState.getStatus).toHaveBeenCalledTimes(2);
     expect(currentMeta.identity?.acpxSessionId).toBe("acpx-fresh");
     expect(currentMeta.identity?.agentSessionId).toBe("agent-fresh");
   });
@@ -1051,7 +1112,7 @@ describe("AcpSessionManager", () => {
       sessionKey: "agent:codex:acp:session-1",
       storeSessionKey: "agent:codex:acp:session-1",
       acp: {
-        ...readySessionMeta(),
+        ...readySessionMeta({ runtimeSessionName: "" }),
         identity: {
           state: "resolved",
           source: "status",

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -331,6 +331,121 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.getStatus).toHaveBeenCalled();
   });
 
+  it("does not treat generic acpx status unavailable as a stale persisted handle", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getStatus.mockResolvedValue({
+      summary: "acpx status unavailable",
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta({
+        runtimeSessionName: "runtime-restored",
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxSessionId: "acpx-restored",
+          agentSessionId: "agent-restored",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "status fallback",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    expect(runtimeState.ensureSession).not.toHaveBeenCalled();
+    const runInput = runtimeState.runTurn.mock.calls[0]?.[0] as
+      | {
+          handle?: {
+            runtimeSessionName?: string;
+            backendSessionId?: string;
+            agentSessionId?: string;
+          };
+        }
+      | undefined;
+    expect(runInput?.handle?.runtimeSessionName).toBe("runtime-restored");
+    expect(runInput?.handle?.backendSessionId).toBe("acpx-restored");
+    expect(runInput?.handle?.agentSessionId).toBe("agent-restored");
+  });
+
+  it("enforces acp.maxConcurrentSessions before restoring persisted runtime handles", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getStatus.mockResolvedValue({
+      summary: "status=alive",
+      details: { status: "alive" },
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      if (sessionKey === "agent:codex:acp:session-a") {
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: readySessionMeta({ runtimeSessionName: "" }),
+        };
+      }
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: readySessionMeta({
+          runtimeSessionName: "runtime-restored",
+          identity: {
+            state: "resolved",
+            source: "status",
+            acpxSessionId: "acpx-restored",
+            agentSessionId: "agent-restored",
+            lastUpdatedAt: Date.now(),
+          },
+        }),
+      };
+    });
+    const limitedCfg = {
+      acp: {
+        ...baseCfg.acp,
+        maxConcurrentSessions: 1,
+      },
+    } as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: limitedCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      text: "first",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    await expect(
+      manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-b",
+        text: "restore",
+        mode: "prompt",
+        requestId: "r2",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_SESSION_INIT_FAILED",
+      message: expect.stringContaining("max concurrent sessions"),
+    });
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+    expect(runtimeState.getStatus.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
   it("reinitializes stale persisted runtime handles using the previous handle as restore input", async () => {
     const runtimeState = createRuntime();
     runtimeState.getStatus

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -44,6 +44,7 @@ export type AcpInitializeSessionInput = {
   agent: string;
   mode: AcpRuntimeSessionMode;
   cwd?: string;
+  env?: Record<string, string>;
   backendId?: string;
 };
 

--- a/src/acp/runtime/types.ts
+++ b/src/acp/runtime/types.ts
@@ -37,6 +37,12 @@ export type AcpRuntimeEnsureInput = {
   mode: AcpRuntimeSessionMode;
   cwd?: string;
   env?: Record<string, string>;
+  /**
+   * Previously persisted runtime handle for this session, if one exists.
+   * Backends can use this to rehydrate backend-specific state during restore
+   * without forcing core to understand adapter-specific handle encoding.
+   */
+  previousHandle?: AcpRuntimeHandle;
 };
 
 export type AcpRuntimeTurnInput = {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -420,7 +420,7 @@ describe("spawnAcpDirect", () => {
     });
   });
 
-  it('maps Codex ACP thinking="off" to reasoningEffort="none" in the bootstrap env', async () => {
+  it('rejects Codex ACP thinking="off" before session init because the Codex CLI does not support it', async () => {
     const result = await spawnAcpDirect(
       {
         task: "Investigate flaky tests",
@@ -432,11 +432,10 @@ describe("spawnAcpDirect", () => {
       },
     );
 
-    expect(result.status).toBe("accepted");
-    const initCall = hoisted.initializeSessionMock.mock.calls[0]?.[0];
-    expect(decodeCodexBootstrapEnv(initCall)).toEqual({
-      reasoningEffort: "none",
-    });
+    expect(result.status).toBe("error");
+    expect(result.error).toContain('thinking="off" is unsupported');
+    expect(result.error).toContain("low, medium, high, xhigh");
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
   it("does not inline delivery for fresh oneshot ACP runs", async () => {
@@ -647,22 +646,39 @@ describe("spawnAcpDirect", () => {
     expect(decodeCodexBootstrapEnv(initCall)).toBeUndefined();
   });
 
-  it("rejects unsupported Codex ACP thinking levels before session init", async () => {
-    const result = await spawnAcpDirect(
-      {
-        task: "hello",
-        agentId: "codex",
-        thinking: "adaptive",
-      },
-      {
-        agentSessionKey: "agent:main:main",
-      },
-    );
+  it.each([
+    {
+      thinking: "adaptive",
+      message: 'thinking="adaptive" is unsupported',
+    },
+    {
+      thinking: "minimal",
+      message: 'thinking="minimal" is unsupported',
+    },
+    {
+      thinking: "none",
+      message: 'Invalid thinking level "none".',
+    },
+  ])(
+    "rejects unsupported Codex ACP thinking=$thinking before session init",
+    async ({ thinking, message }) => {
+      const result = await spawnAcpDirect(
+        {
+          task: "hello",
+          agentId: "codex",
+          thinking,
+        },
+        {
+          agentSessionKey: "agent:main:main",
+        },
+      );
 
-    expect(result.status).toBe("error");
-    expect(result.error).toContain('thinking="adaptive" is unsupported');
-    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
-  });
+      expect(result.status).toBe("error");
+      expect(result.error).toContain(message);
+      expect(result.error).toContain("low, medium, high, xhigh");
+      expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("requires an explicit ACP agent when no config default exists", async () => {
     const result = await spawnAcpDirect(

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -28,6 +28,7 @@ function createDefaultSpawnConfig(): OpenClawConfig {
 
 const hoisted = vi.hoisted(() => {
   const callGatewayMock = vi.fn();
+  const requireAcpRuntimeBackendMock = vi.fn();
   const sessionBindingCapabilitiesMock = vi.fn();
   const sessionBindingBindMock = vi.fn();
   const sessionBindingUnbindMock = vi.fn();
@@ -45,6 +46,7 @@ const hoisted = vi.hoisted(() => {
   };
   return {
     callGatewayMock,
+    requireAcpRuntimeBackendMock,
     sessionBindingCapabilitiesMock,
     sessionBindingBindMock,
     sessionBindingUnbindMock,
@@ -92,6 +94,10 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => hoisted.callGatewayMock(opts),
+}));
+
+vi.mock("../acp/runtime/registry.js", () => ({
+  requireAcpRuntimeBackend: (id?: string) => hoisted.requireAcpRuntimeBackendMock(id),
 }));
 
 vi.mock("../config/sessions.js", async (importOriginal) => {
@@ -220,6 +226,9 @@ describe("spawnAcpDirect", () => {
       }
       return {};
     });
+    hoisted.requireAcpRuntimeBackendMock
+      .mockReset()
+      .mockImplementation((id?: string) => ({ id: id?.trim() || "acpx", runtime: {} }));
 
     hoisted.closeSessionMock.mockReset().mockResolvedValue({
       runtimeClosed: true,
@@ -411,6 +420,25 @@ describe("spawnAcpDirect", () => {
     });
   });
 
+  it('maps Codex ACP thinking="off" to reasoningEffort="none" in the bootstrap env', async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        thinking: "off",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const initCall = hoisted.initializeSessionMock.mock.calls[0]?.[0];
+    expect(decodeCodexBootstrapEnv(initCall)).toEqual({
+      reasoningEffort: "none",
+    });
+  });
+
   it("does not inline delivery for fresh oneshot ACP runs", async () => {
     const result = await spawnAcpDirect(
       {
@@ -580,6 +608,41 @@ describe("spawnAcpDirect", () => {
     const initCall = hoisted.initializeSessionMock.mock.calls[0]?.[0];
     expect(initCall).toMatchObject({
       agent: "claude",
+    });
+    expect(decodeCodexBootstrapEnv(initCall)).toBeUndefined();
+  });
+
+  it("uses the resolved runtime backend instead of assuming acpx when config backend is unset", async () => {
+    hoisted.state.cfg = {
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        allowedAgents: ["codex"],
+      },
+    };
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "custom",
+      runtime: {},
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "codex",
+        thinking: "adaptive",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(hoisted.requireAcpRuntimeBackendMock).toHaveBeenCalledWith(undefined);
+    expect(result.status).toBe("accepted");
+    expect(result.note).toContain('supported only for agentId="codex" on the acpx backend');
+    const initCall = hoisted.initializeSessionMock.mock.calls[0]?.[0];
+    expect(initCall).toMatchObject({
+      agent: "codex",
+      backendId: "custom",
     });
     expect(decodeCodexBootstrapEnv(initCall)).toBeUndefined();
   });

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionBindingRecord } from "../infra/outbound/session-binding-service.js";
 
+const ACPX_CODEX_BOOTSTRAP_ENV_KEY = "OPENCLAW_ACPX_CODEX_BOOTSTRAP";
+
 function createDefaultSpawnConfig(): OpenClawConfig {
   return {
     acp: {
@@ -137,6 +139,18 @@ vi.mock("./acp-spawn-parent-stream.js", () => ({
 
 const { spawnAcpDirect } = await import("./acp-spawn.js");
 
+function decodeCodexBootstrapEnv(input: unknown) {
+  const env = input as { env?: Record<string, string> } | undefined;
+  const encoded = env?.env?.[ACPX_CODEX_BOOTSTRAP_ENV_KEY];
+  if (!encoded) {
+    return undefined;
+  }
+  return JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as {
+    model?: string;
+    reasoningEffort?: string;
+  };
+}
+
 function createSessionBindingCapabilities() {
   return {
     adapterAvailable: true,
@@ -217,6 +231,7 @@ describe("spawnAcpDirect", () => {
         agent: string;
         mode: "persistent" | "oneshot";
         cwd?: string;
+        env?: Record<string, string>;
       };
       const runtimeSessionName = `${args.sessionKey}:runtime`;
       const cwd = typeof args.cwd === "string" ? args.cwd : undefined;
@@ -375,6 +390,27 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
   });
 
+  it("passes Codex model and thinking overrides through the ACP bootstrap env", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        model: "gpt-5.3-codex-spark",
+        thinking: "high",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const initCall = hoisted.initializeSessionMock.mock.calls[0]?.[0];
+    expect(decodeCodexBootstrapEnv(initCall)).toEqual({
+      model: "gpt-5.3-codex-spark",
+      reasoningEffort: "high",
+    });
+  });
+
   it("does not inline delivery for fresh oneshot ACP runs", async () => {
     const result = await spawnAcpDirect(
       {
@@ -485,6 +521,84 @@ describe("spawnAcpDirect", () => {
     expect(result).toMatchObject({
       status: "forbidden",
     });
+  });
+
+  it("accepts ACP spawns and strips unsupported model/thinking overrides for other harnesses", async () => {
+    hoisted.state.cfg = {
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["codex", "claude"],
+      },
+    };
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "claude",
+        model: "claude-opus-4-5",
+        thinking: "medium",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.note).toContain('supported only for agentId="codex" on the acpx backend');
+    const initCall = hoisted.initializeSessionMock.mock.calls[0]?.[0];
+    expect(initCall).toMatchObject({
+      agent: "claude",
+    });
+    expect(decodeCodexBootstrapEnv(initCall)).toBeUndefined();
+  });
+
+  it("ignores invalid thinking overrides for non-Codex ACP harnesses", async () => {
+    hoisted.state.cfg = {
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["codex", "claude"],
+      },
+    };
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "claude",
+        thinking: "adaptive",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.note).toContain('supported only for agentId="codex" on the acpx backend');
+    const initCall = hoisted.initializeSessionMock.mock.calls[0]?.[0];
+    expect(initCall).toMatchObject({
+      agent: "claude",
+    });
+    expect(decodeCodexBootstrapEnv(initCall)).toBeUndefined();
+  });
+
+  it("rejects unsupported Codex ACP thinking levels before session init", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "codex",
+        thinking: "adaptive",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain('thinking="adaptive" is unsupported');
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
   it("requires an explicit ACP agent when no config default exists", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -54,7 +54,7 @@ export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
 export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
 export type SpawnAcpStreamTarget = (typeof ACP_SPAWN_STREAM_TARGETS)[number];
 const ACPX_CODEX_BOOTSTRAP_ENV_KEY = "OPENCLAW_ACPX_CODEX_BOOTSTRAP";
-const ACPX_CODEX_SUPPORTED_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
+const ACPX_CODEX_SUPPORTED_THINKING_LEVELS = ["low", "medium", "high", "xhigh"] as const;
 
 export type SpawnAcpParams = {
   task: string;
@@ -325,10 +325,6 @@ function normalizeCodexReasoningEffort(
   if (!trimmed) {
     return { ok: true };
   }
-  const normalizedRaw = trimmed.toLowerCase();
-  if (normalizedRaw === "none") {
-    return { ok: true, reasoningEffort: "none" };
-  }
   const normalized = normalizeThinkLevel(trimmed);
   if (!normalized) {
     return {
@@ -342,9 +338,21 @@ function normalizeCodexReasoningEffort(
       error: `ACP spawn thinking="adaptive" is unsupported for Codex on acpx. Use one of: ${ACPX_CODEX_SUPPORTED_THINKING_LEVELS.join(", ")}.`,
     };
   }
+  if (normalized === "off") {
+    return {
+      ok: false,
+      error: `ACP spawn thinking="off" is unsupported for Codex on acpx because the Codex CLI accepts only: ${ACPX_CODEX_SUPPORTED_THINKING_LEVELS.join(", ")}.`,
+    };
+  }
+  if (normalized === "minimal") {
+    return {
+      ok: false,
+      error: `ACP spawn thinking="minimal" is unsupported for Codex on acpx because the Codex CLI accepts only: ${ACPX_CODEX_SUPPORTED_THINKING_LEVELS.join(", ")}.`,
+    };
+  }
   return {
     ok: true,
-    reasoningEffort: normalized === "off" ? "none" : normalized,
+    reasoningEffort: normalized,
   };
 }
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -5,6 +5,7 @@ import {
   type AcpSpawnRuntimeCloseHandle,
 } from "../acp/control-plane/spawn.js";
 import { isAcpEnabledByPolicy, resolveAcpAgentPolicyError } from "../acp/policy.js";
+import { requireAcpRuntimeBackend } from "../acp/runtime/registry.js";
 import {
   resolveAcpSessionCwd,
   resolveAcpThreadSessionDetailLines,
@@ -464,8 +465,17 @@ export async function spawnAcpDirect(
       error: agentPolicyError.message,
     };
   }
+  let resolvedBackendId: string;
+  try {
+    resolvedBackendId = requireAcpRuntimeBackend(cfg.acp?.backend).id;
+  } catch (error) {
+    return {
+      status: "error",
+      error: summarizeError(error),
+    };
+  }
   const bootstrapEnv = resolveAcpSpawnBootstrapEnv({
-    backendId: cfg.acp?.backend,
+    backendId: resolvedBackendId,
     agentId: targetAgentId,
     model: params.model,
     thinking: params.thinking,
@@ -537,7 +547,7 @@ export async function spawnAcpDirect(
       mode: runtimeMode,
       cwd: params.cwd,
       env: bootstrapEnv.env,
-      backendId: cfg.acp?.backend,
+      backendId: resolvedBackendId,
     });
     initializedRuntime = {
       runtime: initialized.runtime,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -10,6 +10,7 @@ import {
   resolveAcpThreadSessionDetailLines,
 } from "../acp/runtime/session-identifiers.js";
 import type { AcpRuntimeSessionMode } from "../acp/runtime/types.js";
+import { normalizeThinkLevel } from "../auto-reply/thinking.js";
 import {
   resolveThreadBindingIntroText,
   resolveThreadBindingThreadName,
@@ -51,11 +52,15 @@ export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
 export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
 export type SpawnAcpStreamTarget = (typeof ACP_SPAWN_STREAM_TARGETS)[number];
+const ACPX_CODEX_BOOTSTRAP_ENV_KEY = "OPENCLAW_ACPX_CODEX_BOOTSTRAP";
+const ACPX_CODEX_SUPPORTED_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 
 export type SpawnAcpParams = {
   task: string;
   label?: string;
   agentId?: string;
+  model?: string;
+  thinking?: string;
   cwd?: string;
   mode?: SpawnAcpMode;
   thread?: boolean;
@@ -156,6 +161,11 @@ function normalizeOptionalAgentId(value: string | undefined | null): string | un
     return undefined;
   }
   return normalizeAgentId(trimmed);
+}
+
+function normalizeOptionalBackendId(value: string | undefined | null): string | undefined {
+  const trimmed = (value ?? "").trim().toLowerCase();
+  return trimmed || undefined;
 }
 
 function summarizeError(err: unknown): string {
@@ -302,6 +312,92 @@ function prepareAcpThreadBinding(params: {
   };
 }
 
+function normalizeSpawnModelOverride(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function normalizeCodexReasoningEffort(
+  value: string | undefined,
+): { ok: true; reasoningEffort?: string } | { ok: false; error: string } {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return { ok: true };
+  }
+  const normalizedRaw = trimmed.toLowerCase();
+  if (normalizedRaw === "none") {
+    return { ok: true, reasoningEffort: "none" };
+  }
+  const normalized = normalizeThinkLevel(trimmed);
+  if (!normalized) {
+    return {
+      ok: false,
+      error: `Invalid thinking level "${value}". Codex ACP spawn supports: ${ACPX_CODEX_SUPPORTED_THINKING_LEVELS.join(", ")}.`,
+    };
+  }
+  if (normalized === "adaptive") {
+    return {
+      ok: false,
+      error: `ACP spawn thinking="adaptive" is unsupported for Codex on acpx. Use one of: ${ACPX_CODEX_SUPPORTED_THINKING_LEVELS.join(", ")}.`,
+    };
+  }
+  return {
+    ok: true,
+    reasoningEffort: normalized === "off" ? "none" : normalized,
+  };
+}
+
+function buildCodexAcpxBootstrapEnv(payload: {
+  model?: string;
+  reasoningEffort?: string;
+}): Record<string, string> | undefined {
+  if (!payload.model && !payload.reasoningEffort) {
+    return undefined;
+  }
+  const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return {
+    [ACPX_CODEX_BOOTSTRAP_ENV_KEY]: encoded,
+  };
+}
+
+function formatUnsupportedAcpSpawnOverrideNote(): string {
+  return 'Ignored ACP model/thinking overrides because they are currently supported only for agentId="codex" on the acpx backend.';
+}
+
+function resolveAcpSpawnBootstrapEnv(params: {
+  backendId?: string;
+  agentId: string;
+  model?: string;
+  thinking?: string;
+}): { ok: true; env?: Record<string, string>; note?: string } | { ok: false; error: string } {
+  const model = normalizeSpawnModelOverride(params.model);
+  const thinking = params.thinking?.trim() || undefined;
+  const backendId = normalizeOptionalBackendId(params.backendId) ?? "acpx";
+  if (backendId !== "acpx" || params.agentId !== "codex") {
+    if (!model && !thinking) {
+      return { ok: true };
+    }
+    return {
+      ok: true,
+      note: formatUnsupportedAcpSpawnOverrideNote(),
+    };
+  }
+  const reasoningResult = normalizeCodexReasoningEffort(thinking);
+  if (!reasoningResult.ok) {
+    return reasoningResult;
+  }
+  if (!model && !reasoningResult.reasoningEffort) {
+    return { ok: true };
+  }
+  return {
+    ok: true,
+    env: buildCodexAcpxBootstrapEnv({
+      model,
+      reasoningEffort: reasoningResult.reasoningEffort,
+    }),
+  };
+}
+
 export async function spawnAcpDirect(
   params: SpawnAcpParams,
   ctx: SpawnAcpContext,
@@ -368,6 +464,19 @@ export async function spawnAcpDirect(
       error: agentPolicyError.message,
     };
   }
+  const bootstrapEnv = resolveAcpSpawnBootstrapEnv({
+    backendId: cfg.acp?.backend,
+    agentId: targetAgentId,
+    model: params.model,
+    thinking: params.thinking,
+  });
+  if (!bootstrapEnv.ok) {
+    return {
+      status: "error",
+      error: bootstrapEnv.error,
+    };
+  }
+  const acceptedNotePrefix = bootstrapEnv.note?.trim() || undefined;
 
   const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
@@ -427,6 +536,7 @@ export async function spawnAcpDirect(
       agent: targetAgentId,
       mode: runtimeMode,
       cwd: params.cwd,
+      env: bootstrapEnv.env,
       backendId: cfg.acp?.backend,
     });
     initializedRuntime = {
@@ -603,7 +713,12 @@ export async function spawnAcpDirect(
       runId: childRunId,
       mode: spawnMode,
       ...(streamLogPath ? { streamLogPath } : {}),
-      note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
+      note: [
+        acceptedNotePrefix,
+        spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
+      ]
+        .filter(Boolean)
+        .join(" "),
     };
   }
 
@@ -612,6 +727,11 @@ export async function spawnAcpDirect(
     childSessionKey: sessionKey,
     runId: childRunId,
     mode: spawnMode,
-    note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
+    note: [
+      acceptedNotePrefix,
+      spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
+    ]
+      .filter(Boolean)
+      .join(" "),
   };
 }

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -111,6 +111,8 @@ describe("sessions_spawn tool", () => {
       runtime: "acp",
       task: "investigate the failing CI run",
       agentId: "codex",
+      model: "gpt-5.3-codex-spark",
+      thinking: "high",
       cwd: "/workspace",
       thread: true,
       mode: "session",
@@ -126,6 +128,8 @@ describe("sessions_spawn tool", () => {
       expect.objectContaining({
         task: "investigate the failing CI run",
         agentId: "codex",
+        model: "gpt-5.3-codex-spark",
+        thinking: "high",
         cwd: "/workspace",
         thread: true,
         mode: "session",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -140,6 +140,8 @@ export function createSessionsSpawnTool(
             task,
             label: label || undefined,
             agentId: requestedAgentId,
+            model: modelOverride,
+            thinking: thinkingOverrideRaw,
             cwd,
             mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
             thread,


### PR DESCRIPTION
## Summary

- Problem: `sessions_spawn(runtime:"acp")` publicly accepted `model` and `thinking`, but the ACP spawn path did not forward/apply those overrides.
- Why it matters: ACP spawns silently inherited harness-local defaults instead of the caller’s explicit per-spawn request and was doing it so silently.
- What changed: the Codex/acpx ACP spawn path now forwards model/thinking through a Codex bootstrap env and wrapper that injects Codex CLI overrides before the first task dispatch.
- What did NOT change (scope boundary): this PR does not claim universal ACP override support, does not change non-ACP `sessions_spawn`, does not add other harnesses support, and does not redesign ACP runtime options broadly outside the narrow Codex/acpx spawn override path/tests/docs.

## AI-Assisted Disclosure

- [X] AI-assisted: Yes
- [X] Tools used: Codex/OpenClaw-assisted implementation and iteration
- [X] Testing level: manually validated + targeted automated tests
- [X] Author verification: final code paths, config behavior, and runtime checks were reviewed.

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [X] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [X] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: #40393


## User-visible / Behavior Changes

- sessions_spawn(runtime:"acp", agentId:"codex") now honors model overrides during Codex ACP session setup.,
- sessions_spawn(runtime:"acp", agentId:"codex") now honors supported thinking overrides by validating them for the ---Codex CLI and forwarding them through the Codex bootstrap wrapper before the first task turn.,
- Unsupported Codex/acpx thinking values now fail clearly. For non-Codex or non-acpx ACP harnesses, model / thinking overrides are ignored with an explanatory note.


## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: Linux 6.8.0-100-generic (x64)
- Runtime/container: local OpenClaw dev repo at `/root/openclaw`
- Model/provider: ACP Codex harness via acpx; local Codex defaults inspected and controlled during repro
- Integration/channel (if any): Discord for ACP thread/session observation; local repo tests for verification
- Relevant config (redacted): ACP enabled with acpx backend; local Codex config used during repro to distinguish requested overrides from harness defaults

### Steps

1. Set local Codex default config to a known value different from the desired per-spawn override.
2. Call `sessions_spawn` with `runtime: "acp"`, `agentId: "codex"`, explicit `model`, and explicit `thinking`.
3. Inspect actual Codex/acpx runtime/session metadata to see what model/reasoning the spawned session used.
4. Apply this patch and rerun targeted ACP tests.

### Expected

- Codex ACP spawn should apply the requested model override.,
- Codex ACP spawn should apply supported thinking overrides through the Codex bootstrap wrapper before the first task turn.,
- Unsupported Codex/acpx thinking values should fail clearly instead of silently falling back.

### Actual

- Before this patch, Codex ACP spawn ignored `model` and `thinking` and used harness-local defaults.
- After this patch, the Codex/acpx spawn path forwards and applies those overrides through the Codex bootstrap wrapper before the first task dispatch, with targeted tests passing.

## Evidence

Attach at least one:

- [X] Failing test/log before + passing after
- [X] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local Codex default at the time of repro:
- `model = "gpt-5.4"`
- `model_reasoning_effort = "medium"`

Spawn request used:

```json
{
  "task": "Reply with exactly REPRO_OK. Do not use tools.",
  "label": "acp-codex-model-thinking-repro-20260307-1251",
  "runtime": "acp",
  "agentId": "codex",
  "model": "gpt-5.3-codex-spark",
  "thinking": "high",
  "cwd": "/root/openclaw",
  "thread": true,
  "mode": "run"
}
```

### Observed ACP runtime artifact

File:
- `/root/.acpx/sessions/019cc859-3a05-7063-92d3-f85e919b1375.stream.ndjson`

Relevant line:

```json
6:{"jsonrpc":"2.0","id":2,"result":{"sessionId":"019cc859-54dd-7ed1-94af-ad0f007574fb","models":{"currentModelId":"gpt-5.4/medium",...},"configOptions":[{"id":"model","currentValue":"gpt-5.4",...},{"id":"reasoning_effort","currentValue":"medium",...}]}}
```

### Observed Codex session artifact

File:
- `/root/.codex/sessions/2026/03/07/rollout-2026-03-07T12-50-23-019cc859-54dd-7ed1-94af-ad0f007574fb.jsonl`

Relevant line:

```json
7:{"timestamp":"2026-03-07T12:50:24.117Z","type":"turn_context","payload":{"model":"gpt-5.4",...,"collaboration_mode":{"mode":"default","settings":{"model":"gpt-5.4","reasoning_effort":"medium"}},"effort":"medium",...}}
```

Conclusion:
- requested spawn overrides were:
  - `model = "gpt-5.3-codex-spark"`
  - `thinking = "high"`
- actual spawned Codex ACP session came up as:
  - `model = "gpt-5.4"`
  - `reasoning = "medium"`
- therefore `sessions_spawn(runtime:"acp", agentId:"codex")` ignored the provided `model` and `thinking` values and used harness-local defaults instead

After the patch
---
**Local Codex default at the time of repro:**
- `model = "gpt-5.4"`
- `model_reasoning_effort = "medium"`

Spawn request used:

```json
{
  "task": "Say hi.",
  "label": "acp-codex-spark-high-20260308-2252",
  "runtime": "acp",
  "agentId": "codex",
  "model": "gpt-5.3-codex-spark",
  "thinking": "high",
  "thread": true,
  "mode": "session"
}
```

### Observed ACP runtime artifact

File:
- `/root/.acpx/sessions/019ccfa7-2536-76b1-a438-0e154cdb1b72.stream.ndjson`

Relevant line:

```json
6:{"jsonrpc":"2.0","id":2,"result":{"sessionId":"019ccfa7-34d2-74d2-89be-fea73b912995","models":{"currentModelId":"gpt-5.3-codex-spark/high",...},"configOptions":[{"id":"model","currentValue":"gpt-5.3-codex-spark",...},{"id":"reasoning_effort","currentValue":"high",...}]}}
```

### Observed Codex session artifact

File:
- `/root/.codex/sessions/2026/03/08/rollout-2026-03-08T22-52-47-019ccfa7-34d2-74d2-89be-fea73b912995.jsonl`

Relevant line:

```json
7:{"timestamp":"2026-03-08T22:52:48.236Z","type":"turn_context","payload":{"model":"gpt-5.3-codex-spark",...,"collaboration_mode":{"mode":"default","settings":{"model":"gpt-5.3-codex-spark","reasoning_effort":"high"}},"effort":"high",...}}
```

Conclusion:
- requested spawn overrides were:
 - `model = "gpt-5.3-codex-spark"`
 - `thinking = "high"`
- actual spawned Codex ACP session came up as:
 - `model = "gpt-5.3-codex-spark"`
 - `reasoning = "high"`
- therefore `sessions_spawn(runtime:"acp", agentId:"codex")` applied the provided `model` and `thinking` values correctly for this repro

Notes:

Additional evidence produced 
[acp-codex-invalid-thinking-ultramegahigh-20260308.md](https://github.com/user-attachments/files/25829031/acp-codex-invalid-thinking-ultramegahigh-20260308.md)
[acp-opencode-codex-style-overrides-soft-ignore-20260308.md](https://github.com/user-attachments/files/25829032/acp-opencode-codex-style-overrides-soft-ignore-20260308.md)
[acp-codex-thinking-level-validation-20260309.md](https://github.com/user-attachments/files/25830353/acp-codex-thinking-level-validation-20260309.md)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed the original bug exists on upstream/current branch by code inspection and direct Codex/acpx ACP reproduction.
  - Confirmed the clean branch state passes targeted ACP tests locally.
  - Confirmed the fix branch state is clean and pushable to fork.
  - Did test with model only and thinking only.
  - Tested opencode with model and thinking - Soft fail message > spawns with harness default better than current soft silent fail.
- Edge cases checked:
  - Invalid `thinking` input rejection.
  - Invalid unsupported model (non fixed model list check implemented it will accept any model will fail at API can be implemented but will require updates everytime new model is released)
- What you did **not** verify:
  - Full end-to-end ACP spawn behavior against every ACP harness family.
  - Didn't verify other harnesses but OpenCode and Codex, did not verify non ACPX backends 

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this branch/PR, or fall back to the previous Codex/acpx ACP spawn behavior by reverting the fix commits.
- Files/config to restore:
 Revert the merge commit.
- Known bad symptoms reviewers should watch for:
 Setting unsupported model for codex
 Potential issues with other future backends other than acpx

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `model` is not strictly checked
  - Mitigation: None fixed model list check implemented it will accept any model will fail at API level can be implemented but will require updates everytime new model is released/removed. 
- Risk: Other ACP harnesses beyond Codex/acpx expose different behavior and should not inherit this logic by assumption.
  - Mitigation: scope is intentionally narrowed to Codex/acpx; follow-up harness support should be added with explicit harness-aware handling.
  
 ## IMPLEMENTATION NOTES
  
- Before implementing this I read the docs/experimental/plans/acp-thread-bound-agents.md and the other 2 releted acp documents. Tried to align this to the vision and goals there as much as possible. 
- Initial attempts to implement it universally for all the back ends proved way too complex so this was scoped to at least work for OpenAI codex as Proof-of-Concept until better and more complete solution is implemented to make acp bound agents truly first class.
- Other limiting factors current acp bound agents control surface to gateway openclaw native agents is very limited. Discord /acp command  has issues. Openclaw bound agents are getting confused and try to use session tools/spawn the same way as regular sessions. 
- The Codex-bootstrap-wrapper was inspired by the mcp-proxy implementation they now share a tool from a reported bug on windows installation.
