### PR TITLE
fix: cron module logger now respects consoleLevel setting

### DIFF
--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -27,6 +27,7 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 
@@ -354,7 +355,15 @@ export function buildGatewayCronService(params: {
         deps: createOutboundSendDeps(params.deps),
       });
     },
-    log: getChildLogger({ module: "cron", storePath }),
+    log: (() => {
+      const sub = createSubsystemLogger("cron");
+      return {
+        debug: (obj: unknown, msg?: string) => sub.debug(msg ?? "", typeof obj === "object" && obj !== null ? (obj as Record<string, unknown>) : { value: obj }),
+        info: (obj: unknown, msg?: string) => sub.info(msg ?? "", typeof obj === "object" && obj !== null ? (obj as Record<string, unknown>) : { value: obj }),
+        warn: (obj: unknown, msg?: string) => sub.warn(msg ?? "", typeof obj === "object" && obj !== null ? (obj as Record<string, unknown>) : { value: obj }),
+        error: (obj: unknown, msg?: string) => sub.error(msg ?? "", typeof obj === "object" && obj !== null ? (obj as Record<string, unknown>) : { value: obj }),
+      };
+    })(),
     onEvent: (evt) => {
       params.broadcast("cron", evt, { dropIfSlow: true });
       if (evt.action === "finished") {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -223,7 +223,15 @@ export function getChildLogger(
   opts?: { level?: LogLevel },
 ): TsLogger<LogObj> {
   const base = getLogger();
-  const minLevel = opts?.level ? levelToMinLevel(opts.level) : undefined;
+  // Always resolve minLevel: use the explicit override if provided, otherwise
+  // inherit the parent logger's minLevel.  tslog sub-loggers default to
+  // minLevel=0 (silly) when the parameter is omitted, which would bypass
+  // the configured logging.level filter.  Passing the parent's minLevel
+  // explicitly ensures child loggers respect the same threshold.
+  const settings = resolveSettings();
+  const minLevel = opts?.level
+    ? levelToMinLevel(opts.level)
+    : levelToMinLevel(settings.level);
   const name = bindings ? JSON.stringify(bindings) : undefined;
   return base.getSubLogger({
     name,


### PR DESCRIPTION
## Problem

DEBUG-level logs from the cron module appear in console output despite `logging.consoleLevel` being set to `"info"`, as reported in #40465.

## Root Cause

`getChildLogger()` in `src/logging/logger.ts` passed `undefined` as `minLevel` to tslog's `getSubLogger()` when no explicit level override was provided. In tslog v4, sub-loggers default to `minLevel=0` (silly) when the parameter is omitted instead of inheriting the parent logger's threshold. This allowed DEBUG messages from child loggers (including the cron module) to bypass the configured `logging.level` filter.

## Fix

1. **`src/logging/logger.ts`**: `getChildLogger()` now explicitly resolves and passes the parent logger's `minLevel` when no override is provided.
2. **`src/gateway/server-cron.ts`**: The `CronService` log dependency now uses a `SubsystemLogger` which properly checks both `logging.level` (for file output) and `logging.consoleLevel` (for console output).

Fixes #40465