### PR TITLE
fix(kimi-coding): use native Anthropic tool format instead of OpenAI function format

### DIFF
--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -233,9 +233,6 @@ export function buildKimiCodingProvider(): ProviderConfig {
         cost: KIMI_CODING_DEFAULT_COST,
         contextWindow: KIMI_CODING_DEFAULT_CONTEXT_WINDOW,
         maxTokens: KIMI_CODING_DEFAULT_MAX_TOKENS,
-        compat: {
-          requiresOpenAiAnthropicToolPayload: true,
-        },
       },
     ],
   };

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -31,8 +31,8 @@ describe("resolveProviderCapabilities", () => {
       resolveProviderCapabilities("kimi-code"),
     );
     expect(resolveProviderCapabilities("kimi-code")).toEqual({
-      anthropicToolSchemaMode: "openai-functions",
-      anthropicToolChoiceMode: "openai-string-modes",
+      anthropicToolSchemaMode: "native",
+      anthropicToolChoiceMode: "native",
       providerFamily: "default",
       preserveAnthropicThinkingSignatures: false,
       openAiCompatTurnValidation: true,
@@ -66,9 +66,9 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
-  it("treats kimi aliases as anthropic tool payload compatibility providers", () => {
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(true);
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(true);
+  it("treats kimi aliases as native anthropic tool payload providers", () => {
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(false);
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);
     expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic")).toBe(false);
   });
 

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -34,8 +34,8 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
     providerFamily: "anthropic",
   },
   "kimi-coding": {
-    anthropicToolSchemaMode: "openai-functions",
-    anthropicToolChoiceMode: "openai-string-modes",
+    anthropicToolSchemaMode: "native",
+    anthropicToolChoiceMode: "native",
     preserveAnthropicThinkingSignatures: false,
   },
   mistral: {


### PR DESCRIPTION
## Summary
- Commit 909f26a26 incorrectly set kimi-coding to use OpenAI function format for tool definitions, but kimi-coding's `anthropic-messages` API expects Anthropic native format (`name` + `input_schema`)
- This caused tool calls to be output as plain text XML (`stopReason: "stop"`) instead of structured `tool_use` content blocks (`stopReason: "toolUse"`)
- Reverts kimi-coding's provider capabilities to `"native"` mode and removes the redundant `requiresOpenAiAnthropicToolPayload` compat flag

## Test plan
- [ ] Configure kimi-coding/k2p5 as model provider
- [ ] Send a message that triggers tool usage
- [ ] Verify model returns structured `tool_use` blocks with `stopReason: "toolUse"` instead of plain text XML
