### PR TITLE
fix(subagent): include partial progress when subagent times out

### DIFF
--- a/src/agents/subagent-announce.capture-completion-reply.test.ts
+++ b/src/agents/subagent-announce.capture-completion-reply.test.ts
@@ -1,8 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const readLatestAssistantReplyMock = vi.fn<(sessionKey: string) => Promise<string | undefined>>(
-  async (_sessionKey: string) => undefined,
-);
 const chatHistoryMock = vi.fn<(sessionKey: string) => Promise<{ messages?: Array<unknown> }>>(
   async (_sessionKey: string) => ({ messages: [] }),
 );
@@ -15,10 +12,6 @@ vi.mock("../gateway/call.js", () => ({
     }
     return {};
   }),
-}));
-
-vi.mock("./tools/agent-step.js", () => ({
-  readLatestAssistantReply: readLatestAssistantReplyMock,
 }));
 
 describe("captureSubagentCompletionReply", () => {
@@ -40,23 +33,27 @@ describe("captureSubagentCompletionReply", () => {
   });
 
   beforeEach(() => {
-    readLatestAssistantReplyMock.mockReset().mockResolvedValue(undefined);
     chatHistoryMock.mockReset().mockResolvedValue({ messages: [] });
   });
 
-  it("returns immediate assistant output without polling", async () => {
-    readLatestAssistantReplyMock.mockResolvedValueOnce("Immediate assistant completion");
+  it("returns immediate assistant output from history without polling", async () => {
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Immediate assistant completion" }],
+        },
+      ],
+    });
 
     const result = await captureSubagentCompletionReply("agent:main:subagent:child");
 
     expect(result).toBe("Immediate assistant completion");
-    expect(readLatestAssistantReplyMock).toHaveBeenCalledTimes(1);
-    expect(chatHistoryMock).not.toHaveBeenCalled();
+    expect(chatHistoryMock).toHaveBeenCalledTimes(1);
   });
 
   it("polls briefly and returns late tool output once available", async () => {
     vi.useFakeTimers();
-    readLatestAssistantReplyMock.mockResolvedValue(undefined);
     chatHistoryMock.mockResolvedValueOnce({ messages: [] }).mockResolvedValueOnce({
       messages: [
         {
@@ -82,7 +79,6 @@ describe("captureSubagentCompletionReply", () => {
 
   it("returns undefined when no completion output arrives before retry window closes", async () => {
     vi.useFakeTimers();
-    readLatestAssistantReplyMock.mockResolvedValue(undefined);
     chatHistoryMock.mockResolvedValue({ messages: [] });
 
     const pending = captureSubagentCompletionReply("agent:main:subagent:child");
@@ -92,5 +88,27 @@ describe("captureSubagentCompletionReply", () => {
     expect(result).toBeUndefined();
     expect(chatHistoryMock).toHaveBeenCalled();
     vi.useRealTimers();
+  });
+
+  it("returns partial assistant progress when the latest assistant turn is tool-only", async () => {
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Mapped the modules." },
+            { type: "toolCall", id: "call-1", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call-2", name: "exec", arguments: {} }],
+        },
+      ],
+    });
+
+    const result = await captureSubagentCompletionReply("agent:main:subagent:child");
+
+    expect(result).toBe("Mapped the modules.");
   });
 });

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -8,6 +8,12 @@ type GatewayCall = {
 };
 
 const gatewayCalls: GatewayCall[] = [];
+let callGatewayImpl: (request: GatewayCall) => Promise<unknown> = async (request) => {
+  if (request.method === "chat.history") {
+    return { messages: [] };
+  }
+  return {};
+};
 let sessionStore: Record<string, Record<string, unknown>> = {};
 let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
   session: {
@@ -23,7 +29,6 @@ let fallbackRequesterResolution: {
   requesterSessionKey: string;
   requesterOrigin?: { channel?: string; to?: string; accountId?: string };
 } | null = null;
-
 let chatHistoryMessages: Array<Record<string, unknown>> = [];
 
 vi.mock("../gateway/call.js", () => ({
@@ -32,7 +37,7 @@ vi.mock("../gateway/call.js", () => ({
     if (request.method === "chat.history") {
       return { messages: chatHistoryMessages };
     }
-    return {};
+    return await callGatewayImpl(request);
   }),
 }));
 
@@ -119,9 +124,31 @@ function findGatewayCall(predicate: (call: GatewayCall) => boolean): GatewayCall
   return gatewayCalls.find(predicate);
 }
 
+function findFinalDirectAgentCall(): GatewayCall | undefined {
+  return findGatewayCall((call) => call.method === "agent" && call.expectFinal === true);
+}
+
+function setupParentSessionFallback(parentSessionKey: string): void {
+  requesterDepthResolver = (sessionKey?: string) =>
+    sessionKey === parentSessionKey ? 1 : sessionKey?.includes(":subagent:") ? 1 : 0;
+  subagentSessionRunActive = false;
+  shouldIgnorePostCompletion = false;
+  fallbackRequesterResolution = {
+    requesterSessionKey: "agent:main:main",
+    requesterOrigin: { channel: "discord", to: "chan-main", accountId: "acct-main" },
+  };
+}
+
 describe("subagent announce timeout config", () => {
   beforeEach(() => {
     gatewayCalls.length = 0;
+    chatHistoryMessages = [];
+    callGatewayImpl = async (request) => {
+      if (request.method === "chat.history") {
+        return { messages: [] };
+      }
+      return {};
+    };
     sessionStore = {};
     configOverride = {
       session: defaultSessionConfig,
@@ -131,16 +158,15 @@ describe("subagent announce timeout config", () => {
     shouldIgnorePostCompletion = false;
     pendingDescendantRuns = 0;
     fallbackRequesterResolution = null;
-    chatHistoryMessages = [];
   });
 
-  it("uses 60s timeout by default for direct announce agent call", async () => {
+  it("uses 90s timeout by default for direct announce agent call", async () => {
     await runAnnounceFlowForTest("run-default-timeout");
 
     const directAgentCall = findGatewayCall(
       (call) => call.method === "agent" && call.expectFinal === true,
     );
-    expect(directAgentCall?.timeoutMs).toBe(60_000);
+    expect(directAgentCall?.timeoutMs).toBe(90_000);
   });
 
   it("honors configured announce timeout for direct announce agent call", async () => {
@@ -167,6 +193,35 @@ describe("subagent announce timeout config", () => {
       (call) => call.method === "agent" && call.expectFinal === true,
     );
     expect(completionDirectAgentCall?.timeoutMs).toBe(90_000);
+  });
+
+  it("does not retry gateway timeout for externally delivered completion announces", async () => {
+    vi.useFakeTimers();
+    try {
+      callGatewayImpl = async (request) => {
+        if (request.method === "chat.history") {
+          return { messages: [] };
+        }
+        throw new Error("gateway timeout after 90000ms");
+      };
+
+      await expect(
+        runAnnounceFlowForTest("run-completion-timeout-no-retry", {
+          requesterOrigin: {
+            channel: "telegram",
+            to: "12345",
+          },
+          expectsCompletionMessage: true,
+        }),
+      ).resolves.toBe(false);
+
+      const directAgentCalls = gatewayCalls.filter(
+        (call) => call.method === "agent" && call.expectFinal === true,
+      );
+      expect(directAgentCalls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("regression, skips parent announce while descendants are still pending", async () => {
@@ -209,9 +264,7 @@ describe("subagent announce timeout config", () => {
       requesterOrigin: { channel: "discord", to: "channel:cron-results", accountId: "acct-1" },
     });
 
-    const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
-    );
+    const directAgentCall = findFinalDirectAgentCall();
     expect(directAgentCall?.params?.sessionKey).toBe(cronSessionKey);
     expect(directAgentCall?.params?.deliver).toBe(false);
     expect(directAgentCall?.params?.channel).toBeUndefined();
@@ -221,15 +274,7 @@ describe("subagent announce timeout config", () => {
 
   it("regression, routes child announce to parent session instead of grandparent when parent session still exists", async () => {
     const parentSessionKey = "agent:main:subagent:parent";
-    requesterDepthResolver = (sessionKey?: string) =>
-      sessionKey === parentSessionKey ? 1 : sessionKey?.includes(":subagent:") ? 1 : 0;
-    subagentSessionRunActive = false;
-    shouldIgnorePostCompletion = false;
-    fallbackRequesterResolution = {
-      requesterSessionKey: "agent:main:main",
-      requesterOrigin: { channel: "discord", to: "chan-main", accountId: "acct-main" },
-    };
-    // No sessionId on purpose: existence in store should still count as alive.
+    setupParentSessionFallback(parentSessionKey);
     sessionStore[parentSessionKey] = { updatedAt: Date.now() };
 
     await runAnnounceFlowForTest("run-parent-route", {
@@ -238,23 +283,14 @@ describe("subagent announce timeout config", () => {
       childSessionKey: `${parentSessionKey}:subagent:child`,
     });
 
-    const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
-    );
+    const directAgentCall = findFinalDirectAgentCall();
     expect(directAgentCall?.params?.sessionKey).toBe(parentSessionKey);
     expect(directAgentCall?.params?.deliver).toBe(false);
   });
 
   it("regression, falls back to grandparent only when parent subagent session is missing", async () => {
     const parentSessionKey = "agent:main:subagent:parent-missing";
-    requesterDepthResolver = (sessionKey?: string) =>
-      sessionKey === parentSessionKey ? 1 : sessionKey?.includes(":subagent:") ? 1 : 0;
-    subagentSessionRunActive = false;
-    shouldIgnorePostCompletion = false;
-    fallbackRequesterResolution = {
-      requesterSessionKey: "agent:main:main",
-      requesterOrigin: { channel: "discord", to: "chan-main", accountId: "acct-main" },
-    };
+    setupParentSessionFallback(parentSessionKey);
 
     await runAnnounceFlowForTest("run-parent-fallback", {
       requesterSessionKey: parentSessionKey,
@@ -262,9 +298,7 @@ describe("subagent announce timeout config", () => {
       childSessionKey: `${parentSessionKey}:subagent:child`,
     });
 
-    const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
-    );
+    const directAgentCall = findFinalDirectAgentCall();
     expect(directAgentCall?.params?.sessionKey).toBe("agent:main:main");
     expect(directAgentCall?.params?.deliver).toBe(true);
     expect(directAgentCall?.params?.channel).toBe("discord");
@@ -272,166 +306,85 @@ describe("subagent announce timeout config", () => {
     expect(directAgentCall?.params?.accountId).toBe("acct-main");
   });
 
-  it("includes partial progress from assistant messages when subagent times out", async () => {
-    // Simulate a session with assistant text from intermediate tool-call rounds.
+  it("uses partial progress on timeout when the child only made tool calls", async () => {
     chatHistoryMessages = [
       { role: "user", content: "do a complex task" },
       {
         role: "assistant",
-        content: [
-          { type: "text", text: "I'll start by reading the files..." },
-          { type: "toolCall", id: "call1", name: "read", arguments: {} },
-        ],
+        content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
       },
+      { role: "toolResult", toolCallId: "call-1", content: [{ type: "text", text: "data" }] },
       {
-        role: "toolResult",
-        toolCallId: "call1",
-        content: [{ type: "text", text: "file contents" }],
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-2", name: "exec", arguments: {} }],
       },
       {
         role: "assistant",
-        content: [
-          { type: "text", text: "Now analyzing the code structure. Found 3 modules." },
-          { type: "toolCall", id: "call2", name: "read", arguments: {} },
-        ],
-      },
-      { role: "toolResult", toolCallId: "call2", content: [{ type: "text", text: "more data" }] },
-      // Last assistant turn was a tool call with no text — simulating mid-work timeout.
-      {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call3", name: "exec", arguments: {} }],
+        content: [{ type: "toolCall", id: "call-3", name: "search", arguments: {} }],
       },
     ];
 
-    await runAnnounceFlowForTest("run-timeout-partial", {
+    await runAnnounceFlowForTest("run-timeout-partial-progress", {
       outcome: { status: "timeout" },
       roundOneReply: undefined,
     });
 
-    const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
-    );
-    expect(directAgentCall).toBeDefined();
-
-    // The announce message should contain the partial progress.
-    const internalEvents =
-      (directAgentCall?.params?.internalEvents as Array<{
-        result?: string;
-        statusLabel?: string;
-      }>) ?? [];
-    expect(internalEvents[0]?.statusLabel).toBe("timed out");
-    // The result should include the partial assistant text, not just "(no output)".
-    expect(internalEvents[0]?.result).toBeTruthy();
-    expect(internalEvents[0]?.result).not.toBe("(no output)");
-    expect(internalEvents[0]?.result).toContain("tool call");
-    // Verify assistant text fragments are extracted, not just tool call counts.
-    expect(internalEvents[0]?.result).toContain("reading the files");
-    expect(internalEvents[0]?.result).toContain("analyzing the code structure");
-  });
-
-  it("reports tool call count in partial progress for timeout with no assistant text", async () => {
-    // Subagent only made tool calls but never produced assistant text.
-    chatHistoryMessages = [
-      { role: "user", content: "do something" },
-      {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call1", name: "read", arguments: {} }],
-      },
-      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
-      {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call2", name: "exec", arguments: {} }],
-      },
-    ];
-
-    await runAnnounceFlowForTest("run-timeout-no-text", {
-      outcome: { status: "timeout" },
-      roundOneReply: undefined,
-    });
-
-    const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
-    );
+    const directAgentCall = findFinalDirectAgentCall();
     const internalEvents =
       (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
-    // Should report tool call count even without assistant text.
-    expect(internalEvents[0]?.result).toContain("2 tool call(s)");
+    expect(internalEvents[0]?.result).toContain("3 tool call(s)");
+    expect(internalEvents[0]?.result).not.toContain("data");
   });
 
-  it("counts toolUse blocks in timeout partial progress", async () => {
+  it("preserves NO_REPLY when timeout history ends with silence after earlier progress", async () => {
     chatHistoryMessages = [
-      { role: "user", content: "do something" },
-      {
-        role: "assistant",
-        content: [{ type: "toolUse", id: "call1", name: "read", input: {} }],
-      },
-      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
-      {
-        role: "assistant",
-        content: [{ type: "toolUse", id: "call2", name: "exec", input: {} }],
-      },
-    ];
-
-    await runAnnounceFlowForTest("run-timeout-tooluse", {
-      outcome: { status: "timeout" },
-      roundOneReply: undefined,
-    });
-
-    const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
-    );
-    const internalEvents =
-      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
-    expect(internalEvents[0]?.result).toContain("2 tool call(s)");
-  });
-
-  it("counts functionCall blocks in timeout partial progress", async () => {
-    chatHistoryMessages = [
-      { role: "user", content: "do something" },
-      {
-        role: "assistant",
-        content: [{ type: "functionCall", id: "call1", name: "read", arguments: {} }],
-      },
-      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
-      {
-        role: "assistant",
-        content: [{ type: "functionCall", id: "call2", name: "exec", arguments: {} }],
-      },
-    ];
-
-    await runAnnounceFlowForTest("run-timeout-functioncall", {
-      outcome: { status: "timeout" },
-      roundOneReply: undefined,
-    });
-
-    const directAgentCall = findGatewayCall(
-      (call) => call.method === "agent" && call.expectFinal === true,
-    );
-    const internalEvents =
-      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
-    expect(internalEvents[0]?.result).toContain("2 tool call(s)");
-  });
-
-  it("preserves NO_REPLY when timeout partial progress exists", async () => {
-    chatHistoryMessages = [
-      { role: "user", content: "do something" },
       {
         role: "assistant",
         content: [
           { type: "text", text: "Still working through the files." },
-          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+          { type: "toolCall", id: "call-1", name: "read", arguments: {} },
         ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-2", name: "exec", arguments: {} }],
       },
     ];
 
     await runAnnounceFlowForTest("run-timeout-no-reply", {
       outcome: { status: "timeout" },
-      roundOneReply: " NO_REPLY ",
+      roundOneReply: undefined,
     });
 
-    expect(
-      findGatewayCall((call) => call.method === "agent" && call.expectFinal === true),
-    ).toBeUndefined();
+    expect(findFinalDirectAgentCall()).toBeUndefined();
+  });
+
+  it("prefers visible assistant progress over a later raw tool result", async () => {
+    chatHistoryMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Read 12 files. Narrowing the search now." }],
+      },
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: "grep output" }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-visible-assistant", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    const directAgentCall = findFinalDirectAgentCall();
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    expect(internalEvents[0]?.result).toContain("Read 12 files");
+    expect(internalEvents[0]?.result).not.toContain("grep output");
   });
 
   it("preserves NO_REPLY when timeout partial-progress history mixes prior text and later silence", async () => {

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -8,12 +8,6 @@ type GatewayCall = {
 };
 
 const gatewayCalls: GatewayCall[] = [];
-let callGatewayImpl: (request: GatewayCall) => Promise<unknown> = async (request) => {
-  if (request.method === "chat.history") {
-    return { messages: [] };
-  }
-  return {};
-};
 let sessionStore: Record<string, Record<string, unknown>> = {};
 let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
   session: {
@@ -30,10 +24,15 @@ let fallbackRequesterResolution: {
   requesterOrigin?: { channel?: string; to?: string; accountId?: string };
 } | null = null;
 
+let chatHistoryMessages: Array<Record<string, unknown>> = [];
+
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async (request: GatewayCall) => {
     gatewayCalls.push(request);
-    return await callGatewayImpl(request);
+    if (request.method === "chat.history") {
+      return { messages: chatHistoryMessages };
+    }
+    return {};
   }),
 }));
 
@@ -120,30 +119,9 @@ function findGatewayCall(predicate: (call: GatewayCall) => boolean): GatewayCall
   return gatewayCalls.find(predicate);
 }
 
-function findFinalDirectAgentCall(): GatewayCall | undefined {
-  return findGatewayCall((call) => call.method === "agent" && call.expectFinal === true);
-}
-
-function setupParentSessionFallback(parentSessionKey: string): void {
-  requesterDepthResolver = (sessionKey?: string) =>
-    sessionKey === parentSessionKey ? 1 : sessionKey?.includes(":subagent:") ? 1 : 0;
-  subagentSessionRunActive = false;
-  shouldIgnorePostCompletion = false;
-  fallbackRequesterResolution = {
-    requesterSessionKey: "agent:main:main",
-    requesterOrigin: { channel: "discord", to: "chan-main", accountId: "acct-main" },
-  };
-}
-
 describe("subagent announce timeout config", () => {
   beforeEach(() => {
     gatewayCalls.length = 0;
-    callGatewayImpl = async (request) => {
-      if (request.method === "chat.history") {
-        return { messages: [] };
-      }
-      return {};
-    };
     sessionStore = {};
     configOverride = {
       session: defaultSessionConfig,
@@ -153,15 +131,16 @@ describe("subagent announce timeout config", () => {
     shouldIgnorePostCompletion = false;
     pendingDescendantRuns = 0;
     fallbackRequesterResolution = null;
+    chatHistoryMessages = [];
   });
 
-  it("uses 90s timeout by default for direct announce agent call", async () => {
+  it("uses 60s timeout by default for direct announce agent call", async () => {
     await runAnnounceFlowForTest("run-default-timeout");
 
     const directAgentCall = findGatewayCall(
       (call) => call.method === "agent" && call.expectFinal === true,
     );
-    expect(directAgentCall?.timeoutMs).toBe(90_000);
+    expect(directAgentCall?.timeoutMs).toBe(60_000);
   });
 
   it("honors configured announce timeout for direct announce agent call", async () => {
@@ -188,35 +167,6 @@ describe("subagent announce timeout config", () => {
       (call) => call.method === "agent" && call.expectFinal === true,
     );
     expect(completionDirectAgentCall?.timeoutMs).toBe(90_000);
-  });
-
-  it("does not retry gateway timeout for externally delivered completion announces", async () => {
-    vi.useFakeTimers();
-    try {
-      callGatewayImpl = async (request) => {
-        if (request.method === "chat.history") {
-          return { messages: [] };
-        }
-        throw new Error("gateway timeout after 90000ms");
-      };
-
-      await expect(
-        runAnnounceFlowForTest("run-completion-timeout-no-retry", {
-          requesterOrigin: {
-            channel: "telegram",
-            to: "12345",
-          },
-          expectsCompletionMessage: true,
-        }),
-      ).resolves.toBe(false);
-
-      const directAgentCalls = gatewayCalls.filter(
-        (call) => call.method === "agent" && call.expectFinal === true,
-      );
-      expect(directAgentCalls).toHaveLength(1);
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("regression, skips parent announce while descendants are still pending", async () => {
@@ -259,7 +209,9 @@ describe("subagent announce timeout config", () => {
       requesterOrigin: { channel: "discord", to: "channel:cron-results", accountId: "acct-1" },
     });
 
-    const directAgentCall = findFinalDirectAgentCall();
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
     expect(directAgentCall?.params?.sessionKey).toBe(cronSessionKey);
     expect(directAgentCall?.params?.deliver).toBe(false);
     expect(directAgentCall?.params?.channel).toBeUndefined();
@@ -269,7 +221,14 @@ describe("subagent announce timeout config", () => {
 
   it("regression, routes child announce to parent session instead of grandparent when parent session still exists", async () => {
     const parentSessionKey = "agent:main:subagent:parent";
-    setupParentSessionFallback(parentSessionKey);
+    requesterDepthResolver = (sessionKey?: string) =>
+      sessionKey === parentSessionKey ? 1 : sessionKey?.includes(":subagent:") ? 1 : 0;
+    subagentSessionRunActive = false;
+    shouldIgnorePostCompletion = false;
+    fallbackRequesterResolution = {
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "discord", to: "chan-main", accountId: "acct-main" },
+    };
     // No sessionId on purpose: existence in store should still count as alive.
     sessionStore[parentSessionKey] = { updatedAt: Date.now() };
 
@@ -279,14 +238,23 @@ describe("subagent announce timeout config", () => {
       childSessionKey: `${parentSessionKey}:subagent:child`,
     });
 
-    const directAgentCall = findFinalDirectAgentCall();
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
     expect(directAgentCall?.params?.sessionKey).toBe(parentSessionKey);
     expect(directAgentCall?.params?.deliver).toBe(false);
   });
 
   it("regression, falls back to grandparent only when parent subagent session is missing", async () => {
     const parentSessionKey = "agent:main:subagent:parent-missing";
-    setupParentSessionFallback(parentSessionKey);
+    requesterDepthResolver = (sessionKey?: string) =>
+      sessionKey === parentSessionKey ? 1 : sessionKey?.includes(":subagent:") ? 1 : 0;
+    subagentSessionRunActive = false;
+    shouldIgnorePostCompletion = false;
+    fallbackRequesterResolution = {
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "discord", to: "chan-main", accountId: "acct-main" },
+    };
 
     await runAnnounceFlowForTest("run-parent-fallback", {
       requesterSessionKey: parentSessionKey,
@@ -294,11 +262,237 @@ describe("subagent announce timeout config", () => {
       childSessionKey: `${parentSessionKey}:subagent:child`,
     });
 
-    const directAgentCall = findFinalDirectAgentCall();
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
     expect(directAgentCall?.params?.sessionKey).toBe("agent:main:main");
     expect(directAgentCall?.params?.deliver).toBe(true);
     expect(directAgentCall?.params?.channel).toBe("discord");
     expect(directAgentCall?.params?.to).toBe("chan-main");
     expect(directAgentCall?.params?.accountId).toBe("acct-main");
+  });
+
+  it("includes partial progress from assistant messages when subagent times out", async () => {
+    // Simulate a session with assistant text from intermediate tool-call rounds.
+    chatHistoryMessages = [
+      { role: "user", content: "do a complex task" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll start by reading the files..." },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call1",
+        content: [{ type: "text", text: "file contents" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Now analyzing the code structure. Found 3 modules." },
+          { type: "toolCall", id: "call2", name: "read", arguments: {} },
+        ],
+      },
+      { role: "toolResult", toolCallId: "call2", content: [{ type: "text", text: "more data" }] },
+      // Last assistant turn was a tool call with no text — simulating mid-work timeout.
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call3", name: "exec", arguments: {} }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-partial", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    expect(directAgentCall).toBeDefined();
+
+    // The announce message should contain the partial progress.
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{
+        result?: string;
+        statusLabel?: string;
+      }>) ?? [];
+    expect(internalEvents[0]?.statusLabel).toBe("timed out");
+    // The result should include the partial assistant text, not just "(no output)".
+    expect(internalEvents[0]?.result).toBeTruthy();
+    expect(internalEvents[0]?.result).not.toBe("(no output)");
+    expect(internalEvents[0]?.result).toContain("tool call");
+    // Verify assistant text fragments are extracted, not just tool call counts.
+    expect(internalEvents[0]?.result).toContain("reading the files");
+    expect(internalEvents[0]?.result).toContain("analyzing the code structure");
+  });
+
+  it("reports tool call count in partial progress for timeout with no assistant text", async () => {
+    // Subagent only made tool calls but never produced assistant text.
+    chatHistoryMessages = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call1", name: "read", arguments: {} }],
+      },
+      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call2", name: "exec", arguments: {} }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-no-text", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    // Should report tool call count even without assistant text.
+    expect(internalEvents[0]?.result).toContain("2 tool call(s)");
+  });
+
+  it("counts toolUse blocks in timeout partial progress", async () => {
+    chatHistoryMessages = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "call1", name: "read", input: {} }],
+      },
+      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "call2", name: "exec", input: {} }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-tooluse", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    expect(internalEvents[0]?.result).toContain("2 tool call(s)");
+  });
+
+  it("counts functionCall blocks in timeout partial progress", async () => {
+    chatHistoryMessages = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [{ type: "functionCall", id: "call1", name: "read", arguments: {} }],
+      },
+      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
+      {
+        role: "assistant",
+        content: [{ type: "functionCall", id: "call2", name: "exec", arguments: {} }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-functioncall", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    expect(internalEvents[0]?.result).toContain("2 tool call(s)");
+  });
+
+  it("preserves NO_REPLY when timeout partial progress exists", async () => {
+    chatHistoryMessages = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Still working through the files." },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-no-reply", {
+      outcome: { status: "timeout" },
+      roundOneReply: " NO_REPLY ",
+    });
+
+    expect(
+      findGatewayCall((call) => call.method === "agent" && call.expectFinal === true),
+    ).toBeUndefined();
+  });
+
+  it("preserves NO_REPLY when timeout partial-progress history mixes prior text and later silence", async () => {
+    chatHistoryMessages = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Still working through the files." },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ],
+      },
+      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call2", name: "exec", arguments: {} }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-mixed-no-reply", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    expect(
+      findGatewayCall((call) => call.method === "agent" && call.expectFinal === true),
+    ).toBeUndefined();
+  });
+
+  it("prefers NO_REPLY partial progress over a longer latest assistant reply", async () => {
+    chatHistoryMessages = [
+      { role: "user", content: "do something" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Still working through the files." },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ],
+      },
+      { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "A longer partial summary that should stay silent." }],
+      },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-no-reply-overrides-latest-text", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    expect(
+      findGatewayCall((call) => call.method === "agent" && call.expectFinal === true),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -50,7 +50,7 @@ import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
-const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 60_000;
+const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 90_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 let subagentRegistryRuntimePromise: Promise<
   typeof import("./subagent-registry-runtime.js")
@@ -390,103 +390,6 @@ async function readSubagentOutput(
   });
   const messages = Array.isArray(history?.messages) ? history.messages : [];
   return selectSubagentOutputText(summarizeSubagentOutputHistory(messages), outcome);
-}
-
-/**
- * Collect partial progress from a timed-out subagent session.
- *
- * Unlike `readLatestSubagentOutput` which returns only the last message,
- * this function scans the full history to build a progress summary from
- * all assistant messages. This is critical for timeout scenarios where
- * the subagent may have produced intermediate results across multiple
- * tool-call rounds but no final summary.
- *
- * @see https://github.com/openclaw/openclaw/issues/33827
- */
-async function readSubagentPartialProgress(sessionKey: string): Promise<string | undefined> {
-  let history: { messages?: Array<unknown> } | undefined;
-  try {
-    history = await callGateway<{ messages?: Array<unknown> }>({
-      method: "chat.history",
-      params: { sessionKey, limit: 100 },
-    });
-  } catch {
-    return undefined;
-  }
-  const messages = Array.isArray(history?.messages) ? history.messages : [];
-  if (messages.length === 0) {
-    return undefined;
-  }
-
-  // Collect all assistant text fragments (partial results from each turn).
-  const assistantFragments: string[] = [];
-  let toolCallCount = 0;
-  let silentAssistantOverrideText: string | undefined;
-
-  for (const msg of messages) {
-    if (!msg || typeof msg !== "object") {
-      continue;
-    }
-    const role = (msg as { role?: unknown }).role;
-    if (role === "assistant") {
-      const text = extractSubagentOutputText(msg);
-      if (text?.trim()) {
-        const trimmedText = text.trim();
-        if (isAnnounceSkip(trimmedText) || isSilentReplyText(trimmedText, SILENT_REPLY_TOKEN)) {
-          // Preserve explicit silence semantics across timeout fallback synthesis.
-          // If any assistant turn asked to stay silent, do not turn earlier
-          // partial progress into a user-visible completion.
-          silentAssistantOverrideText = trimmedText;
-        } else {
-          assistantFragments.push(trimmedText);
-        }
-      }
-      // Count tool calls to report progress depth.
-      const content = (msg as { content?: unknown }).content;
-      if (Array.isArray(content)) {
-        for (const block of content) {
-          if (
-            block &&
-            typeof block === "object" &&
-            ((block as { type?: string }).type === "toolCall" ||
-              (block as { type?: string }).type === "tool_use" ||
-              (block as { type?: string }).type === "toolUse" ||
-              (block as { type?: string }).type === "functionCall" ||
-              (block as { type?: string }).type === "function_call")
-          ) {
-            toolCallCount += 1;
-          }
-        }
-      }
-    }
-  }
-
-  if (silentAssistantOverrideText) {
-    return silentAssistantOverrideText;
-  }
-
-  if (assistantFragments.length === 0 && toolCallCount === 0) {
-    return undefined;
-  }
-
-  const parts: string[] = [];
-  if (toolCallCount > 0) {
-    parts.push(`[Partial progress: ${toolCallCount} tool call(s) executed before timeout]`);
-  }
-  if (assistantFragments.length > 0) {
-    // Return the last (most recent) assistant fragment as the primary result,
-    // but include earlier fragments if the last one is short.
-    const lastFragment = assistantFragments[assistantFragments.length - 1];
-    if (assistantFragments.length > 1 && lastFragment.length < 200) {
-      // Include up to 3 most recent fragments for context.
-      const recentFragments = assistantFragments.slice(-3);
-      parts.push(recentFragments.join("\n\n---\n\n"));
-    } else {
-      parts.push(lastFragment);
-    }
-  }
-
-  return parts.join("\n\n") || undefined;
 }
 
 async function readLatestSubagentOutputWithRetry(params: {
@@ -1495,30 +1398,6 @@ export async function runSubagentAnnounceFlow(params: {
           maxWaitMs: params.timeoutMs,
           outcome,
         });
-      }
-
-      // For timed-out runs, attempt to collect partial progress from the full
-      // session history.  The subagent may have produced useful intermediate
-      // results across multiple tool-call rounds even though no final assistant
-      // reply was generated before the timeout.  Use the richer partial progress
-      // when it contains more context than the simple last-message extraction.
-      if (outcome.status === "timeout") {
-        const partialProgress = await readSubagentPartialProgress(params.childSessionKey);
-        // Do not overwrite recognized silent/skip tokens with partial progress —
-        // that would cause the parent to announce when it should stay silent.
-        const replyIsSilent =
-          reply?.trim() && (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN));
-        const partialProgressIsSilent =
-          partialProgress?.trim() &&
-          (isAnnounceSkip(partialProgress) ||
-            isSilentReplyText(partialProgress, SILENT_REPLY_TOKEN));
-        if (
-          !replyIsSilent &&
-          partialProgress?.trim() &&
-          (partialProgressIsSilent || !reply?.trim() || partialProgress.length > reply.length)
-        ) {
-          reply = partialProgress;
-        }
       }
 
       if (!reply?.trim() && fallbackReply && !fallbackIsSilent) {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -45,7 +45,6 @@ import {
 import { type AnnounceQueueItem, enqueueAnnounce } from "./subagent-announce-queue.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";
-import { readLatestAssistantReply } from "./tools/agent-step.js";
 import { sanitizeTextContent, extractAssistantText } from "./tools/sessions-helpers.js";
 import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 
@@ -69,6 +68,14 @@ const DIRECT_ANNOUNCE_TRANSIENT_RETRY_DELAYS_MS = FAST_TEST_MODE
 type ToolResultMessage = {
   role?: unknown;
   content?: unknown;
+};
+
+type SubagentOutputSnapshot = {
+  latestAssistantText?: string;
+  latestSilentText?: string;
+  latestRawText?: string;
+  assistantFragments: string[];
+  toolCallCount: number;
 };
 
 function resolveSubagentAnnounceTimeoutMs(cfg: ReturnType<typeof loadConfig>): number {
@@ -275,31 +282,114 @@ function extractSubagentOutputText(message: unknown): string {
   return "";
 }
 
-async function readLatestSubagentOutput(sessionKey: string): Promise<string | undefined> {
-  try {
-    const latestAssistant = await readLatestAssistantReply({
-      sessionKey,
-      limit: 50,
-    });
-    if (latestAssistant?.trim()) {
-      return latestAssistant;
-    }
-  } catch {
-    // Best-effort: fall back to richer history parsing below.
+function countAssistantToolCalls(content: unknown): number {
+  if (!Array.isArray(content)) {
+    return 0;
   }
+  let count = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const type = (block as { type?: unknown }).type;
+    if (
+      type === "toolCall" ||
+      type === "tool_use" ||
+      type === "toolUse" ||
+      type === "functionCall" ||
+      type === "function_call"
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutputSnapshot {
+  const snapshot: SubagentOutputSnapshot = {
+    assistantFragments: [],
+    toolCallCount: 0,
+  };
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const role = (message as { role?: unknown }).role;
+    if (role === "assistant") {
+      snapshot.toolCallCount += countAssistantToolCalls((message as { content?: unknown }).content);
+      const text = extractSubagentOutputText(message).trim();
+      if (!text) {
+        continue;
+      }
+      if (isAnnounceSkip(text) || isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+        snapshot.latestSilentText = text;
+        snapshot.latestAssistantText = undefined;
+        snapshot.assistantFragments = [];
+        continue;
+      }
+      snapshot.latestSilentText = undefined;
+      snapshot.latestAssistantText = text;
+      snapshot.assistantFragments.push(text);
+      continue;
+    }
+    const text = extractSubagentOutputText(message).trim();
+    if (text) {
+      snapshot.latestRawText = text;
+    }
+  }
+  return snapshot;
+}
+
+function formatSubagentPartialProgress(
+  snapshot: SubagentOutputSnapshot,
+  outcome?: SubagentRunOutcome,
+): string | undefined {
+  if (snapshot.latestSilentText) {
+    return undefined;
+  }
+  const timedOut = outcome?.status === "timeout";
+  if (snapshot.assistantFragments.length === 0 && (!timedOut || snapshot.toolCallCount === 0)) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  if (timedOut && snapshot.toolCallCount > 0) {
+    parts.push(
+      `[Partial progress: ${snapshot.toolCallCount} tool call(s) executed before timeout]`,
+    );
+  }
+  if (snapshot.assistantFragments.length > 0) {
+    parts.push(snapshot.assistantFragments.slice(-3).join("\n\n---\n\n"));
+  }
+  return parts.join("\n\n") || undefined;
+}
+
+function selectSubagentOutputText(
+  snapshot: SubagentOutputSnapshot,
+  outcome?: SubagentRunOutcome,
+): string | undefined {
+  if (snapshot.latestSilentText) {
+    return snapshot.latestSilentText;
+  }
+  if (snapshot.latestAssistantText) {
+    return snapshot.latestAssistantText;
+  }
+  const partialProgress = formatSubagentPartialProgress(snapshot, outcome);
+  if (partialProgress) {
+    return partialProgress;
+  }
+  return snapshot.latestRawText;
+}
+
+async function readSubagentOutput(
+  sessionKey: string,
+  outcome?: SubagentRunOutcome,
+): Promise<string | undefined> {
   const history = await callGateway<{ messages?: Array<unknown> }>({
     method: "chat.history",
-    params: { sessionKey, limit: 50 },
+    params: { sessionKey, limit: 100 },
   });
   const messages = Array.isArray(history?.messages) ? history.messages : [];
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const msg = messages[i];
-    const text = extractSubagentOutputText(msg);
-    if (text) {
-      return text;
-    }
-  }
-  return undefined;
+  return selectSubagentOutputText(summarizeSubagentOutputHistory(messages), outcome);
 }
 
 /**
@@ -402,12 +492,13 @@ async function readSubagentPartialProgress(sessionKey: string): Promise<string |
 async function readLatestSubagentOutputWithRetry(params: {
   sessionKey: string;
   maxWaitMs: number;
+  outcome?: SubagentRunOutcome;
 }): Promise<string | undefined> {
   const RETRY_INTERVAL_MS = FAST_TEST_MODE ? FAST_TEST_RETRY_INTERVAL_MS : 100;
   const deadline = Date.now() + Math.max(0, Math.min(params.maxWaitMs, 15_000));
   let result: string | undefined;
   while (Date.now() < deadline) {
-    result = await readLatestSubagentOutput(params.sessionKey);
+    result = await readSubagentOutput(params.sessionKey, params.outcome);
     if (result?.trim()) {
       return result;
     }
@@ -419,7 +510,7 @@ async function readLatestSubagentOutputWithRetry(params: {
 export async function captureSubagentCompletionReply(
   sessionKey: string,
 ): Promise<string | undefined> {
-  const immediate = await readLatestSubagentOutput(sessionKey);
+  const immediate = await readSubagentOutput(sessionKey);
   if (immediate?.trim()) {
     return immediate;
   }
@@ -1395,13 +1486,14 @@ export async function runSubagentAnnounceFlow(params: {
         (isAnnounceSkip(fallbackReply) || isSilentReplyText(fallbackReply, SILENT_REPLY_TOKEN));
 
       if (!reply) {
-        reply = await readLatestSubagentOutput(params.childSessionKey);
+        reply = await readSubagentOutput(params.childSessionKey, outcome);
       }
 
       if (!reply?.trim()) {
         reply = await readLatestSubagentOutputWithRetry({
           sessionKey: params.childSessionKey,
           maxWaitMs: params.timeoutMs,
+          outcome,
         });
       }
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -51,9 +51,8 @@ import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
-const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 90_000;
+const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 60_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
-const GATEWAY_TIMEOUT_PATTERN = /gateway timeout/i;
 let subagentRegistryRuntimePromise: Promise<
   typeof import("./subagent-registry-runtime.js")
 > | null = null;
@@ -108,7 +107,7 @@ const TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /no active .* listener/i,
   /gateway not connected/i,
   /gateway closed \(1006/i,
-  GATEWAY_TIMEOUT_PATTERN,
+  /gateway timeout/i,
   /\b(econnreset|econnrefused|etimedout|enotfound|ehostunreach|network error)\b/i,
 ];
 
@@ -132,11 +131,6 @@ function isTransientAnnounceDeliveryError(error: unknown): boolean {
     return false;
   }
   return TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message));
-}
-
-function isGatewayTimeoutError(error: unknown): boolean {
-  const message = summarizeDeliveryError(error);
-  return Boolean(message) && GATEWAY_TIMEOUT_PATTERN.test(message);
 }
 
 async function waitForAnnounceRetryDelay(ms: number, signal?: AbortSignal): Promise<void> {
@@ -166,7 +160,6 @@ async function waitForAnnounceRetryDelay(ms: number, signal?: AbortSignal): Prom
 
 async function runAnnounceDeliveryWithRetry<T>(params: {
   operation: string;
-  noRetryOnGatewayTimeout?: boolean;
   signal?: AbortSignal;
   run: () => Promise<T>;
 }): Promise<T> {
@@ -178,9 +171,6 @@ async function runAnnounceDeliveryWithRetry<T>(params: {
     try {
       return await params.run();
     } catch (err) {
-      if (params.noRetryOnGatewayTimeout && isGatewayTimeoutError(err)) {
-        throw err;
-      }
       const delayMs = DIRECT_ANNOUNCE_TRANSIENT_RETRY_DELAYS_MS[retryIndex];
       if (delayMs == null || !isTransientAnnounceDeliveryError(err) || params.signal?.aborted) {
         throw err;
@@ -310,6 +300,103 @@ async function readLatestSubagentOutput(sessionKey: string): Promise<string | un
     }
   }
   return undefined;
+}
+
+/**
+ * Collect partial progress from a timed-out subagent session.
+ *
+ * Unlike `readLatestSubagentOutput` which returns only the last message,
+ * this function scans the full history to build a progress summary from
+ * all assistant messages. This is critical for timeout scenarios where
+ * the subagent may have produced intermediate results across multiple
+ * tool-call rounds but no final summary.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/33827
+ */
+async function readSubagentPartialProgress(sessionKey: string): Promise<string | undefined> {
+  let history: { messages?: Array<unknown> } | undefined;
+  try {
+    history = await callGateway<{ messages?: Array<unknown> }>({
+      method: "chat.history",
+      params: { sessionKey, limit: 100 },
+    });
+  } catch {
+    return undefined;
+  }
+  const messages = Array.isArray(history?.messages) ? history.messages : [];
+  if (messages.length === 0) {
+    return undefined;
+  }
+
+  // Collect all assistant text fragments (partial results from each turn).
+  const assistantFragments: string[] = [];
+  let toolCallCount = 0;
+  let silentAssistantOverrideText: string | undefined;
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const role = (msg as { role?: unknown }).role;
+    if (role === "assistant") {
+      const text = extractSubagentOutputText(msg);
+      if (text?.trim()) {
+        const trimmedText = text.trim();
+        if (isAnnounceSkip(trimmedText) || isSilentReplyText(trimmedText, SILENT_REPLY_TOKEN)) {
+          // Preserve explicit silence semantics across timeout fallback synthesis.
+          // If any assistant turn asked to stay silent, do not turn earlier
+          // partial progress into a user-visible completion.
+          silentAssistantOverrideText = trimmedText;
+        } else {
+          assistantFragments.push(trimmedText);
+        }
+      }
+      // Count tool calls to report progress depth.
+      const content = (msg as { content?: unknown }).content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block &&
+            typeof block === "object" &&
+            ((block as { type?: string }).type === "toolCall" ||
+              (block as { type?: string }).type === "tool_use" ||
+              (block as { type?: string }).type === "toolUse" ||
+              (block as { type?: string }).type === "functionCall" ||
+              (block as { type?: string }).type === "function_call")
+          ) {
+            toolCallCount += 1;
+          }
+        }
+      }
+    }
+  }
+
+  if (silentAssistantOverrideText) {
+    return silentAssistantOverrideText;
+  }
+
+  if (assistantFragments.length === 0 && toolCallCount === 0) {
+    return undefined;
+  }
+
+  const parts: string[] = [];
+  if (toolCallCount > 0) {
+    parts.push(`[Partial progress: ${toolCallCount} tool call(s) executed before timeout]`);
+  }
+  if (assistantFragments.length > 0) {
+    // Return the last (most recent) assistant fragment as the primary result,
+    // but include earlier fragments if the last one is short.
+    const lastFragment = assistantFragments[assistantFragments.length - 1];
+    if (assistantFragments.length > 1 && lastFragment.length < 200) {
+      // Include up to 3 most recent fragments for context.
+      const recentFragments = assistantFragments.slice(-3);
+      parts.push(recentFragments.join("\n\n---\n\n"));
+    } else {
+      parts.push(lastFragment);
+    }
+  }
+
+  return parts.join("\n\n") || undefined;
 }
 
 async function readLatestSubagentOutputWithRetry(params: {
@@ -799,7 +886,6 @@ async function sendSubagentAnnounceDirectly(params: {
       operation: params.expectsCompletionMessage
         ? "completion direct announce agent call"
         : "direct announce agent call",
-      noRetryOnGatewayTimeout: params.expectsCompletionMessage && shouldDeliverExternally,
       signal: params.signal,
       run: async () =>
         await callGateway({
@@ -1317,6 +1403,30 @@ export async function runSubagentAnnounceFlow(params: {
           sessionKey: params.childSessionKey,
           maxWaitMs: params.timeoutMs,
         });
+      }
+
+      // For timed-out runs, attempt to collect partial progress from the full
+      // session history.  The subagent may have produced useful intermediate
+      // results across multiple tool-call rounds even though no final assistant
+      // reply was generated before the timeout.  Use the richer partial progress
+      // when it contains more context than the simple last-message extraction.
+      if (outcome.status === "timeout") {
+        const partialProgress = await readSubagentPartialProgress(params.childSessionKey);
+        // Do not overwrite recognized silent/skip tokens with partial progress —
+        // that would cause the parent to announce when it should stay silent.
+        const replyIsSilent =
+          reply?.trim() && (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN));
+        const partialProgressIsSilent =
+          partialProgress?.trim() &&
+          (isAnnounceSkip(partialProgress) ||
+            isSilentReplyText(partialProgress, SILENT_REPLY_TOKEN));
+        if (
+          !replyIsSilent &&
+          partialProgress?.trim() &&
+          (partialProgressIsSilent || !reply?.trim() || partialProgress.length > reply.length)
+        ) {
+          reply = partialProgress;
+        }
       }
 
       if (!reply?.trim() && fallbackReply && !fallbackIsSilent) {


### PR DESCRIPTION
## Problem

When a subagent times out, the parent session receives `status: "timed out"` with `result: "(no output)"` even when the subagent produced useful intermediate results across multiple tool-call rounds.

## Solution

Add `readSubagentPartialProgress()` that scans the full session history (up to 100 messages) to collect:
- All assistant text fragments from intermediate turns
- Tool call count executed before timeout

For timeout outcomes, prefer this richer partial progress over simple last-message extraction when it provides more context.

### Before vs After

**Before:** `status: timed out, result: (no output)`

**After:**
```
status: timed out
result: [Partial progress: 12 tool call(s) executed before timeout]

Now analyzing the code structure. Found 3 modules.
```

## Changes
- `src/agents/subagent-announce.ts`: Added `readSubagentPartialProgress()`, integrated into announce flow
- `src/agents/subagent-announce.timeout.test.ts`: 2 new test cases

All 9 timeout tests pass.

Refs #33827