### PR TITLE
fix(cli): close cached memory managers on exit to prevent process hang

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -135,6 +135,15 @@ export async function runCli(argv: string[] = process.argv) {
   }
 
   await program.parseAsync(parseArgv);
+
+  // Close cached memory managers so their FSWatcher handles don't keep
+  // the process alive after one-shot CLI commands complete (#40365).
+  try {
+    const { MemoryIndexManager } = await import("../memory/manager.js");
+    await MemoryIndexManager.closeAll();
+  } catch {
+    // Best-effort cleanup; module may not have been loaded.
+  }
 }
 
 export function isCliMainModule(): boolean {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -749,6 +749,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  /** Close all cached MemoryIndexManager instances (for process cleanup). */
+  static async closeAll(): Promise<void> {
+    const managers = [...INDEX_CACHE.values()];
+    await Promise.allSettled(managers.map((m) => m.close()));
+  }
+
   async close(): Promise<void> {
     if (this.closed) {
       return;


### PR DESCRIPTION
## Summary

- Add `MemoryIndexManager.closeAll()` static method to close all cached instances and their chokidar FSWatcher handles
- Call `closeAll()` after `program.parseAsync()` in the CLI entry point so one-shot commands can exit cleanly
- The global `INDEX_CACHE` previously retained managers indefinitely, leaving file watchers active and preventing process exit

## Change Type
Bug fix

## Scope
`src/memory/manager.ts`, `src/cli/run-main.ts`

## Security Impact
No security impact.

Closes #40365

🤖 Generated with [Claude Code](https://claude.com/claude-code)