### PR TITLE
fix(models): remove incorrect tool payload flag for kimi-coding

### DIFF
--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -233,9 +233,7 @@ export function buildKimiCodingProvider(): ProviderConfig {
         cost: KIMI_CODING_DEFAULT_COST,
         contextWindow: KIMI_CODING_DEFAULT_CONTEXT_WINDOW,
         maxTokens: KIMI_CODING_DEFAULT_MAX_TOKENS,
-        compat: {
-          requiresOpenAiAnthropicToolPayload: true,
-        },
+        compat: {},
       },
     ],
   };


### PR DESCRIPTION
## Summary
Fixes #40552

Commit 909f26a added `requiresOpenAiAnthropicToolPayload: true` to the kimi-coding model config, which converts tool definitions from Anthropic native format to OpenAI function format. However, kimi-coding uses the `anthropic-messages` API and expects Anthropic native tool format. This caused tool_use content blocks to be returned as plain text XML with `stopReason: "stop"` instead of structured `tool_use` blocks with `stopReason: "toolUse"`, making tool calling completely non-functional.

## Changes
- Removed `requiresOpenAiAnthropicToolPayload: true` from the kimi-coding model config in `src/agents/models-config.providers.static.ts`

## Testing
- Configure kimi-coding/k2p5 as the model provider
- Send a message that triggers tool usage (e.g. a coding task requiring file reads)
- Verify model returns structured tool_use content blocks with stopReason: "toolUse"

This contribution was developed with AI assistance (Claude Code).