### PR TITLE
fix(cron): filter reasoning payloads and strip thinking tags from announce delivery

### DIFF
--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -3,6 +3,7 @@ import {
   isHeartbeatOnlyResponse,
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
+  pickSummaryFromOutput,
   pickSummaryFromPayloads,
 } from "./helpers.js";
 
@@ -83,6 +84,47 @@ describe("pickLastDeliverablePayload", () => {
     const normal = { text: "ok", isError: undefined };
     const error = { text: "bad", isError: true as const };
     expect(pickLastDeliverablePayload([normal, error])).toBe(normal);
+  });
+});
+
+describe("pickSummaryFromOutput strips thinking tags", () => {
+  it("strips <think> blocks from output text", () => {
+    const text = "<think>Let me analyze this...</think>Here is the summary.";
+    expect(pickSummaryFromOutput(text)).toBe("Here is the summary.");
+  });
+
+  it("returns cleaned text when only thinking tags are present", () => {
+    expect(pickSummaryFromOutput("<think>internal monologue only</think>")).toBeUndefined();
+  });
+});
+
+describe("reasoning payload filtering", () => {
+  it("pickSummaryFromPayloads skips isReasoning payloads", () => {
+    const payloads = [
+      { text: "Reasoning:\n_thinking..._", isReasoning: true },
+      { text: "Final answer" },
+    ];
+    expect(pickSummaryFromPayloads(payloads)).toBe("Final answer");
+  });
+
+  it("pickLastNonEmptyTextFromPayloads skips isReasoning payloads", () => {
+    const payloads = [
+      { text: "Final answer" },
+      { text: "Reasoning:\n_thinking..._", isReasoning: true },
+    ];
+    expect(pickLastNonEmptyTextFromPayloads(payloads)).toBe("Final answer");
+  });
+
+  it("pickLastDeliverablePayload skips isReasoning payloads", () => {
+    const real = { text: "Delivered content" };
+    const reasoning = { text: "Internal reasoning", isReasoning: true as const };
+    expect(pickLastDeliverablePayload([real, reasoning])).toBe(real);
+  });
+
+  it("never falls back to isReasoning payloads even with no other content", () => {
+    const payloads = [{ text: "Reasoning only", isReasoning: true }];
+    expect(pickSummaryFromPayloads(payloads)).toBeUndefined();
+    expect(pickLastNonEmptyTextFromPayloads(payloads)).toBeUndefined();
   });
 });
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -1,3 +1,4 @@
+import { stripThinkingTagsFromText } from "../../agents/pi-embedded-utils.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "../../auto-reply/heartbeat.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
@@ -8,10 +9,11 @@ type DeliveryPayload = {
   mediaUrls?: string[];
   channelData?: Record<string, unknown>;
   isError?: boolean;
+  isReasoning?: boolean;
 };
 
 export function pickSummaryFromOutput(text: string | undefined) {
-  const clean = (text ?? "").trim();
+  const clean = stripThinkingTagsFromText(text ?? "").trim();
   if (!clean) {
     return undefined;
   }
@@ -20,10 +22,10 @@ export function pickSummaryFromOutput(text: string | undefined) {
 }
 
 export function pickSummaryFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
+  payloads: Array<{ text?: string | undefined; isError?: boolean; isReasoning?: boolean }>,
 ) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     const summary = pickSummaryFromOutput(payloads[i]?.text);
@@ -32,6 +34,9 @@ export function pickSummaryFromPayloads(
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     const summary = pickSummaryFromOutput(payloads[i]?.text);
     if (summary) {
       return summary;
@@ -41,19 +46,22 @@ export function pickSummaryFromPayloads(
 }
 
 export function pickLastNonEmptyTextFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
+  payloads: Array<{ text?: string | undefined; isError?: boolean; isReasoning?: boolean }>,
 ) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
-    const clean = (payloads[i]?.text ?? "").trim();
+    const clean = stripThinkingTagsFromText(payloads[i]?.text ?? "").trim();
     if (clean) {
       return clean;
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
-    const clean = (payloads[i]?.text ?? "").trim();
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
+    const clean = stripThinkingTagsFromText(payloads[i]?.text ?? "").trim();
     if (clean) {
       return clean;
     }
@@ -69,7 +77,7 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
     return text || hasMedia || hasChannelData;
   };
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     if (isDeliverable(payloads[i])) {
@@ -77,6 +85,9 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     if (isDeliverable(payloads[i])) {
       return payloads[i];
     }


### PR DESCRIPTION
## Summary
- Cron announce delivery helpers (`pickSummaryFromPayloads`, `pickLastNonEmptyTextFromPayloads`, `pickLastDeliverablePayload`) did not filter out `isReasoning` payloads, causing thinking/reasoning content to leak into delivered summaries
- Now all three picker functions skip `isReasoning: true` payloads (same pattern as `isError` filtering)
- Additionally, `pickSummaryFromOutput` and `pickLastNonEmptyTextFromPayloads` apply `stripThinkingTagsFromText` to strip inline `<think>` tags from text content

## Change Type
Bug fix — prevents thinking/reasoning content from appearing in cron announce messages

## Scope
`src/cron/isolated-agent/helpers.ts` — filter `isReasoning` payloads + strip thinking tags
`src/cron/isolated-agent/helpers.test.ts` — 6 new tests for reasoning filtering and tag stripping

## Security Impact
None — reduces information leakage by not exposing internal reasoning to end users

Closes #40480

🤖 Generated with [Claude Code](https://claude.com/claude-code)