### PR TITLE
fix(telegram): preserve media paths in group chat history entries

### DIFF
--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -33,7 +33,7 @@ export type HistoryEntry = {
   timestamp?: number;
   messageId?: string;
   mediaPaths?: string[];
-  mediaTypes?: string[];
+  mediaTypes?: (string | undefined)[];
 };
 
 export function buildHistoryContext(params: {

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -32,6 +32,8 @@ export type HistoryEntry = {
   body: string;
   timestamp?: number;
   messageId?: string;
+  mediaPaths?: string[];
+  mediaTypes?: string[];
 };
 
 export function buildHistoryContext(params: {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -220,6 +220,10 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
             sender: entry.sender,
             timestamp_ms: entry.timestamp,
             body: entry.body,
+            media_count:
+              entry.mediaPaths && entry.mediaPaths.length > 0
+                ? entry.mediaPaths.length
+                : undefined,
           })),
           null,
           2,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -25,6 +25,8 @@ export type MsgContext = {
     sender: string;
     body: string;
     timestamp?: number;
+    mediaPaths?: string[];
+    mediaTypes?: string[];
   }>;
   /**
    * Raw message body without structural context (history, sender labels).

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -346,9 +346,7 @@ export async function saveMediaSource(
 /** Refresh mtime on media files so they survive the 2-minute TTL cleanup. */
 export async function touchMediaFiles(paths: string[]): Promise<void> {
   const now = new Date();
-  await Promise.allSettled(
-    paths.map((p) => fs.utimes(p, now, now).catch(() => {})),
-  );
+  await Promise.allSettled(paths.map((p) => fs.utimes(p, now, now)));
 }
 
 export async function saveMediaBuffer(

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -343,10 +343,11 @@ export async function saveMediaSource(
   }
 }
 
-/** Refresh mtime on media files so they survive the 2-minute TTL cleanup. */
-export async function touchMediaFiles(paths: string[]): Promise<void> {
+/** Refresh mtime on media files so they survive the 2-minute TTL cleanup.
+ *  Returns per-path settlement results so callers can filter out deleted files. */
+export async function touchMediaFiles(paths: string[]): Promise<PromiseSettledResult<void>[]> {
   const now = new Date();
-  await Promise.allSettled(paths.map((p) => fs.utimes(p, now, now)));
+  return Promise.allSettled(paths.map((p) => fs.utimes(p, now, now)));
 }
 
 export async function saveMediaBuffer(

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -343,6 +343,14 @@ export async function saveMediaSource(
   }
 }
 
+/** Refresh mtime on media files so they survive the 2-minute TTL cleanup. */
+export async function touchMediaFiles(paths: string[]): Promise<void> {
+  const now = new Date();
+  await Promise.allSettled(
+    paths.map((p) => fs.utimes(p, now, now).catch(() => {})),
+  );
+}
+
 export async function saveMediaBuffer(
   buffer: Buffer,
   contentType?: string,

--- a/src/telegram/bot-message-context.body.ts
+++ b/src/telegram/bot-message-context.body.ts
@@ -182,10 +182,7 @@ export async function resolveTelegramInboundBody(params: {
       const { transcribeFirstAudio } = await import("../media-understanding/audio-preflight.js");
       const tempCtx: MsgContext = {
         MediaPaths: allMedia.length > 0 ? allMedia.map((m) => m.path) : undefined,
-        MediaTypes:
-          allMedia.length > 0
-            ? (allMedia.map((m) => m.contentType).filter(Boolean) as string[])
-            : undefined,
+        MediaTypes: allMedia.length > 0 ? allMedia.map((m) => m.contentType) : undefined,
       };
       preflightTranscript = await transcribeFirstAudio({
         ctx: tempCtx,
@@ -265,9 +262,7 @@ export async function resolveTelegramInboundBody(params: {
             timestamp: msg.date ? msg.date * 1000 : undefined,
             messageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
             mediaPaths: allMedia.length > 0 ? allMedia.map((m) => m.path) : undefined,
-            mediaTypes: allMedia.length > 0
-              ? (allMedia.map((m) => m.contentType).filter(Boolean) as string[])
-              : undefined,
+            mediaTypes: allMedia.length > 0 ? allMedia.map((m) => m.contentType) : undefined,
           }
         : null,
     });

--- a/src/telegram/bot-message-context.body.ts
+++ b/src/telegram/bot-message-context.body.ts
@@ -264,6 +264,10 @@ export async function resolveTelegramInboundBody(params: {
             body: rawBody,
             timestamp: msg.date ? msg.date * 1000 : undefined,
             messageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
+            mediaPaths: allMedia.length > 0 ? allMedia.map((m) => m.path) : undefined,
+            mediaTypes: allMedia.length > 0
+              ? (allMedia.map((m) => m.contentType).filter(Boolean) as string[])
+              : undefined,
           }
         : null,
     });

--- a/src/telegram/bot-message-context.body.ts
+++ b/src/telegram/bot-message-context.body.ts
@@ -182,7 +182,10 @@ export async function resolveTelegramInboundBody(params: {
       const { transcribeFirstAudio } = await import("../media-understanding/audio-preflight.js");
       const tempCtx: MsgContext = {
         MediaPaths: allMedia.length > 0 ? allMedia.map((m) => m.path) : undefined,
-        MediaTypes: allMedia.length > 0 ? allMedia.map((m) => m.contentType) : undefined,
+        MediaTypes:
+          allMedia.length > 0
+            ? allMedia.map((m) => m.contentType).filter((t): t is string => t != null)
+            : undefined,
       };
       preflightTranscript = await transcribeFirstAudio({
         ctx: tempCtx,

--- a/src/telegram/bot-message-context.session.ts
+++ b/src/telegram/bot-message-context.session.ts
@@ -184,31 +184,49 @@ export async function buildTelegramInboundContextPayload(params: {
           mediaTypes: e.mediaTypes ? [...e.mediaTypes] : undefined,
         }))
       : [];
-  const inboundHistory =
-    historyEntries.length > 0
-      ? historyEntries.map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-          mediaPaths: entry.mediaPaths,
-          mediaTypes: entry.mediaTypes,
-        }))
-      : undefined;
-  // Touch history media files so they survive the 2-minute TTL cleanup
+  // Touch history media files so they survive the 2-minute TTL cleanup.
+  // Files older than DEFAULT_TTL_MS may already be deleted by cleanOldMedia
+  // (which runs on every saveMediaSource call), so filter out missing paths
+  // after touching to avoid injecting stale refs into context.
   const historyMediaPaths = historyEntries.flatMap((e) => e.mediaPaths ?? []);
+  const survivingMediaPaths = new Set<string>();
   if (historyMediaPaths.length > 0) {
     const { touchMediaFiles } = await import("../media/store.js");
-    await touchMediaFiles(historyMediaPaths);
+    const results = await touchMediaFiles(historyMediaPaths);
+    for (let i = 0; i < historyMediaPaths.length; i++) {
+      if (results[i].status === "fulfilled") {
+        survivingMediaPaths.add(historyMediaPaths[i]);
+      }
+    }
   }
+  // Build inbound history AFTER touching so we can filter stale media paths.
+  const inboundHistory =
+    historyEntries.length > 0
+      ? historyEntries.map((entry) => {
+          const paths = entry.mediaPaths?.filter((p) => survivingMediaPaths.has(p));
+          const types = paths
+            ? entry.mediaTypes?.filter((_, i) =>
+                entry.mediaPaths ? survivingMediaPaths.has(entry.mediaPaths[i]) : false,
+              )
+            : undefined;
+          return {
+            sender: entry.sender,
+            body: entry.body,
+            timestamp: entry.timestamp,
+            mediaPaths: paths && paths.length > 0 ? paths : undefined,
+            mediaTypes: types && types.length > 0 ? types : undefined,
+          };
+        })
+      : undefined;
   const currentMediaForContext = stickerCacheHit ? [] : allMedia;
   // Merge history media into context so the media-understanding pipeline processes them.
   // History refs go into a separate array to avoid populating MediaPath (which triggers
   // sticker handling in bot-message-dispatch when stickerCacheHit already removed the sticker).
+  // Only include paths that survived the touch (file still exists on disk).
   const historyMediaRefs: TelegramMediaRef[] = historyEntries.flatMap((e) =>
-    (e.mediaPaths ?? []).map((p, i) => ({
-      path: p,
-      contentType: e.mediaTypes?.[i],
-    })),
+    (e.mediaPaths ?? [])
+      .map((p, i) => ({ path: p, contentType: e.mediaTypes?.[i] }))
+      .filter((ref) => survivingMediaPaths.has(ref.path)),
   );
   // Primary context media: current attachments + reply media (drives MediaPath/Sticker logic)
   const primaryMedia = [...currentMediaForContext, ...replyMedia];

--- a/src/telegram/bot-message-context.session.ts
+++ b/src/telegram/bot-message-context.session.ts
@@ -174,9 +174,7 @@ export async function buildTelegramInboundContextPayload(params: {
     botUsername: primaryCtx.me?.username?.toLowerCase(),
   });
   const historyEntries =
-    isGroup && historyKey && historyLimit > 0
-      ? (groupHistories.get(historyKey) ?? [])
-      : [];
+    isGroup && historyKey && historyLimit > 0 ? (groupHistories.get(historyKey) ?? []) : [];
   const inboundHistory =
     historyEntries.length > 0
       ? historyEntries.map((entry) => ({
@@ -250,10 +248,7 @@ export async function buildTelegramInboundContextPayload(params: {
     MediaUrl: contextMedia.length > 0 ? contextMedia[0]?.path : undefined,
     MediaPaths: contextMedia.length > 0 ? contextMedia.map((m) => m.path) : undefined,
     MediaUrls: contextMedia.length > 0 ? contextMedia.map((m) => m.path) : undefined,
-    MediaTypes:
-      contextMedia.length > 0
-        ? (contextMedia.map((m) => m.contentType).filter(Boolean) as string[])
-        : undefined,
+    MediaTypes: contextMedia.length > 0 ? contextMedia.map((m) => m.contentType) : undefined,
     Sticker: allMedia[0]?.stickerMetadata,
     StickerMediaIncluded: allMedia[0]?.stickerMetadata ? !stickerCacheHit : undefined,
     ...(locationData ? toLocationContext(locationData) : undefined),

--- a/src/telegram/bot-message-context.session.ts
+++ b/src/telegram/bot-message-context.session.ts
@@ -192,14 +192,19 @@ export async function buildTelegramInboundContextPayload(params: {
     await touchMediaFiles(historyMediaPaths);
   }
   const currentMediaForContext = stickerCacheHit ? [] : allMedia;
-  // Merge history media into context so the media-understanding pipeline processes them
+  // Merge history media into context so the media-understanding pipeline processes them.
+  // History refs go into a separate array to avoid populating MediaPath (which triggers
+  // sticker handling in bot-message-dispatch when stickerCacheHit already removed the sticker).
   const historyMediaRefs: TelegramMediaRef[] = historyEntries.flatMap((e) =>
     (e.mediaPaths ?? []).map((p, i) => ({
       path: p,
       contentType: e.mediaTypes?.[i],
     })),
   );
-  const contextMedia = [...currentMediaForContext, ...replyMedia, ...historyMediaRefs];
+  // Primary context media: current attachments + reply media (drives MediaPath/Sticker logic)
+  const primaryMedia = [...currentMediaForContext, ...replyMedia];
+  // Full context media: primary + history (drives MediaPaths for media-understanding pipeline)
+  const contextMedia = [...primaryMedia, ...historyMediaRefs];
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     BodyForAgent: bodyText,
@@ -243,9 +248,9 @@ export async function buildTelegramInboundContextPayload(params: {
     ForwardedDate: forwardOrigin?.date ? forwardOrigin.date * 1000 : undefined,
     Timestamp: msg.date ? msg.date * 1000 : undefined,
     WasMentioned: isGroup ? effectiveWasMentioned : undefined,
-    MediaPath: contextMedia.length > 0 ? contextMedia[0]?.path : undefined,
-    MediaType: contextMedia.length > 0 ? contextMedia[0]?.contentType : undefined,
-    MediaUrl: contextMedia.length > 0 ? contextMedia[0]?.path : undefined,
+    MediaPath: primaryMedia.length > 0 ? primaryMedia[0]?.path : undefined,
+    MediaType: primaryMedia.length > 0 ? primaryMedia[0]?.contentType : undefined,
+    MediaUrl: primaryMedia.length > 0 ? primaryMedia[0]?.path : undefined,
     MediaPaths: contextMedia.length > 0 ? contextMedia.map((m) => m.path) : undefined,
     MediaUrls: contextMedia.length > 0 ? contextMedia.map((m) => m.path) : undefined,
     MediaTypes: contextMedia.length > 0 ? contextMedia.map((m) => m.contentType) : undefined,

--- a/src/telegram/bot-message-context.session.ts
+++ b/src/telegram/bot-message-context.session.ts
@@ -173,8 +173,17 @@ export async function buildTelegramInboundContextPayload(params: {
   const commandBody = normalizeCommandBody(rawBody, {
     botUsername: primaryCtx.me?.username?.toLowerCase(),
   });
+  // Snapshot the history array to avoid races: appendHistoryEntry mutates the live
+  // array in groupHistories, so concurrent messages during the touchMediaFiles await
+  // could append/shift entries and create inconsistent context.
   const historyEntries =
-    isGroup && historyKey && historyLimit > 0 ? (groupHistories.get(historyKey) ?? []) : [];
+    isGroup && historyKey && historyLimit > 0
+      ? [...(groupHistories.get(historyKey) ?? [])].map((e) => ({
+          ...e,
+          mediaPaths: e.mediaPaths ? [...e.mediaPaths] : undefined,
+          mediaTypes: e.mediaTypes ? [...e.mediaTypes] : undefined,
+        }))
+      : [];
   const inboundHistory =
     historyEntries.length > 0
       ? historyEntries.map((entry) => ({

--- a/src/telegram/bot-message-context.session.ts
+++ b/src/telegram/bot-message-context.session.ts
@@ -173,16 +173,35 @@ export async function buildTelegramInboundContextPayload(params: {
   const commandBody = normalizeCommandBody(rawBody, {
     botUsername: primaryCtx.me?.username?.toLowerCase(),
   });
-  const inboundHistory =
+  const historyEntries =
     isGroup && historyKey && historyLimit > 0
-      ? (groupHistories.get(historyKey) ?? []).map((entry) => ({
+      ? (groupHistories.get(historyKey) ?? [])
+      : [];
+  const inboundHistory =
+    historyEntries.length > 0
+      ? historyEntries.map((entry) => ({
           sender: entry.sender,
           body: entry.body,
           timestamp: entry.timestamp,
+          mediaPaths: entry.mediaPaths,
+          mediaTypes: entry.mediaTypes,
         }))
       : undefined;
+  // Touch history media files so they survive the 2-minute TTL cleanup
+  const historyMediaPaths = historyEntries.flatMap((e) => e.mediaPaths ?? []);
+  if (historyMediaPaths.length > 0) {
+    const { touchMediaFiles } = await import("../media/store.js");
+    await touchMediaFiles(historyMediaPaths);
+  }
   const currentMediaForContext = stickerCacheHit ? [] : allMedia;
-  const contextMedia = [...currentMediaForContext, ...replyMedia];
+  // Merge history media into context so the media-understanding pipeline processes them
+  const historyMediaRefs: TelegramMediaRef[] = historyEntries.flatMap((e) =>
+    (e.mediaPaths ?? []).map((p, i) => ({
+      path: p,
+      contentType: e.mediaTypes?.[i],
+    })),
+  );
+  const contextMedia = [...currentMediaForContext, ...replyMedia, ...historyMediaRefs];
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     BodyForAgent: bodyText,


### PR DESCRIPTION
Fixes #40440

## Summary

When images are sent in a Telegram group chat without @mentioning the bot, media files are downloaded but the history entry only stores placeholder text (`<media:image>`). When the bot is later @mentioned, it can't access the actual media.

This PR preserves media file paths and content types in group chat history entries, and surfaces them when the bot is invoked.

## Changes

- **`src/auto-reply/reply/history.ts`** - Extended `HistoryEntry` with optional `mediaPaths`/`mediaTypes` fields
- **`src/telegram/bot-message-context.body.ts`** - Pass media data into history entries
- **`src/media/store.ts`** - Added `touchMediaFiles()` to refresh mtime so files survive 2-minute TTL
- **`src/telegram/bot-message-context.session.ts`** - Surface media in InboundHistory, touch files on replay, merge into context media
- **`src/auto-reply/templating.ts`** - Extended InboundHistory type
- **`src/auto-reply/reply/inbound-meta.ts`** - Added `media_count` to history JSON output

## How it works

1. When a group message with media is stored as history, `mediaPaths` and `mediaTypes` from the downloaded files are included
2. When history is replayed on @mention, `touchMediaFiles` refreshes mtime to prevent TTL cleanup
3. History media refs are merged into the context media array so the media-understanding pipeline processes them
4. The structured context includes `media_count` so agents know which entries had media

This contribution was developed with AI assistance (Claude Code).