### PR TITLE
fix(kimi-coding): use native Anthropic tool format instead of OpenAI function format

### DIFF
--- a/src/agents/models-config.providers.kimi-coding.test.ts
+++ b/src/agents/models-config.providers.kimi-coding.test.ts
@@ -31,6 +31,17 @@ describe("kimi-coding implicit provider (#22409)", () => {
     expect(provider.models[0].id).toBe("k2p5");
   });
 
+  it("should NOT set requiresOpenAiAnthropicToolPayload on kimi-coding models (regression #40552)", () => {
+    const provider = buildKimiCodingProvider();
+    for (const model of provider.models) {
+      const compat = model.compat as Record<string, unknown> | undefined;
+      expect(
+        compat?.requiresOpenAiAnthropicToolPayload,
+        `model ${model.id} must use native Anthropic tool format, not OpenAI function format`,
+      ).toBeFalsy();
+    }
+  });
+
   it("should not include kimi-coding when no API key is configured", async () => {
     const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
     const envSnapshot = captureEnv(["KIMI_API_KEY"]);

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -233,9 +233,7 @@ export function buildKimiCodingProvider(): ProviderConfig {
         cost: KIMI_CODING_DEFAULT_COST,
         contextWindow: KIMI_CODING_DEFAULT_CONTEXT_WINDOW,
         maxTokens: KIMI_CODING_DEFAULT_MAX_TOKENS,
-        compat: {
-          requiresOpenAiAnthropicToolPayload: true,
-        },
+        compat: {},
       },
     ],
   };

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -233,7 +233,6 @@ export function buildKimiCodingProvider(): ProviderConfig {
         cost: KIMI_CODING_DEFAULT_COST,
         contextWindow: KIMI_CODING_DEFAULT_CONTEXT_WINDOW,
         maxTokens: KIMI_CODING_DEFAULT_MAX_TOKENS,
-        compat: {},
       },
     ],
   };

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -732,7 +732,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
   });
 
-  it("normalizes kimi-coding anthropic tools to OpenAI function format", () => {
+  it("preserves native Anthropic tool format for kimi-coding (regression #40552)", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -744,14 +744,6 @@ describe("applyExtraParamsToAgent", () => {
               type: "object",
               properties: { path: { type: "string" } },
               required: ["path"],
-            },
-          },
-          {
-            type: "function",
-            function: {
-              name: "exec",
-              description: "Run command",
-              parameters: { type: "object", properties: {} },
             },
           },
         ],
@@ -775,71 +767,63 @@ describe("applyExtraParamsToAgent", () => {
     void agent.streamFn?.(model, context, {});
 
     expect(payloads).toHaveLength(1);
+    // tools must stay in native Anthropic format — NOT converted to OpenAI function format
     expect(payloads[0]?.tools).toEqual([
       {
-        type: "function",
-        function: {
-          name: "read",
-          description: "Read file",
-          parameters: {
-            type: "object",
-            properties: { path: { type: "string" } },
-            required: ["path"],
-          },
-        },
-      },
-      {
-        type: "function",
-        function: {
-          name: "exec",
-          description: "Run command",
-          parameters: { type: "object", properties: {} },
+        name: "read",
+        description: "Read file",
+        input_schema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
         },
       },
     ]);
-    expect(payloads[0]?.tool_choice).toEqual({
-      type: "function",
-      function: { name: "read" },
-    });
+    // tool_choice must stay in native Anthropic format
+    expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
   });
 
   it.each([
-    { input: { type: "auto" }, expected: "auto" },
-    { input: { type: "none" }, expected: "none" },
-    { input: { type: "required" }, expected: "required" },
-  ])("normalizes anthropic tool_choice %j for kimi-coding endpoints", ({ input, expected }) => {
-    const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = {
-        tools: [
-          {
-            name: "read",
-            description: "Read file",
-            input_schema: { type: "object", properties: {} },
-          },
-        ],
-        tool_choice: input,
+    { input: { type: "auto" } },
+    { input: { type: "none" } },
+    { input: { type: "required" } },
+  ])(
+    "preserves native anthropic tool_choice %j for kimi-coding (regression #40552)",
+    ({ input }) => {
+      const payloads: Record<string, unknown>[] = [];
+      const baseStreamFn: StreamFn = (_model, _context, options) => {
+        const payload: Record<string, unknown> = {
+          tools: [
+            {
+              name: "read",
+              description: "Read file",
+              input_schema: { type: "object", properties: {} },
+            },
+          ],
+          tool_choice: input,
+        };
+        options?.onPayload?.(payload);
+        payloads.push(payload);
+        return {} as ReturnType<StreamFn>;
       };
-      options?.onPayload?.(payload);
-      payloads.push(payload);
-      return {} as ReturnType<StreamFn>;
-    };
-    const agent = { streamFn: baseStreamFn };
+      const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "kimi-coding", "k2p5", undefined, "low");
+      applyExtraParamsToAgent(agent, undefined, "kimi-coding", "k2p5", undefined, "low");
 
-    const model = {
-      api: "anthropic-messages",
-      provider: "kimi-coding",
-      id: "k2p5",
-      baseUrl: "https://api.kimi.com/coding/",
-    } as Model<"anthropic-messages">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {});
+      const model = {
+        api: "anthropic-messages",
+        provider: "kimi-coding",
+        id: "k2p5",
+        baseUrl: "https://api.kimi.com/coding/",
+      } as Model<"anthropic-messages">;
+      const context: Context = { messages: [] };
+      void agent.streamFn?.(model, context, {});
 
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.tool_choice).toBe(expected);
-  });
+      expect(payloads).toHaveLength(1);
+      // tool_choice must remain in native Anthropic object format, not converted to string
+      expect(payloads[0]?.tool_choice).toEqual(input);
+    },
+  );
 
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {
     const payloads: Record<string, unknown>[] = [];

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -31,8 +31,8 @@ describe("resolveProviderCapabilities", () => {
       resolveProviderCapabilities("kimi-code"),
     );
     expect(resolveProviderCapabilities("kimi-code")).toEqual({
-      anthropicToolSchemaMode: "openai-functions",
-      anthropicToolChoiceMode: "openai-string-modes",
+      anthropicToolSchemaMode: "native",
+      anthropicToolChoiceMode: "native",
       providerFamily: "default",
       preserveAnthropicThinkingSignatures: false,
       openAiCompatTurnValidation: true,
@@ -66,9 +66,9 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
-  it("treats kimi aliases as anthropic tool payload compatibility providers", () => {
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(true);
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(true);
+  it("kimi-coding uses native Anthropic tool format (regression #40552)", () => {
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(false);
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);
     expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic")).toBe(false);
   });
 

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -34,8 +34,8 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
     providerFamily: "anthropic",
   },
   "kimi-coding": {
-    anthropicToolSchemaMode: "openai-functions",
-    anthropicToolChoiceMode: "openai-string-modes",
+    anthropicToolSchemaMode: "native",
+    anthropicToolChoiceMode: "native",
     preserveAnthropicThinkingSignatures: false,
   },
   mistral: {


### PR DESCRIPTION
## Summary

Fixes #40552

Commit `909f26a26` introduced `requiresOpenAiAnthropicToolPayload: true` for kimi-coding and set `anthropicToolSchemaMode: "openai-functions"` + `anthropicToolChoiceMode: "openai-string-modes"` in provider capabilities. This converts Anthropic-native tool definitions to OpenAI function format before sending to the API.

However, kimi-coding's `api.kimi.com/coding/` endpoint uses `anthropic-messages` API and expects **native Anthropic tool format** (`name` + `input_schema`). With the OpenAI conversion, the model receives tools in an incompatible format and falls back to outputting tool calls as plain text/XML instead of structured `tool_use` blocks — completely breaking tool execution.

### Changes

- `src/agents/models-config.providers.static.ts`: Remove `requiresOpenAiAnthropicToolPayload: true` from kimi-coding model config
- `src/agents/provider-capabilities.ts`: Switch kimi-coding to `anthropicToolSchemaMode: "native"` and `anthropicToolChoiceMode: "native"`
- Updated 3 test files to match new behavior and added regression guards

### Regression tests

- `models-config.providers.kimi-coding.test.ts`: Added explicit assertion that kimi-coding models must NOT have `requiresOpenAiAnthropicToolPayload`
- `provider-capabilities.test.ts`: Updated to expect `native` mode for kimi-coding
- `pi-embedded-runner-extraparams.test.ts`: Rewrote kimi-coding tool payload tests to verify tools stay in native Anthropic format (not converted to OpenAI function format)

## Test plan

- [x] `pnpm vitest run src/agents/models-config.providers.kimi-coding.test.ts` — 4 pass
- [x] `pnpm vitest run src/agents/provider-capabilities.test.ts` — 6 pass
- [x] `pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts` — 69 pass
- [x] `pnpm vitest run src/agents/transcript-policy.test.ts` — 19 pass
- [x] `pnpm build` — clean
- [x] `pnpm check` — clean
- [ ] Manual: configure kimi-coding/k2p5 and verify tool_use blocks return with `stopReason: "toolUse"`