### PR TITLE
fix(subagent): include partial progress when subagent times out

### DIFF
--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -24,11 +24,13 @@ let fallbackRequesterResolution: {
   requesterOrigin?: { channel?: string; to?: string; accountId?: string };
 } | null = null;
 
+let chatHistoryMessages: Array<Record<string, unknown>> = [];
+
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async (request: GatewayCall) => {
     gatewayCalls.push(request);
     if (request.method === "chat.history") {
-      return { messages: [] };
+      return { messages: chatHistoryMessages };
     }
     return {};
   }),
@@ -129,6 +131,7 @@ describe("subagent announce timeout config", () => {
     shouldIgnorePostCompletion = false;
     pendingDescendantRuns = 0;
     fallbackRequesterResolution = null;
+    chatHistoryMessages = [];
   });
 
   it("uses 60s timeout by default for direct announce agent call", async () => {
@@ -248,5 +251,88 @@ describe("subagent announce timeout config", () => {
     expect(directAgentCall?.params?.channel).toBe("discord");
     expect(directAgentCall?.params?.to).toBe("chan-main");
     expect(directAgentCall?.params?.accountId).toBe("acct-main");
+  });
+
+  it("includes partial progress from assistant messages when subagent times out", async () => {
+    // Simulate a session with assistant text from intermediate tool-call rounds.
+    chatHistoryMessages = [
+      { role: "user", content: "do a complex task" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll start by reading the files..." },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call1",
+        content: [{ type: "text", text: "file contents" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Now analyzing the code structure. Found 3 modules." },
+          { type: "toolCall", id: "call2", name: "read", arguments: {} },
+        ],
+      },
+      { role: "toolResult", toolCallId: "call2", content: [{ type: "text", text: "more data" }] },
+      // Last assistant turn was a tool call with no text — simulating mid-work timeout.
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call3", name: "exec", arguments: {} }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-partial", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    expect(directAgentCall).toBeDefined();
+
+    // The announce message should contain the partial progress.
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{
+        result?: string;
+        statusLabel?: string;
+      }>) ?? [];
+    expect(internalEvents[0]?.statusLabel).toBe("timed out");
+    // The result should include the partial assistant text, not just "(no output)".
+    expect(internalEvents[0]?.result).toBeTruthy();
+    expect(internalEvents[0]?.result).not.toBe("(no output)");
+    expect(internalEvents[0]?.result).toContain("tool call");
+  });
+
+  it("reports tool call count in partial progress for timeout with no assistant text", async () => {
+    // Subagent only made tool calls but never produced assistant text.
+    chatHistoryMessages = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "read", arguments: {} }],
+      },
+      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call2", name: "exec", arguments: {} }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-no-text", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    // Should report tool call count even without assistant text.
+    expect(internalEvents[0]?.result).toContain("2 tool call(s)");
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -297,6 +297,87 @@ async function readLatestSubagentOutput(sessionKey: string): Promise<string | un
   return undefined;
 }
 
+/**
+ * Collect partial progress from a timed-out subagent session.
+ *
+ * Unlike `readLatestSubagentOutput` which returns only the last message,
+ * this function scans the full history to build a progress summary from
+ * all assistant messages. This is critical for timeout scenarios where
+ * the subagent may have produced intermediate results across multiple
+ * tool-call rounds but no final summary.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/33827
+ */
+async function readSubagentPartialProgress(sessionKey: string): Promise<string | undefined> {
+  let history: { messages?: Array<unknown> } | undefined;
+  try {
+    history = await callGateway<{ messages?: Array<unknown> }>({
+      method: "chat.history",
+      params: { sessionKey, limit: 100 },
+    });
+  } catch {
+    return undefined;
+  }
+  const messages = Array.isArray(history?.messages) ? history.messages : [];
+  if (messages.length === 0) {
+    return undefined;
+  }
+
+  // Collect all assistant text fragments (partial results from each turn).
+  const assistantFragments: string[] = [];
+  let toolCallCount = 0;
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const role = (msg as { role?: unknown }).role;
+    if (role === "assistant") {
+      const text = extractSubagentOutputText(msg);
+      if (text?.trim()) {
+        assistantFragments.push(text.trim());
+      }
+      // Count tool calls to report progress depth.
+      const content = (msg as { content?: unknown }).content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block &&
+            typeof block === "object" &&
+            ((block as { type?: string }).type === "toolCall" ||
+              (block as { type?: string }).type === "tool_use")
+          ) {
+            toolCallCount += 1;
+          }
+        }
+      }
+    }
+  }
+
+  if (assistantFragments.length === 0 && toolCallCount === 0) {
+    return undefined;
+  }
+
+  const parts: string[] = [];
+  if (toolCallCount > 0) {
+    parts.push(`[Partial progress: ${toolCallCount} tool call(s) executed before timeout]`);
+  }
+  if (assistantFragments.length > 0) {
+    // Return the last (most recent) assistant fragment as the primary result,
+    // but include earlier fragments if the last one is short.
+    const lastFragment = assistantFragments[assistantFragments.length - 1];
+    if (assistantFragments.length > 1 && lastFragment.length < 200) {
+      // Include up to 3 most recent fragments for context.
+      const recentFragments = assistantFragments.slice(-3);
+      parts.push(recentFragments.join("\n\n---\n\n"));
+    } else {
+      parts.push(lastFragment);
+    }
+  }
+
+  return parts.join("\n\n") || undefined;
+}
+
 async function readLatestSubagentOutputWithRetry(params: {
   sessionKey: string;
   maxWaitMs: number;
@@ -1300,6 +1381,18 @@ export async function runSubagentAnnounceFlow(params: {
           sessionKey: params.childSessionKey,
           maxWaitMs: params.timeoutMs,
         });
+      }
+
+      // For timed-out runs, attempt to collect partial progress from the full
+      // session history.  The subagent may have produced useful intermediate
+      // results across multiple tool-call rounds even though no final assistant
+      // reply was generated before the timeout.  Use the richer partial progress
+      // when it contains more context than the simple last-message extraction.
+      if (outcome.status === "timeout") {
+        const partialProgress = await readSubagentPartialProgress(params.childSessionKey);
+        if (partialProgress?.trim() && (!reply?.trim() || partialProgress.length > reply.length)) {
+          reply = partialProgress;
+        }
       }
 
       if (!reply?.trim() && fallbackReply && !fallbackIsSilent) {


### PR DESCRIPTION
## Problem

When a subagent times out, the parent session receives a completion event with `status: "timed out"` and `result: "(no output)"`. This happens even when the subagent has produced useful intermediate results across multiple tool-call rounds before the timeout.

The existing `readLatestSubagentOutput()` only retrieves the last message, which may be a tool call with no text. The parent session has no way to know what work was accomplished or how to continue.

## Solution

Add `readSubagentPartialProgress()` that scans the **full session history** (up to 100 messages) to collect:

1. **All assistant text fragments** from intermediate turns (not just the last one)
2. **Tool call count** — reports how many tool calls were executed before timeout

For timeout outcomes, the richer partial progress is preferred over the simple last-message extraction when it provides more context (longer output).

### Example: Before vs After

**Before:**
```
status: timed out
result: (no output)
```

**After:**
```
status: timed out
result: [Partial progress: 12 tool call(s) executed before timeout]

I'll start by reading the files...

---

Now analyzing the code structure. Found 3 modules.
```

## Changes

- `src/agents/subagent-announce.ts`: Added `readSubagentPartialProgress()` and integrated it into the announce flow for timeout outcomes
- `src/agents/subagent-announce.timeout.test.ts`: Added 2 test cases covering partial progress with assistant text and tool-call-only scenarios

## Testing

All 9 tests pass in `subagent-announce.timeout.test.ts`.

Refs #33827