### PR TITLE
fix(memory): migrate Ollama embeddings to /api/embed endpoint

### DIFF
--- a/src/memory/embeddings-ollama.test.ts
+++ b/src/memory/embeddings-ollama.test.ts
@@ -3,10 +3,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createOllamaEmbeddingProvider } from "./embeddings-ollama.js";
 
 describe("embeddings-ollama", () => {
-  it("calls /api/embeddings and returns normalized vectors", async () => {
+  it("calls /api/embed and returns normalized vectors", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [3, 4] }), {
+        new Response(JSON.stringify({ embeddings: [[3, 4]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -31,7 +31,7 @@ describe("embeddings-ollama", () => {
   it("resolves baseUrl/apiKey/headers from models.providers.ollama and strips /v1", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [1, 0] }), {
+        new Response(JSON.stringify({ embeddings: [[1, 0]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -60,7 +60,7 @@ describe("embeddings-ollama", () => {
     await provider.embedQuery("hello");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:11434/api/embeddings",
+      "http://127.0.0.1:11434/api/embed",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -90,7 +90,7 @@ describe("embeddings-ollama", () => {
   it("falls back to env key when models.providers.ollama.apiKey is an unresolved SecretRef", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [1, 0] }), {
+        new Response(JSON.stringify({ embeddings: [[1, 0]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -118,12 +118,45 @@ describe("embeddings-ollama", () => {
     await provider.embedQuery("hello");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:11434/api/embeddings",
+      "http://127.0.0.1:11434/api/embed",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer ollama-env",
         }),
       }),
     );
+  });
+
+  it("supports batch embedding with /api/embed", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            embeddings: [
+              [3, 4],
+              [0, 5],
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { provider } = await createOllamaEmbeddingProvider({
+      config: {} as OpenClawConfig,
+      provider: "ollama",
+      model: "nomic-embed-text",
+      fallback: "none",
+      remote: { baseUrl: "http://127.0.0.1:11434" },
+    });
+
+    const results = await provider.embedBatch(["hello", "world"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // single batch request
+    expect(results).toHaveLength(2);
+    expect(results[0][0]).toBeCloseTo(0.6, 5);
+    expect(results[1][1]).toBeCloseTo(1.0, 5);
   });
 });

--- a/src/memory/embeddings-ollama.ts
+++ b/src/memory/embeddings-ollama.ts
@@ -89,38 +89,35 @@ export async function createOllamaEmbeddingProvider(
   options: EmbeddingProviderOptions,
 ): Promise<{ provider: EmbeddingProvider; client: OllamaEmbeddingClient }> {
   const client = resolveOllamaEmbeddingClient(options);
-  const embedUrl = `${client.baseUrl.replace(/\/$/, "")}/api/embeddings`;
+  const embedUrl = `${client.baseUrl.replace(/\/$/, "")}/api/embed`;
 
-  const embedOne = async (text: string): Promise<number[]> => {
+  const embedBatch = async (texts: string[]): Promise<number[][]> => {
     const json = await withRemoteHttpResponse({
       url: embedUrl,
       ssrfPolicy: client.ssrfPolicy,
       init: {
         method: "POST",
         headers: client.headers,
-        body: JSON.stringify({ model: client.model, prompt: text }),
+        body: JSON.stringify({ model: client.model, input: texts }),
       },
       onResponse: async (res) => {
         if (!res.ok) {
-          throw new Error(`Ollama embeddings HTTP ${res.status}: ${await res.text()}`);
+          throw new Error(`Ollama embed HTTP ${res.status}: ${await res.text()}`);
         }
-        return (await res.json()) as { embedding?: number[] };
+        return (await res.json()) as { embeddings?: number[][] };
       },
     });
-    if (!Array.isArray(json.embedding)) {
-      throw new Error(`Ollama embeddings response missing embedding[]`);
+    if (!Array.isArray(json.embeddings)) {
+      throw new Error(`Ollama embed response missing embeddings[]`);
     }
-    return sanitizeAndNormalizeEmbedding(json.embedding);
+    return json.embeddings.map(sanitizeAndNormalizeEmbedding);
   };
 
   const provider: EmbeddingProvider = {
     id: "ollama",
     model: client.model,
-    embedQuery: embedOne,
-    embedBatch: async (texts: string[]) => {
-      // Ollama /api/embeddings accepts one prompt per request.
-      return await Promise.all(texts.map(embedOne));
-    },
+    embedQuery: async (text) => (await embedBatch([text]))[0],
+    embedBatch,
   };
 
   return {


### PR DESCRIPTION
## Summary

- Migrate from deprecated Ollama `/api/embeddings` endpoint to `/api/embed`
- Old API used `prompt` (single string) + returned `embedding` (single vector)
- New API uses `input` (string or array) + returns `embeddings` (array of vectors)
- Batch embedding now sends all texts in a single HTTP request instead of `Promise.all` per-text requests
- Updated all test cases to match new API format and added batch embedding test

## Change Type
Bug fix

## Scope
`src/memory/embeddings-ollama.ts`, `src/memory/embeddings-ollama.test.ts`

## Security Impact
No security impact.

Closes #39983

🤖 Generated with [Claude Code](https://claude.com/claude-code)