### PR TITLE
fix(tui): refresh on external session reset and clear stale run state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI: subscribe to the current `sessions.changed` lifecycle event and refresh only the active session after external `/new` or `/reset`, clearing stale stream/run state so late old-run events cannot repaint reset history. Carries forward #40472 and fixes #38966. Thanks @wsyjh8.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -236,6 +236,10 @@ export class GatewayChatClient implements TuiBackend {
     });
   }
 
+  async subscribeSessionChanges() {
+    return await this.client.request("sessions.subscribe", {});
+  }
+
   async getGatewayStatus() {
     return await this.client.request("status");
   }

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -105,6 +105,7 @@ export type TuiBackend = {
   listAgents: () => Promise<TuiAgentsList>;
   patchSession: (opts: SessionsPatchParams) => Promise<SessionsPatchResult>;
   resetSession: (key: string, reason?: "new" | "reset") => Promise<unknown>;
+  subscribeSessionChanges?: () => Promise<unknown>;
   getGatewayStatus: () => Promise<unknown>;
   listModels: () => Promise<TuiModelChoice[]>;
 };

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEventHandlers } from "./tui-event-handlers.js";
-import type { AgentEvent, BtwEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import type {
+  AgentEvent,
+  BtwEvent,
+  ChatEvent,
+  SessionsChangedEvent,
+  TuiStateAccess,
+} from "./tui-types.js";
 
 type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {
@@ -1006,5 +1012,219 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
     expect(chatLog.addSystem).not.toHaveBeenCalled();
+  });
+});
+
+describe("tui-event-handlers: handleSessionsChangedEvent", () => {
+  const makeState = (overrides?: Partial<TuiStateAccess>): TuiStateAccess => ({
+    agentDefaultId: "main",
+    sessionMainKey: "agent:main:main",
+    sessionScope: "global",
+    agents: [],
+    currentAgentId: "main",
+    currentSessionKey: "agent:main:main",
+    currentSessionId: "session-1",
+    activeChatRunId: "run-1",
+    historyLoaded: true,
+    sessionInfo: { verboseLevel: "on" },
+    initialSessionApplied: true,
+    isConnected: true,
+    autoMessageSent: false,
+    toolsExpanded: false,
+    showThinking: false,
+    connectionStatus: "connected",
+    activityStatus: "idle",
+    statusTimeout: null,
+    lastCtrlCAt: 0,
+    ...overrides,
+  });
+
+  const makeContext = (state: TuiStateAccess) => {
+    const chatLog = createMockChatLog();
+    const btw = createMockBtwPresenter();
+    const tui = { requestRender: vi.fn() } as unknown as MockTui & HandlerTui;
+    const setActivityStatus = vi.fn();
+    const loadHistory = vi.fn();
+    const refreshSessionInfo = vi.fn();
+    const localRunIds = new Set<string>();
+    const localBtwRunIds = new Set<string>();
+    const noteLocalRunId = (runId: string) => {
+      localRunIds.add(runId);
+    };
+    const forgetLocalRunId = localRunIds.delete.bind(localRunIds);
+    const isLocalRunId = localRunIds.has.bind(localRunIds);
+    const clearLocalRunIds = vi.fn(() => localRunIds.clear());
+    const clearLocalBtwRunIds = vi.fn(() => localBtwRunIds.clear());
+
+    return {
+      chatLog,
+      btw,
+      tui,
+      state,
+      setActivityStatus,
+      loadHistory,
+      refreshSessionInfo,
+      noteLocalRunId,
+      forgetLocalRunId,
+      isLocalRunId,
+      clearLocalRunIds,
+      clearLocalBtwRunIds,
+    };
+  };
+
+  const createSessionHarness = (params?: { state?: Partial<TuiStateAccess> }) => {
+    const state = makeState(params?.state);
+    const context = makeContext(state);
+    const handlers = createEventHandlers({
+      chatLog: context.chatLog,
+      btw: context.btw,
+      tui: context.tui,
+      state,
+      setActivityStatus: context.setActivityStatus,
+      loadHistory: context.loadHistory,
+      refreshSessionInfo: context.refreshSessionInfo,
+      isLocalRunId: context.isLocalRunId,
+      forgetLocalRunId: context.forgetLocalRunId,
+      clearLocalRunIds: context.clearLocalRunIds,
+      clearLocalBtwRunIds: context.clearLocalBtwRunIds,
+    });
+    return {
+      ...context,
+      state,
+      ...handlers,
+    };
+  };
+
+  it("refreshes history on current-session external reset event", () => {
+    const {
+      state,
+      loadHistory,
+      refreshSessionInfo,
+      setActivityStatus,
+      clearLocalRunIds,
+      clearLocalBtwRunIds,
+      tui,
+      handleSessionsChangedEvent,
+    } = createSessionHarness({
+      state: {
+        activeChatRunId: "run-active",
+        historyLoaded: true,
+        pendingOptimisticUserMessage: true,
+      },
+    });
+
+    const sessionEvt: SessionsChangedEvent = {
+      sessionKey: state.currentSessionKey,
+      reason: "reset",
+    };
+
+    handleSessionsChangedEvent(sessionEvt);
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(clearLocalRunIds).toHaveBeenCalledTimes(1);
+    expect(clearLocalBtwRunIds).toHaveBeenCalledTimes(1);
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+    expect(refreshSessionInfo).not.toHaveBeenCalled();
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores reset event for a different session", () => {
+    const {
+      state,
+      loadHistory,
+      refreshSessionInfo,
+      setActivityStatus,
+      clearLocalRunIds,
+      tui,
+      handleSessionsChangedEvent,
+    } = createSessionHarness({
+      state: { activeChatRunId: "run-active", currentSessionKey: "agent:main:main" },
+    });
+
+    const sessionEvt: SessionsChangedEvent = {
+      sessionKey: "agent:other:other",
+      reason: "reset",
+    };
+
+    handleSessionsChangedEvent(sessionEvt);
+
+    expect(state.activeChatRunId).toBe("run-active");
+    expect(clearLocalRunIds).not.toHaveBeenCalled();
+    expect(setActivityStatus).not.toHaveBeenCalled();
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(refreshSessionInfo).not.toHaveBeenCalled();
+    expect(tui.requestRender).not.toHaveBeenCalled();
+  });
+
+  it("refreshes history on current-session new event", () => {
+    const { state, loadHistory, handleSessionsChangedEvent } = createSessionHarness({
+      state: { activeChatRunId: "run-active" },
+    });
+
+    handleSessionsChangedEvent({
+      sessionKey: state.currentSessionKey,
+      reason: "new",
+    } satisfies SessionsChangedEvent);
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-reset session change reasons", () => {
+    const { state, loadHistory, handleSessionsChangedEvent } = createSessionHarness({
+      state: { activeChatRunId: "run-active" },
+    });
+
+    handleSessionsChangedEvent({
+      sessionKey: state.currentSessionKey,
+      reason: "patch",
+    } satisfies SessionsChangedEvent);
+
+    expect(state.activeChatRunId).toBe("run-active");
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale tool events from old runs after external reset", () => {
+    const { state, chatLog, tui, handleChatEvent, handleSessionsChangedEvent, handleAgentEvent } =
+      createSessionHarness({
+        state: { activeChatRunId: null, currentSessionKey: "agent:main:main" },
+      });
+
+    const oldRunId = "run-old";
+    handleChatEvent({
+      runId: oldRunId,
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    });
+
+    expect(state.activeChatRunId).toBe(oldRunId);
+
+    const sessionEvt: SessionsChangedEvent = {
+      sessionKey: state.currentSessionKey,
+      reason: "reset",
+    };
+    handleSessionsChangedEvent(sessionEvt);
+
+    expect(state.activeChatRunId).toBeNull();
+
+    const requestRenderCallsAfterReset = tui.requestRender.mock.calls.length;
+
+    const staleToolEvt: AgentEvent = {
+      runId: oldRunId,
+      stream: "tool",
+      data: {
+        phase: "start",
+        toolCallId: "tc-stale",
+        name: "exec",
+        args: { command: "echo stale" },
+      },
+    };
+    handleAgentEvent(staleToolEvt);
+
+    expect(chatLog.startTool).not.toHaveBeenCalled();
+    expect(tui.requestRender.mock.calls.length).toBe(requestRenderCallsAfterReset);
   });
 });

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1227,4 +1227,83 @@ describe("tui-event-handlers: handleSessionsChangedEvent", () => {
     expect(chatLog.startTool).not.toHaveBeenCalled();
     expect(tui.requestRender.mock.calls.length).toBe(requestRenderCallsAfterReset);
   });
+
+  it("ignores stale chat finals from old runs after external reset", () => {
+    const { state, chatLog, tui, handleChatEvent, handleSessionsChangedEvent } =
+      createSessionHarness({
+        state: { activeChatRunId: null, currentSessionKey: "agent:main:main" },
+      });
+
+    const oldRunId = "run-old";
+    handleChatEvent({
+      runId: oldRunId,
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "before reset" }] },
+    });
+
+    expect(state.activeChatRunId).toBe(oldRunId);
+
+    handleSessionsChangedEvent({
+      sessionKey: state.currentSessionKey,
+      reason: "reset",
+    } satisfies SessionsChangedEvent);
+
+    const requestRenderCallsAfterReset = tui.requestRender.mock.calls.length;
+    chatLog.finalizeAssistant.mockClear();
+    chatLog.dropAssistant.mockClear();
+
+    handleChatEvent({
+      runId: oldRunId,
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [{ type: "text", text: "stale final" }] },
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(tui.requestRender.mock.calls.length).toBe(requestRenderCallsAfterReset);
+  });
+
+  it("clears the streaming watchdog after external reset", () => {
+    vi.useFakeTimers();
+    try {
+      const {
+        state,
+        chatLog,
+        setActivityStatus,
+        handleChatEvent,
+        handleSessionsChangedEvent,
+        dispose,
+      } = createSessionHarness({
+        state: { activeChatRunId: null, currentSessionKey: "agent:main:main" },
+      });
+
+      handleChatEvent({
+        runId: "run-streaming",
+        sessionKey: state.currentSessionKey,
+        state: "delta",
+        message: { role: "assistant", content: [{ type: "text", text: "streaming" }] },
+      });
+
+      expect(state.activeChatRunId).toBe("run-streaming");
+
+      handleSessionsChangedEvent({
+        sessionKey: state.currentSessionKey,
+        reason: "reset",
+      } satisfies SessionsChangedEvent);
+
+      vi.advanceTimersByTime(31_000);
+
+      expect(setActivityStatus).toHaveBeenCalledWith("idle");
+      expect(chatLog.addSystem).not.toHaveBeenCalledWith(
+        expect.stringContaining("streaming watchdog"),
+      );
+      expect(state.activeChatRunId).toBeNull();
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -75,6 +75,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   } = context;
   const finalizedRuns = new Map<string, number>();
   const sessionRuns = new Map<string, number>();
+  const resetSuppressedRuns = new Set<string>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
   let pendingHistoryRefresh = false;
@@ -165,6 +166,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     lastSessionKey = state.currentSessionKey;
     finalizedRuns.clear();
     sessionRuns.clear();
+    resetSuppressedRuns.clear();
     streamAssembler = new TuiStreamAssembler();
     pendingHistoryRefresh = false;
     state.pendingOptimisticUserMessage = false;
@@ -194,6 +196,29 @@ export function createEventHandlers(context: EventHandlerContext) {
     sessionRuns.delete(runId);
     streamAssembler.drop(runId);
     pruneRunMap(finalizedRuns);
+  };
+
+  const suppressCurrentSessionRuns = () => {
+    if (state.activeChatRunId) {
+      resetSuppressedRuns.add(state.activeChatRunId);
+    }
+    if (streamingWatchdogRunId) {
+      resetSuppressedRuns.add(streamingWatchdogRunId);
+    }
+    for (const runId of sessionRuns.keys()) {
+      resetSuppressedRuns.add(runId);
+    }
+    for (const runId of finalizedRuns.keys()) {
+      resetSuppressedRuns.add(runId);
+    }
+    if (resetSuppressedRuns.size > 200) {
+      for (const runId of resetSuppressedRuns) {
+        resetSuppressedRuns.delete(runId);
+        if (resetSuppressedRuns.size <= 150) {
+          break;
+        }
+      }
+    }
   };
 
   const clearActiveRunIfMatch = (runId: string) => {
@@ -325,6 +350,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (!isSameSessionKey(evt.sessionKey, state.currentSessionKey)) {
       return;
     }
+    if (resetSuppressedRuns.has(evt.runId)) {
+      return;
+    }
     if (finalizedRuns.has(evt.runId)) {
       if (evt.state === "delta") {
         return;
@@ -434,6 +462,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as AgentEvent;
     syncSessionKey();
+    if (resetSuppressedRuns.has(evt.runId)) {
+      return;
+    }
     // Agent events (tool streaming, lifecycle) are emitted per-run. Filter against the
     // active chat run id, not the session id. Tool results can arrive after the chat
     // final event, so accept finalized runs for tool updates.
@@ -532,6 +563,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (!isSameSessionKey(evt.sessionKey, state.currentSessionKey)) {
       return;
     }
+    suppressCurrentSessionRuns();
     state.activeChatRunId = null;
     state.pendingOptimisticUserMessage = false;
     pendingHistoryRefresh = false;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -3,7 +3,13 @@ import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
-import type { AgentEvent, BtwEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import type {
+  AgentEvent,
+  BtwEvent,
+  ChatEvent,
+  SessionsChangedEvent,
+  TuiStateAccess,
+} from "./tui-types.js";
 
 type EventHandlerChatLog = {
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;
@@ -514,9 +520,35 @@ export function createEventHandlers(context: EventHandlerContext) {
     tui.requestRender();
   };
 
+  const handleSessionsChangedEvent = (payload: unknown) => {
+    if (!payload || typeof payload !== "object") {
+      return;
+    }
+    const evt = payload as SessionsChangedEvent;
+    syncSessionKey();
+    if (evt.reason !== "new" && evt.reason !== "reset") {
+      return;
+    }
+    if (!isSameSessionKey(evt.sessionKey, state.currentSessionKey)) {
+      return;
+    }
+    state.activeChatRunId = null;
+    state.pendingOptimisticUserMessage = false;
+    pendingHistoryRefresh = false;
+    finalizedRuns.clear();
+    sessionRuns.clear();
+    streamAssembler = new TuiStreamAssembler();
+    clearLocalRunIds?.();
+    clearLocalBtwRunIds?.();
+    clearStreamingWatchdog();
+    setActivityStatus("idle");
+    void loadHistory?.();
+    tui.requestRender();
+  };
+
   const dispose = () => {
     clearStreamingWatchdog();
   };
 
-  return { handleChatEvent, handleAgentEvent, handleBtwEvent, dispose };
+  return { handleChatEvent, handleAgentEvent, handleBtwEvent, handleSessionsChangedEvent, dispose };
 }

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -43,6 +43,12 @@ export type AgentEvent = {
   data?: Record<string, unknown>;
 };
 
+export type SessionsChangedEvent = {
+  sessionKey?: string;
+  reason?: string;
+  ts?: number;
+};
+
 export type ResponseUsageMode = "on" | "off" | "tokens" | "full";
 
 export type SessionInfo = {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -899,23 +899,24 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     abortActive,
   } = sessionActions;
 
-  const { handleChatEvent, handleAgentEvent, handleBtwEvent } = createEventHandlers({
-    chatLog,
-    btw,
-    tui,
-    state,
-    localMode: isLocalMode,
-    setActivityStatus,
-    refreshSessionInfo,
-    loadHistory,
-    noteLocalRunId,
-    isLocalRunId,
-    forgetLocalRunId,
-    clearLocalRunIds,
-    isLocalBtwRunId,
-    forgetLocalBtwRunId,
-    clearLocalBtwRunIds,
-  });
+  const { handleChatEvent, handleAgentEvent, handleBtwEvent, handleSessionsChangedEvent } =
+    createEventHandlers({
+      chatLog,
+      btw,
+      tui,
+      state,
+      localMode: isLocalMode,
+      setActivityStatus,
+      refreshSessionInfo,
+      loadHistory,
+      noteLocalRunId,
+      isLocalRunId,
+      forgetLocalRunId,
+      clearLocalRunIds,
+      isLocalBtwRunId,
+      forgetLocalBtwRunId,
+      clearLocalBtwRunIds,
+    });
 
   let finishTui: (() => void) | null = null;
   const requestExit = (result?: Partial<TuiResult>) => {
@@ -1061,6 +1062,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     if (evt.event === "agent") {
       handleAgentEvent(evt.payload);
     }
+    if (evt.event === "sessions.changed") {
+      handleSessionsChangedEvent(evt.payload);
+    }
   };
 
   client.onConnected = () => {
@@ -1070,6 +1074,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     wasDisconnected = false;
     setConnectionStatus(isLocalMode ? "local ready" : "connected");
     void (async () => {
+      await client.subscribeSessionChanges?.();
       await refreshAgents();
       updateHeader();
       await loadHistory();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: TUI did not refresh when the current session was reset externally (for example via `/new` or `/reset` from another client), so it could keep showing stale transcript/token state.
- Why it matters: users could see outdated conversation state in TUI even though the gateway session had already been reset, and stale tool/run state could still interfere with the refreshed view.
- What changed: `sessions.reset` now broadcasts a lightweight `session` reset event; TUI now listens for that event, refreshes history/session info for the current session, and clears stale in-memory run tracking state.
- What did NOT change (scope boundary): this PR does not redesign the broader event model, does not change session storage format, and does not fully solve all theoretically late stale `chat` events that are still keyed only by `sessionKey`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38966
- Related None

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- TUI now refreshes automatically when the current session is reset externally.
- After an external reset, stale tool/run state is cleared before the refreshed session view is shown.
- No config or default behavior changes for users outside this reset flow.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows (development), issue originally reported on macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): TUI + external session reset flow
- Relevant config (redacted): default local test setup

### Steps

1. Open TUI on a shared/current session.
2. Reset the same session externally (for example via another client using `/new` or `/reset`).
3. Observe TUI behavior before and after this patch.

### Expected

- TUI should refresh history/session info for the current session after the external reset.
- Old run/tool state should not continue to affect the refreshed view.

### Actual

- Before this fix, TUI did not automatically refresh on external reset.
- Stale run/tool state could remain in memory and affect subsequent handling.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the reset flow end-to-end in code; verified that `sessions.reset` now broadcasts a `session` reset event; verified that TUI handles that event by reloading history/session info and clearing stale run state.
- Edge cases checked: reset event for a different session is ignored; stale tool events from an old run are ignored after external reset.
- What you did **not** verify: I did not manually reproduce the full multi-client runtime flow on macOS; verification here is based on targeted TUI handler tests and code-path review.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the new `session` event broadcast/handling changes.
- Files/config to restore:
  - `src/gateway/server-methods/sessions.ts`
  - `src/tui/tui.ts`
  - `src/tui/tui-types.ts`
  - `src/tui/tui-event-handlers.ts`
  - `src/tui/tui-event-handlers.test.ts`
- Known bad symptoms reviewers should watch for:
  - TUI not refreshing on external reset
  - unexpected extra refreshes for unrelated sessions
  - stale tool/run events still appearing after reset

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a `session` reset event could trigger an unnecessary refresh for the wrong session if session matching is incorrect.
  - Mitigation: TUI only handles the event when `sessionKey` matches the current session.
- Risk: stale in-memory run state could continue affecting post-reset behavior.
  - Mitigation: clear `activeChatRunId`, `sessionRuns`, `finalizedRuns`, local run IDs, and recreate `streamAssembler` on current-session reset.
- Risk: late stale `chat` events are still not perfectly distinguishable if they share the same `sessionKey`.
  - Mitigation: scope this PR to the core reset-refresh bug and explicitly leave stricter late-chat disambiguation as follow-up work.