### PR TITLE
fix(telegram): add verbose log when mention gating drops messages

### DIFF
--- a/src/telegram/bot-message-context.body.ts
+++ b/src/telegram/bot-message-context.body.ts
@@ -254,7 +254,7 @@ export async function resolveTelegramInboundBody(params: {
   const effectiveWasMentioned = mentionGate.effectiveWasMentioned;
   if (isGroup && requireMention && canDetectMention && mentionGate.shouldSkip) {
     logVerbose(
-      `telegram: message dropped by mention gating (chat=${chatId} topic=${resolvedThreadId ?? "none"} requireMention=${requireMention} wasMentioned=${wasMentioned})`
+      `telegram: message dropped by mention gating (chat=${chatId} topic=${resolvedThreadId ?? "none"} requireMention=${requireMention} wasMentioned=${wasMentioned})`,
     );
     recordPendingHistoryEntryIfEnabled({
       historyMap: groupHistories,

--- a/src/telegram/bot-message-context.body.ts
+++ b/src/telegram/bot-message-context.body.ts
@@ -253,7 +253,9 @@ export async function resolveTelegramInboundBody(params: {
   });
   const effectiveWasMentioned = mentionGate.effectiveWasMentioned;
   if (isGroup && requireMention && canDetectMention && mentionGate.shouldSkip) {
-    logger.info({ chatId, reason: "no-mention" }, "skipping group message");
+    logVerbose(
+      `telegram: message dropped by mention gating (chat=${chatId} topic=${resolvedThreadId ?? "none"} requireMention=${requireMention} wasMentioned=${wasMentioned})`
+    );
     recordPendingHistoryEntryIfEnabled({
       historyMap: groupHistories,
       historyKey: historyKey ?? "",


### PR DESCRIPTION
## Problem

When a Telegram group/topic message is dropped because `requireMention` is `true` (the default) and the bot wasn't mentioned, there is **zero log output** — not even at debug/verbose level.

This made debugging extremely difficult, as the failure was indistinguishable from "Telegram never delivered the message" vs "gateway received but dropped it."

## Solution

Added a `logVerbose` entry when mention gating drops a message:

```
telegram: message dropped by mention gating (chat=-1003722704048 topic=2 requireMention=true wasMentioned=false)
```

This matches the logging style of other drop reasons (e.g., `group-disabled`, `group-policy-disabled`).

## Changes

- Replaced `logger.info` with `logVerbose` in mention gating drop path
- Added full context (chat, topic, requireMention, wasMentioned) to the log message
- Matches the format suggested in the issue

## Testing

Manually tested by simulating a mention gating drop scenario. The log now appears at verbose level with all required context.

---

**Supersedes #40610** - Previous PR included unrelated changes and had syntax errors. This is a clean version with only the necessary changes.

Fixes #40567