### PR TITLE
fix: batch bug fixes for discord, imessage, heartbeat, acpx and cron

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -141,7 +141,7 @@ export function spawnWithResolvedCommand(
     env: { ...process.env, OPENCLAW_SHELL: "acp" },
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
-    windowsHide: resolved.windowsHide,
+    windowsHide: resolved.windowsHide ?? true,
   });
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -960,13 +960,15 @@ export async function executeJobCore(
     const text = resolveJobPayloadTextForMain(job);
     if (!text) {
       const kind = job.payload.kind;
-      return {
-        status: "skipped",
-        error:
-          kind === "systemEvent"
-            ? "main job requires non-empty systemEvent text"
-            : 'main job requires payload.kind="systemEvent"',
-      };
+      const skipReason =
+        kind === "systemEvent"
+          ? "main job requires non-empty systemEvent text"
+          : 'main job requires payload.kind="systemEvent"';
+      state.deps.log.warn(
+        { jobId: job.id, jobName: job.name, payload: { kind } },
+        `cron: main-session job skipped: ${skipReason}`,
+      );
+      return { status: "skipped", error: skipReason };
     }
     // Preserve the job session namespace for main-target reminders so heartbeat
     // routing can deliver follow-through in the originating channel/thread.

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -383,6 +383,58 @@ describe("preflightDiscordMessage", () => {
     expect(result?.shouldRequireMention).toBe(false);
   });
 
+  it("drops all bot messages when allowBots=false (off)", async () => {
+    const channelId = "channel-bots-off";
+    const guildId = "guild-bots-off";
+    const message = createMessage({
+      id: "m-bots-off",
+      channelId,
+      content: "hello from a bot",
+      author: {
+        id: "some-bot",
+        bot: true,
+        username: "SomeBot",
+      },
+    });
+
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {
+        allowBots: false,
+      } as DiscordConfig,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("drops own messages from the bot user (self-loop guard)", async () => {
+    const channelId = "channel-self-loop";
+    const guildId = "guild-self-loop";
+    const message = createMessage({
+      id: "m-self-1",
+      channelId,
+      content: "hello i am the bot",
+      author: {
+        id: "openclaw-bot",
+        bot: true,
+        username: "OpenClaw",
+      },
+    });
+
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {
+        allowBots: true,
+      } as DiscordConfig,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("drops bot messages without mention when allowBots=mentions", async () => {
     const channelId = "channel-bot-mentions-off";
     const guildId = "guild-bot-mentions-off";

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -159,6 +159,7 @@ export async function preflightDiscordMessage(
     allowBotsSetting === "mentions" ? "mentions" : allowBotsSetting === true ? "all" : "off";
   if (params.botUserId && author.id === params.botUserId) {
     // Always ignore own messages to prevent self-reply loops
+    logVerbose("discord: drop own message (self-loop guard)");
     return null;
   }
 
@@ -187,6 +188,7 @@ export async function preflightDiscordMessage(
 
   if (author.bot) {
     if (allowBotsMode === "off" && !sender.isPluralKit) {
+      logDebug(`[discord-preflight] drop: bot message (allowBots=false) from ${author.id}`);
       logVerbose("discord: drop bot message (allowBots=false)");
       return null;
     }

--- a/src/imessage/monitor/sanitize-outbound.test.ts
+++ b/src/imessage/monitor/sanitize-outbound.test.ts
@@ -53,6 +53,19 @@ describe("sanitizeOutboundText", () => {
     expect(sanitizeOutboundText(text)).toBe("Hello\n\nWorld");
   });
 
+  it("strips [[reply_to_current]] directive", () => {
+    expect(sanitizeOutboundText("[[reply_to_current]] Hello there")).toBe("Hello there");
+  });
+
+  it("strips [[reply_to:ID]] directive", () => {
+    expect(sanitizeOutboundText("[[reply_to:abc-123]] Got it")).toBe("Got it");
+  });
+
+  it("strips reply directive embedded mid-text", () => {
+    const text = "Some text [[reply_to:id-1]] more text";
+    expect(sanitizeOutboundText(text)).not.toContain("[[reply_to:");
+  });
+
   it("handles combined internal markers in one message", () => {
     const text = "<thinking>step 1</thinking>NO_REPLY +#+#+#+# assistant to=final\n\nActual reply";
     const result = sanitizeOutboundText(text);

--- a/src/imessage/monitor/sanitize-outbound.ts
+++ b/src/imessage/monitor/sanitize-outbound.ts
@@ -7,6 +7,8 @@ import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-v
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/g;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/gi;
 const ROLE_TURN_MARKER_RE = /\b(?:user|system|assistant)\s*:\s*$/gm;
+// Reply-routing directives emitted by the assistant must not reach end users.
+const REPLY_TAG_RE = /\[\[reply_to(?:_current|:[^\]]+)?\]\]/g;
 
 /**
  * Strip all assistant-internal scaffolding from outbound text before delivery.
@@ -23,6 +25,7 @@ export function sanitizeOutboundText(text: string): string {
   cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
   cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");
   cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, "");
+  cleaned = cleaned.replace(REPLY_TAG_RE, "");
 
   // Collapse excessive blank lines left after stripping.
   cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();

--- a/src/imessage/send.test.ts
+++ b/src/imessage/send.test.ts
@@ -58,7 +58,7 @@ describe("sendMessageIMessage", () => {
     expect(params.to).toBe("+1555");
   });
 
-  it("adds file attachment with placeholder text", async () => {
+  it("sends media-only attachment without placeholder text", async () => {
     await sendWithDefaults("chat_id:7", "", {
       mediaUrl: "http://x/y.jpg",
       resolveAttachmentImpl: async () => ({
@@ -68,10 +68,23 @@ describe("sendMessageIMessage", () => {
     });
     const params = getSentParams();
     expect(params.file).toBe("/tmp/imessage-media.jpg");
-    expect(params.text).toBe("<media:image>");
+    expect(params.text).toBeUndefined();
   });
 
-  it("normalizes mixed-case parameterized MIME for attachment placeholder text", async () => {
+  it("sends media with text when both provided", async () => {
+    await sendWithDefaults("chat_id:7", "look at this", {
+      mediaUrl: "http://x/y.jpg",
+      resolveAttachmentImpl: async () => ({
+        path: "/tmp/imessage-media.jpg",
+        contentType: "image/jpeg",
+      }),
+    });
+    const params = getSentParams();
+    expect(params.file).toBe("/tmp/imessage-media.jpg");
+    expect(params.text).toBe("look at this");
+  });
+
+  it("sends media-only with audio MIME without placeholder text", async () => {
     await sendWithDefaults("chat_id:7", "", {
       mediaUrl: "http://x/voice",
       resolveAttachmentImpl: async () => ({
@@ -81,7 +94,7 @@ describe("sendMessageIMessage", () => {
     });
     const params = getSentParams();
     expect(params.file).toBe("/tmp/imessage-media.ogg");
-    expect(params.text).toBe("<media:audio>");
+    expect(params.text).toBeUndefined();
   });
 
   it("returns message id when rpc provides one", async () => {

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -1,7 +1,6 @@
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { convertMarkdownTables } from "../markdown/tables.js";
-import { kindFromMime } from "../media/mime.js";
 import { resolveOutboundAttachmentFromUrl } from "../media/outbound-attachment.js";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
@@ -128,12 +127,6 @@ export async function sendMessageIMessage(
       localRoots: opts.mediaLocalRoots,
     });
     filePath = resolved.path;
-    if (!message.trim()) {
-      const kind = kindFromMime(resolved.contentType ?? undefined);
-      if (kind) {
-        message = kind === "image" ? "<media:image>" : `<media:${kind}>`;
-      }
-    }
   }
 
   if (!message.trim() && !filePath) {
@@ -150,10 +143,12 @@ export async function sendMessageIMessage(
   message = prependReplyTagIfNeeded(message, opts.replyToId);
 
   const params: Record<string, unknown> = {
-    text: message,
     service: service || "auto",
     region,
   };
+  if (message.trim()) {
+    params.text = message;
+  }
   if (filePath) {
     params.file = filePath;
   }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -597,7 +597,15 @@ function resolveHeartbeatRunPrompt(params: {
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
-  const prompt = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
+  // Only append workspace path hint when using the default heartbeat prompt.
+  // Custom user-configured prompts already reference their own paths.
+  const hasCustomPrompt = Boolean(
+    (params.heartbeat?.prompt ?? params.cfg.agents?.defaults?.heartbeat?.prompt)?.trim(),
+  );
+  const prompt =
+    hasCustomPrompt || hasExecCompletion || hasCronEvents
+      ? basePrompt
+      : appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
 
   return { prompt, hasExecCompletion, hasCronEvents };
 }


### PR DESCRIPTION
## Summary

Fixes several bugs from open issues.

### Discord fixes-40267
- Add logDebug when bot message is dropped due to allowBots=false
- Add logVerbose when own-message is dropped (self-loop guard)
- Tests: cases for allowBots=false drop and self-loop guard

### iMessage fixes-40252
- Remove placeholder text (less-than-sign media:image greater-than-sign, etc.) for media-only messages
- Only include params.text when message string is non-empty
- Remove unused kindFromMime import
- Tests: updated to reflect new behavior

### iMessage fixes-40302
- Strip reply_to directives in sanitizeOutboundText so they never reach end users
- Tests: reply tag stripping cases

### Heartbeat fixes-40255
- Skip appendHeartbeatWorkspacePathHint when user has a custom heartbeat prompt

### acpx fixes-40340
- Default windowsHide to true when unset to prevent console windows on Windows

### Cron fixes-40261/40266
- Log warn when main-session cron job is skipped due to empty or wrong-kind systemEvent

## Testing
All modified test files pass (pnpm vitest run).
Pre-existing test failures on Windows (symlink/ACL/WSL) are unrelated to this change.