### PR TITLE
Fail fast on startup when default model auth is missing

### DIFF
--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultModelProviderAuthError } from "./server-startup.js";
+
+describe("getDefaultModelProviderAuthError", () => {
+  it("returns a clear startup error when the default model provider has no auth", () => {
+    const error = getDefaultModelProviderAuthError({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+          },
+        },
+      },
+      hasAuthForProviderFn: () => false,
+      resolveAgentDirFn: () => "/tmp/openclaw-agent-main",
+    } satisfies Parameters<typeof getDefaultModelProviderAuthError>[0]);
+
+    expect(error).toContain('Default model "anthropic/claude-opus-4-6" has no configured auth');
+    expect(error).toContain('openclaw models set "openai-codex/gpt-5.4"');
+  });
+
+  it("returns nothing when the default model provider already has auth", () => {
+    const error = getDefaultModelProviderAuthError({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+        },
+      },
+      hasAuthForProviderFn: () => true,
+      resolveAgentDirFn: () => "/tmp/openclaw-agent-main",
+    } satisfies Parameters<typeof getDefaultModelProviderAuthError>[0]);
+
+    expect(error).toBeUndefined();
+  });
+
+  it("skips the auth check when channel startup is disabled", () => {
+    const error = getDefaultModelProviderAuthError({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+          },
+        },
+      },
+      skipChannels: true,
+      hasAuthForProviderFn: () => false,
+      resolveAgentDirFn: () => "/tmp/openclaw-agent-main",
+    } satisfies Parameters<typeof getDefaultModelProviderAuthError>[0]);
+
+    expect(error).toBeUndefined();
+  });
+});

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -1,14 +1,17 @@
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { ACP_SESSION_IDENTITY_RENDERER_VERSION } from "../acp/runtime/session-identifiers.js";
+import { resolveAgentDir } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
   getModelRefStatus,
   resolveConfiguredModelRef,
+  resolveDefaultModelForAgent,
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
 import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
+import { hasAuthForProvider } from "../agents/tools/model-config.helpers.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -30,6 +33,34 @@ import {
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
+
+export function getDefaultModelProviderAuthError(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  skipChannels?: boolean;
+  hasAuthForProviderFn?: typeof hasAuthForProvider;
+  resolveAgentDirFn?: typeof resolveAgentDir;
+}): string | undefined {
+  if (params.skipChannels) {
+    return undefined;
+  }
+
+  const resolved = resolveDefaultModelForAgent({ cfg: params.cfg, agentId: "main" });
+  const agentDir = (params.resolveAgentDirFn ?? resolveAgentDir)(params.cfg, "main");
+  const authOk = (params.hasAuthForProviderFn ?? hasAuthForProvider)({
+    provider: resolved.provider,
+    agentDir,
+  });
+  if (authOk) {
+    return undefined;
+  }
+
+  const modelLabel = `${resolved.provider}/${resolved.model}`;
+  return [
+    `Default model "${modelLabel}" has no configured auth for provider "${resolved.provider}".`,
+    `Configure ${resolved.provider} credentials or switch the default model before starting channels.`,
+    `For example: openclaw models set "openai-codex/gpt-5.4"`,
+  ].join(" ");
+}
 
 export async function startGatewaySidecars(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -59,6 +90,19 @@ export async function startGatewaySidecars(params: {
     }
   } catch (err) {
     params.log.warn(`session lock cleanup failed on startup: ${String(err)}`);
+  }
+
+  // Launch configured channels only when the default model provider has usable auth.
+  // This fails fast with a clear message instead of starting "online but silent".
+  const skipChannels =
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
+  const defaultModelAuthError = getDefaultModelProviderAuthError({
+    cfg: params.cfg,
+    skipChannels,
+  });
+  if (defaultModelAuthError) {
+    throw new Error(defaultModelAuthError);
   }
 
   // Start OpenClaw browser control server (unless disabled via config).
@@ -124,9 +168,6 @@ export async function startGatewaySidecars(params: {
 
   // Launch configured channels so gateway replies via the surface the message came from.
   // Tests can opt out via OPENCLAW_SKIP_CHANNELS (or legacy OPENCLAW_SKIP_PROVIDERS).
-  const skipChannels =
-    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
-    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
   if (!skipChannels) {
     try {
       await params.startChannels();


### PR DESCRIPTION
## Summary
- fail fast before channel startup when the resolved default model provider has no configured auth
- surface a clear actionable startup error instead of letting the gateway appear online but stay silent
- add focused tests for the new startup auth guard

## Testing
- `corepack pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server-startup.test.ts`
- `corepack pnpm exec oxfmt --check src/gateway/server-startup.ts src/gateway/server-startup.test.ts`

Closes #39903.
