### PR TITLE
fix(feishu): preserve docx block tree order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/docx block ordering: preserve the document tree order from `docx.document.convert` when inserting blocks, fixing heading/paragraph/list misordering in newly written Feishu documents. (#40524) Thanks @TaoXieSZ.
 - Agents/cron: suppress the default heartbeat system prompt for cron-triggered embedded runs even when they target non-cron session keys, so cron tasks stop reading `HEARTBEAT.md` and polluting unrelated threads. (#53152) Thanks @Protocol-zero-0.
 
 ## 2026.3.23

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -174,6 +174,50 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.blocks_added).toBe(3);
   });
 
+  it("reorders convert output by document tree instead of raw block array order", async () => {
+    const blocks = [
+      { block_type: 13, block_id: "li2", parent_id: "list1" },
+      { block_type: 4, block_id: "h2" },
+      { block_type: 13, block_id: "li1", parent_id: "list1" },
+      { block_type: 3, block_id: "h1" },
+      { block_type: 12, block_id: "list1", children: ["li1", "li2"] },
+      { block_type: 2, block_id: "p1" },
+    ];
+    convertMock.mockResolvedValue({
+      code: 0,
+      data: {
+        blocks,
+        first_level_block_ids: ["h1", "p1", "h2", "list1"],
+      },
+    });
+
+    blockDescendantCreateMock.mockImplementationOnce(async ({ data }) => ({
+      code: 0,
+      data: {
+        children: (data.children_id as string[]).map((id) => ({ block_id: id })),
+      },
+    }));
+
+    const feishuDocTool = resolveFeishuDocTool();
+
+    await feishuDocTool.execute("tool-call", {
+      action: "append",
+      doc_token: "doc_1",
+      content: "tree reorder",
+    });
+
+    const call = blockDescendantCreateMock.mock.calls[0]?.[0];
+    expect(call?.data.children_id).toEqual(["h1", "p1", "h2", "list1"]);
+    expect((call?.data.descendants as Array<{ block_id: string }>).map((b) => b.block_id)).toEqual([
+      "h1",
+      "p1",
+      "h2",
+      "list1",
+      "li1",
+      "li2",
+    ]);
+  });
+
   it("falls back to size-based convert chunking for long no-heading markdown", async () => {
     let successChunkCount = 0;
     convertMock.mockImplementation(async ({ data }) => {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -159,9 +159,9 @@ function sortBlocksByFirstLevel(blocks: any[], firstLevelIds: string[]): any[] {
     .sort((a, b) => (originalOrder.get(a.block_id) ?? 0) - (originalOrder.get(b.block_id) ?? 0))
     .map((block) => block.block_id);
 
-  const rootIds = (firstLevelIds && firstLevelIds.length > 0 ? firstLevelIds : inferredTopLevelIds).filter(
-    (id, index, arr) => typeof id === "string" && byId.has(id) && arr.indexOf(id) === index,
-  );
+  const rootIds = (
+    firstLevelIds && firstLevelIds.length > 0 ? firstLevelIds : inferredTopLevelIds
+  ).filter((id, index, arr) => typeof id === "string" && byId.has(id) && arr.indexOf(id) === index);
 
   const ordered: any[] = [];
   const visited = new Set<string>();

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -113,12 +113,85 @@ async function convertMarkdown(client: Lark.Client, markdown: string) {
   };
 }
 
+function normalizeChildIds(children: unknown): string[] {
+  if (Array.isArray(children)) {
+    return children.filter((child): child is string => typeof child === "string");
+  }
+  if (typeof children === "string") {
+    return [children];
+  }
+  return [];
+}
+
+// Convert API may return `blocks` in a non-render order.
+// Reconstruct the document tree using first_level_block_ids plus children/parent links,
+// then emit blocks in pre-order so Descendant/Children APIs receive a deterministic sequence.
 function sortBlocksByFirstLevel(blocks: any[], firstLevelIds: string[]): any[] {
-  if (!firstLevelIds || firstLevelIds.length === 0) return blocks;
-  const sorted = firstLevelIds.map((id) => blocks.find((b) => b.block_id === id)).filter(Boolean);
-  const sortedIds = new Set(firstLevelIds);
-  const remaining = blocks.filter((b) => !sortedIds.has(b.block_id));
-  return [...sorted, ...remaining];
+  if (blocks.length <= 1) {
+    return blocks;
+  }
+
+  const byId = new Map<string, any>();
+  const originalOrder = new Map<string, number>();
+  for (const [index, block] of blocks.entries()) {
+    if (typeof block?.block_id === "string") {
+      byId.set(block.block_id, block);
+      originalOrder.set(block.block_id, index);
+    }
+  }
+
+  const childIds = new Set<string>();
+  for (const block of blocks) {
+    for (const childId of normalizeChildIds(block?.children)) {
+      childIds.add(childId);
+    }
+  }
+
+  const inferredTopLevelIds = blocks
+    .filter((block) => {
+      const blockId = block?.block_id;
+      if (typeof blockId !== "string") {
+        return false;
+      }
+      const parentId = typeof block?.parent_id === "string" ? block.parent_id : "";
+      return !childIds.has(blockId) && (!parentId || !byId.has(parentId));
+    })
+    .sort((a, b) => (originalOrder.get(a.block_id) ?? 0) - (originalOrder.get(b.block_id) ?? 0))
+    .map((block) => block.block_id);
+
+  const rootIds = (firstLevelIds && firstLevelIds.length > 0 ? firstLevelIds : inferredTopLevelIds).filter(
+    (id, index, arr) => typeof id === "string" && byId.has(id) && arr.indexOf(id) === index,
+  );
+
+  const ordered: any[] = [];
+  const visited = new Set<string>();
+
+  const visit = (blockId: string) => {
+    if (!byId.has(blockId) || visited.has(blockId)) {
+      return;
+    }
+    visited.add(blockId);
+    const block = byId.get(blockId);
+    ordered.push(block);
+    for (const childId of normalizeChildIds(block?.children)) {
+      visit(childId);
+    }
+  };
+
+  for (const rootId of rootIds) {
+    visit(rootId);
+  }
+
+  // Fallback for malformed/partial trees from Convert API: keep any leftovers in original order.
+  for (const block of blocks) {
+    if (typeof block?.block_id === "string") {
+      visit(block.block_id);
+    } else {
+      ordered.push(block);
+    }
+  }
+
+  return ordered;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- SDK block types */

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -125,10 +125,15 @@ function normalizeChildIds(children: unknown): string[] {
 
 // Convert API may return `blocks` in a non-render order.
 // Reconstruct the document tree using first_level_block_ids plus children/parent links,
-// then emit blocks in pre-order so Descendant/Children APIs receive a deterministic sequence.
-function sortBlocksByFirstLevel(blocks: any[], firstLevelIds: string[]): any[] {
+// then emit blocks in pre-order so Descendant/Children APIs receive one normalized tree contract.
+function normalizeConvertedBlockTree(
+  blocks: any[],
+  firstLevelIds: string[],
+): { orderedBlocks: any[]; rootIds: string[] } {
   if (blocks.length <= 1) {
-    return blocks;
+    const rootIds =
+      blocks.length === 1 && typeof blocks[0]?.block_id === "string" ? [blocks[0].block_id] : [];
+    return { orderedBlocks: blocks, rootIds };
   }
 
   const byId = new Map<string, any>();
@@ -163,7 +168,7 @@ function sortBlocksByFirstLevel(blocks: any[], firstLevelIds: string[]): any[] {
     firstLevelIds && firstLevelIds.length > 0 ? firstLevelIds : inferredTopLevelIds
   ).filter((id, index, arr) => typeof id === "string" && byId.has(id) && arr.indexOf(id) === index);
 
-  const ordered: any[] = [];
+  const orderedBlocks: any[] = [];
   const visited = new Set<string>();
 
   const visit = (blockId: string) => {
@@ -172,7 +177,7 @@ function sortBlocksByFirstLevel(blocks: any[], firstLevelIds: string[]): any[] {
     }
     visited.add(blockId);
     const block = byId.get(blockId);
-    ordered.push(block);
+    orderedBlocks.push(block);
     for (const childId of normalizeChildIds(block?.children)) {
       visit(childId);
     }
@@ -187,11 +192,11 @@ function sortBlocksByFirstLevel(blocks: any[], firstLevelIds: string[]): any[] {
     if (typeof block?.block_id === "string") {
       visit(block.block_id);
     } else {
-      ordered.push(block);
+      orderedBlocks.push(block);
     }
   }
 
-  return ordered;
+  return { orderedBlocks, rootIds };
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- SDK block types */
@@ -332,14 +337,14 @@ async function chunkedConvertMarkdown(client: Lark.Client, markdown: string) {
   const chunks = splitMarkdownByHeadings(markdown);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block types
   const allBlocks: any[] = [];
-  const allFirstLevelBlockIds: string[] = [];
+  const allRootIds: string[] = [];
   for (const chunk of chunks) {
     const { blocks, firstLevelBlockIds } = await convertMarkdownWithFallback(client, chunk);
-    const sorted = sortBlocksByFirstLevel(blocks, firstLevelBlockIds);
-    allBlocks.push(...sorted);
-    allFirstLevelBlockIds.push(...firstLevelBlockIds);
+    const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
+    allBlocks.push(...orderedBlocks);
+    allRootIds.push(...rootIds);
   }
-  return { blocks: allBlocks, firstLevelBlockIds: allFirstLevelBlockIds };
+  return { blocks: allBlocks, firstLevelBlockIds: allRootIds };
 }
 
 /** Insert blocks in batches of MAX_BLOCKS_PER_INSERT to avoid API 400 errors */
@@ -717,8 +722,11 @@ async function uploadFileBlock(
   // Create a placeholder text block first
   const placeholderMd = `[${upload.fileName}](https://example.com/placeholder)`;
   const converted = await convertMarkdown(client, placeholderMd);
-  const sorted = sortBlocksByFirstLevel(converted.blocks, converted.firstLevelBlockIds);
-  const { children: inserted } = await insertBlocks(client, docToken, sorted, blockId);
+  const { orderedBlocks } = normalizeConvertedBlockTree(
+    converted.blocks,
+    converted.firstLevelBlockIds,
+  );
+  const { children: inserted } = await insertBlocks(client, docToken, orderedBlocks, blockId);
 
   // Get the first inserted block - we'll delete it and create the file in its place
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK return shape
@@ -897,11 +905,11 @@ async function writeDoc(
   }
 
   logger?.info?.(`feishu_doc: Converted to ${blocks.length} blocks, inserting...`);
-  const sortedBlocks = sortBlocksByFirstLevel(blocks, firstLevelBlockIds);
+  const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
   const { children: inserted } =
     blocks.length > BATCH_SIZE
-      ? await insertBlocksInBatches(client, docToken, sortedBlocks, firstLevelBlockIds, logger)
-      : await insertBlocksWithDescendant(client, docToken, sortedBlocks, firstLevelBlockIds);
+      ? await insertBlocksInBatches(client, docToken, orderedBlocks, rootIds, logger)
+      : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds);
   const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes);
   logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
 
@@ -927,11 +935,11 @@ async function appendDoc(
   }
 
   logger?.info?.(`feishu_doc: Converted to ${blocks.length} blocks, inserting...`);
-  const sortedBlocks = sortBlocksByFirstLevel(blocks, firstLevelBlockIds);
+  const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
   const { children: inserted } =
     blocks.length > BATCH_SIZE
-      ? await insertBlocksInBatches(client, docToken, sortedBlocks, firstLevelBlockIds, logger)
-      : await insertBlocksWithDescendant(client, docToken, sortedBlocks, firstLevelBlockIds);
+      ? await insertBlocksInBatches(client, docToken, orderedBlocks, rootIds, logger)
+      : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds);
   const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes);
   logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
 
@@ -987,7 +995,7 @@ async function insertDoc(
   logger?.info?.("feishu_doc: Converting markdown...");
   const { blocks, firstLevelBlockIds } = await chunkedConvertMarkdown(client, markdown);
   if (blocks.length === 0) throw new Error("Content is empty");
-  const sortedBlocks = sortBlocksByFirstLevel(blocks, firstLevelBlockIds);
+  const { orderedBlocks, rootIds } = normalizeConvertedBlockTree(blocks, firstLevelBlockIds);
 
   logger?.info?.(
     `feishu_doc: Converted to ${blocks.length} blocks, inserting at index ${insertIndex}...`,
@@ -997,13 +1005,13 @@ async function insertDoc(
       ? await insertBlocksInBatches(
           client,
           docToken,
-          sortedBlocks,
-          firstLevelBlockIds,
+          orderedBlocks,
+          rootIds,
           logger,
           parentId,
           insertIndex,
         )
-      : await insertBlocksWithDescendant(client, docToken, sortedBlocks, firstLevelBlockIds, {
+      : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds, {
           parentBlockId: parentId,
           index: insertIndex,
         });
@@ -1140,10 +1148,13 @@ async function writeTableCells(
 
       const text = rowValues[c] ?? "";
       const converted = await convertMarkdown(client, text);
-      const sorted = sortBlocksByFirstLevel(converted.blocks, converted.firstLevelBlockIds);
+      const { orderedBlocks } = normalizeConvertedBlockTree(
+        converted.blocks,
+        converted.firstLevelBlockIds,
+      );
 
-      if (sorted.length > 0) {
-        await insertBlocks(client, docToken, sorted, cellId);
+      if (orderedBlocks.length > 0) {
+        await insertBlocks(client, docToken, orderedBlocks, cellId);
       }
 
       written++;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu docx markdown writes could produce out-of-order content after `docx.document.convert`, with headings, paragraphs, and list items appearing in the wrong sequence.
- Why it matters: User-facing cloud docs became confusing or misleading, and tasks that rely on writing structured results into Feishu docs could not be trusted.
- What changed: Reworked block ordering to rebuild the converted document tree using `first_level_block_ids`, `children`, and `parent_id`, then emit blocks in pre-order traversal before insertion; added regression coverage for this convert-output ordering case.
- What did NOT change (scope boundary): This PR does not change auth, permissions, network endpoints, config shape, message routing, or how old already-written documents are rendered.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40807
- Related #

## User-visible / Behavior Changes

Feishu docx documents created via the write/append skill now preserve the intended heading/paragraph/list ordering from the source markdown. Previously, blocks could appear out of order (e.g. list items before their section heading).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: OpenCloudOS 9.4
- Runtime/container: OpenClaw on host VM, Node.js v22.22.0
- Model/provider: openai-codex/gpt-5.4
- Integration/channel (if any): Feishu
- Relevant config (redacted): standard Feishu appId/appSecret config via `~/.openclaw/openclaw.json`

### Steps

1. Convert markdown containing a top-level heading, body paragraph, secondary headings, and ordered/bullet list items with Feishu `docx.document.convert`.
2. Insert the returned blocks into a new Feishu docx document using the plugin write/append path.
3. Compare document order before and after reconstructing the block tree from `first_level_block_ids`, `children`, and `parent_id`.

### Expected

- Before fix: convert output could be inserted in the wrong order, e.g. ordered list items appearing before headings or titles appearing later in the document.
- After fix: new test documents preserved the intended structure and ordering.
### Actual

- Before fix: blocks inserted in raw array order, causing headings to appear after body text and ordered list items to appear before their section heading.
- After fix: blocks inserted in correct document tree order via pre-order traversal of the reconstructed block tree.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran targeted Feishu docx tests:
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/docx-batch-insert.test.ts`
  - `extensions/feishu/src/docx.account-selection.test.ts`
  - Confirmed 3 test files / 15 tests passed.
  - Applied the fix to the running Feishu plugin in the installed environment.
  - Created a fresh Feishu doc and rewrote the same structured markdown content.
  - Verified the new document no longer reproduced the previous ordering issue.
- Edge cases checked:
  - Raw `blocks` array order differing from intended document tree order
  - Child block ordering under parent list blocks
  - Fallback handling for leftover/malformed partial trees without dropping blocks
- What you did **not** verify:
  - Tables/complex embedded block types beyond the targeted docx ordering path
  - Behavior of previously created old documents
  - Full repository-wide test suite as a release gate for this PR

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - restore the previous `extensions/feishu/src/docx.ts`
- Files/config to restore:
  - `extensions/feishu/src/docx.ts`
- Known bad symptoms reviewers should watch for:
  - Headings appearing after body text
  - Ordered list items appearing before their section heading
  - Newly written Feishu docx markdown documents showing structurally incorrect order

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Convert API may return partial or malformed tree relationships for some uncommon block types.
  - Mitigation: Preserve a fallback path that appends unvisited leftover blocks in original order instead of dropping them.
- Risk: Ordering changes could affect insertion behavior for some nested docx structures not covered by this regression.
  - Mitigation: Added targeted regression tests and performed real-world validation against a fresh Feishu document write.

