### PR TITLE
fix(discord): graceful fallback when ffprobe is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.
 - Context engine/tests: add bundled-registry regression coverage for cross-chunk resolution, plugin-sdk re-exports, and concurrent chunk registration. (#40460) thanks @dsantoreis.
 - Agents/embedded runner: bound compaction retry waiting and drain embedded runs during SIGUSR1 restart so session lanes recover instead of staying blocked behind compaction. (#40324) thanks @cgdusek.
+- Discord/voice: catch `ffprobe` ENOENT in `getVoiceMessageMetadata` so a missing ffprobe binary returns fallback duration (0) and placeholder waveform instead of crashing the agent WebSocket. (#40382)
 
 ## 2026.3.8
 

--- a/src/discord/voice-message.test.ts
+++ b/src/discord/voice-message.test.ts
@@ -81,7 +81,46 @@ vi.mock("../infra/tmp-openclaw-dir.js", () => ({
   resolvePreferredOpenClawTmpDir: () => "/tmp",
 }));
 
-const { ensureOggOpus } = await import("./voice-message.js");
+const { ensureOggOpus, getAudioDuration, getVoiceMessageMetadata } =
+  await import("./voice-message.js");
+
+describe("getAudioDuration", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    mockExecResults.length = 0;
+  });
+
+  it("parses duration from ffprobe output", async () => {
+    mockExecResults.push({ stdout: "12.34\n" });
+    const duration = await getAudioDuration("/tmp/test.ogg");
+    expect(duration).toBe(12.34);
+  });
+
+  it("throws when ffprobe is not installed", async () => {
+    const enoent = Object.assign(new Error("spawn ffprobe ENOENT"), { code: "ENOENT" });
+    mockExecResults.push({ error: enoent as NodeJS.ErrnoException });
+    await expect(getAudioDuration("/tmp/test.ogg")).rejects.toThrow(/Failed to get audio duration/);
+  });
+});
+
+describe("getVoiceMessageMetadata", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    mockExecResults.length = 0;
+  });
+
+  it("returns fallback duration when ffprobe fails", async () => {
+    const enoent = Object.assign(new Error("spawn ffprobe ENOENT"), { code: "ENOENT" });
+    // getAudioDuration call → fails
+    mockExecResults.push({ error: enoent as NodeJS.ErrnoException });
+    // generateWaveform → ffmpeg pcm extraction call → fails (triggers placeholder)
+    mockExecResults.push({ error: new Error("no ffmpeg") as NodeJS.ErrnoException });
+
+    const metadata = await getVoiceMessageMetadata("/tmp/test.ogg");
+    expect(metadata.durationSecs).toBe(0);
+    expect(metadata.waveform).toBeTruthy();
+  });
+});
 
 describe("ensureOggOpus", () => {
   beforeEach(() => {

--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -214,7 +214,7 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
  */
 export async function getVoiceMessageMetadata(filePath: string): Promise<VoiceMessageMetadata> {
   const [durationSecs, waveform] = await Promise.all([
-    getAudioDuration(filePath),
+    getAudioDuration(filePath).catch(() => 0),
     generateWaveform(filePath),
   ]);
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: When `ffprobe` is absent from the host, `getAudioDuration()` throws an ENOENT error that propagates unhandled through `getVoiceMessageMetadata()`, tearing down the agent WebSocket connection (close code 1006) instead of returning a graceful fallback.
- Why it matters: A missing ffprobe binary crashes voice message handling entirely — the agent connection closes and no message is delivered — rather than delivering the message with duration 0 and a placeholder waveform. ffprobe is an optional system dependency and its absence should not be fatal.
- What changed: Added a `.catch(() => 0)` fallback in `getVoiceMessageMetadata()` so ENOENT (or any error) from `getAudioDuration()` returns duration 0 — matching the existing pattern in `generateWaveform()` which already handles ffmpeg errors gracefully. Added tests covering both the parse path and the ENOENT fallback.
- What did NOT change (scope boundary): No change to `generateWaveform()`, voice message transcription, delivery, or any other Discord handling code.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40382

## User-visible / Behavior Changes

Voice messages received on Discord when `ffprobe` is not installed now deliver with duration `0:00` and a placeholder waveform instead of silently dropping and closing the agent connection.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Linux / macOS (host without ffprobe in PATH)
- Runtime/container: Node 22 / bun
- Model/provider: Any
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord channel configured; `ffprobe` absent from PATH

### Steps

1. Ensure `ffprobe` is not installed (`which ffprobe` returns empty).
2. Have a user send a voice message to the Discord channel.
3. Observe agent behaviour and WebSocket state.

### Expected

- Voice message processed; agent responds with duration 0 and placeholder waveform; connection remains open.

### Actual

- Before fix: WebSocket close code 1006, agent connection torn down.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after — new tests for `getAudioDuration` parse, ENOENT throw, and `getVoiceMessageMetadata` fallback; `vitest run src/discord/voice-message.test.ts` — all pass.
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `ffprobe` ENOENT returns duration 0, normal ffprobe stdout parses correctly to seconds, existing `ensureOggOpus` tests unaffected.
- Edge cases checked: `.catch(() => 0)` catches all errors (not just ENOENT) — permission denied, corrupt binary, etc. all fall back gracefully.
- What you did **not** verify: live Discord voice message test with a real Discord channel and a real ffprobe-absent host.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <sha>` or revert the PR.
- Files/config to restore: `src/discord/voice-message.ts`
- Known bad symptoms reviewers should watch for: missing ffprobe again causing WebSocket close 1006 on voice messages — no regression beyond the pre-fix behaviour.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Duration 0 and a placeholder waveform may appear slightly broken in the Discord UI on clients that display voice message duration.
  - Mitigation: This is already the established fallback for `generateWaveform()` failures. Duration 0 is far preferable to a torn-down connection, and matches Discord's own fallback for unavailable duration metadata.