### PR TITLE
fix(feishu): pass mediaLocalRoots in sendText local-image auto-convert shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/local image auto-convert: pass `mediaLocalRoots` through the `sendText` local-image shim so allowed local image paths upload as Feishu images again instead of falling back to raw path text. (#40623) Thanks @ayanesakura.
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 - Gateway/Control UI: keep dashboard auth tokens in session-scoped browser storage so same-tab refreshes preserve remote token auth without restoring long-lived localStorage token persistence, while scoping tokens to the selected gateway URL and fragment-only bootstrap flow. (#40892) thanks @velvet-shark.
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -52,6 +52,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
         to: "chat_1",
         text: file,
         accountId: "main",
+        mediaLocalRoots: [dir],
       });
 
       expect(sendMediaFeishuMock).toHaveBeenCalledWith(
@@ -59,6 +60,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
           to: "chat_1",
           mediaUrl: file,
           accountId: "main",
+          mediaLocalRoots: [dir],
         }),
       );
       expect(sendMessageFeishuMock).not.toHaveBeenCalled();

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -81,7 +81,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
+  sendText: async ({ cfg, to, text, accountId, replyToId, threadId, mediaLocalRoots }) => {
     const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,
@@ -95,6 +95,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           mediaUrl: localImagePath,
           accountId: accountId ?? undefined,
           replyToMessageId,
+          mediaLocalRoots,
         });
         return { channel: "feishu", ...result };
       } catch (err) {


### PR DESCRIPTION
## Summary

- Problem: The Feishu `sendText` adapter's local-image auto-conversion shim calls `sendMediaFeishu` without `mediaLocalRoots`, so after the CVE-2026-26321 SSRF guard was added, `loadWebMedia` rejects local file reads.
- Why it matters: Users see the raw file path as text instead of an image in Feishu — the shim silently falls back to plain text on error.
- What changed: Destructure `mediaLocalRoots` from `ChannelOutboundContext` in `sendText` and forward it to `sendMediaFeishu`.
- What did NOT change: The `sendMedia` adapter (already passes `mediaLocalRoots`), the `normalizePossibleLocalImagePath` validation logic, and the fallback-to-text error path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations (Feishu)

## Linked Issue/PR

- Closes #40533

## User-visible / Behavior Changes

Local image paths sent via the built-in message tool are now correctly uploaded and delivered as Feishu image messages instead of being sent as plain text.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same `sendMediaFeishu` call, now with the correct `mediaLocalRoots` parameter that was already available in the context
- Command/tool execution surface changed? No
- Data access scope changed? No — `mediaLocalRoots` is computed by the core outbound pipeline and already passed to `sendMedia`; this fix just forwards it to `sendText` as well

## Repro + Verification

### Steps
1. Configure Feishu channel
2. Ask the agent to send a local image (e.g. "send image /tmp/test.png")
3. The message tool puts the path in `text`, triggering the `sendText` auto-convert shim

### Expected
- Image is uploaded and sent as a Feishu image message

### Actual (before fix)
- The raw file path (e.g. `/tmp/test.png`) is sent as plain text

## Evidence

- [x] Failing test/log before + passing after
- Updated existing test to verify `mediaLocalRoots` is forwarded to `sendMediaFeishu`

## Human Verification (required)

- Verified scenarios: All 13 existing Feishu outbound tests pass, including the updated local-image auto-convert test that now asserts `mediaLocalRoots` propagation
- Edge cases checked: `mediaLocalRoots` undefined (no-op, same as before), fallback-to-text path unchanged
- What you did **not** verify: Live Feishu API call with a real local image on Windows

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `extensions/feishu/src/outbound.ts`
- Known bad symptoms reviewers should watch for: Local image auto-convert stops working (falls back to text)

## Risks and Mitigations

- Risk: None — this forwards an existing parameter that was already available in the adapter context but not destructured
  - Mitigation: The `sendMedia` adapter already uses the same parameter successfully