### PR TITLE
fix(agents): prevent false billing error replacing valid response text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/config schema: accept `channels.telegram.actions.editMessage` and `createForumTopic` in strict config validation so existing Telegram action toggles no longer fail as unrecognized keys. (#35498) Thanks @ingyukoh.
 - Agents/cooldowns: default cooldown windows with no recorded failure history to `unknown` instead of `rate_limit`, avoiding false API rate-limit warnings while preserving cooldown recovery probes. (#42911) Thanks @VibhorGautam.
 - Discord/config typing: expose channel-level `autoThread` on the canonical guild-channel config type so strict config loading matches the existing Discord schema and runtime behavior. (#35608) Thanks @ingyukoh.
+- Agents/error rendering: ignore stale assistant `errorMessage` fields on successful turns so background/tool-side failures no longer prepend synthetic billing errors over valid replies. (#40616) Thanks @ingyukoh.
 
 ## 2026.3.8
 

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -101,6 +101,18 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.isError).toBe(true);
   });
 
+  it("does not emit a synthetic billing error for successful turns with stale errorMessage", () => {
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "end_turn",
+        errorMessage: "insufficient credits for embedding model",
+        content: [{ type: "text", text: "Handle payment required errors in your API." }],
+      }),
+    });
+
+    expectSinglePayloadText(payloads, "Handle payment required errors in your API.");
+  });
+
   it("suppresses raw error JSON even when errorMessage is missing", () => {
     const payloads = buildPayloads({
       assistantTexts: [errorJsonPretty],

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -104,7 +104,7 @@ describe("buildEmbeddedRunPayloads", () => {
   it("does not emit a synthetic billing error for successful turns with stale errorMessage", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({
-        stopReason: "end_turn",
+        stopReason: "stop",
         errorMessage: "insufficient credits for embedding model",
         content: [{ type: "text", text: "Handle payment required errors in your API." }],
       }),

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -128,16 +128,17 @@ export function buildEmbeddedRunPayloads(params: {
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts = params.didSendDeterministicApprovalPrompt === true;
   const lastAssistantErrored = params.lastAssistant?.stopReason === "error";
-  const errorText = params.lastAssistant
-    ? suppressAssistantArtifacts
-      ? undefined
-      : formatAssistantErrorText(params.lastAssistant, {
+  const errorText =
+    params.lastAssistant && lastAssistantErrored
+      ? suppressAssistantArtifacts
+        ? undefined
+        : formatAssistantErrorText(params.lastAssistant, {
           cfg: params.config,
           sessionKey: params.sessionKey,
           provider: params.provider,
           model: params.model,
         })
-    : undefined;
+      : undefined;
   const rawErrorMessage = lastAssistantErrored
     ? params.lastAssistant?.errorMessage?.trim() || undefined
     : undefined;

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -133,11 +133,11 @@ export function buildEmbeddedRunPayloads(params: {
       ? suppressAssistantArtifacts
         ? undefined
         : formatAssistantErrorText(params.lastAssistant, {
-          cfg: params.config,
-          sessionKey: params.sessionKey,
-          provider: params.provider,
-          model: params.model,
-        })
+            cfg: params.config,
+            sessionKey: params.sessionKey,
+            provider: params.provider,
+            model: params.model,
+          })
       : undefined;
   const rawErrorMessage = lastAssistantErrored
     ? params.lastAssistant?.errorMessage?.trim() || undefined

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -134,24 +134,17 @@ describe("extractAssistantText", () => {
     );
   });
 
-  it("preserves response text when errorMessage is set from background failure (#13935)", () => {
+  it("preserves response when errorMessage set from background failure (#13935)", () => {
+    const responseText = "Handle payment required errors in your API.";
     const msg = makeAssistantMessage({
       role: "assistant",
-      stopReason: "end_turn",
       errorMessage: "insufficient credits for embedding model",
-      content: [
-        {
-          type: "text",
-          text: "Here is how to handle payment required errors in your API integration.",
-        },
-      ],
+      content: [{ type: "text", text: responseText }],
       timestamp: Date.now(),
     });
 
     const result = extractAssistantText(msg);
-    expect(result).toBe(
-      "Here is how to handle payment required errors in your API integration.",
-    );
+    expect(result).toBe(responseText);
   });
 
   it("strips Minimax tool invocations with extra attributes", () => {

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -139,7 +139,7 @@ describe("extractAssistantText", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
       errorMessage: "insufficient credits for embedding model",
-      stopReason: "end_turn",
+      stopReason: "stop",
       content: [{ type: "text", text: responseText }],
       timestamp: Date.now(),
     });

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -139,6 +139,7 @@ describe("extractAssistantText", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
       errorMessage: "insufficient credits for embedding model",
+      stopReason: "end_turn",
       content: [{ type: "text", text: responseText }],
       timestamp: Date.now(),
     });

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -134,6 +134,26 @@ describe("extractAssistantText", () => {
     );
   });
 
+  it("preserves response text when errorMessage is set from background failure (#13935)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      stopReason: "end_turn",
+      errorMessage: "insufficient credits for embedding model",
+      content: [
+        {
+          type: "text",
+          text: "Here is how to handle payment required errors in your API integration.",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(
+      "Here is how to handle payment required errors in your API integration.",
+    );
+  });
+
   it("strips Minimax tool invocations with extra attributes", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -245,7 +245,9 @@ export function extractAssistantText(msg: AssistantMessage): string {
     }) ?? "";
   // Only apply keyword-based error rewrites when the assistant message is actually an error.
   // Otherwise normal prose that *mentions* errors (e.g. "context overflow") can get clobbered.
-  const errorContext = msg.stopReason === "error" || Boolean(msg.errorMessage?.trim());
+  // Gate on stopReason only — a non-error response with an errorMessage set (e.g. from a
+  // background tool failure) should not have its content rewritten (#13935).
+  const errorContext = msg.stopReason === "error";
   return sanitizeUserFacingText(extracted, { errorContext });
 }
 

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -166,9 +166,9 @@ export function extractAssistantText(message: unknown): string | undefined {
       normalizeText: (text) => text.trim(),
     }) ?? "";
   const stopReason = (message as { stopReason?: unknown }).stopReason;
-  const errorMessage = (message as { errorMessage?: unknown }).errorMessage;
-  const errorContext =
-    stopReason === "error" || (typeof errorMessage === "string" && Boolean(errorMessage.trim()));
+  // Gate on stopReason only — a non-error response with a stale/background errorMessage
+  // should not have its content rewritten with error templates (#13935).
+  const errorContext = stopReason === "error";
 
   return joined ? sanitizeUserFacingText(joined, { errorContext }) : undefined;
 }

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -199,6 +199,16 @@ describe("extractAssistantText", () => {
       "Firebase downgraded us to the free Spark plan. Check whether billing should be re-enabled.",
     );
   });
+
+  it("preserves successful turns with stale background errorMessage", () => {
+    const message = {
+      role: "assistant",
+      stopReason: "end_turn",
+      errorMessage: "insufficient credits for embedding model",
+      content: [{ type: "text", text: "Handle payment required errors in your API." }],
+    };
+    expect(extractAssistantText(message)).toBe("Handle payment required errors in your API.");
+  });
 });
 
 describe("resolveAnnounceTarget", () => {


### PR DESCRIPTION
## Summary

**Problem:** When an `AssistantMessage` has `errorMessage` set (e.g. from a background tool failure like `memory_search` embeddings) but `stopReason` is not `"error"`, `extractAssistantText` and `sessions-helpers` set `errorContext=true`. This causes `sanitizeUserFacingText` to scan the **actual response content** for billing keywords (`"payment required"`, `"credit balance"`, etc.) and replace the entire response with the billing error message — even though the response is valid.

**User impact:** Users see the billing error instead of the actual LLM response. The web interface may show the correct response (different rendering path) while channel delivery (Signal, Telegram) shows the billing error. This matches reports in #13935 where users confirmed the response exists on the web but not on their channel.

**Root cause:** In `extractAssistantText` (pi-embedded-utils.ts:222) and `sessions-helpers.ts`:
```typescript
// Before: errorContext true whenever errorMessage is set
const errorContext = msg.stopReason === "error" || Boolean(msg.errorMessage?.trim());
```

**Fix:** Gate `errorContext` on `stopReason === "error"` only. The error message itself is already formatted separately by `formatAssistantErrorText`, so content text does not need error rewriting when the response completed normally.

## Changes
- `src/agents/pi-embedded-utils.ts`: Remove `errorMessage` from `errorContext` gate
- `src/agents/tools/sessions-helpers.ts`: Same fix, remove unused `errorMessage` variable
- `src/agents/pi-embedded-utils.test.ts`: Add regression test

## Test plan
- [x] New test: response with `stopReason: "end_turn"` + `errorMessage` set + content containing "payment required" preserved, not replaced with billing error
- [x] Existing test: `stopReason: "error"` + content with HTTP error text still correctly rewritten
- [x] Existing test: normal text referencing billing plans still preserved

Fixes #13935