### PR TITLE
fix(web-search): add SecretRef support for provider apiKey resolvers

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -22,6 +22,7 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveGeminiApiKey,
   resolveBraveMode,
 } = __testing;
 
@@ -367,6 +368,14 @@ describe("web_search provider apiKey SecretRef handling", () => {
   it("throws on unresolved SecretRef for Kimi apiKey", () => {
     withEnv({ KIMI_API_KEY: undefined, MOONSHOT_API_KEY: undefined }, () => {
       expect(() => resolveKimiApiKey({ apiKey: secretRef as unknown as string })).toThrow(
+        /unresolved SecretRef/,
+      );
+    });
+  });
+
+  it("throws on unresolved SecretRef for Gemini apiKey", () => {
+    withEnv({ GEMINI_API_KEY: undefined }, () => {
+      expect(() => resolveGeminiApiKey({ apiKey: secretRef as unknown as string })).toThrow(
         /unresolved SecretRef/,
       );
     });

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -346,6 +346,33 @@ describe("web_search kimi config resolution", () => {
   });
 });
 
+describe("web_search provider apiKey SecretRef handling", () => {
+  // Unresolved SecretRef objects must fail fast, not silently drop the key
+  const secretRef = { source: "exec", provider: "vault", id: "test-key" };
+
+  it("throws on unresolved SecretRef for Perplexity apiKey", () => {
+    expect(() => resolvePerplexityApiKey({ apiKey: secretRef as unknown as string })).toThrow(
+      /unresolved SecretRef/,
+    );
+  });
+
+  it("throws on unresolved SecretRef for Grok apiKey", () => {
+    withEnv({ XAI_API_KEY: undefined }, () => {
+      expect(() => resolveGrokApiKey({ apiKey: secretRef as unknown as string })).toThrow(
+        /unresolved SecretRef/,
+      );
+    });
+  });
+
+  it("throws on unresolved SecretRef for Kimi apiKey", () => {
+    withEnv({ KIMI_API_KEY: undefined, MOONSHOT_API_KEY: undefined }, () => {
+      expect(() => resolveKimiApiKey({ apiKey: secretRef as unknown as string })).toThrow(
+        /unresolved SecretRef/,
+      );
+    });
+  });
+});
+
 describe("extractKimiCitations", () => {
   it("collects unique URLs from search_results and tool arguments", () => {
     expect(

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2132,6 +2132,7 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveGeminiApiKey,
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -629,26 +629,26 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   apiKey?: string;
   source: PerplexityApiKeySource;
 } {
-  const fromConfig = normalizeApiKey(perplexity?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: perplexity?.apiKey,
+    path: "tools.web.search.perplexity.apiKey",
+  });
+  const fromConfig = normalizeSecretInput(fromConfigRaw);
   if (fromConfig) {
     return { apiKey: fromConfig, source: "config" };
   }
 
-  const fromEnvPerplexity = normalizeApiKey(process.env.PERPLEXITY_API_KEY);
+  const fromEnvPerplexity = normalizeSecretInput(process.env.PERPLEXITY_API_KEY);
   if (fromEnvPerplexity) {
     return { apiKey: fromEnvPerplexity, source: "perplexity_env" };
   }
 
-  const fromEnvOpenRouter = normalizeApiKey(process.env.OPENROUTER_API_KEY);
+  const fromEnvOpenRouter = normalizeSecretInput(process.env.OPENROUTER_API_KEY);
   if (fromEnvOpenRouter) {
     return { apiKey: fromEnvOpenRouter, source: "openrouter_env" };
   }
 
   return { apiKey: undefined, source: "none" };
-}
-
-function normalizeApiKey(key: unknown): string {
-  return normalizeSecretInput(key);
 }
 
 function inferPerplexityBaseUrlFromApiKey(apiKey?: string): PerplexityBaseUrlHint | undefined {
@@ -755,11 +755,15 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
 }
 
 function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
-  const fromConfig = normalizeApiKey(grok?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: grok?.apiKey,
+    path: "tools.web.search.grok.apiKey",
+  });
+  const fromConfig = normalizeSecretInput(fromConfigRaw);
   if (fromConfig) {
     return fromConfig;
   }
-  const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
+  const fromEnv = normalizeSecretInput(process.env.XAI_API_KEY);
   return fromEnv || undefined;
 }
 
@@ -785,15 +789,19 @@ function resolveKimiConfig(search?: WebSearchConfig): KimiConfig {
 }
 
 function resolveKimiApiKey(kimi?: KimiConfig): string | undefined {
-  const fromConfig = normalizeApiKey(kimi?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: kimi?.apiKey,
+    path: "tools.web.search.kimi.apiKey",
+  });
+  const fromConfig = normalizeSecretInput(fromConfigRaw);
   if (fromConfig) {
     return fromConfig;
   }
-  const fromEnvKimi = normalizeApiKey(process.env.KIMI_API_KEY);
+  const fromEnvKimi = normalizeSecretInput(process.env.KIMI_API_KEY);
   if (fromEnvKimi) {
     return fromEnvKimi;
   }
-  const fromEnvMoonshot = normalizeApiKey(process.env.MOONSHOT_API_KEY);
+  const fromEnvMoonshot = normalizeSecretInput(process.env.MOONSHOT_API_KEY);
   return fromEnvMoonshot || undefined;
 }
 
@@ -821,11 +829,15 @@ function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
 }
 
 function resolveGeminiApiKey(gemini?: GeminiConfig): string | undefined {
-  const fromConfig = normalizeApiKey(gemini?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: gemini?.apiKey,
+    path: "tools.web.search.gemini.apiKey",
+  });
+  const fromConfig = normalizeSecretInput(fromConfigRaw);
   if (fromConfig) {
     return fromConfig;
   }
-  const fromEnv = normalizeApiKey(process.env.GEMINI_API_KEY);
+  const fromEnv = normalizeSecretInput(process.env.GEMINI_API_KEY);
   return fromEnv || undefined;
 }
 


### PR DESCRIPTION
## Summary

- **Problem**: Web search provider `apiKey` resolvers silently drop SecretRef objects, sending requests with no API key (401 errors)
- **Why it matters**: Any deployment using exec/vault/env-file secret providers for web search keys is completely broken — no workaround except plaintext config
- **What changed**: All 4 provider apiKey resolvers (`resolvePerplexityApiKey`, `resolveGrokApiKey`, `resolveKimiApiKey`, `resolveGeminiApiKey`) now use `normalizeResolvedSecretInputString()` instead of the local `normalizeApiKey()` wrapper, matching every other SecretRef-enabled config field
- **What did NOT change**: No behavioral change for plain string apiKey values or env var fallbacks — only SecretRef objects are now handled correctly

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Auth / tokens

## Linked Issue/PR

- Closes #40510
- Related #29580

## User-visible / Behavior Changes

- `tools.web.search.perplexity.apiKey`, `tools.web.search.grok.apiKey`, `tools.web.search.kimi.apiKey`, and `tools.web.search.gemini.apiKey` now correctly resolve SecretRef objects (exec, vault, env-file providers)
- Unresolved SecretRef objects now throw with a clear error instead of silently sending empty API keys

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — SecretRef objects are now correctly resolved instead of silently dropped
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: This change fixes a security-relevant bug where SecretRef was silently bypassed, causing plaintext-less deployments to fail. The fix aligns with the existing `normalizeResolvedSecretInputString` pattern used across all other SecretRef-enabled fields. No new attack surface.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Docker)
- Runtime/container: Docker self-hosted
- Model/provider: Any (web search tool is model-agnostic)
- Integration/channel: N/A
- Relevant config:
  ```json
  {
    "tools": {
      "web": {
        "search": {
          "provider": "perplexity",
          "perplexity": {
            "apiKey": { "source": "exec", "provider": "vault", "id": "my-key" }
          }
        }
      }
    }
  }
  ```

### Steps

1. Configure web search with a SecretRef `apiKey` (any provider)
2. Trigger a web search via the agent
3. Observe 401 error in logs

### Expected

- SecretRef resolves via configured provider, API key is used for the request

### Actual

- SecretRef object silently becomes `""`, request sent with no key, 401 returned

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

**Before fix** (v2026.3.7):
```
[tools] web_search failed: Perplexity Search API error (401):
  {"error":{"message":"Invalid API key provided.","type":"invalid_api_key","code":401}}
```

**After fix** (crabshack-combined build with this branch):
```
[agent/embedded] embedded run tool start: tool=web_search
[agent/embedded] embedded run tool end: tool=web_search
```
No error — web search completes successfully with SecretRef-resolved key (~4s round trip).

**Agent-level verification** (same deployment, before and after fix applied):
```
> try again, I know it will fail, want to see the logs
< Perplexity Search API error (401): {"error":{"message":"Invalid API key provided."}}

> try again, we applied a fix
< Yep — it's working now. The search succeeded and returned a normal result.
```

Unit tests added: 3 new tests verifying that unresolved SecretRef objects throw `/unresolved SecretRef/` for Perplexity, Grok, and Kimi resolvers.

## Human Verification (required)

- Verified scenarios: Deployed patched build to self-hosted Docker instance, confirmed Perplexity web search works with vault-based SecretRef apiKey (was 401 before, succeeds after)
- Edge cases checked: Plain string apiKey still works, env var fallbacks still work, unresolved SecretRef throws clear error
- What you did **not** verify: Grok, Kimi, Gemini with live SecretRef (no active config for those providers — but code pattern is identical and unit tested)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single commit, restore `normalizeApiKey` helper
- Files/config to restore: `src/agents/tools/web-search.ts`
- Known bad symptoms: If reverted, SecretRef apiKey will silently fail again (401 errors)

## Risks and Mitigations

- Risk: Gemini resolver not tested with live SecretRef
  - Mitigation: Code pattern is identical to Perplexity/Grok/Kimi (3-line change per resolver), unit tested, and follows established `normalizeResolvedSecretInputString` contract

---

Implemented and tested by Claude Code (Opus 4.6), reviewed and verified in production by @asyncjason.
