### PR TITLE
fix(gateway): redirect / to control UI basePath

### DIFF
--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -54,6 +54,36 @@ describe("classifyControlUiRequest", () => {
     expect(classified).toEqual({ kind: "redirect", location: "/openclaw/?foo=1" });
   });
 
+  it("returns redirect for gateway root when basePath is set", () => {
+    const classified = classifyControlUiRequest({
+      basePath: "/openclaw",
+      pathname: "/",
+      search: "",
+      method: "GET",
+    });
+    expect(classified).toEqual({ kind: "redirect", location: "/openclaw/" });
+  });
+
+  it("preserves search string when redirecting gateway root to basePath", () => {
+    const classified = classifyControlUiRequest({
+      basePath: "/openclaw",
+      pathname: "/",
+      search: "?ref=email",
+      method: "GET",
+    });
+    expect(classified).toEqual({ kind: "redirect", location: "/openclaw/?ref=email" });
+  });
+
+  it("falls through non-read gateway root requests when basePath is set", () => {
+    const classified = classifyControlUiRequest({
+      basePath: "/openclaw",
+      pathname: "/",
+      search: "",
+      method: "POST",
+    });
+    expect(classified).toEqual({ kind: "not-control-ui" });
+  });
+
   it("classifies basePath subroutes as control ui", () => {
     const classified = classifyControlUiRequest({
       basePath: "/openclaw",

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -39,6 +39,15 @@ export function classifyControlUiRequest(params: {
   }
 
   if (!pathname.startsWith(`${basePath}/`) && pathname !== basePath) {
+    // For installs that mount the Control UI under a base path (e.g. /openclaw),
+    // redirect the gateway root to the UI mount to keep the “open
+    // http://127.0.0.1:18789/” experience discoverable.
+    if (pathname === "/") {
+      if (!isReadHttpMethod(method)) {
+        return { kind: "not-control-ui" };
+      }
+      return { kind: "redirect", location: `${basePath}/${search}` };
+    }
     return { kind: "not-control-ui" };
   }
   if (!isReadHttpMethod(method)) {


### PR DESCRIPTION
Fixes #34298

When Control UI is configured with `basePath`, visiting the gateway root `/` currently returns `Not Found`. This change redirects `/` to the Control UI basePath for read methods (GET/HEAD), so users opening `http://127.0.0.1:18789/` land on the UI.

## Tests
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/control-ui-routing.test.ts`
