### PR TITLE
feat(models auth): add --profile-id flag for OAuth login

### DIFF
--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -263,6 +263,7 @@ type LoginOptions = {
   provider?: string;
   method?: string;
   setDefault?: boolean;
+  profileId?: string;
 };
 
 export function resolveRequestedLoginProviderOrThrow(
@@ -318,6 +319,7 @@ async function runBuiltInOpenAICodexLogin(params: {
 
   const profileId = await writeOAuthCredentials("openai-codex", creds, params.agentDir, {
     syncSiblingAgents: true,
+    profileId: params.opts.profileId,
   });
   await updateConfig((cfg) => {
     let next = applyAuthProfileConfig(cfg, {
@@ -425,12 +427,18 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     },
   });
 
-  for (const profile of result.profiles) {
+  // If user specified a custom profileId, use it for the first profile (single-account OAuth flows)
+  const customProfileId = opts.profileId?.trim();
+  for (let i = 0; i < result.profiles.length; i += 1) {
+    const profile = result.profiles[i];
+    const effectiveProfileId = i === 0 && customProfileId ? customProfileId : profile.profileId;
     upsertAuthProfile({
-      profileId: profile.profileId,
+      profileId: effectiveProfileId,
       credential: profile.credential,
       agentDir,
     });
+    // Update the profileId in the result for downstream config application
+    profile.profileId = effectiveProfileId;
   }
 
   await updateConfig((cfg) => {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -155,11 +155,11 @@ export async function writeOAuthCredentials(
   provider: string,
   creds: OAuthCredentials,
   agentDir?: string,
-  options?: WriteOAuthCredentialsOptions,
+  options?: WriteOAuthCredentialsOptions & { profileId?: string },
 ): Promise<string> {
   const email =
     typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
-  const profileId = `${provider}:${email}`;
+  const profileId = options?.profileId?.trim() || `${provider}:${email}`;
   const resolvedAgentDir = path.resolve(resolveAuthAgentDir(agentDir));
   const targetAgentDirs = options?.syncSiblingAgents
     ? resolveSiblingAgentDirs(resolvedAgentDir)


### PR DESCRIPTION
## Problem

When using `models auth login` with OAuth providers (e.g., OpenAI Codex), the profile ID was automatically generated from the OAuth email claim (e.g., `openai-codex:user@example.com`). This made it impossible to:
- Use human-friendly aliases instead of raw emails
- Maintain multiple OAuth profiles for providers that don't return email
- Have consistent profile naming across different auth methods

## Solution

Add a `--profile-id` flag to allow custom profile naming during OAuth login flows.

## Usage

```bash
# Login with custom profile ID
openclaw models auth login --provider openai-codex --profile-id openai-codex:work

# Login with default behavior (email-based)
openclaw models auth login --provider openai-codex
```

## Implementation

- Add `profileId?: string` to `LoginOptions`
- Pass profileId to `writeOAuthCredentials` for built-in OAuth flows
- For plugin OAuth flows, rename the first profile if custom profileId specified

## Notes

- Only applies to the first profile (single-account OAuth flows)
- Multi-profile auth methods will use auto-generated IDs for additional profiles
- Backward compatible - default behavior unchanged when flag not specified

Fixes: #40402