### PR TITLE
feat(runtime): expose agent and session env markers

### DIFF
--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -185,6 +185,7 @@ Security note:
   - `--url` is override-safe and does not reuse implicit config/env credentials; pass explicit `--token`/`--password` (or file variants)
 - ACP runtime backend child processes receive `OPENCLAW_SHELL=acp`, which can be used for context-specific shell/profile rules.
 - `openclaw acp client` sets `OPENCLAW_SHELL=acp-client` on the spawned bridge process.
+- When ACP client creation is given an agent/session context, the spawned bridge process also receives `OPENCLAW_AGENT_ID` and `OPENCLAW_SESSION_KEY`.
 
 ### `acp client` options
 

--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -29,6 +29,7 @@ Behavior:
 - Output is kept in memory until the session is polled or cleared.
 - If the `process` tool is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`.
 - Spawned exec commands receive `OPENCLAW_SHELL=exec` for context-aware shell/profile rules.
+- When the exec turn is tied to an agent session, spawned child processes also receive `OPENCLAW_AGENT_ID` and `OPENCLAW_SESSION_KEY`.
 
 ## Child process bridging
 

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -64,6 +64,8 @@ OpenClaw also injects context markers into spawned child processes:
 - `OPENCLAW_SHELL=acp`: set for ACP runtime backend process spawns (for example `acpx`).
 - `OPENCLAW_SHELL=acp-client`: set for `openclaw acp client` when it spawns the ACP bridge process.
 - `OPENCLAW_SHELL=tui-local`: set for local TUI `!` shell commands.
+- `OPENCLAW_AGENT_ID`: set for child processes spawned by runtimes such as `exec`, `acp-client`, and `tui-local` when a stable agent identity is available (`main`, `anotherAgent`, etc.).
+- `OPENCLAW_SESSION_KEY`: set for child processes spawned by runtimes such as `exec`, `acp-client`, and `tui-local` when the parent context has a bound session key.
 
 These are runtime markers (not required user config). They can be used in shell/profile logic
 to apply context-specific rules.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -41,6 +41,7 @@ Notes:
 - Host execution (`gateway`/`node`) rejects `env.PATH` and loader overrides (`LD_*`/`DYLD_*`) to
   prevent binary hijacking or injected code.
 - OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment (including PTY and sandbox execution) so shell/profile rules can detect exec-tool context.
+- OpenClaw also injects `OPENCLAW_AGENT_ID` for exec child processes and, when available, `OPENCLAW_SESSION_KEY` so downstream scripts can make deterministic routing decisions without parsing prompts or persona text.
 - Important: sandboxing is **off by default**. If sandboxing is off and `host=sandbox` is explicitly
   configured/requested, exec now fails closed instead of silently running on the gateway host.
   Enable sandboxing or use `host=gateway` with approvals.

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -114,6 +114,7 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - The TUI prompts once per session to allow local execution; declining keeps `!` disabled for the session.
 - Commands run in a fresh, non-interactive shell in the TUI working directory (no persistent `cd`/env).
 - Local shell commands receive `OPENCLAW_SHELL=tui-local` in their environment.
+- When the current TUI session is bound to an agent/session, local shell commands also receive `OPENCLAW_AGENT_ID` and `OPENCLAW_SESSION_KEY`.
 - A lone `!` is sent as a normal message; leading spaces do not trigger local exec.
 
 ## Tool output

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -110,6 +110,29 @@ describe("resolveAcpClientSpawnEnv", () => {
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
     expect(env.OPENAI_API_KEY).toBeUndefined();
   });
+
+  it("injects agent and session markers when explicit context is provided", () => {
+    const env = resolveAcpClientSpawnEnv(
+      { PATH: "/usr/bin" },
+      { agentId: "agent1", sessionKey: "agent:agent2:acp:session-1" },
+    );
+
+    expect(env.OPENCLAW_SHELL).toBe("acp-client");
+    expect(env.OPENCLAW_AGENT_ID).toBe("agent1");
+    expect(env.OPENCLAW_SESSION_KEY).toBe("agent:agent2:acp:session-1");
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("derives agent id from session key when only session context is provided", () => {
+    const env = resolveAcpClientSpawnEnv(
+      { PATH: "/usr/bin" },
+      { sessionKey: "agent:agent2:acp:session-1" },
+    );
+
+    expect(env.OPENCLAW_SHELL).toBe("acp-client");
+    expect(env.OPENCLAW_AGENT_ID).toBe("agent2");
+    expect(env.OPENCLAW_SESSION_KEY).toBe("agent:agent2:acp:session-1");
+  });
 });
 
 describe("resolveAcpClientSpawnInvocation", () => {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -19,6 +19,7 @@ import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
 } from "../plugin-sdk/windows-spawn.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { DANGEROUS_ACP_TOOLS } from "../security/dangerous-tools.js";
 
 const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["read", "search", "web_search", "memory_search"]);
@@ -323,6 +324,8 @@ export type AcpClientOptions = {
   serverArgs?: string[];
   serverVerbose?: boolean;
   verbose?: boolean;
+  agentId?: string;
+  sessionKey?: string;
 };
 
 export type AcpClientHandle = {
@@ -348,7 +351,11 @@ function buildServerArgs(opts: AcpClientOptions): string[] {
 
 export function resolveAcpClientSpawnEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
-  options?: { stripKeys?: ReadonlySet<string> },
+  options?: {
+    stripKeys?: ReadonlySet<string>;
+    agentId?: string;
+    sessionKey?: string;
+  },
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   if (options?.stripKeys) {
@@ -356,7 +363,19 @@ export function resolveAcpClientSpawnEnv(
       delete env[key];
     }
   }
+  const sessionKey = options?.sessionKey?.trim();
+  const runtimeAgentId = options?.agentId?.trim()
+    ? options.agentId.trim()
+    : sessionKey
+      ? resolveAgentIdFromSessionKey(sessionKey)
+      : undefined;
   env.OPENCLAW_SHELL = "acp-client";
+  if (runtimeAgentId) {
+    env.OPENCLAW_AGENT_ID = runtimeAgentId;
+  }
+  if (sessionKey) {
+    env.OPENCLAW_SESSION_KEY = sessionKey;
+  }
   return env;
 }
 
@@ -461,6 +480,8 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const { getActiveSkillEnvKeys } = await import("../agents/skills/env-overrides.runtime.js");
   const spawnEnv = resolveAcpClientSpawnEnv(process.env, {
     stripKeys: getActiveSkillEnvKeys(),
+    agentId: opts.agentId,
+    sessionKey: opts.sessionKey,
   });
   const spawnInvocation = resolveAcpClientSpawnInvocation(
     { serverCommand, serverArgs: effectiveArgs },

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -10,7 +10,7 @@ vi.mock("../infra/system-events.js", () => ({
 
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
+import { emitExecSystemEvent, resolveExecRuntimeEnv } from "./bash-tools.exec-runtime.js";
 
 const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
 const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
@@ -60,5 +60,31 @@ describe("emitExecSystemEvent", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveExecRuntimeEnv", () => {
+  it("derives OPENCLAW_AGENT_ID from the agent session key and keeps the session marker", () => {
+    const env = resolveExecRuntimeEnv({ PATH: "/usr/bin" }, { sessionKey: "agent:agent2:main" });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.OPENCLAW_SHELL).toBe("exec");
+    expect(env.OPENCLAW_AGENT_ID).toBe("agent2");
+    expect(env.OPENCLAW_SESSION_KEY).toBe("agent:agent2:main");
+  });
+
+  it("prefers an explicit agent id over the session-key fallback", () => {
+    const env = resolveExecRuntimeEnv(
+      {
+        OPENCLAW_SHELL: "wrong",
+        OPENCLAW_AGENT_ID: "wrong",
+        PATH: "/usr/bin",
+      },
+      { agentId: "agent1", sessionKey: "agent:agent2:main" },
+    );
+
+    expect(env.OPENCLAW_SHELL).toBe("exec");
+    expect(env.OPENCLAW_AGENT_ID).toBe("agent1");
+    expect(env.OPENCLAW_SESSION_KEY).toBe("agent:agent2:main");
   });
 });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -6,7 +6,10 @@ import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import {
+  resolveAgentIdFromSessionKey,
+  scopedHeartbeatWakeOptions,
+} from "../routing/session-key.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -252,6 +255,20 @@ export function emitExecSystemEvent(
   requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
 }
 
+export function resolveExecRuntimeEnv(
+  baseEnv: Record<string, string>,
+  opts: { agentId?: string; sessionKey?: string },
+): Record<string, string> {
+  const sessionKey = opts.sessionKey?.trim();
+  const runtimeAgentId = opts.agentId?.trim() || resolveAgentIdFromSessionKey(sessionKey);
+  return {
+    ...baseEnv,
+    OPENCLAW_SHELL: "exec",
+    OPENCLAW_AGENT_ID: runtimeAgentId,
+    ...(sessionKey ? { OPENCLAW_SESSION_KEY: sessionKey } : {}),
+  };
+}
+
 export async function runExecProcess(opts: {
   command: string;
   // Execute this instead of `command` (which is kept for display/session/logging).
@@ -268,6 +285,7 @@ export async function runExecProcess(opts: {
   notifyOnExit: boolean;
   notifyOnExitEmptySuccess?: boolean;
   scopeKey?: string;
+  agentId?: string;
   sessionKey?: string;
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
@@ -276,10 +294,10 @@ export async function runExecProcess(opts: {
   const sessionId = createSessionSlug();
   const execCommand = opts.execCommand ?? opts.command;
   const supervisor = getProcessSupervisor();
-  const shellRuntimeEnv: Record<string, string> = {
-    ...opts.env,
-    OPENCLAW_SHELL: "exec",
-  };
+  const shellRuntimeEnv = resolveExecRuntimeEnv(opts.env, {
+    agentId: opts.agentId,
+    sessionKey: opts.sessionKey,
+  });
 
   const session: ProcessSession = {
     id: sessionId,

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -109,6 +109,45 @@ describe("exec PATH login shell merge", () => {
     expect(value).toBe("exec");
   });
 
+  it("injects agent and session markers for host=gateway commands", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:agent2:main",
+    });
+    const result = await tool.execute("call-openclaw-agent-env", {
+      command: 'printf "%s|%s" "${OPENCLAW_AGENT_ID:-}" "${OPENCLAW_SESSION_KEY:-}"',
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(value).toBe("agent2|agent:agent2:main");
+  });
+
+  it("prefers an explicit agent id for legacy or global session contexts", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      agentId: "agent1",
+      sessionKey: "global",
+    });
+    const result = await tool.execute("call-openclaw-agent-explicit", {
+      command: 'printf "%s|%s" "${OPENCLAW_AGENT_ID:-}" "${OPENCLAW_SESSION_KEY:-}"',
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(value).toBe("agent1|global");
+  });
+
   it("throws security violation when env.PATH is provided", async () => {
     if (isWin) {
       return;

--- a/src/agents/bash-tools.exec.pty.test.ts
+++ b/src/agents/bash-tools.exec.pty.test.ts
@@ -29,3 +29,21 @@ test("exec sets OPENCLAW_SHELL in pty mode", async () => {
   const text = result.content?.find((item) => item.type === "text")?.text ?? "";
   expect(text).toContain("exec");
 });
+
+test("exec injects agent and session markers in pty mode", async () => {
+  const tool = createExecTool({
+    allowBackground: false,
+    security: "full",
+    ask: "off",
+    sessionKey: "agent:agent1:main",
+  });
+  const result = await tool.execute("toolcall-openclaw-agent-env", {
+    command:
+      "node -e \"process.stdout.write([process.env.OPENCLAW_AGENT_ID || '', process.env.OPENCLAW_SESSION_KEY || ''].join('|'))\"",
+    pty: true,
+  });
+
+  expect(result.details.status).toBe("completed");
+  const text = result.content?.find((item) => item.type === "text")?.text ?? "";
+  expect(text).toContain("agent1|agent:agent1:main");
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -483,6 +483,7 @@ export function createExecTool(
         notifyOnExit,
         notifyOnExitEmptySuccess,
         scopeKey: defaults?.scopeKey,
+        agentId,
         sessionKey: notifySessionKey,
         timeoutSec: effectiveTimeout,
         onUpdate,

--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
-import { createLocalShellRunner } from "./tui-local-shell.js";
+import { createLocalShellRunner, resolveTuiLocalRuntimeEnv } from "./tui-local-shell.js";
 
 const createSelector = () => {
   const selector = {
@@ -15,6 +15,8 @@ const createSelector = () => {
 function createShellHarness(params?: {
   spawnCommand?: typeof import("node:child_process").spawn;
   env?: Record<string, string>;
+  agentId?: string;
+  sessionKey?: string;
 }) {
   const messages: string[] = [];
   const chatLog = {
@@ -39,6 +41,8 @@ function createShellHarness(params?: {
     createSelector: createSelectorSpy,
     spawnCommand,
     ...(params?.env ? { env: params.env } : {}),
+    ...(params?.agentId ? { agentId: params.agentId } : {}),
+    ...(params?.sessionKey ? { sessionKey: params.sessionKey } : {}),
   });
   return {
     messages,
@@ -49,6 +53,20 @@ function createShellHarness(params?: {
     getLastSelector: () => lastSelector,
   };
 }
+
+describe("resolveTuiLocalRuntimeEnv", () => {
+  it("injects agent and session markers when context is provided", () => {
+    const env = resolveTuiLocalRuntimeEnv(
+      { PATH: "/tmp/bin" },
+      { agentId: "agent1", sessionKey: "agent:agent2:main" },
+    );
+
+    expect(env.OPENCLAW_SHELL).toBe("tui-local");
+    expect(env.OPENCLAW_AGENT_ID).toBe("agent1");
+    expect(env.OPENCLAW_SESSION_KEY).toBe("agent:agent2:main");
+    expect(env.PATH).toBe("/tmp/bin");
+  });
+});
 
 describe("createLocalShellRunner", () => {
   it("logs denial on subsequent ! attempts without re-prompting", async () => {
@@ -86,6 +104,7 @@ describe("createLocalShellRunner", () => {
     const harness = createShellHarness({
       spawnCommand: spawnCommand as unknown as typeof import("node:child_process").spawn,
       env: { PATH: "/tmp/bin", USER: "dev" },
+      sessionKey: "agent:agent2:main",
     });
 
     const firstRun = harness.runLocalShellLine("!echo hi");
@@ -98,6 +117,8 @@ describe("createLocalShellRunner", () => {
     expect(spawnCommand).toHaveBeenCalledTimes(1);
     const spawnOptions = spawnCommand.mock.calls[0]?.[1] as { env?: Record<string, string> };
     expect(spawnOptions.env?.OPENCLAW_SHELL).toBe("tui-local");
+    expect(spawnOptions.env?.OPENCLAW_AGENT_ID).toBe("agent2");
+    expect(spawnOptions.env?.OPENCLAW_SESSION_KEY).toBe("agent:agent2:main");
     expect(spawnOptions.env?.PATH).toBe("/tmp/bin");
     expect(harness.messages).toContain("local shell: enabled for this session");
   });

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { Component, SelectItem } from "@mariozechner/pi-tui";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { createSearchableSelectList } from "./components/selectors.js";
 
 type LocalShellDeps = {
@@ -21,8 +22,25 @@ type LocalShellDeps = {
   spawnCommand?: typeof spawn;
   getCwd?: () => string;
   env?: NodeJS.ProcessEnv;
+  agentId?: string | (() => string | undefined);
+  sessionKey?: string | (() => string | undefined);
   maxOutputChars?: number;
 };
+
+export function resolveTuiLocalRuntimeEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  opts: { agentId?: string; sessionKey?: string },
+): NodeJS.ProcessEnv {
+  const sessionKey = opts.sessionKey?.trim();
+  const runtimeAgentId =
+    opts.agentId?.trim() || (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined);
+  return {
+    ...baseEnv,
+    OPENCLAW_SHELL: "tui-local",
+    ...(runtimeAgentId ? { OPENCLAW_AGENT_ID: runtimeAgentId } : {}),
+    ...(sessionKey ? { OPENCLAW_SESSION_KEY: sessionKey } : {}),
+  };
+}
 
 export function createLocalShellRunner(deps: LocalShellDeps) {
   let localExecAsked = false;
@@ -31,6 +49,9 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
   const spawnCommand = deps.spawnCommand ?? spawn;
   const getCwd = deps.getCwd ?? (() => process.cwd());
   const env = deps.env ?? process.env;
+  const getAgentId = typeof deps.agentId === "function" ? deps.agentId : () => deps.agentId;
+  const getSessionKey =
+    typeof deps.sessionKey === "function" ? deps.sessionKey : () => deps.sessionKey;
   const maxChars = deps.maxOutputChars ?? 40_000;
 
   const ensureLocalExecAllowed = async (): Promise<boolean> => {
@@ -111,7 +132,10 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         // and is gated behind an explicit in-session approval prompt.
         shell: true,
         cwd: getCwd(),
-        env: { ...env, OPENCLAW_SHELL: "tui-local" },
+        env: resolveTuiLocalRuntimeEnv(env, {
+          agentId: getAgentId(),
+          sessionKey: getSessionKey(),
+        }),
       });
 
       let stdout = "";

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -853,6 +853,8 @@ export async function runTui(opts: TuiOptions) {
     tui,
     openOverlay,
     closeOverlay,
+    agentId: () => state.currentAgentId || undefined,
+    sessionKey: () => state.currentSessionKey || undefined,
   });
   updateAutocompleteProvider();
   const submitHandler = createEditorSubmitHandler({


### PR DESCRIPTION
## Summary

This PR exposes two deterministic runtime markers to spawned child processes across several OpenClaw shell/runtime entry points:

- `OPENCLAW_AGENT_ID`
- `OPENCLAW_SESSION_KEY` (when a session key is available)

This now covers:

- `exec`
- `acp-client`
- `tui-local`

Existing shell markers remain unchanged:

- `OPENCLAW_SHELL=exec`
- `OPENCLAW_SHELL=acp-client`
- `OPENCLAW_SHELL=tui-local`

## Motivation

In multi-agent deployments, downstream scripts often need to branch on **which agent is currently running**. Before this change there was no stable runtime marker for that, so users had to rely on brittle heuristics such as:

- inferring identity from prompt/persona text,
- guessing from workspace layout,
- or parsing internal session-key structure opportunistically.

That is awkward and unreliable for automation.

A concrete example from my setup: multiple cooperating agents share scripting paths for commit attribution, config selection, and side-effect routing. Those scripts need a deterministic identity contract, not a prompt-level guess.

This PR provides:

- `OPENCLAW_AGENT_ID` for stable identity
- `OPENCLAW_SESSION_KEY` for richer per-session context

## What changed

### `exec`
- Added `resolveExecRuntimeEnv(...)` in `src/agents/bash-tools.exec-runtime.ts`
- `runExecProcess(...)` now injects:
  - `OPENCLAW_SHELL=exec`
  - `OPENCLAW_AGENT_ID`
  - `OPENCLAW_SESSION_KEY` (when available)
- `OPENCLAW_AGENT_ID` prefers an explicit `agentId` and otherwise falls back to deriving from the session key
- Fixed an explicit `agentId` propagation gap in `createExecTool(...)` so legacy/global contexts do not incorrectly collapse to `main`

### `acp-client`
- `resolveAcpClientSpawnEnv(...)` now accepts optional agent/session context
- When provided, the spawned bridge process receives:
  - `OPENCLAW_AGENT_ID`
  - `OPENCLAW_SESSION_KEY`

### `tui-local`
- Added a local-shell env resolver for the TUI `!` shell path
- When the current TUI session is bound to an agent/session, the spawned local shell receives:
  - `OPENCLAW_AGENT_ID`
  - `OPENCLAW_SESSION_KEY`

## Tests

Added/updated tests covering:

- exec runtime env resolution helper behavior
- host=gateway exec env injection
- PTY exec env injection
- explicit agent-id preservation in legacy/global exec contexts
- ACP client env injection
- TUI local-shell env injection

Commands run locally:

```bash
corepack pnpm vitest run \
  src/agents/bash-tools.exec-runtime.test.ts \
  src/agents/bash-tools.exec.path.test.ts \
  src/agents/bash-tools.exec.pty.test.ts \
  src/acp/client.test.ts \
  src/tui/tui-local-shell.test.ts
```

## Documentation

Updated docs to clarify that runtime-injected identity/session markers are no longer exec-only and now apply (when context exists) to:

- `exec`
- `acp-client`
- `tui-local`

## Notes

I intentionally did **not** widen this to the ACP backend runtime marker (`OPENCLAW_SHELL=acp`) in the same PR. That path lives across the `acpx` extension/runtime boundary and seemed better as a follow-up change after landing the lower-risk entry points above.
