### PR TITLE
fix: allow negative group IDs in groupAllowFrom validation (#40444)

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -1,15 +1,70 @@
 import { describe, expect, it } from "vitest";
-import { normalizeAllowFrom } from "./bot-access.js";
+import { normalizeAllowFrom, resolveSenderAllowMatch } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
+  it("accepts positive sender IDs and negative group chat IDs", () => {
     const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
 
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["-1001234567890", "-100999", "745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone"],
     });
+  });
+
+  it("accepts negative Telegram group/supergroup chat IDs in groupAllowFrom", () => {
+    const result = normalizeAllowFrom(["-1001234567890", "-987654321"]);
+
+    expect(result).toEqual({
+      entries: ["-1001234567890", "-987654321"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("handles wildcard with negative IDs", () => {
+    const result = normalizeAllowFrom(["*", "-1001234567890", "123"]);
+
+    expect(result).toEqual({
+      entries: ["-1001234567890", "123"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("strips tg: prefix from negative IDs", () => {
+    const result = normalizeAllowFrom(["tg:-1001234567890"]);
+
+    expect(result).toEqual({
+      entries: ["-1001234567890"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+});
+
+describe("resolveSenderAllowMatch", () => {
+  it("matches a negative group chat ID in the allowlist", () => {
+    const allow = normalizeAllowFrom(["-1001234567890"]);
+    const result = resolveSenderAllowMatch({
+      allow,
+      senderId: "-1001234567890",
+    });
+
+    expect(result).toEqual({ allowed: true, matchKey: "-1001234567890", matchSource: "id" });
+  });
+
+  it("rejects a sender not in the allowlist", () => {
+    const allow = normalizeAllowFrom(["-1001234567890"]);
+    const result = resolveSenderAllowMatch({
+      allow,
+      senderId: "-999",
+    });
+
+    expect(result).toEqual({ allowed: false });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,12 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  // Allow optional leading minus for negative Telegram group/supergroup chat IDs
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

- Problem: Telegram group/supergroup chat IDs are always negative integers (e.g., `-1001234567890`). The `normalizeAllowFrom` regex `^\d+$` rejects any value with a leading `-`, causing all `groupAllowFrom` entries for Telegram groups to be flagged as invalid and silently dropped.
- Why it matters: The `groupPolicy: allowlist` + `groupAllowFrom` feature is completely non-functional for Telegram groups — all group messages are blocked with `reason: not-allowed` even when the group's chat ID is explicitly listed.
- What changed: Updated the validation regex in `src/telegram/bot-access.ts` from `^\d+$` to `^-?\d+$` (both the invalid-entry filter and the valid-ID filter) to accept an optional leading minus sign. Updated tests accordingly.
- What did NOT change (scope boundary): The `parseTelegramAllowFromId` in onboarding (`src/channels/plugins/onboarding/telegram.ts`) was intentionally left unchanged — it handles DM `allowFrom` user IDs which are always positive. Other channel `^\d+$` patterns (Discord, Signal, etc.) are unrelated and correct for their ID formats.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #40444

## User-visible / Behavior Changes

- `groupAllowFrom` entries with negative Telegram group/supergroup chat IDs (e.g., `-1001234567890`) are now accepted as valid instead of being silently rejected.
- Gateway logs will no longer emit `warn telegram/bot-access Invalid allowFrom entry:` for negative numeric IDs.
- Users no longer need to set `groupPolicy: none` as a workaround.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Telegram

### Steps

1. Configure `groupPolicy: allowlist` and `groupAllowFrom: ["-1001234567890"]` for a Telegram account.
2. Send a message in the Telegram group with chat ID `-1001234567890`.
3. Observe that the message is now processed instead of being silently dropped.

### Expected

- Group messages from allowed groups are processed.

### Actual (before fix)

- All group messages silently dropped with `reason: not-allowed` and gateway warning about invalid allowFrom entries.

## Evidence

- [x] Failing test/log before + passing after

Before: `normalizeAllowFrom(["-1001234567890"])` returns `{ entries: [], invalidEntries: ["-1001234567890"] }`.
After: `normalizeAllowFrom(["-1001234567890"])` returns `{ entries: ["-1001234567890"], invalidEntries: [] }`.

## Human Verification (required)

- Verified scenarios: Regex validation accepts negative IDs, strips `tg:` prefix from negative IDs, rejects non-numeric strings.
- Edge cases checked: Double minus (`--123`), embedded minus (`12-34`), empty string, pure positive IDs still work.
- What you did **not** verify: Full integration test with a live Telegram bot (requires bot token and real group).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the regex back to `^\d+$` in `src/telegram/bot-access.ts`.
- Files/config to restore: `src/telegram/bot-access.ts`
- Known bad symptoms reviewers should watch for: None expected; the only change is accepting a wider set of valid numeric IDs.

## Risks and Mitigations

None — this strictly widens the set of accepted numeric ID strings from positive-only to positive-or-negative, which matches Telegram's actual ID format.