### PR TITLE
Fix one-shot exit hangs by tearing down cached memory managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Logging/probe observations: suppress structured embedded and model-fallback probe warnings on the console without hiding error or fatal output. (#41338) thanks @altaywtf.
 - Agents/fallback: treat HTTP 499 responses as transient in both raw-text and structured failover paths so Anthropic-style client-closed overload responses trigger model fallback reliably. (#41468) thanks @zeroasterisk.
 - Plugins/context-engine model auth: expose `runtime.modelAuth` and plugin-sdk auth helpers so plugins can resolve provider/model API keys through the normal auth pipeline. (#41090) thanks @xinhuagu.
+- CLI/memory teardown: close cached memory search/index managers in the one-shot CLI shutdown path so watcher-backed memory caches no longer keep completed CLI runs alive after output finishes. (#40389) thanks @Julbarth.
 
 ## 2026.3.8
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -28,7 +28,7 @@ vi.mock("../infra/runtime-guard.js", () => ({
   assertSupportedRuntime: assertRuntimeMock,
 }));
 
-vi.mock("../memory/index.js", () => ({
+vi.mock("../memory/search-manager.js", () => ({
   closeAllMemorySearchManagers: closeAllMemorySearchManagersMock,
 }));
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -6,6 +6,7 @@ const loadDotEnvMock = vi.hoisted(() => vi.fn());
 const normalizeEnvMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
+const closeAllMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("./route.js", () => ({
   tryRouteCli: tryRouteCliMock,
@@ -27,6 +28,10 @@ vi.mock("../infra/runtime-guard.js", () => ({
   assertSupportedRuntime: assertRuntimeMock,
 }));
 
+vi.mock("../memory/index.js", () => ({
+  closeAllMemorySearchManagers: closeAllMemorySearchManagersMock,
+}));
+
 const { runCli } = await import("./run-main.js");
 
 describe("runCli exit behavior", () => {
@@ -43,6 +48,7 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "status"]);
 
     expect(tryRouteCliMock).toHaveBeenCalledWith(["node", "openclaw", "status"]);
+    expect(closeAllMemorySearchManagersMock).toHaveBeenCalledTimes(1);
     expect(exitSpy).not.toHaveBeenCalled();
     exitSpy.mockRestore();
   });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -15,7 +15,7 @@ import { normalizeWindowsArgv } from "./windows-argv.js";
 
 async function closeCliMemoryManagers(): Promise<void> {
   try {
-    const { closeAllMemorySearchManagers } = await import("../memory/index.js");
+    const { closeAllMemorySearchManagers } = await import("../memory/search-manager.js");
     await closeAllMemorySearchManagers();
   } catch {
     // Best-effort teardown for short-lived CLI processes.

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -13,6 +13,15 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { tryRouteCli } from "./route.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
+async function closeCliMemoryManagers(): Promise<void> {
+  try {
+    const { closeAllMemorySearchManagers } = await import("../memory/index.js");
+    await closeAllMemorySearchManagers();
+  } catch {
+    // Best-effort teardown for short-lived CLI processes.
+  }
+}
+
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
   const index = argv.indexOf("--update");
   if (index === -1) {
@@ -82,59 +91,63 @@ export async function runCli(argv: string[] = process.argv) {
   // Enforce the minimum supported runtime before doing any work.
   assertSupportedRuntime();
 
-  if (await tryRouteCli(normalizedArgv)) {
-    return;
-  }
-
-  // Capture all console output into structured logs while keeping stdout/stderr behavior.
-  enableConsoleCapture();
-
-  const { buildProgram } = await import("./program.js");
-  const program = buildProgram();
-
-  // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
-  // These log the error and exit gracefully instead of crashing without trace.
-  installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
-
-  const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
-  // Register the primary command (builtin or subcli) so help and command parsing
-  // are correct even with lazy command registration.
-  const primary = getPrimaryCommand(parseArgv);
-  if (primary) {
-    const { getProgramContext } = await import("./program/program-context.js");
-    const ctx = getProgramContext(program);
-    if (ctx) {
-      const { registerCoreCliByName } = await import("./program/command-registry.js");
-      await registerCoreCliByName(program, ctx, primary, parseArgv);
+  try {
+    if (await tryRouteCli(normalizedArgv)) {
+      return;
     }
-    const { registerSubCliByName } = await import("./program/register.subclis.js");
-    await registerSubCliByName(program, primary);
-  }
 
-  const hasBuiltinPrimary =
-    primary !== null && program.commands.some((command) => command.name() === primary);
-  const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
-    argv: parseArgv,
-    primary,
-    hasBuiltinPrimary,
-  });
-  if (!shouldSkipPluginRegistration) {
-    // Register plugin CLI commands before parsing
-    const { registerPluginCliCommands } = await import("../plugins/cli.js");
-    const { loadValidatedConfigForPluginRegistration } =
-      await import("./program/register.subclis.js");
-    const config = await loadValidatedConfigForPluginRegistration();
-    if (config) {
-      registerPluginCliCommands(program, config);
+    // Capture all console output into structured logs while keeping stdout/stderr behavior.
+    enableConsoleCapture();
+
+    const { buildProgram } = await import("./program.js");
+    const program = buildProgram();
+
+    // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
+    // These log the error and exit gracefully instead of crashing without trace.
+    installUnhandledRejectionHandler();
+
+    process.on("uncaughtException", (error) => {
+      console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
+      process.exit(1);
+    });
+
+    const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
+    // Register the primary command (builtin or subcli) so help and command parsing
+    // are correct even with lazy command registration.
+    const primary = getPrimaryCommand(parseArgv);
+    if (primary) {
+      const { getProgramContext } = await import("./program/program-context.js");
+      const ctx = getProgramContext(program);
+      if (ctx) {
+        const { registerCoreCliByName } = await import("./program/command-registry.js");
+        await registerCoreCliByName(program, ctx, primary, parseArgv);
+      }
+      const { registerSubCliByName } = await import("./program/register.subclis.js");
+      await registerSubCliByName(program, primary);
     }
-  }
 
-  await program.parseAsync(parseArgv);
+    const hasBuiltinPrimary =
+      primary !== null && program.commands.some((command) => command.name() === primary);
+    const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
+      argv: parseArgv,
+      primary,
+      hasBuiltinPrimary,
+    });
+    if (!shouldSkipPluginRegistration) {
+      // Register plugin CLI commands before parsing
+      const { registerPluginCliCommands } = await import("../plugins/cli.js");
+      const { loadValidatedConfigForPluginRegistration } =
+        await import("./program/register.subclis.js");
+      const config = await loadValidatedConfigForPluginRegistration();
+      if (config) {
+        registerPluginCliCommands(program, config);
+      }
+    }
+
+    await program.parseAsync(parseArgv);
+  } finally {
+    await closeCliMemoryManagers();
+  }
 }
 
 export function isCliMainModule(): boolean {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,4 +4,8 @@ export type {
   MemorySearchManager,
   MemorySearchResult,
 } from "./types.js";
-export { getMemorySearchManager, type MemorySearchManagerResult } from "./search-manager.js";
+export {
+  closeAllMemorySearchManagers,
+  getMemorySearchManager,
+  type MemorySearchManagerResult,
+} from "./search-manager.js";

--- a/src/memory/manager-runtime.ts
+++ b/src/memory/manager-runtime.ts
@@ -1,1 +1,1 @@
-export { MemoryIndexManager } from "./manager.js";
+export { closeAllMemoryIndexManagers, MemoryIndexManager } from "./manager.js";

--- a/src/memory/manager.get-concurrency.test.ts
+++ b/src/memory/manager.get-concurrency.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
+import {
+  closeAllMemoryIndexManagers,
+  MemoryIndexManager as RawMemoryIndexManager,
+} from "./manager.js";
 import "./test-runtime-mocks.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -77,5 +81,38 @@ describe("memory manager cache hydration", () => {
     expect(hoisted.providerCreateCalls).toBe(1);
 
     await managers[0].close();
+  });
+
+  it("drains in-flight manager creation during global teardown", async () => {
+    const indexPath = path.join(workspaceDir, "index.sqlite");
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath, vector: { enabled: false } },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    hoisted.providerDelayMs = 100;
+
+    const pendingResult = RawMemoryIndexManager.get({ cfg, agentId: "main" });
+    await closeAllMemoryIndexManagers();
+    const firstManager = await pendingResult;
+
+    const secondManager = await RawMemoryIndexManager.get({ cfg, agentId: "main" });
+
+    expect(firstManager).toBeTruthy();
+    expect(secondManager).toBeTruthy();
+    expect(Object.is(secondManager, firstManager)).toBe(false);
+    expect(hoisted.providerCreateCalls).toBe(2);
+
+    await secondManager?.close?.();
   });
 });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -42,6 +42,21 @@ const log = createSubsystemLogger("memory");
 const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 const INDEX_CACHE_PENDING = new Map<string, Promise<MemoryIndexManager>>();
 
+export async function closeAllMemoryIndexManagers(): Promise<void> {
+  const managers = Array.from(INDEX_CACHE.values());
+  if (managers.length === 0) {
+    return;
+  }
+  for (const manager of managers) {
+    try {
+      await manager.close();
+    } catch (err) {
+      log.warn(`failed to close memory index manager: ${String(err)}`);
+    }
+  }
+  INDEX_CACHE.clear();
+}
+
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
   protected readonly cfg: OpenClawConfig;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -43,10 +43,12 @@ const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 const INDEX_CACHE_PENDING = new Map<string, Promise<MemoryIndexManager>>();
 
 export async function closeAllMemoryIndexManagers(): Promise<void> {
-  const managers = Array.from(INDEX_CACHE.values());
-  if (managers.length === 0) {
-    return;
+  const pending = Array.from(INDEX_CACHE_PENDING.values());
+  if (pending.length > 0) {
+    await Promise.allSettled(pending);
   }
+  const managers = Array.from(INDEX_CACHE.values());
+  INDEX_CACHE.clear();
   for (const manager of managers) {
     try {
       await manager.close();
@@ -54,7 +56,6 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
       log.warn(`failed to close memory index manager: ${String(err)}`);
     }
   }
-  INDEX_CACHE.clear();
 }
 
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -263,4 +263,17 @@ describe("getMemorySearchManager caching", () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
+
+  it("closes builtin index managers on teardown after runtime is loaded", async () => {
+    const retryAgentId = "teardown-with-fallback";
+    const { manager } = await createFailedQmdSearchHarness({
+      agentId: retryAgentId,
+      errorMessage: "qmd query failed",
+    });
+    await manager.search("hello");
+
+    await closeAllMemorySearchManagers();
+
+    expect(mockCloseAllMemoryIndexManagers).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -29,53 +29,53 @@ function createManagerStatus(params: {
   };
 }
 
-const qmdManagerStatus = createManagerStatus({
-  backend: "qmd",
-  provider: "qmd",
-  model: "qmd",
-  requestedProvider: "qmd",
-  withMemorySourceCounts: true,
-});
-
-const fallbackManagerStatus = createManagerStatus({
-  backend: "builtin",
-  provider: "openai",
-  model: "text-embedding-3-small",
-  requestedProvider: "openai",
-});
-
-const mockPrimary = {
+const mockPrimary = vi.hoisted(() => ({
   search: vi.fn(async () => []),
   readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
-  status: vi.fn(() => qmdManagerStatus),
+  status: vi.fn(() =>
+    createManagerStatus({
+      backend: "qmd",
+      provider: "qmd",
+      model: "qmd",
+      requestedProvider: "qmd",
+      withMemorySourceCounts: true,
+    }),
+  ),
   sync: vi.fn(async () => {}),
   probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
   probeVectorAvailability: vi.fn(async () => true),
   close: vi.fn(async () => {}),
-};
+}));
 
-const fallbackSearch = vi.fn(async () => [
-  {
-    path: "MEMORY.md",
-    startLine: 1,
-    endLine: 1,
-    score: 1,
-    snippet: "fallback",
-    source: "memory" as const,
-  },
-]);
-
-const fallbackManager = {
-  search: fallbackSearch,
+const fallbackManager = vi.hoisted(() => ({
+  search: vi.fn(async () => [
+    {
+      path: "MEMORY.md",
+      startLine: 1,
+      endLine: 1,
+      score: 1,
+      snippet: "fallback",
+      source: "memory" as const,
+    },
+  ]),
   readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
-  status: vi.fn(() => fallbackManagerStatus),
+  status: vi.fn(() =>
+    createManagerStatus({
+      backend: "builtin",
+      provider: "openai",
+      model: "text-embedding-3-small",
+      requestedProvider: "openai",
+    }),
+  ),
   sync: vi.fn(async () => {}),
   probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
   probeVectorAvailability: vi.fn(async () => true),
   close: vi.fn(async () => {}),
-};
+}));
 
-const mockMemoryIndexGet = vi.fn(async () => fallbackManager);
+const fallbackSearch = fallbackManager.search;
+const mockMemoryIndexGet = vi.hoisted(() => vi.fn(async () => fallbackManager));
+const mockCloseAllMemoryIndexManagers = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("./qmd-manager.js", () => ({
   QmdMemoryManager: {
@@ -87,10 +87,11 @@ vi.mock("./manager.js", () => ({
   MemoryIndexManager: {
     get: mockMemoryIndexGet,
   },
+  closeAllMemoryIndexManagers: mockCloseAllMemoryIndexManagers,
 }));
 
 import { QmdMemoryManager } from "./qmd-manager.js";
-import { getMemorySearchManager } from "./search-manager.js";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./search-manager.js";
 // eslint-disable-next-line @typescript-eslint/unbound-method -- mocked static function
 const createQmdManagerMock = vi.mocked(QmdMemoryManager.create);
 
@@ -119,7 +120,8 @@ async function createFailedQmdSearchHarness(params: { agentId: string; errorMess
   return { cfg, manager: requireManager(first), firstResult: first };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await closeAllMemorySearchManagers();
   mockPrimary.search.mockClear();
   mockPrimary.readFile.mockClear();
   mockPrimary.status.mockClear();
@@ -134,6 +136,7 @@ beforeEach(() => {
   fallbackManager.probeEmbeddingAvailability.mockClear();
   fallbackManager.probeVectorAvailability.mockClear();
   fallbackManager.close.mockClear();
+  mockCloseAllMemoryIndexManagers.mockClear();
   mockMemoryIndexGet.mockClear();
   mockMemoryIndexGet.mockResolvedValue(fallbackManager);
   createQmdManagerMock.mockClear();
@@ -242,5 +245,22 @@ describe("getMemorySearchManager caching", () => {
     mockMemoryIndexGet.mockRejectedValueOnce(new Error("No API key found for provider openai"));
 
     await expect(firstManager.search("hello")).rejects.toThrow("qmd query failed");
+  });
+
+  it("closes cached managers on global teardown", async () => {
+    const cfg = createQmdCfg("teardown-agent");
+    const first = await getMemorySearchManager({ cfg, agentId: "teardown-agent" });
+    const firstManager = requireManager(first);
+
+    await closeAllMemorySearchManagers();
+
+    expect(mockPrimary.close).toHaveBeenCalledTimes(1);
+    expect(mockCloseAllMemoryIndexManagers).toHaveBeenCalledTimes(1);
+
+    const second = await getMemorySearchManager({ cfg, agentId: "teardown-agent" });
+    expect(second.manager).toBeTruthy();
+    expect(second.manager).not.toBe(firstManager);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -83,7 +83,7 @@ vi.mock("./qmd-manager.js", () => ({
   },
 }));
 
-vi.mock("./manager.js", () => ({
+vi.mock("./manager-runtime.js", () => ({
   MemoryIndexManager: {
     get: mockMemoryIndexGet,
   },

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedQmdConfig } from "./backend-config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
+import { closeAllMemoryIndexManagers } from "./manager.js";
 import type {
   MemoryEmbeddingProbeResult,
   MemorySearchManager,
@@ -83,6 +84,19 @@ export async function getMemorySearchManager(params: {
     const message = err instanceof Error ? err.message : String(err);
     return { manager: null, error: message };
   }
+}
+
+export async function closeAllMemorySearchManagers(): Promise<void> {
+  const managers = Array.from(QMD_MANAGER_CACHE.values());
+  QMD_MANAGER_CACHE.clear();
+  for (const manager of managers) {
+    try {
+      await manager.close?.();
+    } catch (err) {
+      log.warn(`failed to close qmd memory manager: ${String(err)}`);
+    }
+  }
+  await closeAllMemoryIndexManagers();
 }
 
 class FallbackMemoryManager implements MemorySearchManager {

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -95,8 +95,10 @@ export async function closeAllMemorySearchManagers(): Promise<void> {
       log.warn(`failed to close qmd memory manager: ${String(err)}`);
     }
   }
-  const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
-  await closeAllMemoryIndexManagers();
+  if (managerRuntimePromise !== null) {
+    const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
+    await closeAllMemoryIndexManagers();
+  }
 }
 
 class FallbackMemoryManager implements MemorySearchManager {

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -2,7 +2,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedQmdConfig } from "./backend-config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
-import { closeAllMemoryIndexManagers } from "./manager.js";
 import type {
   MemoryEmbeddingProbeResult,
   MemorySearchManager,
@@ -96,6 +95,7 @@ export async function closeAllMemorySearchManagers(): Promise<void> {
       log.warn(`failed to close qmd memory manager: ${String(err)}`);
     }
   }
+  const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
   await closeAllMemoryIndexManagers();
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: One-shot CLI runs can emit successful completion events but still hang on exit.
- Why it matters: Bench/automation workflows can time out even when the task itself completed.
- What changed: Added explicit global teardown for cached memory search/index managers and called teardown in CLI `finally`; also drained in-flight index manager creations during teardown.
- What did NOT change (scope boundary): No model routing/tool behavior changes, no plugin/channel behavior changes, no secret/token handling changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40365
- Related #40367

## User-visible / Behavior Changes

One-shot CLI commands now exit cleanly after completion in scenarios where cached memory-manager watcher handles previously kept the process alive.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 14.0 (local repro); CI includes Linux/Windows jobs
- Runtime/container: Node.js + pnpm
- Model/provider: N/A (provider-independent; reproduced with successful one-shot completion)
- Integration/channel (if any): CLI one-shot run
- Relevant config (redacted): default memory settings (memory search enabled)

### Steps

1. Run one-shot CLI command on pre-fix build with default memory enabled.
2. Observe completion events emitted successfully.
3. Process remains alive instead of exiting.

### Expected

- Process exits after successful completion.

### Actual

- Process can remain alive due to lingering memory-manager resources (watcher handles), with race risk from in-flight manager creation.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced one-shot hang before fix.
  - Confirmed clean exit after fix.
  - Ran targeted tests:
    - `pnpm exec vitest run src/cli/run-main.exit.test.ts`
    - `pnpm exec vitest run src/memory/search-manager.test.ts`
    - `pnpm exec vitest run src/memory/manager.get-concurrency.test.ts`
- Edge cases checked:
  - Teardown called through lazy runtime boundary (no eager manager import path).
  - Global teardown drains pending manager creations.
  - QMD manager cache teardown still closes and resets as expected.
- What you did **not** verify:
  - Long-duration stress testing across all providers/channels.
  - Full production workload profiling.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit set.
- Files/config to restore: `src/cli/run-main.ts`, `src/cli/run-main.exit.test.ts`, `src/memory/manager.ts`, `src/memory/manager-runtime.ts`, `src/memory/search-manager.ts`, `src/memory/search-manager.test.ts`, `src/memory/manager.get-concurrency.test.ts`, `src/memory/index.ts`
- Known bad symptoms reviewers should watch for: one-shot process not exiting, or teardown-time errors in memory shutdown path.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Teardown during in-flight creation could cause lifecycle races.
  - Mitigation: Explicitly await pending creations before closing cached managers.
- Risk: Accidental eager loading of memory manager module on non-memory paths.
  - Mitigation: Teardown path uses lazy runtime import boundary; tests cover behavior.
