### PR TITLE
feat(discord): archive ACP-created threads on /acp close

### DIFF
--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -755,6 +755,32 @@ describe("/acp command", () => {
     });
   });
 
+  it("preserves runtime notice in archive close replies", async () => {
+    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
+      createSpawnedAcpThreadSession(),
+    );
+    hoisted.readAcpSessionEntryMock.mockReturnValue(createAcpSessionEntry());
+    hoisted.sessionBindingUnbindMock.mockResolvedValue([
+      createSpawnedAcpThreadSession() as SessionBindingRecord,
+    ]);
+    hoisted.closeMock.mockRejectedValue(
+      new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "backend unavailable"),
+    );
+
+    const result = await runThreadAcpCommand("/acp close", baseCfg);
+
+    expect(result?.reply?.text).toBe(
+      "✅ ACP session closed and thread archived (backend unavailable).",
+    );
+    expect(result?.reply?.channelData).toEqual({
+      discord: {
+        archiveCurrentThreadAfterReply: true,
+        archiveFailureText:
+          "⚠️ ACP session closed, but thread archive failed (backend unavailable).",
+      },
+    });
+  });
+
   it("keeps the existing close reply for manually attached Discord threads", async () => {
     mockBoundThreadSession();
     hoisted.sessionBindingUnbindMock.mockResolvedValue([

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -130,6 +130,8 @@ type FakeBinding = {
     label?: string;
     boundBy?: string;
     webhookId?: string;
+    spawnedThread?: boolean;
+    spawnedBy?: "acp" | "subagent";
   };
 };
 
@@ -207,6 +209,29 @@ function createBoundThreadSession(sessionKey: string = defaultAcpSessionKey) {
   return createSessionBinding({
     targetSessionKey: sessionKey,
     conversation: createThreadConversation(),
+  });
+}
+
+function createSpawnedAcpThreadSession(sessionKey: string = defaultAcpSessionKey) {
+  return createSessionBinding({
+    targetSessionKey: sessionKey,
+    conversation: createThreadConversation(),
+    metadata: {
+      boundBy: "user-1",
+      spawnedThread: true,
+      spawnedBy: "acp",
+    },
+  });
+}
+
+function createBoundTelegramSession(sessionKey: string = defaultAcpSessionKey) {
+  return createSessionBinding({
+    targetSessionKey: sessionKey,
+    conversation: {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "-1003841603622:topic:498",
+    },
   });
 }
 
@@ -464,6 +489,8 @@ describe("/acp command", () => {
         targetKind: "session",
         placement: "child",
         metadata: expect.objectContaining({
+          spawnedThread: true,
+          spawnedBy: "acp",
           introText: expect.stringContaining("cwd: /home/bob/clawd"),
         }),
       }),
@@ -701,7 +728,34 @@ describe("/acp command", () => {
     expect(hoisted.runTurnMock).not.toHaveBeenCalled();
   });
 
-  it("closes an ACP session, unbinds thread targets, and clears metadata", async () => {
+  it("archives ACP-created Discord threads on /acp close", async () => {
+    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
+      createSpawnedAcpThreadSession(),
+    );
+    hoisted.readAcpSessionEntryMock.mockReturnValue(createAcpSessionEntry());
+    hoisted.sessionBindingUnbindMock.mockResolvedValue([
+      createSpawnedAcpThreadSession() as SessionBindingRecord,
+    ]);
+
+    const result = await runThreadAcpCommand("/acp close", baseCfg);
+
+    expect(hoisted.closeMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.sessionBindingUnbindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetSessionKey: defaultAcpSessionKey,
+        reason: "manual",
+      }),
+    );
+    expect(result?.reply?.text).toBe("✅ ACP session closed and thread archived.");
+    expect(result?.reply?.channelData).toEqual({
+      discord: {
+        archiveCurrentThreadAfterReply: true,
+        archiveFailureText: "⚠️ ACP session closed, but thread archive failed.",
+      },
+    });
+  });
+
+  it("keeps the existing close reply for manually attached Discord threads", async () => {
     mockBoundThreadSession();
     hoisted.sessionBindingUnbindMock.mockResolvedValue([
       createBoundThreadSession() as SessionBindingRecord,
@@ -718,6 +772,46 @@ describe("/acp command", () => {
     );
     expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalled();
     expect(result?.reply?.text).toContain("Removed 1 binding");
+    expect(result?.reply?.channelData).toBeUndefined();
+  });
+
+  it("fails safe when spawned ownership metadata is incomplete", async () => {
+    mockBoundThreadSession();
+    hoisted.sessionBindingUnbindMock.mockResolvedValue([
+      createSessionBinding({
+        targetSessionKey: defaultAcpSessionKey,
+        conversation: createThreadConversation(),
+        metadata: {
+          boundBy: "user-1",
+          spawnedThread: true,
+        },
+      }) as SessionBindingRecord,
+    ]);
+
+    const result = await runThreadAcpCommand("/acp close", baseCfg);
+
+    expect(result?.reply?.text).toContain("Removed 1 binding");
+    expect(result?.reply?.channelData).toBeUndefined();
+  });
+
+  it("keeps non-Discord /acp close behavior unchanged", async () => {
+    hoisted.sessionBindingResolveByConversationMock.mockImplementation(
+      (ref: { channel?: string; accountId?: string; conversationId?: string }) =>
+        ref.channel === "telegram" &&
+        ref.accountId === "default" &&
+        ref.conversationId === "-1003841603622:topic:498"
+          ? createBoundTelegramSession()
+          : null,
+    );
+    hoisted.readAcpSessionEntryMock.mockReturnValue(createAcpSessionEntry());
+    hoisted.sessionBindingUnbindMock.mockResolvedValue([
+      createBoundTelegramSession() as SessionBindingRecord,
+    ]);
+
+    const result = await runTelegramAcpCommand("/acp close", baseCfg);
+
+    expect(result?.reply?.text).toContain("Removed 1 binding");
+    expect(result?.reply?.channelData).toBeUndefined();
   });
 
   it("lists ACP sessions from the session store", async () => {

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -630,11 +630,11 @@ export async function handleAcpCloseAction(
         return {
           shouldContinue: false,
           reply: {
-            text: "✅ ACP session closed and thread archived.",
+            text: `✅ ACP session closed and thread archived${runtimeNotice}.`,
             channelData: {
               discord: {
                 archiveCurrentThreadAfterReply: true,
-                archiveFailureText: "⚠️ ACP session closed, but thread archive failed.",
+                archiveFailureText: `⚠️ ACP session closed, but thread archive failed${runtimeNotice}.`,
               },
             },
           },

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -36,9 +36,11 @@ import {
 } from "../../../infra/outbound/session-binding-service.js";
 import type { CommandHandlerResult, HandleCommandsParams } from "../commands-types.js";
 import {
+  resolveAcpCommandChannel,
   resolveAcpCommandAccountId,
   resolveAcpCommandBindingContext,
   resolveAcpCommandConversationId,
+  resolveAcpCommandThreadId,
 } from "./context.js";
 import {
   ACP_STEER_OUTPUT_LIMIT,
@@ -172,6 +174,7 @@ async function bindSpawnedAcpSessionToThread(params: {
 
   const label = params.label || params.agentId;
   const conversationId = currentConversationId;
+  const spawnedDiscordThread = spawnPolicy.channel === "discord" && placement === "child";
 
   try {
     const binding = await bindingService.bind({
@@ -191,6 +194,8 @@ async function bindSpawnedAcpSessionToThread(params: {
         agentId: params.agentId,
         label,
         boundBy: senderId || "unknown",
+        spawnedThread: spawnedDiscordThread,
+        spawnedBy: spawnedDiscordThread ? "acp" : undefined,
         introText: resolveThreadBindingIntroText({
           agentId: params.agentId,
           label,
@@ -223,6 +228,29 @@ async function bindSpawnedAcpSessionToThread(params: {
       error: message || `Failed to bind a ${channel} thread/conversation to the new ACP session.`,
     };
   }
+}
+
+function shouldArchiveAcpCreatedDiscordThread(params: {
+  commandParams: HandleCommandsParams;
+  removedBindings: SessionBindingRecord[];
+}): boolean {
+  if (resolveAcpCommandChannel(params.commandParams) !== "discord") {
+    return false;
+  }
+  const currentThreadId = resolveAcpCommandThreadId(params.commandParams);
+  if (!currentThreadId) {
+    return false;
+  }
+  return params.removedBindings.some((binding) => {
+    if (binding.conversation.channel !== "discord") {
+      return false;
+    }
+    if (binding.conversation.conversationId.trim() !== currentThreadId) {
+      return false;
+    }
+    const metadata = binding.metadata;
+    return metadata?.spawnedThread === true && metadata?.spawnedBy === "acp";
+  });
 }
 
 async function cleanupFailedSpawn(params: {
@@ -592,6 +620,26 @@ export async function handleAcpCloseAction(
         targetSessionKey: sessionKey,
         reason: "manual",
       });
+
+      if (
+        shouldArchiveAcpCreatedDiscordThread({
+          commandParams: params,
+          removedBindings,
+        })
+      ) {
+        return {
+          shouldContinue: false,
+          reply: {
+            text: "✅ ACP session closed and thread archived.",
+            channelData: {
+              discord: {
+                archiveCurrentThreadAfterReply: true,
+                archiveFailureText: "⚠️ ACP session closed, but thread archive failed.",
+              },
+            },
+          },
+        };
+      }
 
       return stopWithText(
         `✅ Closed ACP session ${sessionKey}${runtimeNotice}. Removed ${removedBindings.length} binding${removedBindings.length === 1 ? "" : "s"}.`,

--- a/src/channels/plugins/outbound/discord.test.ts
+++ b/src/channels/plugins/outbound/discord.test.ts
@@ -295,6 +295,52 @@ describe("discordOutbound", () => {
     expect(result).toEqual(DEFAULT_DISCORD_SEND_RESULT);
   });
 
+  it("honors sendDiscord overrides for archive-after-reply payloads", async () => {
+    const sendDiscordOverride = vi.fn().mockResolvedValue({
+      messageId: "override-msg-1",
+      channelId: "override-thread-1",
+    });
+
+    const result = await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:parent-1",
+      payload: {
+        text: "✅ ACP session closed and thread archived.",
+        channelData: {
+          discord: {
+            archiveCurrentThreadAfterReply: true,
+            archiveFailureText: "⚠️ ACP session closed, but thread archive failed.",
+          },
+        },
+      },
+      accountId: "default",
+      threadId: "thread-1",
+      deps: {
+        sendDiscord: sendDiscordOverride,
+      },
+    });
+
+    expect(sendDiscordOverride).toHaveBeenCalledWith(
+      "channel:thread-1",
+      "✅ ACP session closed and thread archived.",
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+    expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+    expect(hoisted.archiveDiscordThreadMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        threadId: "thread-1",
+      }),
+    );
+    expect(result).toEqual({
+      channel: "discord",
+      messageId: "override-msg-1",
+      channelId: "override-thread-1",
+    });
+  });
+
   it("edits the reply to partial success text when thread archive fails", async () => {
     hoisted.archiveDiscordThreadMock.mockRejectedValueOnce(new Error("archive failed"));
 

--- a/src/channels/plugins/outbound/discord.test.ts
+++ b/src/channels/plugins/outbound/discord.test.ts
@@ -3,13 +3,17 @@ import { normalizeDiscordOutboundTarget } from "../normalize/discord.js";
 
 const hoisted = vi.hoisted(() => {
   const sendMessageDiscordMock = vi.fn();
+  const editMessageDiscordMock = vi.fn();
   const sendPollDiscordMock = vi.fn();
   const sendWebhookMessageDiscordMock = vi.fn();
+  const archiveDiscordThreadMock = vi.fn();
   const getThreadBindingManagerMock = vi.fn();
   return {
     sendMessageDiscordMock,
+    editMessageDiscordMock,
     sendPollDiscordMock,
     sendWebhookMessageDiscordMock,
+    archiveDiscordThreadMock,
     getThreadBindingManagerMock,
   };
 });
@@ -19,9 +23,21 @@ vi.mock("../../../discord/send.js", async (importOriginal) => {
   return {
     ...actual,
     sendMessageDiscord: (...args: unknown[]) => hoisted.sendMessageDiscordMock(...args),
+    editMessageDiscord: (...args: unknown[]) => hoisted.editMessageDiscordMock(...args),
     sendPollDiscord: (...args: unknown[]) => hoisted.sendPollDiscordMock(...args),
     sendWebhookMessageDiscord: (...args: unknown[]) =>
       hoisted.sendWebhookMessageDiscordMock(...args),
+  };
+});
+
+vi.mock("../../../discord/monitor/thread-bindings.discord-api.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../discord/monitor/thread-bindings.discord-api.js")
+    >();
+  return {
+    ...actual,
+    archiveDiscordThread: (...args: unknown[]) => hoisted.archiveDiscordThreadMock(...args),
   };
 });
 
@@ -85,15 +101,24 @@ describe("normalizeDiscordOutboundTarget", () => {
   });
 
   it("passes through channel: prefixed targets", () => {
-    expect(normalizeDiscordOutboundTarget("channel:123")).toEqual({ ok: true, to: "channel:123" });
+    expect(normalizeDiscordOutboundTarget("channel:123")).toEqual({
+      ok: true,
+      to: "channel:123",
+    });
   });
 
   it("passes through user: prefixed targets", () => {
-    expect(normalizeDiscordOutboundTarget("user:123")).toEqual({ ok: true, to: "user:123" });
+    expect(normalizeDiscordOutboundTarget("user:123")).toEqual({
+      ok: true,
+      to: "user:123",
+    });
   });
 
   it("passes through channel name strings", () => {
-    expect(normalizeDiscordOutboundTarget("general")).toEqual({ ok: true, to: "general" });
+    expect(normalizeDiscordOutboundTarget("general")).toEqual({
+      ok: true,
+      to: "general",
+    });
   });
 
   it("returns error for empty target", () => {
@@ -105,7 +130,10 @@ describe("normalizeDiscordOutboundTarget", () => {
   });
 
   it("trims whitespace", () => {
-    expect(normalizeDiscordOutboundTarget("  123  ")).toEqual({ ok: true, to: "channel:123" });
+    expect(normalizeDiscordOutboundTarget("  123  ")).toEqual({
+      ok: true,
+      to: "channel:123",
+    });
   });
 });
 
@@ -115,6 +143,10 @@ describe("discordOutbound", () => {
       messageId: "msg-1",
       channelId: "ch-1",
     });
+    hoisted.editMessageDiscordMock.mockClear().mockResolvedValue({
+      messageId: "msg-1",
+      channelId: "thread-1",
+    });
     hoisted.sendPollDiscordMock.mockClear().mockResolvedValue({
       messageId: "poll-1",
       channelId: "ch-1",
@@ -123,6 +155,7 @@ describe("discordOutbound", () => {
       messageId: "msg-webhook-1",
       channelId: "thread-1",
     });
+    hoisted.archiveDiscordThreadMock.mockClear().mockResolvedValue(undefined);
     hoisted.getThreadBindingManagerMock.mockClear().mockReturnValue(null);
   });
 
@@ -225,6 +258,70 @@ describe("discordOutbound", () => {
       text: "fallback",
       result,
     });
+  });
+
+  it("archives the current thread after sending archive-aware payloads", async () => {
+    const result = await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:parent-1",
+      payload: {
+        text: "✅ ACP session closed and thread archived.",
+        channelData: {
+          discord: {
+            archiveCurrentThreadAfterReply: true,
+            archiveFailureText: "⚠️ ACP session closed, but thread archive failed.",
+          },
+        },
+      },
+      accountId: "default",
+      threadId: "thread-1",
+    });
+
+    expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:thread-1",
+      "✅ ACP session closed and thread archived.",
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+    expect(hoisted.sendWebhookMessageDiscordMock).not.toHaveBeenCalled();
+    expect(hoisted.archiveDiscordThreadMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        threadId: "thread-1",
+      }),
+    );
+    expect(hoisted.editMessageDiscordMock).not.toHaveBeenCalled();
+    expect(result).toEqual(DEFAULT_DISCORD_SEND_RESULT);
+  });
+
+  it("edits the reply to partial success text when thread archive fails", async () => {
+    hoisted.archiveDiscordThreadMock.mockRejectedValueOnce(new Error("archive failed"));
+
+    await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:parent-1",
+      payload: {
+        text: "✅ ACP session closed and thread archived.",
+        channelData: {
+          discord: {
+            archiveCurrentThreadAfterReply: true,
+            archiveFailureText: "⚠️ ACP session closed, but thread archive failed.",
+          },
+        },
+      },
+      accountId: "default",
+      threadId: "thread-1",
+    });
+
+    expect(hoisted.editMessageDiscordMock).toHaveBeenCalledWith(
+      "thread-1",
+      "msg-1",
+      { content: "⚠️ ACP session closed, but thread archive failed." },
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
   });
 
   it("routes poll sends to thread target when threadId is provided", async () => {

--- a/src/channels/plugins/outbound/discord.test.ts
+++ b/src/channels/plugins/outbound/discord.test.ts
@@ -264,6 +264,7 @@ describe("discordOutbound", () => {
     const result = await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:parent-1",
+      text: "✅ ACP session closed and thread archived.",
       payload: {
         text: "✅ ACP session closed and thread archived.",
         channelData: {
@@ -297,6 +298,7 @@ describe("discordOutbound", () => {
 
   it("honors sendDiscord overrides for archive-after-reply payloads", async () => {
     const sendDiscordOverride = vi.fn().mockResolvedValue({
+      channel: "discord",
       messageId: "override-msg-1",
       channelId: "override-thread-1",
     });
@@ -304,6 +306,7 @@ describe("discordOutbound", () => {
     const result = await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:parent-1",
+      text: "✅ ACP session closed and thread archived.",
       payload: {
         text: "✅ ACP session closed and thread archived.",
         channelData: {
@@ -347,6 +350,7 @@ describe("discordOutbound", () => {
     await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:parent-1",
+      text: "✅ ACP session closed and thread archived.",
       payload: {
         text: "✅ ACP session closed and thread archived.",
         channelData: {

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -78,11 +78,13 @@ async function sendDiscordArchiveAfterReplyPayload(
   const accountId = ctx.accountId ?? undefined;
   const text = ctx.payload.text ?? "";
 
-  const sent = await sendMessageDiscord(target, text, {
+  const send = ctx.deps?.sendDiscord ?? sendMessageDiscord;
+  const sent = await send(target, text, {
     cfg: ctx.cfg,
     accountId,
     replyTo: ctx.replyToId ?? undefined,
     silent: ctx.silent ?? undefined,
+    verbose: false,
   });
   const delivery = { channel: "discord" as const, ...sent };
 

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -1,13 +1,16 @@
 import type { OpenClawConfig } from "../../../config/config.js";
+import { archiveDiscordThread } from "../../../discord/monitor/thread-bindings.discord-api.js";
 import {
   getThreadBindingManager,
   type ThreadBindingRecord,
 } from "../../../discord/monitor/thread-bindings.js";
 import {
+  editMessageDiscord,
   sendMessageDiscord,
   sendPollDiscord,
   sendWebhookMessageDiscord,
 } from "../../../discord/send.js";
+import { logVerbose } from "../../../globals.js";
 import type { OutboundIdentity } from "../../../infra/outbound/identity.js";
 import { normalizeDiscordOutboundTarget } from "../normalize/discord.js";
 import type { ChannelOutboundAdapter } from "../types.js";
@@ -36,6 +39,82 @@ function resolveDiscordWebhookIdentity(params: {
   const username = (usernameRaw || fallbackUsername || "").slice(0, 80) || undefined;
   const avatarUrl = params.identity?.avatarUrl?.trim() || undefined;
   return { username, avatarUrl };
+}
+
+type DiscordArchiveAfterReplyChannelData = {
+  archiveCurrentThreadAfterReply?: boolean;
+  archiveFailureText?: string;
+};
+
+function resolveArchiveAfterReplyChannelData(
+  channelData: Record<string, unknown> | undefined,
+): DiscordArchiveAfterReplyChannelData | null {
+  const discordData = channelData?.discord;
+  if (!discordData || typeof discordData !== "object") {
+    return null;
+  }
+  const archiveData = discordData as {
+    archiveCurrentThreadAfterReply?: unknown;
+    archiveFailureText?: unknown;
+  };
+  if (archiveData.archiveCurrentThreadAfterReply !== true) {
+    return null;
+  }
+  return {
+    archiveCurrentThreadAfterReply: true,
+    archiveFailureText:
+      typeof archiveData.archiveFailureText === "string"
+        ? archiveData.archiveFailureText.trim() || undefined
+        : undefined,
+  };
+}
+
+async function sendDiscordArchiveAfterReplyPayload(
+  ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0],
+  archiveAfterReply: DiscordArchiveAfterReplyChannelData,
+) {
+  const threadId = String(ctx.threadId).trim();
+  const target = resolveDiscordOutboundTarget({ to: ctx.to, threadId });
+  const accountId = ctx.accountId ?? undefined;
+  const text = ctx.payload.text ?? "";
+
+  const sent = await sendMessageDiscord(target, text, {
+    cfg: ctx.cfg,
+    accountId,
+    replyTo: ctx.replyToId ?? undefined,
+    silent: ctx.silent ?? undefined,
+  });
+  const delivery = { channel: "discord" as const, ...sent };
+
+  try {
+    await archiveDiscordThread({
+      cfg: ctx.cfg,
+      accountId: accountId ?? "default",
+      threadId,
+    });
+  } catch (error) {
+    logVerbose(`discord outbound thread archive failed for ${threadId}: ${String(error)}`);
+    const failureText = archiveAfterReply.archiveFailureText?.trim();
+    if (failureText && sent.messageId) {
+      try {
+        await editMessageDiscord(
+          threadId,
+          sent.messageId,
+          { content: failureText },
+          {
+            cfg: ctx.cfg,
+            accountId,
+          },
+        );
+      } catch (editError) {
+        logVerbose(
+          `discord outbound archive failure message edit failed for ${threadId}:${sent.messageId}: ${String(editError)}`,
+        );
+      }
+    }
+  }
+
+  return delivery;
 }
 
 async function maybeSendDiscordWebhookText(params: {
@@ -84,8 +163,20 @@ export const discordOutbound: ChannelOutboundAdapter = {
   textChunkLimit: 2000,
   pollMaxOptions: 10,
   resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-  sendPayload: async (ctx) =>
-    await sendTextMediaPayload({ channel: "discord", ctx, adapter: discordOutbound }),
+  sendPayload: async (ctx) => {
+    const archiveAfterReply = resolveArchiveAfterReplyChannelData(ctx.payload.channelData);
+    const threadId =
+      ctx.threadId !== undefined && ctx.threadId !== null ? String(ctx.threadId).trim() : "";
+    const hasMedia = Boolean(ctx.payload.mediaUrl) || Boolean(ctx.payload.mediaUrls?.length);
+    if (!archiveAfterReply || !threadId || hasMedia) {
+      return await sendTextMediaPayload({
+        channel: "discord",
+        ctx,
+        adapter: discordOutbound,
+      });
+    }
+    return await sendDiscordArchiveAfterReplyPayload(ctx, archiveAfterReply);
+  },
   sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity, silent }) => {
     if (!silent) {
       const webhookResult = await maybeSendDiscordWebhookText({

--- a/src/discord/monitor/thread-bindings.discord-api.ts
+++ b/src/discord/monitor/thread-bindings.discord-api.ts
@@ -1,4 +1,5 @@
 import { ChannelType, Routes } from "discord-api-types/v10";
+import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { createDiscordRestClient } from "../client.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
@@ -286,4 +287,26 @@ export async function createThreadForBinding(params: {
     );
     return null;
   }
+}
+
+export async function archiveDiscordThread(params: {
+  cfg?: OpenClawConfig;
+  accountId: string;
+  token?: string;
+  threadId: string;
+}): Promise<void> {
+  const threadId = params.threadId.trim();
+  if (!threadId) {
+    throw new Error("Discord thread id is required");
+  }
+  const rest = createDiscordRestClient(
+    {
+      accountId: params.accountId,
+      token: params.token,
+    },
+    params.cfg,
+  ).rest;
+  await rest.patch(Routes.channel(threadId), {
+    body: { archived: true },
+  });
 }

--- a/src/discord/monitor/thread-bindings.lifecycle.test.ts
+++ b/src/discord/monitor/thread-bindings.lifecycle.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 
 const hoisted = vi.hoisted(() => {
   const sendMessageDiscord = vi.fn(async (_to: string, _text: string, _opts?: unknown) => ({}));
@@ -22,7 +23,9 @@ const hoisted = vi.hoisted(() => {
       post: restPost,
     },
   }));
-  const createThreadDiscord = vi.fn(async (..._args: unknown[]) => ({ id: "thread-created" }));
+  const createThreadDiscord = vi.fn(async (..._args: unknown[]) => ({
+    id: "thread-created",
+  }));
   const readAcpSessionEntry = vi.fn();
   return {
     sendMessageDiscord,
@@ -435,7 +438,10 @@ describe("thread binding lifecycle", () => {
       });
 
       vi.setSystemTime(new Date("2026-02-20T00:00:30.000Z"));
-      const touched = manager.touchThread({ threadId: "thread-1", persist: false });
+      const touched = manager.touchThread({
+        threadId: "thread-1",
+        persist: false,
+      });
       expect(touched).not.toBeNull();
 
       const record = manager.getByThreadId("thread-1");
@@ -549,6 +555,43 @@ describe("thread binding lifecycle", () => {
     expect(hoisted.restPost).toHaveBeenCalledTimes(1);
   });
 
+  it("stores spawned ACP thread metadata on child thread bindings", async () => {
+    const manager = createThreadBindingManager({
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 0,
+    });
+
+    const bound = await getSessionBindingService().bind({
+      targetSessionKey: "agent:codex:acp:spawned",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel-parent",
+        parentConversationId: "parent-1",
+      },
+      placement: "child",
+      metadata: {
+        agentId: "codex",
+        boundBy: "user-1",
+        spawnedThread: true,
+        spawnedBy: "acp",
+      },
+    });
+
+    expect(bound.metadata).toMatchObject({
+      spawnedThread: true,
+      spawnedBy: "acp",
+    });
+    expect(manager.getByThreadId("thread-created")).toMatchObject({
+      spawnedThread: true,
+      spawnedBy: "acp",
+    });
+  });
+
   it("creates a new thread when spawning from an already bound thread", async () => {
     const manager = createThreadBindingManager({
       accountId: "default",
@@ -566,7 +609,9 @@ describe("thread binding lifecycle", () => {
       agentId: "main",
     });
     hoisted.createThreadDiscord.mockClear();
-    hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-2" });
+    hoisted.createThreadDiscord.mockResolvedValueOnce({
+      id: "thread-created-2",
+    });
 
     const childBinding = await autoBindSpawnedDiscordSubagent({
       accountId: "default",
@@ -606,7 +651,9 @@ describe("thread binding lifecycle", () => {
       parent_id: "parent-1",
     });
     hoisted.createThreadDiscord.mockClear();
-    hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-lookup" });
+    hoisted.createThreadDiscord.mockResolvedValueOnce({
+      id: "thread-created-lookup",
+    });
 
     const childBinding = await autoBindSpawnedDiscordSubagent({
       accountId: "default",
@@ -644,7 +691,9 @@ describe("thread binding lifecycle", () => {
       parent_id: "parent-runtime",
     });
     hoisted.createThreadDiscord.mockClear();
-    hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-runtime" });
+    hoisted.createThreadDiscord.mockResolvedValueOnce({
+      id: "thread-created-runtime",
+    });
 
     const childBinding = await autoBindSpawnedDiscordSubagent({
       accountId: "runtime",
@@ -683,7 +732,9 @@ describe("thread binding lifecycle", () => {
     });
 
     hoisted.createThreadDiscord.mockClear();
-    hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-token-refresh" });
+    hoisted.createThreadDiscord.mockResolvedValueOnce({
+      id: "thread-created-token-refresh",
+    });
     hoisted.createDiscordRestClient.mockClear();
 
     const bound = await manager.bindTarget({
@@ -901,7 +952,10 @@ describe("thread binding lifecycle", () => {
     const result = await reconcileAcpThreadBindingsOnStartup({
       cfg: {} as OpenClawConfig,
       accountId: "default",
-      healthProbe: async () => ({ status: "stale", reason: "status-timeout-running-stale" }),
+      healthProbe: async () => ({
+        status: "stale",
+        reason: "status-timeout-running-stale",
+      }),
     });
 
     expect(result.checked).toBe(1);
@@ -945,7 +999,10 @@ describe("thread binding lifecycle", () => {
     const result = await reconcileAcpThreadBindingsOnStartup({
       cfg: {} as OpenClawConfig,
       accountId: "default",
-      healthProbe: async () => ({ status: "uncertain", reason: "status-timeout" }),
+      healthProbe: async () => ({
+        status: "uncertain",
+        reason: "status-timeout",
+      }),
     });
 
     expect(result.checked).toBe(1);

--- a/src/discord/monitor/thread-bindings.manager.ts
+++ b/src/discord/monitor/thread-bindings.manager.ts
@@ -55,6 +55,7 @@ import {
   THREAD_BINDINGS_SWEEP_INTERVAL_MS,
   type ThreadBindingManager,
   type ThreadBindingRecord,
+  type ThreadBindingSpawnedBy,
 } from "./thread-bindings.types.js";
 
 function registerManager(manager: ThreadBindingManager) {
@@ -145,6 +146,8 @@ function toSessionBindingRecord(
       webhookId: record.webhookId,
       webhookToken: record.webhookToken,
       boundBy: record.boundBy,
+      spawnedThread: record.spawnedThread === true ? true : undefined,
+      spawnedBy: record.spawnedBy,
       lastActivityAt: record.lastActivityAt,
       idleTimeoutMs: resolveThreadBindingIdleTimeoutMs({
         record,
@@ -316,6 +319,11 @@ export function createThreadBindingManager(
       }
 
       const now = Date.now();
+      const spawnedBy =
+        typeof bindParams.spawnedBy === "string" &&
+        (bindParams.spawnedBy === "acp" || bindParams.spawnedBy === "subagent")
+          ? (bindParams.spawnedBy as ThreadBindingSpawnedBy)
+          : undefined;
       const record: ThreadBindingRecord = {
         accountId,
         channelId,
@@ -327,6 +335,8 @@ export function createThreadBindingManager(
         webhookId: webhookId || undefined,
         webhookToken: webhookToken || undefined,
         boundBy: bindParams.boundBy?.trim() || "system",
+        spawnedThread: bindParams.spawnedThread === true ? true : undefined,
+        spawnedBy,
         boundAt: now,
         lastActivityAt: now,
         idleTimeoutMs,
@@ -379,7 +389,11 @@ export function createThreadBindingManager(
         });
         // Use bot send path for farewell messages so unbound threads don't process
         // webhook echoes as fresh inbound turns when allowBots is enabled.
-        void maybeSendBindingMessage({ record: removed, text: farewell, preferWebhook: false });
+        void maybeSendBindingMessage({
+          record: removed,
+          text: farewell,
+          preferWebhook: false,
+        });
       }
       return removed;
     },
@@ -462,10 +476,16 @@ export function createThreadBindingManager(
             at: number;
           }> = [];
           if (inactivityExpiresAt != null && now >= inactivityExpiresAt) {
-            expirationCandidates.push({ reason: "idle-expired", at: inactivityExpiresAt });
+            expirationCandidates.push({
+              reason: "idle-expired",
+              at: inactivityExpiresAt,
+            });
           }
           if (maxAgeExpiresAt != null && now >= maxAgeExpiresAt) {
-            expirationCandidates.push({ reason: "max-age-expired", at: maxAgeExpiresAt });
+            expirationCandidates.push({
+              reason: "max-age-expired",
+              at: maxAgeExpiresAt,
+            });
           }
           if (expirationCandidates.length > 0) {
             expirationCandidates.sort((a, b) => a.at - b.at);
@@ -554,6 +574,10 @@ export function createThreadBindingManager(
         typeof metadata.boundBy === "string" ? metadata.boundBy.trim() || undefined : undefined;
       const agentId =
         typeof metadata.agentId === "string" ? metadata.agentId.trim() || undefined : undefined;
+      const spawnedThread = metadata.spawnedThread === true;
+      const spawnedByRaw = typeof metadata.spawnedBy === "string" ? metadata.spawnedBy.trim() : "";
+      const spawnedBy: ThreadBindingSpawnedBy | undefined =
+        spawnedByRaw === "acp" || spawnedByRaw === "subagent" ? spawnedByRaw : undefined;
       let threadId: string | undefined;
       let channelId = input.conversation.parentConversationId?.trim() || undefined;
       let createThread = false;
@@ -582,6 +606,8 @@ export function createThreadBindingManager(
         label,
         boundBy,
         introText,
+        spawnedThread,
+        spawnedBy,
       });
       return bound
         ? toSessionBindingRecord(bound, {

--- a/src/discord/monitor/thread-bindings.state.ts
+++ b/src/discord/monitor/thread-bindings.state.ts
@@ -12,6 +12,7 @@ import {
   type PersistedThreadBindingsPayload,
   type ThreadBindingManager,
   type ThreadBindingRecord,
+  type ThreadBindingSpawnedBy,
   type ThreadBindingTargetKind,
 } from "./thread-bindings.types.js";
 
@@ -164,6 +165,10 @@ function normalizePersistedBinding(threadIdKey: string, raw: unknown): ThreadBin
   const webhookToken =
     typeof value.webhookToken === "string" ? value.webhookToken.trim() || undefined : undefined;
   const boundBy = typeof value.boundBy === "string" ? value.boundBy.trim() || "system" : "system";
+  const spawnedThread = value.spawnedThread === true ? true : undefined;
+  const spawnedByRaw = typeof value.spawnedBy === "string" ? value.spawnedBy.trim() : "";
+  const spawnedBy: ThreadBindingSpawnedBy | undefined =
+    spawnedByRaw === "acp" || spawnedByRaw === "subagent" ? spawnedByRaw : undefined;
   const boundAt =
     typeof value.boundAt === "number" && Number.isFinite(value.boundAt)
       ? Math.floor(value.boundAt)
@@ -215,6 +220,8 @@ function normalizePersistedBinding(threadIdKey: string, raw: unknown): ThreadBin
     webhookId,
     webhookToken,
     boundBy,
+    spawnedThread,
+    spawnedBy,
     boundAt,
     lastActivityAt,
     idleTimeoutMs: migratedIdleTimeoutMs,

--- a/src/discord/monitor/thread-bindings.types.ts
+++ b/src/discord/monitor/thread-bindings.types.ts
@@ -1,4 +1,5 @@
 export type ThreadBindingTargetKind = "subagent" | "acp";
+export type ThreadBindingSpawnedBy = "subagent" | "acp";
 
 export type ThreadBindingRecord = {
   accountId: string;
@@ -11,6 +12,10 @@ export type ThreadBindingRecord = {
   webhookId?: string;
   webhookToken?: string;
   boundBy: string;
+  /** True when OpenClaw created this thread while binding the target session. */
+  spawnedThread?: boolean;
+  /** Which OpenClaw subsystem created the spawned thread. */
+  spawnedBy?: ThreadBindingSpawnedBy;
   boundAt: number;
   lastActivityAt: number;
   /** Inactivity timeout window in milliseconds (0 disables inactivity auto-unfocus). */
@@ -56,6 +61,8 @@ export type ThreadBindingManager = {
     introText?: string;
     webhookId?: string;
     webhookToken?: string;
+    spawnedThread?: boolean;
+    spawnedBy?: ThreadBindingSpawnedBy;
   }) => Promise<ThreadBindingRecord | null>;
   unbindThread: (params: {
     threadId: string;


### PR DESCRIPTION
## Summary
When `/acp close` is used inside a Discord thread that OpenClaw itself created for an ACP session, OpenClaw now:
1. closes the ACP session
2. unbinds the thread/session
3. archives the Discord thread

This reduces stale task-thread clutter while preserving history.

## Scope
In scope:
- Discord threads only
- ACP-created threads only
- archive, not delete

Out of scope:
- Telegram topics / Slack reply threads / generic cross-channel conversation closing
- deleting threads
- archiving manually attached or reused existing threads
- idle-time auto-archive

## Behavior
- ACP-created Discord thread: `/acp close` closes, unbinds, then archives the thread
- manually attached/reused thread: existing close behavior remains unchanged
- archive failure: close/unbind still succeed and the reply is downgraded to a partial-success warning
- missing ownership metadata fails safe (no archive)

## Implementation
- Thread binding metadata now records whether the thread was spawned by ACP
- `/acp close` checks that metadata before requesting Discord thread archive
- Discord outbound payload handling supports archive-after-reply so the success message is sent before the thread is archived

## Tests
Added/updated tests for:
- ACP-created Discord thread bindings storing spawned metadata
- `/acp close` archiving ACP-created Discord threads
- `/acp close` not archiving manually attached Discord threads
- fail-safe behavior when ownership metadata is incomplete
- non-Discord behavior unchanged
- Discord outbound archive-after-reply success and partial-failure behavior

Executed:
- `npx vitest run src/auto-reply/reply/commands-acp.test.ts src/channels/plugins/outbound/discord.test.ts src/discord/monitor/thread-bindings.lifecycle.test.ts`
