### PR TITLE
fix(acpx): add windowsHide: true to all Windows spawn paths

### DIFF
--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -240,6 +240,7 @@ export function resolveWindowsSpawnProgramCandidate(
       command: resolvedCommand,
       leadingArgv: [],
       resolution: "unresolved-wrapper",
+      windowsHide: true,
     };
   }
 
@@ -247,6 +248,7 @@ export function resolveWindowsSpawnProgramCandidate(
     command: resolvedCommand,
     leadingArgv: [],
     resolution: "direct",
+    windowsHide: true,
   };
 }
 
@@ -268,6 +270,7 @@ export function applyWindowsSpawnProgramPolicy(params: {
       leadingArgv: [],
       resolution: "shell-fallback",
       shell: true,
+      windowsHide: true,
     };
   }
   throw new Error(


### PR DESCRIPTION
## Problem

Windows console windows were flashing on every ACP spawn because `windowsHide` was not set for all spawn resolution paths.

## Solution

Ensure `windowsHide: true` is set for all Windows spawn paths:
- `unresolved-wrapper` (cmd/bat files without resolved entrypoint)
- `direct` (non-.js/.cmd/.bat executables)
- `shell-fallback` (when shell execution is required)

Previously only `node-entrypoint` and `exe-entrypoint` had `windowsHide` set.

## Impact

- No more console window flash on Windows when spawning ACP processes
- Consistent behavior across all spawn paths

Fixes: #40340