### PR TITLE
fix(update): surface EBUSY recovery hint when gateway locks install dir on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Models/Kimi Coding: send `anthropic-messages` tools in native Anthropic format again so `kimi-coding` stops degrading tool calls into XML/plain-text pseudo invocations instead of real `tool_use` blocks. (#38669, #39907, #40552) Thanks @opriz.
 - Context engine/tests: add bundled-registry regression coverage for cross-chunk resolution, plugin-sdk re-exports, and concurrent chunk registration. (#40460) thanks @dsantoreis.
 - Agents/embedded runner: bound compaction retry waiting and drain embedded runs during SIGUSR1 restart so session lanes recover instead of staying blocked behind compaction. (#40324) thanks @cgdusek.
+- CLI/update: surface an EBUSY recovery hint when a running process locks the install directory during npm global update on Windows, and scope detection to the rename syscall to avoid false positives. (#40724) Thanks @ademczuk.
 
 ## 2026.3.8
 

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -42,6 +42,16 @@ describe("inferUpdateFailureHints", () => {
     expect(hints.join("\n")).toContain("--omit=optional");
   });
 
+  it("returns EBUSY hint when Windows directory lock blocks npm rename", () => {
+    const result = makeResult(
+      "global update (omit optional)",
+      "npm error code EBUSY\nnpm error syscall rename\nnpm error path C:\\node_modules\\openclaw\nnpm error errno -4082",
+    );
+    const hints = inferUpdateFailureHints(result);
+    expect(hints.join("\n")).toContain("EBUSY");
+    expect(hints.join("\n")).toContain("openclaw gateway stop");
+  });
+
   it("does not return npm hints for non-npm install modes", () => {
     const result = makeResult(
       "global update",

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -67,7 +67,11 @@ export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
 
   // Windows: a running process (gateway or the CLI itself) locks node_modules/openclaw,
   // blocking the npm rename that global installs require.
-  if (failedStep.name.startsWith("global update") && stderr.includes("ebusy") && stderr.includes("rename")) {
+  if (
+    failedStep.name.startsWith("global update") &&
+    stderr.includes("ebusy") &&
+    stderr.includes("rename")
+  ) {
     hints.push(
       "Detected directory lock (EBUSY). On Windows a running process (typically the gateway) holds a lock on the install directory.",
     );

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -65,6 +65,15 @@ export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
     hints.push("If it still fails: npm i -g openclaw@latest --omit=optional");
   }
 
+  // Windows: the running process locks node_modules/openclaw, blocking npm rename
+  if (failedStep.name.startsWith("global update") && stderr.includes("ebusy")) {
+    hints.push(
+      "Detected directory lock (EBUSY). On Windows the running gateway holds a lock on the install directory.",
+    );
+    hints.push("Stop the gateway first: openclaw gateway stop");
+    hints.push("Then update manually: npm i -g openclaw@latest");
+  }
+
   return hints;
 }
 

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -65,10 +65,11 @@ export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
     hints.push("If it still fails: npm i -g openclaw@latest --omit=optional");
   }
 
-  // Windows: the running process locks node_modules/openclaw, blocking npm rename
+  // Windows: a running process (gateway or the CLI itself) locks node_modules/openclaw,
+  // blocking the npm rename that global installs require.
   if (failedStep.name.startsWith("global update") && stderr.includes("ebusy")) {
     hints.push(
-      "Detected directory lock (EBUSY). On Windows the running gateway holds a lock on the install directory.",
+      "Detected directory lock (EBUSY). On Windows a running process (typically the gateway) holds a lock on the install directory.",
     );
     hints.push("Stop the gateway first: openclaw gateway stop");
     hints.push("Then update manually: npm i -g openclaw@latest");

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -67,7 +67,7 @@ export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
 
   // Windows: a running process (gateway or the CLI itself) locks node_modules/openclaw,
   // blocking the npm rename that global installs require.
-  if (failedStep.name.startsWith("global update") && stderr.includes("ebusy")) {
+  if (failedStep.name.startsWith("global update") && stderr.includes("ebusy") && stderr.includes("rename")) {
     hints.push(
       "Detected directory lock (EBUSY). On Windows a running process (typically the gateway) holds a lock on the install directory.",
     );


### PR DESCRIPTION
## Summary

- Problem: On Windows, `openclaw update` fails with `EBUSY errno -4082` when a running process (e.g. the gateway) holds a lock on `node_modules/openclaw` during the npm global rename step. The error is silent - no recovery guidance.
- Why it matters: Users hit this on every update attempt while the gateway is running. Without a hint, they open issues or give up. The fix path is simple (`openclaw gateway stop`) but non-obvious.
- What changed: Added an EBUSY branch to `inferUpdateFailureHints` in `src/cli/update-cli/progress.ts`. Detection is scoped to the rename syscall (`stderr.includes("rename")`) so it doesn't fire on unrelated EBUSY errors. Matching test added to `progress.test.ts`.
- What did NOT change (scope boundary): No changes to the update flow, gateway lifecycle, EACCES hints, node-gyp hints, or any other code path. CHANGELOG.md line-ending normalisation only (CRLF to LF throughout) with no content changes beyond the new entry.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40540
- Related #40615 (prior attempt by @dsantoreis - closed by barnacle; this PR extracts only the EBUSY hint)

## User-visible / Behavior Changes

When `openclaw update` fails with an EBUSY / directory-lock error on Windows, the CLI now prints three recovery hints:

1. "Detected directory lock (EBUSY). On Windows a running process (typically the gateway) holds a lock on the install directory."
2. "Stop the gateway first: openclaw gateway stop"
3. "Then update manually: npm i -g openclaw@latest"

No change to behaviour on macOS, Linux, or Windows when no EBUSY error occurs.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Windows 11 (EBUSY is Windows-specific; `errno -4082` does not occur on POSIX)
- Runtime/container: Node 22, npm global install
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Gateway running as background process

### Steps

1. Start `openclaw gateway run` (or launch via app)
2. Run `openclaw update` while gateway is active
3. Observe EBUSY error in the output

### Expected

- Recovery hints displayed: stop the gateway, then retry with `npm i -g openclaw@latest`

### Actual (before fix)

- Silent EBUSY failure, no guidance, user must search/file issue to find the fix

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test case in `progress.test.ts`: "returns EBUSY hint when Windows directory lock blocks npm rename". All 4 tests in the file pass.

## Human Verification (required)

- Verified scenarios: unit test confirms EBUSY+rename combination triggers exactly 3 hints; test confirms EBUSY without "rename" does not trigger hints; existing EACCES + node-gyp test cases unaffected.
- Edge cases checked: EBUSY without "rename" substring (e.g. file-handle lock on a different file) - does not fire; other `failedStep.name` values - does not fire; both conditions required.
- What you did **not** verify: live end-to-end on a real Windows machine while gateway is active. The EBUSY condition requires npm's rename attempt to be blocked, which needs an actual running gateway process.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `src/cli/update-cli/progress.ts` to remove the EBUSY branch; hints won't appear.
- Files/config to restore: `src/cli/update-cli/progress.ts` only (test and changelog changes are safe to leave).
- Known bad symptoms reviewers should watch for: EBUSY hint appearing on non-Windows platforms or for non-rename EBUSY errors (guarded by both `"ebusy"` and `"rename"` checks in stderr).

## Risks and Mitigations

- Risk: A non-standard npm build might produce EBUSY stderr output without the word "rename", causing the hint to not fire when it should.
  - Mitigation: The hint is advisory only - the update will still fail and users can find the gateway-stop workaround from other sources. The false-negative is preferable to a false-positive on unrelated EBUSY errors.