### PR TITLE
fix(doctor): clarify best-effort wording for invalid config diagnostics

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1675,7 +1675,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   let shouldWriteConfig = false;
   const fixHints: string[] = [];
   if (snapshot.exists && !snapshot.valid && snapshot.legacyIssues.length === 0) {
-    note("Config invalid; doctor will run with best-effort config.", "Config");
+    note(
+      "Config invalid; doctor will run with a best-effort snapshot for diagnostics (gateway startup still fails until repaired).",
+      "Config",
+    );
     noteIncludeConfinementWarning(snapshot);
   }
   const warnings = snapshot.warnings ?? [];


### PR DESCRIPTION
## Summary
- Clarify doctor output so operators understand best-effort is diagnostic only; gateway startup remains blocked until config is repaired.
- Keep scope intentionally small and single-purpose.

## Linked Issue
- Closes #40651

## Verification
- Targeted tests:
  - `pnpm vitest src/commands/doctor-config-flow.safe-bins.test.ts src/gateway/call.test.ts`
  - Passed locally before split PRs.