### PR TITLE
fix(tools): recognize catalog-known tools in allowlist validation

### DIFF
--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { stripPluginOnlyAllowlist, type PluginToolGroups } from "./tool-policy.js";
+
+// Mock isKnownCoreToolId so the test doesn't depend on the real tool catalog.
+vi.mock(import("./tool-catalog.js"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    isKnownCoreToolId: (id: string) => ["apply_patch", "read", "write", "exec"].includes(id),
+  };
+});
 
 const pluginGroups: PluginToolGroups = {
   all: ["lobster", "workflow_tool"],
@@ -52,5 +61,28 @@ describe("stripPluginOnlyAllowlist", () => {
     );
     expect(policy.policy?.allow).toEqual(["read", "lobster"]);
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
+  });
+
+  it("does not flag catalog-known tools as unknown when not in runtime coreTools (#40538)", () => {
+    // `apply_patch` is in the core catalog (coding profile) but not in the runtime
+    // coreTools set because it's only instantiated for OpenAI-compatible providers.
+    const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
+    const policy = stripPluginOnlyAllowlist(
+      { allow: ["read", "apply_patch"] },
+      emptyPlugins,
+      coreTools,
+    );
+    expect(policy.policy?.allow).toEqual(["read", "apply_patch"]);
+    expect(policy.unknownAllowlist).toEqual([]);
+    expect(policy.strippedAllowlist).toBe(false);
+  });
+
+  it("keeps allowlist when only catalog-known tools are present (#40538)", () => {
+    // Even if no runtime core tools match, catalog-known tools should prevent stripping.
+    const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
+    const policy = stripPluginOnlyAllowlist({ allow: ["apply_patch"] }, emptyPlugins, coreTools);
+    expect(policy.policy?.allow).toEqual(["apply_patch"]);
+    expect(policy.unknownAllowlist).toEqual([]);
+    expect(policy.strippedAllowlist).toBe(false);
   });
 });

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -1,3 +1,4 @@
+import { isKnownCoreToolId } from "./tool-catalog.js";
 import {
   expandToolGroups,
   normalizeToolList,
@@ -173,10 +174,15 @@ export function stripPluginOnlyAllowlist(
       entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
     const expanded = expandToolGroups([entry]);
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
-    if (isCoreEntry) {
+    // Also recognize tools defined in the core catalog but not instantiated for the
+    // current provider (e.g. `apply_patch` is only available with OpenAI-compatible
+    // providers but is listed in built-in profiles like `coding`).  Without this
+    // check these entries are incorrectly flagged as unknown. (#40538)
+    const isCatalogEntry = !isCoreEntry && expanded.some((tool) => isKnownCoreToolId(tool));
+    if (isCoreEntry || isCatalogEntry) {
       hasCoreEntry = true;
     }
-    if (!isCoreEntry && !isPluginEntry) {
+    if (!isCoreEntry && !isCatalogEntry && !isPluginEntry) {
       unknownAllowlist.push(entry);
     }
   }


### PR DESCRIPTION
Closes #40538

## Summary
- `stripPluginOnlyAllowlist` incorrectly flags provider-specific core tools (e.g. `apply_patch`) as "unknown" when they aren't instantiated for the current provider
- Adds an `isKnownCoreToolId` check against the full tool catalog so these entries are recognized as valid core tools
- Prevents the spurious `tools.allow contains unknown entries` warning when using built-in profiles like `coding` on non-OpenAI providers

## Changes
- `tool-policy.ts`: import `isKnownCoreToolId` from tool-catalog; add `isCatalogEntry` check in `stripPluginOnlyAllowlist` so catalog-known tools don't get added to `unknownAllowlist` and correctly set `hasCoreEntry`
- `tool-policy.plugin-only-allowlist.test.ts`: add 2 tests covering catalog-known tools not flagged as unknown

## Test plan
- [x] All 8 existing + new tests pass
- [x] `apply_patch` in `coding` profile no longer triggers unknown entry warning on Anthropic provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)