### PR TITLE
fix(tools): parse JSON-string toolCall arguments

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,3 +1,5 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -621,8 +621,19 @@ describe("decodeHtmlEntitiesInObject", () => {
 
     const wrapped = wrapStreamFnDecodeXaiToolCallArguments(baseFn as unknown as StreamFn);
     const stream = wrapped(
-      { provider: "xai", api: "openai-responses", id: "grok" },
-      { prompt: "", messages: [] },
+      {
+        provider: "xai",
+        api: "openai-responses",
+        id: "grok",
+        name: "Grok",
+        baseUrl: "https://example.invalid/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1,
+        maxTokens: 1,
+      },
+      { messages: [] },
       {},
     ) as ReturnType<typeof streamSimple>;
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -13,6 +13,7 @@ import {
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
+  wrapStreamFnDecodeXaiToolCallArguments,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
 
@@ -593,6 +594,39 @@ describe("decodeHtmlEntitiesInObject", () => {
       "source .env &amp;&amp; psql &quot;$DB&quot; -c &lt;query&gt;",
     );
     expect(result).toBe('source .env && psql "$DB" -c <query>');
+  });
+
+  it("parses toolCall arguments that are JSON strings", async () => {
+    const baseFn = () =>
+      ({
+        async result() {
+          return {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "read",
+                arguments: '{"path":"/tmp/x"}',
+              },
+            ],
+          };
+        },
+        async *[Symbol.asyncIterator]() {
+          // no partial events needed
+        },
+      }) as unknown as ReturnType<typeof streamSimple>;
+
+    const wrapped = wrapStreamFnDecodeXaiToolCallArguments(baseFn as unknown as StreamFn);
+    const stream = wrapped(
+      { provider: "xai", api: "openai-responses", id: "grok" },
+      { prompt: "", messages: [] },
+      {},
+    ) as ReturnType<typeof streamSimple>;
+
+    const message = await stream.result();
+    const call = (message as unknown as { content: Array<{ arguments?: unknown }> }).content[0];
+    expect(call?.arguments).toEqual({ path: "/tmp/x" });
   });
 
   it("recursively decodes nested objects", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -483,7 +483,21 @@ function decodeXaiToolCallArgumentsInMessage(message: unknown): void {
     if (typedBlock.type !== "toolCall" || !typedBlock.arguments) {
       continue;
     }
-    if (typeof typedBlock.arguments === "object") {
+
+    // Some OpenAI-compatible providers (e.g. opencode-go/glm-5) emit tool-call
+    // arguments as a JSON *string*.
+    if (typeof typedBlock.arguments === "string") {
+      const raw = typedBlock.arguments.trim();
+      if (raw.startsWith("{") || raw.startsWith("[")) {
+        try {
+          typedBlock.arguments = JSON.parse(raw) as unknown;
+        } catch {
+          // fall through to potential HTML decoding
+        }
+      }
+    }
+
+    if (typeof typedBlock.arguments === "object" && typedBlock.arguments) {
       typedBlock.arguments = decodeHtmlEntitiesInObject(typedBlock.arguments);
     }
   }
@@ -524,7 +538,7 @@ function wrapStreamDecodeXaiToolCallArguments(
   return stream;
 }
 
-function wrapStreamFnDecodeXaiToolCallArguments(baseFn: StreamFn): StreamFn {
+export function wrapStreamFnDecodeXaiToolCallArguments(baseFn: StreamFn): StreamFn {
   return (model, context, options) => {
     const maybeStream = baseFn(model, context, options);
     if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {

--- a/src/media/ffmpeg-exec.ts
+++ b/src/media/ffmpeg-exec.ts
@@ -23,22 +23,58 @@ function resolveExecOptions(
   };
 }
 
-export async function runFfprobe(args: string[], options?: MediaExecOptions): Promise<string> {
-  const { stdout } = await execFileAsync(
-    "ffprobe",
-    args,
-    resolveExecOptions(MEDIA_FFPROBE_TIMEOUT_MS, options),
+function isMissingBinaryError(err: unknown, binary: string): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const anyErr = err as { code?: unknown; path?: unknown; message?: unknown };
+  const code = typeof anyErr.code === "string" ? anyErr.code : "";
+  const errPath = typeof anyErr.path === "string" ? anyErr.path : "";
+  const message = typeof anyErr.message === "string" ? anyErr.message : "";
+  if (code !== "ENOENT") {
+    return false;
+  }
+  return errPath === binary || message.includes(binary);
+}
+
+function missingBinaryMessage(binary: string): string {
+  return (
+    `Required media binary "${binary}" was not found in PATH (ENOENT). ` +
+    `Install FFmpeg (includes ${binary}) and try again. ` +
+    `macOS: \`brew install ffmpeg\`. Ubuntu/Debian: \`sudo apt-get install ffmpeg\`.`
   );
-  return stdout.toString();
+}
+
+export async function runFfprobe(args: string[], options?: MediaExecOptions): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      "ffprobe",
+      args,
+      resolveExecOptions(MEDIA_FFPROBE_TIMEOUT_MS, options),
+    );
+    return stdout.toString();
+  } catch (err) {
+    if (isMissingBinaryError(err, "ffprobe")) {
+      throw new Error(missingBinaryMessage("ffprobe"), { cause: err });
+    }
+    throw err;
+  }
 }
 
 export async function runFfmpeg(args: string[], options?: MediaExecOptions): Promise<string> {
-  const { stdout } = await execFileAsync(
-    "ffmpeg",
-    args,
-    resolveExecOptions(MEDIA_FFMPEG_TIMEOUT_MS, options),
-  );
-  return stdout.toString();
+  try {
+    const { stdout } = await execFileAsync(
+      "ffmpeg",
+      args,
+      resolveExecOptions(MEDIA_FFMPEG_TIMEOUT_MS, options),
+    );
+    return stdout.toString();
+  } catch (err) {
+    if (isMissingBinaryError(err, "ffmpeg")) {
+      throw new Error(missingBinaryMessage("ffmpeg"), { cause: err });
+    }
+    throw err;
+  }
 }
 
 export function parseFfprobeCsvFields(stdout: string, maxFields: number): string[] {


### PR DESCRIPTION
Some OpenAI-compatible providers emit tool-call `arguments` as a JSON *string* (instead of an object), which breaks tool invocation.

This normalizes tool-call blocks by parsing JSON-string arguments when they look like JSON, while keeping the existing HTML entity decoding for object arguments.

Tests (local):
- `pnpm build`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts`

AI-assisted: yes (human-reviewed).