### PR TITLE
fix(skills): surface tool-policy blocked skills in status output

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -1,8 +1,20 @@
 import path from "node:path";
+import { resolveDefaultAgentId } from "./agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { buildAgentMainSessionKey } from "../routing/session-key.js";
 import { evaluateEntryRequirementsForCurrentPlatform } from "../shared/entry-status.js";
+import { normalizeStringList } from "../shared/frontmatter.js";
 import type { RequirementConfigCheck, Requirements } from "../shared/requirements.js";
 import { CONFIG_DIR } from "../utils.js";
+import {
+  isToolAllowedByPolicies,
+  resolveEffectiveToolPolicy,
+} from "./pi-tools.policy.js";
+import {
+  mergeAlsoAllowPolicy,
+  normalizeToolName,
+  resolveToolProfilePolicy,
+} from "./tool-policy.js";
 import {
   hasBinary,
   isBundledSkillAllowed,
@@ -41,6 +53,9 @@ export type SkillStatusEntry = {
   always: boolean;
   disabled: boolean;
   blockedByAllowlist: boolean;
+  blockedByToolPolicy: boolean;
+  allowedTools: string[];
+  blockedTools: string[];
   eligible: boolean;
   requirements: Requirements;
   missing: Requirements;
@@ -166,12 +181,95 @@ function normalizeInstallOptions(
   return [toOption(preferred.spec, preferred.index)];
 }
 
+type SkillToolPolicyContext = {
+  isAllowed: (toolName: string) => boolean;
+};
+
+function parseAllowedTools(entry: SkillEntry): string[] {
+  const raw =
+    entry.frontmatter["allowed-tools"] ??
+    entry.frontmatter["allowed_tools"] ??
+    entry.frontmatter.allowedTools;
+  if (typeof raw !== "string" || !raw.trim()) {
+    return [];
+  }
+
+  const normalizeTools = (value: unknown): string[] =>
+    Array.isArray(value)
+      ? value
+          .map((tool) => normalizeToolName(String(tool)))
+          .filter(Boolean)
+      : [];
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      const normalized = normalizeTools(parsed);
+      if (normalized.length > 0) {
+        return Array.from(new Set(normalized));
+      }
+    } catch {
+      // Fallback to comma-separated parsing below.
+    }
+  }
+
+  return Array.from(new Set(normalizeStringList(trimmed).map((tool) => normalizeToolName(tool))));
+}
+
+function resolveSkillToolPolicyContext(params: {
+  config?: OpenClawConfig;
+  agentId: string;
+}): SkillToolPolicyContext {
+  if (!params.config) {
+    return { isAllowed: () => true };
+  }
+
+  const sessionKey = buildAgentMainSessionKey({ agentId: params.agentId });
+  const {
+    profile,
+    providerProfile,
+    profileAlsoAllow,
+    providerProfileAlsoAllow,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+  } = resolveEffectiveToolPolicy({
+    config: params.config,
+    sessionKey,
+  });
+
+  const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(profile),
+    profileAlsoAllow,
+  );
+  const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(providerProfile),
+    providerProfileAlsoAllow,
+  );
+
+  const policies = [
+    profilePolicyWithAlsoAllow,
+    providerProfilePolicyWithAlsoAllow,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+  ];
+
+  return {
+    isAllowed: (toolName: string) => isToolAllowedByPolicies(normalizeToolName(toolName), policies),
+  };
+}
+
 function buildSkillStatus(
   entry: SkillEntry,
   config?: OpenClawConfig,
   prefs?: SkillsInstallPreferences,
   eligibility?: SkillEligibilityContext,
   bundledNames?: Set<string>,
+  toolPolicy?: SkillToolPolicyContext,
 ): SkillStatusEntry {
   const skillKey = resolveSkillKey(entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
@@ -200,7 +298,13 @@ function buildSkillStatus(
       isEnvSatisfied,
       isConfigSatisfied,
     });
-  const eligible = !disabled && !blockedByAllowlist && requirementsSatisfied;
+
+  const allowedTools = parseAllowedTools(entry);
+  const blockedTools = allowedTools.filter((toolName) => !(toolPolicy?.isAllowed(toolName) ?? true));
+  const blockedByToolPolicy = allowedTools.length > 0 && blockedTools.length === allowedTools.length;
+
+  const eligible =
+    !disabled && !blockedByAllowlist && !blockedByToolPolicy && requirementsSatisfied;
 
   return {
     name: entry.skill.name,
@@ -216,6 +320,9 @@ function buildSkillStatus(
     always,
     disabled,
     blockedByAllowlist,
+    blockedByToolPolicy,
+    allowedTools,
+    blockedTools,
     eligible,
     requirements: required,
     missing,
@@ -231,6 +338,7 @@ export function buildWorkspaceSkillStatus(
     managedSkillsDir?: string;
     entries?: SkillEntry[];
     eligibility?: SkillEligibilityContext;
+    agentId?: string;
   },
 ): SkillStatusReport {
   const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
@@ -243,11 +351,21 @@ export function buildWorkspaceSkillStatus(
       bundledSkillsDir: bundledContext.dir,
     });
   const prefs = resolveSkillsInstallPreferences(opts?.config);
+  const agentId = opts?.agentId?.trim() || resolveDefaultAgentId(opts?.config ?? {});
+  const toolPolicy = resolveSkillToolPolicyContext({ config: opts?.config, agentId });
+
   return {
     workspaceDir,
     managedSkillsDir,
     skills: skillEntries.map((entry) =>
-      buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility, bundledContext.names),
+      buildSkillStatus(
+        entry,
+        opts?.config,
+        prefs,
+        opts?.eligibility,
+        bundledContext.names,
+        toolPolicy,
+      ),
     ),
   };
 }

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -6,6 +6,7 @@ import type { SkillEntry } from "./skills/types.js";
 function makeEntry(params: {
   name: string;
   source?: string;
+  frontmatter?: Record<string, string>;
   os?: string[];
   requires?: { bins?: string[]; env?: string[]; config?: string[] };
   install?: Array<{
@@ -27,7 +28,7 @@ function makeEntry(params: {
       baseDir: `/tmp/${params.name}`,
       disableModelInvocation: false,
     },
-    frontmatter: {},
+    frontmatter: params.frontmatter ?? {},
     metadata: {
       ...(params.os ? { os: params.os } : {}),
       ...(params.requires ? { requires: params.requires } : {}),
@@ -106,6 +107,26 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(skill?.blockedByAllowlist).toBe(true);
     expect(skill?.eligible).toBe(false);
     expect(skill?.bundled).toBe(true);
+  });
+
+  it("marks skills blocked by tool policy when all allowed-tools are unavailable", async () => {
+    const entry = makeEntry({
+      name: "terminal-command-execution",
+      frontmatter: {
+        "allowed-tools": '["exec", "process"]',
+      },
+    });
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", {
+      entries: [entry],
+      config: { tools: { profile: "messaging" } },
+    });
+    const skill = report.skills.find((reportEntry) => reportEntry.name === "terminal-command-execution");
+
+    expect(skill).toBeDefined();
+    expect(skill?.blockedByToolPolicy).toBe(true);
+    expect(skill?.blockedTools).toEqual(["exec", "process"]);
+    expect(skill?.eligible).toBe(false);
   });
 
   it("filters install options by OS", async () => {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -73,6 +73,7 @@ describe("registerSkillsCli", () => {
 
     expect(buildWorkspaceSkillStatusMock).toHaveBeenCalledWith("/tmp/workspace", {
       config: { gateway: {} },
+      agentId: "main",
     });
     expect(formatSkillsListMock).toHaveBeenCalledWith(
       report,

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -35,6 +35,9 @@ function formatSkillStatus(skill: SkillStatusEntry): string {
   if (skill.blockedByAllowlist) {
     return theme.warn("🚫 blocked");
   }
+  if (skill.blockedByToolPolicy) {
+    return theme.warn("🚫 tool policy");
+  }
   return theme.error("✗ missing");
 }
 
@@ -60,6 +63,9 @@ function formatSkillMissingSummary(skill: SkillStatusEntry): string {
   if (skill.missing.os.length > 0) {
     missing.push(`os: ${skill.missing.os.join(", ")}`);
   }
+  if (skill.blockedByToolPolicy && skill.blockedTools.length > 0) {
+    missing.push(`tools: ${skill.blockedTools.join(", ")}`);
+  }
   return missing.join("; ");
 }
 
@@ -77,6 +83,9 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
         eligible: s.eligible,
         disabled: s.disabled,
         blockedByAllowlist: s.blockedByAllowlist,
+        blockedByToolPolicy: s.blockedByToolPolicy,
+        allowedTools: s.allowedTools,
+        blockedTools: s.blockedTools,
         source: s.source,
         bundled: s.bundled,
         primaryEnv: s.primaryEnv,
@@ -161,7 +170,9 @@ export function formatSkillInfo(
       ? theme.warn("⏸ Disabled")
       : skill.blockedByAllowlist
         ? theme.warn("🚫 Blocked by allowlist")
-        : theme.error("✗ Missing requirements");
+        : skill.blockedByToolPolicy
+          ? theme.warn("🚫 Blocked by tool policy")
+          : theme.error("✗ Missing requirements");
 
   lines.push(`${emoji} ${theme.heading(skill.name)} ${status}`);
   lines.push("");
@@ -176,6 +187,14 @@ export function formatSkillInfo(
   }
   if (skill.primaryEnv) {
     lines.push(`${theme.muted("  Primary env:")} ${skill.primaryEnv}`);
+  }
+  if (skill.allowedTools.length > 0) {
+    lines.push(`${theme.muted("  Allowed tools:")} ${skill.allowedTools.join(", ")}`);
+  }
+  if (skill.blockedByToolPolicy && skill.blockedTools.length > 0) {
+    lines.push(
+      `${theme.muted("  Tool policy blocked:")} ${theme.warn(skill.blockedTools.join(", "))}`,
+    );
   }
 
   const hasRequirements =
@@ -240,9 +259,16 @@ export function formatSkillInfo(
 export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOptions): string {
   const eligible = report.skills.filter((s) => s.eligible);
   const disabled = report.skills.filter((s) => s.disabled);
-  const blocked = report.skills.filter((s) => s.blockedByAllowlist && !s.disabled);
+  const blockedByAllowlist = report.skills.filter((s) => s.blockedByAllowlist && !s.disabled);
+  const blockedByToolPolicy = report.skills.filter(
+    (s) => s.blockedByToolPolicy && !s.disabled && !s.blockedByAllowlist,
+  );
   const missingReqs = report.skills.filter(
-    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist,
+    (s) =>
+      !s.eligible &&
+      !s.disabled &&
+      !s.blockedByAllowlist &&
+      !s.blockedByToolPolicy,
   );
 
   if (opts.json) {
@@ -252,12 +278,18 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
           total: report.skills.length,
           eligible: eligible.length,
           disabled: disabled.length,
-          blocked: blocked.length,
+          blockedByAllowlist: blockedByAllowlist.length,
+          blockedByToolPolicy: blockedByToolPolicy.length,
           missingRequirements: missingReqs.length,
         },
         eligible: eligible.map((s) => s.name),
         disabled: disabled.map((s) => s.name),
-        blocked: blocked.map((s) => s.name),
+        blockedByAllowlist: blockedByAllowlist.map((s) => s.name),
+        blockedByToolPolicy: blockedByToolPolicy.map((s) => ({
+          name: s.name,
+          blockedTools: s.blockedTools,
+          allowedTools: s.allowedTools,
+        })),
         missingRequirements: missingReqs.map((s) => ({
           name: s.name,
           missing: s.missing,
@@ -275,7 +307,12 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   lines.push(`${theme.muted("Total:")} ${report.skills.length}`);
   lines.push(`${theme.success("✓")} ${theme.muted("Eligible:")} ${eligible.length}`);
   lines.push(`${theme.warn("⏸")} ${theme.muted("Disabled:")} ${disabled.length}`);
-  lines.push(`${theme.warn("🚫")} ${theme.muted("Blocked by allowlist:")} ${blocked.length}`);
+  lines.push(
+    `${theme.warn("🚫")} ${theme.muted("Blocked by allowlist:")} ${blockedByAllowlist.length}`,
+  );
+  lines.push(
+    `${theme.warn("🚫")} ${theme.muted("Blocked by tool policy:")} ${blockedByToolPolicy.length}`,
+  );
   lines.push(`${theme.error("✗")} ${theme.muted("Missing requirements:")} ${missingReqs.length}`);
 
   if (eligible.length > 0) {

--- a/src/cli/skills-cli.test.ts
+++ b/src/cli/skills-cli.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-status.js";
+import type { SkillEntry } from "../agents/skills.js";
+import { captureEnv } from "../test-utils/env.js";
 import { createEmptyInstallChecks } from "./requirements-test-fixtures.js";
 import { formatSkillInfo, formatSkillsCheck, formatSkillsList } from "./skills-cli.format.js";
 
@@ -23,6 +28,9 @@ function createMockSkill(overrides: Partial<SkillStatusEntry> = {}): SkillStatus
     always: false,
     disabled: false,
     blockedByAllowlist: false,
+    blockedByToolPolicy: false,
+    allowedTools: [],
+    blockedTools: [],
     eligible: true,
     ...createEmptyInstallChecks(),
     ...overrides,
@@ -108,6 +116,14 @@ describe("skills-cli", () => {
       expect(output).toContain("eligible-one");
       expect(output).not.toContain("not-eligible");
     });
+
+    it("outputs JSON with --json flag", () => {
+      const report = createMockReport([createMockSkill({ name: "json-skill" })]);
+      const output = formatSkillsList(report, { json: true });
+      const parsed = JSON.parse(output);
+      expect(parsed.skills).toHaveLength(1);
+      expect(parsed.skills[0].name).toBe("json-skill");
+    });
   });
 
   describe("formatSkillInfo", () => {
@@ -148,6 +164,13 @@ describe("skills-cli", () => {
       expect(output).toContain("Any binaries");
       expect(output).toContain("API_KEY");
     });
+
+    it("outputs JSON with --json flag", () => {
+      const report = createMockReport([createMockSkill({ name: "info-skill" })]);
+      const output = formatSkillInfo(report, "info-skill", { json: true });
+      const parsed = JSON.parse(output);
+      expect(parsed.name).toBe("info-skill");
+    });
   });
 
   describe("formatSkillsCheck", () => {
@@ -170,50 +193,99 @@ describe("skills-cli", () => {
       expect(output).toContain("go"); // missing binary
       expect(output).toContain("npx clawhub");
     });
+
+    it("outputs JSON with --json flag", () => {
+      const report = createMockReport([
+        createMockSkill({ name: "skill-1", eligible: true }),
+        createMockSkill({ name: "skill-2", eligible: false }),
+      ]);
+      const output = formatSkillsCheck(report, { json: true });
+      const parsed = JSON.parse(output);
+      expect(parsed.summary.eligible).toBe(1);
+      expect(parsed.summary.total).toBe(2);
+    });
   });
 
-  describe("JSON output", () => {
-    it.each([
-      {
-        formatter: "list",
-        output: formatSkillsList(createMockReport([createMockSkill({ name: "json-skill" })]), {
-          json: true,
-        }),
-        assert: (parsed: Record<string, unknown>) => {
-          const skills = parsed.skills as Array<Record<string, unknown>>;
-          expect(skills).toHaveLength(1);
-          expect(skills[0]?.name).toBe("json-skill");
+  describe("integration: loads real skills from bundled directory", () => {
+    let tempWorkspaceDir = "";
+    let tempBundledDir = "";
+    let envSnapshot: ReturnType<typeof captureEnv>;
+    let buildWorkspaceSkillStatus: typeof import("../agents/skills-status.js").buildWorkspaceSkillStatus;
+
+    beforeAll(async () => {
+      envSnapshot = captureEnv(["OPENCLAW_BUNDLED_SKILLS_DIR"]);
+      tempWorkspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-skills-test-"));
+      tempBundledDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-skills-test-"));
+      process.env.OPENCLAW_BUNDLED_SKILLS_DIR = tempBundledDir;
+      ({ buildWorkspaceSkillStatus } = await import("../agents/skills-status.js"));
+    });
+
+    afterAll(() => {
+      if (tempWorkspaceDir) {
+        fs.rmSync(tempWorkspaceDir, { recursive: true, force: true });
+      }
+      if (tempBundledDir) {
+        fs.rmSync(tempBundledDir, { recursive: true, force: true });
+      }
+      envSnapshot.restore();
+    });
+
+    const createEntries = (): SkillEntry[] => {
+      const baseDir = path.join(tempWorkspaceDir, "peekaboo");
+      return [
+        {
+          skill: {
+            name: "peekaboo",
+            description: "Capture UI screenshots",
+            source: "openclaw-bundled",
+            filePath: path.join(baseDir, "SKILL.md"),
+            baseDir,
+          } as SkillEntry["skill"],
+          frontmatter: {},
+          metadata: { emoji: "📸" },
         },
-      },
-      {
-        formatter: "info",
-        output: formatSkillInfo(
-          createMockReport([createMockSkill({ name: "info-skill" })]),
-          "info-skill",
-          { json: true },
-        ),
-        assert: (parsed: Record<string, unknown>) => {
-          expect(parsed.name).toBe("info-skill");
-        },
-      },
-      {
-        formatter: "check",
-        output: formatSkillsCheck(
-          createMockReport([
-            createMockSkill({ name: "skill-1", eligible: true }),
-            createMockSkill({ name: "skill-2", eligible: false }),
-          ]),
-          { json: true },
-        ),
-        assert: (parsed: Record<string, unknown>) => {
-          const summary = parsed.summary as Record<string, unknown>;
-          expect(summary.eligible).toBe(1);
-          expect(summary.total).toBe(2);
-        },
-      },
-    ])("outputs JSON with --json flag for $formatter", ({ output, assert }) => {
-      const parsed = JSON.parse(output) as Record<string, unknown>;
-      assert(parsed);
+      ];
+    };
+
+    it("loads bundled skills and formats them", async () => {
+      const entries = createEntries();
+      const report = buildWorkspaceSkillStatus(tempWorkspaceDir, {
+        managedSkillsDir: "/nonexistent",
+        entries,
+      });
+
+      // Should have loaded some skills
+      expect(report.skills.length).toBeGreaterThan(0);
+
+      // Format should work without errors
+      const listOutput = formatSkillsList(report, {});
+      expect(listOutput).toContain("Skills");
+
+      const checkOutput = formatSkillsCheck(report, {});
+      expect(checkOutput).toContain("Total:");
+
+      // JSON output should be valid
+      const jsonOutput = formatSkillsList(report, { json: true });
+      const parsed = JSON.parse(jsonOutput);
+      expect(parsed.skills).toBeInstanceOf(Array);
+    });
+
+    it("formats info for a real bundled skill (peekaboo)", async () => {
+      const entries = createEntries();
+      const report = buildWorkspaceSkillStatus(tempWorkspaceDir, {
+        managedSkillsDir: "/nonexistent",
+        entries,
+      });
+
+      // peekaboo is a bundled skill that should always exist
+      const peekaboo = report.skills.find((s) => s.name === "peekaboo");
+      if (!peekaboo) {
+        throw new Error("peekaboo fixture skill missing");
+      }
+
+      const output = formatSkillInfo(report, "peekaboo", {});
+      expect(output).toContain("peekaboo");
+      expect(output).toContain("Details:");
     });
   });
 });

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -19,9 +19,13 @@ type SkillStatusReport = Awaited<
 
 async function loadSkillsStatusReport(): Promise<SkillStatusReport> {
   const config = loadConfig();
-  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const defaultAgentId = resolveDefaultAgentId(config);
+  const workspaceDir = resolveAgentWorkspaceDir(config, defaultAgentId);
   const { buildWorkspaceSkillStatus } = await import("../agents/skills-status.js");
-  return buildWorkspaceSkillStatus(workspaceDir, { config });
+  return buildWorkspaceSkillStatus(workspaceDir, {
+    config,
+    agentId: defaultAgentId,
+  });
 }
 
 async function runSkillsAction(render: (report: SkillStatusReport) => string): Promise<void> {

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -6,21 +6,27 @@ import { note } from "../terminal/note.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
 
 export function noteWorkspaceStatus(cfg: OpenClawConfig) {
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, defaultAgentId);
   const legacyWorkspace = detectLegacyWorkspaceDirs({ workspaceDir });
   if (legacyWorkspace.legacyDirs.length > 0) {
     note(formatLegacyWorkspaceWarning(legacyWorkspace), "Extra workspace");
   }
 
-  const skillsReport = buildWorkspaceSkillStatus(workspaceDir, { config: cfg });
+  const skillsReport = buildWorkspaceSkillStatus(workspaceDir, {
+    config: cfg,
+    agentId: defaultAgentId,
+  });
   note(
     [
       `Eligible: ${skillsReport.skills.filter((s) => s.eligible).length}`,
       `Missing requirements: ${
-        skillsReport.skills.filter((s) => !s.eligible && !s.disabled && !s.blockedByAllowlist)
-          .length
+        skillsReport.skills.filter(
+          (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist && !s.blockedByToolPolicy,
+        ).length
       }`,
       `Blocked by allowlist: ${skillsReport.skills.filter((s) => s.blockedByAllowlist).length}`,
+      `Blocked by tool policy: ${skillsReport.skills.filter((s) => s.blockedByToolPolicy).length}`,
     ].join("\n"),
     "Skills status",
   );

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -56,19 +56,28 @@ export async function setupSkills(
   const report = buildWorkspaceSkillStatus(workspaceDir, { config: cfg });
   const eligible = report.skills.filter((s) => s.eligible);
   const unsupportedOs = report.skills.filter(
-    (s) => !s.disabled && !s.blockedByAllowlist && s.missing.os.length > 0,
+    (s) => !s.disabled && !s.blockedByAllowlist && !s.blockedByToolPolicy && s.missing.os.length > 0,
   );
   const missing = report.skills.filter(
-    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist && s.missing.os.length === 0,
+    (s) =>
+      !s.eligible &&
+      !s.disabled &&
+      !s.blockedByAllowlist &&
+      !s.blockedByToolPolicy &&
+      s.missing.os.length === 0,
   );
-  const blocked = report.skills.filter((s) => s.blockedByAllowlist);
+  const blockedByAllowlist = report.skills.filter((s) => s.blockedByAllowlist);
+  const blockedByToolPolicy = report.skills.filter(
+    (s) => !s.disabled && !s.blockedByAllowlist && s.blockedByToolPolicy,
+  );
 
   await prompter.note(
     [
       `Eligible: ${eligible.length}`,
       `Missing requirements: ${missing.length}`,
       `Unsupported on this OS: ${unsupportedOs.length}`,
-      `Blocked by allowlist: ${blocked.length}`,
+      `Blocked by allowlist: ${blockedByAllowlist.length}`,
+      `Blocked by tool policy: ${blockedByToolPolicy.length}`,
     ].join("\n"),
     "Skills status",
   );


### PR DESCRIPTION
## Summary
- detect when a skill's `allowed-tools` are fully filtered by the active tool policy
- mark those skills as blocked in `openclaw skills list`, `openclaw skills check`, and `openclaw skills info`
- include blocked/allowed tool details in JSON + human-readable output
- pass the default agent id into skills-status callers so policy evaluation matches agent scope
- include tool-policy blocked counts in onboarding and doctor skill summaries

## Why
`openclaw skills list` could report a skill as ready even when runtime tool policy removed all of its allowed tools (e.g., terminal-command-execution under a messaging profile). This makes the mismatch explicit.

## Validation
- `bash /Users/newdldewdl/.openclaw/workspace/skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /Users/newdldewdl/clawd/openclaw-worktrees/issue-40414-tool-policy`

Closes #40414
