### PR TITLE
feat(gateway): support gateway.launchd.processType config for macOS

### DIFF
--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -205,6 +205,7 @@ export async function maybeRepairGatewayDaemon(params: {
             programArguments,
             workingDirectory,
             environment,
+            processType: params.cfg.gateway?.launchd?.processType,
           });
         } catch (err) {
           note(`Gateway service install failed: ${String(err)}`, "Gateway");

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -367,6 +367,7 @@ export async function maybeRepairGatewayServiceConfig(
       programArguments: updatedPlan.programArguments,
       workingDirectory: updatedPlan.workingDirectory,
       environment: updatedPlan.environment,
+      processType: cfgForServiceInstall.gateway?.launchd?.processType,
     });
   } catch (err) {
     runtime.error(`Gateway service update failed: ${String(err)}`);

--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -66,6 +66,7 @@ export async function installGatewayDaemonNonInteractive(params: {
       programArguments,
       workingDirectory,
       environment,
+      processType: params.nextConfig.gateway?.launchd?.processType,
     });
   } catch (err) {
     runtime.error(`Gateway service install failed: ${String(err)}`);

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -413,4 +413,14 @@ export type GatewayConfig = {
    * Set to 0 to disable. Default: 5.
    */
   channelHealthCheckMinutes?: number;
+  /**
+   * macOS launchd ProcessType for the Gateway LaunchAgent.
+   * Set to "Standard" to prevent macOS from killing the gateway under thermal
+   * management / App Nap when running heavy agent workloads.
+   * Default: unset (macOS default behavior).
+   * Options: "Standard" | "Interactive" | "Background" | "Adaptive"
+   */
+  launchd?: {
+    processType?: "Standard" | "Interactive" | "Background" | "Adaptive";
+  };
 };

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -94,6 +94,7 @@ export function buildLaunchAgentPlist({
   stdoutPath,
   stderrPath,
   environment,
+  processType,
 }: {
   label: string;
   comment?: string;
@@ -102,6 +103,7 @@ export function buildLaunchAgentPlist({
   stdoutPath: string;
   stderrPath: string;
   environment?: Record<string, string | undefined>;
+  processType?: string;
 }): string {
   const argsXml = programArguments
     .map((arg) => `\n      <string>${plistEscape(arg)}</string>`)
@@ -113,5 +115,8 @@ export function buildLaunchAgentPlist({
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>Umask</key>\n    <integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  const processTypeXml = processType?.trim()
+    ? `\n    <key>ProcessType</key>\n    <string>${plistEscape(processType.trim())}</string>`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>Umask</key>\n    <integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}${processTypeXml}\n  </dict>\n</plist>\n`;
 }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -76,6 +76,7 @@ export function buildLaunchAgentPlist({
   stdoutPath,
   stderrPath,
   environment,
+  processType,
 }: {
   label?: string;
   comment?: string;
@@ -84,6 +85,7 @@ export function buildLaunchAgentPlist({
   stdoutPath: string;
   stderrPath: string;
   environment?: Record<string, string | undefined>;
+  processType?: string;
 }): string {
   return buildLaunchAgentPlistImpl({
     label,
@@ -93,6 +95,7 @@ export function buildLaunchAgentPlist({
     stdoutPath,
     stderrPath,
     environment,
+    processType,
   });
 }
 
@@ -377,6 +380,7 @@ export async function installLaunchAgent({
   workingDirectory,
   environment,
   description,
+  processType,
 }: GatewayServiceInstallArgs): Promise<{ plistPath: string }> {
   const { logDir, stdoutPath, stderrPath } = resolveGatewayLogPaths(env);
   await fs.mkdir(logDir, { recursive: true });
@@ -406,6 +410,7 @@ export async function installLaunchAgent({
     stdoutPath,
     stderrPath,
     environment,
+    processType,
   });
   await fs.writeFile(plistPath, plist, "utf8");
 

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -7,6 +7,7 @@ export type GatewayServiceInstallArgs = {
   workingDirectory?: string;
   environment?: GatewayServiceEnv;
   description?: string;
+  processType?: string;
 };
 
 export type GatewayServiceManageArgs = {


### PR DESCRIPTION
## Problem

On macOS, the OpenClaw gateway can be killed by the OS under thermal management / App Nap when running heavy agent workloads. macOS sends SIGTERM with 'immediate reason = inefficient', classifying the gateway as a throttle-eligible background process.

## Solution

Add a new config key `gateway.launchd.processType` that gets written into the LaunchAgent plist during `openclaw gateway install`. Setting it to `Standard` tells macOS the process is a normal interactive-priority daemon and should not be throttled or killed.

## Usage

```json
{
  "gateway": {
    "launchd": {
      "processType": "Standard"
    }
  }
}
```

## Options

- `Standard` - Normal interactive-priority daemon (recommended for heavy workloads)
- `Interactive` - Highest priority, for user-interactive apps
- `Background` - Lowest priority, for background tasks
- `Adaptive` - Let macOS decide based on current workload

**Default:** unset (macOS default behavior)

Fixes: #40406