### PR TITLE
Agent: add gateway run service seam

### DIFF
--- a/src/agents/run/backends/types.ts
+++ b/src/agents/run/backends/types.ts
@@ -1,0 +1,6 @@
+export type AgentBackendCapabilities = {
+  toolCalls: boolean;
+  streamingText: boolean;
+  reasoningDeltas: boolean;
+  parallelToolCalls: boolean;
+};

--- a/src/agents/run/service.test.ts
+++ b/src/agents/run/service.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  agentCommandFromIngress: vi.fn(),
+}));
+
+vi.mock("../../commands/agent.js", () => ({
+  agentCommandFromIngress: mocks.agentCommandFromIngress,
+}));
+
+import { runAgent } from "./service.js";
+
+describe("runAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prefers explicit identity runId over opts.runId", async () => {
+    mocks.agentCommandFromIngress.mockResolvedValue({
+      payloads: [{ text: "ok", mediaUrl: null }],
+      meta: { durationMs: 1 },
+    });
+
+    const result = await runAgent({
+      source: "gateway",
+      identity: { runId: "explicit-run", sessionKey: "agent:main:main" },
+      opts: {
+        message: "hi",
+        runId: "opts-run",
+        sessionKey: "agent:main:main",
+        senderIsOwner: false,
+      },
+    });
+
+    expect(mocks.agentCommandFromIngress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "explicit-run",
+        sessionKey: "agent:main:main",
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result.identity.runId).toBe("explicit-run");
+    expect(result.backend).toBe("legacy");
+  });
+
+  it("falls back to opts.runId before generating a new runId", async () => {
+    mocks.agentCommandFromIngress.mockResolvedValue({
+      payloads: [],
+      meta: { durationMs: 2 },
+    });
+
+    const withOptsRunId = await runAgent({
+      source: "agent-command",
+      opts: {
+        message: "hi",
+        runId: "opts-run",
+        senderIsOwner: true,
+      },
+    });
+    expect(withOptsRunId.identity.runId).toBe("opts-run");
+
+    const generated = await runAgent({
+      source: "agent-command",
+      opts: {
+        message: "hi",
+        senderIsOwner: true,
+      },
+    });
+    expect(generated.identity.runId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("returns the legacy result with resolved identity metadata", async () => {
+    mocks.agentCommandFromIngress.mockResolvedValue({
+      payloads: [{ text: "done", mediaUrl: null }],
+      meta: { durationMs: 3, stopReason: "completed" },
+    });
+
+    const result = await runAgent({
+      source: "gateway",
+      identity: { runId: "run-123", sessionKey: "agent:main:main", idempotencyKey: "idem-123" },
+      opts: {
+        message: "hi",
+        senderIsOwner: false,
+      },
+    });
+
+    expect(result).toEqual({
+      payloads: [{ text: "done", mediaUrl: null }],
+      meta: { durationMs: 3, stopReason: "completed" },
+      identity: {
+        runId: "run-123",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "idem-123",
+      },
+      backend: "legacy",
+    });
+  });
+});

--- a/src/agents/run/service.ts
+++ b/src/agents/run/service.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from "node:crypto";
+import { createDefaultDeps } from "../../cli/deps.js";
+import { agentCommandFromIngress } from "../../commands/agent.js";
+import type { AgentCommandIngressOpts } from "../../commands/agent/types.js";
+import { defaultRuntime } from "../../runtime.js";
+import type {
+  AgentRunBackend,
+  AgentRunIdentity,
+  AgentRunRequest,
+  AgentRunResult,
+} from "./types.js";
+
+type ResolvedAgentRunConfig = {
+  identity: AgentRunIdentity;
+  backend: AgentRunBackend;
+  opts: AgentCommandIngressOpts;
+};
+
+function resolveRunIdentity(request: AgentRunRequest): AgentRunIdentity {
+  const runId = request.identity?.runId ?? request.opts.runId?.trim() ?? randomUUID();
+  const sessionKey = request.identity?.sessionKey ?? request.opts.sessionKey;
+  return {
+    runId,
+    sessionKey,
+    idempotencyKey: request.identity?.idempotencyKey,
+  };
+}
+
+function normalizeAgentRunRequest(request: AgentRunRequest): AgentRunRequest {
+  return {
+    ...request,
+    opts: {
+      ...request.opts,
+      runId: request.opts.runId?.trim() || undefined,
+      sessionKey: request.opts.sessionKey?.trim() || undefined,
+    },
+  };
+}
+
+function resolveAgentRunConfig(request: AgentRunRequest): ResolvedAgentRunConfig {
+  const normalized = normalizeAgentRunRequest(request);
+  const identity = resolveRunIdentity(normalized);
+  return {
+    identity,
+    backend: normalized.backend ?? "legacy",
+    opts: {
+      ...normalized.opts,
+      runId: identity.runId,
+      sessionKey: identity.sessionKey ?? normalized.opts.sessionKey,
+    },
+  };
+}
+
+export async function runAgent(request: AgentRunRequest): Promise<AgentRunResult> {
+  const resolved = resolveAgentRunConfig(request);
+  const result = await agentCommandFromIngress(
+    resolved.opts,
+    request.runtime ?? defaultRuntime,
+    request.deps ?? createDefaultDeps(),
+  );
+  return {
+    ...result,
+    identity: resolved.identity,
+    backend: resolved.backend,
+  };
+}

--- a/src/agents/run/types.ts
+++ b/src/agents/run/types.ts
@@ -1,0 +1,30 @@
+import type { CliDeps } from "../../cli/deps.js";
+import type {
+  AgentCommandIngressOpts,
+  AgentCommandIngressResult,
+} from "../../commands/agent/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+export type AgentRunBackend = "legacy" | "embedded" | "acp" | "chutes";
+
+export type AgentRunSource = "agent-command" | "gateway";
+
+export type AgentRunIdentity = {
+  runId: string;
+  sessionKey?: string;
+  idempotencyKey?: string;
+};
+
+export type AgentRunRequest = {
+  source: AgentRunSource;
+  backend?: AgentRunBackend;
+  identity?: Partial<AgentRunIdentity>;
+  opts: AgentCommandIngressOpts;
+  runtime?: RuntimeEnv;
+  deps?: CliDeps;
+};
+
+export type AgentRunResult = AgentCommandIngressResult & {
+  identity: AgentRunIdentity;
+  backend: AgentRunBackend;
+};

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -1,7 +1,9 @@
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import type { ClientToolDefinition } from "../../agents/pi-embedded-runner/run/params.js";
+import type { EmbeddedPiRunMeta } from "../../agents/pi-embedded-runner/types.js";
 import type { SpawnedRunMetadata } from "../../agents/spawned-context.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
+import type { OutboundPayloadJson } from "../../infra/outbound/payloads.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 
 /** Image content block for Claude API multimodal messages. */
@@ -85,4 +87,9 @@ export type AgentCommandOpts = {
 export type AgentCommandIngressOpts = Omit<AgentCommandOpts, "senderIsOwner"> & {
   /** Ingress callsites must always pass explicit owner authorization state. */
   senderIsOwner: boolean;
+};
+
+export type AgentCommandIngressResult = {
+  payloads: OutboundPayloadJson[];
+  meta: EmbeddedPiRunMeta;
 };

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -346,6 +346,28 @@ describe("gateway agent handler", () => {
     resetTimeConfig();
   });
 
+  it("preserves the completed gateway result shape", async () => {
+    primeMainAgentRun();
+
+    const respond = await runMainAgent("test", "test-completed-shape");
+
+    await vi.waitFor(() => expect(respond).toHaveBeenCalledTimes(2));
+    expect(respond).toHaveBeenLastCalledWith(
+      true,
+      {
+        runId: "test-completed-shape",
+        status: "ok",
+        summary: "completed",
+        result: {
+          payloads: [{ text: "ok" }],
+          meta: { durationMs: 100 },
+        },
+      },
+      undefined,
+      { runId: "test-completed-shape" },
+    );
+  });
+
   it.each([
     {
       name: "passes senderIsOwner=false for write-scoped gateway callers",

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,12 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { listAgentIds } from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
+import { runAgent } from "../../agents/run/service.js";
+import type { AgentRunRequest } from "../../agents/run/types.js";
 import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
-import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
   mergeSessionEntry,
@@ -170,19 +171,22 @@ async function runSessionResetFromAgent(params: {
 }
 
 function dispatchAgentRunFromGateway(params: {
-  ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
+  request: AgentRunRequest;
   runId: string;
   idempotencyKey: string;
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
 }) {
-  void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
+  void runAgent(params.request)
     .then((result) => {
       const payload = {
         runId: params.runId,
         status: "ok" as const,
         summary: "completed",
-        result,
+        result: {
+          payloads: result.payloads,
+          meta: result.meta,
+        },
       };
       setGatewayDedupeEntry({
         dedupe: params.context.dedupe,
@@ -672,44 +676,54 @@ export const agentHandlers: GatewayRequestHandlers = {
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
     dispatchAgentRunFromGateway({
-      ingressOpts: {
-        message,
-        images,
-        to: resolvedTo,
-        sessionId: resolvedSessionId,
-        sessionKey: resolvedSessionKey,
-        thinking: request.thinking,
-        deliver,
-        deliveryTargetMode,
-        channel: resolvedChannel,
-        accountId: resolvedAccountId,
-        threadId: resolvedThreadId,
-        runContext: {
-          messageChannel: originMessageChannel,
+      request: {
+        source: "gateway",
+        identity: {
+          runId,
+          sessionKey: resolvedSessionKey,
+          idempotencyKey: idem,
+        },
+        runtime: defaultRuntime,
+        deps: context.deps,
+        opts: {
+          message,
+          images,
+          to: resolvedTo,
+          sessionId: resolvedSessionId,
+          sessionKey: resolvedSessionKey,
+          thinking: request.thinking,
+          deliver,
+          deliveryTargetMode,
+          channel: resolvedChannel,
           accountId: resolvedAccountId,
+          threadId: resolvedThreadId,
+          runContext: {
+            messageChannel: originMessageChannel,
+            accountId: resolvedAccountId,
+            groupId: resolvedGroupId,
+            groupChannel: resolvedGroupChannel,
+            groupSpace: resolvedGroupSpace,
+            currentThreadTs: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
+          },
           groupId: resolvedGroupId,
           groupChannel: resolvedGroupChannel,
           groupSpace: resolvedGroupSpace,
-          currentThreadTs: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
-        },
-        groupId: resolvedGroupId,
-        groupChannel: resolvedGroupChannel,
-        groupSpace: resolvedGroupSpace,
-        spawnedBy: spawnedByValue,
-        timeout: request.timeout?.toString(),
-        bestEffortDeliver,
-        messageChannel: originMessageChannel,
-        runId,
-        lane: request.lane,
-        extraSystemPrompt: request.extraSystemPrompt,
-        internalEvents: request.internalEvents,
-        inputProvenance,
-        // Internal-only: allow workspace override for spawned subagent runs.
-        workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
           spawnedBy: spawnedByValue,
-          workspaceDir: request.workspaceDir,
-        }),
-        senderIsOwner,
+          timeout: request.timeout?.toString(),
+          bestEffortDeliver,
+          messageChannel: originMessageChannel,
+          runId,
+          lane: request.lane,
+          extraSystemPrompt: request.extraSystemPrompt,
+          internalEvents: request.internalEvents,
+          inputProvenance,
+          // Internal-only: allow workspace override for spawned subagent runs.
+          workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
+            spawnedBy: spawnedByValue,
+            workspaceDir: request.workspaceDir,
+          }),
+          senderIsOwner,
+        },
       },
       runId,
       idempotencyKey: idem,


### PR DESCRIPTION
## Summary
- add a first `src/agents/run` service seam for canonical agent execution requests
- route gateway `agent` submissions through `runAgent(...)` instead of calling `agentCommandFromIngress(...)` directly
- preserve the gateway completed-result payload shape while attaching run identity inside the internal service layer
- add focused tests for the new service and gateway regression coverage

## Testing
- `pnpm test -- src/agents/run/service.test.ts src/gateway/server-methods/agent.test.ts`
- `pnpm build`

## Notes
This is PR 1 of the planned agent/run stack. It intentionally keeps execution behavior on the existing legacy path and only introduces the new internal seam plus the gateway migration onto it.

Planned follow-ups:
1. extract the legacy executor behind the run service so `src/commands/agent.ts` becomes a thin wrapper
2. add shared run-time tools/memory wiring to the canonical runtime layer
3. add explicit backend adapters for embedded/ACP execution
