### PR TITLE
fix: make exec approval modal scrollable

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2131,11 +2131,20 @@
 
 .exec-approval-card {
   width: min(540px, 100%);
+  max-height: min(80vh, 600px);
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 20px;
   animation: scale-in 0.2s var(--ease-out);
+  display: flex;
+  flex-direction: column;
+}
+
+.exec-approval-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .exec-approval-header {
@@ -2175,6 +2184,8 @@
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
+  max-height: 40vh;
+  overflow-y: auto;
 }
 
 .exec-approval-meta {

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -45,21 +45,23 @@ export function renderExecApprovalPrompt(state: AppViewState) {
               : nothing
           }
         </div>
-        <div class="exec-approval-command mono">${request.command}</div>
-        <div class="exec-approval-meta">
-          ${renderMetaRow("Host", request.host)}
-          ${renderMetaRow("Agent", request.agentId)}
-          ${renderMetaRow("Session", request.sessionKey)}
-          ${renderMetaRow("CWD", request.cwd)}
-          ${renderMetaRow("Resolved", request.resolvedPath)}
-          ${renderMetaRow("Security", request.security)}
-          ${renderMetaRow("Ask", request.ask)}
+        <div class="exec-approval-body">
+          <div class="exec-approval-command mono">${request.command}</div>
+          <div class="exec-approval-meta">
+            ${renderMetaRow("Host", request.host)}
+            ${renderMetaRow("Agent", request.agentId)}
+            ${renderMetaRow("Session", request.sessionKey)}
+            ${renderMetaRow("CWD", request.cwd)}
+            ${renderMetaRow("Resolved", request.resolvedPath)}
+            ${renderMetaRow("Security", request.security)}
+            ${renderMetaRow("Ask", request.ask)}
+          </div>
+          ${
+            state.execApprovalError
+              ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
+              : nothing
+          }
         </div>
-        ${
-          state.execApprovalError
-            ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
-            : nothing
-        }
         <div class="exec-approval-actions">
           <button
             class="btn primary"

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -56,12 +56,12 @@ export function renderExecApprovalPrompt(state: AppViewState) {
             ${renderMetaRow("Security", request.security)}
             ${renderMetaRow("Ask", request.ask)}
           </div>
-          ${
-            state.execApprovalError
-              ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
-              : nothing
-          }
         </div>
+        ${
+          state.execApprovalError
+            ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
+            : nothing
+        }
         <div class="exec-approval-actions">
           <button
             class="btn primary"


### PR DESCRIPTION
## Summary

Fixes #40619

The exec approval modal in Control UI can overflow the viewport when the command string is long (multi-line shell pipelines, long JSON, etc.), pushing the Approve/Deny buttons off-screen.

- Added `max-height` and flex column layout to `.exec-approval-card` so the modal stays within viewport bounds
- Wrapped command preview + metadata in a scrollable `.exec-approval-body` container
- Added `max-height: 40vh` with `overflow-y: auto` on `.exec-approval-command` for very long commands
- Header and action buttons always remain visible and reachable

## Test plan

- [ ] Trigger an exec approval with a short command — modal should look unchanged
- [ ] Trigger an exec approval with a very long command (multi-line pipeline, long JSON) — command area scrolls, buttons stay visible
- [ ] Test on small viewport (e.g. 768px height) — modal fits within 80vh, content scrollable
- [ ] Verify keyboard navigation (Tab to buttons) still works