### PR TITLE
fix(imessage): strip reply directive tags instead of rendering as literal text

### DIFF
--- a/src/imessage/send.test.ts
+++ b/src/imessage/send.test.ts
@@ -90,36 +90,30 @@ describe("sendMessageIMessage", () => {
     expect(result.messageId).toBe("123");
   });
 
-  it("prepends reply tag as the first token when replyToId is provided", async () => {
+  it("strips reply tags instead of embedding them as literal text", async () => {
     await sendWithDefaults("chat_id:123", "  hello\nworld", {
       replyToId: "abc-123",
     });
     const params = getSentParams();
-    expect(params.text).toBe("[[reply_to:abc-123]] hello\nworld");
+    expect(params.text).toBe("hello\nworld");
   });
 
-  it("rewrites an existing leading reply tag to keep the requested id first", async () => {
-    await sendWithDefaults("chat_id:123", " [[reply_to:old-id]] hello", {
-      replyToId: "new-id",
-    });
+  it("strips existing reply_to tags from AI output", async () => {
+    await sendWithDefaults("chat_id:123", "hello [[reply_to:old-id]] world");
     const params = getSentParams();
-    expect(params.text).toBe("[[reply_to:new-id]] hello");
+    expect(params.text).toBe("hello  world");
   });
 
-  it("sanitizes replyToId before writing the leading reply tag", async () => {
-    await sendWithDefaults("chat_id:123", "hello", {
-      replyToId: " [ab]\n\u0000c\td ] ",
-    });
-    const params = getSentParams();
-    expect(params.text).toBe("[[reply_to:abcd]] hello");
-  });
-
-  it("skips reply tagging when sanitized replyToId is empty", async () => {
-    await sendWithDefaults("chat_id:123", "hello", {
-      replyToId: "[]\u0000\n\r",
-    });
+  it("strips reply_to_current tags from AI output", async () => {
+    await sendWithDefaults("chat_id:123", "[[reply_to_current]] hello");
     const params = getSentParams();
     expect(params.text).toBe("hello");
+  });
+
+  it("preserves text content when no reply tags are present", async () => {
+    await sendWithDefaults("chat_id:123", "hello world");
+    const params = getSentParams();
+    expect(params.text).toBe("hello world");
   });
 
   it("normalizes string message_id values from rpc result", async () => {

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -34,50 +34,7 @@ export type IMessageSendResult = {
   messageId: string;
 };
 
-const LEADING_REPLY_TAG_RE = /^\s*\[\[\s*reply_to\s*:\s*([^\]\n]+)\s*\]\]\s*/i;
-const MAX_REPLY_TO_ID_LENGTH = 256;
-
-function stripUnsafeReplyTagChars(value: string): string {
-  let next = "";
-  for (const ch of value) {
-    const code = ch.charCodeAt(0);
-    if ((code >= 0 && code <= 31) || code === 127 || ch === "[" || ch === "]") {
-      continue;
-    }
-    next += ch;
-  }
-  return next;
-}
-
-function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
-  const trimmed = rawReplyToId?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const sanitized = stripUnsafeReplyTagChars(trimmed).trim();
-  if (!sanitized) {
-    return undefined;
-  }
-  if (sanitized.length > MAX_REPLY_TO_ID_LENGTH) {
-    return sanitized.slice(0, MAX_REPLY_TO_ID_LENGTH);
-  }
-  return sanitized;
-}
-
-function prependReplyTagIfNeeded(message: string, replyToId?: string): string {
-  const resolvedReplyToId = sanitizeReplyToId(replyToId);
-  if (!resolvedReplyToId) {
-    return message;
-  }
-  const replyTag = `[[reply_to:${resolvedReplyToId}]]`;
-  const existingLeadingTag = message.match(LEADING_REPLY_TAG_RE);
-  if (existingLeadingTag) {
-    const remainder = message.slice(existingLeadingTag[0].length).trimStart();
-    return remainder ? `${replyTag} ${remainder}` : replyTag;
-  }
-  const trimmedMessage = message.trimStart();
-  return trimmedMessage ? `${replyTag} ${trimmedMessage}` : replyTag;
-}
+const ALL_REPLY_TAGS_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]*)\s*\]\]/gi;
 
 function resolveMessageId(result: Record<string, unknown> | null | undefined): string | null {
   if (!result) {
@@ -147,7 +104,9 @@ export async function sendMessageIMessage(
     });
     message = convertMarkdownTables(message, tableMode);
   }
-  message = prependReplyTagIfNeeded(message, opts.replyToId);
+  // iMessage has no native reply-threading RPC parameter, so strip any
+  // reply directive tags that would otherwise render as literal text.
+  message = message.replace(ALL_REPLY_TAGS_RE, "").trim();
 
   const params: Record<string, unknown> = {
     text: message,


### PR DESCRIPTION
## Summary
- `sendMessageIMessage` previously called `prependReplyTagIfNeeded` which embedded `[[reply_to:ID]]` tags in the message text
- Since iMessage RPC has no native reply-threading parameter, these tags were sent as literal visible text to recipients
- Now strips all `[[reply_to_current]]` and `[[reply_to:ID]]` tags from outgoing text before sending
- Removed unused `prependReplyTagIfNeeded`, `sanitizeReplyToId`, and `stripUnsafeReplyTagChars` functions

## Change Type
Bug fix — prevents reply directive tags from appearing as literal text in iMessage

## Scope
`src/imessage/send.ts` — replace prepend-reply-tag logic with strip-reply-tag
`src/imessage/send.test.ts` — updated 4 tests to verify stripping behavior

## Security Impact
None

Closes #40302

🤖 Generated with [Claude Code](https://claude.com/claude-code)