### PR TITLE
fix: filter delivery-mirror audit entries from LLM context, webchat, and API — eliminates escalating duplicate messages

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -268,4 +268,64 @@ describe("installToolResultContextGuard", () => {
     expect(oldResult.details).toBeUndefined();
     expect(newResult.details).toBeUndefined();
   });
+
+  it("strips delivery-mirror messages from context", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 100_000,
+    });
+
+    const deliveryMirror = castAgentMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Hello from mirror" }],
+      provider: "openclaw",
+      model: "delivery-mirror",
+      timestamp: Date.now(),
+    });
+
+    const realAssistant = castAgentMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Hello from LLM" }],
+      provider: "anthropic",
+      model: "claude-3",
+      timestamp: Date.now(),
+    });
+
+    const contextForNextCall = [makeUser("hi"), realAssistant, deliveryMirror, makeUser("thanks")];
+
+    const result = (await agent.transformContext?.(
+      contextForNextCall,
+      new AbortController().signal,
+    )) as AgentMessage[];
+
+    expect(result).toHaveLength(3);
+    expect(result.some((m) => "model" in m && m.model === "delivery-mirror")).toBe(false);
+    expect(result.some((m) => "model" in m && m.model === "claude-3")).toBe(true);
+  });
+
+  it("preserves array identity when no delivery-mirror messages present", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 100_000,
+    });
+
+    const contextForNextCall = [
+      makeUser("hi"),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+        provider: "anthropic",
+        model: "claude-3",
+        timestamp: Date.now(),
+      }),
+    ];
+
+    const result = await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+
+    expect(result).toBe(contextForNextCall);
+  });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
 import {
   CHARS_PER_TOKEN_ESTIMATE,
   TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
@@ -208,13 +209,23 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const contextMessages = Array.isArray(transformed) ? transformed : messages;
+
+    // Strip delivery-mirror entries before they reach the LLM.
+    // These are internal cross-channel delivery audit records (provider=openclaw,
+    // model=delivery-mirror) that should never appear in the model context.
+    // Pre-check avoids allocating a new array when none exist, preserving
+    // reference equality for the common case.
+    const filtered = contextMessages.some(isDeliveryMirrorMessage)
+      ? contextMessages.filter((msg) => !isDeliveryMirrorMessage(msg))
+      : contextMessages;
+
     enforceToolResultContextBudgetInPlace({
-      messages: contextMessages,
+      messages: filtered,
       contextBudgetChars,
       maxSingleToolResultChars,
     });
 
-    return contextMessages;
+    return filtered;
   }) as GuardableTransformContext;
 
   return () => {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -19,7 +19,10 @@ import {
   validateSessionId,
 } from "./paths.js";
 import { resolveSessionResetPolicy } from "./reset.js";
-import { appendAssistantMessageToSessionTranscript } from "./transcript.js";
+import {
+  appendAssistantMessageToSessionTranscript,
+  isDeliveryMirrorMessage,
+} from "./transcript.js";
 import type { SessionEntry } from "./types.js";
 
 function useTempSessionsFixture(prefix: string) {
@@ -380,5 +383,54 @@ describe("resolveAndPersistSessionFile", () => {
     expect(result.sessionEntry.sessionId).toBe(sessionId);
     const saved = loadSessionStore(fixture.storePath(), { skipCache: true });
     expect(saved[sessionKey]?.sessionFile).toBe(fallbackSessionFile);
+  });
+});
+
+describe("isDeliveryMirrorMessage", () => {
+  it("returns true for delivery-mirror messages", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for regular assistant messages", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-3",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for user messages", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null/undefined/non-object", () => {
+    expect(isDeliveryMirrorMessage(null)).toBe(false);
+    expect(isDeliveryMirrorMessage(undefined)).toBe(false);
+    expect(isDeliveryMirrorMessage("string")).toBe(false);
+  });
+
+  it("returns false when provider matches but model does not", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "gpt-4",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -433,4 +433,14 @@ describe("isDeliveryMirrorMessage", () => {
       }),
     ).toBe(false);
   });
+
+  it("returns false when model matches but provider does not", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "anthropic",
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -145,12 +145,7 @@ export function isDeliveryMirrorMessage(msg: unknown): boolean {
   if (!("role" in msg) || !("provider" in msg) || !("model" in msg)) {
     return false;
   }
-  return (
-    typeof msg.role === "string" &&
-    msg.role.toLowerCase() === "assistant" &&
-    msg.provider === "openclaw" &&
-    msg.model === "delivery-mirror"
-  );
+  return msg.role === "assistant" && msg.provider === "openclaw" && msg.model === "delivery-mirror";
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -130,6 +130,29 @@ export async function resolveSessionTranscriptFile(params: {
   };
 }
 
+/**
+ * Returns true when a transcript message is an internal delivery-mirror entry
+ * written by {@link appendAssistantMessageToSessionTranscript} for cross-channel
+ * delivery auditing.  These must be excluded from LLM context and API responses
+ * to prevent duplicate-message artifacts.
+ *
+ * Refs: #33263, #38061, #39469
+ */
+export function isDeliveryMirrorMessage(msg: unknown): boolean {
+  if (!msg || typeof msg !== "object") {
+    return false;
+  }
+  if (!("role" in msg) || !("provider" in msg) || !("model" in msg)) {
+    return false;
+  }
+  return (
+    typeof msg.role === "string" &&
+    msg.role.toLowerCase() === "assistant" &&
+    msg.provider === "openclaw" &&
+    msg.model === "delivery-mirror"
+  );
+}
+
 export async function appendAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -10,6 +10,7 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
+import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -794,10 +795,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
+    const visibleMessages = bounded.messages.filter((msg) => !isDeliveryMirrorMessage(msg));
     respond(true, {
       sessionKey,
       sessionId,
-      messages: bounded.messages,
+      messages: visibleMessages,
       thinkingLevel,
       verboseLevel,
     });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -760,11 +760,12 @@ export const chatHandlers: GatewayRequestHandlers = {
     const sessionId = entry?.sessionId;
     const rawMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+    const visible = rawMessages.filter((msg) => !isDeliveryMirrorMessage(msg));
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
-    const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+    const sliced = visible.length > max ? visible.slice(-max) : visible;
     const sanitized = stripEnvelopeFromMessages(sliced);
     const normalized = sanitizeChatHistoryMessages(sanitized);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
@@ -795,11 +796,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
-    const visibleMessages = bounded.messages.filter((msg) => !isDeliveryMirrorMessage(msg));
     respond(true, {
       sessionKey,
       sessionId,
-      messages: visibleMessages,
+      messages: bounded.messages,
       thinkingLevel,
       verboseLevel,
     });

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -15,6 +15,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
 import { unbindThreadBindingsBySessionKey } from "../../discord/monitor/thread-bindings.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
@@ -646,7 +647,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const allMessages = readSessionMessages(entry.sessionId, storePath, entry.sessionFile);
-    const messages = limit < allMessages.length ? allMessages.slice(-limit) : allMessages;
+    const filtered = allMessages.filter((msg) => !isDeliveryMirrorMessage(msg));
+    const messages = limit < filtered.length ? filtered.slice(-limit) : filtered;
     respond(true, { messages }, undefined);
   },
   "sessions.compact": async ({ params, respond }) => {


### PR DESCRIPTION
## Summary

`delivery-mirror` entries (`provider=openclaw`, `model=delivery-mirror`) are internal cross-channel delivery audit records created by `appendAssistantMessageToSessionTranscript()`. Because they use `appendMessage()` which produces `type:"message"` entries, they are indistinguishable from real LLM responses and leak into three consumer paths, causing:

- **LLM context pollution**: `buildSessionContext()` includes duplicates in the prompt (escalating 2x to 6-8x over a session)
- **Webchat UI duplication**: `chat.history` returns raw audit entries rendered as assistant messages
- **API response noise**: `sessions.get` exposes internal records to API consumers

Tracked in #33263, #38061, #39469. Related: #30316, #39795.

## Approach

**Consumer-side filtering at all three read paths**, leaving the write path unchanged:

| Consumer | File | What changed |
|---|---|---|
| LLM context | `tool-result-context-guard.ts` | Filter in `transformContext` pipeline |
| Webchat UI | `chat.ts` | Filter in `chat.history` handler |
| API | `sessions.ts` | Filter in `sessions.get` handler |
| Predicate | `transcript.ts` | New `isDeliveryMirrorMessage()` co-located with write path |

### Why not fix the write path?

`appendCustomEntry()` (creates `type:"custom_entry"`, invisible to consumers) was investigated, but `SessionManager._persist()` defers disk writes until at least one `type:"message"` + `role:"assistant"` entry exists, making it unreliable for standalone audit entries. Additionally, existing JSONL session files already contain old-format entries, so consumer filters are needed regardless.

### Array identity preservation

The `transformContext` filter uses a `some()` pre-check and only allocates a new array when delivery-mirror entries actually exist, preserving reference equality for the common case (verified by test).

### Type safety

All type narrowing uses TypeScript's `in` operator for property checks — zero type assertions (`as`) in production code.

## Tests

- **7 new tests** across 2 files:
  - `sessions.test.ts`: 5 unit tests for `isDeliveryMirrorMessage` predicate (positive match, negative role, negative provider, negative model, non-object input)
  - `tool-result-context-guard.test.ts`: 2 integration tests (strips delivery-mirror from context; preserves array identity when none present)

## Pre-existing test failures

4 gateway tests fail on clean `main` (verified by stashing changes and running on base commit):
- `server-channels`
- `talk-config` x2
- `agents-mutate`

These are **not caused by this PR**.