### PR TITLE
fix(telegram): accept negative group/supergroup IDs in groupAllowFrom allowlist

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,32 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
+  it("accepts positive sender IDs and negative group/supergroup chat IDs", () => {
     const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
 
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["-1001234567890", "-100999", "745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone"],
     });
+  });
+
+  it("accepts wildcard", () => {
+    const result = normalizeAllowFrom(["*"]);
+    expect(result.hasWildcard).toBe(true);
+    expect(result.entries).toEqual([]);
+  });
+
+  it("rejects non-numeric entries like @usernames", () => {
+    const result = normalizeAllowFrom(["@username", "notanid"]);
+    expect(result.invalidEntries).toEqual(["@username", "notanid"]);
+    expect(result.entries).toEqual([]);
+  });
+
+  it("accepts negative supergroup IDs in groupAllowFrom", () => {
+    const result = normalizeAllowFrom([-1003890514701]);
+    expect(result.entries).toEqual(["-1003890514701"]);
+    expect(result.invalidEntries).toEqual([]);
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,7 +31,7 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
+        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs (positive for users, negative for groups/supergroups).",
         'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

Fixes #40444

Telegram supergroup and group chat IDs are **always negative integers** (e.g. `-1003890514701`). The `normalizeAllowFrom` function in `src/telegram/bot-access.ts` was validating entries with `/^\d+$/` which rejects any value with a leading `-`, making `groupPolicy: 'allowlist'` completely non-functional for Telegram groups.

## Root Cause

`bot-access.ts` had its own inline regex `/^\d+$/` that was inconsistent with the centralized `isNumericTelegramUserId()` in `src/channels/telegram/allow-from.ts`, which already correctly uses `/^-?\d+$/`.

## Fix

Change the two occurrences of `/^\d+$/` in `bot-access.ts` to `/^-?\d+$/` — aligning it with `allow-from.ts`.

```diff
- const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+ const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
  ...
- const ids = normalized.filter((value) => /^\d+$/.test(value));
+ const ids = normalized.filter((value) => /^-?\d+$/.test(value));
```

## Tests

- Updated existing test to reflect correct behavior (negative group IDs are valid)
- Added 3 new test cases covering wildcards, @username rejection, and negative supergroup IDs
- All 4 tests pass ✅

## Impact

- `groupPolicy: 'allowlist'` now works correctly for Telegram groups and supergroups
- No breaking change for existing DM allowlists (positive user IDs still work)
- The security audit (`audit-channel.ts`) and doctor flow (`doctor-config-flow.ts`) already used the correct `isNumericTelegramUserId()` function — no changes needed there