### PR TITLE
[AI-assisted] Follow up bootstrap reuse and zsh completion init

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -111,7 +111,10 @@ import {
 } from "../runs.js";
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
-import { prepareSessionManagerForRun } from "../session-manager-init.js";
+import {
+  prepareSessionManagerForRun,
+  shouldInjectBootstrapContext,
+} from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
@@ -796,16 +799,18 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-      });
+    const injectBootstrapContext = await shouldInjectBootstrapContext(params.sessionFile);
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } = injectBootstrapContext
+      ? await resolveBootstrapContextForRun({
+          workspaceDir: effectiveWorkspace,
+          config: params.config,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          contextMode: params.bootstrapContextMode,
+          runKind: params.bootstrapContextRunKind,
+        })
+      : { bootstrapFiles: [], contextFiles: [] };
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { shouldInjectBootstrapContext } from "./session-manager-init.js";
+
+const tempRoots: string[] = [];
+
+async function makeSessionFile(content?: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-bootstrap-"));
+  tempRoots.push(root);
+  const sessionFile = path.join(root, "session.jsonl");
+  if (content !== undefined) {
+    await fs.writeFile(sessionFile, content, "utf-8");
+  }
+  return sessionFile;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("shouldInjectBootstrapContext", () => {
+  it("injects bootstrap context when the transcript does not exist yet", async () => {
+    const sessionFile = await makeSessionFile();
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("injects bootstrap context when the transcript only has a session header", async () => {
+    const sessionFile = await makeSessionFile(
+      `${JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" })}\n`,
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("keeps bootstrap context when the transcript only has pre-assistant messages", async () => {
+    const sessionFile = await makeSessionFile(
+      [
+        JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      ].join("\n"),
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("skips bootstrap context after the transcript already has an assistant message", async () => {
+    const sessionFile = await makeSessionFile(
+      [
+        JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+      ].join("\n"),
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(false);
+  });
+
+  it("falls back to injecting bootstrap context when the transcript is malformed", async () => {
+    const sessionFile = await makeSessionFile("{not-json}\n");
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -3,6 +3,36 @@ import fs from "node:fs/promises";
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
+export async function shouldInjectBootstrapContext(sessionFile: string): Promise<boolean> {
+  let content: string;
+  try {
+    content = await fs.readFile(sessionFile, "utf-8");
+  } catch {
+    return true;
+  }
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line) as {
+        type?: string;
+        message?: { role?: string };
+      };
+      if (entry.type === "message" && entry.message?.role === "assistant") {
+        return false;
+      }
+    } catch {
+      // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly yet.
+      return true;
+    }
+  }
+
+  return true;
+}
+
 /**
  * pi-coding-agent SessionManager persistence quirk:
  * - If the file exists but has no assistant message, SessionManager marks itself `flushed=true`

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { generateZshCompletion } from "./completion-cli.js";
+
+describe("generateZshCompletion", () => {
+  it("initializes compinit only when compdef is unavailable", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("status").description("show status");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain("if ! (( $+functions[compdef] )); then");
+    expect(script).toContain("autoload -Uz compinit");
+    expect(script).toContain("compinit");
+    expect(script).toContain("compdef _openclaw_root_completion openclaw");
+  });
+});

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -376,10 +376,15 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 }
 
-function generateZshCompletion(program: Command): string {
+export function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
 #compdef ${rootCmd}
+
+if ! (( $+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit
+fi
 
 _${rootCmd}_root_completion() {
   local -a commands


### PR DESCRIPTION
## Summary

- Problem: the closed PR #40177 bundled unrelated fixes, and review found two still-valid follow-up issues in the remaining bootstrap/zsh changes.
- Why it matters: bootstrap reuse must not skip AGENTS/bootstrap context for transcripts that only have pre-assistant messages, and zsh completion should not autoload `compinit` outside the guard.
- What changed: bootstrap skipping now only activates after an assistant transcript entry already exists, and generated zsh completion now guards both `autoload -Uz compinit` and `compinit` together.
- What did NOT change (scope boundary): this PR does not touch the superseded macOS remote-auth UI work from #40177.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #9157
- Closes #14289
- Related #40177

## User-visible / Behavior Changes

- Existing embedded sessions now keep bootstrap context until the transcript has at least one persisted assistant turn.
- `source <(openclaw completion --shell zsh)` initializes completion more safely in shells that already loaded `compdef`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: mocked unit tests only
- Integration/channel (if any): embedded runner, zsh completion
- Relevant config (redacted): default embedded session transcript JSONL

### Steps

1. Reuse an embedded-agent session whose transcript contains only pre-assistant messages.
2. Run another message through the embedded runner.
3. Source generated zsh completion in a shell with and without preloaded completion.

### Expected

- Bootstrap context is still injected until an assistant message exists.
- zsh completion only autoloads and runs `compinit` when `compdef` is unavailable.

### Actual

- Verified by targeted unit tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  `pnpm exec vitest run src/agents/pi-embedded-runner/session-manager-init.test.ts src/cli/completion-cli.test.ts`
  `pnpm exec oxfmt --check src/agents/pi-embedded-runner/session-manager-init.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/session-manager-init.test.ts src/cli/completion-cli.ts src/cli/completion-cli.test.ts`
- Edge cases checked:
  missing transcript, header-only transcript, pre-assistant user-only transcript, transcript with assistant message, malformed transcript, zsh completion with existing `compdef`.
- What you did **not** verify:
  full repo `pnpm build`/full CI matrix in this local environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  Revert commit 6ead0bd32.
- Files/config to restore:
  `src/agents/pi-embedded-runner/*` and `src/cli/completion-cli.ts`.
- Known bad symptoms reviewers should watch for:
  AGENTS/bootstrap missing after retrying user-only transcripts, or zsh completion unexpectedly re-running completion initialization.

## Risks and Mitigations

- Risk:
  Bootstrap skipping still depends on transcript shape.
  - Mitigation:
    The guard now keys off assistant persistence specifically and has regression tests for user-only transcripts.
- Risk:
  zsh completion init behavior can vary across shell setups.
  - Mitigation:
    The generated script now follows the standard `compdef` availability guard pattern used by common zsh frameworks.
