### PR TITLE
feat(channels): add InboxAPI email channel extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,6 +31,11 @@
           - "src/imessage/**"
           - "extensions/imessage/**"
           - "docs/channels/imessage.md"
+"channel: inboxapi":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/inboxapi/**"
+          - "docs/channels/inboxapi.md"
 "channel: line":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/inboxapi/index.ts
+++ b/extensions/inboxapi/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/inboxapi";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/inboxapi";
+import { createInboxApiPlugin } from "./src/channel.js";
+import { setInboxApiRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "inboxapi",
+  name: "InboxAPI Email",
+  description: "Email channel plugin for OpenClaw via InboxAPI",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setInboxApiRuntime(api.runtime);
+    api.registerChannel({ plugin: createInboxApiPlugin() });
+  },
+};
+
+export default plugin;

--- a/extensions/inboxapi/openclaw.plugin.json
+++ b/extensions/inboxapi/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "inboxapi",
+  "channels": ["inboxapi"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/inboxapi/package.json
+++ b/extensions/inboxapi/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@openclaw/inboxapi",
+  "version": "2026.3.9",
+  "description": "InboxAPI email channel plugin for OpenClaw",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "inboxapi",
+      "label": "InboxAPI Email",
+      "selectionLabel": "InboxAPI (Email)",
+      "docsPath": "/channels/inboxapi",
+      "docsLabel": "inboxapi",
+      "blurb": "Send and receive email through InboxAPI.",
+      "order": 95
+    },
+    "install": {
+      "npmSpec": "@openclaw/inboxapi",
+      "localPath": "extensions/inboxapi",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/inboxapi/src/accounts.test.ts
+++ b/extensions/inboxapi/src/accounts.test.ts
@@ -7,17 +7,12 @@ describe("listAccountIds", () => {
     expect(listAccountIds({ channels: {} })).toEqual([]);
   });
 
-  it("returns default when accessToken is set", () => {
-    const cfg = { channels: { inboxapi: { accessToken: "tok" } } };
+  it("returns default when channel section exists", () => {
+    const cfg = { channels: { inboxapi: {} } };
     expect(listAccountIds(cfg)).toEqual(["default"]);
   });
 
-  it("returns default when domain is set", () => {
-    const cfg = { channels: { inboxapi: { domain: "example.inboxapi.ai" } } };
-    expect(listAccountIds(cfg)).toEqual(["default"]);
-  });
-
-  it("returns named accounts", () => {
+  it("returns default + named accounts", () => {
     const cfg = {
       channels: {
         inboxapi: {
@@ -25,21 +20,10 @@ describe("listAccountIds", () => {
         },
       },
     };
-    expect(listAccountIds(cfg)).toEqual(["prod", "staging"]);
-  });
-
-  it("returns default + named accounts", () => {
-    const cfg = {
-      channels: {
-        inboxapi: {
-          accessToken: "base",
-          accounts: { prod: { accessToken: "tok1" } },
-        },
-      },
-    };
     const ids = listAccountIds(cfg);
     expect(ids).toContain("default");
     expect(ids).toContain("prod");
+    expect(ids).toContain("staging");
   });
 });
 

--- a/extensions/inboxapi/src/accounts.test.ts
+++ b/extensions/inboxapi/src/accounts.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { listAccountIds, resolveAccount } from "./accounts.js";
+
+describe("listAccountIds", () => {
+  it("returns empty for no config", () => {
+    expect(listAccountIds({})).toEqual([]);
+    expect(listAccountIds({ channels: {} })).toEqual([]);
+  });
+
+  it("returns default when accessToken is set", () => {
+    const cfg = { channels: { inboxapi: { accessToken: "tok" } } };
+    expect(listAccountIds(cfg)).toEqual(["default"]);
+  });
+
+  it("returns default when domain is set", () => {
+    const cfg = { channels: { inboxapi: { domain: "example.inboxapi.ai" } } };
+    expect(listAccountIds(cfg)).toEqual(["default"]);
+  });
+
+  it("returns named accounts", () => {
+    const cfg = {
+      channels: {
+        inboxapi: {
+          accounts: { prod: { accessToken: "tok1" }, staging: { accessToken: "tok2" } },
+        },
+      },
+    };
+    expect(listAccountIds(cfg)).toEqual(["prod", "staging"]);
+  });
+
+  it("returns default + named accounts", () => {
+    const cfg = {
+      channels: {
+        inboxapi: {
+          accessToken: "base",
+          accounts: { prod: { accessToken: "tok1" } },
+        },
+      },
+    };
+    const ids = listAccountIds(cfg);
+    expect(ids).toContain("default");
+    expect(ids).toContain("prod");
+  });
+});
+
+describe("resolveAccount", () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.INBOXAPI_ACCESS_TOKEN;
+    delete process.env.INBOXAPI_DOMAIN;
+    delete process.env.INBOXAPI_FROM_NAME;
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it("returns defaults for empty config", () => {
+    const account = resolveAccount({});
+    expect(account.accountId).toBe("default");
+    expect(account.enabled).toBe(true);
+    expect(account.mcpEndpoint).toBe("https://mcp.inboxapi.ai/mcp");
+    expect(account.credentialsPath).toBe("~/.local/inboxapi/credentials.json");
+    expect(account.pollIntervalMs).toBe(30_000);
+    expect(account.pollBatchSize).toBe(20);
+    expect(account.dmPolicy).toBe("allowlist");
+    expect(account.allowFrom).toEqual([]);
+    expect(account.textChunkLimit).toBe(50_000);
+  });
+
+  it("merges base config", () => {
+    const cfg = {
+      channels: {
+        inboxapi: {
+          accessToken: "my-token",
+          domain: "test.inboxapi.ai",
+          fromName: "TestBot",
+          pollIntervalMs: 60_000,
+        },
+      },
+    };
+    const account = resolveAccount(cfg);
+    expect(account.accessToken).toBe("my-token");
+    expect(account.domain).toBe("test.inboxapi.ai");
+    expect(account.fromName).toBe("TestBot");
+    expect(account.pollIntervalMs).toBe(60_000);
+  });
+
+  it("account overrides take priority", () => {
+    const cfg = {
+      channels: {
+        inboxapi: {
+          accessToken: "base-token",
+          domain: "base.inboxapi.ai",
+          accounts: {
+            prod: {
+              accessToken: "prod-token",
+              domain: "prod.inboxapi.ai",
+            },
+          },
+        },
+      },
+    };
+    const account = resolveAccount(cfg, "prod");
+    expect(account.accountId).toBe("prod");
+    expect(account.accessToken).toBe("prod-token");
+    expect(account.domain).toBe("prod.inboxapi.ai");
+  });
+
+  it("falls back to env vars", () => {
+    process.env.INBOXAPI_ACCESS_TOKEN = "env-token";
+    process.env.INBOXAPI_DOMAIN = "env.inboxapi.ai";
+    const account = resolveAccount({});
+    expect(account.accessToken).toBe("env-token");
+    expect(account.domain).toBe("env.inboxapi.ai");
+  });
+
+  it("parses allowFrom from CSV string", () => {
+    const cfg = {
+      channels: {
+        inboxapi: {
+          allowFrom: "alice@example.com, Bob@Example.COM, charlie@test.com",
+        },
+      },
+    };
+    const account = resolveAccount(cfg);
+    expect(account.allowFrom).toEqual(["alice@example.com", "bob@example.com", "charlie@test.com"]);
+  });
+
+  it("parses allowFrom from array", () => {
+    const cfg = {
+      channels: {
+        inboxapi: {
+          allowFrom: ["Alice@Example.com", "Bob@Test.com"],
+        },
+      },
+    };
+    const account = resolveAccount(cfg);
+    expect(account.allowFrom).toEqual(["alice@example.com", "bob@test.com"]);
+  });
+});

--- a/extensions/inboxapi/src/accounts.ts
+++ b/extensions/inboxapi/src/accounts.ts
@@ -28,23 +28,16 @@ function parseAllowFrom(raw: string | string[] | undefined): string[] {
 
 /**
  * List all configured account IDs for this channel.
- * Returns ["default"] if there's a base config with credentials, plus any named accounts.
+ * Always includes "default" when the channel section exists, because
+ * resolveAccount falls back to the default credentials file path
+ * (~/.local/inboxapi/credentials.json) even without explicit config fields.
+ * Also includes any named accounts under channels.inboxapi.accounts.
  */
 export function listAccountIds(cfg: any): string[] {
   const channelCfg = getChannelConfig(cfg);
   if (!channelCfg) return [];
 
-  const ids = new Set<string>();
-
-  // If base config has an access token or env var, there's a "default" account
-  const hasBaseCreds =
-    channelCfg.accessToken ||
-    process.env.INBOXAPI_ACCESS_TOKEN ||
-    channelCfg.credentialsPath ||
-    channelCfg.domain;
-  if (hasBaseCreds) {
-    ids.add("default");
-  }
+  const ids = new Set<string>(["default"]);
 
   // Named accounts
   if (channelCfg.accounts) {

--- a/extensions/inboxapi/src/accounts.ts
+++ b/extensions/inboxapi/src/accounts.ts
@@ -1,0 +1,94 @@
+/**
+ * Account resolution: reads config from channels.inboxapi,
+ * merges per-account overrides, falls back to environment variables.
+ */
+
+import type { InboxApiChannelConfig, ResolvedInboxApiAccount } from "./types.js";
+
+const DEFAULT_MCP_ENDPOINT = "https://mcp.inboxapi.ai/mcp";
+const DEFAULT_CREDENTIALS_PATH = "~/.local/inboxapi/credentials.json";
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_POLL_BATCH_SIZE = 20;
+const DEFAULT_TEXT_CHUNK_LIMIT = 50_000;
+
+/** Extract the channel config from the full OpenClaw config object. */
+function getChannelConfig(cfg: any): InboxApiChannelConfig | undefined {
+  return cfg?.channels?.inboxapi;
+}
+
+/** Parse allowFrom from string or array to string[]. */
+function parseAllowFrom(raw: string | string[] | undefined): string[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.filter(Boolean).map((s) => s.toLowerCase().trim());
+  return raw
+    .split(",")
+    .map((s) => s.toLowerCase().trim())
+    .filter(Boolean);
+}
+
+/**
+ * List all configured account IDs for this channel.
+ * Returns ["default"] if there's a base config with credentials, plus any named accounts.
+ */
+export function listAccountIds(cfg: any): string[] {
+  const channelCfg = getChannelConfig(cfg);
+  if (!channelCfg) return [];
+
+  const ids = new Set<string>();
+
+  // If base config has an access token or env var, there's a "default" account
+  const hasBaseCreds =
+    channelCfg.accessToken ||
+    process.env.INBOXAPI_ACCESS_TOKEN ||
+    channelCfg.credentialsPath ||
+    channelCfg.domain;
+  if (hasBaseCreds) {
+    ids.add("default");
+  }
+
+  // Named accounts
+  if (channelCfg.accounts) {
+    for (const id of Object.keys(channelCfg.accounts)) {
+      ids.add(id);
+    }
+  }
+
+  return Array.from(ids);
+}
+
+/**
+ * Resolve a specific account by ID with full defaults applied.
+ * Falls back to env vars for the "default" account.
+ */
+export function resolveAccount(cfg: any, accountId?: string | null): ResolvedInboxApiAccount {
+  const channelCfg = getChannelConfig(cfg) ?? {};
+  const id = accountId || "default";
+
+  // Account-specific overrides (if named account exists)
+  const accountOverride = channelCfg.accounts?.[id] ?? {};
+
+  // Env var fallbacks
+  const envAccessToken = process.env.INBOXAPI_ACCESS_TOKEN ?? "";
+  const envDomain = process.env.INBOXAPI_DOMAIN ?? "";
+  const envFromName = process.env.INBOXAPI_FROM_NAME ?? "";
+
+  // Merge: account override > base channel config > env var > default
+  return {
+    accountId: id,
+    enabled: accountOverride.enabled ?? channelCfg.enabled ?? true,
+    mcpEndpoint: accountOverride.mcpEndpoint ?? channelCfg.mcpEndpoint ?? DEFAULT_MCP_ENDPOINT,
+    credentialsPath:
+      accountOverride.credentialsPath ?? channelCfg.credentialsPath ?? DEFAULT_CREDENTIALS_PATH,
+    accessToken: accountOverride.accessToken ?? channelCfg.accessToken ?? envAccessToken,
+    domain: accountOverride.domain ?? channelCfg.domain ?? envDomain,
+    fromName: accountOverride.fromName ?? channelCfg.fromName ?? envFromName,
+    pollIntervalMs:
+      accountOverride.pollIntervalMs ?? channelCfg.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    pollBatchSize:
+      accountOverride.pollBatchSize ?? channelCfg.pollBatchSize ?? DEFAULT_POLL_BATCH_SIZE,
+    dmPolicy: accountOverride.dmPolicy ?? channelCfg.dmPolicy ?? "allowlist",
+    allowFrom: parseAllowFrom(accountOverride.allowFrom ?? channelCfg.allowFrom),
+    textChunkLimit:
+      accountOverride.textChunkLimit ?? channelCfg.textChunkLimit ?? DEFAULT_TEXT_CHUNK_LIMIT,
+  };
+}

--- a/extensions/inboxapi/src/auth.test.ts
+++ b/extensions/inboxapi/src/auth.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolveAccessToken, resolveDomain } from "./auth.js";
+import type { ResolvedInboxApiAccount } from "./types.js";
+
+function makeAccount(overrides: Partial<ResolvedInboxApiAccount> = {}): ResolvedInboxApiAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    mcpEndpoint: "https://mcp.inboxapi.ai/mcp",
+    credentialsPath: "/nonexistent/credentials.json",
+    accessToken: "",
+    domain: "",
+    fromName: "",
+    pollIntervalMs: 30_000,
+    pollBatchSize: 20,
+    dmPolicy: "allowlist",
+    allowFrom: [],
+    textChunkLimit: 50_000,
+    ...overrides,
+  };
+}
+
+describe("resolveAccessToken", () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.INBOXAPI_ACCESS_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it("uses config accessToken first", async () => {
+    const account = makeAccount({ accessToken: "config-token" });
+    expect(await resolveAccessToken(account)).toBe("config-token");
+  });
+
+  it("falls back to env var", async () => {
+    process.env.INBOXAPI_ACCESS_TOKEN = "env-token";
+    const account = makeAccount();
+    expect(await resolveAccessToken(account)).toBe("env-token");
+  });
+
+  it("returns empty string when no credentials", async () => {
+    const account = makeAccount();
+    expect(await resolveAccessToken(account)).toBe("");
+  });
+});
+
+describe("resolveDomain", () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.INBOXAPI_DOMAIN;
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it("uses config domain first", async () => {
+    const account = makeAccount({ domain: "test.inboxapi.ai" });
+    expect(await resolveDomain(account)).toBe("test.inboxapi.ai");
+  });
+
+  it("falls back to env var", async () => {
+    process.env.INBOXAPI_DOMAIN = "env.inboxapi.ai";
+    const account = makeAccount();
+    expect(await resolveDomain(account)).toBe("env.inboxapi.ai");
+  });
+
+  it("returns empty string when no domain", async () => {
+    const account = makeAccount();
+    expect(await resolveDomain(account)).toBe("");
+  });
+});

--- a/extensions/inboxapi/src/auth.ts
+++ b/extensions/inboxapi/src/auth.ts
@@ -1,0 +1,80 @@
+/**
+ * JWT credential management for InboxAPI.
+ * Loads credentials from file or config, handles token resolution.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import type { InboxApiCredentials, ResolvedInboxApiAccount } from "./types.js";
+
+/**
+ * Expand ~ to home directory in paths.
+ */
+function expandHome(p: string): string {
+  if (p.startsWith("~/") || p === "~") {
+    return resolve(homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Load credentials from the InboxAPI credentials file.
+ * Returns null if file doesn't exist or can't be parsed.
+ */
+export async function loadCredentialsFile(
+  credentialsPath: string,
+): Promise<InboxApiCredentials | null> {
+  try {
+    const fullPath = expandHome(credentialsPath);
+    const raw = await readFile(fullPath, "utf-8");
+    return JSON.parse(raw) as InboxApiCredentials;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the access token for an account.
+ * Resolution order: config accessToken → env INBOXAPI_ACCESS_TOKEN → credentials file
+ */
+export async function resolveAccessToken(account: ResolvedInboxApiAccount): Promise<string> {
+  // 1. Direct config value
+  if (account.accessToken) {
+    return account.accessToken;
+  }
+
+  // 2. Environment variable (already merged in resolveAccount, but double-check)
+  if (process.env.INBOXAPI_ACCESS_TOKEN) {
+    return process.env.INBOXAPI_ACCESS_TOKEN;
+  }
+
+  // 3. Credentials file
+  const creds = await loadCredentialsFile(account.credentialsPath);
+  if (creds?.accessToken) {
+    return creds.accessToken;
+  }
+
+  return "";
+}
+
+/**
+ * Resolve the domain for an account.
+ * Resolution order: config domain → env INBOXAPI_DOMAIN → credentials file
+ */
+export async function resolveDomain(account: ResolvedInboxApiAccount): Promise<string> {
+  if (account.domain) {
+    return account.domain;
+  }
+
+  if (process.env.INBOXAPI_DOMAIN) {
+    return process.env.INBOXAPI_DOMAIN;
+  }
+
+  const creds = await loadCredentialsFile(account.credentialsPath);
+  if (creds?.domain) {
+    return creds.domain;
+  }
+
+  return "";
+}

--- a/extensions/inboxapi/src/channel.ts
+++ b/extensions/inboxapi/src/channel.ts
@@ -223,9 +223,10 @@ export function createInboxApiPlugin() {
             const rt = getInboxApiRuntime();
             const currentCfg = await rt.config.loadConfig();
 
-            // CommandAuthorized defaults to false; the framework's authorizers
-            // handle command authorization based on DM policy/pairing state
-            const msgFields = buildInboundMsgFields(email, account.accountId, false);
+            // The monitor's checkAccess already verified the sender is allowed
+            // by DM policy / pairing store, so grant command authorization
+            // (matches Synology Chat's commandAuthorized: auth.allowed pattern)
+            const msgFields = buildInboundMsgFields(email, account.accountId, true);
             const msgCtx = rt.channel.reply.finalizeInboundContext(msgFields);
 
             await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({

--- a/extensions/inboxapi/src/channel.ts
+++ b/extensions/inboxapi/src/channel.ts
@@ -29,6 +29,7 @@ function waitUntilAbort(signal?: AbortSignal, onAbort?: () => void): Promise<voi
       resolve();
     };
     if (!signal) {
+      resolve();
       return;
     }
     if (signal.aborted) {

--- a/extensions/inboxapi/src/channel.ts
+++ b/extensions/inboxapi/src/channel.ts
@@ -1,0 +1,325 @@
+/**
+ * InboxAPI Email Channel Plugin for OpenClaw.
+ *
+ * Implements the ChannelPlugin interface following the Synology Chat pattern.
+ */
+
+import {
+  DEFAULT_ACCOUNT_ID,
+  setAccountEnabledInConfigSection,
+  buildChannelConfigSchema,
+} from "openclaw/plugin-sdk/inboxapi";
+import { z } from "zod";
+import { listAccountIds, resolveAccount } from "./accounts.js";
+import { resolveAccessToken } from "./auth.js";
+import { whoami, sendReply as clientSendReply } from "./client.js";
+import { buildInboundMsgFields } from "./inbound.js";
+import { startPolling } from "./monitor.js";
+import { sendOutboundText } from "./outbound.js";
+import { getInboxApiRuntime } from "./runtime.js";
+import type { ResolvedInboxApiAccount } from "./types.js";
+
+const CHANNEL_ID = "inboxapi";
+const InboxApiConfigSchema = buildChannelConfigSchema(z.object({}).passthrough());
+
+function waitUntilAbort(signal?: AbortSignal, onAbort?: () => void): Promise<void> {
+  return new Promise((resolve) => {
+    const complete = () => {
+      onAbort?.();
+      resolve();
+    };
+    if (!signal) {
+      return;
+    }
+    if (signal.aborted) {
+      complete();
+      return;
+    }
+    signal.addEventListener("abort", complete, { once: true });
+  });
+}
+
+export function createInboxApiPlugin() {
+  return {
+    id: CHANNEL_ID,
+
+    meta: {
+      id: CHANNEL_ID,
+      label: "InboxAPI Email",
+      selectionLabel: "InboxAPI (Email)",
+      detailLabel: "InboxAPI (Email)",
+      docsPath: "/channels/inboxapi",
+      blurb: "Send and receive email through InboxAPI",
+      order: 95,
+    },
+
+    capabilities: {
+      chatTypes: ["direct" as const],
+      media: false,
+      threads: true,
+      reactions: false,
+      edit: false,
+      unsend: false,
+      reply: true,
+      effects: false,
+      blockStreaming: false,
+    },
+
+    reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+
+    configSchema: InboxApiConfigSchema,
+
+    config: {
+      listAccountIds: (cfg: any) => listAccountIds(cfg),
+
+      resolveAccount: (cfg: any, accountId?: string | null) => resolveAccount(cfg, accountId),
+
+      defaultAccountId: (_cfg: any) => DEFAULT_ACCOUNT_ID,
+
+      setAccountEnabled: ({ cfg, accountId, enabled }: any) => {
+        const channelConfig = cfg?.channels?.[CHANNEL_ID] ?? {};
+        if (accountId === DEFAULT_ACCOUNT_ID) {
+          return {
+            ...cfg,
+            channels: {
+              ...cfg.channels,
+              [CHANNEL_ID]: { ...channelConfig, enabled },
+            },
+          };
+        }
+        return setAccountEnabledInConfigSection({
+          cfg,
+          sectionKey: `channels.${CHANNEL_ID}`,
+          accountId,
+          enabled,
+        });
+      },
+    },
+
+    pairing: {
+      idLabel: "emailAddress",
+      normalizeAllowEntry: (entry: string) => entry.toLowerCase().trim(),
+      notifyApproval: async (_opts: { cfg: any; id: string }) => {
+        // Email doesn't have a good way to push approval notifications
+        // without knowing the sender's email from context
+      },
+    },
+
+    security: {
+      resolveDmPolicy: ({
+        cfg,
+        accountId,
+        account,
+      }: {
+        cfg: any;
+        accountId?: string | null;
+        account: ResolvedInboxApiAccount;
+      }) => {
+        const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+        const channelCfg = (cfg as any).channels?.inboxapi;
+        const useAccountPath = Boolean(channelCfg?.accounts?.[resolvedAccountId]);
+        const basePath = useAccountPath
+          ? `channels.inboxapi.accounts.${resolvedAccountId}.`
+          : "channels.inboxapi.";
+        return {
+          policy: account.dmPolicy ?? "allowlist",
+          allowFrom: account.allowFrom ?? [],
+          policyPath: `${basePath}dmPolicy`,
+          allowFromPath: basePath,
+          approveHint: "openclaw pairing approve inboxapi <email>",
+          normalizeEntry: (raw: string) => raw.toLowerCase().trim(),
+        };
+      },
+      collectWarnings: ({ account }: { account: ResolvedInboxApiAccount }) => {
+        const warnings: string[] = [];
+        if (!account.accessToken && !process.env.INBOXAPI_ACCESS_TOKEN) {
+          warnings.push(
+            "- InboxAPI: no access token configured. Check credentials file or set INBOXAPI_ACCESS_TOKEN.",
+          );
+        }
+        if (account.dmPolicy === "open") {
+          warnings.push(
+            '- InboxAPI: dmPolicy="open" allows any sender to email the bot. Consider "allowlist" for production use.',
+          );
+        }
+        if (account.dmPolicy === "allowlist" && account.allowFrom.length === 0) {
+          warnings.push(
+            '- InboxAPI: dmPolicy="allowlist" with empty allowFrom blocks all senders. Add email addresses or set dmPolicy="open".',
+          );
+        }
+        return warnings;
+      },
+    },
+
+    messaging: {
+      normalizeTarget: (target: string) => {
+        const trimmed = target.trim();
+        if (!trimmed) return undefined;
+        return trimmed.replace(/^inboxapi:/i, "").trim();
+      },
+      targetResolver: {
+        looksLikeId: (id: string) => {
+          const trimmed = id?.trim();
+          if (!trimmed) return false;
+          // Email addresses or inboxapi: prefix
+          return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmed) || /^inboxapi:/i.test(trimmed);
+        },
+        hint: "<email@address>",
+      },
+    },
+
+    directory: {
+      self: async () => null,
+      listPeers: async () => [],
+      listGroups: async () => [],
+    },
+
+    outbound: {
+      deliveryMode: "gateway" as const,
+      textChunkLimit: 50_000,
+
+      sendText: async ({ to, text, accountId, cfg }: any) => {
+        return sendOutboundText({ to, text, accountId, cfg });
+      },
+
+      sendMedia: async ({ to, mediaUrl, accountId, cfg }: any) => {
+        // Email doesn't directly support media URLs without attachments;
+        // embed as a link in the message body
+        const text = mediaUrl ? `[Attachment](${mediaUrl})` : "";
+        return sendOutboundText({ to, text, accountId, cfg });
+      },
+    },
+
+    gateway: {
+      startAccount: async (ctx: any) => {
+        const { cfg, accountId, log } = ctx;
+        const account = resolveAccount(cfg, accountId);
+
+        if (!account.enabled) {
+          log?.info?.(`InboxAPI account ${accountId} is disabled, skipping`);
+          return waitUntilAbort(ctx.abortSignal);
+        }
+
+        const accessToken = await resolveAccessToken(account);
+        if (!accessToken) {
+          log?.warn?.(`InboxAPI account ${accountId} not configured (no access token found)`);
+          return waitUntilAbort(ctx.abortSignal);
+        }
+
+        if (account.dmPolicy === "allowlist" && account.allowFrom.length === 0) {
+          log?.warn?.(
+            `InboxAPI account ${accountId} has dmPolicy=allowlist but empty allowFrom; refusing to start`,
+          );
+          return waitUntilAbort(ctx.abortSignal);
+        }
+
+        log?.info?.(`Starting InboxAPI email channel (account: ${accountId})`);
+
+        // Start polling in the background
+        const pollingPromise = startPolling({
+          account: { ...account, accessToken },
+          deliver: async (email) => {
+            const rt = getInboxApiRuntime();
+            const currentCfg = await rt.config.loadConfig();
+
+            const msgFields = buildInboundMsgFields(email, account.accountId);
+            const msgCtx = rt.channel.reply.finalizeInboundContext(msgFields);
+
+            await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+              ctx: msgCtx,
+              cfg: currentCfg,
+              dispatcherOptions: {
+                deliver: async (payload: { text?: string; body?: string }) => {
+                  const text = payload?.text ?? payload?.body;
+                  if (text) {
+                    try {
+                      // Reply to the original email to maintain threading
+                      await clientSendReply(
+                        {
+                          mcpEndpoint: account.mcpEndpoint,
+                          accessToken,
+                          fromName: account.fromName,
+                        },
+                        {
+                          email_id: email.id,
+                          body: text,
+                        },
+                      );
+                    } catch (err: any) {
+                      log?.error?.(`InboxAPI: failed to send reply: ${err.message}`);
+                    }
+                  }
+                },
+                onReplyStart: () => {
+                  log?.info?.(`Agent reply started for email from ${email.from}`);
+                },
+              },
+            });
+          },
+          log,
+          abortSignal: ctx.abortSignal,
+        });
+
+        // Wait for either polling to end or abort signal
+        await Promise.race([
+          pollingPromise,
+          waitUntilAbort(ctx.abortSignal, () => {
+            log?.info?.(`Stopping InboxAPI email channel (account: ${accountId})`);
+          }),
+        ]);
+      },
+
+      stopAccount: async (ctx: any) => {
+        ctx.log?.info?.(`InboxAPI account ${ctx.accountId} stopped`);
+      },
+    },
+
+    status: {
+      probeAccount: async ({ cfg, accountId }: { cfg: any; accountId?: string }) => {
+        const account = resolveAccount(cfg, accountId);
+        const accessToken = await resolveAccessToken(account);
+        if (!accessToken) {
+          return { ok: false, error: "No access token configured" };
+        }
+        try {
+          const identity = await whoami({
+            mcpEndpoint: account.mcpEndpoint,
+            accessToken,
+          });
+          return {
+            ok: true,
+            detail: `Connected as ${identity.accountName} (${identity.email})`,
+          };
+        } catch (err: any) {
+          return { ok: false, error: err.message };
+        }
+      },
+    },
+
+    agentPrompt: {
+      messageToolHints: () => [
+        "",
+        "### InboxAPI Email Formatting",
+        "You are communicating via email through InboxAPI. Email-specific guidelines:",
+        "",
+        "**Threading**: Replies maintain email threading automatically. Each conversation",
+        "  maps to an email thread (using References/In-Reply-To headers).",
+        "",
+        "**Formatting**: Emails support full Markdown. Use headers, lists, code blocks,",
+        "  and links freely. Keep emails well-structured and readable.",
+        "",
+        "**Subject awareness**: The email subject is the conversation label. Reference it",
+        "  when relevant to provide context.",
+        "",
+        "**Length**: Emails can be long-form (up to 50,000 characters). No need to",
+        "  artificially truncate responses — provide complete, thorough answers.",
+        "",
+        "**Best practices**:",
+        "- Write in a professional email tone",
+        "- Use clear sections with headers for long responses",
+        "- Include relevant context since email threads may span days",
+        "- Sign off appropriately for the context",
+      ],
+    },
+  };
+}

--- a/extensions/inboxapi/src/channel.ts
+++ b/extensions/inboxapi/src/channel.ts
@@ -179,15 +179,15 @@ export function createInboxApiPlugin() {
       deliveryMode: "gateway" as const,
       textChunkLimit: 50_000,
 
-      sendText: async ({ to, text, accountId, cfg }: any) => {
-        return sendOutboundText({ to, text, accountId, cfg });
+      sendText: async ({ to, text, replyToId, accountId, cfg }: any) => {
+        return sendOutboundText({ to, text, replyToId, accountId, cfg });
       },
 
-      sendMedia: async ({ to, mediaUrl, accountId, cfg }: any) => {
+      sendMedia: async ({ to, mediaUrl, replyToId, accountId, cfg }: any) => {
         // Email doesn't directly support media URLs without attachments;
         // embed as a link in the message body
-        const text = mediaUrl ? `[Attachment](${mediaUrl})` : "";
-        return sendOutboundText({ to, text, accountId, cfg });
+        const body = mediaUrl ? `[Attachment](${mediaUrl})` : "";
+        return sendOutboundText({ to, text: body, replyToId, accountId, cfg });
       },
     },
 
@@ -223,7 +223,9 @@ export function createInboxApiPlugin() {
             const rt = getInboxApiRuntime();
             const currentCfg = await rt.config.loadConfig();
 
-            const msgFields = buildInboundMsgFields(email, account.accountId);
+            // CommandAuthorized defaults to false; the framework's authorizers
+            // handle command authorization based on DM policy/pairing state
+            const msgFields = buildInboundMsgFields(email, account.accountId, false);
             const msgCtx = rt.channel.reply.finalizeInboundContext(msgFields);
 
             await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({

--- a/extensions/inboxapi/src/client.test.ts
+++ b/extensions/inboxapi/src/client.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { InboxApiClientOptions } from "./client.js";
+import { whoami, getEmailCount, sendEmail, sendReply } from "./client.js";
+
+const opts: InboxApiClientOptions = {
+  mcpEndpoint: "https://mcp.inboxapi.ai/mcp",
+  accessToken: "test-token",
+  fromName: "TestBot",
+};
+
+function mcpResponse(result: any) {
+  return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(status: number, statusText: string) {
+  return new Response(null, { status, statusText });
+}
+
+describe("whoami", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("calls whoami tool and parses result", async () => {
+    const identity = {
+      accountName: "test-bot",
+      email: "test-bot@b24510.inboxapi.ai",
+      domain: "b24510.inboxapi.ai",
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mcpResponse({
+        content: [{ type: "text", text: JSON.stringify(identity) }],
+      }),
+    );
+
+    const result = await whoami(opts);
+    expect(result).toEqual(identity);
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://mcp.inboxapi.ai/mcp");
+    expect((init as any).method).toBe("POST");
+    expect((init as any).headers.Authorization).toBe("Bearer test-token");
+
+    const body = JSON.parse((init as any).body);
+    expect(body.method).toBe("tools/call");
+    expect(body.params.name).toBe("whoami");
+  });
+});
+
+describe("getEmailCount", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("returns count from result", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mcpResponse({
+        content: [{ type: "text", text: JSON.stringify({ count: 42 }) }],
+      }),
+    );
+    const count = await getEmailCount(opts);
+    expect(count).toBe(42);
+  });
+
+  it("passes since parameter", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mcpResponse({
+        content: [{ type: "text", text: "5" }],
+      }),
+    );
+    const count = await getEmailCount(opts, "2026-03-09T00:00:00Z");
+
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as any).body);
+    expect(body.params.arguments.since).toBe("2026-03-09T00:00:00Z");
+    expect(count).toBe(5);
+  });
+});
+
+describe("sendEmail", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("sends email with correct params", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mcpResponse({
+        content: [{ type: "text", text: JSON.stringify({ success: true, messageId: "m1" }) }],
+      }),
+    );
+
+    const result = await sendEmail(opts, {
+      to: "user@example.com",
+      subject: "Test",
+      body: "Hello",
+    });
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe("m1");
+
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as any).body);
+    expect(body.params.name).toBe("send_email");
+    expect(body.params.arguments.to).toBe("user@example.com");
+    expect(body.params.arguments.subject).toBe("Test");
+    expect(body.params.arguments.from_name).toBe("TestBot");
+  });
+});
+
+describe("sendReply", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("replies with correct params", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mcpResponse({
+        content: [{ type: "text", text: JSON.stringify({ success: true }) }],
+      }),
+    );
+
+    const result = await sendReply(opts, {
+      email_id: "e123",
+      body: "Reply text",
+    });
+    expect(result.success).toBe(true);
+
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as any).body);
+    expect(body.params.name).toBe("send_reply");
+    expect(body.params.arguments.email_id).toBe("e123");
+  });
+});
+
+describe("error handling", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("throws on non-OK response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      errorResponse(500, "Internal Server Error"),
+    );
+    await expect(whoami(opts)).rejects.toThrow("InboxAPI MCP call failed: 500");
+  });
+
+  it("retries on 429", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(errorResponse(429, "Too Many Requests")).mockResolvedValueOnce(
+      mcpResponse({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              accountName: "bot",
+              email: "bot@test.ai",
+              domain: "test.ai",
+            }),
+          },
+        ],
+      }),
+    );
+
+    const result = await whoami(opts);
+    expect(result.accountName).toBe("bot");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on MCP error result", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mcpResponse({
+        isError: true,
+        content: [{ type: "text", text: "auth failed" }],
+      }),
+    );
+    await expect(whoami(opts)).rejects.toThrow("InboxAPI error: auth failed");
+  });
+});

--- a/extensions/inboxapi/src/client.ts
+++ b/extensions/inboxapi/src/client.ts
@@ -1,0 +1,206 @@
+/**
+ * HTTP client for the InboxAPI MCP endpoint.
+ * Wraps MCP tool calls as JSON-RPC requests.
+ */
+
+import type { InboxApiEmail, InboxApiWhoAmI } from "./types.js";
+
+export interface InboxApiClientOptions {
+  mcpEndpoint: string;
+  accessToken: string;
+  fromName?: string;
+}
+
+interface McpToolCallResult {
+  content?: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}
+
+/**
+ * Call an MCP tool on the InboxAPI server.
+ */
+async function callMcpTool(
+  opts: InboxApiClientOptions,
+  toolName: string,
+  args: Record<string, unknown> = {},
+): Promise<McpToolCallResult> {
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: Date.now(),
+    method: "tools/call",
+    params: { name: toolName, arguments: args },
+  });
+
+  const res = await fetch(opts.mcpEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.accessToken}`,
+    },
+    body,
+  });
+
+  if (res.status === 429) {
+    // Rate limited — back off and retry once
+    await sleep(2000);
+    const retry = await fetch(opts.mcpEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${opts.accessToken}`,
+      },
+      body,
+    });
+    if (!retry.ok) {
+      throw new Error(`InboxAPI MCP call failed: ${retry.status} ${retry.statusText}`);
+    }
+    const retryData = await retry.json();
+    return retryData.result ?? {};
+  }
+
+  if (!res.ok) {
+    throw new Error(`InboxAPI MCP call failed: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json();
+  return data.result ?? {};
+}
+
+/** Extract text content from MCP tool result */
+function extractText(result: McpToolCallResult): string {
+  if (result.isError) {
+    const errText = result.content?.find((c) => c.type === "text")?.text;
+    throw new Error(`InboxAPI error: ${errText ?? "unknown error"}`);
+  }
+  return result.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+/** Parse JSON from MCP text result */
+function parseJsonResult<T>(result: McpToolCallResult): T {
+  const text = extractText(result);
+  return JSON.parse(text) as T;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// --- Public API ---
+
+/** Get the agent's identity (account name, email, domain) */
+export async function whoami(opts: InboxApiClientOptions): Promise<InboxApiWhoAmI> {
+  const result = await callMcpTool(opts, "whoami");
+  return parseJsonResult<InboxApiWhoAmI>(result);
+}
+
+/** Get the total email count, optionally filtered by since timestamp */
+export async function getEmailCount(opts: InboxApiClientOptions, since?: string): Promise<number> {
+  const args: Record<string, unknown> = {};
+  if (since) args.since = since;
+  const result = await callMcpTool(opts, "get_email_count", args);
+  const text = extractText(result);
+  // Response is typically a number or JSON with count
+  const parsed = JSON.parse(text);
+  return typeof parsed === "number" ? parsed : (parsed.count ?? 0);
+}
+
+/** Get emails, optionally filtered */
+export async function getEmails(
+  opts: InboxApiClientOptions,
+  params?: { limit?: number; since?: string },
+): Promise<InboxApiEmail[]> {
+  const args: Record<string, unknown> = {};
+  if (params?.limit) args.limit = params.limit;
+  if (params?.since) args.since = params.since;
+  const result = await callMcpTool(opts, "get_emails", args);
+  return parseJsonResult<InboxApiEmail[]>(result);
+}
+
+/** Get the most recent email */
+export async function getLastEmail(opts: InboxApiClientOptions): Promise<InboxApiEmail | null> {
+  const result = await callMcpTool(opts, "get_last_email");
+  const text = extractText(result);
+  if (!text || text === "null" || text === "No emails found") return null;
+  return JSON.parse(text) as InboxApiEmail;
+}
+
+/** Get a specific email by ID */
+export async function getEmail(
+  opts: InboxApiClientOptions,
+  emailId: string,
+): Promise<InboxApiEmail | null> {
+  const result = await callMcpTool(opts, "get_email", { email_id: emailId });
+  const text = extractText(result);
+  if (!text || text === "null") return null;
+  return JSON.parse(text) as InboxApiEmail;
+}
+
+/** Get a full email thread */
+export async function getThread(
+  opts: InboxApiClientOptions,
+  emailId: string,
+): Promise<InboxApiEmail[]> {
+  const result = await callMcpTool(opts, "get_thread", { email_id: emailId });
+  return parseJsonResult<InboxApiEmail[]>(result);
+}
+
+/** Send a new email */
+export async function sendEmail(
+  opts: InboxApiClientOptions,
+  params: {
+    to: string;
+    subject: string;
+    body: string;
+    from_name?: string;
+  },
+): Promise<{ success: boolean; messageId?: string }> {
+  const args: Record<string, unknown> = {
+    to: params.to,
+    subject: params.subject,
+    body: params.body,
+  };
+  if (params.from_name ?? opts.fromName) {
+    args.from_name = params.from_name ?? opts.fromName;
+  }
+  const result = await callMcpTool(opts, "send_email", args);
+  const text = extractText(result);
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Some responses are just confirmation text
+    return { success: !result.isError, messageId: undefined };
+  }
+}
+
+/** Reply to an existing email */
+export async function sendReply(
+  opts: InboxApiClientOptions,
+  params: {
+    email_id: string;
+    body: string;
+    from_name?: string;
+  },
+): Promise<{ success: boolean; messageId?: string }> {
+  const args: Record<string, unknown> = {
+    email_id: params.email_id,
+    body: params.body,
+  };
+  if (params.from_name ?? opts.fromName) {
+    args.from_name = params.from_name ?? opts.fromName;
+  }
+  const result = await callMcpTool(opts, "send_reply", args);
+  const text = extractText(result);
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { success: !result.isError, messageId: undefined };
+  }
+}
+
+/** Get the address book */
+export async function getAddressbook(
+  opts: InboxApiClientOptions,
+): Promise<Array<{ name: string; email: string }>> {
+  const result = await callMcpTool(opts, "get_addressbook");
+  return parseJsonResult<Array<{ name: string; email: string }>>(result);
+}

--- a/extensions/inboxapi/src/inbound.test.ts
+++ b/extensions/inboxapi/src/inbound.test.ts
@@ -48,15 +48,15 @@ describe("mapEmailToInbound", () => {
     expect(ctx.conversationLabel).toBe("(no subject)");
   });
 
-  it("includes replyToId from inReplyTo", () => {
-    const ctx = mapEmailToInbound(makeEmail({ inReplyTo: "<parent@example.com>" }));
-    expect(ctx.replyToId).toBe("<parent@example.com>");
+  it("stores InboxAPI internal ID as replyToInternalId", () => {
+    const ctx = mapEmailToInbound(makeEmail({ id: "internal-123" }));
+    expect(ctx.replyToInternalId).toBe("internal-123");
   });
 });
 
 describe("buildInboundMsgFields", () => {
   it("builds SDK-compatible fields", () => {
-    const fields = buildInboundMsgFields(makeEmail(), "default");
+    const fields = buildInboundMsgFields(makeEmail(), "default", false);
     expect(fields.From).toBe("inboxapi:alice@example.com");
     expect(fields.To).toBe("inboxapi:bot@inboxapi.ai");
     expect(fields.OriginatingChannel).toBe("inboxapi");
@@ -64,6 +64,34 @@ describe("buildInboundMsgFields", () => {
     expect(fields.ChatType).toBe("direct");
     expect(fields.ConversationLabel).toBe("Test Subject");
     expect(fields.SenderName).toBe("Alice");
+    expect(fields.CommandAuthorized).toBe(false);
+  });
+
+  it("sets MessageSid and MessageSidFull", () => {
+    const fields = buildInboundMsgFields(makeEmail(), "default", false);
+    expect(fields.MessageSid).toBe("e1");
+    expect(fields.MessageSidFull).toBe("<msg1@example.com>");
+  });
+
+  it("sets MessageThreadId from thread root", () => {
+    const email = makeEmail({ references: ["<root@example.com>", "<mid@example.com>"] });
+    const fields = buildInboundMsgFields(email, "default", false);
+    expect(fields.MessageThreadId).toBe("<root@example.com>");
+  });
+
+  it("uses InboxAPI internal ID as ReplyToId", () => {
+    const fields = buildInboundMsgFields(makeEmail({ id: "internal-456" }), "default", false);
+    expect(fields.ReplyToId).toBe("internal-456");
+  });
+
+  it("handles invalid date gracefully", () => {
+    const fields = buildInboundMsgFields(makeEmail({ date: "invalid" }), "default", false);
+    expect(Number.isFinite(fields.Timestamp)).toBe(true);
+    expect(fields.Timestamp).toBeGreaterThan(0);
+  });
+
+  it("passes commandAuthorized through", () => {
+    const fields = buildInboundMsgFields(makeEmail(), "default", true);
     expect(fields.CommandAuthorized).toBe(true);
   });
 });

--- a/extensions/inboxapi/src/inbound.test.ts
+++ b/extensions/inboxapi/src/inbound.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { mapEmailToInbound, buildInboundMsgFields } from "./inbound.js";
+import type { InboxApiEmail } from "./types.js";
+
+function makeEmail(overrides: Partial<InboxApiEmail> = {}): InboxApiEmail {
+  return {
+    id: "e1",
+    messageId: "<msg1@example.com>",
+    from: "Alice <alice@example.com>",
+    to: "bot@inboxapi.ai",
+    subject: "Test Subject",
+    text: "Hello from Alice",
+    date: "2026-03-09T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("mapEmailToInbound", () => {
+  it("maps basic email", () => {
+    const ctx = mapEmailToInbound(makeEmail());
+    expect(ctx.body).toBe("Hello from Alice");
+    expect(ctx.from).toBe("alice@example.com");
+    expect(ctx.senderName).toBe("Alice");
+    expect(ctx.conversationLabel).toBe("Test Subject");
+    expect(ctx.currentMessageId).toBe("<msg1@example.com>");
+    expect(ctx.chatType).toBe("direct");
+  });
+
+  it("falls back to HTML body", () => {
+    const ctx = mapEmailToInbound(
+      makeEmail({ text: undefined, html: "<p>Hello <b>World</b></p>" }),
+    );
+    expect(ctx.body).toBe("Hello World");
+  });
+
+  it("uses fromName when available", () => {
+    const ctx = mapEmailToInbound(makeEmail({ fromName: "Alice Jones" }));
+    expect(ctx.senderName).toBe("Alice Jones");
+  });
+
+  it("uses email as sender name fallback", () => {
+    const ctx = mapEmailToInbound(makeEmail({ from: "alice@example.com" }));
+    expect(ctx.senderName).toBe("alice@example.com");
+  });
+
+  it("handles no subject", () => {
+    const ctx = mapEmailToInbound(makeEmail({ subject: "" }));
+    expect(ctx.conversationLabel).toBe("(no subject)");
+  });
+
+  it("includes replyToId from inReplyTo", () => {
+    const ctx = mapEmailToInbound(makeEmail({ inReplyTo: "<parent@example.com>" }));
+    expect(ctx.replyToId).toBe("<parent@example.com>");
+  });
+});
+
+describe("buildInboundMsgFields", () => {
+  it("builds SDK-compatible fields", () => {
+    const fields = buildInboundMsgFields(makeEmail(), "default");
+    expect(fields.From).toBe("inboxapi:alice@example.com");
+    expect(fields.OriginatingChannel).toBe("inboxapi");
+    expect(fields.AccountId).toBe("default");
+    expect(fields.ChatType).toBe("direct");
+    expect(fields.ConversationLabel).toBe("Test Subject");
+    expect(fields.SenderName).toBe("Alice");
+    expect(fields.CommandAuthorized).toBe(true);
+  });
+});

--- a/extensions/inboxapi/src/inbound.test.ts
+++ b/extensions/inboxapi/src/inbound.test.ts
@@ -58,6 +58,7 @@ describe("buildInboundMsgFields", () => {
   it("builds SDK-compatible fields", () => {
     const fields = buildInboundMsgFields(makeEmail(), "default");
     expect(fields.From).toBe("inboxapi:alice@example.com");
+    expect(fields.To).toBe("inboxapi:bot@inboxapi.ai");
     expect(fields.OriginatingChannel).toBe("inboxapi");
     expect(fields.AccountId).toBe("default");
     expect(fields.ChatType).toBe("direct");

--- a/extensions/inboxapi/src/inbound.ts
+++ b/extensions/inboxapi/src/inbound.ts
@@ -54,7 +54,7 @@ export function buildInboundMsgFields(email: InboxApiEmail, accountId: string) {
     RawBody: ctx.body,
     CommandBody: ctx.body,
     From: `${CHANNEL_ID}:${ctx.from}`,
-    To: `${CHANNEL_ID}:${ctx.from}`,
+    To: `${CHANNEL_ID}:${Array.isArray(email.to) ? email.to[0] : email.to}`,
     SessionKey: ctx.sessionKey,
     AccountId: accountId,
     OriginatingChannel: CHANNEL_ID,

--- a/extensions/inboxapi/src/inbound.ts
+++ b/extensions/inboxapi/src/inbound.ts
@@ -3,7 +3,12 @@
  * Converts InboxAPI emails into the format expected by OpenClaw's routing.
  */
 
-import { deriveSessionKey, extractSenderEmail, extractSenderName } from "./threading.js";
+import {
+  deriveSessionKey,
+  extractSenderEmail,
+  extractSenderName,
+  getThreadRootId,
+} from "./threading.js";
 import type { InboxApiEmail } from "./types.js";
 
 const CHANNEL_ID = "inboxapi";
@@ -15,7 +20,8 @@ export interface InboundEmailContext {
   sessionKey: string;
   conversationLabel: string;
   currentMessageId: string;
-  replyToId?: string;
+  /** InboxAPI internal ID for replying */
+  replyToInternalId: string;
   chatType: "direct";
 }
 
@@ -39,7 +45,8 @@ export function mapEmailToInbound(email: InboxApiEmail): InboundEmailContext {
     sessionKey: deriveSessionKey(email),
     conversationLabel: email.subject || "(no subject)",
     currentMessageId: email.messageId,
-    replyToId: email.inReplyTo,
+    // Use InboxAPI internal ID for reply operations (not RFC Message-ID)
+    replyToInternalId: email.id,
     chatType: "direct",
   };
 }
@@ -47,8 +54,14 @@ export function mapEmailToInbound(email: InboxApiEmail): InboundEmailContext {
 /**
  * Build the full MsgContext fields for SDK finalizeInboundContext.
  */
-export function buildInboundMsgFields(email: InboxApiEmail, accountId: string) {
+export function buildInboundMsgFields(
+  email: InboxApiEmail,
+  accountId: string,
+  commandAuthorized: boolean,
+) {
   const ctx = mapEmailToInbound(email);
+  const ts = Date.parse(email.date);
+  const threadRootId = getThreadRootId(email);
   return {
     Body: ctx.body,
     RawBody: ctx.body,
@@ -65,10 +78,14 @@ export function buildInboundMsgFields(email: InboxApiEmail, accountId: string) {
     Provider: CHANNEL_ID,
     Surface: CHANNEL_ID,
     ConversationLabel: ctx.conversationLabel,
-    Timestamp: new Date(email.date).getTime() || Date.now(),
+    Timestamp: Number.isFinite(ts) ? ts : Date.now(),
     CurrentMessageId: ctx.currentMessageId,
-    ReplyToId: ctx.replyToId,
-    CommandAuthorized: true,
+    // Store the InboxAPI internal ID for reply operations
+    ReplyToId: ctx.replyToInternalId,
+    MessageSid: email.id,
+    MessageSidFull: email.messageId,
+    MessageThreadId: threadRootId,
+    CommandAuthorized: commandAuthorized,
   };
 }
 

--- a/extensions/inboxapi/src/inbound.ts
+++ b/extensions/inboxapi/src/inbound.ts
@@ -1,0 +1,89 @@
+/**
+ * Inbound email → MsgContext mapping.
+ * Converts InboxAPI emails into the format expected by OpenClaw's routing.
+ */
+
+import { deriveSessionKey, extractSenderEmail, extractSenderName } from "./threading.js";
+import type { InboxApiEmail } from "./types.js";
+
+const CHANNEL_ID = "inboxapi";
+
+export interface InboundEmailContext {
+  body: string;
+  from: string;
+  senderName: string;
+  sessionKey: string;
+  conversationLabel: string;
+  currentMessageId: string;
+  replyToId?: string;
+  chatType: "direct";
+}
+
+/**
+ * Map an InboxAPI email to an inbound message context.
+ */
+export function mapEmailToInbound(email: InboxApiEmail): InboundEmailContext {
+  const senderEmail = extractSenderEmail(email.from);
+  const senderName = email.fromName || extractSenderName(email.from) || senderEmail;
+
+  // Prefer plain text body; strip HTML tags as fallback
+  let body = email.text ?? "";
+  if (!body && email.html) {
+    body = stripHtml(email.html);
+  }
+
+  return {
+    body,
+    from: senderEmail,
+    senderName,
+    sessionKey: deriveSessionKey(email),
+    conversationLabel: email.subject || "(no subject)",
+    currentMessageId: email.messageId,
+    replyToId: email.inReplyTo,
+    chatType: "direct",
+  };
+}
+
+/**
+ * Build the full MsgContext fields for SDK finalizeInboundContext.
+ */
+export function buildInboundMsgFields(email: InboxApiEmail, accountId: string) {
+  const ctx = mapEmailToInbound(email);
+  return {
+    Body: ctx.body,
+    RawBody: ctx.body,
+    CommandBody: ctx.body,
+    From: `${CHANNEL_ID}:${ctx.from}`,
+    To: `${CHANNEL_ID}:${ctx.from}`,
+    SessionKey: ctx.sessionKey,
+    AccountId: accountId,
+    OriginatingChannel: CHANNEL_ID,
+    OriginatingTo: `${CHANNEL_ID}:${ctx.from}`,
+    ChatType: ctx.chatType,
+    SenderName: ctx.senderName,
+    SenderId: ctx.from,
+    Provider: CHANNEL_ID,
+    Surface: CHANNEL_ID,
+    ConversationLabel: ctx.conversationLabel,
+    Timestamp: new Date(email.date).getTime() || Date.now(),
+    CurrentMessageId: ctx.currentMessageId,
+    ReplyToId: ctx.replyToId,
+    CommandAuthorized: true,
+  };
+}
+
+/** Simple HTML tag stripper for fallback text extraction */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/extensions/inboxapi/src/monitor.test.ts
+++ b/extensions/inboxapi/src/monitor.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the client module
+vi.mock("./client.js", () => ({
+  whoami: vi.fn(),
+  getLastEmail: vi.fn(),
+  getEmails: vi.fn(),
+}));
+
+// Mock auth module
+vi.mock("./auth.js", () => ({
+  resolveAccessToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+import { whoami, getLastEmail, getEmails } from "./client.js";
+import { startPolling } from "./monitor.js";
+import type { ResolvedInboxApiAccount, InboxApiEmail } from "./types.js";
+
+function makeAccount(overrides: Partial<ResolvedInboxApiAccount> = {}): ResolvedInboxApiAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    mcpEndpoint: "https://mcp.inboxapi.ai/mcp",
+    credentialsPath: "~/.local/inboxapi/credentials.json",
+    accessToken: "test-token",
+    domain: "test.inboxapi.ai",
+    fromName: "TestBot",
+    pollIntervalMs: 50, // fast for tests
+    pollBatchSize: 20,
+    dmPolicy: "open",
+    allowFrom: [],
+    textChunkLimit: 50_000,
+    ...overrides,
+  };
+}
+
+function makeEmail(overrides: Partial<InboxApiEmail> = {}): InboxApiEmail {
+  return {
+    id: "e1",
+    messageId: `<${Date.now()}@example.com>`,
+    from: "sender@example.com",
+    to: "bot@inboxapi.ai",
+    subject: "Test",
+    text: "Hello",
+    date: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("startPolling", () => {
+  beforeEach(() => {
+    vi.mocked(whoami).mockReset();
+    vi.mocked(getLastEmail).mockReset();
+    vi.mocked(getEmails).mockReset();
+  });
+
+  it("verifies identity on startup", async () => {
+    const controller = new AbortController();
+    vi.mocked(whoami).mockResolvedValue({
+      accountName: "test",
+      email: "test@inboxapi.ai",
+      domain: "inboxapi.ai",
+    });
+    vi.mocked(getLastEmail).mockResolvedValue(null);
+    vi.mocked(getEmails).mockResolvedValue([]);
+
+    // Abort after a short delay
+    setTimeout(() => controller.abort(), 100);
+
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    await startPolling({
+      account: makeAccount(),
+      deliver: vi.fn(),
+      log,
+      abortSignal: controller.signal,
+    });
+
+    expect(whoami).toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("connected as test"));
+  });
+
+  it("stops when no access token", async () => {
+    const { resolveAccessToken } = await import("./auth.js");
+    vi.mocked(resolveAccessToken).mockResolvedValueOnce("");
+
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    await startPolling({
+      account: makeAccount({ accessToken: "" }),
+      deliver: vi.fn(),
+      log,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("no access token"));
+  });
+
+  it("delivers new emails", async () => {
+    const controller = new AbortController();
+    const deliver = vi.fn();
+    const email = makeEmail({ messageId: "<new@example.com>" });
+
+    vi.mocked(whoami).mockResolvedValue({
+      accountName: "test",
+      email: "test@inboxapi.ai",
+      domain: "inboxapi.ai",
+    });
+    vi.mocked(getLastEmail).mockResolvedValue(null);
+
+    let callCount = 0;
+    vi.mocked(getEmails).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return [email];
+      // Abort after first successful poll
+      controller.abort();
+      return [];
+    });
+
+    await startPolling({
+      account: makeAccount(),
+      deliver,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: controller.signal,
+    });
+
+    expect(deliver).toHaveBeenCalledWith(email);
+  });
+
+  it("skips emails not in allowlist", async () => {
+    const controller = new AbortController();
+    const deliver = vi.fn();
+    const email = makeEmail({ from: "blocked@example.com" });
+
+    vi.mocked(whoami).mockResolvedValue({
+      accountName: "test",
+      email: "test@inboxapi.ai",
+      domain: "inboxapi.ai",
+    });
+    vi.mocked(getLastEmail).mockResolvedValue(null);
+
+    let callCount = 0;
+    vi.mocked(getEmails).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return [email];
+      controller.abort();
+      return [];
+    });
+
+    await startPolling({
+      account: makeAccount({ dmPolicy: "allowlist", allowFrom: ["allowed@example.com"] }),
+      deliver,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: controller.signal,
+    });
+
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("does not re-deliver seen emails", async () => {
+    const controller = new AbortController();
+    const deliver = vi.fn();
+    const email = makeEmail({ messageId: "<seen@example.com>" });
+
+    vi.mocked(whoami).mockResolvedValue({
+      accountName: "test",
+      email: "test@inboxapi.ai",
+      domain: "inboxapi.ai",
+    });
+    vi.mocked(getLastEmail).mockResolvedValue(null);
+
+    let callCount = 0;
+    vi.mocked(getEmails).mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 2) return [email]; // same email both polls
+      controller.abort();
+      return [];
+    });
+
+    await startPolling({
+      account: makeAccount(),
+      deliver,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: controller.signal,
+    });
+
+    // Should only be delivered once despite appearing in two polls
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/inboxapi/src/monitor.test.ts
+++ b/extensions/inboxapi/src/monitor.test.ts
@@ -211,6 +211,40 @@ describe("startPolling", () => {
     expect(deliver).toHaveBeenCalledTimes(1);
   });
 
+  it("retries delivery on transient failure", async () => {
+    const controller = new AbortController();
+    const deliver = vi.fn();
+    const email = makeEmail({ messageId: "<retry@example.com>" });
+
+    vi.mocked(whoami).mockResolvedValue({
+      accountName: "test",
+      email: "test@inboxapi.ai",
+      domain: "inboxapi.ai",
+    });
+    vi.mocked(getLastEmail).mockResolvedValue(null);
+
+    let pollCycle = 0;
+    vi.mocked(getEmails).mockImplementation(async () => {
+      pollCycle++;
+      if (pollCycle <= 2) return [email];
+      controller.abort();
+      return [];
+    });
+
+    // First call fails, second call succeeds
+    deliver.mockRejectedValueOnce(new Error("transient failure")).mockResolvedValueOnce(undefined);
+
+    await startPolling({
+      account: makeAccount(),
+      deliver,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: controller.signal,
+    });
+
+    // Should be called twice: once failing, once succeeding
+    expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
   it("paginates through all new emails before advancing high-water mark", async () => {
     const controller = new AbortController();
     const deliver = vi.fn();

--- a/extensions/inboxapi/src/monitor.test.ts
+++ b/extensions/inboxapi/src/monitor.test.ts
@@ -112,6 +112,27 @@ describe("startPolling", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("no access token"));
   });
 
+  it("stops polling when high-water mark bootstrap fails", async () => {
+    vi.mocked(whoami).mockResolvedValue({
+      accountName: "test",
+      email: "test@inboxapi.ai",
+      domain: "inboxapi.ai",
+    });
+    vi.mocked(getLastEmail).mockRejectedValue(new Error("API timeout"));
+
+    const deliver = vi.fn();
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    await startPolling({
+      account: makeAccount(),
+      deliver,
+      log,
+    });
+
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("refusing to poll"));
+    expect(deliver).not.toHaveBeenCalled();
+    expect(getEmails).not.toHaveBeenCalled();
+  });
+
   it("delivers new emails", async () => {
     const controller = new AbortController();
     const deliver = vi.fn();

--- a/extensions/inboxapi/src/monitor.test.ts
+++ b/extensions/inboxapi/src/monitor.test.ts
@@ -12,6 +12,19 @@ vi.mock("./auth.js", () => ({
   resolveAccessToken: vi.fn().mockResolvedValue("test-token"),
 }));
 
+// Mock SDK dm-policy functions used by monitor.ts
+const mockReadStoreAllowFrom = vi.fn().mockResolvedValue([]);
+const mockResolveDmGroupAccess = vi.fn().mockReturnValue({
+  decision: "allow",
+  reason: "open",
+  effectiveAllowFrom: [],
+  effectiveGroupAllowFrom: [],
+});
+vi.mock("openclaw/plugin-sdk/inboxapi", () => ({
+  readStoreAllowFromForDmPolicy: (...args: any[]) => mockReadStoreAllowFrom(...args),
+  resolveDmGroupAccessWithLists: (...args: any[]) => mockResolveDmGroupAccess(...args),
+}));
+
 import { whoami, getLastEmail, getEmails } from "./client.js";
 import { startPolling } from "./monitor.js";
 import type { ResolvedInboxApiAccount, InboxApiEmail } from "./types.js";
@@ -52,6 +65,13 @@ describe("startPolling", () => {
     vi.mocked(whoami).mockReset();
     vi.mocked(getLastEmail).mockReset();
     vi.mocked(getEmails).mockReset();
+    mockReadStoreAllowFrom.mockReset().mockResolvedValue([]);
+    mockResolveDmGroupAccess.mockReset().mockReturnValue({
+      decision: "allow",
+      reason: "open",
+      effectiveAllowFrom: [],
+      effectiveGroupAllowFrom: [],
+    });
   });
 
   it("verifies identity on startup", async () => {
@@ -64,7 +84,6 @@ describe("startPolling", () => {
     vi.mocked(getLastEmail).mockResolvedValue(null);
     vi.mocked(getEmails).mockResolvedValue([]);
 
-    // Abort after a short delay
     setTimeout(() => controller.abort(), 100);
 
     const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -109,7 +128,6 @@ describe("startPolling", () => {
     vi.mocked(getEmails).mockImplementation(async () => {
       callCount++;
       if (callCount === 1) return [email];
-      // Abort after first successful poll
       controller.abort();
       return [];
     });
@@ -124,7 +142,7 @@ describe("startPolling", () => {
     expect(deliver).toHaveBeenCalledWith(email);
   });
 
-  it("skips emails not in allowlist", async () => {
+  it("skips emails blocked by DM policy", async () => {
     const controller = new AbortController();
     const deliver = vi.fn();
     const email = makeEmail({ from: "blocked@example.com" });
@@ -135,6 +153,12 @@ describe("startPolling", () => {
       domain: "inboxapi.ai",
     });
     vi.mocked(getLastEmail).mockResolvedValue(null);
+    mockResolveDmGroupAccess.mockReturnValue({
+      decision: "block",
+      reason: "dm-allowlist-not-matched",
+      effectiveAllowFrom: [],
+      effectiveGroupAllowFrom: [],
+    });
 
     let callCount = 0;
     vi.mocked(getEmails).mockImplementation(async () => {
@@ -152,6 +176,9 @@ describe("startPolling", () => {
     });
 
     expect(deliver).not.toHaveBeenCalled();
+    expect(mockReadStoreAllowFrom).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "inboxapi", dmPolicy: "allowlist" }),
+    );
   });
 
   it("does not re-deliver seen emails", async () => {
@@ -169,7 +196,7 @@ describe("startPolling", () => {
     let callCount = 0;
     vi.mocked(getEmails).mockImplementation(async () => {
       callCount++;
-      if (callCount <= 2) return [email]; // same email both polls
+      if (callCount <= 2) return [email];
       controller.abort();
       return [];
     });
@@ -181,7 +208,54 @@ describe("startPolling", () => {
       abortSignal: controller.signal,
     });
 
-    // Should only be delivered once despite appearing in two polls
     expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("paginates through all new emails before advancing high-water mark", async () => {
+    const controller = new AbortController();
+    const deliver = vi.fn();
+
+    const e1 = makeEmail({ messageId: "<e1@x.com>", date: "2026-03-09T01:00:00Z" });
+    const e2 = makeEmail({ messageId: "<e2@x.com>", date: "2026-03-09T02:00:00Z" });
+    const e3 = makeEmail({ messageId: "<e3@x.com>", date: "2026-03-09T03:00:00Z" });
+
+    vi.mocked(whoami).mockResolvedValue({
+      accountName: "test",
+      email: "test@inboxapi.ai",
+      domain: "inboxapi.ai",
+    });
+    vi.mocked(getLastEmail).mockResolvedValue(null);
+
+    let pollCycle = 0;
+    let pageInCycle = 0;
+    vi.mocked(getEmails).mockImplementation(async () => {
+      if (pollCycle === 0) {
+        pageInCycle++;
+        // First page: 2 emails (= pollBatchSize, so pagination continues)
+        if (pageInCycle === 1) return [e2, e1];
+        // Second page: 1 email (< pollBatchSize, pagination stops)
+        if (pageInCycle === 2) return [e3];
+        return [];
+      }
+      controller.abort();
+      return [];
+    });
+
+    // Use a deliver callback that marks first poll cycle done after all deliveries
+    deliver.mockImplementation(async () => {
+      if (deliver.mock.calls.length === 3) {
+        pollCycle = 1;
+      }
+    });
+
+    await startPolling({
+      account: makeAccount({ pollBatchSize: 2 }),
+      deliver,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: controller.signal,
+    });
+
+    // All 3 emails should be delivered (none skipped by pagination)
+    expect(deliver).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/inboxapi/src/monitor.ts
+++ b/extensions/inboxapi/src/monitor.ts
@@ -60,7 +60,9 @@ export async function startPolling(deps: MonitorDeps): Promise<void> {
     return;
   }
 
-  // Establish high-water mark from most recent email
+  // Establish high-water mark from most recent email.
+  // Fail closed: if we can't establish the mark, stop polling to avoid
+  // replaying old inbox messages into the agent.
   let lastSeenDate: string | undefined;
   let seenMessageIds = new Set<string>();
 
@@ -74,7 +76,10 @@ export async function startPolling(deps: MonitorDeps): Promise<void> {
       log?.info?.("InboxAPI: no existing emails, starting fresh");
     }
   } catch (err: any) {
-    log?.warn?.(`InboxAPI: failed to get last email for high-water mark: ${err.message}`);
+    log?.error?.(
+      `InboxAPI: failed to establish high-water mark, refusing to poll to avoid replaying old messages: ${err.message}`,
+    );
+    return;
   }
 
   // Polling loop

--- a/extensions/inboxapi/src/monitor.ts
+++ b/extensions/inboxapi/src/monitor.ts
@@ -103,18 +103,20 @@ export async function startPolling(deps: MonitorDeps): Promise<void> {
 
         // Deliver oldest-first
         for (const email of newEmails.reverse()) {
-          seenMessageIds.add(email.messageId);
-
           // Check DM policy (including pairing store)
           const senderEmail = extractSenderEmail(email.from);
           const allowed = await checkAccess(senderEmail, account);
           if (!allowed) {
+            seenMessageIds.add(email.messageId);
             log?.info?.(`InboxAPI: rejected email from ${senderEmail} (not allowed by DM policy)`);
             continue;
           }
 
           try {
             await deliver(email);
+            // Mark as seen only after successful delivery so transient
+            // failures are retried on the next poll cycle.
+            seenMessageIds.add(email.messageId);
           } catch (err: any) {
             log?.error?.(`InboxAPI: failed to deliver email ${email.messageId}: ${err.message}`);
           }

--- a/extensions/inboxapi/src/monitor.ts
+++ b/extensions/inboxapi/src/monitor.ts
@@ -1,0 +1,144 @@
+/**
+ * Polling-based inbound monitor for InboxAPI.
+ * Polls for new emails and dispatches them to the agent.
+ */
+
+import { resolveAccessToken } from "./auth.js";
+import type { InboxApiClientOptions } from "./client.js";
+import { getEmails, getLastEmail, whoami } from "./client.js";
+import { extractSenderEmail } from "./threading.js";
+import type { ResolvedInboxApiAccount, InboxApiEmail } from "./types.js";
+
+export interface MonitorDeps {
+  account: ResolvedInboxApiAccount;
+  deliver: (email: InboxApiEmail) => Promise<void>;
+  log?: {
+    info?: (...args: any[]) => void;
+    warn?: (...args: any[]) => void;
+    error?: (...args: any[]) => void;
+  };
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Build client options from a resolved account.
+ */
+async function buildClientOptions(
+  account: ResolvedInboxApiAccount,
+): Promise<InboxApiClientOptions> {
+  const accessToken = await resolveAccessToken(account);
+  return {
+    mcpEndpoint: account.mcpEndpoint,
+    accessToken,
+    fromName: account.fromName,
+  };
+}
+
+/**
+ * Start the polling loop for new emails.
+ * Establishes a high-water mark on startup and polls for new emails.
+ */
+export async function startPolling(deps: MonitorDeps): Promise<void> {
+  const { account, deliver, log, abortSignal } = deps;
+  const clientOpts = await buildClientOptions(account);
+
+  if (!clientOpts.accessToken) {
+    log?.warn?.("InboxAPI: no access token available, polling disabled");
+    return;
+  }
+
+  // Verify connectivity
+  try {
+    const identity = await whoami(clientOpts);
+    log?.info?.(`InboxAPI: connected as ${identity.accountName} (${identity.email})`);
+  } catch (err: any) {
+    log?.error?.(`InboxAPI: failed to verify identity: ${err.message}`);
+    return;
+  }
+
+  // Establish high-water mark from most recent email
+  let lastSeenDate: string | undefined;
+  let seenMessageIds = new Set<string>();
+
+  try {
+    const lastEmail = await getLastEmail(clientOpts);
+    if (lastEmail) {
+      lastSeenDate = lastEmail.date;
+      seenMessageIds.add(lastEmail.messageId);
+      log?.info?.(`InboxAPI: high-water mark set to ${lastSeenDate}`);
+    } else {
+      log?.info?.("InboxAPI: no existing emails, starting fresh");
+    }
+  } catch (err: any) {
+    log?.warn?.(`InboxAPI: failed to get last email for high-water mark: ${err.message}`);
+  }
+
+  // Polling loop
+  while (!abortSignal?.aborted) {
+    await sleep(account.pollIntervalMs);
+    if (abortSignal?.aborted) break;
+
+    try {
+      const emails = await getEmails(clientOpts, {
+        limit: account.pollBatchSize,
+        since: lastSeenDate,
+      });
+
+      // Filter to truly new emails (not yet seen)
+      const newEmails = emails.filter((e) => !seenMessageIds.has(e.messageId));
+      if (newEmails.length === 0) continue;
+
+      // Process newest-first for high-water mark, but deliver oldest-first
+      for (const email of newEmails.reverse()) {
+        seenMessageIds.add(email.messageId);
+
+        // Check DM policy
+        const senderEmail = extractSenderEmail(email.from);
+        if (!isAllowed(senderEmail, account)) {
+          log?.info?.(`InboxAPI: rejected email from ${senderEmail} (not in allowlist)`);
+          continue;
+        }
+
+        try {
+          await deliver(email);
+        } catch (err: any) {
+          log?.error?.(`InboxAPI: failed to deliver email ${email.messageId}: ${err.message}`);
+        }
+      }
+
+      // Update high-water mark to the most recent email
+      const newestEmail = emails[0];
+      if (newestEmail) {
+        lastSeenDate = newestEmail.date;
+      }
+
+      // Prune seen set to avoid unbounded growth (keep last 1000)
+      if (seenMessageIds.size > 1000) {
+        const arr = Array.from(seenMessageIds);
+        seenMessageIds = new Set(arr.slice(arr.length - 500));
+      }
+    } catch (err: any) {
+      log?.error?.(`InboxAPI: poll error: ${err.message}`);
+    }
+  }
+}
+
+/** Check if a sender is allowed under the account's DM policy */
+function isAllowed(senderEmail: string, account: ResolvedInboxApiAccount): boolean {
+  switch (account.dmPolicy) {
+    case "disabled":
+      return false;
+    case "open":
+      return true;
+    case "allowlist":
+    case "pairing":
+      if (account.allowFrom.length === 0) return false;
+      return account.allowFrom.includes(senderEmail.toLowerCase());
+    default:
+      return false;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/extensions/inboxapi/src/monitor.ts
+++ b/extensions/inboxapi/src/monitor.ts
@@ -3,11 +3,15 @@
  * Polls for new emails and dispatches them to the agent.
  */
 
+import {
+  readStoreAllowFromForDmPolicy,
+  resolveDmGroupAccessWithLists,
+} from "openclaw/plugin-sdk/inboxapi";
 import { resolveAccessToken } from "./auth.js";
 import type { InboxApiClientOptions } from "./client.js";
 import { getEmails, getLastEmail, whoami } from "./client.js";
 import { extractSenderEmail } from "./threading.js";
-import type { ResolvedInboxApiAccount, InboxApiEmail } from "./types.js";
+import type { InboxApiEmail, ResolvedInboxApiAccount } from "./types.js";
 
 export interface MonitorDeps {
   account: ResolvedInboxApiAccount;
@@ -79,40 +83,66 @@ export async function startPolling(deps: MonitorDeps): Promise<void> {
     if (abortSignal?.aborted) break;
 
     try {
-      const emails = await getEmails(clientOpts, {
-        limit: account.pollBatchSize,
-        since: lastSeenDate,
-      });
+      // Fetch pages until all new emails are consumed, so we never
+      // advance the high-water mark past unprocessed messages.
+      let pageSince = lastSeenDate;
+      let latestDate = lastSeenDate;
 
-      // Filter to truly new emails (not yet seen)
-      const newEmails = emails.filter((e) => !seenMessageIds.has(e.messageId));
-      if (newEmails.length === 0) continue;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        if (abortSignal?.aborted) break;
 
-      // Process newest-first for high-water mark, but deliver oldest-first
-      for (const email of newEmails.reverse()) {
-        seenMessageIds.add(email.messageId);
+        const emails = await getEmails(clientOpts, {
+          limit: account.pollBatchSize,
+          since: pageSince,
+        });
 
-        // Check DM policy
-        const senderEmail = extractSenderEmail(email.from);
-        if (!isAllowed(senderEmail, account)) {
-          log?.info?.(`InboxAPI: rejected email from ${senderEmail} (not in allowlist)`);
-          continue;
+        // Filter to truly new emails (not yet seen)
+        const newEmails = emails.filter((e) => !seenMessageIds.has(e.messageId));
+        if (newEmails.length === 0) break;
+
+        // Deliver oldest-first
+        for (const email of newEmails.reverse()) {
+          seenMessageIds.add(email.messageId);
+
+          // Check DM policy (including pairing store)
+          const senderEmail = extractSenderEmail(email.from);
+          const allowed = await checkAccess(senderEmail, account);
+          if (!allowed) {
+            log?.info?.(`InboxAPI: rejected email from ${senderEmail} (not allowed by DM policy)`);
+            continue;
+          }
+
+          try {
+            await deliver(email);
+          } catch (err: any) {
+            log?.error?.(`InboxAPI: failed to deliver email ${email.messageId}: ${err.message}`);
+          }
         }
 
-        try {
-          await deliver(email);
-        } catch (err: any) {
-          log?.error?.(`InboxAPI: failed to deliver email ${email.messageId}: ${err.message}`);
+        // Track the newest date we've processed in this page.
+        // Don't assume any particular ordering — find the max date explicitly.
+        for (const e of emails) {
+          if (!latestDate || e.date > latestDate) {
+            latestDate = e.date;
+          }
         }
+        // Advance page cursor to latest date to avoid re-fetching
+        if (latestDate) {
+          pageSince = latestDate;
+        }
+
+        // If we got fewer than a full page, no more pages to fetch
+        if (emails.length < account.pollBatchSize) break;
       }
 
-      // Update high-water mark to the most recent email
-      const newestEmail = emails[0];
-      if (newestEmail) {
-        lastSeenDate = newestEmail.date;
+      // Only advance high-water mark after all pages are consumed
+      if (latestDate) {
+        lastSeenDate = latestDate;
       }
 
-      // Prune seen set to avoid unbounded growth (keep last 1000)
+      // Prune seen set to avoid unbounded growth: when it exceeds 1000,
+      // trim down to the most recent 500 entries.
       if (seenMessageIds.size > 1000) {
         const arr = Array.from(seenMessageIds);
         seenMessageIds = new Set(arr.slice(arr.length - 500));
@@ -123,20 +153,30 @@ export async function startPolling(deps: MonitorDeps): Promise<void> {
   }
 }
 
-/** Check if a sender is allowed under the account's DM policy */
-function isAllowed(senderEmail: string, account: ResolvedInboxApiAccount): boolean {
-  switch (account.dmPolicy) {
-    case "disabled":
-      return false;
-    case "open":
-      return true;
-    case "allowlist":
-    case "pairing":
-      if (account.allowFrom.length === 0) return false;
-      return account.allowFrom.includes(senderEmail.toLowerCase());
-    default:
-      return false;
-  }
+/** Check if a sender is allowed under the account's DM policy, including pairing store */
+async function checkAccess(
+  senderEmail: string,
+  account: ResolvedInboxApiAccount,
+): Promise<boolean> {
+  // Read pairing store approvals for pairing/open policies
+  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+    provider: "inboxapi",
+    accountId: account.accountId,
+    dmPolicy: account.dmPolicy,
+  });
+
+  const access = resolveDmGroupAccessWithLists({
+    isGroup: false,
+    dmPolicy: account.dmPolicy,
+    groupPolicy: "disabled",
+    allowFrom: account.allowFrom,
+    groupAllowFrom: [],
+    storeAllowFrom,
+    isSenderAllowed: (allowEntries) =>
+      allowEntries.some((entry) => entry.toLowerCase() === senderEmail.toLowerCase()),
+  });
+
+  return access.decision === "allow";
 }
 
 function sleep(ms: number): Promise<void> {

--- a/extensions/inboxapi/src/outbound.test.ts
+++ b/extensions/inboxapi/src/outbound.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies
+vi.mock("./client.js", () => ({
+  sendEmail: vi.fn(),
+  sendReply: vi.fn(),
+}));
+
+vi.mock("./auth.js", () => ({
+  resolveAccessToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+import { sendEmail, sendReply } from "./client.js";
+import { sendOutboundText } from "./outbound.js";
+
+const baseCfg = {
+  channels: {
+    inboxapi: {
+      accessToken: "test-token",
+      mcpEndpoint: "https://mcp.inboxapi.ai/mcp",
+      fromName: "TestBot",
+    },
+  },
+};
+
+describe("sendOutboundText", () => {
+  beforeEach(() => {
+    vi.mocked(sendEmail).mockReset();
+    vi.mocked(sendReply).mockReset();
+  });
+
+  it("sends new email when no replyToId", async () => {
+    vi.mocked(sendEmail).mockResolvedValue({ success: true, messageId: "m1" });
+
+    const result = await sendOutboundText({
+      to: "user@example.com",
+      text: "Hello",
+      cfg: baseCfg,
+    });
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: "test-token" }),
+      expect.objectContaining({
+        to: "user@example.com",
+        subject: "Message from OpenClaw",
+        body: "Hello",
+      }),
+    );
+    expect(result.channel).toBe("inboxapi");
+    expect(result.messageId).toBe("m1");
+  });
+
+  it("sends reply when replyToId is present", async () => {
+    vi.mocked(sendReply).mockResolvedValue({ success: true, messageId: "m2" });
+
+    const result = await sendOutboundText({
+      to: "user@example.com",
+      text: "Reply text",
+      replyToId: "e123",
+      cfg: baseCfg,
+    });
+
+    expect(sendReply).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: "test-token" }),
+      expect.objectContaining({
+        email_id: "e123",
+        body: "Reply text",
+      }),
+    );
+    expect(result.messageId).toBe("m2");
+  });
+
+  it("strips inboxapi: prefix from target", async () => {
+    vi.mocked(sendEmail).mockResolvedValue({ success: true });
+
+    await sendOutboundText({
+      to: "inboxapi:user@example.com",
+      text: "Hello",
+      cfg: baseCfg,
+    });
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ to: "user@example.com" }),
+    );
+  });
+
+  it("throws when no access token", async () => {
+    const { resolveAccessToken } = await import("./auth.js");
+    vi.mocked(resolveAccessToken).mockResolvedValueOnce("");
+
+    await expect(
+      sendOutboundText({
+        to: "user@example.com",
+        text: "Hello",
+        cfg: { channels: { inboxapi: {} } },
+      }),
+    ).rejects.toThrow("access token not configured");
+  });
+});

--- a/extensions/inboxapi/src/outbound.ts
+++ b/extensions/inboxapi/src/outbound.ts
@@ -1,0 +1,79 @@
+/**
+ * Outbound adapter: sends emails via InboxAPI.
+ */
+
+import { resolveAccount } from "./accounts.js";
+import { resolveAccessToken } from "./auth.js";
+import type { InboxApiClientOptions } from "./client.js";
+import { sendEmail, sendReply } from "./client.js";
+import type { ResolvedInboxApiAccount } from "./types.js";
+
+const CHANNEL_ID = "inboxapi";
+
+/**
+ * Build client options from a resolved account.
+ */
+async function buildClientOptions(
+  account: ResolvedInboxApiAccount,
+): Promise<InboxApiClientOptions> {
+  const accessToken = await resolveAccessToken(account);
+  return {
+    mcpEndpoint: account.mcpEndpoint,
+    accessToken,
+    fromName: account.fromName,
+  };
+}
+
+/**
+ * Send a text reply or new email.
+ * If replyToId is present, uses send_reply to maintain threading.
+ * Otherwise sends a new email with auto-generated subject.
+ */
+export async function sendOutboundText({
+  to,
+  text,
+  replyToId,
+  subject,
+  accountId,
+  cfg,
+}: {
+  to: string;
+  text: string;
+  replyToId?: string;
+  subject?: string;
+  accountId?: string;
+  cfg: any;
+}): Promise<{ channel: string; messageId: string; chatId: string }> {
+  const account = resolveAccount(cfg ?? {}, accountId);
+  const clientOpts = await buildClientOptions(account);
+
+  if (!clientOpts.accessToken) {
+    throw new Error("InboxAPI access token not configured");
+  }
+
+  let messageId: string | undefined;
+
+  if (replyToId) {
+    // Reply to an existing email thread
+    const result = await sendReply(clientOpts, {
+      email_id: replyToId,
+      body: text,
+    });
+    messageId = result.messageId;
+  } else {
+    // New email
+    const emailTo = to.replace(/^inboxapi:/i, "");
+    const result = await sendEmail(clientOpts, {
+      to: emailTo,
+      subject: subject ?? "Message from OpenClaw",
+      body: text,
+    });
+    messageId = result.messageId;
+  }
+
+  return {
+    channel: CHANNEL_ID,
+    messageId: messageId ?? `inboxapi-${Date.now()}`,
+    chatId: to,
+  };
+}

--- a/extensions/inboxapi/src/runtime.ts
+++ b/extensions/inboxapi/src/runtime.ts
@@ -1,0 +1,8 @@
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
+import type { PluginRuntime } from "openclaw/plugin-sdk/inboxapi";
+
+const { setRuntime: setInboxApiRuntime, getRuntime: getInboxApiRuntime } =
+  createPluginRuntimeStore<PluginRuntime>(
+    "InboxAPI runtime not initialized - plugin not registered",
+  );
+export { getInboxApiRuntime, setInboxApiRuntime };

--- a/extensions/inboxapi/src/threading.test.ts
+++ b/extensions/inboxapi/src/threading.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  getThreadRootId,
+  deriveSessionKey,
+  extractSenderEmail,
+  extractSenderName,
+} from "./threading.js";
+import type { InboxApiEmail } from "./types.js";
+
+function makeEmail(overrides: Partial<InboxApiEmail> = {}): InboxApiEmail {
+  return {
+    id: "e1",
+    messageId: "<msg1@example.com>",
+    from: "sender@example.com",
+    to: "bot@inboxapi.ai",
+    subject: "Test",
+    date: "2026-03-09T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("getThreadRootId", () => {
+  it("uses first entry in References", () => {
+    const email = makeEmail({
+      references: ["<root@example.com>", "<mid@example.com>"],
+      inReplyTo: "<mid@example.com>",
+    });
+    expect(getThreadRootId(email)).toBe("<root@example.com>");
+  });
+
+  it("falls back to In-Reply-To", () => {
+    const email = makeEmail({
+      inReplyTo: "<parent@example.com>",
+    });
+    expect(getThreadRootId(email)).toBe("<parent@example.com>");
+  });
+
+  it("uses self Message-ID for new threads", () => {
+    const email = makeEmail();
+    expect(getThreadRootId(email)).toBe("<msg1@example.com>");
+  });
+});
+
+describe("deriveSessionKey", () => {
+  it("produces stable hash-based key", () => {
+    const email = makeEmail();
+    const key = deriveSessionKey(email);
+    expect(key).toMatch(/^inboxapi-[0-9a-f]{16}$/);
+    // Same email produces same key
+    expect(deriveSessionKey(email)).toBe(key);
+  });
+
+  it("same thread root produces same key", () => {
+    const e1 = makeEmail({ messageId: "<msg1@x.com>", references: ["<root@x.com>"] });
+    const e2 = makeEmail({ messageId: "<msg2@x.com>", references: ["<root@x.com>"] });
+    expect(deriveSessionKey(e1)).toBe(deriveSessionKey(e2));
+  });
+
+  it("different threads produce different keys", () => {
+    const e1 = makeEmail({ messageId: "<a@x.com>" });
+    const e2 = makeEmail({ messageId: "<b@x.com>" });
+    expect(deriveSessionKey(e1)).not.toBe(deriveSessionKey(e2));
+  });
+});
+
+describe("extractSenderEmail", () => {
+  it("extracts from angle-bracket format", () => {
+    expect(extractSenderEmail("Alice <alice@example.com>")).toBe("alice@example.com");
+  });
+
+  it("handles plain email", () => {
+    expect(extractSenderEmail("bob@example.com")).toBe("bob@example.com");
+  });
+
+  it("lowercases", () => {
+    expect(extractSenderEmail("BOB@EXAMPLE.COM")).toBe("bob@example.com");
+  });
+});
+
+describe("extractSenderName", () => {
+  it("extracts name from angle-bracket format", () => {
+    expect(extractSenderName("Alice Smith <alice@example.com>")).toBe("Alice Smith");
+  });
+
+  it("strips quotes", () => {
+    expect(extractSenderName('"Alice Smith" <alice@example.com>')).toBe("Alice Smith");
+  });
+
+  it("returns empty for plain email", () => {
+    expect(extractSenderName("alice@example.com")).toBe("");
+  });
+});

--- a/extensions/inboxapi/src/threading.ts
+++ b/extensions/inboxapi/src/threading.ts
@@ -1,0 +1,53 @@
+/**
+ * Email thread → session key mapping.
+ * Uses the thread root Message-ID to derive a stable session key.
+ */
+
+import { createHash } from "node:crypto";
+import type { InboxApiEmail } from "./types.js";
+
+/**
+ * Derive the thread root Message-ID from email headers.
+ * Resolution: first entry in References → In-Reply-To → self Message-ID
+ */
+export function getThreadRootId(email: InboxApiEmail): string {
+  // References header lists the full thread chain; first entry is the root
+  if (email.references && email.references.length > 0) {
+    return email.references[0];
+  }
+  // In-Reply-To points to the parent (often the root for simple threads)
+  if (email.inReplyTo) {
+    return email.inReplyTo;
+  }
+  // Self Message-ID (this is a new thread)
+  return email.messageId;
+}
+
+/**
+ * Derive a stable session key from an email's thread root.
+ * Format: inboxapi-<sha256-prefix>
+ */
+export function deriveSessionKey(email: InboxApiEmail): string {
+  const rootId = getThreadRootId(email);
+  const hash = createHash("sha256").update(rootId).digest("hex").slice(0, 16);
+  return `inboxapi-${hash}`;
+}
+
+/**
+ * Extract the sender email address from a From header value.
+ * Handles formats like "Name <email@example.com>" or plain "email@example.com"
+ */
+export function extractSenderEmail(from: string): string {
+  const match = from.match(/<([^>]+)>/);
+  if (match) return match[1].toLowerCase();
+  return from.toLowerCase().trim();
+}
+
+/**
+ * Extract the sender display name from a From header value.
+ */
+export function extractSenderName(from: string): string {
+  const match = from.match(/^(.+?)\s*<[^>]+>/);
+  if (match) return match[1].trim().replace(/^["']|["']$/g, "");
+  return "";
+}

--- a/extensions/inboxapi/src/types.ts
+++ b/extensions/inboxapi/src/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Type definitions for the InboxAPI email channel plugin.
+ */
+
+/** Raw channel config from openclaw.json channels.inboxapi */
+export interface InboxApiChannelConfig {
+  enabled?: boolean;
+  mcpEndpoint?: string;
+  credentialsPath?: string;
+  accessToken?: string;
+  domain?: string;
+  fromName?: string;
+  pollIntervalMs?: number;
+  pollBatchSize?: number;
+  dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
+  allowFrom?: string | string[];
+  textChunkLimit?: number;
+  accounts?: Record<string, InboxApiAccountRaw>;
+}
+
+/** Raw per-account config (overrides base config) */
+export interface InboxApiAccountRaw {
+  enabled?: boolean;
+  mcpEndpoint?: string;
+  credentialsPath?: string;
+  accessToken?: string;
+  domain?: string;
+  fromName?: string;
+  pollIntervalMs?: number;
+  pollBatchSize?: number;
+  dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
+  allowFrom?: string | string[];
+  textChunkLimit?: number;
+}
+
+/** Fully resolved account config with defaults applied */
+export interface ResolvedInboxApiAccount {
+  accountId: string;
+  enabled: boolean;
+  mcpEndpoint: string;
+  credentialsPath: string;
+  accessToken: string;
+  domain: string;
+  fromName: string;
+  pollIntervalMs: number;
+  pollBatchSize: number;
+  dmPolicy: "open" | "allowlist" | "pairing" | "disabled";
+  allowFrom: string[];
+  textChunkLimit: number;
+}
+
+/** Credentials file format (~/.local/inboxapi/credentials.json) */
+export interface InboxApiCredentials {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  domain?: string;
+  accountName?: string;
+}
+
+/** Email object returned by InboxAPI */
+export interface InboxApiEmail {
+  id: string;
+  messageId: string;
+  from: string;
+  fromName?: string;
+  to: string | string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  date: string;
+  inReplyTo?: string;
+  references?: string[];
+  attachments?: InboxApiAttachment[];
+}
+
+/** Email attachment */
+export interface InboxApiAttachment {
+  filename: string;
+  contentType: string;
+  size: number;
+  content?: string; // base64
+}
+
+/** WhoAmI response */
+export interface InboxApiWhoAmI {
+  accountName: string;
+  email: string;
+  domain: string;
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/plugin-sdk/imessage.d.ts",
       "default": "./dist/plugin-sdk/imessage.js"
     },
+    "./plugin-sdk/inboxapi": {
+      "types": "./dist/plugin-sdk/inboxapi.d.ts",
+      "default": "./dist/plugin-sdk/inboxapi.js"
+    },
     "./plugin-sdk/whatsapp": {
       "types": "./dist/plugin-sdk/whatsapp.d.ts",
       "default": "./dist/plugin-sdk/whatsapp.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,12 @@ importers:
 
   extensions/imessage: {}
 
+  extensions/inboxapi:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
   extensions/irc:
     dependencies:
       zod:

--- a/src/plugin-sdk/inboxapi.ts
+++ b/src/plugin-sdk/inboxapi.ts
@@ -7,3 +7,7 @@ export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";
 export { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+export {
+  readStoreAllowFromForDmPolicy,
+  resolveDmGroupAccessWithLists,
+} from "../security/dm-policy-shared.js";

--- a/src/plugin-sdk/inboxapi.ts
+++ b/src/plugin-sdk/inboxapi.ts
@@ -1,0 +1,9 @@
+// Narrow plugin-sdk surface for the bundled inboxapi plugin.
+// Keep this list additive and scoped to symbols used under extensions/inboxapi.
+
+export { setAccountEnabledInConfigSection } from "../channels/plugins/config-helpers.js";
+export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { PluginRuntime } from "../plugins/runtime/types.js";
+export type { OpenClawPluginApi } from "../plugins/types.js";
+export { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -33,6 +33,7 @@
     "src/plugin-sdk/feishu.ts",
     "src/plugin-sdk/google-gemini-cli-auth.ts",
     "src/plugin-sdk/googlechat.ts",
+    "src/plugin-sdk/inboxapi.ts",
     "src/plugin-sdk/irc.ts",
     "src/plugin-sdk/llm-task.ts",
     "src/plugin-sdk/lobster.ts",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -49,6 +49,7 @@ const pluginSdkEntrypoints = [
   "slack",
   "signal",
   "imessage",
+  "inboxapi",
   "whatsapp",
   "line",
   "msteams",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ const pluginSdkSubpaths = [
   "slack",
   "signal",
   "imessage",
+  "inboxapi",
   "whatsapp",
   "line",
   "msteams",


### PR DESCRIPTION
## Summary

- Add a new channel extension that integrates [InboxAPI](https://inboxapi.ai) as a bidirectional email channel, enabling agents to receive and reply to emails through OpenClaw's routing, security, and gateway lifecycle
- Polling-based inbound monitor with high-water mark tracking, MCP endpoint HTTP client with rate limit retry, and email threading via Message-ID/References header hashing
- Full ChannelPlugin implementation with config, security (DM policy), gateway, outbound adapters, and 53 unit tests across 7 test files

## Test plan

- [x] `pnpm test extensions/inboxapi` — all 53 tests pass (accounts, auth, client, inbound, monitor, outbound, threading)
- [x] `pnpm build` — no type errors or `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings
- [x] `pnpm check` — lint/format passes
- [ ] Configure a real InboxAPI account, start gateway, verify agent receives and replies to emails
- [ ] `openclaw channels status --probe` — verify InboxAPI shows as connected
- [ ] Test `dmPolicy=allowlist` — verify unlisted senders are rejected
