### PR TITLE
Feat/UI active primary model

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -713,6 +713,27 @@ export function renderApp(state: AppViewState) {
                 },
                 onConfigReload: () => loadConfig(state),
                 onConfigSave: () => saveAgentsConfig(state),
+                onDefaultModelChange: (modelId) => {
+                  const basePath = ["agents", "defaults", "model"];
+                  if (!modelId) {
+                    removeConfigFormValue(state, basePath);
+                    return;
+                  }
+                  const currentConfig = getCurrentConfigValue() as
+                    | { agents?: { defaults?: { model?: unknown } } }
+                    | null;
+                  const existing = currentConfig?.agents?.defaults?.model;
+                  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                    const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
+                    const next = {
+                      primary: modelId,
+                      ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
+                    };
+                    updateConfigFormValue(state, basePath, next);
+                    return;
+                  }
+                  updateConfigFormValue(state, basePath, modelId);
+                },
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
                 onSkillsFilterChange: (next) => (state.skillsFilter = next),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -720,11 +720,15 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, basePath);
                     return;
                   }
-                  const currentConfig = getCurrentConfigValue() as
-                    | { agents?: { defaults?: { model?: unknown } } }
-                    | null;
+                  const currentConfig = getCurrentConfigValue() as {
+                    agents?: { defaults?: { model?: unknown } };
+                  } | null;
                   const existing = currentConfig?.agents?.defaults?.model;
-                  updateConfigFormValue(state, basePath, buildPrimaryModelConfig(modelId, existing));
+                  updateConfigFormValue(
+                    state,
+                    basePath,
+                    buildPrimaryModelConfig(modelId, existing),
+                  );
                 },
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
@@ -793,7 +797,11 @@ export function renderApp(state: AppViewState) {
                     ? (list[index] as { model?: unknown })
                     : undefined;
                   const existing = entry?.model;
-                  updateConfigFormValue(state, basePath, buildPrimaryModelConfig(modelId, existing));
+                  updateConfigFormValue(
+                    state,
+                    basePath,
+                    buildPrimaryModelConfig(modelId, existing),
+                  );
                 },
                 onModelFallbacksChange: (agentId, fallbacks) => {
                   const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -69,6 +69,7 @@ import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
 import {
+  buildPrimaryModelConfig,
   resolveAgentConfig,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
@@ -723,16 +724,7 @@ export function renderApp(state: AppViewState) {
                     | { agents?: { defaults?: { model?: unknown } } }
                     | null;
                   const existing = currentConfig?.agents?.defaults?.model;
-                  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                    const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
-                    const next = {
-                      primary: modelId,
-                      ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-                    };
-                    updateConfigFormValue(state, basePath, next);
-                    return;
-                  }
-                  updateConfigFormValue(state, basePath, modelId);
+                  updateConfigFormValue(state, basePath, buildPrimaryModelConfig(modelId, existing));
                 },
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
@@ -801,16 +793,7 @@ export function renderApp(state: AppViewState) {
                     ? (list[index] as { model?: unknown })
                     : undefined;
                   const existing = entry?.model;
-                  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                    const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
-                    const next = {
-                      primary: modelId,
-                      ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-                    };
-                    updateConfigFormValue(state, basePath, next);
-                  } else {
-                    updateConfigFormValue(state, basePath, modelId);
-                  }
+                  updateConfigFormValue(state, basePath, buildPrimaryModelConfig(modelId, existing));
                 },
                 onModelFallbacksChange: (agentId, fallbacks) => {
                   const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);

--- a/ui/src/ui/views/agents-overview.node.test.ts
+++ b/ui/src/ui/views/agents-overview.node.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveOverviewModelState } from "./agents.ts";
+
+describe("resolveOverviewModelState", () => {
+  it("exposes global default primary separately from agent override", () => {
+    const result = resolveOverviewModelState(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5",
+              fallbacks: ["openai/gpt-5-mini"],
+            },
+          },
+          list: [{ id: "main" }],
+        },
+      } as Record<string, unknown>,
+      "main",
+    );
+
+    expect(result.defaultPrimary).toBe("openai/gpt-5");
+    expect(result.effectivePrimary).toBe("openai/gpt-5");
+    expect(result.modelFallbacks).toEqual(["openai/gpt-5-mini"]);
+  });
+
+  it("prefers agent override for effective primary while keeping global default visible", () => {
+    const result = resolveOverviewModelState(
+      {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5",
+          },
+          list: [{ id: "writer", model: "minimax/abab-6.5s-chat" }],
+        },
+      } as Record<string, unknown>,
+      "writer",
+    );
+
+    expect(result.defaultPrimary).toBe("openai/gpt-5");
+    expect(result.modelPrimary).toBe("minimax/abab-6.5s-chat");
+    expect(result.effectivePrimary).toBe("minimax/abab-6.5s-chat");
+  });
+});

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -121,7 +121,7 @@ describe("buildPrimaryModelConfig", () => {
       }),
     ).toEqual({
       primary: "openai/gpt-5",
-      fallback: ["openai/gpt-5-mini"],
+      fallbacks: ["openai/gpt-5-mini"],
     });
   });
 

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPrimaryModelConfig,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
   sortLocaleStrings,
@@ -96,5 +97,38 @@ describe("sortLocaleStrings", () => {
 
   it("accepts any iterable input, including sets", () => {
     expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("buildPrimaryModelConfig", () => {
+  it("preserves modern fallbacks arrays when updating primary", () => {
+    expect(
+      buildPrimaryModelConfig("openai/gpt-5", {
+        primary: "openai/gpt-4.1",
+        fallbacks: ["openai/gpt-5-mini"],
+      }),
+    ).toEqual({
+      primary: "openai/gpt-5",
+      fallbacks: ["openai/gpt-5-mini"],
+    });
+  });
+
+  it("preserves legacy fallback arrays when updating primary", () => {
+    expect(
+      buildPrimaryModelConfig("openai/gpt-5", {
+        primary: "openai/gpt-4.1",
+        fallback: ["openai/gpt-5-mini"],
+      }),
+    ).toEqual({
+      primary: "openai/gpt-5",
+      fallback: ["openai/gpt-5-mini"],
+    });
+  });
+
+  it("returns a plain string when no fallback list exists", () => {
+    expect(buildPrimaryModelConfig("openai/gpt-5", "openai/gpt-4.1")).toBe("openai/gpt-5");
+    expect(buildPrimaryModelConfig("openai/gpt-5", { primary: "openai/gpt-4.1" })).toBe(
+      "openai/gpt-5",
+    );
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -254,7 +254,7 @@ export function resolveEffectiveModelFallbacks(
 export function buildPrimaryModelConfig(
   primary: string,
   existingModel?: unknown,
-): string | { primary: string; fallbacks?: string[]; fallback?: string[] } {
+): string | { primary: string; fallbacks?: string[] } {
   const trimmedPrimary = primary.trim();
   if (!trimmedPrimary) {
     return "";
@@ -262,17 +262,11 @@ export function buildPrimaryModelConfig(
   if (!existingModel || typeof existingModel !== "object" || Array.isArray(existingModel)) {
     return trimmedPrimary;
   }
-  const record = existingModel as Record<string, unknown>;
-  if (Array.isArray(record.fallbacks)) {
+  const fallbacks = resolveModelFallbacks(existingModel);
+  if (fallbacks) {
     return {
       primary: trimmedPrimary,
-      fallbacks: record.fallbacks.filter((entry): entry is string => typeof entry === "string"),
-    };
-  }
-  if (Array.isArray(record.fallback)) {
-    return {
-      primary: trimmedPrimary,
-      fallback: record.fallback.filter((entry): entry is string => typeof entry === "string"),
+      fallbacks,
     };
   }
   return trimmedPrimary;

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -251,6 +251,33 @@ export function resolveEffectiveModelFallbacks(
   return resolveModelFallbacks(entryModel) ?? resolveModelFallbacks(defaultModel);
 }
 
+export function buildPrimaryModelConfig(
+  primary: string,
+  existingModel?: unknown,
+): string | { primary: string; fallbacks?: string[]; fallback?: string[] } {
+  const trimmedPrimary = primary.trim();
+  if (!trimmedPrimary) {
+    return "";
+  }
+  if (!existingModel || typeof existingModel !== "object" || Array.isArray(existingModel)) {
+    return trimmedPrimary;
+  }
+  const record = existingModel as Record<string, unknown>;
+  if (Array.isArray(record.fallbacks)) {
+    return {
+      primary: trimmedPrimary,
+      fallbacks: record.fallbacks.filter((entry): entry is string => typeof entry === "string"),
+    };
+  }
+  if (Array.isArray(record.fallback)) {
+    return {
+      primary: trimmedPrimary,
+      fallback: record.fallback.filter((entry): entry is string => typeof entry === "string"),
+    };
+  }
+  return trimmedPrimary;
+}
+
 function addModelId(target: Set<string>, value: unknown) {
   if (typeof value !== "string") {
     return;

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -79,6 +79,7 @@ export type AgentsProps = {
   onToolsOverridesChange: (agentId: string, alsoAllow: string[], deny: string[]) => void;
   onConfigReload: () => void;
   onConfigSave: () => void;
+  onDefaultModelChange: (modelId: string | null) => void;
   onModelChange: (agentId: string, modelId: string | null) => void;
   onModelFallbacksChange: (agentId: string, fallbacks: string[]) => void;
   onChannelsRefresh: () => void;
@@ -98,6 +99,36 @@ export type AgentContext = {
   skillsLabel: string;
   isDefault: boolean;
 };
+
+export function resolveOverviewModelState(
+  configForm: Record<string, unknown> | null,
+  agentId: string,
+) {
+  const config = resolveAgentConfig(configForm, agentId);
+  const model = config.entry?.model
+    ? resolveModelLabel(config.entry?.model)
+    : resolveModelLabel(config.defaults?.model);
+  const defaultModel = resolveModelLabel(config.defaults?.model);
+  const modelPrimary =
+    resolveModelPrimary(config.entry?.model) || (model !== "-" ? normalizeModelValue(model) : null);
+  const defaultPrimary =
+    resolveModelPrimary(config.defaults?.model) ||
+    (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
+  const effectivePrimary = modelPrimary ?? defaultPrimary ?? null;
+  const modelFallbacks = resolveEffectiveModelFallbacks(
+    config.entry?.model,
+    config.defaults?.model,
+  );
+
+  return {
+    model,
+    defaultModel,
+    modelPrimary,
+    defaultPrimary,
+    effectivePrimary,
+    modelFallbacks,
+  };
+}
 
 export function renderAgents(props: AgentsProps) {
   const agents = props.agentsList?.agents ?? [];
@@ -182,6 +213,7 @@ export function renderAgents(props: AgentsProps) {
                         configDirty: props.configDirty,
                         onConfigReload: props.onConfigReload,
                         onConfigSave: props.onConfigSave,
+                        onDefaultModelChange: props.onDefaultModelChange,
                         onModelChange: props.onModelChange,
                         onModelFallbacksChange: props.onModelFallbacksChange,
                       })
@@ -357,6 +389,7 @@ function renderAgentOverview(params: {
   configDirty: boolean;
   onConfigReload: () => void;
   onConfigSave: () => void;
+  onDefaultModelChange: (modelId: string | null) => void;
   onModelChange: (agentId: string, modelId: string | null) => void;
   onModelFallbacksChange: (agentId: string, fallbacks: string[]) => void;
 }) {
@@ -372,6 +405,7 @@ function renderAgentOverview(params: {
     configDirty,
     onConfigReload,
     onConfigSave,
+    onDefaultModelChange,
     onModelChange,
     onModelFallbacksChange,
   } = params;
@@ -380,19 +414,9 @@ function renderAgentOverview(params: {
     agentFilesList && agentFilesList.agentId === agent.id ? agentFilesList.workspace : null;
   const workspace =
     workspaceFromFiles || config.entry?.workspace || config.defaults?.workspace || "default";
-  const model = config.entry?.model
-    ? resolveModelLabel(config.entry?.model)
-    : resolveModelLabel(config.defaults?.model);
-  const defaultModel = resolveModelLabel(config.defaults?.model);
-  const modelPrimary =
-    resolveModelPrimary(config.entry?.model) || (model !== "-" ? normalizeModelValue(model) : null);
-  const defaultPrimary =
-    resolveModelPrimary(config.defaults?.model) ||
-    (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
-  const effectivePrimary = modelPrimary ?? defaultPrimary ?? null;
-  const modelFallbacks = resolveEffectiveModelFallbacks(
-    config.entry?.model,
-    config.defaults?.model,
+  const { model, defaultPrimary, effectivePrimary, modelFallbacks } = resolveOverviewModelState(
+    configForm,
+    agent.id,
   );
   const fallbackText = modelFallbacks ? modelFallbacks.join(", ") : "";
   const identityName =
@@ -446,6 +470,20 @@ function renderAgentOverview(params: {
 
       <div class="agent-model-select" style="margin-top: 20px;">
         <div class="label">Model Selection</div>
+        <div class="row" style="gap: 12px; flex-wrap: wrap; margin-bottom: 12px;">
+          <label class="field" style="min-width: 260px; flex: 1;">
+            <span>Active Primary Model (global default)</span>
+            <select
+              .value=${defaultPrimary ?? ""}
+              ?disabled=${!configForm || configLoading || configSaving}
+              @change=${(e: Event) =>
+                onDefaultModelChange((e.target as HTMLSelectElement).value || null)}
+            >
+              <option value="">Unset</option>
+              ${buildModelOptions(configForm, defaultPrimary ?? undefined)}
+            </select>
+          </label>
+        </div>
         <div class="row" style="gap: 12px; flex-wrap: wrap;">
           <label class="field" style="min-width: 260px; flex: 1;">
             <span>Primary model${isDefault ? " (default)" : ""}</span>


### PR DESCRIPTION
  ## Summary

  - add a clear global `Active Primary Model` selector to the Agents overview
  - update `agents.defaults.model` directly from the Dashboard instead of requiring raw config edits
  - preserve existing default-model fallbacks when changing the global primary model
  - keep existing per-agent model override behavior unchanged

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes: None
  - Related: None

  ## User-visible / Behavior Changes

  - Adds a global `Active Primary Model` selector in the Agents overview.
  - Users can change the default primary model from the Dashboard without editing raw config.
  - Existing per-agent model override controls remain unchanged.

  ## Security Impact (required)

  - New permissions/capabilities? `No`
  - Secrets/tokens handling changed? `No`
  - New/changed network calls? `No`
  - Command/tool execution surface changed? `No`
  - Data access scope changed? `No`
  - If any `Yes`, explain risk + mitigation: `N/A`

  ## Repro + Verification

  ### Environment

  - OS: Windows 11
  - Runtime/container: local UI dev/test environment
  - Model/provider: config-driven, provider-agnostic
  - Integration/channel (if any): none
  - Relevant config (redacted): `agents.defaults.model` plus optional agent-level `model` overrides

  ### Steps

  1. Open the Agents overview for a configured installation.
  2. Change the new global `Active Primary Model` selector.
  3. Save config and verify `agents.defaults.model` updates.
  4. Verify an agent with its own model override still keeps that override.

  ### Expected

  - The global selector updates the default primary model.
  - Existing default fallbacks are preserved.
  - Agent-specific overrides are not removed or rewritten.

  ### Actual

  - Implemented as above.
  - Added focused node-level coverage for default-vs-override model state resolution.

  ## Evidence

  - [ ] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - Verified scenarios:
    - global default primary model is resolved separately from agent override state
    - agent override remains the effective model when present
    - default fallbacks remain attached when changing the global primary model
  - Edge cases checked:
    - defaults stored as string
    - defaults stored as object with `primary` and `fallbacks`
    - agent entry with no override
  - What I did **not** verify:
    - full browser interaction coverage
    - broader auth/profile management flows

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? `Yes`
  - Config/env changes? `No`
  - Migration needed? `No`
  - If yes, exact upgrade steps: `N/A`

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: revert this PR
  - Files/config to restore:
    - `ui/src/ui/views/agents.ts`
    - `ui/src/ui/app-render.ts`
  - Known bad symptoms reviewers should watch for:
    - global selector accidentally overwriting agent-level overrides
    - default fallbacks being dropped when changing the global model

  ## Risks and Mitigations

  - Risk: reviewers may read this as a full model-profile management solution
    - Mitigation: scope is intentionally limited to a global default primary-model selector only

  - Risk: future UI changes could conflate global defaults with per-agent overrides again
    - Mitigation: added focused tests around overview model-state resolution