### PR TITLE
feat(tui): prioritize configured models in model picker

### DIFF
--- a/src/commands/model-picker.ts
+++ b/src/commands/model-picker.ts
@@ -58,7 +58,7 @@ function hasAuthForProvider(
   return false;
 }
 
-function createProviderAuthChecker(params: {
+export function createProviderAuthChecker(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
 }): (provider: string) => boolean {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCommandHandlers } from "./tui-command-handlers.js";
+import { createCommandHandlers, partitionModelItems } from "./tui-command-handlers.js";
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
@@ -169,5 +169,71 @@ describe("tui command handlers", () => {
     expect(addUser).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith("not connected to gateway — message not sent");
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
+  });
+});
+
+describe("partitionModelItems", () => {
+  const models = [
+    { id: "gpt-4o", provider: "openai", name: "GPT-4o", contextWindow: 128_000 },
+    { id: "claude-opus-4-6", provider: "anthropic", name: "Claude Opus 4.6", contextWindow: 200_000, reasoning: true },
+    { id: "gemini-2.5-pro", provider: "google", name: "Gemini 2.5 Pro" },
+    { id: "llama-3", provider: "groq", name: "Llama 3" },
+  ];
+
+  it("places authenticated providers before unauthenticated", () => {
+    const items = partitionModelItems(models, (p) => p === "anthropic");
+
+    expect(items[0]!.value).toBe("anthropic/claude-opus-4-6");
+    expect(items.length).toBe(4);
+    expect(items[1]!.value).toBe("openai/gpt-4o");
+    expect(items[2]!.value).toBe("google/gemini-2.5-pro");
+    expect(items[3]!.value).toBe("groq/llama-3");
+  });
+
+  it("preserves original order when no models have auth", () => {
+    const items = partitionModelItems(models, () => false);
+
+    expect(items.map((i) => i.value)).toEqual([
+      "openai/gpt-4o",
+      "anthropic/claude-opus-4-6",
+      "google/gemini-2.5-pro",
+      "groq/llama-3",
+    ]);
+  });
+
+  it("preserves original order when all models have auth", () => {
+    const items = partitionModelItems(models, () => true);
+
+    expect(items.map((i) => i.value)).toEqual([
+      "openai/gpt-4o",
+      "anthropic/claude-opus-4-6",
+      "google/gemini-2.5-pro",
+      "groq/llama-3",
+    ]);
+  });
+
+  it("includes context window and reasoning in description", () => {
+    const items = partitionModelItems(models, () => true);
+    const anthropic = items.find((i) => i.value === "anthropic/claude-opus-4-6");
+
+    expect(anthropic!.description).toContain("Claude Opus 4.6");
+    expect(anthropic!.description).toContain("ctx 200k");
+    expect(anthropic!.description).toContain("reasoning");
+  });
+
+  it("handles multiple authenticated providers", () => {
+    const authed = new Set(["openai", "google"]);
+    const items = partitionModelItems(models, (p) => authed.has(p));
+
+    expect(items.map((i) => i.value)).toEqual([
+      "openai/gpt-4o",
+      "google/gemini-2.5-pro",
+      "anthropic/claude-opus-4-6",
+      "groq/llama-3",
+    ]);
+  });
+
+  it("returns empty array for empty models list", () => {
+    expect(partitionModelItems([], () => true)).toEqual([]);
   });
 });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -242,4 +242,11 @@ describe("partitionModelItems", () => {
   it("returns empty array for empty models list", () => {
     expect(partitionModelItems([], () => true)).toEqual([]);
   });
+
+  it("sanitizes control characters in model metadata", () => {
+    const models = [{ id: "model\x1b[31m-evil", provider: "bad\x1b]52;;base64\x07provider" }];
+    const items = partitionModelItems(models, () => true);
+    expect(items[0].label).not.toContain("\x1b");
+    expect(items[0].label).not.toContain("\x07");
+  });
 });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -175,7 +175,13 @@ describe("tui command handlers", () => {
 describe("partitionModelItems", () => {
   const models = [
     { id: "gpt-4o", provider: "openai", name: "GPT-4o", contextWindow: 128_000 },
-    { id: "claude-opus-4-6", provider: "anthropic", name: "Claude Opus 4.6", contextWindow: 200_000, reasoning: true },
+    {
+      id: "claude-opus-4-6",
+      provider: "anthropic",
+      name: "Claude Opus 4.6",
+      contextWindow: 200_000,
+      reasoning: true,
+    },
     { id: "gemini-2.5-pro", provider: "google", name: "Gemini 2.5 Pro" },
     { id: "llama-3", provider: "groq", name: "Llama 3" },
   ];
@@ -183,11 +189,11 @@ describe("partitionModelItems", () => {
   it("places authenticated providers before unauthenticated", () => {
     const items = partitionModelItems(models, (p) => p === "anthropic");
 
-    expect(items[0]!.value).toBe("anthropic/claude-opus-4-6");
+    expect(items[0].value).toBe("anthropic/claude-opus-4-6");
     expect(items.length).toBe(4);
-    expect(items[1]!.value).toBe("openai/gpt-4o");
-    expect(items[2]!.value).toBe("google/gemini-2.5-pro");
-    expect(items[3]!.value).toBe("groq/llama-3");
+    expect(items[1].value).toBe("openai/gpt-4o");
+    expect(items[2].value).toBe("google/gemini-2.5-pro");
+    expect(items[3].value).toBe("groq/llama-3");
   });
 
   it("preserves original order when no models have auth", () => {
@@ -217,7 +223,7 @@ describe("partitionModelItems", () => {
     const anthropic = items.find((i) => i.value === "anthropic/claude-opus-4-6");
 
     expect(anthropic!.description).toContain("Claude Opus 4.6");
-    expect(anthropic!.description).toContain("ctx 200k");
+    expect(anthropic!.description).toContain("ctx 195k");
     expect(anthropic!.description).toContain("reasoning");
   });
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -111,9 +111,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       }
 
       // Partition models: show configured/authenticated providers first.
-      // Skip partitioning in remote mode (--url) because loadConfig() returns
-      // local auth which doesn't reflect the remote gateway's credentials.
-      const hasAuth = opts.url ? () => false : createProviderAuthChecker({ cfg: loadConfig() });
+      // Skip partitioning in remote mode (--url or config gateway.mode=remote)
+      // because loadConfig() returns local auth which doesn't reflect the
+      // remote gateway's credentials.
+      const cfg = loadConfig();
+      const isRemote = opts.url || cfg.gateway?.mode === "remote";
+      const hasAuth = isRemote ? () => false : createProviderAuthChecker({ cfg });
       const items = partitionModelItems(models, hasAuth);
 
       const selector = createSearchableSelectList(items, 9);

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -127,11 +127,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`model set failed: ${String(err)}`);
+          chatLog.addSystem(`model set failed: ${sanitizeRenderableText(String(err))}`);
         }
       });
     } catch (err) {
-      chatLog.addSystem(`model list failed: ${String(err)}`);
+      chatLog.addSystem(`model list failed: ${sanitizeRenderableText(String(err))}`);
       tui.requestRender();
     }
   };
@@ -304,7 +304,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             applySessionInfoFromPatch(result);
             await refreshSessionInfo();
           } catch (err) {
-            chatLog.addSystem(`model set failed: ${String(err)}`);
+            chatLog.addSystem(`model set failed: ${sanitizeRenderableText(String(err))}`);
           }
         }
         break;

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -5,6 +5,9 @@ import {
   normalizeUsageDisplay,
   resolveResponseUsageMode,
 } from "../auto-reply/thinking.js";
+import { createProviderAuthChecker } from "../commands/model-picker.js";
+import { formatTokenK } from "../commands/models/shared.js";
+import { loadConfig } from "../config/config.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -16,9 +19,6 @@ import {
   createSettingsList,
 } from "./components/selectors.js";
 import type { GatewayChatClient } from "./gateway-chat.js";
-import { loadConfig } from "../config/config.js";
-import { createProviderAuthChecker } from "../commands/model-picker.js";
-import { formatTokenK } from "../commands/models/shared.js";
 import { sanitizeRenderableText } from "./tui-formatters.js";
 import { formatStatusSummary } from "./tui-status-summary.js";
 import type {
@@ -111,6 +111,8 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       }
 
       // Partition models: show configured/authenticated providers first
+      // Note: agentDir not passed — agent-scoped auth credentials are not checked.
+      // CommandHandlerContext doesn't expose agentDir yet; thread it through when available.
       const hasAuth = createProviderAuthChecker({ cfg: loadConfig() });
       const items = partitionModelItems(models, hasAuth);
 
@@ -525,7 +527,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
 
 /** Build select items from model list, partitioned by auth status. */
 export function partitionModelItems(
-  models: { id: string; provider: string; name?: string; contextWindow?: number; reasoning?: boolean }[],
+  models: {
+    id: string;
+    provider: string;
+    name?: string;
+    contextWindow?: number;
+    reasoning?: boolean;
+  }[],
   hasAuth: (provider: string) => boolean,
 ): SelectItem[] {
   const configuredItems: SelectItem[] = [];
@@ -534,9 +542,15 @@ export function partitionModelItems(
   for (const model of models) {
     const value = `${model.provider}/${model.id}`;
     const descParts: string[] = [];
-    if (model.name && model.name !== model.id) descParts.push(model.name);
-    if (model.contextWindow) descParts.push(`ctx ${formatTokenK(model.contextWindow)}`);
-    if (model.reasoning) descParts.push("reasoning");
+    if (model.name && model.name !== model.id) {
+      descParts.push(model.name);
+    }
+    if (model.contextWindow) {
+      descParts.push(`ctx ${formatTokenK(model.contextWindow)}`);
+    }
+    if (model.reasoning) {
+      descParts.push("reasoning");
+    }
 
     const item: SelectItem = {
       value,

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -110,10 +110,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         return;
       }
 
-      // Partition models: show configured/authenticated providers first
-      // Note: agentDir not passed — agent-scoped auth credentials are not checked.
-      // CommandHandlerContext doesn't expose agentDir yet; thread it through when available.
-      const hasAuth = createProviderAuthChecker({ cfg: loadConfig() });
+      // Partition models: show configured/authenticated providers first.
+      // Skip partitioning in remote mode (--url) because loadConfig() returns
+      // local auth which doesn't reflect the remote gateway's credentials.
+      const hasAuth = opts.url ? () => false : createProviderAuthChecker({ cfg: loadConfig() });
       const items = partitionModelItems(models, hasAuth);
 
       const selector = createSearchableSelectList(items, 9);

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -123,7 +123,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             key: state.currentSessionKey,
             model: value,
           });
-          chatLog.addSystem(`model set to ${value}`);
+          chatLog.addSystem(`model set to ${sanitizeRenderableText(value)}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
@@ -554,8 +554,8 @@ export function partitionModelItems(
 
     const item: SelectItem = {
       value,
-      label: value,
-      description: descParts.join(" · "),
+      label: sanitizeRenderableText(value),
+      description: sanitizeRenderableText(descParts.join(" · ")),
     };
 
     if (hasAuth(model.provider)) {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -16,6 +16,9 @@ import {
   createSettingsList,
 } from "./components/selectors.js";
 import type { GatewayChatClient } from "./gateway-chat.js";
+import { loadConfig } from "../config/config.js";
+import { createProviderAuthChecker } from "../commands/model-picker.js";
+import { formatTokenK } from "../commands/models/shared.js";
 import { sanitizeRenderableText } from "./tui-formatters.js";
 import { formatStatusSummary } from "./tui-status-summary.js";
 import type {
@@ -106,11 +109,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         tui.requestRender();
         return;
       }
-      const items = models.map((model) => ({
-        value: `${model.provider}/${model.id}`,
-        label: `${model.provider}/${model.id}`,
-        description: model.name && model.name !== model.id ? model.name : "",
-      }));
+
+      // Partition models: show configured/authenticated providers first
+      const hasAuth = createProviderAuthChecker({ cfg: loadConfig() });
+      const items = partitionModelItems(models, hasAuth);
+
       const selector = createSearchableSelectList(items, 9);
       openSelector(selector, async (value) => {
         try {
@@ -518,4 +521,35 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     openSettings,
     setAgent,
   };
+}
+
+/** Build select items from model list, partitioned by auth status. */
+export function partitionModelItems(
+  models: { id: string; provider: string; name?: string; contextWindow?: number; reasoning?: boolean }[],
+  hasAuth: (provider: string) => boolean,
+): SelectItem[] {
+  const configuredItems: SelectItem[] = [];
+  const otherItems: SelectItem[] = [];
+
+  for (const model of models) {
+    const value = `${model.provider}/${model.id}`;
+    const descParts: string[] = [];
+    if (model.name && model.name !== model.id) descParts.push(model.name);
+    if (model.contextWindow) descParts.push(`ctx ${formatTokenK(model.contextWindow)}`);
+    if (model.reasoning) descParts.push("reasoning");
+
+    const item: SelectItem = {
+      value,
+      label: value,
+      description: descParts.join(" · "),
+    };
+
+    if (hasAuth(model.provider)) {
+      configuredItems.push(item);
+    } else {
+      otherItems.push(item);
+    }
+  }
+
+  return configuredItems.length > 0 ? [...configuredItems, ...otherItems] : [...otherItems];
 }


### PR DESCRIPTION
Fixes #40412

## Summary

The TUI model picker shows all 600+ models, making it hard to find configured models. This PR partitions models by auth status so configured providers appear first.

## Changes

- **`src/commands/model-picker.ts`** - Exported `createProviderAuthChecker` for reuse
- **`src/tui/tui-command-handlers.ts`** - Modified `openModelSelector` to partition models by auth status; extracted `partitionModelItems` helper with richer descriptions (context window, reasoning hints)
- **`src/tui/tui-command-handlers.test.ts`** - 6 tests for partitioning behavior

## How it works

1. When the model picker opens, models are partitioned into "has auth" vs "no auth"
2. Authenticated provider models appear first, followed by the rest
3. If no provider has auth, all models show in original order (fallback)
4. Descriptions now include context window size and reasoning capability
5. Existing `SearchableSelectList` fuzzy search continues to work across all models

All changes are client-side in the TUI - the gateway `models.list` response is unchanged.

This contribution was developed with AI assistance (Claude Code).