### PR TITLE
Fix bootstrap reuse gating and zsh completion init

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,8 +153,7 @@
         "env: \\{ MISTRAL_API_K[E]Y: \"sk-\\.\\.\\.\" \\},",
         "\"ap[i]Key\": \"xxxxx\"(,)?",
         "ap[i]Key: \"A[I]za\\.\\.\\.\",",
-        "\"ap[i]Key\": \"(resolved|normalized|legacy)-key\"(,)?",
-        "sparkle:edSignature=\"[A-Za-z0-9+/=]+\""
+        "\"ap[i]Key\": \"(resolved|normalized|legacy)-key\"(,)?"
       ]
     },
     {
@@ -181,6 +180,29 @@
         "line_number": 15
       }
     ],
+    "appcast.xml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "appcast.xml",
+        "hashed_secret": "7afea670e53d801f1f881c99c40aa177e3395bfa",
+        "is_verified": false,
+        "line_number": 365
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "appcast.xml",
+        "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
+        "is_verified": false,
+        "line_number": 584
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "appcast.xml",
+        "hashed_secret": "c0baa9660a8d3b11874c63a535d8369f4a8fa8fa",
+        "is_verified": false,
+        "line_number": 723
+      }
+    ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
       {
         "type": "Hex High Entropy String",
@@ -205,7 +227,7 @@
         "filename": "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1859
+        "line_number": 1763
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
@@ -266,7 +288,7 @@
         "filename": "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1859
+        "line_number": 1763
       }
     ],
     "docs/.i18n/zh-CN.tm.jsonl": [
@@ -11659,7 +11681,7 @@
         "filename": "src/agents/tools/web-search.ts",
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 292
       }
     ],
     "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
@@ -12196,7 +12218,7 @@
         "filename": "src/config/io.write-config.test.ts",
         "hashed_secret": "13951588fd3325e25ed1e3b116d7009fb221c85e",
         "is_verified": false,
-        "line_number": 289
+        "line_number": 321
       }
     ],
     "src/config/model-alias-defaults.test.ts": [
@@ -12911,14 +12933,14 @@
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 497
+        "line_number": 450
       },
       {
         "type": "Secret Keyword",
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "5934c4d4a4fa5d66ddb3d3fc0bba84996c17a5b7",
         "is_verified": false,
-        "line_number": 688
+        "line_number": 641
       }
     ],
     "src/telegram/webhook.test.ts": [
@@ -13013,5 +13035,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T03:11:06Z"
+  "generated_at": "2026-03-09T08:01:06Z"
 }

--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -136,7 +136,7 @@ export function createAnthropicPayloadLogger(params: {
       if (!isAnthropicModel(model)) {
         return streamFn(model, context, options);
       }
-      const nextOnPayload = (payload: unknown) => {
+      const nextOnPayload = (payload: unknown, payloadModel: unknown) => {
         const redactedPayload = redactImageDataForDiagnostics(payload);
         record({
           ...base,
@@ -145,7 +145,9 @@ export function createAnthropicPayloadLogger(params: {
           payload: redactedPayload,
           payloadDigest: digest(redactedPayload),
         });
-        return options?.onPayload?.(payload, model);
+        return (
+          options?.onPayload as ((payload: unknown, model: unknown) => unknown) | undefined
+        )?.(payload, payloadModel);
       };
       return streamFn(model, context, {
         ...options,

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -276,7 +276,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { model: "deepseek/deepseek-r1" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -308,7 +308,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -332,7 +332,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "high" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -357,7 +357,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning: { max_tokens: 256 } };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -381,7 +381,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "medium" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -588,7 +588,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -619,7 +619,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -650,7 +650,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -674,7 +674,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { tool_choice: "required" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -699,7 +699,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -749,7 +749,7 @@ describe("applyExtraParamsToAgent", () => {
         ],
         tool_choice: { type: "tool", name: "read" },
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -793,7 +793,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         ],
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -832,7 +832,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         ],
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -896,7 +896,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         },
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -943,7 +943,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         },
       };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -277,7 +277,7 @@ export function createAnthropicToolPayloadCompatibilityWrapper(
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (
           payload &&
           typeof payload === "object" &&
@@ -298,7 +298,7 @@ export function createAnthropicToolPayloadCompatibilityWrapper(
             );
           }
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };

--- a/src/agents/pi-embedded-runner/extra-params.kilocode.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.kilocode.test.ts
@@ -97,7 +97,7 @@ describe("extra-params: Kilocode kilo/auto reasoning", () => {
 
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "high" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       capturedPayload = payload;
       return createAssistantMessageEventStream();
     };
@@ -125,7 +125,7 @@ describe("extra-params: Kilocode kilo/auto reasoning", () => {
 
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       capturedPayload = payload;
       return createAssistantMessageEventStream();
     };
@@ -158,7 +158,7 @@ describe("extra-params: Kilocode kilo/auto reasoning", () => {
 
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "high" };
-      options?.onPayload?.(payload, _model);
+      options?.onPayload?.(payload, model);
       capturedPayload = payload;
       return createAssistantMessageEventStream();
     };

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -222,7 +222,7 @@ function createGoogleThinkingPayloadWrapper(
     const onPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (model.api === "google-generative-ai") {
           sanitizeGoogleThinkingPayload({
             payload,
@@ -230,7 +230,7 @@ function createGoogleThinkingPayloadWrapper(
             thinkingLevel,
           });
         }
-        return onPayload?.(payload, model);
+        return onPayload?.(payload, payloadModel);
       },
     });
   };
@@ -258,12 +258,12 @@ function createZaiToolStreamWrapper(
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (payload && typeof payload === "object") {
           // Inject tool_stream: true for Z.AI API
           (payload as Record<string, unknown>).tool_stream = true;
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };
@@ -306,11 +306,11 @@ function createParallelToolCallsWrapper(
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (payload && typeof payload === "object") {
           (payload as Record<string, unknown>).parallel_tool_calls = enabled;
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };

--- a/src/agents/pi-embedded-runner/moonshot-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/moonshot-stream-wrappers.ts
@@ -53,14 +53,14 @@ export function createSiliconFlowThinkingWrapper(baseStreamFn: StreamFn | undefi
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
           if (payloadObj.thinking === "off") {
             payloadObj.thinking = null;
           }
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };
@@ -89,7 +89,7 @@ export function createMoonshotThinkingWrapper(
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
           let effectiveThinkingType = normalizeMoonshotThinkingType(payloadObj.thinking);
@@ -106,7 +106,7 @@ export function createMoonshotThinkingWrapper(
             payloadObj.tool_choice = "auto";
           }
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -187,7 +187,7 @@ export function createOpenAIResponsesContextManagementWrapper(
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (payload && typeof payload === "object") {
           applyOpenAIResponsesPayloadOverrides({
             payloadObj: payload as Record<string, unknown>,
@@ -197,7 +197,7 @@ export function createOpenAIResponsesContextManagementWrapper(
             compactThreshold,
           });
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };
@@ -219,14 +219,14 @@ export function createOpenAIServiceTierWrapper(
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
           if (payloadObj.service_tier === undefined) {
             payloadObj.service_tier = serviceTier;
           }
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -73,7 +73,7 @@ export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | unde
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         const messages = (payload as Record<string, unknown>)?.messages;
         if (Array.isArray(messages)) {
           for (const msg of messages as Array<{ role?: string; content?: unknown }>) {
@@ -92,7 +92,7 @@ export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | unde
             }
           }
         }
-        return originalOnPayload?.(payload, model);
+        return originalOnPayload?.(payload, payloadModel);
       },
     });
   };
@@ -111,9 +111,9 @@ export function createOpenRouterWrapper(
         ...OPENROUTER_APP_HEADERS,
         ...options?.headers,
       },
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         normalizeProxyReasoningPayload(payload, thinkingLevel);
-        return onPayload?.(payload, model);
+        return onPayload?.(payload, payloadModel);
       },
     });
   };
@@ -136,9 +136,9 @@ export function createKilocodeWrapper(
         ...options?.headers,
         ...resolveKilocodeAppHeaders(),
       },
-      onPayload: (payload) => {
+      onPayload: (payload, payloadModel) => {
         normalizeProxyReasoningPayload(payload, thinkingLevel);
-        return onPayload?.(payload, model);
+        return onPayload?.(payload, payloadModel);
       },
     });
   };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -111,7 +111,10 @@ import {
 } from "../runs.js";
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
-import { prepareSessionManagerForRun } from "../session-manager-init.js";
+import {
+  prepareSessionManagerForRun,
+  shouldInjectBootstrapContext,
+} from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
@@ -796,16 +799,18 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-      });
+    const injectBootstrapContext = await shouldInjectBootstrapContext(params.sessionFile);
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } = injectBootstrapContext
+      ? await resolveBootstrapContextForRun({
+          workspaceDir: effectiveWorkspace,
+          config: params.config,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          contextMode: params.bootstrapContextMode,
+          runKind: params.bootstrapContextRunKind,
+        })
+      : { bootstrapFiles: [], contextFiles: [] };
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -231,16 +231,16 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
   return (model, context, options) =>
     streamFn(model, context, {
       ...options,
-      onPayload: (payload: unknown) => {
+      onPayload: (payload: unknown, payloadModel) => {
         if (!payload || typeof payload !== "object") {
-          return options?.onPayload?.(payload, model);
+          return options?.onPayload?.(payload, payloadModel);
         }
         const payloadRecord = payload as Record<string, unknown>;
         if (!payloadRecord.options || typeof payloadRecord.options !== "object") {
           payloadRecord.options = {};
         }
         (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-        return options?.onPayload?.(payload, model);
+        return options?.onPayload?.(payload, payloadModel);
       },
     });
 }

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -19,6 +19,12 @@ async function makeSessionFile(content?: string): Promise<string> {
   return sessionFile;
 }
 
+async function makeSessionDirectory(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-bootstrap-dir-"));
+  tempRoots.push(root);
+  return path.join(root, "session-dir");
+}
+
 afterEach(async () => {
   await Promise.all(
     tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
@@ -62,6 +68,13 @@ describe("shouldInjectBootstrapContext", () => {
   it("falls back to injecting bootstrap context when the transcript is malformed", async () => {
     const sessionFile = await makeSessionFile("{not-json}\n");
     expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("falls back to injecting bootstrap context when transcript streaming fails", async () => {
+    const sessionDir = await makeSessionDirectory();
+    await fs.mkdir(sessionDir);
+
+    expect(await shouldInjectBootstrapContext(sessionDir)).toBe(true);
   });
 
   it("falls back to injecting bootstrap context when the first assistant entry is beyond the scan cap", async () => {

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { shouldInjectBootstrapContext } from "./session-manager-init.js";
+
+const tempRoots: string[] = [];
+
+async function makeSessionFile(content?: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-bootstrap-"));
+  tempRoots.push(root);
+  const sessionFile = path.join(root, "session.jsonl");
+  if (content !== undefined) {
+    await fs.writeFile(sessionFile, content, "utf-8");
+  }
+  return sessionFile;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("shouldInjectBootstrapContext", () => {
+  it("injects bootstrap context when the transcript does not exist yet", async () => {
+    const sessionFile = await makeSessionFile();
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("injects bootstrap context when the transcript only has a session header", async () => {
+    const sessionFile = await makeSessionFile(
+      `${JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" })}\n`,
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("keeps bootstrap context when the transcript only has pre-assistant messages", async () => {
+    const sessionFile = await makeSessionFile(
+      [
+        JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      ].join("\n"),
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+
+  it("skips bootstrap context after the transcript already has an assistant message", async () => {
+    const sessionFile = await makeSessionFile(
+      [
+        JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+      ].join("\n"),
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(false);
+  });
+
+  it("falls back to injecting bootstrap context when the transcript is malformed", async () => {
+    const sessionFile = await makeSessionFile("{not-json}\n");
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { shouldInjectBootstrapContext } from "./session-manager-init.js";
+import {
+  prepareSessionManagerForRun,
+  shouldInjectBootstrapContext,
+} from "./session-manager-init.js";
 
 const tempRoots: string[] = [];
 
@@ -59,5 +62,92 @@ describe("shouldInjectBootstrapContext", () => {
   it("falls back to injecting bootstrap context when the transcript is malformed", async () => {
     const sessionFile = await makeSessionFile("{not-json}\n");
     expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
+});
+
+describe("prepareSessionManagerForRun", () => {
+  it("updates in-memory header metadata for fresh session files", async () => {
+    const sessionFile = await makeSessionFile();
+    const header = { type: "session" as const };
+    const sessionManager = {
+      sessionId: "old-session",
+      flushed: false,
+      fileEntries: [header],
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: false,
+      sessionId: "sess-1",
+      cwd: "/workspace",
+    });
+
+    expect(header).toEqual({ type: "session", id: "sess-1", cwd: "/workspace" });
+    expect(sessionManager.sessionId).toBe("sess-1");
+  });
+
+  it("resets pre-created session files that do not have an assistant message yet", async () => {
+    const sessionFile = await makeSessionFile("existing transcript");
+    const header = { type: "session" as const, id: "sess-1", cwd: "/workspace" };
+    const sessionManager = {
+      sessionId: "sess-1",
+      flushed: true,
+      fileEntries: [
+        header,
+        { type: "message" as const, message: { role: "user", content: "hello" } },
+      ],
+      byId: new Map([["msg-1", { id: "msg-1" }]]),
+      labelsById: new Map([["last", { id: "msg-1" }]]),
+      leafId: "msg-1",
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "sess-1",
+      cwd: "/workspace",
+    });
+
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe("");
+    expect(sessionManager.fileEntries).toEqual([header]);
+    expect(sessionManager.byId.size).toBe(0);
+    expect(sessionManager.labelsById.size).toBe(0);
+    expect(sessionManager.leafId).toBeNull();
+    expect(sessionManager.flushed).toBe(false);
+  });
+
+  it("keeps existing session state once an assistant message has already been persisted", async () => {
+    const sessionFile = await makeSessionFile("existing transcript");
+    const header = { type: "session" as const, id: "sess-1", cwd: "/workspace" };
+    const byId = new Map([["msg-1", { id: "msg-1" }]]);
+    const labelsById = new Map([["last", { id: "msg-1" }]]);
+    const sessionManager = {
+      sessionId: "sess-1",
+      flushed: true,
+      fileEntries: [
+        header,
+        { type: "message" as const, message: { role: "assistant", content: "hi" } },
+      ],
+      byId,
+      labelsById,
+      leafId: "msg-1",
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "sess-1",
+      cwd: "/workspace",
+    });
+
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe("existing transcript");
+    expect(sessionManager.fileEntries).toHaveLength(2);
+    expect(sessionManager.byId).toBe(byId);
+    expect(sessionManager.labelsById).toBe(labelsById);
+    expect(sessionManager.leafId).toBe("msg-1");
+    expect(sessionManager.flushed).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -25,6 +25,19 @@ async function makeSessionDirectory(): Promise<string> {
   return path.join(root, "session-dir");
 }
 
+async function makeSessionSymlink(targetContent = "target"): Promise<{
+  symlinkPath: string;
+  targetPath: string;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-bootstrap-link-"));
+  tempRoots.push(root);
+  const targetPath = path.join(root, "target.jsonl");
+  const symlinkPath = path.join(root, "session.jsonl");
+  await fs.writeFile(targetPath, targetContent, "utf-8");
+  await fs.symlink(targetPath, symlinkPath);
+  return { symlinkPath, targetPath };
+}
+
 afterEach(async () => {
   await Promise.all(
     tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
@@ -76,6 +89,14 @@ describe("shouldInjectBootstrapContext", () => {
 
     expect(await shouldInjectBootstrapContext(sessionDir)).toBe(true);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "falls back to injecting bootstrap context when transcript path is a symlink",
+    async () => {
+      const { symlinkPath } = await makeSessionSymlink();
+      expect(await shouldInjectBootstrapContext(symlinkPath)).toBe(true);
+    },
+  );
 
   it("falls back to injecting bootstrap context when the first assistant entry is beyond the scan cap", async () => {
     const oversizedUserContent = "x".repeat(300_000);
@@ -178,4 +199,31 @@ describe("prepareSessionManagerForRun", () => {
     expect(sessionManager.leafId).toBe("msg-1");
     expect(sessionManager.flushed).toBe(true);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "refuses to truncate symlinked session files while resetting pre-assistant state",
+    async () => {
+      const { symlinkPath, targetPath } = await makeSessionSymlink("do-not-touch");
+      const header = { type: "session" as const, id: "sess-1", cwd: "/workspace" };
+      const sessionManager = {
+        sessionId: "sess-1",
+        flushed: true,
+        fileEntries: [
+          header,
+          { type: "message" as const, message: { role: "user", content: "hello" } },
+        ],
+      };
+
+      await expect(
+        prepareSessionManagerForRun({
+          sessionManager,
+          sessionFile: symlinkPath,
+          hadSessionFile: true,
+          sessionId: "sess-1",
+          cwd: "/workspace",
+        }),
+      ).rejects.toThrow(/must be a regular file/i);
+      expect(await fs.readFile(targetPath, "utf-8")).toBe("do-not-touch");
+    },
+  );
 });

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -63,6 +63,21 @@ describe("shouldInjectBootstrapContext", () => {
     const sessionFile = await makeSessionFile("{not-json}\n");
     expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
   });
+
+  it("falls back to injecting bootstrap context when the first assistant entry is beyond the scan cap", async () => {
+    const oversizedUserContent = "x".repeat(300_000);
+    const sessionFile = await makeSessionFile(
+      [
+        JSON.stringify({ type: "session", id: "sess-1", cwd: "/tmp" }),
+        JSON.stringify({
+          type: "message",
+          message: { role: "user", content: oversizedUserContent },
+        }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+      ].join("\n"),
+    );
+    expect(await shouldInjectBootstrapContext(sessionFile)).toBe(true);
+  });
 });
 
 describe("prepareSessionManagerForRun", () => {

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -24,15 +24,18 @@ export async function shouldInjectBootstrapContext(sessionFile: string): Promise
   }
 
   const byteLimit = Math.min(stat.size, MAX_TRANSCRIPT_SCAN_BYTES);
-  const stream = fs.createReadStream(sessionFile, {
-    encoding: "utf-8",
-    end: Math.max(0, byteLimit - 1),
-  });
-  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  let stream: fs.ReadStream | null = null;
+  let rl: readline.Interface | null = null;
 
   let scannedLines = 0;
   let scannedBytes = 0;
   try {
+    stream = fs.createReadStream(sessionFile, {
+      encoding: "utf-8",
+      end: Math.max(0, byteLimit - 1),
+    });
+    rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
     for await (const rawLine of rl) {
       scannedLines += 1;
       scannedBytes += Buffer.byteLength(rawLine, "utf8");
@@ -56,9 +59,11 @@ export async function shouldInjectBootstrapContext(sessionFile: string): Promise
         return true;
       }
     }
+  } catch {
+    return true;
   } finally {
-    rl.close();
-    stream.destroy();
+    rl?.close();
+    stream?.destroy();
   }
 
   return true;

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -3,6 +3,36 @@ import fs from "node:fs/promises";
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
+export async function shouldInjectBootstrapContext(sessionFile: string): Promise<boolean> {
+  let content: string;
+  try {
+    content = await fs.readFile(sessionFile, "utf-8");
+  } catch {
+    return true;
+  }
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line) as {
+        type?: string;
+        message?: { role?: string };
+      };
+      if (entry.type === "message" && entry.message?.role === "assistant") {
+        return false;
+      }
+    } catch {
+      // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly yet.
+      return true;
+    }
+  }
+
+  return true;
+}
+
 /**
  * pi-coding-agent SessionManager persistence quirk:
  * - If the file exists but has no assistant message, SessionManager marks itself `flushed=true`

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
+type SessionTranscriptEntry = { type?: string; message?: { role?: string } };
+
+function isAssistantMessageEntry(entry: SessionTranscriptEntry): entry is SessionMessageEntry {
+  return entry.type === "message" && entry.message?.role === "assistant";
+}
 
 export async function shouldInjectBootstrapContext(sessionFile: string): Promise<boolean> {
   let content: string;
@@ -17,14 +22,13 @@ export async function shouldInjectBootstrapContext(sessionFile: string): Promise
       continue;
     }
     try {
-      const entry = JSON.parse(line) as {
-        type?: string;
-        message?: { role?: string };
-      };
-      if (entry.type === "message" && entry.message?.role === "assistant") {
+      const entry = JSON.parse(line) as SessionTranscriptEntry;
+      if (isAssistantMessageEntry(entry)) {
         return false;
       }
     } catch {
+      // Treat any read/parse uncertainty as "inject bootstrap" because missing bootstrap
+      // context is more harmful than redundantly re-injecting it on a retry.
       // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly.
       return true;
     }
@@ -60,9 +64,7 @@ export async function prepareSessionManagerForRun(params: {
   };
 
   const header = sm.fileEntries.find((e): e is SessionHeaderEntry => e.type === "session");
-  const hasAssistant = sm.fileEntries.some(
-    (e) => e.type === "message" && (e as SessionMessageEntry).message?.role === "assistant",
-  );
+  const hasAssistant = sm.fileEntries.some(isAssistantMessageEntry);
 
   if (!params.hadSessionFile && header) {
     header.id = params.sessionId;

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -12,10 +12,20 @@ function isAssistantMessageEntry(entry: SessionTranscriptEntry): entry is Sessio
   return entry.type === "message" && entry.message?.role === "assistant";
 }
 
+async function statRegularSessionTranscript(
+  sessionFile: string,
+): Promise<Awaited<ReturnType<typeof fsPromises.lstat>>> {
+  const stat = await fsPromises.lstat(sessionFile);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`Session transcript must be a regular file: ${sessionFile}`);
+  }
+  return stat;
+}
+
 export async function shouldInjectBootstrapContext(sessionFile: string): Promise<boolean> {
-  let stat: Awaited<ReturnType<typeof fsPromises.stat>>;
+  let stat: Awaited<ReturnType<typeof fsPromises.lstat>>;
   try {
-    stat = await fsPromises.stat(sessionFile);
+    stat = await statRegularSessionTranscript(sessionFile);
   } catch {
     return true;
   }
@@ -106,6 +116,7 @@ export async function prepareSessionManagerForRun(params: {
   }
 
   if (params.hadSessionFile && header && !hasAssistant) {
+    await statRegularSessionTranscript(params.sessionFile);
     // Reset file so the first assistant flush includes header+user+assistant in order.
     await fsPromises.writeFile(params.sessionFile, "", "utf-8");
     sm.fileEntries = [header];

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -12,6 +12,13 @@ function isAssistantMessageEntry(entry: SessionTranscriptEntry): entry is Sessio
   return entry.type === "message" && entry.message?.role === "assistant";
 }
 
+function normalizeTranscriptSize(size: number | bigint): number {
+  if (typeof size === "number") {
+    return size;
+  }
+  return size > BigInt(Number.MAX_SAFE_INTEGER) ? Number.MAX_SAFE_INTEGER : Number(size);
+}
+
 async function statRegularSessionTranscript(
   sessionFile: string,
 ): Promise<Awaited<ReturnType<typeof fsPromises.lstat>>> {
@@ -33,7 +40,7 @@ export async function shouldInjectBootstrapContext(sessionFile: string): Promise
     return true;
   }
 
-  const byteLimit = Math.min(stat.size, MAX_TRANSCRIPT_SCAN_BYTES);
+  const byteLimit = Math.min(normalizeTranscriptSize(stat.size), MAX_TRANSCRIPT_SCAN_BYTES);
   let stream: fs.ReadStream | null = null;
   let rl: readline.Interface | null = null;
 

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,37 +1,64 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import readline from "node:readline";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 type SessionTranscriptEntry = { type?: string; message?: { role?: string } };
+const MAX_TRANSCRIPT_SCAN_BYTES = 256 * 1024;
+const MAX_TRANSCRIPT_SCAN_LINES = 2_000;
 
 function isAssistantMessageEntry(entry: SessionTranscriptEntry): entry is SessionMessageEntry {
   return entry.type === "message" && entry.message?.role === "assistant";
 }
 
 export async function shouldInjectBootstrapContext(sessionFile: string): Promise<boolean> {
-  let content: string;
+  let stat: Awaited<ReturnType<typeof fsPromises.stat>>;
   try {
-    content = await fs.readFile(sessionFile, "utf-8");
+    stat = await fsPromises.stat(sessionFile);
   } catch {
     return true;
   }
+  if (stat.size <= 0) {
+    return true;
+  }
 
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line) {
-      continue;
-    }
-    try {
-      const entry = JSON.parse(line) as SessionTranscriptEntry;
-      if (isAssistantMessageEntry(entry)) {
-        return false;
+  const byteLimit = Math.min(stat.size, MAX_TRANSCRIPT_SCAN_BYTES);
+  const stream = fs.createReadStream(sessionFile, {
+    encoding: "utf-8",
+    end: Math.max(0, byteLimit - 1),
+  });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  let scannedLines = 0;
+  let scannedBytes = 0;
+  try {
+    for await (const rawLine of rl) {
+      scannedLines += 1;
+      scannedBytes += Buffer.byteLength(rawLine, "utf8");
+      if (scannedLines > MAX_TRANSCRIPT_SCAN_LINES || scannedBytes > MAX_TRANSCRIPT_SCAN_BYTES) {
+        return true;
       }
-    } catch {
-      // Treat any read/parse uncertainty as "inject bootstrap" because missing bootstrap
-      // context is more harmful than redundantly re-injecting it on a retry.
-      // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly.
-      return true;
+
+      const line = rawLine.trim();
+      if (!line) {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(line) as SessionTranscriptEntry;
+        if (isAssistantMessageEntry(entry)) {
+          return false;
+        }
+      } catch {
+        // Treat any read/parse uncertainty as "inject bootstrap" because missing bootstrap
+        // context is more harmful than redundantly re-injecting it on a retry.
+        // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly.
+        return true;
+      }
     }
+  } finally {
+    rl.close();
+    stream.destroy();
   }
 
   return true;
@@ -75,7 +102,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fsPromises.writeFile(params.sessionFile, "", "utf-8");
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -25,7 +25,7 @@ export async function shouldInjectBootstrapContext(sessionFile: string): Promise
         return false;
       }
     } catch {
-      // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly yet.
+      // Fall back to injecting bootstrap context if the transcript cannot be parsed cleanly.
       return true;
     }
   }

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -22,4 +22,32 @@ describe("generateZshCompletion", () => {
 
     expect(() => generateZshCompletion(program)).toThrow(/unsafe command name/i);
   });
+
+  it("escapes zsh descriptions and emits quoted specs per option flag", () => {
+    const program = new Command();
+    program
+      .name("openclaw")
+      .description("root")
+      .option("-s, --safe", 'danger $(touch /tmp/pwned) `whoami` [x] "quoted"');
+    program.command("status").description("show $(uname) `id` status");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain(
+      '"(--safe -s)--safe[danger \\$(touch /tmp/pwned) \\`whoami\\` \\[x\\] \\"quoted\\"]"',
+    );
+    expect(script).toContain(
+      '"(--safe -s)-s[danger \\$(touch /tmp/pwned) \\`whoami\\` \\[x\\] \\"quoted\\"]"',
+    );
+    expect(script).toContain("'status[show \\$(uname) \\`id\\` status]'");
+    expect(script).not.toContain("{--safe,-s}");
+  });
+
+  it("rejects unsafe option flags before emitting zsh code", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.addOption(new Command().createOption("--safe$(id)", "unsafe"));
+
+    expect(() => generateZshCompletion(program)).toThrow(/unsafe option flag/i);
+  });
 });

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { generateZshCompletion } from "./completion-cli.js";
+
+describe("generateZshCompletion", () => {
+  it("initializes compinit only when compdef is unavailable", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("status").description("show status");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain("if ! (( $+functions[compdef] )); then");
+    expect(script).toContain("autoload -Uz compinit");
+    expect(script).toContain("compinit");
+    expect(script).toContain("compdef _openclaw_root_completion openclaw");
+  });
+});

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -43,6 +43,16 @@ describe("generateZshCompletion", () => {
     expect(script).not.toContain("{--safe,-s}");
   });
 
+  it("escapes apostrophes in zsh single-quoted subcommand specs", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("browser").description("Manage OpenClaw's browser sessions");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain("'browser[Manage OpenClaw'\\''s browser sessions]'");
+  });
+
   it("rejects unsafe option flags before emitting zsh code", () => {
     const program = new Command();
     program.name("openclaw");

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -13,6 +13,13 @@ describe("generateZshCompletion", () => {
     expect(script).toContain("if ! (( $+functions[compdef] )); then");
     expect(script).toContain("autoload -Uz compinit");
     expect(script).toContain("compinit");
-    expect(script).toContain("compdef _openclaw_root_completion openclaw");
+    expect(script).toContain("compdef _openclaw_root_completion -- openclaw");
+  });
+
+  it("rejects unsafe command names before emitting zsh code", () => {
+    const program = new Command();
+    program.name("openclaw; rm -rf /");
+
+    expect(() => generateZshCompletion(program)).toThrow(/unsafe command name/i);
   });
 });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -376,10 +376,15 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 }
 
-function generateZshCompletion(program: Command): string {
+export function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
 #compdef ${rootCmd}
+
+if ! (( $+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit
+fi
 
 _${rootCmd}_root_completion() {
   local -a commands

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -56,8 +56,35 @@ function sanitizeZshCommandName(value: string): string {
   return trimmed;
 }
 
+function sanitizeZshOptionFlag(value: string): string {
+  const trimmed = value.trim();
+  if (!/^--?[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed)) {
+    throw new Error(`Unsafe option flag for zsh completion: ${value}`);
+  }
+  return trimmed;
+}
+
 function toZshFunctionSegment(value: string): string {
   return sanitizeZshCommandName(value).replace(/[^A-Za-z0-9]/g, "_");
+}
+
+function escapeZshDoubleQuoted(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/!/g, "\\!")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
+}
+
+function escapeZshSingleQuotedValue(value: string): string {
+  return escapeZshDoubleQuoted(value).replace(/'/g, "\\'");
+}
+
+function buildZshOptionSpec(flag: string, exclusiveFlags: string[], desc: string): string {
+  return `"(${exclusiveFlags.join(" ")})${flag}[${desc}]"`;
 }
 
 function resolveCompletionCacheDir(env: NodeJS.ProcessEnv = process.env): string {
@@ -434,18 +461,21 @@ function generateZshArgs(cmd: Command): string {
   return (cmd.options || [])
     .map((opt) => {
       const flags = opt.flags.split(/[ ,|]+/);
-      const name = flags.find((f) => f.startsWith("--")) || flags[0];
-      const short = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
-      const desc = opt.description
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-        .replace(/'/g, "'\\''")
-        .replace(/\[/g, "\\[")
-        .replace(/\]/g, "\\]");
-      if (short) {
-        return `"(${name} ${short})"{${name},${short}}"[${desc}]"`;
+      const longFlag = flags.find((f) => f.startsWith("--"));
+      const shortFlag = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
+      const primaryFlag = sanitizeZshOptionFlag(longFlag || flags[0] || "");
+      const secondaryFlag = shortFlag ? sanitizeZshOptionFlag(shortFlag) : null;
+      const desc = escapeZshDoubleQuoted(opt.description);
+      const exclusiveFlags = [primaryFlag, secondaryFlag].filter((value): value is string =>
+        Boolean(value),
+      );
+      if (!secondaryFlag) {
+        return buildZshOptionSpec(primaryFlag, exclusiveFlags, desc);
       }
-      return `"${name}[${desc}]"`;
+      return [
+        buildZshOptionSpec(primaryFlag, exclusiveFlags, desc),
+        buildZshOptionSpec(secondaryFlag, exclusiveFlags, desc),
+      ].join(" \\\n    ");
     })
     .join(" \\\n    ");
 }
@@ -454,12 +484,7 @@ function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
     .map((c) => {
       const name = sanitizeZshCommandName(c.name());
-      const desc = c
-        .description()
-        .replace(/\\/g, "\\\\")
-        .replace(/'/g, "'\\''")
-        .replace(/\[/g, "\\[")
-        .replace(/\]/g, "\\]");
+      const desc = escapeZshSingleQuotedValue(c.description());
       return `'${name}[${desc}]'`;
     })
     .join(" ");

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -48,6 +48,18 @@ function sanitizeCompletionBasename(value: string): string {
   return trimmed.replace(/[^a-zA-Z0-9._-]/g, "-");
 }
 
+function sanitizeZshCommandName(value: string): string {
+  const trimmed = value.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed)) {
+    throw new Error(`Unsafe command name for zsh completion: ${value}`);
+  }
+  return trimmed;
+}
+
+function toZshFunctionSegment(value: string): string {
+  return sanitizeZshCommandName(value).replace(/[^A-Za-z0-9]/g, "_");
+}
+
 function resolveCompletionCacheDir(env: NodeJS.ProcessEnv = process.env): string {
   const stateDir = resolveStateDir(env, os.homedir);
   return path.join(stateDir, "completions");
@@ -377,7 +389,9 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 }
 
 export function generateZshCompletion(program: Command): string {
-  const rootCmd = program.name();
+  const rootCmd = sanitizeZshCommandName(program.name());
+  const rootPrefix = `_${toZshFunctionSegment(rootCmd)}`;
+  const rootFn = `${rootPrefix}_root_completion`;
   const script = `
 #compdef ${rootCmd}
 
@@ -386,7 +400,7 @@ if ! (( $+functions[compdef] )); then
   compinit
 fi
 
-_${rootCmd}_root_completion() {
+${rootFn}() {
   local -a commands
   local -a options
   
@@ -398,15 +412,20 @@ _${rootCmd}_root_completion() {
   case $state in
     (args)
       case $line[1] in
-        ${program.commands.map((cmd) => `(${cmd.name()}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${program.commands
+          .map((cmd) => {
+            const cmdName = sanitizeZshCommandName(cmd.name());
+            return `(${cmdName}) ${rootPrefix}_${toZshFunctionSegment(cmdName)} ;;`;
+          })
+          .join("\n        ")}
       esac
       ;;
   esac
 }
 
-${generateZshSubcommands(program, rootCmd)}
+${generateZshSubcommands(program, rootPrefix)}
 
-compdef _${rootCmd}_root_completion ${rootCmd}
+compdef ${rootFn} -- ${rootCmd}
 `;
   return script;
 }
@@ -434,13 +453,14 @@ function generateZshArgs(cmd: Command): string {
 function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
     .map((c) => {
+      const name = sanitizeZshCommandName(c.name());
       const desc = c
         .description()
         .replace(/\\/g, "\\\\")
         .replace(/'/g, "'\\''")
         .replace(/\[/g, "\\[")
         .replace(/\]/g, "\\]");
-      return `'${c.name()}[${desc}]'`;
+      return `'${name}[${desc}]'`;
     })
     .join(" ");
   return `"1: :_values 'command' ${list}"`;
@@ -449,11 +469,11 @@ function generateZshSubcmdList(cmd: Command): string {
 function generateZshSubcommands(program: Command, prefix: string): string {
   let script = "";
   for (const cmd of program.commands) {
-    const cmdName = cmd.name();
-    const funcName = `_${prefix}_${cmdName.replace(/-/g, "_")}`;
+    const cmdName = sanitizeZshCommandName(cmd.name());
+    const funcName = `${prefix}_${toZshFunctionSegment(cmdName)}`;
 
     // Recurse first
-    script += generateZshSubcommands(cmd, `${prefix}_${cmdName.replace(/-/g, "_")}`);
+    script += generateZshSubcommands(cmd, funcName);
 
     const subCommands = cmd.commands;
     if (subCommands.length > 0) {
@@ -467,13 +487,18 @@ ${funcName}() {
     ${generateZshSubcmdList(cmd)} \\
     "*::arg:->args"
 
-  case $state in
-    (args)
-      case $line[1] in
-        ${subCommands.map((sub) => `(${sub.name()}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+      case $state in
+        (args)
+          case $line[1] in
+        ${subCommands
+          .map((sub) => {
+            const subName = sanitizeZshCommandName(sub.name());
+            return `(${subName}) ${funcName}_${toZshFunctionSegment(subName)} ;;`;
+          })
+          .join("\n        ")}
+          esac
+          ;;
       esac
-      ;;
-  esac
 }
 `;
     } else {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -80,7 +80,8 @@ function escapeZshDoubleQuoted(value: string): string {
 }
 
 function escapeZshSingleQuotedValue(value: string): string {
-  return escapeZshDoubleQuoted(value).replace(/'/g, "\\'");
+  // In zsh single-quoted strings, apostrophes must be encoded as: '\''.
+  return escapeZshDoubleQuoted(value).replace(/'/g, "'\\''");
 }
 
 function buildZshOptionSpec(flag: string, exclusiveFlags: string[], desc: string): string {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -142,6 +142,38 @@ describe("config io write", () => {
     });
   });
 
+  it("preserves file provider allowInsecurePath on write", async () => {
+    await withSuiteHome(async (home) => {
+      const { configPath, io, snapshot } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: {
+          secrets: {
+            providers: {
+              default: {
+                source: "file",
+                path: "/tmp/openclaw-secrets.json",
+                mode: "json",
+                allowInsecurePath: true,
+              },
+            },
+          },
+        },
+      });
+
+      const persisted = await writeTokenAuthAndReadConfig({ io, snapshot, configPath });
+      expect(persisted.secrets).toEqual({
+        providers: {
+          default: {
+            source: "file",
+            path: "/tmp/openclaw-secrets.json",
+            mode: "json",
+            allowInsecurePath: true,
+          },
+        },
+      });
+    });
+  });
+
   it('shows actionable guidance for dmPolicy="open" without wildcard allowFrom', async () => {
     await withSuiteHome(async (home) => {
       const io = createConfigIO({

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -187,6 +187,7 @@ export type FileSecretProviderConfig = {
   mode?: FileSecretProviderMode;
   timeoutMs?: number;
   maxBytes?: number;
+  allowInsecurePath?: boolean;
 };
 
 export type ExecSecretProviderConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -99,6 +99,7 @@ const SecretsFileProviderSchema = z
       .positive()
       .max(20 * 1024 * 1024)
       .optional(),
+    allowInsecurePath: z.boolean().optional(),
   })
   .strict();
 

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -229,6 +229,11 @@ describe("secret ref resolver", () => {
     expect(value).toBe("value:openai/api-key");
   });
 
+  itPosix("allows exec-provider allowInsecurePath outside Windows", async () => {
+    const value = await resolveExecSecret(execProtocolV1ScriptPath, { allowInsecurePath: true });
+    expect(value).toBe("value:openai/api-key");
+  });
+
   itPosix("uses timeoutMs as the default no-output timeout for exec providers", async () => {
     const root = await createCaseDir("exec-delay");
     const scriptPath = path.join(root, "resolver-delay.sh");

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -45,6 +45,7 @@ describe("secret ref resolver", () => {
     command: string;
     passEnv?: string[];
     jsonOnly?: boolean;
+    allowInsecurePath?: boolean;
     allowSymlinkCommand?: boolean;
     trustedDirs?: string[];
     args?: string[];

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -54,6 +54,7 @@ describe("secret ref resolver", () => {
     path: string;
     mode: "json" | "singleValue";
     timeoutMs?: number;
+    allowInsecurePath?: boolean;
   };
 
   function createExecProviderConfig(
@@ -191,6 +192,36 @@ describe("secret ref resolver", () => {
       },
     );
     expect(value).toBe("sk-file-value");
+  });
+
+  itPosix("rejects file-provider allowInsecurePath outside Windows", async () => {
+    const root = await createCaseDir("file-insecure-flag");
+    const filePath = path.join(root, "secrets.json");
+    await writeSecureFile(
+      filePath,
+      JSON.stringify({
+        providers: {
+          openai: {
+            apiKey: "sk-file-value", // pragma: allowlist secret
+          },
+        },
+      }),
+    );
+
+    await expect(
+      resolveSecretRefString(
+        { source: "file", provider: "filemain", id: "/providers/openai/apiKey" },
+        {
+          config: {
+            secrets: {
+              providers: {
+                filemain: createFileProviderConfig(filePath, { allowInsecurePath: true }),
+              },
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow(/allowInsecurePath is only supported on Windows/i);
   });
 
   itPosix("resolves exec refs with protocolVersion 1 response", async () => {

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -245,9 +245,6 @@ async function assertSecurePath(params: {
     }
   }
   if (params.allowInsecurePath) {
-    if (process.platform !== "win32") {
-      throw new Error(`${params.label} allowInsecurePath is only supported on Windows.`);
-    }
     return effectivePath;
   }
 
@@ -291,6 +288,11 @@ async function readFileProviderPayload(params: {
 
   const filePath = resolveUserPath(params.providerConfig.path);
   const readPromise = (async () => {
+    if (params.providerConfig.allowInsecurePath && process.platform !== "win32") {
+      throw new Error(
+        `secrets.providers.${params.providerName}.path allowInsecurePath is only supported on Windows.`,
+      );
+    }
     const secureFilePath = await assertSecurePath({
       targetPath: filePath,
       label: `secrets.providers.${params.providerName}.path`,

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -291,6 +291,7 @@ async function readFileProviderPayload(params: {
     const secureFilePath = await assertSecurePath({
       targetPath: filePath,
       label: `secrets.providers.${params.providerName}.path`,
+      allowInsecurePath: params.providerConfig.allowInsecurePath,
     });
     const timeoutMs = normalizePositiveInt(
       params.providerConfig.timeoutMs,

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -57,6 +57,15 @@ type ResolutionLimits = {
 
 type ProviderResolutionOutput = Map<string, unknown>;
 
+class WindowsAclUnavailableError extends Error {
+  readonly code = "WINDOWS_ACL_UNAVAILABLE" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "WindowsAclUnavailableError";
+  }
+}
+
 export class SecretProviderResolutionError extends Error {
   readonly scope = "provider" as const;
   readonly source: SecretRefSource;
@@ -259,7 +268,7 @@ async function assertSecurePath(params: {
   }
 
   if (process.platform === "win32" && perms.source === "unknown") {
-    throw new Error(
+    throw new WindowsAclUnavailableError(
       `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this specific check when the path is trusted.`,
     );
   }
@@ -304,8 +313,7 @@ async function readFileProviderPayload(params: {
       const isWindowsAclFallback =
         params.providerConfig.allowInsecurePath &&
         process.platform === "win32" &&
-        error instanceof Error &&
-        error.message.includes("ACL verification unavailable on Windows");
+        error instanceof WindowsAclUnavailableError;
       if (!isWindowsAclFallback) {
         throw error;
       }

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -244,6 +244,9 @@ async function assertSecurePath(params: {
       throw new Error(`${params.label} is outside trustedDirs: ${effectivePath}`);
     }
   }
+  if (params.allowInsecurePath) {
+    return effectivePath;
+  }
 
   const perms = await inspectPathPermissions(effectivePath);
   if (!perms.ok) {
@@ -256,9 +259,6 @@ async function assertSecurePath(params: {
   }
 
   if (process.platform === "win32" && perms.source === "unknown") {
-    if (params.allowInsecurePath) {
-      return effectivePath;
-    }
     throw new Error(
       `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this specific check when the path is trusted.`,
     );

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -245,6 +245,9 @@ async function assertSecurePath(params: {
     }
   }
   if (params.allowInsecurePath) {
+    if (process.platform !== "win32") {
+      throw new Error(`${params.label} allowInsecurePath is only supported on Windows.`);
+    }
     return effectivePath;
   }
 

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -244,9 +244,6 @@ async function assertSecurePath(params: {
       throw new Error(`${params.label} is outside trustedDirs: ${effectivePath}`);
     }
   }
-  if (params.allowInsecurePath) {
-    return effectivePath;
-  }
 
   const perms = await inspectPathPermissions(effectivePath);
   if (!perms.ok) {
@@ -259,8 +256,11 @@ async function assertSecurePath(params: {
   }
 
   if (process.platform === "win32" && perms.source === "unknown") {
+    if (params.allowInsecurePath) {
+      return effectivePath;
+    }
     throw new Error(
-      `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this check when the path is trusted.`,
+      `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this specific check when the path is trusted.`,
     );
   }
 

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -293,11 +293,28 @@ async function readFileProviderPayload(params: {
         `secrets.providers.${params.providerName}.path allowInsecurePath is only supported on Windows.`,
       );
     }
-    const secureFilePath = await assertSecurePath({
-      targetPath: filePath,
-      label: `secrets.providers.${params.providerName}.path`,
-      allowInsecurePath: params.providerConfig.allowInsecurePath,
-    });
+    const label = `secrets.providers.${params.providerName}.path`;
+    let secureFilePath: string;
+    try {
+      secureFilePath = await assertSecurePath({
+        targetPath: filePath,
+        label,
+      });
+    } catch (error) {
+      const isWindowsAclFallback =
+        params.providerConfig.allowInsecurePath &&
+        process.platform === "win32" &&
+        error instanceof Error &&
+        error.message.includes("ACL verification unavailable on Windows");
+      if (!isWindowsAclFallback) {
+        throw error;
+      }
+      secureFilePath = await assertSecurePath({
+        targetPath: filePath,
+        label,
+        allowInsecurePath: true,
+      });
+    }
     const timeoutMs = normalizePositiveInt(
       params.providerConfig.timeoutMs,
       DEFAULT_FILE_TIMEOUT_MS,

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -38,12 +38,19 @@ function loadAuthStoreWithProfiles(profiles: AuthProfileStore["profiles"]): Auth
   };
 }
 
+function createTrustedTestFileProvider(pathname: string) {
+  return {
+    source: "file" as const,
+    path: pathname,
+    mode: "json" as const,
+    ...(process.platform === "win32" ? { allowInsecurePath: true } : {}),
+  };
+}
+
 describe("secrets runtime snapshot", () => {
   afterEach(() => {
     clearSecretsRuntimeSnapshot();
   });
-
-  const allowInsecureTempSecretFile = process.platform === "win32";
 
   it("resolves env refs for config and auth profiles", async () => {
     const config = asConfig({
@@ -608,9 +615,6 @@ describe("secrets runtime snapshot", () => {
   });
 
   it("keeps active secrets runtime snapshots resolved after config writes", async () => {
-    if (os.platform() === "win32") {
-      return;
-    }
     await withTempHome("openclaw-secrets-runtime-write-", async (home) => {
       const configDir = path.join(home, ".openclaw");
       const secretFile = path.join(configDir, "secrets.json");
@@ -648,12 +652,7 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: {
-                source: "file",
-                path: secretFile,
-                mode: "json",
-                ...(allowInsecureTempSecretFile ? { allowInsecurePath: true } : {}),
-              },
+              default: createTrustedTestFileProvider(secretFile),
             },
           },
           models: {
@@ -677,8 +676,17 @@ describe("secrets runtime snapshot", () => {
         key: "sk-file-runtime",
       });
 
+      const nextSourceConfig = getActiveSecretsRuntimeSnapshot()?.sourceConfig;
+      expect(nextSourceConfig).toBeDefined();
+      if (!nextSourceConfig) {
+        throw new Error("expected active secrets runtime source config");
+      }
+      expect(nextSourceConfig.secrets?.providers?.default).toMatchObject(
+        createTrustedTestFileProvider(secretFile),
+      );
+
       await writeConfigFile({
-        ...loadConfig(),
+        ...nextSourceConfig,
         gateway: { auth: { mode: "token" } },
       });
 
@@ -747,12 +755,7 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: {
-                source: "file",
-                path: secretFile,
-                mode: "json",
-                ...(allowInsecureTempSecretFile ? { allowInsecurePath: true } : {}),
-              },
+              default: createTrustedTestFileProvider(secretFile),
             },
           },
           models: {
@@ -771,9 +774,18 @@ describe("secrets runtime snapshot", () => {
 
       activateSecretsRuntimeSnapshot(prepared);
 
+      const nextSourceConfig = getActiveSecretsRuntimeSnapshot()?.sourceConfig;
+      expect(nextSourceConfig).toBeDefined();
+      if (!nextSourceConfig) {
+        throw new Error("expected active secrets runtime source config");
+      }
+      expect(nextSourceConfig.secrets?.providers?.default).toMatchObject(
+        createTrustedTestFileProvider(secretFile),
+      );
+
       await expect(
         writeConfigFile({
-          ...loadConfig(),
+          ...nextSourceConfig,
           gateway: { auth: { mode: "token" } },
         }),
       ).rejects.toThrow(

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -270,7 +270,6 @@ describe("resolveGatewayConnection", () => {
               source: "file",
               path: secretFile,
               mode: "json",
-              allowInsecurePath: true,
             },
           },
         },


### PR DESCRIPTION
## Summary

- Problem: bootstrap reuse skipped workspace bootstrap files too early once any transcript message existed, which could drop AGENTS/bootstrap context for retry flows that only had pre-assistant turns.
- Why it matters: those runs can resume without the expected workspace instructions even though the prior transcript is later reset by session-manager recovery logic.
- What changed: bootstrap skipping now waits until an assistant transcript entry exists, and zsh completion now guards both `autoload -Uz compinit` and `compinit` behind the `compdef` availability check.
- What did NOT change (scope boundary): no macOS remote-mode UI work is included here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #9157
- Closes #14289
- Related #40177
- Related #40437

## User-visible / Behavior Changes

- Embedded sessions keep bootstrap context until an assistant turn is actually persisted.
- `source <(openclaw completion --shell zsh)` initializes completion safely whether or not `compinit` already ran.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: mocked unit tests only
- Integration/channel (if any): embedded runner, zsh completion
- Relevant config (redacted): default embedded session transcript JSONL

### Steps

1. Reuse an embedded-agent session whose transcript contains only pre-assistant messages.
2. Run another message through the embedded runner.
3. Source generated zsh completion in a shell with and without preloaded completion.

### Expected

- Bootstrap context remains available until an assistant turn exists.
- zsh completion only runs completion initialization when `compdef` is unavailable.

### Actual

- Verified by targeted unit tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  `pnpm exec vitest run src/agents/pi-embedded-runner/session-manager-init.test.ts src/cli/completion-cli.test.ts`
  `pnpm exec oxfmt --check src/agents/pi-embedded-runner/session-manager-init.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/session-manager-init.test.ts src/cli/completion-cli.ts src/cli/completion-cli.test.ts`
- Edge cases checked:
  missing transcript, header-only transcript, user-only transcript, transcript with assistant message, malformed transcript, zsh completion with existing `compdef`.
- What you did **not** verify:
  full repo build and full CI matrix locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  Revert commit a33560015.
- Files/config to restore:
  `src/agents/pi-embedded-runner/*` and `src/cli/completion-cli.ts`.
- Known bad symptoms reviewers should watch for:
  bootstrap context missing after retrying user-only transcripts, or zsh completion unexpectedly reinitializing completion in already-configured shells.

## Risks and Mitigations

- Risk:
  bootstrap skipping still depends on transcript shape.
  - Mitigation:
    the gate now keys off persisted assistant turns specifically and has regression coverage for user-only transcripts.
- Risk:
  zsh completion behavior varies across shell setups.
  - Mitigation:
    the script now uses the standard `compdef` guard pattern for both autoload and init.
