### PR TITLE
fix(heartbeat): use 60s retry delay for requests-in-flight skips

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -260,6 +260,17 @@ export type AgentDefaultsConfig = {
      * Default: false (only the final heartbeat payload is delivered).
      */
     includeReasoning?: boolean;
+    /**
+     * Retry delay in milliseconds when a heartbeat is skipped because the
+     * main lane has requests in flight (active conversation).
+     *
+     * A longer delay prevents the heartbeat from firing immediately when a
+     * conversation turn completes, which would hold the session write lock
+     * and block channel message delivery (e.g. Telegram).
+     *
+     * Default: 60000 (60 seconds).
+     */
+    retryDelayMs?: number;
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -158,9 +158,10 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // The wake layer retries after DEFAULT_RETRY_MS (1 s).  No scheduleNext()
-    // is called inside runOnce, so we must wait for the full cooldown.
-    await vi.advanceTimersByTimeAsync(1_000);
+    // The wake layer retries after the in-flight retry delay (60 s default).
+    // No scheduleNext() is called inside runOnce, so we must wait for the
+    // full cooldown.
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(runSpy).toHaveBeenCalledTimes(2);
 
     runner.stop();
@@ -171,7 +172,8 @@ describe("startHeartbeatRunner", () => {
     vi.setSystemTime(new Date(0));
 
     // Simulate a long-running heartbeat: the first 5 calls return
-    // requests-in-flight (retries from the wake layer), then the 6th succeeds.
+    // requests-in-flight (retries from the wake layer at 60s intervals),
+    // then the 6th succeeds.
     let callCount = 0;
     const runSpy = vi.fn().mockImplementation(async () => {
       callCount++;
@@ -192,15 +194,14 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // Simulate 4 more retries at short intervals (wake layer retries).
+    // Simulate 4 more retries at 60s intervals (wake layer retries).
     for (let i = 0; i < 4; i++) {
-      requestHeartbeatNow({ reason: "retry", coalesceMs: 0 });
-      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(60_000);
     }
     expect(runSpy).toHaveBeenCalledTimes(5);
 
     // The next interval tick at ~t=60m should still fire — the schedule
-    // must not have been pushed to t=30m * 6 = 180m by the 5 retries.
+    // must not have been pushed forward by the 5 retries.
     await vi.advanceTimersByTimeAsync(30 * 60_000);
     expect(runSpy).toHaveBeenCalledTimes(6);
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -57,6 +57,7 @@ import {
   type HeartbeatWakeHandler,
   requestHeartbeatNow,
   setHeartbeatWakeHandler,
+  setInFlightRetryMs,
 } from "./heartbeat-wake.js";
 import type { OutboundSendDeps } from "./outbound/deliver.js";
 import { deliverOutboundPayloads } from "./outbound/deliver.js";
@@ -1088,6 +1089,12 @@ export function startHeartbeatRunner(opts: {
 
     state.cfg = cfg;
     state.agents = nextAgents;
+    // Apply configured retry delay for requests-in-flight skips to the
+    // wake layer so it backs off instead of retrying after ~1 second.
+    const retryDelayMs = cfg.agents?.defaults?.heartbeat?.retryDelayMs;
+    if (typeof retryDelayMs === "number") {
+      setInFlightRetryMs(retryDelayMs);
+    }
     const nextEnabled = nextAgents.size > 0;
     if (!initialized) {
       if (!nextEnabled) {

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -5,13 +5,15 @@ import {
   requestHeartbeatNow,
   resetHeartbeatWakeStateForTests,
   setHeartbeatWakeHandler,
+  setInFlightRetryMs,
 } from "./heartbeat-wake.js";
 
 describe("heartbeat-wake", () => {
-  async function expectRetryAfterDefaultDelay(params: {
+  async function expectRetryAfterDelay(params: {
     handler: ReturnType<typeof vi.fn>;
     initialReason: string;
     expectedRetryReason: string;
+    retryDelayMs: number;
   }) {
     setHeartbeatWakeHandler(
       params.handler as unknown as Parameters<typeof setHeartbeatWakeHandler>[0],
@@ -21,10 +23,10 @@ describe("heartbeat-wake", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(params.handler).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(params.retryDelayMs / 2);
     expect(params.handler).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(params.retryDelayMs / 2);
     expect(params.handler).toHaveBeenCalledTimes(2);
     expect(params.handler.mock.calls[1]?.[0]).toEqual({ reason: params.expectedRetryReason });
   }
@@ -59,16 +61,32 @@ describe("heartbeat-wake", () => {
     expect(hasPendingHeartbeatWake()).toBe(false);
   });
 
-  it("retries requests-in-flight after the default retry delay", async () => {
+  it("retries requests-in-flight after the default in-flight retry delay (60s)", async () => {
     vi.useFakeTimers();
     const handler = vi
       .fn()
       .mockResolvedValueOnce({ status: "skipped", reason: "requests-in-flight" })
       .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
-    await expectRetryAfterDefaultDelay({
+    await expectRetryAfterDelay({
       handler,
       initialReason: "interval",
       expectedRetryReason: "interval",
+      retryDelayMs: 60_000,
+    });
+  });
+
+  it("respects custom retryDelayMs for requests-in-flight", async () => {
+    vi.useFakeTimers();
+    setInFlightRetryMs(120_000);
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: "requests-in-flight" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    await expectRetryAfterDelay({
+      handler,
+      initialReason: "interval",
+      expectedRetryReason: "interval",
+      retryDelayMs: 120_000,
     });
   });
 
@@ -84,9 +102,9 @@ describe("heartbeat-wake", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(handler).toHaveBeenCalledTimes(1);
 
-    // Retry is now waiting for 1000ms. This should not preempt cooldown.
+    // Retry is now waiting for 60 000ms. This should not preempt cooldown.
     requestHeartbeatNow({ reason: "hook:wake", coalesceMs: 0 });
-    await vi.advanceTimersByTimeAsync(998);
+    await vi.advanceTimersByTimeAsync(59_998);
     expect(handler).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
@@ -94,16 +112,17 @@ describe("heartbeat-wake", () => {
     expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "hook:wake" });
   });
 
-  it("retries thrown handler errors after the default retry delay", async () => {
+  it("retries thrown handler errors after the default error retry delay (1s)", async () => {
     vi.useFakeTimers();
     const handler = vi
       .fn()
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce({ status: "skipped", reason: "disabled" });
-    await expectRetryAfterDefaultDelay({
+    await expectRetryAfterDelay({
       handler,
       initialReason: "exec-event",
       expectedRetryReason: "exec-event",
+      retryDelayMs: 1_000,
     });
   });
 
@@ -273,7 +292,7 @@ describe("heartbeat-wake", () => {
       sessionKey: "agent:ops:discord:channel:alerts",
     });
 
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(handler).toHaveBeenCalledTimes(2);
     expect(handler.mock.calls[1]?.[0]).toEqual({
       reason: "cron:job-1",

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -35,6 +35,8 @@ let timerKind: WakeTimerKind | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
+const DEFAULT_IN_FLIGHT_RETRY_MS = 60_000;
+let inFlightRetryMs = DEFAULT_IN_FLIGHT_RETRY_MS;
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
@@ -154,13 +156,15 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
         };
         const res = await active(wakeOpts);
         if (res.status === "skipped" && res.reason === "requests-in-flight") {
-          // The main lane is busy; retry this wake target soon.
+          // The main lane is busy; retry after a longer backoff so the
+          // heartbeat does not fire the instant the conversation turn
+          // completes and block Telegram messages with a long write lock.
           queuePendingWakeReason({
             reason: pendingWake.reason ?? "retry",
             agentId: pendingWake.agentId,
             sessionKey: pendingWake.sessionKey,
           });
-          schedule(DEFAULT_RETRY_MS, "retry");
+          schedule(inFlightRetryMs, "retry");
         }
       }
     } catch {
@@ -247,6 +251,19 @@ export function hasPendingHeartbeatWake() {
   return pendingWakes.size > 0 || Boolean(timer) || scheduled;
 }
 
+/**
+ * Configure the retry delay used when a heartbeat is skipped because the
+ * main lane has requests in flight (active conversation). A longer delay
+ * prevents the heartbeat from firing immediately when a conversation turn
+ * completes, which would hold the session write lock and block channel
+ * message delivery (e.g. Telegram).
+ *
+ * Default: 60 000 ms (60 s).
+ */
+export function setInFlightRetryMs(ms: number) {
+  inFlightRetryMs = Number.isFinite(ms) && ms > 0 ? ms : DEFAULT_IN_FLIGHT_RETRY_MS;
+}
+
 export function resetHeartbeatWakeStateForTests() {
   if (timer) {
     clearTimeout(timer);
@@ -259,4 +276,5 @@ export function resetHeartbeatWakeStateForTests() {
   running = false;
   handlerGeneration += 1;
   handler = null;
+  inFlightRetryMs = DEFAULT_IN_FLIGHT_RETRY_MS;
 }


### PR DESCRIPTION
## Summary

After PR #39182 fixed heartbeat drift, when a heartbeat is skipped due to `requests-in-flight` (active conversation), the wake layer retried via `DEFAULT_RETRY_MS` (~1 second). This caused the heartbeat to fire instantly when a conversation turn completed, holding the session write lock for up to 600s and blocking Telegram message delivery.

## Changes

- Add `DEFAULT_IN_FLIGHT_RETRY_MS` (60s) in `heartbeat-wake.ts` — used only for `requests-in-flight` skips
- Keep `DEFAULT_RETRY_MS` (1s) unchanged for error retries
- Add configurable `heartbeat.retryDelayMs` config option in `AgentDefaultsConfig`
- Export `setInFlightRetryMs()` from `heartbeat-wake` module
- Wire config through heartbeat runner's `updateConfig()` path
- Update existing tests for new 60s default; add test for custom `retryDelayMs`

## Why 60s?

The heartbeat interval is typically 30m. A 1s retry means the heartbeat fires almost instantly after the conversation ends, grabbing the session write lock for up to 600s. A 60s backoff gives enough breathing room for Telegram messages to be processed while still retrying well within the heartbeat interval. Users can tune this via `heartbeat.retryDelayMs` if needed.

Fixes #40611

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] `pnpm test src/infra/heartbeat-wake.test.ts` — 14 tests pass (includes new custom delay test)
- [x] `pnpm test src/infra/heartbeat-runner.scheduler.test.ts` — 8 tests pass
- [x] Full `pnpm test` — only pre-existing unrelated failure in `run.message-tool-policy.test.ts`