### PR TITLE
fix(exec): use StringDecoder to prevent Chinese text mojibake in system messages

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -36,7 +36,11 @@ function escapeForCmdExe(arg: string): string {
 }
 
 function buildCmdExeCommandLine(resolvedCommand: string, args: string[]): string {
-  return [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
+  const cmdLine = [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
+  // Switch console codepage to UTF-8 before running the command so that
+  // multi-byte characters (e.g. Chinese) are emitted as UTF-8 instead of the
+  // system's default codepage (often GBK/cp936 on Chinese Windows).
+  return `chcp 65001 >nul && ${cmdLine}`;
 }
 
 /**

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { StringDecoder } from "node:string_decoder";
 import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { logDebug, logError } from "../logger.js";
@@ -296,13 +297,24 @@ export async function runCommandWithTimeout(
       child.stdin.end();
     }
 
+    // Use StringDecoder to handle multi-byte UTF-8 characters that may be split
+    // across Buffer chunks (e.g. Chinese text). Without this, partial byte
+    // sequences at chunk boundaries become U+FFFD replacement characters (mojibake).
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     child.stdout?.on("data", (d) => {
-      stdout += d.toString();
+      stdout += stdoutDecoder.write(d);
       armNoOutputTimer();
     });
+    child.stdout?.on("end", () => {
+      stdout += stdoutDecoder.end();
+    });
     child.stderr?.on("data", (d) => {
-      stderr += d.toString();
+      stderr += stderrDecoder.write(d);
       armNoOutputTimer();
+    });
+    child.stderr?.on("end", () => {
+      stderr += stderrDecoder.end();
     });
     child.on("error", (err) => {
       if (settled) {

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -138,4 +138,55 @@ describe("createChildAdapter", () => {
     };
     expect(spawnArgs.options?.env).toEqual({ FOO: "bar", COUNT: "12" });
   });
+
+  it("decodes multi-byte UTF-8 characters split across stdout chunks", async () => {
+    const { child } = createStubChild(5555);
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const adapter = await createChildAdapter({
+      argv: ["node", "-e", "''"],
+      stdinMode: "pipe-open",
+    });
+
+    const chunks: string[] = [];
+    adapter.onStdout((chunk) => chunks.push(chunk));
+
+    // "你好" in UTF-8 is 6 bytes: e4 bd a0 e5 a5 bd
+    // Split the first character across two Buffer chunks to simulate
+    // a multi-byte boundary split that causes mojibake without StringDecoder.
+    const fullBytes = Buffer.from("你好", "utf8"); // [e4, bd, a0, e5, a5, bd]
+    const part1 = fullBytes.subarray(0, 2); // [e4, bd] — incomplete first char
+    const part2 = fullBytes.subarray(2); // [a0, e5, a5, bd] — rest
+
+    child.stdout!.emit("data", part1);
+    child.stdout!.emit("data", part2);
+    child.stdout!.emit("end");
+
+    const result = chunks.join("");
+    expect(result).toBe("你好");
+  });
+
+  it("decodes multi-byte UTF-8 characters split across stderr chunks", async () => {
+    const { child } = createStubChild(6666);
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const adapter = await createChildAdapter({
+      argv: ["node", "-e", "''"],
+      stdinMode: "pipe-open",
+    });
+
+    const chunks: string[] = [];
+    adapter.onStderr((chunk) => chunks.push(chunk));
+
+    // "中文" in UTF-8 is 6 bytes: e4 b8 ad e6 96 87
+    // Split in the middle of the second character.
+    const fullBytes = Buffer.from("中文", "utf8");
+    const part1 = fullBytes.subarray(0, 4); // first char + 1 byte of second
+    const part2 = fullBytes.subarray(4); // remaining 2 bytes of second char
+
+    child.stderr!.emit("data", part1);
+    child.stderr!.emit("data", part2);
+    child.stderr!.emit("end");
+
+    const result = chunks.join("");
+    expect(result).toBe("中文");
+  });
 });

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { killProcessTree } from "../../kill-tree.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
@@ -107,15 +108,33 @@ export async function createChildAdapter(params: {
       }
     : undefined;
 
+  // Use StringDecoder to handle multi-byte UTF-8 characters that may be split
+  // across Buffer chunks (e.g. Chinese text). Without this, partial byte
+  // sequences at chunk boundaries become U+FFFD replacement characters (mojibake).
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
   const onStdout = (listener: (chunk: string) => void) => {
     child.stdout.on("data", (chunk) => {
-      listener(chunk.toString());
+      listener(stdoutDecoder.write(chunk));
+    });
+    child.stdout.on("end", () => {
+      const remaining = stdoutDecoder.end();
+      if (remaining) {
+        listener(remaining);
+      }
     });
   };
 
   const onStderr = (listener: (chunk: string) => void) => {
     child.stderr.on("data", (chunk) => {
-      listener(chunk.toString());
+      listener(stderrDecoder.write(chunk));
+    });
+    child.stderr.on("end", () => {
+      const remaining = stderrDecoder.end();
+      if (remaining) {
+        listener(remaining);
+      }
     });
   };
 


### PR DESCRIPTION
## Summary

Fixes Chinese text mojibake on Windows when exec command output is routed through system messages.

**Two-layer fix:**

1. **Root cause — codepage mismatch (`chcp 65001`):** Windows cmd.exe defaults to the system codepage (GBK/cp936 on Chinese Windows), not UTF-8. Prepends `chcp 65001 >/dev/null &&` to cmd.exe command lines so child processes emit UTF-8.

2. **Defense-in-depth — chunk boundary handling (`StringDecoder`):** `Buffer.toString()` can corrupt multi-byte UTF-8 characters that span buffer chunk boundaries. `StringDecoder` buffers incomplete sequences until complete characters can be emitted.

## Changes

| File | Change |
|------|--------|
| `src/process/exec.ts` | `buildCmdExeCommandLine` prepends `chcp 65001 >/dev/null &&`; `runCommandWithTimeout` uses `StringDecoder` |
| `src/process/supervisor/adapters/child.ts` | `onStdout`/`onStderr` use `StringDecoder` for chunk boundary safety |
| `src/process/supervisor/adapters/child.test.ts` | Tests for multi-byte UTF-8 split across stdout/stderr chunks |

## Test plan

- [ ] On Chinese Windows 11: run `dir` and `powershell Get-ChildItem` — Chinese filenames should display correctly
- [ ] On English Windows: verify `chcp 65001` doesn't break ASCII-only output  
- [ ] On macOS/Linux: no behavioral change (cmd.exe wrapper path is Windows-only)
- [ ] Existing tests pass (`child.test.ts` StringDecoder tests)

Fixes #40613