### PR TITLE
fix(heartbeat): respect custom prompt without appending path hint

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1087,6 +1087,7 @@ describe("runHeartbeatOnce", () => {
     reason?: "interval" | "wake";
     queueCronEvent?: boolean;
     replyText?: string;
+    customPrompt?: string;
   }) {
     const tmpDir = await createCaseDir("openclaw-hb");
     const storePath = path.join(tmpDir, "sessions.json");
@@ -1110,11 +1111,15 @@ describe("runHeartbeatOnce", () => {
       await fs.mkdir(path.join(workspaceDir, "HEARTBEAT.md"), { recursive: true });
     }
 
+    const heartbeatCfg: Record<string, unknown> = { every: "5m", target: "whatsapp" };
+    if (params.customPrompt) {
+      heartbeatCfg.prompt = params.customPrompt;
+    }
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
           workspace: workspaceDir,
-          heartbeat: { every: "5m", target: "whatsapp" },
+          heartbeat: heartbeatCfg,
         },
       },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -1168,6 +1173,27 @@ describe("runHeartbeatOnce", () => {
       const expectedPath = path.join(workspaceDir, "HEARTBEAT.md").replace(/\\/g, "/");
       expect(calledCtx.Body).toContain(`use workspace file ${expectedPath} (exact case)`);
       expect(calledCtx.Body).toContain("Do not read docs/heartbeat.md.");
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
+  it("does not append workspace path hint when user configured a custom heartbeat prompt", async () => {
+    const customPrompt = "Read HEARTBEAT.md from system prompt context only. Do not read any file.";
+    const { res, replySpy } = await runHeartbeatFileScenario({
+      fileState: "actionable",
+      reason: "interval",
+      replyText: "Checked logs",
+      customPrompt,
+    });
+    try {
+      expect(res.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      // Custom prompt should be used as-is without appended path hint
+      expect(calledCtx.Body).toContain(customPrompt);
+      expect(calledCtx.Body).not.toContain("use workspace file");
+      expect(calledCtx.Body).not.toContain("Do not read docs/heartbeat.md.");
     } finally {
       replySpy.mockRestore();
     }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -506,12 +506,20 @@ function resolveHeartbeatRunPrompt(params: {
     .map((event) => event.text);
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
   const hasCronEvents = cronEvents.length > 0;
+  const isCustomHeartbeatPrompt = Boolean(
+    params.heartbeat?.prompt ?? params.cfg.agents?.defaults?.heartbeat?.prompt,
+  );
   const basePrompt = hasExecCompletion
     ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
-  const prompt = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
+  // Only append workspace path hint for the default heartbeat prompt.
+  // Custom user prompts should be respected as-is (#40255).
+  const prompt =
+    isCustomHeartbeatPrompt || hasExecCompletion || hasCronEvents
+      ? basePrompt
+      : appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
 
   return { prompt, hasExecCompletion, hasCronEvents };
 }


### PR DESCRIPTION
## Summary

- Fix `appendHeartbeatWorkspacePathHint` unconditionally appending workspace path guidance to heartbeat prompts, even when the user configured a custom prompt
- Now only appends the path hint when using the default heartbeat prompt, respecting user-configured custom prompts as-is
- Added test verifying custom prompts are not modified

## Change Type
Bug fix

## Scope
`src/infra/heartbeat-runner.ts`, `src/infra/heartbeat-runner.returns-default-unset.test.ts`

## Security Impact
No security impact.

Closes #40255

🤖 Generated with [Claude Code](https://claude.com/claude-code)