### PR TITLE
feat(tui): add searchable filter to model picker select

### DIFF
--- a/src/commands/model-picker.ts
+++ b/src/commands/model-picker.ts
@@ -325,6 +325,7 @@ export async function promptDefaultModel(
     message: params.message ?? "Default model",
     options,
     initialValue,
+    searchable: true,
   });
 
   if (selection === KEEP_VALUE) {

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -1,4 +1,5 @@
 import {
+  autocomplete,
   autocompleteMultiselect,
   cancel,
   confirm,
@@ -62,17 +63,31 @@ export function createClackPrompter(): WizardPrompter {
     note: async (message, title) => {
       emitNote(message, title);
     },
-    select: async (params) =>
-      guardCancel(
+    select: async (params) => {
+      const options = params.options.map((opt) => {
+        const base = { value: opt.value, label: opt.label };
+        return opt.hint === undefined ? base : { ...base, hint: stylePromptHint(opt.hint) };
+      }) as Option<(typeof params.options)[number]["value"]>[];
+
+      if (params.searchable) {
+        return guardCancel(
+          await autocomplete({
+            message: stylePromptMessage(params.message),
+            options,
+            initialValue: params.initialValue,
+            filter: tokenizedOptionFilter,
+          }),
+        );
+      }
+
+      return guardCancel(
         await select({
           message: stylePromptMessage(params.message),
-          options: params.options.map((opt) => {
-            const base = { value: opt.value, label: opt.label };
-            return opt.hint === undefined ? base : { ...base, hint: stylePromptHint(opt.hint) };
-          }) as Option<(typeof params.options)[number]["value"]>[],
+          options,
           initialValue: params.initialValue,
         }),
-      ),
+      );
+    },
     multiselect: async (params) => {
       const options = params.options.map((opt) => {
         const base = { value: opt.value, label: opt.label };

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -8,6 +8,7 @@ export type WizardSelectParams<T = string> = {
   message: string;
   options: Array<WizardSelectOption<T>>;
   initialValue?: T;
+  searchable?: boolean;
 };
 
 export type WizardMultiSelectParams<T = string> = {


### PR DESCRIPTION
## Problem

When there are many models available (especially for providers with dozens of models), finding a specific model in the TUI picker requires scrolling through a long list.

## Solution

Add search/filter functionality to the model picker select prompt using clack's `autocomplete` component.

## Changes

- Add `searchable?: boolean` to `WizardSelectParams`
- Update `createClackPrompter` to use `autocomplete` when `searchable=true`
- Enable searchable for `promptDefaultModel` select
- Multi-select already had searchable enabled

## Impact

- Much easier to find specific models when there are many options
- Tokenized search supports multiple keywords (e.g., "claude 3.5" matches "claude-3-5-sonnet")
- Consistent with existing multi-select search behavior

Fixes: #40412