### PR TITLE
fix(browser): surface 429 rate limit errors with actionable hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - Models/Alibaba Cloud Model Studio: wire `MODELSTUDIO_API_KEY` through shared env auth, implicit provider discovery, and shell-env fallback so onboarding works outside the wizard too. (#40634) Thanks @pomelo-nwu.
 - ACP/sessions_spawn: implicitly stream `mode="run"` ACP spawns to parent only for eligible subagent orchestrator sessions (heartbeat `target: "last"` with a usable session-local route), restoring parent progress relays without thread binding. (#42404) Thanks @davidguttman.
 - Sessions/reset model recompute: clear stale runtime model, context-token, and system-prompt metadata before session resets recompute the replacement session, so resets pick up current defaults and explicit overrides instead of reusing old runtime model state. (#41173) thanks @PonyX-lab.
+- Browser/Browserbase 429 handling: surface stable no-retry rate-limit guidance without buffering discarded HTTP 429 response bodies from remote browser services. (#40491) thanks @mvanhorn.
 
 ## 2026.3.8
 

--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -174,10 +174,9 @@ export async function fetchCdpChecked(
     );
     if (!res.ok) {
       if (res.status === 429) {
-        const text = await res.text().catch(() => "");
-        const detail = text ? ` (${text.slice(0, 200)})` : "";
+        // Do not reflect upstream response text into the error surface (log/agent injection risk)
         throw new Error(
-          `${BROWSER_RATE_LIMIT_MESSAGE}${detail} Do NOT retry - wait for the current session to complete, or upgrade your plan.`,
+          `${BROWSER_RATE_LIMIT_MESSAGE} Do NOT retry - wait for the current session to complete, or upgrade your plan.`,
         );
       }
       throw new Error(`HTTP ${res.status}`);

--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -3,7 +3,7 @@ import { isLoopbackHost } from "../gateway/net.js";
 import { rawDataToString } from "../infra/ws.js";
 import { getDirectAgentForCdp, withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
 import { CDP_HTTP_REQUEST_TIMEOUT_MS, CDP_WS_HANDSHAKE_TIMEOUT_MS } from "./cdp-timeouts.js";
-import { BROWSER_RATE_LIMIT_MESSAGE } from "./client-fetch.js";
+import { resolveBrowserRateLimitMessage } from "./client-fetch.js";
 import { getChromeExtensionRelayAuthHeaders } from "./extension-relay.js";
 
 export { isLoopbackHost };
@@ -175,9 +175,7 @@ export async function fetchCdpChecked(
     if (!res.ok) {
       if (res.status === 429) {
         // Do not reflect upstream response text into the error surface (log/agent injection risk)
-        throw new Error(
-          `${BROWSER_RATE_LIMIT_MESSAGE} Do NOT retry - wait for the current session to complete, or upgrade your plan.`,
-        );
+        throw new Error(`${resolveBrowserRateLimitMessage(url)} Do NOT retry the browser tool.`);
       }
       throw new Error(`HTTP ${res.status}`);
     }

--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -172,6 +172,14 @@ export async function fetchCdpChecked(
       fetch(url, { ...init, headers, signal: ctrl.signal }),
     );
     if (!res.ok) {
+      if (res.status === 429) {
+        const text = await res.text().catch(() => "");
+        const detail = text ? ` (${text.slice(0, 200)})` : "";
+        throw new Error(
+          `Browserbase rate limit reached (max concurrent sessions).${detail} ` +
+            `Do NOT retry - wait for the current session to complete, or upgrade your plan.`,
+        );
+      }
       throw new Error(`HTTP ${res.status}`);
     }
     return res;

--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -3,6 +3,7 @@ import { isLoopbackHost } from "../gateway/net.js";
 import { rawDataToString } from "../infra/ws.js";
 import { getDirectAgentForCdp, withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
 import { CDP_HTTP_REQUEST_TIMEOUT_MS, CDP_WS_HANDSHAKE_TIMEOUT_MS } from "./cdp-timeouts.js";
+import { BROWSER_RATE_LIMIT_MESSAGE } from "./client-fetch.js";
 import { getChromeExtensionRelayAuthHeaders } from "./extension-relay.js";
 
 export { isLoopbackHost };
@@ -176,8 +177,7 @@ export async function fetchCdpChecked(
         const text = await res.text().catch(() => "");
         const detail = text ? ` (${text.slice(0, 200)})` : "";
         throw new Error(
-          `Browserbase rate limit reached (max concurrent sessions).${detail} ` +
-            `Do NOT retry - wait for the current session to complete, or upgrade your plan.`,
+          `${BROWSER_RATE_LIMIT_MESSAGE}${detail} Do NOT retry - wait for the current session to complete, or upgrade your plan.`,
         );
       }
       throw new Error(`HTTP ${res.status}`);

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -139,9 +139,11 @@ describe("fetchBrowserJson loopback auth", () => {
   });
 
   it("surfaces 429 from HTTP URL as rate-limit error with no-retry hint", async () => {
+    const text = vi.fn(async () => "max concurrent sessions exceeded");
+    const cancel = vi.fn(async () => {});
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response("max concurrent sessions exceeded", { status: 429 })),
+      vi.fn(async () => ({ ok: false, status: 429, text, body: { cancel } }) as Response),
     );
 
     const thrown = await fetchBrowserJson<{ ok: boolean }>("http://127.0.0.1:18888/").catch(
@@ -155,6 +157,8 @@ describe("fetchBrowserJson loopback auth", () => {
     expect(thrown.message).toContain("Browser service rate limit reached");
     expect(thrown.message).toContain("Do NOT retry the browser tool");
     expect(thrown.message).not.toContain("max concurrent sessions exceeded");
+    expect(text).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("surfaces 429 from HTTP URL without body detail when empty", async () => {

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -139,11 +139,12 @@ describe("fetchBrowserJson loopback auth", () => {
   });
 
   it("surfaces 429 from HTTP URL as rate-limit error with no-retry hint", async () => {
-    const text = vi.fn(async () => "max concurrent sessions exceeded");
-    const cancel = vi.fn(async () => {});
+    const response = new Response("max concurrent sessions exceeded", { status: 429 });
+    const text = vi.spyOn(response, "text");
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({ ok: false, status: 429, text, body: { cancel } }) as Response),
+      vi.fn(async () => response),
     );
 
     const thrown = await fetchBrowserJson<{ ok: boolean }>("http://127.0.0.1:18888/").catch(

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserDispatchResponse } from "./routes/dispatcher.js";
+
+function okDispatchResponse(): BrowserDispatchResponse {
+  return { status: 200, body: { ok: true } };
+}
 
 const mocks = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({
@@ -9,7 +14,7 @@ const mocks = vi.hoisted(() => ({
     },
   })),
   startBrowserControlServiceFromConfig: vi.fn(async () => ({ ok: true })),
-  dispatch: vi.fn(async () => ({ status: 200, body: { ok: true } })),
+  dispatch: vi.fn(async (): Promise<BrowserDispatchResponse> => okDispatchResponse()),
 }));
 
 vi.mock("../config/config.js", async (importOriginal) => {
@@ -57,7 +62,7 @@ describe("fetchBrowserJson loopback auth", () => {
       },
     });
     mocks.startBrowserControlServiceFromConfig.mockReset().mockResolvedValue({ ok: true });
-    mocks.dispatch.mockReset().mockResolvedValue({ status: 200, body: { ok: true } });
+    mocks.dispatch.mockReset().mockResolvedValue(okDispatchResponse());
   });
 
   afterEach(() => {
@@ -147,13 +152,16 @@ describe("fetchBrowserJson loopback auth", () => {
     if (!(thrown instanceof Error)) {
       throw new Error(`Expected Error, got ${String(thrown)}`);
     }
-    expect(thrown.message).toContain("rate limit reached");
+    expect(thrown.message).toContain("Browser service rate limit reached");
     expect(thrown.message).toContain("Do NOT retry the browser tool");
-    expect(thrown.message).toContain("max concurrent sessions exceeded");
+    expect(thrown.message).not.toContain("max concurrent sessions exceeded");
   });
 
   it("surfaces 429 from HTTP URL without body detail when empty", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response("", { status: 429 })));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 429 })),
+    );
 
     const thrown = await fetchBrowserJson<{ ok: boolean }>("http://127.0.0.1:18888/").catch(
       (err: unknown) => err,
@@ -165,6 +173,25 @@ describe("fetchBrowserJson loopback auth", () => {
     }
     expect(thrown.message).toContain("rate limit reached");
     expect(thrown.message).toContain("Do NOT retry the browser tool");
+  });
+
+  it("keeps Browserbase-specific wording for Browserbase 429 responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("max concurrent sessions exceeded", { status: 429 })),
+    );
+
+    const thrown = await fetchBrowserJson<{ ok: boolean }>(
+      "https://connect.browserbase.com/session",
+    ).catch((err: unknown) => err);
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) {
+      throw new Error(`Expected Error, got ${String(thrown)}`);
+    }
+    expect(thrown.message).toContain("Browserbase rate limit reached");
+    expect(thrown.message).toContain("upgrade your plan");
+    expect(thrown.message).not.toContain("max concurrent sessions exceeded");
   });
 
   it("non-429 errors still produce generic messages", async () => {
@@ -197,9 +224,9 @@ describe("fetchBrowserJson loopback auth", () => {
     if (!(thrown instanceof Error)) {
       throw new Error(`Expected Error, got ${String(thrown)}`);
     }
-    expect(thrown.message).toContain("rate limit reached");
+    expect(thrown.message).toContain("Browser service rate limit reached");
     expect(thrown.message).toContain("Do NOT retry the browser tool");
-    expect(thrown.message).toContain("too many sessions");
+    expect(thrown.message).not.toContain("too many sessions");
   });
 
   it("keeps absolute URL failures wrapped as reachability errors", async () => {

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -133,6 +133,75 @@ describe("fetchBrowserJson loopback auth", () => {
     expect(thrown.message).not.toContain("Can't reach the OpenClaw browser control service");
   });
 
+  it("surfaces 429 from HTTP URL as rate-limit error with no-retry hint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("max concurrent sessions exceeded", { status: 429 })),
+    );
+
+    const thrown = await fetchBrowserJson<{ ok: boolean }>("http://127.0.0.1:18888/").catch(
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) {
+      throw new Error(`Expected Error, got ${String(thrown)}`);
+    }
+    expect(thrown.message).toContain("rate limit reached");
+    expect(thrown.message).toContain("Do NOT retry the browser tool");
+    expect(thrown.message).toContain("max concurrent sessions exceeded");
+  });
+
+  it("surfaces 429 from HTTP URL without body detail when empty", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("", { status: 429 })));
+
+    const thrown = await fetchBrowserJson<{ ok: boolean }>("http://127.0.0.1:18888/").catch(
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) {
+      throw new Error(`Expected Error, got ${String(thrown)}`);
+    }
+    expect(thrown.message).toContain("rate limit reached");
+    expect(thrown.message).toContain("Do NOT retry the browser tool");
+  });
+
+  it("non-429 errors still produce generic messages", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("internal error", { status: 500 })),
+    );
+
+    const thrown = await fetchBrowserJson<{ ok: boolean }>("http://127.0.0.1:18888/").catch(
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) {
+      throw new Error(`Expected Error, got ${String(thrown)}`);
+    }
+    expect(thrown.message).toContain("internal error");
+    expect(thrown.message).not.toContain("rate limit");
+  });
+
+  it("surfaces 429 from dispatcher path as rate-limit error", async () => {
+    mocks.dispatch.mockResolvedValueOnce({
+      status: 429,
+      body: { error: "too many sessions" },
+    });
+
+    const thrown = await fetchBrowserJson<{ ok: boolean }>("/tabs").catch((err: unknown) => err);
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) {
+      throw new Error(`Expected Error, got ${String(thrown)}`);
+    }
+    expect(thrown.message).toContain("rate limit reached");
+    expect(thrown.message).toContain("Do NOT retry the browser tool");
+    expect(thrown.message).toContain("too many sessions");
+  });
+
   it("keeps absolute URL failures wrapped as reachability errors", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -153,6 +153,14 @@ function appendBrowserToolModelHint(message: string): string {
   return `${message} ${BROWSER_TOOL_MODEL_HINT}`;
 }
 
+async function discardResponseBody(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    // Best effort only; we're already returning a stable error message.
+  }
+}
+
 function enhanceDispatcherPathError(url: string, err: unknown): Error {
   const msg = normalizeErrorMessage(err);
   const suffix = `${resolveBrowserFetchOperatorHint(url)} ${BROWSER_TOOL_MODEL_HINT}`;
@@ -205,13 +213,14 @@ async function fetchHttpJson<T>(
   try {
     const res = await fetch(url, { ...init, signal: ctrl.signal });
     if (!res.ok) {
-      const text = await res.text().catch(() => "");
       if (isRateLimitStatus(res.status)) {
         // Do not reflect upstream response text into the error surface (log/agent injection risk)
+        await discardResponseBody(res);
         throw new BrowserServiceError(
           `${resolveBrowserRateLimitMessage(url)} ${BROWSER_TOOL_MODEL_HINT}`,
         );
       }
+      const text = await res.text().catch(() => "");
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
     return (await res.json()) as T;

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -102,6 +102,14 @@ const BROWSER_TOOL_MODEL_HINT =
   "Do NOT retry the browser tool — it will keep failing. " +
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
+const BROWSER_RATE_LIMIT_MESSAGE =
+  "Browserbase rate limit reached (max concurrent sessions). " +
+  "Wait for the current session to complete, or upgrade your plan.";
+
+function isRateLimitStatus(status: number): boolean {
+  return status === 429;
+}
+
 function resolveBrowserFetchOperatorHint(url: string): string {
   const isLocal = !isAbsoluteHttp(url);
   return isLocal
@@ -176,6 +184,12 @@ async function fetchHttpJson<T>(
     const res = await fetch(url, { ...init, signal: ctrl.signal });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
+      if (isRateLimitStatus(res.status)) {
+        const detail = text ? ` (${text.slice(0, 200)})` : "";
+        throw new BrowserServiceError(
+          `${BROWSER_RATE_LIMIT_MESSAGE}${detail} ${BROWSER_TOOL_MODEL_HINT}`,
+        );
+      }
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
     return (await res.json()) as T;
@@ -269,6 +283,15 @@ export async function fetchBrowserJson<T>(
     });
 
     if (result.status >= 400) {
+      if (isRateLimitStatus(result.status)) {
+        const detail =
+          result.body && typeof result.body === "object" && "error" in result.body
+            ? ` (${String((result.body as { error?: unknown }).error).slice(0, 200)})`
+            : "";
+        throw new BrowserServiceError(
+          `${BROWSER_RATE_LIMIT_MESSAGE}${detail} ${BROWSER_TOOL_MODEL_HINT}`,
+        );
+      }
       const message =
         result.body && typeof result.body === "object" && "error" in result.body
           ? String((result.body as { error?: unknown }).error)

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -185,10 +185,8 @@ async function fetchHttpJson<T>(
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       if (isRateLimitStatus(res.status)) {
-        const detail = text ? ` (${text.slice(0, 200)})` : "";
-        throw new BrowserServiceError(
-          `${BROWSER_RATE_LIMIT_MESSAGE}${detail} ${BROWSER_TOOL_MODEL_HINT}`,
-        );
+        // Do not reflect upstream response text into the error surface (log/agent injection risk)
+        throw new BrowserServiceError(`${BROWSER_RATE_LIMIT_MESSAGE} ${BROWSER_TOOL_MODEL_HINT}`);
       }
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
@@ -284,13 +282,8 @@ export async function fetchBrowserJson<T>(
 
     if (result.status >= 400) {
       if (isRateLimitStatus(result.status)) {
-        const detail =
-          result.body && typeof result.body === "object" && "error" in result.body
-            ? ` (${String((result.body as { error?: unknown }).error).slice(0, 200)})`
-            : "";
-        throw new BrowserServiceError(
-          `${BROWSER_RATE_LIMIT_MESSAGE}${detail} ${BROWSER_TOOL_MODEL_HINT}`,
-        );
+        // Do not reflect upstream response text into the error surface (log/agent injection risk)
+        throw new BrowserServiceError(`${BROWSER_RATE_LIMIT_MESSAGE} ${BROWSER_TOOL_MODEL_HINT}`);
       }
       const message =
         result.body && typeof result.body === "object" && "error" in result.body

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -102,7 +102,7 @@ const BROWSER_TOOL_MODEL_HINT =
   "Do NOT retry the browser tool — it will keep failing. " +
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
-const BROWSER_RATE_LIMIT_MESSAGE =
+export const BROWSER_RATE_LIMIT_MESSAGE =
   "Browserbase rate limit reached (max concurrent sessions). " +
   "Wait for the current session to complete, or upgrade your plan.";
 

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -102,12 +102,34 @@ const BROWSER_TOOL_MODEL_HINT =
   "Do NOT retry the browser tool — it will keep failing. " +
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
-export const BROWSER_RATE_LIMIT_MESSAGE =
+const BROWSER_SERVICE_RATE_LIMIT_MESSAGE =
+  "Browser service rate limit reached. " +
+  "Wait for the current session to complete, or retry later.";
+
+const BROWSERBASE_RATE_LIMIT_MESSAGE =
   "Browserbase rate limit reached (max concurrent sessions). " +
   "Wait for the current session to complete, or upgrade your plan.";
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
+}
+
+function isBrowserbaseUrl(url: string): boolean {
+  if (!isAbsoluteHttp(url)) {
+    return false;
+  }
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "browserbase.com" || host.endsWith(".browserbase.com");
+  } catch {
+    return false;
+  }
+}
+
+export function resolveBrowserRateLimitMessage(url: string): string {
+  return isBrowserbaseUrl(url)
+    ? BROWSERBASE_RATE_LIMIT_MESSAGE
+    : BROWSER_SERVICE_RATE_LIMIT_MESSAGE;
 }
 
 function resolveBrowserFetchOperatorHint(url: string): string {
@@ -186,7 +208,9 @@ async function fetchHttpJson<T>(
       const text = await res.text().catch(() => "");
       if (isRateLimitStatus(res.status)) {
         // Do not reflect upstream response text into the error surface (log/agent injection risk)
-        throw new BrowserServiceError(`${BROWSER_RATE_LIMIT_MESSAGE} ${BROWSER_TOOL_MODEL_HINT}`);
+        throw new BrowserServiceError(
+          `${resolveBrowserRateLimitMessage(url)} ${BROWSER_TOOL_MODEL_HINT}`,
+        );
       }
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
@@ -283,7 +307,9 @@ export async function fetchBrowserJson<T>(
     if (result.status >= 400) {
       if (isRateLimitStatus(result.status)) {
         // Do not reflect upstream response text into the error surface (log/agent injection risk)
-        throw new BrowserServiceError(`${BROWSER_RATE_LIMIT_MESSAGE} ${BROWSER_TOOL_MODEL_HINT}`);
+        throw new BrowserServiceError(
+          `${resolveBrowserRateLimitMessage(url)} ${BROWSER_TOOL_MODEL_HINT}`,
+        );
       }
       const message =
         result.body && typeof result.body === "object" && "error" in result.body

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -367,7 +367,7 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
         lastErr = err;
         // Don't retry rate-limit errors; retrying worsens the 429.
         const errMsg = err instanceof Error ? err.message : String(err);
-        if (errMsg.includes("rate limit") || errMsg.includes("429")) {
+        if (errMsg.includes("rate limit")) {
           break;
         }
         const delay = 250 + attempt * 250;

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -365,6 +365,11 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
         return connected;
       } catch (err) {
         lastErr = err;
+        // Don't retry rate-limit errors; retrying worsens the 429.
+        const errMsg = err instanceof Error ? err.message : String(err);
+        if (errMsg.includes("rate limit") || errMsg.includes("429")) {
+          break;
+        }
         const delay = 250 + attempt * 250;
         await new Promise((r) => setTimeout(r, delay));
       }


### PR DESCRIPTION
Fixes #40390

## Summary

When Browserbase returns 429 (max concurrent sessions exceeded), users see a generic "Browser control failed" message leading to unnecessary gateway restarts and agent retry loops.

This PR detects 429 responses and surfaces actionable error messages with explicit "do not retry" guidance.

## Changes

- **`src/browser/client-fetch.ts`** - Detect 429 in both HTTP and dispatcher paths, throw `BrowserServiceError` with rate-limit message and `BROWSER_TOOL_MODEL_HINT`
- **`src/browser/cdp.helpers.ts`** - Detect 429 in `fetchCdpChecked` with descriptive error
- **`src/browser/pw-session.ts`** - Break out of `connectBrowser` retry loop on rate-limit errors (prevents retry amplification)
- **`src/browser/client-fetch.loopback-auth.test.ts`** - 4 test cases for 429 detection

## Error message

```
Browserbase rate limit reached (max concurrent sessions).
Wait for the current session to complete, or upgrade your plan.
Do NOT retry the browser tool - it will keep failing.
```

This contribution was developed with AI assistance (Claude Code).