### PR TITLE
fix: include wake reason in shouldInspectPendingEvents

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -513,7 +513,10 @@ async function resolveHeartbeatPreflight(params: {
     event.contextKey?.startsWith("cron:"),
   );
   const shouldInspectPendingEvents =
-    reasonFlags.isExecEventReason || reasonFlags.isCronEventReason || hasTaggedCronEvents;
+    reasonFlags.isExecEventReason ||
+    reasonFlags.isCronEventReason ||
+    reasonFlags.isWakeReason ||
+    hasTaggedCronEvents;
   const shouldBypassFileGates =
     reasonFlags.isExecEventReason ||
     reasonFlags.isCronEventReason ||


### PR DESCRIPTION
## Problem

When a plugin enqueues a system event via `enqueueSystemEvent()` and requests an immediate heartbeat wake with `requestHeartbeatNow({ reason: 'wake' })`, the heartbeat fires but the system events are silently dropped.

## Root Cause

In `heartbeat-runner.ts`, `shouldBypassFileGates` correctly includes `isWakeReason`, so the heartbeat fires even without a HEARTBEAT.md file. However, `shouldInspectPendingEvents` was missing `isWakeReason`, causing the pending system events queue to be ignored:

```typescript
// ✅ Wake bypasses file gates
const shouldBypassFileGates =
    reasonFlags.isExecEventReason || reasonFlags.isCronEventReason || reasonFlags.isWakeReason || hasTaggedCronEvents;

// ❌ But wake does NOT inspect pending events
const shouldInspectPendingEvents =
    reasonFlags.isExecEventReason || reasonFlags.isCronEventReason || hasTaggedCronEvents;
```

## Fix

Add `reasonFlags.isWakeReason` to `shouldInspectPendingEvents`, matching its inclusion in `shouldBypassFileGates`.

## Context

Discovered via the `openclaw-agentmail-listener` plugin. When an email arrives:
1. Plugin calls `enqueueSystemEvent(emailSummary, { sessionKey })` ✅
2. Plugin calls `requestHeartbeatNow({ reason: 'wake', sessionKey })` ✅
3. Heartbeat fires (file gates bypassed) ✅
4. But `pendingEvents` resolves to `[]` because wake reason isn't inspected ❌
5. Agent gets standard heartbeat prompt with no email context ❌

## Testing

All existing heartbeat tests pass (60 tests across 7 test files).