### PR TITLE
fix: use atomic write for saveJsonFile to prevent JSON corruption

### DIFF
--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -18,6 +19,25 @@ export function saveJsonFile(pathname: string, data: unknown) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
+  const content = `${JSON.stringify(data, null, 2)}\n`;
+  const tmp = `${pathname}.${randomUUID()}.tmp`;
+  let renamed = false;
+  try {
+    fs.writeFileSync(tmp, content, "utf8");
+    try {
+      fs.chmodSync(tmp, 0o600);
+    } catch {
+      // best-effort; ignore on platforms without chmod
+    }
+    fs.renameSync(tmp, pathname);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try {
+        fs.rmSync(tmp, { force: true });
+      } catch {
+        // cleanup best-effort
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #40508

Use atomic write (write to temp file + rename) for `saveJsonFile` to prevent JSON corruption during crashes or concurrent writes.

## Changes

- Write to a temporary file first
- Rename temp file to final path (atomic on most filesystems)
- Clean up temp file on failure
- Preserve chmod 0o600 permission

## Test Plan

- Manual testing of concurrent writes
- Verified no JSON corruption after crashes

Closes #40508