### PR TITLE
fix(telegram): accept negative group chat IDs in groupAllowFrom (#40444)

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,58 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
+  it("accepts positive sender IDs and negative group chat IDs as valid numeric entries", () => {
     const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
 
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["-1001234567890", "-100999", "745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone"],
+    });
+  });
+
+  it("rejects non-numeric entries like usernames", () => {
+    const result = normalizeAllowFrom(["@username", "not-a-number", "abc123"]);
+
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@username", "not-a-number", "abc123"],
+    });
+  });
+
+  it("handles wildcard entry", () => {
+    const result = normalizeAllowFrom(["*", "745123456"]);
+
+    expect(result).toEqual({
+      entries: ["745123456"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("strips telegram/tg prefix before validation", () => {
+    const result = normalizeAllowFrom(["telegram:123", "tg:-100999", "TG:456"]);
+
+    expect(result).toEqual({
+      entries: ["123", "-100999", "456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("returns empty result for undefined input", () => {
+    const result = normalizeAllowFrom(undefined);
+
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: false,
+      invalidEntries: [],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,7 +31,7 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
+        "- allowFrom/groupAllowFrom authorization requires numeric Telegram IDs only (positive user IDs or negative group/supergroup chat IDs).",
         'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,

--- a/src/telegram/group-access.policy-access.test.ts
+++ b/src/telegram/group-access.policy-access.test.ts
@@ -235,6 +235,55 @@ describe("evaluateTelegramGroupPolicyAccess – chat allowlist vs sender allowli
     expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
   });
 
+  it("allows group via groupAllowFrom chatId even with checkChatAllowlist enabled (#40444)", () => {
+    // Production path: checkChatAllowlist=true, no groups config → resolveGroupPolicy
+    // returns allowed:false.  The chatId in groupAllowFrom should still unblock.
+    const groupChatAllow = {
+      entries: ["-1003890514701"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    };
+
+    const result = runAccess({
+      chatId: "-1003890514701",
+      effectiveGroupAllow: groupChatAllow,
+      senderId: "999",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: false, // no groups config entry
+      }),
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
+  it("allows group via groupAllowFrom chatId even without sender identity (#40444)", () => {
+    // Anonymous sender (e.g. admin messages, forwarded posts) should still be
+    // allowed when the group's chatId is explicitly listed in groupAllowFrom.
+    const groupChatAllow = {
+      entries: ["-1003890514701"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    };
+
+    const result = runAccess({
+      chatId: "-1003890514701",
+      effectiveGroupAllow: groupChatAllow,
+      senderId: undefined,
+      senderUsername: undefined,
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: false,
+      }),
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
   it("rejects group when its chat ID is NOT in groupAllowFrom", () => {
     const groupChatAllow = {
       entries: ["-1003890514701"],

--- a/src/telegram/group-access.policy-access.test.ts
+++ b/src/telegram/group-access.policy-access.test.ts
@@ -212,4 +212,52 @@ describe("evaluateTelegramGroupPolicyAccess – chat allowlist vs sender allowli
 
     expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
   });
+
+  it("allows group when its negative chat ID is listed in groupAllowFrom (#40444)", () => {
+    const groupChatAllow = {
+      entries: ["-1003890514701"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    };
+
+    const result = runAccess({
+      chatId: "-1003890514701",
+      effectiveGroupAllow: groupChatAllow,
+      senderId: "999", // sender NOT in entries — but chat ID IS
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: false,
+        allowed: false,
+      }),
+      checkChatAllowlist: false,
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
+  it("rejects group when its chat ID is NOT in groupAllowFrom", () => {
+    const groupChatAllow = {
+      entries: ["-1003890514701"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    };
+
+    const result = runAccess({
+      chatId: "-100999888777", // different group
+      effectiveGroupAllow: groupChatAllow,
+      senderId: "999",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: false,
+        allowed: false,
+      }),
+      checkChatAllowlist: false,
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-policy-allowlist-unauthorized",
+      groupPolicy: "allowlist",
+    });
+  });
 });

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -161,9 +161,19 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   // Check chat-level allowlist first so that groups explicitly listed in the
   // `groups` config are not blocked by the sender-level "empty allowlist" guard.
   let chatExplicitlyAllowed = false;
+  // Check if the chat ID itself is listed in groupAllowFrom (negative Telegram
+  // supergroup/group IDs).  This lets users allowlist groups directly via
+  // groupAllowFrom without needing a separate `groups` config entry.
+  const chatIdAllowedByGroupAllowFrom = params.effectiveGroupAllow.entries.includes(
+    String(params.chatId),
+  );
   if (params.checkChatAllowlist) {
     const groupAllowlist = params.resolveGroupPolicy(params.chatId);
-    if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
+    if (
+      groupAllowlist.allowlistEnabled &&
+      !groupAllowlist.allowed &&
+      !chatIdAllowedByGroupAllowFrom
+    ) {
       return { allowed: false, reason: "group-chat-not-allowed", groupPolicy };
     }
     // The chat is explicitly allowed when it has a dedicated entry in the groups
@@ -172,6 +182,14 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
     if (groupAllowlist.allowlistEnabled && groupAllowlist.allowed && groupAllowlist.groupConfig) {
       chatExplicitlyAllowed = true;
     }
+    if (chatIdAllowedByGroupAllowFrom) {
+      chatExplicitlyAllowed = true;
+    }
+  }
+  // When the group chat ID is explicitly listed in groupAllowFrom, treat it as
+  // a group-level allowlist entry that bypasses sender-identity checks.
+  if (chatIdAllowedByGroupAllowFrom) {
+    return { allowed: true, groupPolicy };
   }
   if (groupPolicy === "allowlist" && params.enforceAllowlistAuthorization) {
     const senderId = params.senderId ?? "";
@@ -189,11 +207,7 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
           allow: params.effectiveGroupAllow,
           senderId,
           senderUsername: params.senderUsername ?? "",
-        }) ||
-        // Allow if the chat ID itself is listed in groupAllowFrom (negative
-        // Telegram supergroup/group IDs).  This lets users allowlist groups
-        // directly via groupAllowFrom without needing a separate groups config.
-        params.effectiveGroupAllow.entries.includes(String(params.chatId)),
+        }),
     });
     if (!senderAuthorization.allowed && senderAuthorization.reason === "missing_match_input") {
       return { allowed: false, reason: "group-policy-allowlist-no-sender", groupPolicy };

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -189,7 +189,11 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
           allow: params.effectiveGroupAllow,
           senderId,
           senderUsername: params.senderUsername ?? "",
-        }),
+        }) ||
+        // Allow if the chat ID itself is listed in groupAllowFrom (negative
+        // Telegram supergroup/group IDs).  This lets users allowlist groups
+        // directly via groupAllowFrom without needing a separate groups config.
+        params.effectiveGroupAllow.entries.includes(String(params.chatId)),
     });
     if (!senderAuthorization.allowed && senderAuthorization.reason === "missing_match_input") {
       return { allowed: false, reason: "group-policy-allowlist-no-sender", groupPolicy };


### PR DESCRIPTION
## Summary
- `normalizeAllowFrom` in `bot-access.ts` validates entries with `/^\d+$/`, which rejects negative integers — but Telegram supergroup/group chat IDs are always negative (e.g. `-1003890514701`)
- Users setting `groupAllowFrom: [-1003890514701]` see all entries silently rejected as invalid, and all group messages dropped with `reason: not-allowed`
- Fix the regex to `/^-?\d+$/` so negative numeric IDs are accepted as valid entries
- Extend `evaluateTelegramGroupPolicyAccess` to match `chatId` against `groupAllowFrom` entries, so negative group IDs in `groupAllowFrom` work as group-level allowlisting
- The chatId check runs **before** both the `group-chat-not-allowed` early return and the sender-identity gate, so it is reachable in the production path (`checkChatAllowlist: true`) and for anonymous senders

## Root cause
```typescript
// bot-access.ts line 47 — only matches non-negative integers
const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
```
Telegram supergroup IDs like `-1003890514701` fail this check and are classified as invalid, causing the warning log and empty entries list.

## Test plan
- [x] Updated test: `normalizeAllowFrom` now accepts negative IDs as valid numeric entries (was explicitly testing they were invalid)
- [x] Added test: non-numeric entries like `@username` are still rejected
- [x] Added test: wildcard handling preserved
- [x] Added test: `telegram:`/`tg:` prefix stripping works with negative IDs
- [x] Added test: group allowed when its negative chat ID is listed in `groupAllowFrom`
- [x] Added test: group allowed via `groupAllowFrom` chatId with `checkChatAllowlist: true` (production path)
- [x] Added test: group allowed via `groupAllowFrom` chatId even without sender identity (anonymous senders)
- [x] Added test: group rejected when its chat ID is NOT in `groupAllowFrom`
- [x] All telegram tests pass — 781/785 (4 pre-existing failures on main unrelated to this change)

Fixes #40444

🤖 Generated with [Claude Code](https://claude.com/claude-code)