### PR TITLE
fix(agents): check billing errors before context overflow heuristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1045,6 +1045,7 @@ Docs: https://docs.openclaw.ai
 - Browser/Navigate: resolve the correct `targetId` in navigate responses after renderer swaps. (#25326) Thanks @stone-jin and @vincentkoc.
 - FS/Sandbox workspace boundaries: add a dedicated `outside-workspace` safe-open error code for root-escape checks, and propagate specific outside-workspace messages across edit/browser/media consumers instead of generic not-found/invalid-path fallbacks. (#29715) Thanks @YuzuruS.
 - Diagnostics/Stuck session signal: add configurable stuck-session warning threshold via `diagnostics.stuckSessionWarnMs` (default 120000ms) to reduce false-positive warnings on long multi-tool turns. (#31032)
+- Agents/error classification: check billing errors before context overflow heuristics in the agent runner catch block so spend-limit and quota errors show the billing-specific message instead of being misclassified as "Context overflow: prompt too large". (#40378)
 
 ## 2026.2.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1045,7 +1045,7 @@ Docs: https://docs.openclaw.ai
 - Browser/Navigate: resolve the correct `targetId` in navigate responses after renderer swaps. (#25326) Thanks @stone-jin and @vincentkoc.
 - FS/Sandbox workspace boundaries: add a dedicated `outside-workspace` safe-open error code for root-escape checks, and propagate specific outside-workspace messages across edit/browser/media consumers instead of generic not-found/invalid-path fallbacks. (#29715) Thanks @YuzuruS.
 - Diagnostics/Stuck session signal: add configurable stuck-session warning threshold via `diagnostics.stuckSessionWarnMs` (default 120000ms) to reduce false-positive warnings on long multi-tool turns. (#31032)
-- Agents/error classification: check billing errors before context overflow heuristics in the agent runner catch block so spend-limit and quota errors show the billing-specific message instead of being misclassified as "Context overflow: prompt too large". (#40378)
+- Agents/error classification: check billing errors before context overflow heuristics in the agent runner catch block so spend-limit and quota errors show the billing-specific message instead of being misclassified as "Context overflow: prompt too large". (#40409) Thanks @ademczuk.
 
 ## 2026.2.26
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -439,6 +439,18 @@ describe("isLikelyContextOverflowError", () => {
       expect(isLikelyContextOverflowError(sample)).toBe(false);
     }
   });
+
+  it("excludes billing errors even when text matches context overflow patterns", () => {
+    const samples = [
+      "402 Payment Required: request token limit exceeded for this billing plan",
+      "insufficient credits: request size exceeds your current plan limits",
+      "Your credit balance is too low. Maximum request token limit exceeded.",
+    ];
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample)).toBe(true);
+      expect(isLikelyContextOverflowError(sample)).toBe(false);
+    }
+  });
 });
 
 describe("isTransientHttpError", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -138,6 +138,13 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
     return false;
   }
 
+  // Billing/quota errors can contain patterns like "request size exceeds" or
+  // "maximum token limit exceeded" that match the context overflow heuristic.
+  // Billing is a more specific error class — exclude it early.
+  if (isBillingErrorMessage(errorMessage)) {
+    return false;
+  }
+
   if (CONTEXT_WINDOW_TOO_SMALL_RE.test(errorMessage)) {
     return false;
   }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -6,8 +6,10 @@ import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
+  BILLING_ERROR_USER_MESSAGE,
   isCompactionFailureError,
   isContextOverflowError,
+  isBillingErrorMessage,
   isLikelyContextOverflowError,
   isTransientHttpError,
   sanitizeUserFacingText,
@@ -514,8 +516,9 @@ export async function runAgentTurnWithFallback(params: {
       break;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      const isContextOverflow = isLikelyContextOverflowError(message);
-      const isCompactionFailure = isCompactionFailureError(message);
+      const isBilling = isBillingErrorMessage(message);
+      const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
+      const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
@@ -610,11 +613,13 @@ export async function runAgentTurnWithFallback(params: {
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
-      const fallbackText = isContextOverflow
-        ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
-        : isRoleOrderingError
-          ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+      const fallbackText = isBilling
+        ? BILLING_ERROR_USER_MESSAGE
+        : isContextOverflow
+          ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
+          : isRoleOrderingError
+            ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1628,3 +1628,72 @@ describe("runReplyAgent transient HTTP retry", () => {
     expect(payload?.text).toContain("Recovered response");
   });
 });
+
+describe("runReplyAgent billing error classification", () => {
+  // Regression guard for the runner-level catch block in runAgentTurnWithFallback.
+  // Billing errors from providers like OpenRouter can contain token/size wording that
+  // matches context overflow heuristics. This test verifies the final user-visible
+  // message is the billing-specific one, not the "Context overflow" fallback.
+  it("returns billing message for mixed-signal error (billing text + overflow patterns)", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error("402 Payment Required: request token limit exceeded for this billing plan"),
+    );
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("billing error");
+    expect(payload?.text).not.toContain("Context overflow");
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: Billing/quota errors from providers like OpenRouter contain text patterns (e.g. "request size exceeds", "token limit exceeded") that match the broad context overflow regex in `isLikelyContextOverflowError`. Spend-limit errors display "Context overflow: prompt too large" instead of the billing message with dashboard link.
- Why it matters: Users misread a billing block as a context size problem and waste time reducing prompt length rather than topping up their account.
- What changed: Added an `isBillingErrorMessage` early-exit guard at the top of `isLikelyContextOverflowError()`, following the existing rate-limit and reasoning-constraint guard pattern. Added an explicit billing check in the `agent-runner-execution.ts` catch block so billing errors surface `BILLING_ERROR_USER_MESSAGE` instead of the generic "Agent failed" fallback.
- What did NOT change (scope boundary): No changes to billing error detection logic itself (`isBillingErrorMessage`), model fallback behaviour, or any other error classification path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40378

## User-visible / Behavior Changes

When a provider returns a billing/quota error whose text overlaps with context overflow patterns, the CLI now shows the billing-specific message (with account dashboard link) instead of "Context overflow: prompt too large". No change for genuine context overflow errors.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22 / Bun
- Model/provider: OpenRouter (or any provider returning overlapping billing + context error text)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Configure an OpenRouter provider with an exhausted quota
2. Send a request that triggers the spend limit
3. Observe the error message shown to the user

### Expected

- Billing error message with account dashboard link

### Actual (before fix)

- "Context overflow: prompt too large" because the billing error text matches the overflow regex

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 46 `pi-embedded-helpers.isbillingerrormessage.test.ts` tests pass (3 new). All 56 `model-fallback.test.ts` tests pass (unchanged - confirms guard doesn't break fallback). TypeScript compiles clean.

## Human Verification (required)

- Verified scenarios: billing errors with overlapping context-overflow text patterns correctly short-circuit the overflow check; standard context overflow errors unaffected; rate-limit and reasoning-constraint guards continue to work.
- Edge cases checked: errors matching billing AND overflow AND rate-limit patterns - billing guard fires first (order preserved); empty/null stderr - no regression.
- What you did **not** verify: live end-to-end with a real OpenRouter quota-exhausted key. Unit test covers the classification logic; the catch-block path requires a live provider to exercise fully.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `src/agents/pi-embedded-helpers/errors.ts` to remove the `isBillingErrorMessage` guard. Billing errors will fall through to overflow classification again.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/auto-reply/reply/agent-runner-execution.ts`
- Known bad symptoms reviewers should watch for: genuine billing errors shown as context overflow messages (regression to pre-fix behaviour).

## Risks and Mitigations

- Risk: A future billing error message that does NOT match the `isBillingErrorMessage` patterns would still fall through to the overflow classifier.
  - Mitigation: `isBillingErrorMessage` has 46 test cases covering known billing patterns; the early-exit is conservative and only fires on confirmed billing text.