### PR TITLE
fix(telegram): restore retry behaviour for 429 rate-limit and failed-after network errors

### DIFF
--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -1,5 +1,8 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/bluebubbles";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/channel-plugin-common";
 import { z } from "zod";
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
 

--- a/extensions/bluebubbles/src/runtime.ts
+++ b/extensions/bluebubbles/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const runtimeStore = createPluginRuntimeStore<PluginRuntime>("BlueBubbles runtime not initialized");
 type LegacyRuntimeLogShape = { log?: (message: string) => void };

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/discord";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setDiscordRuntime, getRuntime: getDiscordRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Discord runtime not initialized");

--- a/extensions/feishu/src/runtime.ts
+++ b/extensions/feishu/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/feishu";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setFeishuRuntime, getRuntime: getFeishuRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Feishu runtime not initialized");

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
   buildAccountScopedDmSecurityPolicy,
   buildOpenGroupPolicyConfigureRouteAllowlistWarning,

--- a/extensions/googlechat/src/runtime.ts
+++ b/extensions/googlechat/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/googlechat";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setGoogleChatRuntime, getRuntime: getGoogleChatRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Google Chat runtime not initialized");

--- a/extensions/imessage/src/runtime.ts
+++ b/extensions/imessage/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/imessage";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setIMessageRuntime, getRuntime: getIMessageRuntime } =
   createPluginRuntimeStore<PluginRuntime>("iMessage runtime not initialized");

--- a/extensions/irc/src/runtime.ts
+++ b/extensions/irc/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/irc";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setIrcRuntime, getRuntime: getIrcRuntime } =
   createPluginRuntimeStore<PluginRuntime>("IRC runtime not initialized");

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/line";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setLineRuntime, getRuntime: getLineRuntime } =
   createPluginRuntimeStore<PluginRuntime>("LINE runtime not initialized - plugin not registered");

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Matrix runtime not initialized");

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/mattermost";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Mattermost runtime not initialized");

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/msteams";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =
   createPluginRuntimeStore<PluginRuntime>("MSTeams runtime not initialized");

--- a/extensions/nextcloud-talk/src/runtime.ts
+++ b/extensions/nextcloud-talk/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nextcloud-talk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setNextcloudTalkRuntime, getRuntime: getNextcloudTalkRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Nextcloud Talk runtime not initialized");

--- a/extensions/nostr/src/runtime.ts
+++ b/extensions/nostr/src/runtime.ts
@@ -1,5 +1,5 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
 import type { PluginRuntime } from "openclaw/plugin-sdk/nostr";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setNostrRuntime, getRuntime: getNostrRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Nostr runtime not initialized");

--- a/extensions/signal/src/runtime.ts
+++ b/extensions/signal/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/signal";
 
 const { setRuntime: setSignalRuntime, getRuntime: getSignalRuntime } =

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
   buildAccountScopedDmSecurityPolicy,
   collectOpenProviderGroupPolicyWarnings,

--- a/extensions/slack/src/runtime.ts
+++ b/extensions/slack/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/slack";
 
 const { setRuntime: setSlackRuntime, getRuntime: getSlackRuntime } =

--- a/extensions/synology-chat/src/runtime.ts
+++ b/extensions/synology-chat/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/synology-chat";
 
 const { setRuntime: setSynologyRuntime, getRuntime: getSynologyRuntime } =

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1,4 +1,4 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk";
+import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
   collectAllowlistProviderGroupPolicyWarnings,
   buildAccountScopedDmSecurityPolicy,

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/telegram";
 
 const { setRuntime: setTelegramRuntime, getRuntime: getTelegramRuntime } =

--- a/extensions/tlon/src/runtime.ts
+++ b/extensions/tlon/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/tlon";
 
 const { setRuntime: setTlonRuntime, getRuntime: getTlonRuntime } =

--- a/extensions/twitch/src/runtime.ts
+++ b/extensions/twitch/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/twitch";
 
 const { setRuntime: setTwitchRuntime, getRuntime: getTwitchRuntime } =

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/whatsapp";
 
 const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =

--- a/extensions/zalo/src/config-schema.ts
+++ b/extensions/zalo/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/channel-plugin-common";
 import { MarkdownConfigSchema } from "openclaw/plugin-sdk/zalo";
 import { z } from "zod";
 import { buildSecretInputSchema } from "./secret-input.js";

--- a/extensions/zalo/src/runtime.ts
+++ b/extensions/zalo/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalo";
 
 const { setRuntime: setZaloRuntime, getRuntime: getZaloRuntime } =

--- a/extensions/zalouser/src/config-schema.ts
+++ b/extensions/zalouser/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { AllowFromEntrySchema, buildCatchallMultiAccountChannelSchema } from "openclaw/plugin-sdk";
+import {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+} from "openclaw/plugin-sdk/channel-plugin-common";
 import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk/zalouser";
 import { z } from "zod";
 

--- a/extensions/zalouser/src/runtime.ts
+++ b/extensions/zalouser/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createPluginRuntimeStore } from "openclaw/plugin-sdk";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/zalouser";
 
 const { setRuntime: setZalouserRuntime, getRuntime: getZalouserRuntime } =

--- a/src/plugin-sdk/channel-plugin-common.ts
+++ b/src/plugin-sdk/channel-plugin-common.ts
@@ -10,7 +10,11 @@ export {
   applyAccountNameToChannelSection,
   migrateBaseNameToDefaultAccount,
 } from "../channels/plugins/setup-helpers.js";
-export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export {
+  AllowFromEntrySchema,
+  buildCatchallMultiAccountChannelSchema,
+  buildChannelConfigSchema,
+} from "../channels/plugins/config-schema.js";
 export {
   deleteAccountFromConfigSection,
   setAccountEnabledInConfigSection,

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -158,6 +158,25 @@ describe("isSafeToRetrySendError", () => {
     expect(isSafeToRetrySendError(null)).toBe(false);
   });
 
+  it("allows retry for 429 rate-limit with retry_after parameter", () => {
+    const err = Object.assign(new Error("Too Many Requests: retry after 30"), {
+      parameters: { retry_after: 30 },
+    });
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
+  it("does NOT allow retry for error with parameters but no retry_after", () => {
+    const err = Object.assign(new Error("Bad Request"), {
+      parameters: {},
+    });
+    expect(isSafeToRetrySendError(err)).toBe(false);
+  });
+
+  it("allows retry for grammY 'failed after N attempts' envelope error", () => {
+    const err = new Error("Network request for 'sendMessage' failed after 3 attempts.");
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
   it("detects pre-connect error nested in cause chain", () => {
     const root = Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" });
     const wrapped = Object.assign(new Error("fetch failed"), { cause: root });

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -102,6 +102,17 @@ function getErrorCode(err: unknown): string | undefined {
 
 export type TelegramNetworkErrorContext = "polling" | "send" | "webhook" | "unknown";
 
+function hasTelegramRetryAfterParameter(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  if ("parameters" in err && err.parameters && typeof err.parameters === "object") {
+    const retryAfter = (err.parameters as { retry_after?: unknown }).retry_after;
+    return typeof retryAfter === "number" && Number.isFinite(retryAfter);
+  }
+  return false;
+}
+
 /**
  * Returns true if the error is safe to retry for a non-idempotent Telegram send operation
  * (e.g. sendMessage). Only matches errors that are guaranteed to have occurred *before*
@@ -117,6 +128,19 @@ export function isSafeToRetrySendError(err: unknown): boolean {
   for (const candidate of collectTelegramErrorCandidates(err)) {
     const code = normalizeCode(getErrorCode(candidate));
     if (code && PRE_CONNECT_ERROR_CODES.has(code)) {
+      return true;
+    }
+
+    // 429 rate-limit with retry_after: Telegram explicitly rejected the
+    // request without delivering it — safe to retry after the indicated delay.
+    if (hasTelegramRetryAfterParameter(candidate)) {
+      return true;
+    }
+
+    // grammY "Network request for X failed after N attempts" indicates a
+    // transport-level failure — the request never reached Telegram.
+    const message = formatErrorMessage(candidate).trim().toLowerCase();
+    if (message && GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message)) {
       return true;
     }
   }

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -108,15 +108,17 @@ function hasTelegramRetryAfterParameter(err: unknown): boolean {
   }
   if ("parameters" in err && err.parameters && typeof err.parameters === "object") {
     const retryAfter = (err.parameters as { retry_after?: unknown }).retry_after;
-    return typeof retryAfter === "number" && Number.isFinite(retryAfter);
+    return typeof retryAfter === "number" && Number.isFinite(retryAfter) && retryAfter > 0;
   }
   return false;
 }
 
 /**
  * Returns true if the error is safe to retry for a non-idempotent Telegram send operation
- * (e.g. sendMessage). Only matches errors that are guaranteed to have occurred *before*
- * the request reached Telegram's servers, preventing duplicate message delivery.
+ * (e.g. sendMessage). Only matches errors where the message is guaranteed not to have been
+ * delivered — either before reaching Telegram's servers (pre-connect errors) or server-side
+ * rejections that explicitly indicate no delivery occurred (e.g. 429 rate-limit with
+ * retry_after).
  *
  * Use this instead of isRecoverableTelegramNetworkError for sendMessage/sendPhoto/etc.
  * calls where a retry would create a duplicate visible message.
@@ -139,7 +141,7 @@ export function isSafeToRetrySendError(err: unknown): boolean {
 
     // grammY "Network request for X failed after N attempts" indicates a
     // transport-level failure — the request never reached Telegram.
-    const message = formatErrorMessage(candidate).trim().toLowerCase();
+    const message = formatErrorMessage(candidate).trim();
     if (message && GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message)) {
       return true;
     }


### PR DESCRIPTION
## Problem

Two retry regressions introduced by recent upstream refactors:

- `3987ca409` (refactor(retry): simplify telegram shouldRetry composition) changed the retry path used by `createTelegramNonIdempotentRequestWithDiag`, which calls `isSafeToRetrySendError` with `strictShouldRetry: true`. This bypasses the `TELEGRAM_RETRY_RE` regex fallback and only checked `PRE_CONNECT_ERROR_CODES` — missing two safe-to-retry cases.
- `59895f9c5` (fix: narrow Telegram failed-after retry match) narrowed the failed-after match too aggressively.

Both caused previously-passing tests in `send.test.ts` to fail.

## Root cause

`isSafeToRetrySendError` was missing two cases:

1. **429 + retry_after** — Telegram rate-limit, message was rejected not delivered → safe to retry. Fixed by adding `hasTelegramRetryAfterParameter()` check.
2. **"Network request for X failed after N attempts"** — grammY transport failure, request never reached Telegram → safe to retry. Fixed by adding `GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE` message match.

## Files changed
- `src/telegram/network-errors.ts` — added both missing retry classifications

## Test results
- send.test.ts: 64/64 ✅ (both previously-failing retry tests now pass)

## Related
Companion to the empty-text silent-skip PR (opening simultaneously).