### PR TITLE
fix(gateway): suggest `openclaw doctor --fix` and .bak recovery in invalid-config startup error

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -312,7 +312,7 @@ export async function startGatewayServer(
         ? formatConfigIssueLines(configSnapshot.issues, "", { normalizeRoot: true }).join("\n")
         : "Unknown validation issue.";
     throw new Error(
-      `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor")}" to repair, then retry.`,
+      `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor --fix")}" to repair, then retry.\nIf the issue persists, restore from the backup: cp ${configSnapshot.path}.bak ${configSnapshot.path}`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Updated the gateway invalid-config startup error message to suggest `openclaw doctor --fix` (instead of just `openclaw doctor`) for direct repair
- Added a hint to restore from `.bak` backup if the fix doesn't resolve the issue

Fixes #40652

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Verify `pnpm check` passes
- [ ] Manually trigger invalid config and confirm the new error message shows `--fix` flag and `.bak` recovery hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)