### PR TITLE
docs: quote bracket-notation paths in config CLI examples

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -18,7 +18,7 @@ openclaw config file
 openclaw config get browser.executablePath
 openclaw config set browser.executablePath "/usr/bin/google-chrome"
 openclaw config set agents.defaults.heartbeat.every "2h"
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 openclaw config unset tools.web.search.apiKey
 openclaw config validate
 openclaw config validate --json
@@ -26,18 +26,19 @@ openclaw config validate --json
 
 ## Paths
 
-Paths use dot or bracket notation:
+Paths use dot or bracket notation. **Quote paths containing brackets** to prevent
+shell glob expansion:
 
 ```bash
 openclaw config get agents.defaults.workspace
-openclaw config get agents.list[0].id
+openclaw config get 'agents.list[0].id'
 ```
 
 Use the agent list index to target a specific agent:
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[1].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[1].tools.exec.node' "node-id-or-name"
 ```
 
 ## Values

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -329,14 +329,14 @@ Per-agent override:
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 ```
 
 Unset to allow any node:
 
 ```bash
 openclaw config unset tools.exec.node
-openclaw config unset agents.list[0].tools.exec.node
+openclaw config unset 'agents.list[0].tools.exec.node'
 ```
 
 ## Permissions map

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -90,7 +90,7 @@ Per-agent node binding (use the agent list index in config):
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 ```
 
 Control UI: the Nodes tab includes a small “Exec node binding” panel for the same settings.

--- a/docs/zh-CN/cli/config.md
+++ b/docs/zh-CN/cli/config.md
@@ -23,24 +23,25 @@ x-i18n:
 openclaw config get browser.executablePath
 openclaw config set browser.executablePath "/usr/bin/google-chrome"
 openclaw config set agents.defaults.heartbeat.every "2h"
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 openclaw config unset tools.web.search.apiKey
 ```
 
 ## 路径
 
-路径使用点号或括号表示法：
+路径使用点号或括号表示法。**包含括号的路径需要加引号**以防止
+shell 将其解释为通配符：
 
 ```bash
 openclaw config get agents.defaults.workspace
-openclaw config get agents.list[0].id
+openclaw config get 'agents.list[0].id'
 ```
 
 使用智能体列表索引来定位特定智能体：
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[1].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[1].tools.exec.node' "node-id-or-name"
 ```
 
 ## 值

--- a/docs/zh-CN/nodes/index.md
+++ b/docs/zh-CN/nodes/index.md
@@ -305,14 +305,14 @@ openclaw config set tools.exec.node "node-id-or-name"
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 ```
 
 取消设置以允许任何节点：
 
 ```bash
 openclaw config unset tools.exec.node
-openclaw config unset agents.list[0].tools.exec.node
+openclaw config unset 'agents.list[0].tools.exec.node'
 ```
 
 ## 权限映射

--- a/docs/zh-CN/tools/exec.md
+++ b/docs/zh-CN/tools/exec.md
@@ -80,7 +80,7 @@ x-i18n:
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 ```
 
 控制 UI：Nodes 标签页包含一个小的"Exec 节点绑定"面板用于相同的设置。


### PR DESCRIPTION
## Summary

Fixes #40641

All `openclaw config set/get/unset` examples using bracket notation (`agents.list[0]...`) were unquoted, causing shells (bash/zsh) to interpret `[0]` as a glob pattern — resulting in "no matches found" errors.

Wrapped all bracket-notation paths in single quotes across 6 doc files (EN + zh-CN):
- `docs/cli/config.md`
- `docs/tools/exec.md`
- `docs/nodes/index.md`
- `docs/zh-CN/cli/config.md`
- `docs/zh-CN/tools/exec.md`
- `docs/zh-CN/nodes/index.md`

Also added a note in the Paths section explaining why quoting is needed.

## Test plan

- [ ] Verify `openclaw config set 'agents.list[0].tools.exec.node' "test"` works without shell error
- [ ] Verify unquoted `openclaw config set agents.list[0].tools.exec.node "test"` still fails (expected shell behavior)
- [ ] Verify dot notation alternative `openclaw config set agents.list.0.tools.exec.node "test"` works without quoting