### PR TITLE
fix(test): fix broken Telegram DM auth assertion on main

### DIFF
--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1243,6 +1243,7 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).toHaveBeenCalledWith(
       12345,
       "You are not authorized to use this command.",
+      {},
     );
   });
 


### PR DESCRIPTION
## Problem

The "blocks native DM commands for unpaired users" test in `bot.test.ts` fails on current `main` — `sendMessageSpy` is called with a third `threadParams` argument (`{}`) after #34873, but the assertion was not updated.

This is a single-assertion fix: adds the expected `{}` to match the actual call signature.

Supersedes #37631 (rebased onto current main).