### PR TITLE
fix(session): strip thinking blocks from loaded session history

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareSessionManagerForRun } from "./session-manager-init.js";
+
+function makeSessionManager(fileEntries: unknown[]) {
+  return {
+    sessionId: "test-session",
+    flushed: false,
+    fileEntries,
+    byId: new Map(),
+    labelsById: new Map(),
+    leafId: null,
+  };
+}
+
+describe("prepareSessionManagerForRun", () => {
+  const tmpDirs: string[] = [];
+
+  async function makeTmpSessionFile(content: string): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-init-test-"));
+    tmpDirs.push(dir);
+    const file = path.join(dir, "session.jsonl");
+    await fs.writeFile(file, content, "utf-8");
+    return file;
+  }
+
+  afterEach(async () => {
+    for (const dir of tmpDirs) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+    tmpDirs.length = 0;
+  });
+
+  it("strips thinking blocks from loaded assistant messages", async () => {
+    const sessionFile = await makeTmpSessionFile("");
+    const entries = [
+      { type: "session", id: "s1", cwd: "/tmp" },
+      {
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal reasoning", signature: "abc123" },
+            { type: "text", text: "Here is my response." },
+          ],
+        },
+      },
+    ];
+    const sm = makeSessionManager(entries);
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "s1",
+      cwd: "/tmp",
+    });
+
+    const assistantMsg = (entries[2] as { type: string; message: { content: unknown[] } }).message;
+    expect(assistantMsg.content).toHaveLength(1);
+    expect((assistantMsg.content[0] as { type: string }).type).toBe("text");
+  });
+
+  it("strips redacted_thinking blocks from loaded assistant messages", async () => {
+    const sessionFile = await makeTmpSessionFile("");
+    const entries = [
+      { type: "session", id: "s1", cwd: "/tmp" },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "redacted_thinking", data: "opaque" },
+            { type: "text", text: "Response text." },
+          ],
+        },
+      },
+    ];
+    const sm = makeSessionManager(entries);
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "s1",
+      cwd: "/tmp",
+    });
+
+    const msg = (entries[1] as { type: string; message: { content: unknown[] } }).message;
+    expect(msg.content).toHaveLength(1);
+    expect((msg.content[0] as { type: string }).type).toBe("text");
+  });
+
+  it("preserves assistant turn when all content was thinking-only", async () => {
+    const sessionFile = await makeTmpSessionFile("");
+    const entries = [
+      { type: "session", id: "s1", cwd: "/tmp" },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "only thinking" }],
+        },
+      },
+    ];
+    const sm = makeSessionManager(entries);
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "s1",
+      cwd: "/tmp",
+    });
+
+    const msg = (entries[1] as { type: string; message: { content: unknown[] } }).message;
+    expect(msg.content).toHaveLength(1);
+    expect((msg.content[0] as { type: string }).type).toBe("text");
+  });
+
+  it("does not strip thinking blocks for new sessions", async () => {
+    const sessionFile = await makeTmpSessionFile("");
+    const entries = [
+      { type: "session", id: "new-id", cwd: "/tmp" },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "reasoning" },
+            { type: "text", text: "response" },
+          ],
+        },
+      },
+    ];
+    const sm = makeSessionManager(entries);
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: false,
+      sessionId: "new-id",
+      cwd: "/tmp",
+    });
+
+    const msg = (entries[1] as { type: string; message: { content: unknown[] } }).message;
+    // New session: thinking blocks should be preserved
+    expect(msg.content).toHaveLength(2);
+  });
+
+  it("leaves user and tool_use messages untouched", async () => {
+    const sessionFile = await makeTmpSessionFile("");
+    const entries = [
+      { type: "session", id: "s1", cwd: "/tmp" },
+      {
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "question" }],
+        },
+      },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "reasoning" },
+            { type: "tool_use", id: "t1", name: "search", input: {} },
+          ],
+        },
+      },
+    ];
+    const sm = makeSessionManager(entries);
+
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "s1",
+      cwd: "/tmp",
+    });
+
+    // User message untouched
+    const userMsg = (entries[1] as { type: string; message: { content: unknown[] } }).message;
+    expect(userMsg.content).toHaveLength(1);
+
+    // Assistant message: thinking stripped, tool_use preserved
+    const assistantMsg = (entries[2] as { type: string; message: { content: unknown[] } }).message;
+    expect(assistantMsg.content).toHaveLength(1);
+    expect((assistantMsg.content[0] as { type: string }).type).toBe("tool_use");
+  });
+});

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
-type SessionMessageEntry = { type: "message"; message?: { role?: string } };
+type SessionMessageEntry = {
+  type: "message";
+  message?: { role?: string; content?: Array<{ type?: string }> };
+};
 
 /**
  * pi-coding-agent SessionManager persistence quirk:
@@ -49,5 +52,37 @@ export async function prepareSessionManagerForRun(params: {
     sm.labelsById?.clear?.();
     sm.leafId = null;
     sm.flushed = false;
+  }
+
+  // Strip `thinking` and `redacted_thinking` blocks from loaded assistant
+  // messages.  After a gateway restart the session file is deserialized from
+  // JSON which can corrupt the opaque `signature` field on these blocks.  The
+  // Anthropic API then rejects the request with "thinking or redacted_thinking
+  // blocks in the latest assistant message cannot be modified" (#40512).
+  // Stripping them at load time is safe: thinking blocks are internal reasoning
+  // that the API does not require for conversation continuation.
+  if (params.hadSessionFile) {
+    stripThinkingBlocksFromLoadedEntries(sm.fileEntries);
+  }
+}
+
+function stripThinkingBlocksFromLoadedEntries(
+  entries: Array<SessionHeaderEntry | SessionMessageEntry | { type: string }>,
+): void {
+  for (const entry of entries) {
+    if (entry.type !== "message") {
+      continue;
+    }
+    const msg = (entry as SessionMessageEntry).message;
+    if (msg?.role !== "assistant" || !Array.isArray(msg.content)) {
+      continue;
+    }
+    const filtered = msg.content.filter((block) => {
+      const blockType = block?.type;
+      return blockType !== "thinking" && blockType !== "redacted_thinking";
+    });
+    if (filtered.length !== msg.content.length) {
+      msg.content = filtered.length > 0 ? filtered : [{ type: "text" }];
+    }
   }
 }


### PR DESCRIPTION
Closes #40512

## Summary
- Strips `thinking` and `redacted_thinking` blocks from assistant messages when reloading session history from disk in `prepareSessionManagerForRun`
- After a gateway restart, session `.jsonl` deserialization corrupts the opaque `signature` field on thinking blocks, causing the Anthropic API to reject with "thinking or redacted_thinking blocks cannot be modified"
- Stripping at load time is safe — thinking blocks are internal reasoning not required for conversation continuation

## Changes
- `session-manager-init.ts`: add `stripThinkingBlocksFromLoadedEntries` helper; call it when `hadSessionFile` is true
- `session-manager-init.test.ts`: 5 new tests (strips thinking, strips redacted_thinking, preserves turn when all-thinking, skips new sessions, leaves user/tool_use untouched)

## Test plan
- [x] All 5 tests pass
- [x] Verified fix only applies to disk-loaded entries, not in-memory messages during tool-use loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)