### PR TITLE
fix: use absolute node path in macOS LaunchAgent plist

### DIFF
--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -65,6 +65,40 @@ describe("resolveGatewayProgramArguments", () => {
     expect(result.programArguments[1]).not.toContain("@2026.1.21-2");
   });
 
+  it("falls back to process.execPath when nodePath is not absolute", async () => {
+    // launchd resolves ProgramArguments[0] before EnvironmentVariables, so a
+    // bare "node" would fail. The fix ensures a non-absolute nodePath is
+    // replaced with process.execPath.
+    const entryPath = path.resolve("/usr/local/lib/node_modules/openclaw/dist/entry.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({
+      port: 18789,
+      runtime: "node",
+      nodePath: "node", // bare name, not absolute
+    });
+
+    expect(path.isAbsolute(result.programArguments[0]!)).toBe(true);
+    expect(result.programArguments[0]).toBe(process.execPath);
+  });
+
+  it("uses provided absolute nodePath when runtime is node", async () => {
+    const entryPath = path.resolve("/usr/local/lib/node_modules/openclaw/dist/entry.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({
+      port: 18789,
+      runtime: "node",
+      nodePath: "/opt/homebrew/bin/node",
+    });
+
+    expect(result.programArguments[0]).toBe("/opt/homebrew/bin/node");
+  });
+
   it("falls back to node_modules package dist when .bin path is not resolved", async () => {
     const argv1 = path.resolve("/tmp/.npm/_npx/63c3/node_modules/.bin/openclaw");
     const indexPath = path.resolve("/tmp/.npm/_npx/63c3/node_modules/openclaw/dist/index.js");

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -167,8 +167,12 @@ async function resolveCliProgramArguments(params: {
   const runtime = params.runtime ?? "auto";
 
   if (runtime === "node") {
-    const nodePath =
+    const resolvedNodePath =
       params.nodePath ?? (isNodeRuntime(execPath) ? execPath : await resolveNodePath());
+    // launchd resolves ProgramArguments[0] before applying EnvironmentVariables,
+    // so a bare "node" will fail even when PATH is set in the plist. Ensure the
+    // runtime path is always absolute; fall back to process.execPath if not.
+    const nodePath = path.isAbsolute(resolvedNodePath) ? resolvedNodePath : execPath;
     const cliEntrypointPath = await resolveCliEntrypointPathForService();
     return {
       programArguments: [nodePath, cliEntrypointPath, ...params.args],


### PR DESCRIPTION
## Summary

- Guard `resolveCliProgramArguments()` to ensure the resolved node path is always absolute before placing it into `programArguments`. When `nodePath` is not absolute (e.g. a bare `"node"` string), falls back to `process.execPath` which is always an absolute path to the running Node binary.
- macOS `launchd` resolves `ProgramArguments[0]` **before** applying `EnvironmentVariables`, so a bare `node` in the plist fails even when `PATH` is correctly set in the `EnvironmentVariables` dict.
- Adds tests verifying the absolute-path fallback and that a provided absolute `nodePath` is preserved.

Closes #40659

## Test plan

- [x] Existing `program-args.test.ts` tests still pass (3 original tests)
- [x] New test: bare `"node"` as `nodePath` with `runtime: "node"` falls back to `process.execPath` (absolute)
- [x] New test: absolute `/opt/homebrew/bin/node` as `nodePath` is preserved
- [x] Related `launchd.test.ts` and `daemon-install-helpers.test.ts` all pass (29 tests)
- [x] TypeScript type check passes (`tsc --noEmit`)
