### PR TITLE
fix(telegram): accept negative group IDs in groupAllowFrom allowlist

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
+  it("accepts positive user IDs and negative group/supergroup IDs", () => {
     const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
 
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["-1001234567890", "-100999", "745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone"],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

- **Problem:** Telegram supergroup/group chat IDs are always negative (e.g. `-1003890514701`), but `normalizeAllowFrom` used regex `^\d+$` which only accepts non-negative integers, causing all group messages to be dropped with `reason: not-allowed`.
- **Why it matters:** `groupPolicy: "allowlist"` was completely broken for Telegram groups — users could not whitelist any group.
- **What changed:** Updated regex from `^\d+$` to `^-?\d+$` in `src/telegram/bot-access.ts` to accept negative IDs.
- **What did NOT change:** DM allowlist behavior; only group/supergroup ID validation.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #40444

## User-visible / Behavior Changes

`channels.telegram.groupAllowFrom` now correctly accepts negative group/supergroup IDs (e.g. `-1003890514701`). Messages from whitelisted groups are no longer silently dropped.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS
- OpenClaw version: 2026.3.8

### Steps

1. Add `groupAllowFrom: [-1003890514701]` and `groupPolicy: "allowlist"` to `channels.telegram` in `openclaw.json`
2. Restart gateway, send a message from the configured group

### Expected

Messages from the whitelisted group are processed.

### Actual (before fix)

Messages were dropped with `reason: not-allowed` and log showed "Invalid allowFrom entry".

## Evidence

- [x] Unit test updated in `src/telegram/bot-access.test.ts` — negative IDs now accepted as valid entries

## Human Verification

- Verified: `pnpm test src/telegram/bot-access.test.ts` passes
- Edge cases: positive user IDs still work; `@username` still rejected as invalid

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**