### PR TITLE
fix(doctor): clarify best-effort config wording

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1305,7 +1305,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   let shouldWriteConfig = false;
   const fixHints: string[] = [];
   if (snapshot.exists && !snapshot.valid && snapshot.legacyIssues.length === 0) {
-    note("Config invalid; doctor will run with best-effort config.", "Config");
+    note(
+      "Config invalid; gateway startup remains blocked until this is fixed. Doctor will run diagnostics with best-effort config.",
+      "Config",
+    );
     noteIncludeConfinementWarning(snapshot);
   }
   const warnings = snapshot.warnings ?? [];


### PR DESCRIPTION
## Summary

- Clarifies the doctor "best-effort config" message to explicitly state that gateway startup remains blocked until the config is fixed
- Previous wording ("Config invalid; doctor will run with best-effort config.") could be misread as if the gateway would continue starting up
- New wording: "Config invalid; gateway startup remains blocked until this is fixed. Doctor will run diagnostics with best-effort config."

Fixes #40651

## Test plan

- [ ] Run `openclaw doctor` with an intentionally invalid config file and verify the updated message is displayed
- [ ] Confirm the message clearly communicates that startup is blocked and best-effort applies only to diagnostics