### PR TITLE
feat(gateway): operator push.register + push on chat completion

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -102,6 +102,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "chat.abort",
     "browser.request",
     "push.test",
+    "push.register",
   ],
   [ADMIN_SCOPE]: [
     "channels.logout",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+import { loadApnsRegistration, resolveApnsAuthConfigFromEnv, sendApnsAlert } from "../infra/push-apns.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
@@ -326,6 +327,8 @@ export type AgentEventHandlerOptions = {
   resolveSessionKeyForRun: (runId: string) => string | undefined;
   clearAgentRunContext: (runId: string) => void;
   toolEventRecipients: ToolEventRecipientRegistry;
+  nodeRegistry: import("./node-registry.js").NodeRegistry;
+  getSubscribersForSession: (sessionKey: string) => string[];
 };
 
 export function createAgentEventHandler({
@@ -337,6 +340,8 @@ export function createAgentEventHandler({
   resolveSessionKeyForRun,
   clearAgentRunContext,
   toolEventRecipients,
+  nodeRegistry,
+  getSubscribersForSession,
 }: AgentEventHandlerOptions) {
   const emitChatDelta = (
     sessionKey: string,
@@ -490,6 +495,34 @@ export function createAgentEventHandler({
       };
       broadcast("chat", payload);
       nodeSendToSession(sessionKey, "chat", payload);
+
+      // Fire-and-forget: push notification to disconnected subscribers
+      if (text && !shouldSuppressSilent) {
+        void (async () => {
+          try {
+            const subscribers = getSubscribersForSession(sessionKey);
+            if (subscribers.length === 0) return;
+            const auth = await resolveApnsAuthConfigFromEnv();
+            if (!auth.ok) return;
+            for (const subscriberId of subscribers) {
+              if (nodeRegistry.get(subscriberId)) continue; // still connected
+              const registration = await loadApnsRegistration(subscriberId);
+              if (!registration) continue;
+              const truncatedBody = text.length > 200 ? text.slice(0, 197) + "\u2026" : text;
+              await sendApnsAlert({
+                auth: auth.value,
+                registration,
+                nodeId: subscriberId,
+                title: "OpenClaw",
+                body: truncatedBody,
+              }).catch(() => {});
+            }
+          } catch {
+            // Silently ignore push failures
+          }
+        })();
+      }
+
       return;
     }
     const payload = {

--- a/src/gateway/server-methods/push.ts
+++ b/src/gateway/server-methods/push.ts
@@ -1,6 +1,7 @@
 import {
   loadApnsRegistration,
   normalizeApnsEnvironment,
+  registerApnsToken,
   resolveApnsAuthConfigFromEnv,
   sendApnsAlert,
 } from "../../infra/push-apns.js";
@@ -69,5 +70,37 @@ export const pushHandlers: GatewayRequestHandlers = {
       });
       respond(true, result, undefined);
     });
+  },
+
+  "push.register": async ({ params, client, respond }) => {
+    const token = typeof params.token === "string" ? params.token.trim() : "";
+    const topic = typeof params.topic === "string" ? params.topic.trim() : "";
+    const environment = params.environment;
+
+    if (!token) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "token required"));
+      return;
+    }
+    if (!topic) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "topic required"));
+      return;
+    }
+
+    const nodeId =
+      (client?.connect?.device?.id as string | undefined) ??
+      (client?.connect?.client?.id as string | undefined) ??
+      "";
+    if (!nodeId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "device identity required"));
+      return;
+    }
+
+    try {
+      await registerApnsToken({ nodeId, token, topic, environment });
+      respond(true, { nodeId, registered: true }, undefined);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
+    }
   },
 };

--- a/src/gateway/server-node-subscriptions.ts
+++ b/src/gateway/server-node-subscriptions.ts
@@ -27,6 +27,7 @@ export type NodeSubscriptionManager = {
     listConnected?: NodeListConnectedFn | null,
     sendEvent?: NodeSendEventFn | null,
   ) => void;
+  getSubscribersForSession: (sessionKey: string) => string[];
   clear: () => void;
 };
 
@@ -147,6 +148,18 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     }
   };
 
+  const getSubscribersForSession = (sessionKey: string): string[] => {
+    const normalizedSessionKey = sessionKey.trim();
+    if (!normalizedSessionKey) {
+      return [];
+    }
+    const subs = sessionSubscribers.get(normalizedSessionKey);
+    if (!subs || subs.size === 0) {
+      return [];
+    }
+    return Array.from(subs);
+  };
+
   const clear = () => {
     nodeSubscriptions.clear();
     sessionSubscribers.clear();
@@ -159,6 +172,7 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     sendToSession,
     sendToAllSubscribed,
     sendToAllConnected,
+    getSubscribersForSession,
     clear,
   };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -726,6 +726,8 @@ export async function startGatewayServer(
           resolveSessionKeyForRun,
           clearAgentRunContext,
           toolEventRecipients,
+          nodeRegistry,
+          getSubscribersForSession: nodeSubscriptions.getSubscribersForSession,
         }),
       );
 


### PR DESCRIPTION
## Summary

- **Operator push registration**: Adds `push.register` RPC method to `WRITE_SCOPE`, allowing operator-role clients (iOS app) to register APNs tokens directly instead of requiring node role
- **Push on chat completion**: Sends fire-and-forget APNs alerts to disconnected session subscribers when `emitChatFinal()` fires with a non-empty response
- **Subscription query**: Adds `getSubscribersForSession()` to the node subscription manager for looking up who's subscribed to a session

## Context

The iOS chat client connects as `role: "operator"`, but APNs registration was only accessible via `node.event` (restricted to `role: "node"`). Additionally, even if registration worked, nothing triggered a push when a chat response completed for a disconnected client.

## Files changed

| File | Change |
|------|--------|
| `src/gateway/method-scopes.ts` | Add `push.register` to `WRITE_SCOPE` |
| `src/gateway/server-methods/push.ts` | New `push.register` handler using client device identity |
| `src/gateway/server-node-subscriptions.ts` | Add `getSubscribersForSession()` method |
| `src/gateway/server-chat.ts` | Push alerts to disconnected subscribers in `emitChatFinal()` |
| `src/gateway/server.impl.ts` | Wire `nodeRegistry` + `getSubscribersForSession` into agent event handler |

## Test plan

- [ ] Connect iOS client as operator → `push.register` succeeds → token stored in `~/.openclaw/push/apns-registrations.json`
- [ ] Background iOS app → send chat message → push notification arrives on device
- [ ] Already-connected subscriber does NOT receive duplicate push
- [ ] No APNs token registered → push silently skipped
- [ ] Push failure does not block chat completion (fire-and-forget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)