### PR TITLE
fix(agents): clear stale tool call history between heartbeat cycles

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -4,6 +4,7 @@ import type { SessionState } from "../logging/diagnostic-session-state.js";
 import {
   CRITICAL_THRESHOLD,
   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+  STALE_HISTORY_GAP_MS,
   TOOL_CALL_HISTORY_SIZE,
   WARNING_THRESHOLD,
   detectToolCallLoop,
@@ -589,6 +590,66 @@ describe("tool-loop-detection", () => {
       const stats = getToolCallStats(state);
       expect(stats.mostFrequent?.toolName).toBe("read");
       expect(stats.mostFrequent?.count).toBe(7);
+    });
+  });
+
+  describe("stale history cleanup (regression #40144)", () => {
+    it("clears stale tool call history when time gap exceeds threshold", () => {
+      const state = createState();
+      // Simulate a heartbeat cycle: record some tool calls
+      for (let i = 0; i < 5; i += 1) {
+        recordToolCall(state, "read", { path: "/a.txt" }, `hb1-${i}`);
+      }
+      expect(state.toolCallHistory?.length).toBe(5);
+
+      // Simulate time gap > STALE_HISTORY_GAP_MS by backdating all entries
+      for (const entry of state.toolCallHistory ?? []) {
+        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+      }
+
+      // Next heartbeat cycle records a tool call — stale history should be cleared first
+      recordToolCall(state, "read", { path: "/a.txt" }, "hb2-0");
+
+      // History should only contain the new call, not the stale ones
+      expect(state.toolCallHistory?.length).toBe(1);
+    });
+
+    it("does not clear history when calls are within the time window", () => {
+      const state = createState();
+      for (let i = 0; i < 5; i += 1) {
+        recordToolCall(state, "read", { path: "/a.txt" }, `call-${i}`);
+      }
+      expect(state.toolCallHistory?.length).toBe(5);
+
+      // Record another call immediately — history should not be cleared
+      recordToolCall(state, "read", { path: "/a.txt" }, "call-5");
+      expect(state.toolCallHistory?.length).toBe(6);
+    });
+
+    it("prevents false positive loop detection across separate heartbeat cycles", () => {
+      const state = createState();
+      const config = enabledLoopDetectionConfig;
+
+      // First heartbeat: record identical tool calls (below warning threshold)
+      for (let i = 0; i < WARNING_THRESHOLD - 2; i += 1) {
+        recordToolCall(state, "message", { text: "status" }, `hb1-${i}`, config);
+      }
+      const firstResult = detectToolCallLoop(state, "message", { text: "status" }, config);
+      expect(firstResult.stuck).toBe(false);
+
+      // Backdate all entries to simulate time passing between heartbeat cycles
+      for (const entry of state.toolCallHistory ?? []) {
+        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+      }
+
+      // Second heartbeat: same tool calls should NOT accumulate with first cycle
+      for (let i = 0; i < WARNING_THRESHOLD - 2; i += 1) {
+        recordToolCall(state, "message", { text: "status" }, `hb2-${i}`, config);
+      }
+      const secondResult = detectToolCallLoop(state, "message", { text: "status" }, config);
+      // Without the fix, this would be a false positive warning because
+      // history from both cycles would be combined
+      expect(secondResult.stuck).toBe(false);
     });
   });
 });

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -651,5 +651,32 @@ describe("tool-loop-detection", () => {
       // history from both cycles would be combined
       expect(secondResult.stuck).toBe(false);
     });
+
+    it("detectToolCallLoop ignores stale history even when called before recordToolCall (real call ordering)", () => {
+      const state = createState();
+      const config = enabledLoopDetectionConfig;
+
+      // First heartbeat: drive history to WARNING_THRESHOLD with real ordering
+      // (detect before record, mirroring runBeforeToolCallHook).
+      for (let i = 0; i < WARNING_THRESHOLD; i += 1) {
+        detectToolCallLoop(state, "message", { text: "status" }, config);
+        recordToolCall(state, "message", { text: "status" }, `hb1-${i}`, config);
+      }
+
+      // Backdate all entries to simulate time passing between heartbeat cycles
+      for (const entry of state.toolCallHistory ?? []) {
+        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+      }
+
+      // Second heartbeat: the FIRST detectToolCallLoop call must not see the
+      // stale WARNING_THRESHOLD entries — this is the exact scenario that was
+      // a false positive before the staleness guard was added to the detector.
+      const result = detectToolCallLoop(state, "message", { text: "status" }, config);
+      expect(result.stuck).toBe(false);
+
+      // After detection, record the call to mirror real ordering.
+      recordToolCall(state, "message", { text: "status" }, "hb2-0", config);
+      expect(state.toolCallHistory?.length).toBe(1);
+    });
   });
 });

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -368,6 +368,23 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
 }
 
 /**
+ * Return a non-stale view of the tool call history.  When the most recent
+ * entry is older than STALE_HISTORY_GAP_MS the entire history is considered
+ * stale (e.g. leftover from a previous heartbeat cycle) and an empty array
+ * is returned.  This helper is shared between detection and recording so that
+ * stale entries never influence loop decisions regardless of call ordering.
+ */
+function effectiveHistory(
+  history: NonNullable<SessionState["toolCallHistory"]>,
+): NonNullable<SessionState["toolCallHistory"]> {
+  const lastEntry = history.at(-1);
+  if (lastEntry && Date.now() - lastEntry.timestamp > STALE_HISTORY_GAP_MS) {
+    return [];
+  }
+  return history;
+}
+
+/**
  * Detect if an agent is stuck in a repetitive tool call loop.
  * Checks if the same tool+params combination has been called excessively.
  */
@@ -381,7 +398,9 @@ export function detectToolCallLoop(
   if (!resolvedConfig.enabled) {
     return { stuck: false };
   }
-  const history = state.toolCallHistory ?? [];
+  // Use staleness-aware view so stale history from a previous heartbeat
+  // cycle never causes false-positive warnings (#40144).
+  const history = effectiveHistory(state.toolCallHistory ?? []);
   const currentHash = hashToolCall(toolName, params);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
@@ -514,10 +533,7 @@ export function recordToolCall(
 
   // Clear stale history when there's a significant time gap (e.g. between
   // heartbeat cycles) to prevent false positive loop detection (#40144).
-  const lastEntry = state.toolCallHistory.at(-1);
-  if (lastEntry && Date.now() - lastEntry.timestamp > STALE_HISTORY_GAP_MS) {
-    state.toolCallHistory = [];
-  }
+  state.toolCallHistory = effectiveHistory(state.toolCallHistory);
 
   state.toolCallHistory.push({
     toolName,

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -28,6 +28,8 @@ export const TOOL_CALL_HISTORY_SIZE = 30;
 export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+/** If the most recent tool call is older than this, consider the history stale and reset. */
+export const STALE_HISTORY_GAP_MS = 60_000;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
   enabled: false,
   historySize: TOOL_CALL_HISTORY_SIZE,
@@ -507,6 +509,13 @@ export function recordToolCall(
 ): void {
   const resolvedConfig = resolveLoopDetectionConfig(config);
   if (!state.toolCallHistory) {
+    state.toolCallHistory = [];
+  }
+
+  // Clear stale history when there's a significant time gap (e.g. between
+  // heartbeat cycles) to prevent false positive loop detection (#40144).
+  const lastEntry = state.toolCallHistory.at(-1);
+  if (lastEntry && Date.now() - lastEntry.timestamp > STALE_HISTORY_GAP_MS) {
     state.toolCallHistory = [];
   }
 


### PR DESCRIPTION
## Summary

Fixes #40144

`toolCallHistory` in session state persists across heartbeat cycles. When a heartbeat runs, its tool calls are appended to the history array. The next heartbeat (e.g. 5 minutes later) inherits that history, and if it calls similar tools, the loop detector counts them against the accumulated total — triggering false positive warnings even though each individual cycle is normal.

### Root cause

`recordToolCall()` never checks whether existing history entries are stale. A heartbeat that ran 5 minutes ago is a completely separate logical turn, but the detector treats it as a continuation.

### Fix

Added a stale history check at the start of `recordToolCall()`: if the most recent entry in `toolCallHistory` is older than 60 seconds (`STALE_HISTORY_GAP_MS`), the entire history is cleared before recording the new call. This ensures separate heartbeat cycles are evaluated independently.

### Regression tests

Three new tests in `tool-loop-detection.test.ts`:
1. **Clears stale history** — verifies old entries are purged when time gap exceeds threshold
2. **Preserves recent history** — verifies history is NOT cleared when calls are within the time window
3. **Prevents false positive across heartbeat cycles** — simulates two heartbeat cycles with identical tool calls separated by a time gap, confirms no false warning

## Test plan

- [x] `pnpm vitest run src/agents/tool-loop-detection.test.ts` — 32 pass (3 new)
- [x] `pnpm build` — clean
- [x] `pnpm check` — clean
- [ ] Manual: configure heartbeat with short interval, verify no false positive loop warnings after 2-3 cycles