### PR TITLE
fix(telegram): accept negative group/supergroup IDs in groupAllowFrom

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,47 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
+  it("accepts positive sender IDs and negative group chat IDs", () => {
     const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
 
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["-1001234567890", "-100999", "745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone"],
+    });
+  });
+
+  it("accepts numeric entries as integers", () => {
+    const result = normalizeAllowFrom([-1003890514701, 745123456]);
+
+    expect(result).toEqual({
+      entries: ["-1003890514701", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("handles wildcard correctly", () => {
+    const result = normalizeAllowFrom(["*", "123"]);
+
+    expect(result).toEqual({
+      entries: ["123"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("returns empty for undefined input", () => {
+    const result = normalizeAllowFrom(undefined);
+
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: false,
+      invalidEntries: [],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

- Fix `normalizeAllowFrom` regex from `/^\d+$/` to `/^-?\d+$/` to accept negative Telegram group/supergroup chat IDs
- Telegram group and supergroup IDs are always negative (e.g. `-1003890514701`), but the old regex only matched positive integers, making `groupPolicy: "allowlist"` completely non-functional for groups
- Added comprehensive test cases for negative IDs, integer inputs, wildcards, and undefined input

## Change Type
Bug fix

## Scope
`src/telegram/bot-access.ts`, `src/telegram/bot-access.test.ts`

## Security Impact
No security impact. This change allows negative numeric IDs that were previously incorrectly rejected. The validation still rejects non-numeric entries (e.g. `@username`).

Closes #40444

🤖 Generated with [Claude Code](https://claude.com/claude-code)