### PR TITLE
fix(discord): log dropped bot messages at debug level with config hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 - Security/system.run: fail closed for approval-backed interpreter/runtime commands when OpenClaw cannot bind exactly one concrete local file operand, while extending best-effort direct-file binding to additional runtime forms. Thanks @tdjackey for reporting.
 - Gateway/session reset auth: split conversation `/new` and `/reset` handling away from the admin-only `sessions.reset` control-plane RPC so write-scoped gateway callers can no longer reach the privileged reset path through `agent`. Thanks @tdjackey for reporting.
 - Telegram/final preview delivery followup: keep ambiguous missing-`message_id` finals only when a preview was already visible, while first-preview/no-id cases still fall back so Telegram users do not lose the final reply. (#41932) thanks @hougangdev.
+- Discord/preflight: log dropped bot messages at debug level with the bot's username and a config hint (`channels.discord.allowBots`) so users can diagnose silent message drops without enabling verbose logging. (#40267)
 
 ## 2026.3.8
 

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -1,11 +1,19 @@
 import { ChannelType } from "@buape/carbon";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const logDebugMock = vi.hoisted(() => vi.fn());
 const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../media-understanding/audio-preflight.js", () => ({
   transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
 }));
+vi.mock("../../logger.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logger.js")>();
+  return {
+    ...actual,
+    logDebug: (...args: unknown[]) => logDebugMock(...args),
+  };
+});
 import {
   __testing as sessionBindingTesting,
   registerSessionBindingAdapter,
@@ -381,6 +389,32 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.boundSessionKey).toBe(threadBinding.targetSessionKey);
     expect(result?.shouldRequireMention).toBe(false);
+  });
+
+  it("drops bot messages when allowBots is not set (defaults to off)", async () => {
+    const channelId = "channel-bot-off";
+    const guildId = "guild-bot-off";
+    const message = createMessage({
+      id: "m-bot-off",
+      channelId,
+      content: "relay chatter",
+      author: {
+        id: "relay-bot-default",
+        bot: true,
+        username: "RelayDefault",
+      },
+    });
+
+    logDebugMock.mockClear();
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {} as DiscordConfig,
+    });
+
+    expect(result).toBeNull();
+    expect(logDebugMock).toHaveBeenCalledWith(expect.stringContaining("allowBots not enabled"));
   });
 
   it("drops bot messages without mention when allowBots=mentions", async () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -30,6 +30,7 @@ import { logDebug } from "../../logger.js";
 import { getChildLogger } from "../../logging.js";
 import { buildPairingReply } from "../../pairing/pairing-messages.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+import { sanitizeForLog } from "../../terminal/ansi.js";
 import { fetchPluralKitMessageInfo } from "../pluralkit.js";
 import { sendMessageDiscord } from "../send.js";
 import {
@@ -187,7 +188,9 @@ export async function preflightDiscordMessage(
 
   if (author.bot) {
     if (allowBotsMode === "off" && !sender.isPluralKit) {
-      logVerbose("discord: drop bot message (allowBots=false)");
+      logDebug(
+        `[discord-preflight] drop: bot message from ${sanitizeForLog(author.username ?? author.id)} (allowBots not enabled; set channels.discord.allowBots to true or "mentions" to accept bot messages)`,
+      );
       return null;
     }
   }


### PR DESCRIPTION
## Summary

When `channels.discord.allowBots` is unset or false, bot messages are silently dropped with only a `logVerbose` entry. Users debugging Discord bot-to-bot workflows have no way to discover their messages are being filtered, or what config key to change.

This upgrades the drop log from `logVerbose` to `logDebug`, includes the bot's username (sanitised via `sanitizeForLog` to prevent log forging per CWE-117) and the config key needed to allow bot messages, and adds a covering test for the default-off path (previously untested).

No change to drop behaviour itself, no change to the `allowBots` default.

## Change type

- [x] Bug fix

## Linked issue

Closes #40267

## What changed

- `message-handler.preflight.ts`: replaced `logVerbose("discord: drop bot message (allowBots=false)")` with `logDebug(...)` that includes the bot username (wrapped in `sanitizeForLog()`) and a config hint pointing to `channels.discord.allowBots`
- `message-handler.preflight.ts`: added `import { sanitizeForLog } from "../../terminal/ansi.js"` to sanitise user-controlled Discord usernames before log interpolation
- `message-handler.preflight.test.ts`: added test covering the default-off path with `logDebug` assertion verifying the drop message content
- `CHANGELOG.md`: entry appended to end of Unreleased Fixes section

## Verification

- `pnpm vitest run src/discord/monitor/message-handler.preflight.test.ts` - 18 tests (17 existing + 1 new). Currently blocked by an upstream regression (`getOAuthProviders is not a function` from `59bc3c663` on main) that affects all test files importing the auth-profiles module chain. Confirmed identical failure on `upstream/main` HEAD.
- Manually verified: `allowBots` unset (drop + debug log with sanitised username), `allowBots: false` (drop + debug log), `allowBots: true` (message passes through)