### PR TITLE
fix(bluebubbles): keep monitor normalizer self-contained

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -1,7 +1,14 @@
+import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 import { normalizeWebhookMessage, normalizeWebhookReaction } from "./monitor-normalize.js";
 
 describe("normalizeWebhookMessage", () => {
+  it("keeps the normalizer self-contained for packaged plugin loads", () => {
+    const source = fs.readFileSync(new URL("./monitor-normalize.ts", import.meta.url), "utf8");
+
+    expect(source).not.toContain("../../../src/");
+  });
+
   it("falls back to DM chatGuid handle when sender handle is missing", () => {
     const result = normalizeWebhookMessage({
       type: "new-message",

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -1,6 +1,18 @@
-import { parseFiniteNumber } from "../../../src/infra/parse-finite-number.js";
 import { extractHandleFromChatGuid, normalizeBlueBubblesHandle } from "./targets.js";
 import type { BlueBubblesAttachment } from "./types.js";
+
+function parseFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)


### PR DESCRIPTION
## Summary
- inline the finite-number parser used by BlueBubbles webhook normalization
- stop importing `src/infra/parse-finite-number.js` from inside the extension package
- add a regression test that keeps the normalizer self-contained for packaged plugin loads

Fixes #40507

## Root cause
`extensions/bluebubbles/src/monitor-normalize.ts` imported `../../../src/infra/parse-finite-number.js`. That works in the monorepo, but the packaged BlueBubbles extension does not ship the root `src/` tree, so plugin loading fails at runtime.

## Verification
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/vitest run extensions/bluebubbles/src/monitor-normalize.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxfmt --check extensions/bluebubbles/src/monitor-normalize.ts extensions/bluebubbles/src/monitor-normalize.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxlint extensions/bluebubbles/src/monitor-normalize.ts extensions/bluebubbles/src/monitor-normalize.test.ts`
