### PR TITLE
fix(web-search): throw on unresolved SecretRef apiKey instead of silently dropping

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -23,6 +23,7 @@ const {
   resolveKimiBaseUrl,
   extractKimiCitations,
   resolveBraveMode,
+  normalizeApiKey,
 } = __testing;
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
@@ -391,5 +392,26 @@ describe("resolveBraveMode", () => {
 
   it("falls back to 'web' for unrecognized mode values", () => {
     expect(resolveBraveMode({ mode: "invalid" })).toBe("web");
+  });
+});
+
+describe("normalizeApiKey SecretRef handling", () => {
+  it("normalizes plain string API keys", () => {
+    expect(normalizeApiKey("sk-test-123")).toBe("sk-test-123");
+  });
+
+  it("returns empty string for undefined/null", () => {
+    expect(normalizeApiKey(undefined)).toBe("");
+    expect(normalizeApiKey(null)).toBe("");
+  });
+
+  it("throws on unresolved SecretRef objects instead of silently dropping them", () => {
+    const secretRef = { source: "env", provider: "default", id: "PERPLEXITY_API_KEY" };
+    expect(() => normalizeApiKey(secretRef)).toThrow(/unresolved SecretRef/i);
+  });
+
+  it("includes SecretRef details in error message", () => {
+    const secretRef = { source: "file", provider: "vault", id: "grok-key" };
+    expect(() => normalizeApiKey(secretRef)).toThrow(/file:vault:grok-key/);
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { isSecretRef, normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import { logVerbose } from "../../globals.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
@@ -648,6 +648,12 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
 }
 
 function normalizeApiKey(key: unknown): string {
+  if (isSecretRef(key)) {
+    throw new Error(
+      `web_search provider apiKey: unresolved SecretRef "${key.source}:${key.provider}:${key.id}". ` +
+        `Resolve the secret reference against an active gateway runtime or provide a plain string API key.`,
+    );
+  }
   return normalizeSecretInput(key);
 }
 
@@ -2122,4 +2128,5 @@ export const __testing = {
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
+  normalizeApiKey,
 } as const;


### PR DESCRIPTION
## Summary
- `normalizeApiKey()` in web-search.ts called `normalizeSecretInput()` which returns `""` for non-string values, causing SecretRef objects configured as `apiKey` to be silently dropped
- Now detects `SecretRef` objects via `isSecretRef()` and throws a clear error with the ref details, so users know their secret reference was not resolved
- Affects all 4 web search providers: Perplexity, Grok, Kimi, and Gemini

## Change Type
Bug fix — prevents silent misconfiguration when apiKey is a SecretRef

## Scope
`src/agents/tools/web-search.ts` — single function change + test export
`src/agents/tools/web-search.test.ts` — 4 new tests for SecretRef handling

## Security Impact
None — fails fast instead of proceeding without authentication

Closes #40510

🤖 Generated with [Claude Code](https://claude.com/claude-code)