### PR TITLE
fix(cron): reduce timer debug logs to trace level

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -508,7 +508,8 @@ export function armTimer(state: CronServiceState) {
           typeof j.state.nextRunAtMs === "number" &&
           Number.isFinite(j.state.nextRunAtMs),
       ).length ?? 0;
-    state.deps.log.debug(
+    // Use trace level for detailed timer diagnostics; debug is too verbose for normal operation
+    state.deps.log.trace(
       { jobCount, enabledCount, withNextRun },
       "cron: armTimer skipped - no jobs with nextRunAtMs",
     );
@@ -536,7 +537,8 @@ export function armTimer(state: CronServiceState) {
       state.deps.log.error({ err: String(err) }, "cron: timer tick failed");
     });
   }, clampedDelay);
-  state.deps.log.debug(
+  // Use trace level for detailed timer diagnostics; debug is too verbose for normal operation
+  state.deps.log.trace(
     { nextAt, delayMs: clampedDelay, clamped: delay > MAX_TIMER_DELAY_MS },
     "cron: timer armed",
   );


### PR DESCRIPTION
## Problem

The cron timer module was logging DEBUG-level messages ('timer armed', 'armTimer skipped') on every scheduling cycle, producing verbose output even when logging.consoleLevel was set to 'info'.

## Solution

Changed these messages from `debug` to `trace` level. These are internal diagnostics for debugging the scheduler itself, not useful for normal operation.

## Impact

- Users setting `logging.consoleLevel: "info"` will no longer see verbose cron timer logs
- Trace logs still available when explicitly debugging cron internals

Fixes: #40465