### PR TITLE
fix(subagent): inject trigger to requester after direct delivery succ…

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -819,7 +819,7 @@ async function sendSubagentAnnounceDirectly(params: {
     // When direct delivery succeeds for group topic sessions, still inject a
     // lightweight trigger into the requester session so the main agent is aware
     // of the sub-agent completion (fixes #40605).
-    if (shouldDeliverExternally && !params.requesterIsSubagent) {
+    if (shouldDeliverExternally) {
       try {
         await callGateway({
           method: "agent",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -816,6 +816,33 @@ async function sendSubagentAnnounceDirectly(params: {
         }),
     });
 
+    // When direct delivery succeeds for group topic sessions, still inject a
+    // lightweight trigger into the requester session so the main agent is aware
+    // of the sub-agent completion (fixes #40605).
+    if (shouldDeliverExternally && !params.requesterIsSubagent) {
+      try {
+        await callGateway({
+          method: "agent",
+          params: {
+            sessionKey: canonicalRequesterSessionKey,
+            message: params.triggerMessage,
+            deliver: false,
+            internalEvents: params.internalEvents,
+            inputProvenance: {
+              kind: "inter_session",
+              sourceSessionKey: params.sourceSessionKey,
+              sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+              sourceTool: params.sourceTool ?? "subagent_announce",
+            },
+            idempotencyKey: `${params.directIdempotencyKey}:trigger`,
+          },
+          timeoutMs: announceTimeoutMs,
+        });
+      } catch {
+        // Best-effort trigger injection; don't fail the entire announce if this fails
+      }
+    }
+
     return {
       delivered: true,
       path: "direct",


### PR DESCRIPTION
## Problem

When a sub-agent completes in a group topic session and direct delivery succeeds, the completion message is sent to the topic but the main agent receives no notification. This leaves the orchestrator unaware of completion.

## Solution

After successful direct delivery to external channels, inject a lightweight internal trigger (`deliver=false`) into the requester session so the main agent can acknowledge completion and perform follow-up orchestration.

## Changes

- Added trigger injection after `sendSubagentAnnounceDirectly()` succeeds
- Only triggers when `shouldDeliverExternally && !requesterIsSubagent`
- Best-effort: failures don't break the announce flow
- 27 lines added to `src/agents/subagent-announce.ts`

Fixes #40605