### PR TITLE
fix(agents): correct sandbox path guidance in system prompt

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -389,7 +389,10 @@ export function buildAgentSystemPrompt(params: {
       : sanitizedWorkspaceDir;
   const workspaceGuidance =
     params.sandboxInfo?.enabled && sanitizedSandboxContainerWorkspace
-      ? `For read/write/edit/apply_patch, file paths resolve against host workspace: ${sanitizedWorkspaceDir}. For bash/exec commands, use sandbox container paths under ${sanitizedSandboxContainerWorkspace} (or relative paths from that workdir), not host paths. Prefer relative paths so both sandboxed exec and file tools work consistently.`
+      ? `Sandboxed environment. Container working directory: ${sanitizedSandboxContainerWorkspace}
+- Always use container paths (${sanitizedSandboxContainerWorkspace}/file.txt) or relative paths (./file.txt)
+- All tools (read/write/edit/bash/exec) accept container paths; path mapping to host is automatic
+- Never use host paths like ${sanitizedWorkspaceDir} - they don't exist in the container`
       : "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.";
   const safetySection = [
     "## Safety",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -526,7 +526,7 @@ export function buildAgentSystemPrompt(params: {
             ? `Sandbox container workdir: ${sanitizeForPromptLiteral(params.sandboxInfo.containerWorkspaceDir)}`
             : "",
           params.sandboxInfo.workspaceDir
-            ? `Sandbox host mount source (file tools bridge only; not valid inside sandbox exec): ${sanitizeForPromptLiteral(params.sandboxInfo.workspaceDir)}`
+            ? `Sandbox host mount source (internal bridge mapping; do not use in tool calls): ${sanitizeForPromptLiteral(params.sandboxInfo.workspaceDir)}`
             : "",
           params.sandboxInfo.workspaceAccess
             ? `Agent workspace access: ${params.sandboxInfo.workspaceAccess}${


### PR DESCRIPTION
## AI-Assisted PR 🤖

- [x] This PR was created with AI assistance (Claude Sonnet 4.6)
- [x] Testing degree: **Code review and static analysis** - verified path mapping implementation in sandbox-paths.ts and fs-bridge.ts aligns with the fix
- [x] I understand what the code does: Updates sandbox system prompt to provide unified container-path guidance instead of contradictory host/container path instructions
- [x] The fix aligns with actual implementation: `mapContainerWorkspacePath()` automatically converts container paths to host paths transparently
- [ ] Session logs: Available upon request


## Summary

- Problem: Sandbox mode system prompt provides contradictory path guidance - tells AI to use host paths for file operations but container paths for bash commands
- Why it matters: AI agents get confused about which path space to use, leading to potential file operation failures in sandboxed environments
- What changed: Updated `workspaceGuidance` in system-prompt.ts to provide unified container-path-only guidance
- What did NOT change (scope boundary): No changes to tool implementations, path mapping logic, or sandbox infrastructure - only prompt clarification

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## User-visible / Behavior Changes

AI agents in sandbox mode will receive clearer, unified path guidance:
- Before: Confusing mixed guidance (host paths for files, container paths for bash)
- After: Clear container-only path guidance with emphasis on relative paths

No breaking changes - existing relative paths continue to work as before.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS/Linux (sandbox mode)
- Runtime/container: Docker sandbox
- Model/provider: Any
- Integration/channel (if any): N/A
- Relevant config (redacted): `sandboxInfo.enabled = true`

### Steps

1. Enable sandbox mode for an agent session
2. Ask AI to perform file operations (read/write/edit)
3. Observe AI's path usage in tool calls

### Expected

AI uses container paths (`/workspace/file.txt`) or relative paths consistently

### Actual

Before fix: AI receives contradictory guidance and may use wrong path types
<img width="749" height="416" alt="image" src="https://github.com/user-attachments/assets/49c911a5-cdd5-4f38-85f9-4b56051160e7" />

After fix: AI receives clear container-path-only guidance

## Evidence

Attached screenshots:
- [x] Git diff showing code changes (before/after comparison)
<img width="1283" height="653" alt="image" src="https://github.com/user-attachments/assets/10b61ae3-56fb-4ec1-b50a-8af33a4fb3c5" />
<img width="1583" height="720" alt="image" src="https://github.com/user-attachments/assets/24a3ac84-d7cc-4127-ab70-ede43fcb60bc" />


- [x] Test results showing all 7069 tests passed
first pr:

<img width="825" height="700" alt="image" src="https://github.com/user-attachments/assets/a36dabec-1f32-48c5-9103-ec5a7db67e83" />
update1:

<img width="587" height="598" alt="image" src="https://github.com/user-attachments/assets/935335ef-530f-4fb5-bd12-8871e525978c" />


Code analysis evidence:
- `mapContainerWorkspacePath()` in sandbox-paths.ts:165-182 automatically converts container→host paths
- `SandboxFsBridge` handles path resolution transparently
- Original prompt incorrectly told AI to use host paths for file operations

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Code review of path mapping implementation in sandbox-paths.ts and fs-bridge.ts
- Edge cases checked: Relative paths, absolute container paths, path mapping logic
- What you did **not** verify: Live sandbox session testing (requires full sandbox environment setup)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit or cherry-pick the inverse
- Files/config to restore: src/agents/system-prompt.ts (lines 392 and 529)
- Known bad symptoms reviewers should watch for: AI using host paths in sandbox mode, file operation failures

## Risks and Mitigations

- Risk: AI may have adapted to the old (incorrect) guidance in some edge cases
  - Mitigation: The new guidance aligns with actual implementation; relative paths work in both old and new guidance
- Risk: Untested in live sandbox environment
  - Mitigation: Low risk as this only changes prompt text, not tool behavior; path mapping logic unchanged


