### PR TITLE
fix(gateway): allow localhost Control UI to connect without token

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -75,6 +75,7 @@ export function evaluateMissingDeviceIdentity(params: {
   authOk: boolean;
   hasSharedAuth: boolean;
   isLocalClient: boolean;
+  authMode?: string;
 }): MissingDeviceIdentityDecision {
   if (params.hasDeviceIdentity) {
     return { kind: "allow" };
@@ -93,6 +94,19 @@ export function evaluateMissingDeviceIdentity(params: {
     }
   }
   if (roleCanSkipDeviceIdentity(params.role, params.sharedAuthOk)) {
+    return { kind: "allow" };
+  }
+  // For localhost Control UI connections with allowInsecureAuth, allow missing token
+  // so the UI can show a token prompt. This fixes #17745 where localhost users
+  // could never enter a token because the connection closed immediately.
+  if (
+    params.isControlUi &&
+    params.controlUiAuthPolicy.allowInsecureAuthConfigured &&
+    params.isLocalClient &&
+    params.authMode === "token" &&
+    !params.authOk &&
+    !params.sharedAuthOk
+  ) {
     return { kind: "allow" };
   }
   if (!params.authOk && params.hasSharedAuth) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -625,6 +625,7 @@ export function attachGatewayWsMessageHandler(params: {
             authOk,
             hasSharedAuth,
             isLocalClient,
+            authMode: resolvedAuth.mode,
           });
           if (decision.kind === "allow") {
             return true;


### PR DESCRIPTION
## Summary

Fixes #17745

Allow localhost Control UI connections with missing token so users can enter a token in the UI.

## Problem

On localhost, users see:
> disconnected (1008): unauthorized: gateway token missing

This prevents them from entering a token.

## Solution

- Add exception for localhost Control UI with missing token
- Allow connection with allowInsecureAuth configured
- Pass authMode to connect policy

## Test Plan

- Unit tests pass (4 tests)
- Manual testing on localhost

Closes #17745