### PR TITLE
fix(telegram): accept negative group/supergroup IDs in groupAllowFrom

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,63 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
-    const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
+  it("accepts positive sender IDs", () => {
+    const result = normalizeAllowFrom(["745123456", " tg:123456 "]);
+
+    expect(result).toEqual({
+      entries: ["745123456", "123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("accepts negative group/supergroup chat IDs", () => {
+    const result = normalizeAllowFrom(["-1001234567890", -100999, "745123456"]);
+
+    expect(result).toEqual({
+      entries: ["-1001234567890", "-100999", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("rejects non-numeric entries like @usernames", () => {
+    const result = normalizeAllowFrom(["@someone", "not-a-number", "745123456"]);
 
     expect(result).toEqual({
       entries: ["745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone", "not-a-number"],
+    });
+  });
+
+  it("handles mixed valid and invalid entries", () => {
+    const result = normalizeAllowFrom([
+      "-1001234567890",
+      " tg:-100999 ",
+      "745123456",
+      "@someone",
+    ]);
+
+    expect(result).toEqual({
+      entries: ["-1001234567890", "-100999", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@someone"],
+    });
+  });
+
+  it("supports wildcard entry", () => {
+    const result = normalizeAllowFrom(["*", "745123456"]);
+
+    expect(result).toEqual({
+      entries: ["745123456"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: [],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -38,17 +38,23 @@ function warnInvalidAllowFromEntries(entries: string[]) {
   }
 }
 
+/**
+ * Regex that matches a numeric Telegram ID (positive user/bot IDs and
+ * negative group/supergroup/channel IDs like `-1001234567890`).
+ */
+const NUMERIC_TG_ID = /^-?\d+$/;
+
 export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAllowFrom => {
   const entries = (list ?? []).map((value) => String(value).trim()).filter(Boolean);
   const hasWildcard = entries.includes("*");
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !NUMERIC_TG_ID.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => NUMERIC_TG_ID.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Problem

Telegram supergroup and group chat IDs are **always negative** integers (e.g. `-1001234567890`). The `normalizeAllowFrom` function in `src/telegram/bot-access.ts` validates entries with the regex `/^\d+$/`, which only matches non-negative integers. This causes **all** Telegram group IDs to be rejected as invalid, making `groupPolicy: "allowlist"` completely non-functional for Telegram groups.

Users are forced to use `groupPolicy: "open"` (no access control) as the only workaround.

Fixes #40444

## Fix

- Extract a named `NUMERIC_TG_ID` constant using `/^-?\d+$/` to accept both positive user/bot IDs and negative group/supergroup/channel IDs
- Replace the two inline regex occurrences with the named constant for consistency
- Update existing test that incorrectly treated negative IDs as invalid
- Add comprehensive test cases: positive IDs, negative group IDs, mixed entries, @username rejection, and wildcard support

## Testing

- Updated `src/telegram/bot-access.test.ts` with 5 test cases covering:
  - Positive sender IDs (existing behavior preserved)
  - Negative group/supergroup chat IDs (new: now accepted)
  - Non-numeric entries like `@username` (still rejected)
  - Mixed valid and invalid entries
  - Wildcard (`*`) entry support

## Changes

| File | Change |
|------|--------|
| `src/telegram/bot-access.ts` | Replace `/^\d+$/` → `/^-?\d+$/` via named `NUMERIC_TG_ID` constant |
| `src/telegram/bot-access.test.ts` | Update + expand test coverage for negative IDs |