### PR TITLE
fix(agents): re-expose configured tools and memory plugins

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3257,6 +3257,8 @@ public struct ChatSendParams: Codable, Sendable {
     public let deliver: Bool?
     public let attachments: [AnyCodable]?
     public let timeoutms: Int?
+    public let systeminputprovenance: [String: AnyCodable]?
+    public let systemprovenancereceipt: String?
     public let idempotencykey: String
 
     public init(
@@ -3266,6 +3268,8 @@ public struct ChatSendParams: Codable, Sendable {
         deliver: Bool?,
         attachments: [AnyCodable]?,
         timeoutms: Int?,
+        systeminputprovenance: [String: AnyCodable]?,
+        systemprovenancereceipt: String?,
         idempotencykey: String)
     {
         self.sessionkey = sessionkey
@@ -3274,6 +3278,8 @@ public struct ChatSendParams: Codable, Sendable {
         self.deliver = deliver
         self.attachments = attachments
         self.timeoutms = timeoutms
+        self.systeminputprovenance = systeminputprovenance
+        self.systemprovenancereceipt = systemprovenancereceipt
         self.idempotencykey = idempotencykey
     }
 
@@ -3284,6 +3290,8 @@ public struct ChatSendParams: Codable, Sendable {
         case deliver
         case attachments
         case timeoutms = "timeoutMs"
+        case systeminputprovenance = "systemInputProvenance"
+        case systemprovenancereceipt = "systemProvenanceReceipt"
         case idempotencykey = "idempotencyKey"
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3257,6 +3257,8 @@ public struct ChatSendParams: Codable, Sendable {
     public let deliver: Bool?
     public let attachments: [AnyCodable]?
     public let timeoutms: Int?
+    public let systeminputprovenance: [String: AnyCodable]?
+    public let systemprovenancereceipt: String?
     public let idempotencykey: String
 
     public init(
@@ -3266,6 +3268,8 @@ public struct ChatSendParams: Codable, Sendable {
         deliver: Bool?,
         attachments: [AnyCodable]?,
         timeoutms: Int?,
+        systeminputprovenance: [String: AnyCodable]?,
+        systemprovenancereceipt: String?,
         idempotencykey: String)
     {
         self.sessionkey = sessionkey
@@ -3274,6 +3278,8 @@ public struct ChatSendParams: Codable, Sendable {
         self.deliver = deliver
         self.attachments = attachments
         self.timeoutms = timeoutms
+        self.systeminputprovenance = systeminputprovenance
+        self.systemprovenancereceipt = systemprovenancereceipt
         self.idempotencykey = idempotencykey
     }
 
@@ -3284,6 +3290,8 @@ public struct ChatSendParams: Codable, Sendable {
         case deliver
         case attachments
         case timeoutms = "timeoutMs"
+        case systeminputprovenance = "systemInputProvenance"
+        case systemprovenancereceipt = "systemProvenanceReceipt"
         case idempotencykey = "idempotencyKey"
     }
 }

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   filterToolsByPolicy,
   isToolAllowedByPolicyName,
+  resolveEffectiveToolPolicy,
   resolveSubagentToolPolicy,
 } from "./pi-tools.policy.js";
 import { createStubTool } from "./test-helpers/pi-tool-stubs.js";
@@ -174,5 +175,61 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     const policy = resolveSubagentToolPolicy(leafCfg);
     // Default depth=1, maxSpawnDepth=1 → leaf
     expect(isToolAllowedByPolicyName("sessions_spawn", policy)).toBe(false);
+  });
+});
+
+describe("resolveEffectiveToolPolicy", () => {
+  it("implicitly re-exposes exec and process when tools.exec is configured", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+        exec: { host: "sandbox" },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["exec", "process"]);
+  });
+
+  it("implicitly re-exposes read, write, and edit when tools.fs is configured", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+        fs: { workspaceOnly: false },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
+  });
+
+  it("merges explicit alsoAllow with implicit tool-section exposure", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["web_search"],
+        exec: { host: "sandbox" },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["web_search", "exec", "process"]);
+  });
+
+  it("uses agent tool sections when resolving implicit exposure", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "coder",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
+    expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });
 });

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -2,6 +2,7 @@ import { getChannelDock } from "../channels/dock.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveChannelGroupToolsPolicy } from "../config/group-policy.js";
+import type { AgentToolsConfig } from "../config/types.tools.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveThreadParentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
@@ -196,6 +197,37 @@ function resolveProviderToolPolicy(params: {
   return undefined;
 }
 
+function resolveExplicitProfileAlsoAllow(tools?: OpenClawConfig["tools"]): string[] | undefined {
+  return Array.isArray(tools?.alsoAllow) ? tools.alsoAllow : undefined;
+}
+
+function hasExplicitToolSection(section: unknown): boolean {
+  return section !== undefined && section !== null;
+}
+
+function resolveImplicitProfileAlsoAllow(params: {
+  globalTools?: OpenClawConfig["tools"];
+  agentTools?: AgentToolsConfig;
+}): string[] | undefined {
+  const implicit = new Set<string>();
+  if (
+    hasExplicitToolSection(params.agentTools?.exec) ||
+    hasExplicitToolSection(params.globalTools?.exec)
+  ) {
+    implicit.add("exec");
+    implicit.add("process");
+  }
+  if (
+    hasExplicitToolSection(params.agentTools?.fs) ||
+    hasExplicitToolSection(params.globalTools?.fs)
+  ) {
+    implicit.add("read");
+    implicit.add("write");
+    implicit.add("edit");
+  }
+  return implicit.size > 0 ? Array.from(implicit) : undefined;
+}
+
 export function resolveEffectiveToolPolicy(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
@@ -226,6 +258,15 @@ export function resolveEffectiveToolPolicy(params: {
     modelProvider: params.modelProvider,
     modelId: params.modelId,
   });
+  const explicitProfileAlsoAllow =
+    resolveExplicitProfileAlsoAllow(agentTools) ?? resolveExplicitProfileAlsoAllow(globalTools);
+  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({ globalTools, agentTools });
+  const profileAlsoAllow =
+    explicitProfileAlsoAllow || implicitProfileAlsoAllow
+      ? Array.from(
+          new Set([...(explicitProfileAlsoAllow ?? []), ...(implicitProfileAlsoAllow ?? [])]),
+        )
+      : undefined;
   return {
     agentId,
     globalPolicy: pickSandboxToolPolicy(globalTools),
@@ -235,11 +276,7 @@ export function resolveEffectiveToolPolicy(params: {
     profile,
     providerProfile: agentProviderPolicy?.profile ?? providerPolicy?.profile,
     // alsoAllow is applied at the profile stage (to avoid being filtered out early).
-    profileAlsoAllow: Array.isArray(agentTools?.alsoAllow)
-      ? agentTools?.alsoAllow
-      : Array.isArray(globalTools?.alsoAllow)
-        ? globalTools?.alsoAllow
-        : undefined,
+    profileAlsoAllow,
     providerProfileAlsoAllow: Array.isArray(agentProviderPolicy?.alsoAllow)
       ? agentProviderPolicy?.alsoAllow
       : Array.isArray(providerPolicy?.alsoAllow)

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,7 +1,7 @@
 async function readChunkWithIdleTimeout(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   chunkTimeoutMs: number,
-): Promise<ReadableStreamReadResult<Uint8Array>> {
+): Promise<Awaited<ReturnType<typeof reader.read>>> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
 

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
+import {
+  normalizePluginsConfig,
+  resolveEffectiveEnableState,
+  resolveEnableState,
+} from "./config-state.js";
 
 describe("normalizePluginsConfig", () => {
   it("uses default memory slot when not specified", () => {
@@ -108,6 +112,37 @@ describe("resolveEffectiveEnableState", () => {
         },
       },
     });
+    expect(state).toEqual({ enabled: false, reason: "disabled in config" });
+  });
+});
+
+describe("resolveEnableState", () => {
+  it("keeps the selected memory slot plugin enabled even when omitted from plugins.allow", () => {
+    const state = resolveEnableState(
+      "memory-core",
+      "bundled",
+      normalizePluginsConfig({
+        allow: ["telegram"],
+        slots: { memory: "memory-core" },
+      }),
+    );
+    expect(state).toEqual({ enabled: true });
+  });
+
+  it("keeps explicit disable authoritative for the selected memory slot plugin", () => {
+    const state = resolveEnableState(
+      "memory-core",
+      "bundled",
+      normalizePluginsConfig({
+        allow: ["telegram"],
+        slots: { memory: "memory-core" },
+        entries: {
+          "memory-core": {
+            enabled: false,
+          },
+        },
+      }),
+    );
     expect(state).toEqual({ enabled: false, reason: "disabled in config" });
   });
 });

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -197,18 +197,18 @@ export function resolveEnableState(
   if (config.deny.includes(id)) {
     return { enabled: false, reason: "blocked by denylist" };
   }
-  if (config.allow.length > 0 && !config.allow.includes(id)) {
-    return { enabled: false, reason: "not in allowlist" };
+  const entry = config.entries[id];
+  if (entry?.enabled === false) {
+    return { enabled: false, reason: "disabled in config" };
   }
   if (config.slots.memory === id) {
     return { enabled: true };
   }
-  const entry = config.entries[id];
+  if (config.allow.length > 0 && !config.allow.includes(id)) {
+    return { enabled: false, reason: "not in allowlist" };
+  }
   if (entry?.enabled === true) {
     return { enabled: true };
-  }
-  if (entry?.enabled === false) {
-    return { enabled: false, reason: "disabled in config" };
   }
   if (origin === "bundled" && BUNDLED_ENABLED_BY_DEFAULT.has(id)) {
     return { enabled: true };


### PR DESCRIPTION
## Summary
- implicitly re-expose `exec`/`process` when `tools.exec` is explicitly configured under a restrictive profile
- implicitly re-expose `read`/`write`/`edit` when `tools.fs` is explicitly configured under a restrictive profile
- keep the selected memory slot plugin enabled even when `plugins.allow` omits it, while preserving explicit `plugins.entries.<id>.enabled = false`
- unblock gate with a tiny `ReadableStream` return-type fix in `src/media/read-response-with-limit.ts`

## Testing
- pnpm vitest run src/media/read-response-with-limit.test.ts src/agents/pi-tools.policy.test.ts src/plugins/config-state.test.ts src/agents/pi-tools-agent-config.test.ts
- pnpm check
- pnpm build

Closes #37466
Closes #40361
