### PR TITLE
fix(agents): strip orphaned tool_result blocks in Anthropic turn validation

### DIFF
--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -730,3 +730,68 @@ describe("validateAnthropicTurns strips orphaned tool_result blocks", () => {
     expect((result[1] as { content: unknown }).content).toBe("legacy-content");
   });
 });
+
+describe("validateAnthropicTurns tool pairing across consecutive user messages", () => {
+  it("preserves tool_result in a later consecutive user message (merged before stripping)", () => {
+    // Regression: assistant(toolUse) -> user(text) -> user(toolResult)
+    // The toolResult is valid after merging the two user messages.
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "tu-1", name: "read_file" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "some context" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "toolResult", toolUseId: "tu-1" }],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = validateAnthropicTurns(msgs);
+
+    // After merge: assistant(toolUse) -> user(text + toolResult)
+    expect(result).toHaveLength(2);
+    const userContent = (result[1] as { content: { type: string; toolUseId?: string }[] }).content;
+    // toolResult must survive - it pairs with the assistant's toolUse
+    const toolResults = userContent.filter((b) => b.type === "toolResult");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].toolUseId).toBe("tu-1");
+    // toolUse must also survive in the assistant message
+    const assistantContent = (result[0] as { content: { type: string; id?: string }[] }).content;
+    const toolUses = assistantContent.filter((b) => b.type === "toolUse");
+    expect(toolUses).toHaveLength(1);
+  });
+
+  it("preserves tool_result when system message sits between assistant and user", () => {
+    // Regression: assistant(toolUse) -> system -> user(toolResult)
+    // The backward search should skip system messages.
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "tu-2", name: "bash" }],
+      },
+      {
+        role: "system",
+        content: [{ type: "text", text: "system marker" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "toolResult", toolUseId: "tu-2" }],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = validateAnthropicTurns(msgs);
+
+    // system message stays, toolResult must survive
+    const userMsgs = result.filter((m) => (m as { role: string }).role === "user");
+    expect(userMsgs.length).toBeGreaterThanOrEqual(1);
+    const userContent = (userMsgs[0] as { content: { type: string; toolUseId?: string }[] })
+      .content;
+    const toolResults = userContent.filter((b) => b.type === "toolResult");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].toolUseId).toBe("tu-2");
+  });
+});

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -512,3 +512,208 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     expect(result).toHaveLength(3);
   });
 });
+
+describe("validateAnthropicTurns strips orphaned tool_result blocks", () => {
+  it("should strip tool_result blocks without matching tool_use in prior assistant", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "No tools here" }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result" }] },
+          { type: "text", text: "Thanks" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const userContent = (result[2] as { content?: unknown[] }).content;
+    // Orphaned tool_result should be stripped, text preserved
+    expect(userContent).toEqual([{ type: "text", text: "Thanks" }]);
+  });
+
+  it("should preserve tool_result blocks with matching tool_use in prior assistant", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "tool-1", name: "test", input: {} },
+          { type: "text", text: "Checking" },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result" }] },
+          { type: "text", text: "Thanks" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const userContent = (result[2] as { content?: unknown[] }).content;
+    expect(userContent).toEqual([
+      { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result" }] },
+      { type: "text", text: "Thanks" },
+    ]);
+  });
+
+  it("should strip only orphaned tool_result blocks in a mix", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tools" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "tool-1", name: "test1", input: {} },
+          { type: "toolUse", id: "tool-2", name: "test2", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result 1" }] },
+          { type: "toolResult", toolUseId: "tool-2", content: [{ type: "text", text: "Result 2" }] },
+          { type: "toolResult", toolUseId: "tool-3", content: [{ type: "text", text: "Orphan" }] },
+          { type: "text", text: "Done" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const userContent = (result[2] as { content?: unknown[] }).content;
+    // tool-1 and tool-2 results kept, tool-3 orphan stripped
+    expect(userContent).toEqual([
+      { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result 1" }] },
+      { type: "toolResult", toolUseId: "tool-2", content: [{ type: "text", text: "Result 2" }] },
+      { type: "text", text: "Done" },
+    ]);
+  });
+
+  it("should insert fallback text when all user content is orphaned tool_result", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "No tools" }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result" }] },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const userContent = (result[2] as { content?: unknown[] }).content;
+    expect(userContent).toEqual([{ type: "text", text: "[tool results omitted]" }]);
+  });
+
+  it("should strip tool_result when there is no preceding assistant message", () => {
+    const msgs = asMessages([
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result" }] },
+          { type: "text", text: "Hello" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(1);
+    const userContent = (result[0] as { content?: unknown[] }).content;
+    expect(userContent).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("is idempotent - running twice produces same result", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "No tools" }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result" }] },
+          { type: "text", text: "Thanks" },
+        ],
+      },
+    ]);
+
+    const firstPass = validateAnthropicTurns(msgs);
+    const secondPass = validateAnthropicTurns(firstPass);
+
+    expect(secondPass).toEqual(firstPass);
+  });
+
+  it("strips orphaned tool_result after dangling tool_use is stripped", () => {
+    // Scenario: assistant has tool_use with non-Anthropic ID, user has matching tool_result.
+    // stripDanglingAnthropicToolUses strips the tool_use (no matching result with that ID in user),
+    // then stripOrphanedAnthropicToolResults strips the now-orphaned tool_result.
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "tool-A", name: "test", input: {} },
+          { type: "toolUse", id: "tool-B", name: "test2", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-A", content: [{ type: "text", text: "Result A" }] },
+          // tool-B result is missing, so tool-B tool_use gets stripped by stripDanglingAnthropicToolUses
+          { type: "text", text: "Done" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    // tool-A preserved in both assistant and user
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([
+      { type: "toolUse", id: "tool-A", name: "test", input: {} },
+    ]);
+    const userContent = (result[2] as { content?: unknown[] }).content;
+    expect(userContent).toEqual([
+      { type: "toolResult", toolUseId: "tool-A", content: [{ type: "text", text: "Result A" }] },
+      { type: "text", text: "Done" },
+    ]);
+  });
+
+  it("does not crash when user content is non-array", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hi" }],
+      },
+      {
+        role: "user",
+        content: "legacy-content",
+      },
+    ] as unknown as AgentMessage[];
+
+    expect(() => validateAnthropicTurns(msgs)).not.toThrow();
+    const result = validateAnthropicTurns(msgs);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -580,8 +580,16 @@ describe("validateAnthropicTurns strips orphaned tool_result blocks", () => {
       {
         role: "user",
         content: [
-          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result 1" }] },
-          { type: "toolResult", toolUseId: "tool-2", content: [{ type: "text", text: "Result 2" }] },
+          {
+            type: "toolResult",
+            toolUseId: "tool-1",
+            content: [{ type: "text", text: "Result 1" }],
+          },
+          {
+            type: "toolResult",
+            toolUseId: "tool-2",
+            content: [{ type: "text", text: "Result 2" }],
+          },
           { type: "toolResult", toolUseId: "tool-3", content: [{ type: "text", text: "Orphan" }] },
           { type: "text", text: "Done" },
         ],
@@ -664,8 +672,9 @@ describe("validateAnthropicTurns strips orphaned tool_result blocks", () => {
 
   it("strips orphaned tool_result after dangling tool_use is stripped", () => {
     // Scenario: assistant has tool_use with non-Anthropic ID, user has matching tool_result.
-    // stripDanglingAnthropicToolUses strips the tool_use (no matching result with that ID in user),
-    // then stripOrphanedAnthropicToolResults strips the now-orphaned tool_result.
+    // stripDanglingAnthropicToolUses strips tool-B's tool_use (no matching result in user).
+    // stripOrphanedAnthropicToolResults preserves tool-A's tool_result (tool-A still valid).
+    // Net result: only tool-A round-trip survives.
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },
       {
@@ -678,7 +687,11 @@ describe("validateAnthropicTurns strips orphaned tool_result blocks", () => {
       {
         role: "user",
         content: [
-          { type: "toolResult", toolUseId: "tool-A", content: [{ type: "text", text: "Result A" }] },
+          {
+            type: "toolResult",
+            toolUseId: "tool-A",
+            content: [{ type: "text", text: "Result A" }],
+          },
           // tool-B result is missing, so tool-B tool_use gets stripped by stripDanglingAnthropicToolUses
           { type: "text", text: "Done" },
         ],
@@ -690,9 +703,7 @@ describe("validateAnthropicTurns strips orphaned tool_result blocks", () => {
     expect(result).toHaveLength(3);
     // tool-A preserved in both assistant and user
     const assistantContent = (result[1] as { content?: unknown[] }).content;
-    expect(assistantContent).toEqual([
-      { type: "toolUse", id: "tool-A", name: "test", input: {} },
-    ]);
+    expect(assistantContent).toEqual([{ type: "toolUse", id: "tool-A", name: "test", input: {} }]);
     const userContent = (result[2] as { content?: unknown[] }).content;
     expect(userContent).toEqual([
       { type: "toolResult", toolUseId: "tool-A", content: [{ type: "text", text: "Result A" }] },
@@ -715,5 +726,7 @@ describe("validateAnthropicTurns strips orphaned tool_result blocks", () => {
     expect(() => validateAnthropicTurns(msgs)).not.toThrow();
     const result = validateAnthropicTurns(msgs);
     expect(result).toHaveLength(2);
+    // Non-array content must be preserved as-is, not replaced with []
+    expect((result[1] as { content: unknown }).content).toBe("legacy-content");
   });
 });

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -69,8 +69,15 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       continue;
     }
 
+    // If assistant content is not an array (legacy string format), it can't
+    // contain tool_use blocks, so keep it unchanged.
+    if (!Array.isArray(assistantMsg.content)) {
+      result.push(msg);
+      continue;
+    }
+
     // Filter out tool_use blocks that don't have matching tool_result
-    const originalContent = Array.isArray(assistantMsg.content) ? assistantMsg.content : [];
+    const originalContent = assistantMsg.content;
     const filteredContent = originalContent.filter((block) => {
       if (!block) {
         return false;

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -33,30 +33,40 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       content?: AnthropicContentBlock[];
     };
 
-    // Get the next message to check for tool_result blocks
-    const nextMsg = messages[i + 1];
-    const nextMsgRole =
-      nextMsg && typeof nextMsg === "object"
-        ? ((nextMsg as { role?: unknown }).role as string | undefined)
-        : undefined;
-
-    // If next message is not user, keep the assistant message as-is
-    if (nextMsgRole !== "user") {
-      result.push(msg);
-      continue;
-    }
-
-    // Collect tool_use_ids from the next user message's tool_result blocks
-    const nextUserMsg = nextMsg as {
-      content?: AnthropicContentBlock[];
-    };
+    // Scan forward across all consecutive user messages (and skip system
+    // messages) to collect tool_result ids. This handles transcripts where
+    // tool results end up in a later user message or after a system marker.
     const validToolUseIds = new Set<string>();
-    if (Array.isArray(nextUserMsg.content)) {
-      for (const block of nextUserMsg.content) {
-        if (block && block.type === "toolResult" && block.toolUseId) {
-          validToolUseIds.add(block.toolUseId);
+    let foundUser = false;
+    for (let j = i + 1; j < messages.length; j++) {
+      const nextMsg = messages[j];
+      const nextMsgRole =
+        nextMsg && typeof nextMsg === "object"
+          ? ((nextMsg as { role?: unknown }).role as string | undefined)
+          : undefined;
+      // Stop at the next assistant message
+      if (nextMsgRole === "assistant") {
+        break;
+      }
+      // Skip system messages
+      if (nextMsgRole !== "user") {
+        continue;
+      }
+      foundUser = true;
+      const nextUserMsg = nextMsg as { content?: AnthropicContentBlock[] };
+      if (Array.isArray(nextUserMsg.content)) {
+        for (const block of nextUserMsg.content) {
+          if (block && block.type === "toolResult" && block.toolUseId) {
+            validToolUseIds.add(block.toolUseId);
+          }
         }
       }
+    }
+
+    // If no user message follows, keep the assistant message as-is
+    if (!foundUser) {
+      result.push(msg);
+      continue;
     }
 
     // Filter out tool_use blocks that don't have matching tool_result
@@ -208,25 +218,33 @@ function stripOrphanedAnthropicToolResults(messages: AgentMessage[]): AgentMessa
       content?: AnthropicContentBlock[];
     };
 
-    // Get the previous message to check for tool_use blocks
-    const prevMsg = messages[i - 1];
-    const prevMsgRole =
-      prevMsg && typeof prevMsg === "object"
-        ? ((prevMsg as { role?: unknown }).role as string | undefined)
-        : undefined;
-
-    // Collect tool_use ids from the preceding assistant message
+    // Scan backward to the nearest assistant message (skipping system
+    // messages) to collect tool_use ids. This handles transcripts where
+    // a system marker sits between the assistant and user messages.
     const validToolUseIds = new Set<string>();
-    if (prevMsgRole === "assistant") {
-      const prevAssistantMsg = prevMsg as {
-        content?: AnthropicContentBlock[];
-      };
-      if (Array.isArray(prevAssistantMsg.content)) {
-        for (const block of prevAssistantMsg.content) {
-          if (block && block.type === "toolUse" && block.id) {
-            validToolUseIds.add(block.id);
+    for (let j = i - 1; j >= 0; j--) {
+      const prevMsg = messages[j];
+      const prevMsgRole =
+        prevMsg && typeof prevMsg === "object"
+          ? ((prevMsg as { role?: unknown }).role as string | undefined)
+          : undefined;
+      // Found the nearest assistant message - collect its tool_use ids
+      if (prevMsgRole === "assistant") {
+        const prevAssistantMsg = prevMsg as {
+          content?: AnthropicContentBlock[];
+        };
+        if (Array.isArray(prevAssistantMsg.content)) {
+          for (const block of prevAssistantMsg.content) {
+            if (block && block.type === "toolUse" && block.id) {
+              validToolUseIds.add(block.id);
+            }
           }
         }
+        break;
+      }
+      // Skip system messages, stop at another user message
+      if (prevMsgRole === "user") {
+        break;
       }
     }
 
@@ -272,14 +290,16 @@ function stripOrphanedAnthropicToolResults(messages: AgentMessage[]): AgentMessa
  * and orphaned tool_result blocks that lack corresponding tool_use blocks.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
-  // First, strip dangling tool_use blocks from assistant messages
-  const strippedToolUses = stripDanglingAnthropicToolUses(messages);
-  // Then, strip orphaned tool_result blocks from user messages
-  const strippedToolResults = stripOrphanedAnthropicToolResults(strippedToolUses);
-
-  return validateTurnsWithConsecutiveMerge({
-    messages: strippedToolResults,
+  // Merge consecutive user turns first so tool pairing checks operate on
+  // the post-merge transcript. Without this, a tool_result in a later
+  // consecutive user message would be incorrectly stripped as "orphaned".
+  const merged = validateTurnsWithConsecutiveMerge({
+    messages,
     role: "user",
     merge: mergeConsecutiveUserTurns,
   });
+  // Strip dangling tool_use blocks from assistant messages
+  const strippedToolUses = stripDanglingAnthropicToolUses(merged);
+  // Strip orphaned tool_result blocks from user messages
+  return stripOrphanedAnthropicToolResults(strippedToolUses);
 }

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -184,17 +184,97 @@ export function mergeConsecutiveUserTurns(
 }
 
 /**
+ * Strips orphaned tool_result blocks from user messages when the immediately
+ * preceding assistant message does not contain a matching tool_use block.
+ * This fixes the "tool_result blocks found without matching tool_use" error from Anthropic.
+ */
+function stripOrphanedAnthropicToolResults(messages: AgentMessage[]): AgentMessage[] {
+  const result: AgentMessage[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") {
+      result.push(msg);
+      continue;
+    }
+
+    const msgRole = (msg as { role?: unknown }).role as string | undefined;
+    if (msgRole !== "user") {
+      result.push(msg);
+      continue;
+    }
+
+    const userMsg = msg as {
+      content?: AnthropicContentBlock[];
+    };
+
+    // Get the previous message to check for tool_use blocks
+    const prevMsg = messages[i - 1];
+    const prevMsgRole =
+      prevMsg && typeof prevMsg === "object"
+        ? ((prevMsg as { role?: unknown }).role as string | undefined)
+        : undefined;
+
+    // Collect tool_use ids from the preceding assistant message
+    const validToolUseIds = new Set<string>();
+    if (prevMsgRole === "assistant") {
+      const prevAssistantMsg = prevMsg as {
+        content?: AnthropicContentBlock[];
+      };
+      if (Array.isArray(prevAssistantMsg.content)) {
+        for (const block of prevAssistantMsg.content) {
+          if (block && block.type === "toolUse" && block.id) {
+            validToolUseIds.add(block.id);
+          }
+        }
+      }
+    }
+
+    // Filter out tool_result blocks that don't have matching tool_use
+    const originalContent = Array.isArray(userMsg.content) ? userMsg.content : [];
+    const filteredContent = originalContent.filter((block) => {
+      if (!block) {
+        return false;
+      }
+      if (block.type !== "toolResult") {
+        return true;
+      }
+      // Keep tool_result if its toolUseId is in the valid set
+      return validToolUseIds.has(block.toolUseId || "");
+    });
+
+    // If all content would be removed, insert a minimal fallback text block
+    if (originalContent.length > 0 && filteredContent.length === 0) {
+      result.push({
+        ...userMsg,
+        content: [{ type: "text", text: "[tool results omitted]" }],
+      } as AgentMessage);
+    } else {
+      result.push({
+        ...userMsg,
+        content: filteredContent,
+      } as AgentMessage);
+    }
+  }
+
+  return result;
+}
+
+/**
  * Validates and fixes conversation turn sequences for Anthropic API.
  * Anthropic requires strict alternating user→assistant pattern.
  * Merges consecutive user messages together.
- * Also strips dangling tool_use blocks that lack corresponding tool_result blocks.
+ * Also strips dangling tool_use blocks that lack corresponding tool_result blocks,
+ * and orphaned tool_result blocks that lack corresponding tool_use blocks.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
   // First, strip dangling tool_use blocks from assistant messages
-  const stripped = stripDanglingAnthropicToolUses(messages);
+  const strippedToolUses = stripDanglingAnthropicToolUses(messages);
+  // Then, strip orphaned tool_result blocks from user messages
+  const strippedToolResults = stripOrphanedAnthropicToolResults(strippedToolUses);
 
   return validateTurnsWithConsecutiveMerge({
-    messages: stripped,
+    messages: strippedToolResults,
     role: "user",
     merge: mergeConsecutiveUserTurns,
   });

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -231,7 +231,11 @@ function stripOrphanedAnthropicToolResults(messages: AgentMessage[]): AgentMessa
     }
 
     // Filter out tool_result blocks that don't have matching tool_use
-    const originalContent = Array.isArray(userMsg.content) ? userMsg.content : [];
+    if (!Array.isArray(userMsg.content)) {
+      result.push(msg);
+      continue;
+    }
+    const originalContent = userMsg.content;
     const filteredContent = originalContent.filter((block) => {
       if (!block) {
         return false;


### PR DESCRIPTION
Fixes #40433

## Summary

When a session transcript contains tool calls from a non-Anthropic provider and Anthropic is the fallback, the sanitize-on-retry path strips `tool_use` blocks but leaves corresponding `tool_result` blocks orphaned, causing a permanent 400 error loop.

This PR adds `stripOrphanedAnthropicToolResults()` to `turns.ts` that mirrors `stripDanglingAnthropicToolUses()` in reverse: for each user message, it strips `toolResult` content blocks whose `toolUseId` has no matching `toolUse` in the preceding assistant message.

## Changes

- **`src/agents/pi-embedded-helpers/turns.ts`** - Added `stripOrphanedAnthropicToolResults()` and updated `validateAnthropicTurns()` to call it after `stripDanglingAnthropicToolUses()`
- **`src/agents/pi-embedded-helpers.validate-turns.test.ts`** - 8 test cases covering orphaned stripping, mixed matched/orphaned, fallback text, idempotency, and pipeline interaction

## How it works

1. `stripDanglingAnthropicToolUses` runs first (strips tool_use without matching tool_result)
2. `stripOrphanedAnthropicToolResults` runs second (strips tool_result without matching tool_use)
3. When all content would be removed, inserts `[tool results omitted]` fallback (matching existing `[tool calls omitted]` pattern)

This contribution was developed with AI assistance (Claude Code).