### PR TITLE
fix: add auto-delivery hints to browser, nodes, and canvas tool descriptions

### DIFF
--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -300,6 +300,7 @@ export function createBrowserTool(opts?: {
       "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
       `target selects browser location (sandbox|host|node). Default: ${targetDefault}.`,
       hostHint,
+      "When this tool returns images (screenshot/snapshot), the media is delivered automatically to the user. Do not re-send it via the message tool.",
     ].join(" "),
     parameters: BrowserToolSchema,
     execute: async (_toolCallId, args) => {

--- a/src/agents/tools/canvas-tool.ts
+++ b/src/agents/tools/canvas-tool.ts
@@ -83,7 +83,7 @@ export function createCanvasTool(options?: { config?: OpenClawConfig }): AnyAgen
     label: "Canvas",
     name: "canvas",
     description:
-      "Control node canvases (present/hide/navigate/eval/snapshot/A2UI). Use snapshot to capture the rendered UI.",
+      "Control node canvases (present/hide/navigate/eval/snapshot/A2UI). Use snapshot to capture the rendered UI. Snapshots are delivered automatically to the user. Do not re-send them via the message tool.",
     parameters: CanvasToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -176,7 +176,7 @@ export function createNodesTool(options?: {
     label: "Nodes",
     name: "nodes",
     description:
-      "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/run/invoke).",
+      "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/run/invoke). When this tool captures images (camera/screen), the media is delivered automatically to the user. Do not re-send it via the message tool.",
     parameters: NodesToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -176,7 +176,7 @@ export function createNodesTool(options?: {
     label: "Nodes",
     name: "nodes",
     description:
-      "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/run/invoke). When this tool captures images (camera/screen), the media is delivered automatically to the user. Do not re-send it via the message tool.",
+      "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/run/invoke). When this tool captures or retrieves images (camera/photos), the media is delivered automatically to the user. Do not re-send it via the message tool.",
     parameters: NodesToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Problem: Tools returning `MEDIA:` paths (browser, nodes, canvas) lack auto-delivery documentation in their descriptions
- Why it matters: The agent incorrectly claims media was not sent, or re-sends it explicitly via the message tool, causing false statements and duplicate media delivery
- What changed: Added auto-delivery hints to browser, nodes, and canvas tool descriptions, following the existing TTS tool pattern
- What did NOT change: Tool execution logic, MEDIA: protocol, auto-attach behavior, TTS tool description

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #40668

- Related #20153
- Related #20735

## User-visible / Behavior Changes

The agent will be aware that screenshots, camera captures, and canvas snapshots are auto-delivered to the user, reducing false "I couldn't send the image" claims and duplicate media sends.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (aarch64)
- Runtime/container: Node 22
- Model/provider: Any
- Integration/channel: All (Slack, Telegram, WhatsApp, etc.)
- Relevant config: Default

### Steps

1. Use `browser` tool with `action=screenshot`
2. Agent receives `MEDIA:/path` in tool result; image is auto-delivered to user
3. Before fix: Agent claims "I couldn't send the image" or re-sends via message tool
4. After fix: Agent knows media was auto-delivered and responds accordingly

### Expected

- Agent acknowledges the screenshot was delivered

### Actual

- Agent claims media was not sent or sends it again

## Evidence

- [x] Trace/log snippets

The TTS tool already has this pattern working (`src/agents/tools/tts-tool.ts`):
```typescript
description: `Convert text to speech. Audio is delivered automatically from the tool result — reply with NO_REPLY ...`
```

Affected tools now include equivalent hints:
- `browser-tool.ts`: "When this tool returns images (screenshot/snapshot), the media is delivered automatically to the user."
- `nodes-tool.ts`: "When this tool captures images (camera/screen), the media is delivered automatically to the user."
- `canvas-tool.ts`: "Snapshots are delivered automatically to the user."

## Human Verification (required)

- Verified scenarios: Tool descriptions match TTS tool pattern; lint/format/typecheck pass; related tests pass (27 tests)
- Edge cases checked: Tools with multiple actions — hint applies only to media-returning actions (screenshot, camera, snapshot)
- What you did **not** verify: Live end-to-end test on a running instance

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the three tool description changes
- Files/config to restore: `src/agents/tools/browser-tool.ts`, `src/agents/tools/nodes-tool.ts`, `src/agents/tools/canvas-tool.ts`
- Known bad symptoms reviewers should watch for: None expected — description-only change

## Risks and Mitigations

None — this is a documentation-only change to tool descriptions. No execution logic is modified.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)