### PR TITLE
fix: use atomic write for auth-profiles.json to prevent corruption

### DIFF
--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadJsonFile, saveJsonFile } from "./json-file.js";
+
+describe("saveJsonFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes valid JSON that loadJsonFile can read back", () => {
+    const filePath = path.join(tmpDir, "test.json");
+    const data = { version: 1, profiles: { "openai:default": { type: "api_key", key: "sk-test" } } };
+    saveJsonFile(filePath, data);
+    const loaded = loadJsonFile(filePath);
+    expect(loaded).toEqual(data);
+  });
+
+  it("creates parent directories when they do not exist", () => {
+    const filePath = path.join(tmpDir, "a", "b", "test.json");
+    saveJsonFile(filePath, { ok: true });
+    expect(loadJsonFile(filePath)).toEqual({ ok: true });
+  });
+
+  it("overwrites existing file atomically", () => {
+    const filePath = path.join(tmpDir, "test.json");
+    saveJsonFile(filePath, { version: 1 });
+    saveJsonFile(filePath, { version: 2 });
+    expect(loadJsonFile(filePath)).toEqual({ version: 2 });
+  });
+
+  it("does not leave temp files on success", () => {
+    const filePath = path.join(tmpDir, "test.json");
+    saveJsonFile(filePath, { ok: true });
+    const files = fs.readdirSync(tmpDir);
+    expect(files).toEqual(["test.json"]);
+  });
+
+  it("cleans up temp file and re-throws when writeFileSync fails", () => {
+    const filePath = path.join(tmpDir, "test.json");
+    // Make the directory read-only after mkdir to cause writeFileSync to fail
+    // on the temp file.
+    const spy = vi.spyOn(fs, "writeFileSync").mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+    expect(() => saveJsonFile(filePath, { ok: true })).toThrow("disk full");
+    spy.mockRestore();
+    // No temp files should remain.
+    const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".tmp"));
+    expect(files).toHaveLength(0);
+  });
+
+  it("sets file permissions to 0o600", () => {
+    const filePath = path.join(tmpDir, "test.json");
+    saveJsonFile(filePath, { secure: true });
+    const stat = fs.statSync(filePath);
+    // Mask with 0o777 to ignore sticky/setuid bits.
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("produces parseable JSON after many rapid sequential writes", () => {
+    const filePath = path.join(tmpDir, "rapid.json");
+    for (let i = 0; i < 50; i++) {
+      saveJsonFile(filePath, { iteration: i, data: "x".repeat(200) });
+    }
+    const result = loadJsonFile(filePath) as { iteration: number };
+    expect(result.iteration).toBe(49);
+    // Verify the file is valid JSON by reading raw content.
+    const raw = fs.readFileSync(filePath, "utf8");
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+});
+
+describe("loadJsonFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns undefined for non-existent file", () => {
+    expect(loadJsonFile(path.join(tmpDir, "nope.json"))).toBeUndefined();
+  });
+
+  it("returns undefined for invalid JSON", () => {
+    const filePath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(filePath, "not json {{{");
+    expect(loadJsonFile(filePath)).toBeUndefined();
+  });
+});

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -13,11 +14,30 @@ export function loadJsonFile(pathname: string): unknown {
   }
 }
 
+/**
+ * Atomically write JSON to disk: serialize to a temp file in the same
+ * directory, then `fs.renameSync` over the target.  `rename(2)` is atomic
+ * on POSIX when source and destination live on the same filesystem, so
+ * concurrent readers never see a half-written file.
+ */
 export function saveJsonFile(pathname: string, data: unknown) {
   const dir = path.dirname(pathname);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
+  const content = `${JSON.stringify(data, null, 2)}\n`;
+  // Temp file in the same directory guarantees same filesystem for atomic rename.
+  const tmpPath = path.join(dir, `.${path.basename(pathname)}.${crypto.randomBytes(6).toString("hex")}.tmp`);
+  try {
+    fs.writeFileSync(tmpPath, content, { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, pathname);
+  } catch (err) {
+    // Clean up the temp file on failure so we don't leave orphans.
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Ignore cleanup errors (file may not exist).
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #40471

- **Problem**: `auth-profiles.json` is periodically corrupted when multiple services (Telegram polling, MQTT listener, cron jobs) trigger concurrent auth token refreshes. Two JSON objects get concatenated—first complete, second truncated—rendering the file unparseable with `json.decoder.JSONDecodeError: Extra data`.

- **Solution**: Replace the direct `fs.writeFileSync` in `saveJsonFile()` (`src/infra/json-file.ts`) with an atomic write-to-temp-then-rename pattern:
  1. Serialize JSON to a temp file (`.filename.randomhex.tmp`) in the **same directory** as the target
  2. Use `fs.renameSync()` to atomically replace the original file — `rename(2)` is atomic on POSIX when source and destination are on the same filesystem
  3. Clean up the temp file on failure to prevent orphaned files

- **Scope**: This fix applies to all callers of `saveJsonFile`, including auth profile store writes, OAuth credential saves, CLI credential writes, and other JSON persistence throughout the codebase. The function is the single write path for `auth-profiles.json`.

## Test plan

- [x] Added `src/infra/json-file.test.ts` with tests covering:
  - Round-trip write + read correctness
  - Parent directory auto-creation
  - Atomic overwrite of existing files
  - No temp file leakage on success
  - Temp file cleanup on write failure
  - File permissions (0o600)
  - Rapid sequential writes produce valid JSON
  - `loadJsonFile` edge cases (missing file, corrupt JSON)
- [x] All 8 tests pass locally

Generated with [Claude Code](https://claude.com/claude-code)