### PR TITLE
fix(auth): sync openai-codex cli credentials to default profile slot

### DIFF
--- a/src/agents/auth-profiles.codex-cli-sync.test.ts
+++ b/src/agents/auth-profiles.codex-cli-sync.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
+
+/**
+ * The sync target profile ID used by syncExternalCliCredentials for Codex CLI.
+ * Must match the CODEX_CLI_SYNC_PROFILE_ID constant in external-cli-sync.ts.
+ */
+const CODEX_SYNC_PROFILE_ID = "openai-codex:default";
+
+const mocks = vi.hoisted(() => ({
+  readCodexCliCredentialsCached: vi.fn().mockReturnValue(null),
+  readQwenCliCredentialsCached: vi.fn().mockReturnValue(null),
+  readMiniMaxCliCredentialsCached: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("./cli-credentials.js", () => ({
+  readCodexCliCredentialsCached: mocks.readCodexCliCredentialsCached,
+  readQwenCliCredentialsCached: mocks.readQwenCliCredentialsCached,
+  readMiniMaxCliCredentialsCached: mocks.readMiniMaxCliCredentialsCached,
+}));
+
+const { syncExternalCliCredentials } = await import("./auth-profiles/external-cli-sync.js");
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("codex CLI credential sync", () => {
+  it("syncs Codex CLI credentials into the default profile slot", () => {
+    const now = Date.now();
+    const codexCreds = {
+      type: "oauth" as const,
+      provider: "openai-codex" as const,
+      access: "codex-access-token",
+      refresh: "codex-refresh-token",
+      expires: now + 60 * 60 * 1000,
+    };
+    mocks.readCodexCliCredentialsCached.mockReturnValue(codexCreds);
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {},
+    };
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
+    expect(mutated).toBe(true);
+    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "codex-access-token",
+      refresh: "codex-refresh-token",
+    });
+  });
+
+  it("does not sync when Codex CLI credentials are unavailable", () => {
+    mocks.readCodexCliCredentialsCached.mockReturnValue(null);
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {},
+    };
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
+    expect(mutated).toBe(false);
+    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toBeUndefined();
+  });
+
+  it("updates stale Codex CLI credentials with fresher ones", () => {
+    const now = Date.now();
+    const freshCreds = {
+      type: "oauth" as const,
+      provider: "openai-codex" as const,
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+      expires: now + 2 * 60 * 60 * 1000,
+    };
+    mocks.readCodexCliCredentialsCached.mockReturnValue(freshCreds);
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [CODEX_SYNC_PROFILE_ID]: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "stale-access-token",
+          refresh: "stale-refresh-token",
+          expires: now - 60 * 1000, // expired
+        },
+      },
+    };
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
+    expect(mutated).toBe(true);
+    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+    });
+  });
+
+  it("skips sync when existing default profile is still fresh", () => {
+    const now = Date.now();
+    const existingCreds = {
+      type: "oauth" as const,
+      provider: "openai-codex",
+      access: "existing-access",
+      refresh: "existing-refresh",
+      expires: now + 60 * 60 * 1000, // 1 hour from now, well within freshness
+    };
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [CODEX_SYNC_PROFILE_ID]: existingCreds,
+      },
+    };
+
+    const mutated = syncExternalCliCredentials(store);
+
+    // The freshness guard must prevent the credential reader from being invoked.
+    expect(mocks.readCodexCliCredentialsCached).not.toHaveBeenCalled();
+    expect(mutated).toBe(false);
+    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+      access: "existing-access",
+    });
+  });
+
+  it("syncs Codex credentials with accountId metadata", () => {
+    const now = Date.now();
+    const codexCreds = {
+      type: "oauth" as const,
+      provider: "openai-codex" as const,
+      access: "codex-access-token",
+      refresh: "codex-refresh-token",
+      expires: now + 60 * 60 * 1000,
+      accountId: "user-123",
+    };
+    mocks.readCodexCliCredentialsCached.mockReturnValue(codexCreds);
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {},
+    };
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
+    expect(mutated).toBe(true);
+    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "codex-access-token",
+      accountId: "user-123",
+    });
+  });
+
+  it("does not write into the deprecated codex-cli profile slot", () => {
+    const now = Date.now();
+    const codexCreds = {
+      type: "oauth" as const,
+      provider: "openai-codex" as const,
+      access: "codex-access-token",
+      refresh: "codex-refresh-token",
+      expires: now + 60 * 60 * 1000,
+    };
+    mocks.readCodexCliCredentialsCached.mockReturnValue(codexCreds);
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {},
+    };
+
+    syncExternalCliCredentials(store);
+
+    // Must never touch the deprecated profile ID that doctor-auth removes.
+    expect(store.profiles["openai-codex:codex-cli"]).toBeUndefined();
+    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toBeDefined();
+  });
+});

--- a/src/agents/auth-profiles.codex-cli-sync.test.ts
+++ b/src/agents/auth-profiles.codex-cli-sync.test.ts
@@ -1,12 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { AUTH_STORE_VERSION, CODEX_CLI_SYNC_PROFILE_ID } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-
-/**
- * The sync target profile ID used by syncExternalCliCredentials for Codex CLI.
- * Must match the CODEX_CLI_SYNC_PROFILE_ID constant in external-cli-sync.ts.
- */
-const CODEX_SYNC_PROFILE_ID = "openai-codex:default";
 
 const mocks = vi.hoisted(() => ({
   readCodexCliCredentialsCached: vi.fn().mockReturnValue(null),
@@ -47,7 +41,7 @@ describe("codex CLI credential sync", () => {
 
     expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
     expect(mutated).toBe(true);
-    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+    expect(store.profiles[CODEX_CLI_SYNC_PROFILE_ID]).toMatchObject({
       type: "oauth",
       provider: "openai-codex",
       access: "codex-access-token",
@@ -67,7 +61,7 @@ describe("codex CLI credential sync", () => {
 
     expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
     expect(mutated).toBe(false);
-    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toBeUndefined();
+    expect(store.profiles[CODEX_CLI_SYNC_PROFILE_ID]).toBeUndefined();
   });
 
   it("updates stale Codex CLI credentials with fresher ones", () => {
@@ -84,7 +78,7 @@ describe("codex CLI credential sync", () => {
     const store: AuthProfileStore = {
       version: AUTH_STORE_VERSION,
       profiles: {
-        [CODEX_SYNC_PROFILE_ID]: {
+        [CODEX_CLI_SYNC_PROFILE_ID]: {
           type: "oauth",
           provider: "openai-codex",
           access: "stale-access-token",
@@ -98,7 +92,7 @@ describe("codex CLI credential sync", () => {
 
     expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
     expect(mutated).toBe(true);
-    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+    expect(store.profiles[CODEX_CLI_SYNC_PROFILE_ID]).toMatchObject({
       access: "fresh-access-token",
       refresh: "fresh-refresh-token",
     });
@@ -117,7 +111,7 @@ describe("codex CLI credential sync", () => {
     const store: AuthProfileStore = {
       version: AUTH_STORE_VERSION,
       profiles: {
-        [CODEX_SYNC_PROFILE_ID]: existingCreds,
+        [CODEX_CLI_SYNC_PROFILE_ID]: existingCreds,
       },
     };
 
@@ -126,7 +120,7 @@ describe("codex CLI credential sync", () => {
     // The freshness guard must prevent the credential reader from being invoked.
     expect(mocks.readCodexCliCredentialsCached).not.toHaveBeenCalled();
     expect(mutated).toBe(false);
-    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+    expect(store.profiles[CODEX_CLI_SYNC_PROFILE_ID]).toMatchObject({
       access: "existing-access",
     });
   });
@@ -152,7 +146,7 @@ describe("codex CLI credential sync", () => {
 
     expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalled();
     expect(mutated).toBe(true);
-    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toMatchObject({
+    expect(store.profiles[CODEX_CLI_SYNC_PROFILE_ID]).toMatchObject({
       type: "oauth",
       provider: "openai-codex",
       access: "codex-access-token",
@@ -180,6 +174,6 @@ describe("codex CLI credential sync", () => {
 
     // Must never touch the deprecated profile ID that doctor-auth removes.
     expect(store.profiles["openai-codex:codex-cli"]).toBeUndefined();
-    expect(store.profiles[CODEX_SYNC_PROFILE_ID]).toBeDefined();
+    expect(store.profiles[CODEX_CLI_SYNC_PROFILE_ID]).toBeDefined();
   });
 });

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -9,6 +9,18 @@ export const CODEX_CLI_PROFILE_ID = "openai-codex:codex-cli";
 export const QWEN_CLI_PROFILE_ID = "qwen-portal:qwen-cli";
 export const MINIMAX_CLI_PROFILE_ID = "minimax-portal:minimax-cli";
 
+/**
+ * Sync target for Codex CLI credentials.
+ *
+ * We intentionally use `openai-codex:default` — the same slot that
+ * `openclaw models auth login --provider openai-codex` writes to — so that
+ * the two auth paths converge on a single, non-deprecated profile.
+ *
+ * The legacy `CODEX_CLI_PROFILE_ID` (`openai-codex:codex-cli`) is treated as
+ * deprecated by `maybeRemoveDeprecatedCliAuthProfiles` in `doctor-auth.ts`.
+ */
+export const CODEX_CLI_SYNC_PROFILE_ID = "openai-codex:default";
+
 export const AUTH_STORE_LOCK_OPTIONS = {
   retries: {
     retries: 10,

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -1,4 +1,5 @@
 import {
+  readCodexCliCredentialsCached,
   readQwenCliCredentialsCached,
   readMiniMaxCliCredentialsCached,
 } from "../cli-credentials.js";
@@ -10,6 +11,20 @@ import {
   log,
 } from "./constants.js";
 import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
+
+/**
+ * Target profile ID for Codex CLI credential sync.
+ *
+ * We intentionally sync into `openai-codex:default` — the same slot that
+ * `openclaw models auth login --provider openai-codex` writes to — so that
+ * the two auth paths converge on a single, non-deprecated profile.
+ *
+ * The legacy constant `CODEX_CLI_PROFILE_ID` (`openai-codex:codex-cli`) is
+ * treated as deprecated by `maybeRemoveDeprecatedCliAuthProfiles` in
+ * `doctor-auth.ts`; syncing into it would cause persistent warning churn on
+ * every `openclaw doctor` run.
+ */
+const CODEX_CLI_SYNC_PROFILE_ID = "openai-codex:default";
 
 function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCredential): boolean {
   if (!a) {
@@ -30,6 +45,8 @@ function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCr
   );
 }
 
+const EXTERNAL_CLI_PROVIDERS = new Set(["qwen-portal", "minimax-portal", "openai-codex"]);
+
 function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: number): boolean {
   if (!cred) {
     return false;
@@ -37,7 +54,7 @@ function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: nu
   if (cred.type !== "oauth" && cred.type !== "token") {
     return false;
   }
-  if (cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
+  if (!EXTERNAL_CLI_PROVIDERS.has(cred.provider)) {
     return false;
   }
   if (typeof cred.expires !== "number") {
@@ -82,13 +99,28 @@ function syncExternalCliCredentialsForProvider(
 }
 
 /**
- * Sync OAuth credentials from external CLI tools (Qwen Code CLI, MiniMax CLI) into the store.
+ * Sync OAuth credentials from external CLI tools (Codex CLI, Qwen Code CLI,
+ * MiniMax CLI) into the store.
  *
  * Returns true if any credentials were updated.
  */
 export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
   let mutated = false;
   const now = Date.now();
+
+  // Sync from Codex CLI (keychain / ~/.codex/auth.json)
+  // Target: openai-codex:default (not the deprecated openai-codex:codex-cli)
+  if (
+    syncExternalCliCredentialsForProvider(
+      store,
+      CODEX_CLI_SYNC_PROFILE_ID,
+      "openai-codex",
+      () => readCodexCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS }),
+      now,
+    )
+  ) {
+    mutated = true;
+  }
 
   // Sync from Qwen Code CLI
   const existingQwen = store.profiles[QWEN_CLI_PROFILE_ID];

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -4,6 +4,7 @@ import {
   readMiniMaxCliCredentialsCached,
 } from "../cli-credentials.js";
 import {
+  CODEX_CLI_SYNC_PROFILE_ID,
   EXTERNAL_CLI_NEAR_EXPIRY_MS,
   EXTERNAL_CLI_SYNC_TTL_MS,
   QWEN_CLI_PROFILE_ID,
@@ -11,20 +12,6 @@ import {
   log,
 } from "./constants.js";
 import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
-
-/**
- * Target profile ID for Codex CLI credential sync.
- *
- * We intentionally sync into `openai-codex:default` — the same slot that
- * `openclaw models auth login --provider openai-codex` writes to — so that
- * the two auth paths converge on a single, non-deprecated profile.
- *
- * The legacy constant `CODEX_CLI_PROFILE_ID` (`openai-codex:codex-cli`) is
- * treated as deprecated by `maybeRemoveDeprecatedCliAuthProfiles` in
- * `doctor-auth.ts`; syncing into it would cause persistent warning churn on
- * every `openclaw doctor` run.
- */
-const CODEX_CLI_SYNC_PROFILE_ID = "openai-codex:default";
 
 function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCredential): boolean {
   if (!a) {


### PR DESCRIPTION
Fixes a regression where the `openai-codex` provider is not injected into `models.json` when users authenticate via the Codex CLI.

The root cause was that `syncExternalCliCredentials` was missing the synchronization logic for Codex CLI credentials.

This PR adds the missing sync logic and intentionally targets the `openai-codex:default` profile slot. This aligns the external CLI sync path with the `openclaw models auth login --provider openai-codex` command, ensuring both auth methods converge on a single, non-deprecated profile.

Syncing into the legacy `openai-codex:codex-cli` slot was avoided because it is flagged as deprecated by `maybeRemoveDeprecatedCliAuthProfiles` in `doctor-auth.ts`, which would cause persistent warning churn on every `openclaw doctor` run.

Fixes #40364

## Test Plan

- Added `auth-profiles.codex-cli-sync.test.ts` with 6 test cases covering:
  - Successful sync into the default profile slot
  - No-op when credentials are unavailable
  - Updating stale credentials with fresher ones
  - Skipping sync when the existing profile is still fresh
  - Syncing `accountId` metadata
  - Explicit verification that the deprecated `codex-cli` slot is never written to
- Ran all existing `auth-profiles` and `models-config` tests to ensure no regressions.

## AI-Assisted Contribution

This PR was authored with the assistance of an AI tool (Manus). The AI helped identify the missing sync logic, analyzed the conflict with the deprecated profile cleanup in `doctor-auth.ts`, and generated the fix along with the test suite. I have reviewed and tested the code to ensure it meets the project's standards.