### PR TITLE
fix(cron): filter reasoning/thinking payloads from announce delivery

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -331,6 +331,7 @@ export function buildEmbeddedRunPayloads(params: {
       mediaUrls: item.media?.length ? item.media : undefined,
       mediaUrl: item.media?.[0],
       isError: item.isError,
+      isReasoning: item.isReasoning,
       replyToId: item.replyToId,
       replyToTag: item.replyToTag,
       replyToCurrent: item.replyToCurrent,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -61,6 +61,7 @@ export type EmbeddedPiRunResult = {
     mediaUrls?: string[];
     replyToId?: string;
     isError?: boolean;
+    isReasoning?: boolean;
   }>;
   meta: EmbeddedPiRunMeta;
   // True if a messaging tool (telegram, whatsapp, discord, slack, sessions_send)

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -31,6 +31,19 @@ describe("pickSummaryFromPayloads", () => {
     ];
     expect(pickSummaryFromPayloads(payloads)).toBe("normal text");
   });
+
+  it("skips reasoning payloads in first pass", () => {
+    const payloads = [
+      { text: "Final answer" },
+      { text: "Reasoning:\n_thinking step_", isReasoning: true },
+    ];
+    expect(pickSummaryFromPayloads(payloads)).toBe("Final answer");
+  });
+
+  it("never falls back to reasoning payloads", () => {
+    const payloads = [{ text: "Reasoning:\n_thinking step_", isReasoning: true }];
+    expect(pickSummaryFromPayloads(payloads)).toBeUndefined();
+  });
 });
 
 describe("pickLastNonEmptyTextFromPayloads", () => {
@@ -54,6 +67,19 @@ describe("pickLastNonEmptyTextFromPayloads", () => {
       { text: "bad", isError: true },
     ];
     expect(pickLastNonEmptyTextFromPayloads(payloads)).toBe("good");
+  });
+
+  it("skips reasoning payloads in first pass", () => {
+    const payloads = [
+      { text: "Actual output" },
+      { text: "Reasoning:\n_thinking..._", isReasoning: true },
+    ];
+    expect(pickLastNonEmptyTextFromPayloads(payloads)).toBe("Actual output");
+  });
+
+  it("never falls back to reasoning payloads", () => {
+    const payloads = [{ text: "Reasoning:\n_thinking..._", isReasoning: true }];
+    expect(pickLastNonEmptyTextFromPayloads(payloads)).toBeUndefined();
   });
 });
 
@@ -83,6 +109,17 @@ describe("pickLastDeliverablePayload", () => {
     const normal = { text: "ok", isError: undefined };
     const error = { text: "bad", isError: true as const };
     expect(pickLastDeliverablePayload([normal, error])).toBe(normal);
+  });
+
+  it("skips reasoning payloads in first pass", () => {
+    const real = { text: "Delivered content" };
+    const reasoning = { text: "Reasoning:\n_thinking..._", isReasoning: true as const };
+    expect(pickLastDeliverablePayload([real, reasoning])).toBe(real);
+  });
+
+  it("never falls back to reasoning payloads", () => {
+    const reasoning = { text: "Reasoning:\n_thinking..._", isReasoning: true as const };
+    expect(pickLastDeliverablePayload([reasoning])).toBeUndefined();
   });
 });
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -6,7 +6,7 @@ import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
 
 type DeliveryPayload = Pick<
   ReplyPayload,
-  "text" | "mediaUrl" | "mediaUrls" | "interactive" | "channelData" | "isError"
+  "text" | "mediaUrl" | "mediaUrls" | "interactive" | "channelData" | "isError" | "isReasoning"
 >;
 
 export function pickSummaryFromOutput(text: string | undefined) {
@@ -19,10 +19,10 @@ export function pickSummaryFromOutput(text: string | undefined) {
 }
 
 export function pickSummaryFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
+  payloads: Array<{ text?: string | undefined; isError?: boolean; isReasoning?: boolean }>,
 ) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     const summary = pickSummaryFromOutput(payloads[i]?.text);
@@ -31,6 +31,9 @@ export function pickSummaryFromPayloads(
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     const summary = pickSummaryFromOutput(payloads[i]?.text);
     if (summary) {
       return summary;
@@ -40,10 +43,10 @@ export function pickSummaryFromPayloads(
 }
 
 export function pickLastNonEmptyTextFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
+  payloads: Array<{ text?: string | undefined; isError?: boolean; isReasoning?: boolean }>,
 ) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     const clean = (payloads[i]?.text ?? "").trim();
@@ -52,6 +55,9 @@ export function pickLastNonEmptyTextFromPayloads(
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     const clean = (payloads[i]?.text ?? "").trim();
     if (clean) {
       return clean;
@@ -67,7 +73,7 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
     return hasOutboundReplyContent(p, { trimText: true }) || hasInteractive || hasChannelData;
   };
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     if (isDeliverable(payloads[i])) {
@@ -75,6 +81,9 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     if (isDeliverable(payloads[i])) {
       return payloads[i];
     }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -843,7 +843,12 @@ export async function runCronIsolatedAgentTurn(params: {
     lastErrorPayloadIndex >= 0 &&
     payloads
       .slice(lastErrorPayloadIndex + 1)
-      .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
+      .some(
+        (payload) =>
+          payload?.isError !== true &&
+          payload?.isReasoning !== true &&
+          Boolean(payload?.text?.trim()),
+      );
   // Tool wrappers can emit transient/false-positive error payloads before a valid final
   // assistant payload.  Only treat payload errors as recoverable when (a) the run itself
   // did not report a model/context-level error and (b) a non-error payload follows.

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -820,7 +820,7 @@ export async function runCronIsolatedAgentTurn(params: {
   if (isAborted()) {
     return withRunSession({ status: "error", error: abortReason(), ...telemetry });
   }
-  const firstText = payloads[0]?.text ?? "";
+  const firstText = payloads.find((p) => !p.isReasoning)?.text ?? "";
   let summary = pickSummaryFromPayloads(payloads) ?? pickSummaryFromOutput(firstText);
   let outputText = pickLastNonEmptyTextFromPayloads(payloads);
   let synthesizedText = outputText?.trim() || summary?.trim() || undefined;


### PR DESCRIPTION
## Summary

- Filters reasoning/thinking payloads from cron announce delivery pipeline end-to-end
- Propagates `isReasoning` flag through `buildEmbeddedRunPayloads` `.map()` return and `EmbeddedPiRunResult` type
- Filters reasoning in all 3 payload-selection helpers + `firstText` fallback + error-recovery detection
- Reasoning payloads are **never** deliverable and **never** mask error status

### Root cause

The `isReasoning` flag was correctly set internally by `buildEmbeddedRunPayloads()` but:
1. Not propagated in the `.map()` return value (`payloads.ts`)
2. Not declared on the `EmbeddedPiRunResult` payload type (`types.ts`)
3. Not filtered in cron delivery helpers (`helpers.ts`)
4. Not filtered in `firstText` fallback (`run.ts:754`)
5. Not excluded from error-recovery detection (`run.ts:844`)

### Commits
1. `39d426d` — Filter reasoning in helpers + add `isReasoning` to `EmbeddedPiRunResult` type
2. `3877d9a` — Fix `firstText` fallback bypass (Codex review)
3. `b003338` — Propagate `isReasoning` in `buildEmbeddedRunPayloads` `.map()` (Greptile review)
4. `402ba05` — Exclude reasoning from `hasSuccessfulPayloadAfterLastError` (Codex P2 review)

### Reasoning-only scenario trace (run.ts:754-764)

| Variable | Value | Why |
|---|---|---|
| `firstText` | `""` | `.find((p) => !p.isReasoning)` finds nothing |
| `pickSummaryFromPayloads()` | `undefined` | Both passes skip `isReasoning` |
| `pickLastNonEmptyTextFromPayloads()` | `undefined` | Both passes skip `isReasoning` |
| `synthesizedText` | `undefined` | Both sources undefined |
| `pickLastDeliverablePayload()` | `undefined` | Both passes skip `isReasoning` |
| `hasSuccessfulPayloadAfterLastError` | `false` | Reasoning excluded from recovery check |
| **`deliveryPayloads`** | **`[]`** | Nothing delivered |

Closes #40480

## Test plan

- [x] All 26 helpers tests pass (20 existing + 6 new)
- [x] `pnpm check` succeeds
- [ ] Manual test: cron with thinking-enabled model → verify announce delivery contains only the final answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)