### PR TITLE
fix(agents): disable Photon WASM image resize in read tool

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -444,6 +444,7 @@ type SandboxToolParams = {
 export function createSandboxedReadTool(params: SandboxToolParams) {
   const base = createReadTool(params.root, {
     operations: createSandboxReadOperations(params),
+    autoResizeImages: false,
   }) as unknown as AnyAgentTool;
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -364,7 +364,7 @@ export function createOpenClawCodingTools(options?: {
             : sandboxed,
         ];
       }
-      const freshReadTool = createReadTool(workspaceRoot);
+      const freshReadTool = createReadTool(workspaceRoot, { autoResizeImages: false });
       const wrapped = createOpenClawReadTool(freshReadTool, {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,


### PR DESCRIPTION
## Summary

Fixes #40590

The `read` tool was double-processing images through two separate pipelines:

1. **Photon (Rust/WASM)** in `pi-coding-agent`'s `createReadTool` (`autoResizeImages: true` by default) — decodes image bytes via WASM, resizes with Lanczos3, re-encodes to PNG/JPEG
2. **OpenClaw's `sanitizeToolResultImages`** (sharp/sips) — decodes the already-processed result and resizes again

The Photon WASM decode/encode pipeline could produce incorrect image content for certain JPEG files (e.g., mobile camera JPEGs with complex EXIF data), causing the read tool to display a completely different image than the actual file on disk.

**Fix:** Set `autoResizeImages: false` when calling `createReadTool` from pi-coding-agent, since OpenClaw already has its own image sanitization pipeline (`sanitizeToolResultImages` → `resizeImageBase64IfNeeded` → sharp/sips) that correctly handles image resizing and size enforcement. This eliminates the redundant Photon processing while keeping OpenClaw's own pipeline intact.

**Changes:**
- `src/agents/pi-tools.read.ts`: Add `autoResizeImages: false` to sandboxed read tool creation
- `src/agents/pi-tools.ts`: Add `autoResizeImages: false` to host read tool creation

## Test plan

- [x] All existing `pi-tools.read` tests pass (9/9)
- [x] All `tool-images` tests pass (7/7)
- [x] All `pi-tools.create-openclaw-coding-tools` tests pass (34/34)
- [x] All `image-ops` tests pass (3/3)
- [x] TypeScript type check passes for modified files
- [ ] Manual test: read an image file via the read tool and verify correct content is displayed
- [ ] Verify that image dimension/size limits are still enforced by OpenClaw's sanitizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)