### PR TITLE
fix(agents): check billing errors before context overflow classification

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -28,7 +28,7 @@ import {
   resolveModelRefFromString,
 } from "./model-selection.js";
 import type { FailoverReason } from "./pi-embedded-helpers.js";
-import { isLikelyContextOverflowError } from "./pi-embedded-helpers.js";
+import { isBillingErrorMessage, isLikelyContextOverflowError } from "./pi-embedded-helpers.js";
 
 const log = createSubsystemLogger("model-fallback");
 
@@ -558,11 +558,17 @@ export async function runWithModelFallback<T>(params: {
     }
     const err = attemptRun.error;
     {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      // Billing errors are more specific than context overflow and must be
+      // checked first: some billing messages contain size-related text that
+      // matches the broad context overflow heuristic.
+      if (isBillingErrorMessage(errMessage)) {
+        throw err;
+      }
       // Context overflow errors should be handled by the inner runner's
       // compaction/retry logic, not by model fallback.  If one escapes as a
       // throw, rethrow it immediately rather than trying a different model
       // that may have a smaller context window and fail worse.
-      const errMessage = err instanceof Error ? err.message : String(err);
       if (isLikelyContextOverflowError(errMessage)) {
         throw err;
       }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -43,6 +43,7 @@ import {
   formatAssistantErrorText,
   isAuthAssistantError,
   isBillingAssistantError,
+  isBillingErrorMessage,
   isCompactionFailureError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,
@@ -966,14 +967,23 @@ export async function runEmbeddedPiAgent(
             ? (() => {
                 if (promptError) {
                   const errorText = describeUnknownError(promptError);
-                  if (isLikelyContextOverflowError(errorText)) {
+                  // Billing errors can contain size-related text that matches
+                  // the context overflow heuristic; exclude them first.
+                  if (
+                    !isBillingErrorMessage(errorText) &&
+                    isLikelyContextOverflowError(errorText)
+                  ) {
                     return { text: errorText, source: "promptError" as const };
                   }
                   // Prompt submission failed with a non-overflow error. Do not
                   // inspect prior assistant errors from history for this attempt.
                   return null;
                 }
-                if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
+                if (
+                  assistantErrorText &&
+                  !isBillingErrorMessage(assistantErrorText) &&
+                  isLikelyContextOverflowError(assistantErrorText)
+                ) {
                   return { text: assistantErrorText, source: "assistantError" as const };
                 }
                 return null;


### PR DESCRIPTION
## Summary
Fixes #40378

Billing errors from providers (e.g. OpenRouter returning "insufficient credits" or HTTP 402) can contain size-related text that matches the broad context overflow heuristic in `isLikelyContextOverflowError()`. This causes billing errors to be misclassified as "Context overflow: prompt too large" instead of showing the correct billing-specific message directing users to check their billing dashboard.

## Changes
- In `src/agents/model-fallback.ts`: check `isBillingErrorMessage()` before `isLikelyContextOverflowError()` in the fallback catch block, with early return for billing errors
- In `src/agents/pi-embedded-runner/run.ts`: guard both `promptError` and `assistantErrorText` overflow checks with `!isBillingErrorMessage()` so billing errors are never classified as context overflow

## Testing
- Configure a provider with a spent/limited API key (e.g. OpenRouter with spend limit reached)
- Send a message that triggers the billing error
- Verify the billing-specific error message is shown instead of the context overflow message

This contribution was developed with AI assistance (Claude Code).