### PR TITLE
fix: tolerate Telegram @BotUsername suffix in inline directives

### DIFF
--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -178,4 +178,33 @@ describe("extractModelDirective", () => {
       expect(result.hasDirective).toBe(false);
     });
   });
+
+  describe("Telegram @BotUsername suffix", () => {
+    it("recognizes /model@BotName with argument", () => {
+      const result = extractModelDirective("/model@MyBot gpt-5");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("gpt-5");
+      expect(result.cleaned).toBe("");
+    });
+
+    it("recognizes /model@BotName without argument", () => {
+      const result = extractModelDirective("/model@MyBot");
+      expect(result.hasDirective).toBe(true);
+      expect(result.cleaned).toBe("");
+    });
+
+    it("recognizes alias with @BotName suffix", () => {
+      const result = extractModelDirective("/opus@MyBot", {
+        aliases: ["opus"],
+      });
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("opus");
+    });
+
+    it("recognizes /model@BotName mid-message", () => {
+      const result = extractModelDirective("switch to /model@MyBot gpt-5 please");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("gpt-5");
+    });
+  });
 });

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -15,7 +15,7 @@ export function extractModelDirective(
   }
 
   const modelMatch = body.match(
-    /(?:^|\s)\/model(?=$|\s|:)\s*:?\s*([A-Za-z0-9_.:@-]+(?:\/[A-Za-z0-9_.:@-]+)*)?/i,
+    /(?:^|\s)\/model(?:@\w+)?(?=$|\s|:)\s*:?\s*([A-Za-z0-9_.:@-]+(?:\/[A-Za-z0-9_.:@-]+)*)?/i,
   );
 
   const aliases = (options?.aliases ?? []).map((alias) => alias.trim()).filter(Boolean);
@@ -24,7 +24,7 @@ export function extractModelDirective(
       ? null
       : body.match(
           new RegExp(
-            `(?:^|\\s)\\/(${aliases.map(escapeRegExp).join("|")})(?=$|\\s|:)(?:\\s*:\\s*)?`,
+            `(?:^|\\s)\\/(${aliases.map(escapeRegExp).join("|")})(?:@\\w+)?(?=$|\\s|:)(?:\\s*:\\s*)?`,
             "i",
           ),
         );

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -23,7 +23,7 @@ const matchLevelDirective = (
   names: string[],
 ): { start: number; end: number; rawLevel?: string } | null => {
   const namePattern = names.map(escapeRegExp).join("|");
-  const match = body.match(new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)`, "i"));
+  const match = body.match(new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?:@\\w+)?(?=$|\\s|:)`, "i"));
   if (!match || match.index === undefined) {
     return null;
   }
@@ -79,7 +79,7 @@ const extractSimpleDirective = (
 ): { cleaned: string; hasDirective: boolean } => {
   const namePattern = names.map(escapeRegExp).join("|");
   const match = body.match(
-    new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)(?:\\s*:\\s*)?`, "i"),
+    new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?:@\\w+)?(?=$|\\s|:)(?:\\s*:\\s*)?`, "i"),
   );
   const cleaned = match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim();
   return {

--- a/src/auto-reply/reply/exec/directive.ts
+++ b/src/auto-reply/reply/exec/directive.ts
@@ -172,7 +172,7 @@ export function extractExecDirective(body?: string): ExecDirectiveParse {
       invalidNode: false,
     };
   }
-  const re = /(?:^|\s)\/exec(?=$|\s|:)/i;
+  const re = /(?:^|\s)\/exec(?:@\w+)?(?=$|\s|:)/i;
   const match = re.exec(body);
   if (!match) {
     return {

--- a/src/auto-reply/reply/queue/directive.ts
+++ b/src/auto-reply/reply/queue/directive.ts
@@ -143,7 +143,7 @@ export function extractQueueDirective(body?: string): {
       hasOptions: false,
     };
   }
-  const re = /(?:^|\s)\/queue(?=$|\s|:)/i;
+  const re = /(?:^|\s)\/queue(?:@\w+)?(?=$|\s|:)/i;
   const match = re.exec(body);
   if (!match) {
     return {

--- a/src/auto-reply/reply/reply-inline.ts
+++ b/src/auto-reply/reply/reply-inline.ts
@@ -6,9 +6,9 @@ const INLINE_SIMPLE_COMMAND_ALIASES = new Map<string, string>([
   ["/whoami", "/whoami"],
   ["/id", "/whoami"],
 ]);
-const INLINE_SIMPLE_COMMAND_RE = /(?:^|\s)\/(help|commands|whoami|id)(?=$|\s|:)/i;
+const INLINE_SIMPLE_COMMAND_RE = /(?:^|\s)\/(help|commands|whoami|id)(?:@\w+)?(?=$|\s|:)/i;
 
-const INLINE_STATUS_RE = /(?:^|\s)\/status(?=$|\s|:)(?:\s*:\s*)?/gi;
+const INLINE_STATUS_RE = /(?:^|\s)\/status(?:@\w+)?(?=$|\s|:)(?:\s*:\s*)?/gi;
 
 export function extractInlineSimpleCommand(body?: string): {
   command: string;


### PR DESCRIPTION
## Problem

In Telegram group chats, the client appends `@BotUsername` to slash commands (e.g. `/model@MyBot gpt-5` instead of `/model gpt-5`). All inline directive extractors used a regex lookahead `(?=$|\s|:)` that did not account for the `@BotName` suffix, causing every directive to fail silently.

## Fix

Added an optional `(?:@\w+)?` group before the lookahead in all affected directive regex patterns:

- `/model` (`src/auto-reply/model.ts`)
- `/think`, `/verbose`, `/reasoning`, `/elevated`, `/notice` (`src/auto-reply/reply/directives.ts`)
- `/status`, `/help`, `/commands`, `/whoami`, `/id` (`src/auto-reply/reply/reply-inline.ts`)
- `/exec` (`src/auto-reply/reply/exec/directive.ts`)
- `/queue` (`src/auto-reply/reply/queue/directive.ts`)
- Model aliases (`src/auto-reply/model.ts`)

## Tests

Added 4 test cases for the `@BotUsername` suffix in `model.test.ts`:
- `/model@BotName` with argument
- `/model@BotName` without argument
- Alias with `@BotName` suffix
- `/model@BotName` mid-message

All 29 tests pass.

Fixes #40637