### PR TITLE
fix(telegram): move network fallback to resolver-scoped dispatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Cron/state errors: record `lastErrorReason` in cron job state and keep the gateway schema aligned with the full failover-reason set, including regression coverage for protocol conformance. (#14382) thanks @futuremind2026.
 - Tools/web search: recover OpenRouter Perplexity citation extraction from `message.annotations` when chat-completions responses omit top-level citations. (#40881) Thanks @laurieluo.
 - Security/external content: treat whitespace-delimited `EXTERNAL UNTRUSTED CONTENT` boundary markers like underscore-delimited variants so prompt wrappers cannot bypass marker sanitization. (#35983) Thanks @urianpaul94.
+- Telegram/network env-proxy: apply configured transport policy to proxied HTTPS dispatchers as well as direct `NO_PROXY` bypasses, so resolver-scoped IPv4 fallback and network settings work consistently for env-proxied Telegram traffic. (#40740) Thanks @sircrumpet.
 
 ## 2026.3.8
 

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -57,18 +57,38 @@ function installGatewayRuntime(params?: { probeOk?: boolean; botUsername?: strin
   const probeTelegram = vi.fn(async () =>
     params?.probeOk ? { ok: true, bot: { username: params.botUsername ?? "bot" } } : { ok: false },
   );
+  const collectUnmentionedGroupIds = vi.fn(() => ({
+    groupIds: [] as string[],
+    unresolvedGroups: 0,
+    hasWildcardUnmentionedGroups: false,
+  }));
+  const auditGroupMembership = vi.fn(async () => ({
+    ok: true,
+    checkedGroups: 0,
+    unresolvedGroups: 0,
+    hasWildcardUnmentionedGroups: false,
+    groups: [],
+    elapsedMs: 0,
+  }));
   setTelegramRuntime({
     channel: {
       telegram: {
         monitorTelegramProvider,
         probeTelegram,
+        collectUnmentionedGroupIds,
+        auditGroupMembership,
       },
     },
     logging: {
       shouldLogVerbose: () => false,
     },
   } as unknown as PluginRuntime);
-  return { monitorTelegramProvider, probeTelegram };
+  return {
+    monitorTelegramProvider,
+    probeTelegram,
+    collectUnmentionedGroupIds,
+    auditGroupMembership,
+  };
 }
 
 describe("telegramPlugin duplicate token guard", () => {
@@ -178,6 +198,52 @@ describe("telegramPlugin duplicate token guard", () => {
         autoSelectFamily: false,
         dnsResultOrder: "ipv4first",
       },
+    });
+  });
+
+  it("passes account proxy and network settings into Telegram membership audits", async () => {
+    const { collectUnmentionedGroupIds, auditGroupMembership } = installGatewayRuntime({
+      probeOk: true,
+      botUsername: "opsbot",
+    });
+
+    collectUnmentionedGroupIds.mockReturnValue({
+      groupIds: ["-100123"],
+      unresolvedGroups: 0,
+      hasWildcardUnmentionedGroups: false,
+    });
+
+    const cfg = createCfg();
+    cfg.channels!.telegram!.accounts!.ops = {
+      ...cfg.channels!.telegram!.accounts!.ops,
+      proxy: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+      groups: {
+        "-100123": { requireMention: false },
+      },
+    };
+    const account = telegramPlugin.config.resolveAccount(cfg, "ops");
+
+    await telegramPlugin.status!.auditAccount!({
+      account,
+      timeoutMs: 5000,
+      probe: { ok: true, bot: { id: 123 }, elapsedMs: 1 },
+      cfg,
+    });
+
+    expect(auditGroupMembership).toHaveBeenCalledWith({
+      token: "token-ops",
+      botId: 123,
+      groupIds: ["-100123"],
+      proxyUrl: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+      timeoutMs: 5000,
     });
   });
 

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -193,6 +193,7 @@ describe("telegramPlugin duplicate token guard", () => {
     });
 
     expect(probeTelegram).toHaveBeenCalledWith("token-ops", 5000, {
+      accountId: "ops",
       proxyUrl: "http://127.0.0.1:8888",
       network: {
         autoSelectFamily: false,

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -149,6 +149,38 @@ describe("telegramPlugin duplicate token guard", () => {
     );
   });
 
+  it("passes account proxy and network settings into Telegram probes", async () => {
+    const { probeTelegram } = installGatewayRuntime({
+      probeOk: true,
+      botUsername: "opsbot",
+    });
+
+    const cfg = createCfg();
+    cfg.channels!.telegram!.accounts!.ops = {
+      ...cfg.channels!.telegram!.accounts!.ops,
+      proxy: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    };
+    const account = telegramPlugin.config.resolveAccount(cfg, "ops");
+
+    await telegramPlugin.status!.probeAccount!({
+      account,
+      timeoutMs: 5000,
+      cfg,
+    });
+
+    expect(probeTelegram).toHaveBeenCalledWith("token-ops", 5000, {
+      proxyUrl: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+  });
+
   it("forwards mediaLocalRoots to sendMessageTelegram for outbound media sends", async () => {
     const sendMessageTelegram = vi.fn(async () => ({ messageId: "tg-1" }));
     setTelegramRuntime({

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -438,11 +438,10 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     collectStatusIssues: collectTelegramStatusIssues,
     buildChannelSummary: ({ snapshot }) => buildTokenChannelStatusSummary(snapshot),
     probeAccount: async ({ account, timeoutMs }) =>
-      getTelegramRuntime().channel.telegram.probeTelegram(
-        account.token,
-        timeoutMs,
-        account.config.proxy,
-      ),
+      getTelegramRuntime().channel.telegram.probeTelegram(account.token, timeoutMs, {
+        proxyUrl: account.config.proxy,
+        network: account.config.network,
+      }),
     auditAccount: async ({ account, timeoutMs, probe, cfg }) => {
       const groups =
         cfg.channels?.telegram?.accounts?.[account.accountId]?.groups ??
@@ -531,11 +530,10 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       const token = (account.token ?? "").trim();
       let telegramBotLabel = "";
       try {
-        const probe = await getTelegramRuntime().channel.telegram.probeTelegram(
-          token,
-          2500,
-          account.config.proxy,
-        );
+        const probe = await getTelegramRuntime().channel.telegram.probeTelegram(token, 2500, {
+          proxyUrl: account.config.proxy,
+          network: account.config.network,
+        });
         const username = probe.ok ? probe.bot?.username?.trim() : null;
         if (username) {
           telegramBotLabel = ` (@${username})`;

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -439,6 +439,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     buildChannelSummary: ({ snapshot }) => buildTokenChannelStatusSummary(snapshot),
     probeAccount: async ({ account, timeoutMs }) =>
       getTelegramRuntime().channel.telegram.probeTelegram(account.token, timeoutMs, {
+        accountId: account.accountId,
         proxyUrl: account.config.proxy,
         network: account.config.network,
       }),
@@ -532,6 +533,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       let telegramBotLabel = "";
       try {
         const probe = await getTelegramRuntime().channel.telegram.probeTelegram(token, 2500, {
+          accountId: account.accountId,
           proxyUrl: account.config.proxy,
           network: account.config.network,
         });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -467,6 +467,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         botId,
         groupIds,
         proxyUrl: account.config.proxy,
+        network: account.config.network,
         timeoutMs,
       });
       return { ...audit, unresolvedGroups, hasWildcardUnmentionedGroups };

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -48,6 +48,7 @@ describe("makeProxyFetch", () => {
     undiciFetch.mockResolvedValue({ ok: true });
 
     const proxyFetch = makeProxyFetch(proxyUrl);
+    expect(proxyAgentSpy).not.toHaveBeenCalled();
     await proxyFetch("https://api.example.com/v1/audio");
 
     expect(proxyAgentSpy).toHaveBeenCalledWith(proxyUrl);

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -11,13 +11,19 @@ type ProxyFetchWithMetadata = typeof fetch & {
  * Uses undici's ProxyAgent under the hood.
  */
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
-  const agent = new ProxyAgent(proxyUrl);
+  let agent: ProxyAgent | null = null;
+  const resolveAgent = (): ProxyAgent => {
+    if (!agent) {
+      agent = new ProxyAgent(proxyUrl);
+    }
+    return agent;
+  };
   // undici's fetch is runtime-compatible with global fetch but the types diverge
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
   const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
       ...(init as Record<string, unknown>),
-      dispatcher: agent,
+      dispatcher: resolveAgent(),
     }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
   Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
     value: proxyUrl,

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,6 +1,11 @@
 import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import { logWarn } from "../../logger.js";
 
+export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
+type ProxyFetchWithMetadata = typeof fetch & {
+  [PROXY_FETCH_PROXY_URL]?: string;
+};
+
 /**
  * Create a fetch function that routes requests through the given HTTP proxy.
  * Uses undici's ProxyAgent under the hood.
@@ -9,11 +14,27 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const agent = new ProxyAgent(proxyUrl);
   // undici's fetch is runtime-compatible with global fetch but the types diverge
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
-  return ((input: RequestInfo | URL, init?: RequestInit) =>
+  const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
       ...(init as Record<string, unknown>),
       dispatcher: agent,
-    }) as unknown as Promise<Response>) as typeof fetch;
+    }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
+  Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
+    value: proxyUrl,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return proxyFetch;
+}
+
+export function getProxyUrlFromFetch(fetchImpl?: typeof fetch): string | undefined {
+  const proxyUrl = (fetchImpl as ProxyFetchWithMetadata | undefined)?.[PROXY_FETCH_PROXY_URL];
+  if (typeof proxyUrl !== "string") {
+    return undefined;
+  }
+  const trimmed = proxyUrl.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 /**

--- a/src/telegram/audit-membership-runtime.ts
+++ b/src/telegram/audit-membership-runtime.ts
@@ -5,6 +5,7 @@ import type {
   TelegramGroupMembershipAudit,
   TelegramGroupMembershipAuditEntry,
 } from "./audit.js";
+import { resolveTelegramFetch } from "./fetch.js";
 import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -16,7 +17,8 @@ type TelegramGroupMembershipAuditData = Omit<TelegramGroupMembershipAudit, "elap
 export async function auditTelegramGroupMembershipImpl(
   params: AuditTelegramGroupMembershipParams,
 ): Promise<TelegramGroupMembershipAuditData> {
-  const fetcher = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : fetch;
+  const proxyFetch = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : undefined;
+  const fetcher = resolveTelegramFetch(proxyFetch, { network: params.network }) ?? fetch;
   const base = `${TELEGRAM_API_BASE}/bot${params.token}`;
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 

--- a/src/telegram/audit-membership-runtime.ts
+++ b/src/telegram/audit-membership-runtime.ts
@@ -18,7 +18,7 @@ export async function auditTelegramGroupMembershipImpl(
   params: AuditTelegramGroupMembershipParams,
 ): Promise<TelegramGroupMembershipAuditData> {
   const proxyFetch = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : undefined;
-  const fetcher = resolveTelegramFetch(proxyFetch, { network: params.network }) ?? fetch;
+  const fetcher = resolveTelegramFetch(proxyFetch, { network: params.network });
   const base = `${TELEGRAM_API_BASE}/bot${params.token}`;
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 

--- a/src/telegram/audit.test.ts
+++ b/src/telegram/audit.test.ts
@@ -2,16 +2,22 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let collectTelegramUnmentionedGroupIds: typeof import("./audit.js").collectTelegramUnmentionedGroupIds;
 let auditTelegramGroupMembership: typeof import("./audit.js").auditTelegramGroupMembership;
+const undiciFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return {
+    ...actual,
+    fetch: undiciFetch,
+  };
+});
 
 function mockGetChatMemberStatus(status: string) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValueOnce(
-      new Response(JSON.stringify({ ok: true, result: { status } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    ),
+  undiciFetch.mockResolvedValueOnce(
+    new Response(JSON.stringify({ ok: true, result: { status } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
   );
 }
 
@@ -31,7 +37,7 @@ describe("telegram audit", () => {
   });
 
   beforeEach(() => {
-    vi.unstubAllGlobals();
+    undiciFetch.mockReset();
   });
 
   it("collects unmentioned numeric group ids and flags wildcard", async () => {

--- a/src/telegram/audit.ts
+++ b/src/telegram/audit.ts
@@ -1,4 +1,5 @@
 import type { TelegramGroupConfig } from "../config/types.js";
+import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 
 export type TelegramGroupMembershipAuditEntry = {
   chatId: string;
@@ -64,6 +65,7 @@ export type AuditTelegramGroupMembershipParams = {
   botId: number;
   groupIds: string[];
   proxyUrl?: string;
+  network?: TelegramNetworkConfig;
   timeoutMs: number;
 };
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -123,6 +123,7 @@ export const registerTelegramHandlers = ({
   accountId,
   bot,
   opts,
+  telegramFetchImpl,
   runtime,
   mediaMaxBytes,
   telegramCfg,
@@ -371,7 +372,7 @@ export const registerTelegramHandlers = ({
       for (const { ctx } of entry.messages) {
         let media;
         try {
-          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, telegramFetchImpl);
         } catch (mediaErr) {
           if (!isRecoverableMediaGroupError(mediaErr)) {
             throw mediaErr;
@@ -475,7 +476,7 @@ export const registerTelegramHandlers = ({
         },
         mediaMaxBytes,
         opts.token,
-        opts.proxyFetch,
+        telegramFetchImpl,
       );
       if (!media) {
         return [];
@@ -986,7 +987,7 @@ export const registerTelegramHandlers = ({
 
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
-      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, telegramFetchImpl);
     } catch (mediaErr) {
       if (isMediaSizeLimitError(mediaErr)) {
         if (sendOversizeWarning) {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -94,6 +94,7 @@ export type RegisterTelegramHandlerParams = {
   bot: Bot;
   mediaMaxBytes: number;
   opts: TelegramBotOptions;
+  telegramFetchImpl?: typeof fetch;
   runtime: RuntimeEnv;
   telegramCfg: TelegramAccountConfig;
   allowFrom?: Array<string | number>;

--- a/src/telegram/bot.media.e2e-harness.ts
+++ b/src/telegram/bot.media.e2e-harness.ts
@@ -6,6 +6,9 @@ export const middlewareUseSpy: Mock = vi.fn();
 export const onSpy: Mock = vi.fn();
 export const stopSpy: Mock = vi.fn();
 export const sendChatActionSpy: Mock = vi.fn();
+export const undiciFetchSpy: Mock = vi.fn((input: RequestInfo | URL, init?: RequestInit) =>
+  globalThis.fetch(input, init),
+);
 
 async function defaultSaveMediaBuffer(buffer: Buffer, contentType?: string) {
   return {
@@ -80,6 +83,14 @@ const throttlerSpy = vi.fn(() => "throttler");
 vi.mock("@grammyjs/transformer-throttler", () => ({
   apiThrottler: () => throttlerSpy(),
 }));
+
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return {
+    ...actual,
+    fetch: (...args: Parameters<typeof undiciFetchSpy>) => undiciFetchSpy(...args),
+  };
+});
 
 vi.mock("../media/store.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../media/store.js")>();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -439,6 +439,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     accountId: account.accountId,
     bot,
     opts,
+    telegramFetchImpl: fetchImpl as unknown as typeof fetch | undefined,
     runtime,
     mediaMaxBytes,
     telegramCfg,

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -293,6 +293,62 @@ describe("resolveMedia getFile retry", () => {
     expect(getFile).toHaveBeenCalledTimes(3);
     expect(result).toBeNull();
   });
+
+  it("uses caller-provided fetch impl for file downloads", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
+    const callerFetch = vi.fn() as unknown as typeof fetch;
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf-data"),
+      contentType: "application/pdf",
+      fileName: "file_42.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_42---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    const result = await resolveMedia(
+      makeCtx("document", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      callerFetch,
+    );
+
+    expect(result).not.toBeNull();
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchImpl: callerFetch,
+      }),
+    );
+  });
+
+  it("uses caller-provided fetch impl for sticker downloads", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "stickers/file_0.webp" });
+    const callerFetch = vi.fn() as unknown as typeof fetch;
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("sticker-data"),
+      contentType: "image/webp",
+      fileName: "file_0.webp",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.webp",
+      contentType: "image/webp",
+    });
+
+    const result = await resolveMedia(
+      makeCtx("sticker", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      callerFetch,
+    );
+
+    expect(result).not.toBeNull();
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchImpl: callerFetch,
+      }),
+    );
+  });
 });
 
 describe("resolveMedia original filename preservation", () => {

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -92,12 +92,20 @@ async function resolveTelegramFileWithRetry(
   }
 }
 
-function resolveRequiredFetchImpl(proxyFetch?: typeof fetch): typeof fetch {
-  const fetchImpl = proxyFetch ?? globalThis.fetch;
-  if (!fetchImpl) {
+function resolveRequiredFetchImpl(fetchImpl?: typeof fetch): typeof fetch {
+  const resolved = fetchImpl ?? globalThis.fetch;
+  if (!resolved) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  return fetchImpl;
+  return resolved;
+}
+
+function resolveOptionalFetchImpl(fetchImpl?: typeof fetch): typeof fetch | null {
+  try {
+    return resolveRequiredFetchImpl(fetchImpl);
+  } catch {
+    return null;
+  }
 }
 
 /** Default idle timeout for Telegram media downloads (30 seconds). */
@@ -134,7 +142,7 @@ async function resolveStickerMedia(params: {
   ctx: TelegramContext;
   maxBytes: number;
   token: string;
-  proxyFetch?: typeof fetch;
+  fetchImpl?: typeof fetch;
 }): Promise<
   | {
       path: string;
@@ -145,7 +153,7 @@ async function resolveStickerMedia(params: {
   | null
   | undefined
 > {
-  const { msg, ctx, maxBytes, token, proxyFetch } = params;
+  const { msg, ctx, maxBytes, token, fetchImpl } = params;
   if (!msg.sticker) {
     return undefined;
   }
@@ -165,15 +173,15 @@ async function resolveStickerMedia(params: {
       logVerbose("telegram: getFile returned no file_path for sticker");
       return null;
     }
-    const fetchImpl = proxyFetch ?? globalThis.fetch;
-    if (!fetchImpl) {
+    const resolvedFetchImpl = resolveOptionalFetchImpl(fetchImpl);
+    if (!resolvedFetchImpl) {
       logVerbose("telegram: fetch not available for sticker download");
       return null;
     }
     const saved = await downloadAndSaveTelegramFile({
       filePath: file.file_path,
       token,
-      fetchImpl,
+      fetchImpl: resolvedFetchImpl,
       maxBytes,
     });
 
@@ -229,7 +237,7 @@ export async function resolveMedia(
   ctx: TelegramContext,
   maxBytes: number,
   token: string,
-  proxyFetch?: typeof fetch,
+  fetchImpl?: typeof fetch,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -242,7 +250,7 @@ export async function resolveMedia(
     ctx,
     maxBytes,
     token,
-    proxyFetch,
+    fetchImpl,
   });
   if (stickerResolved !== undefined) {
     return stickerResolved;
@@ -263,7 +271,7 @@ export async function resolveMedia(
   const saved = await downloadAndSaveTelegramFile({
     filePath: file.file_path,
     token,
-    fetchImpl: resolveRequiredFetchImpl(proxyFetch),
+    fetchImpl: resolveRequiredFetchImpl(fetchImpl),
     maxBytes,
     telegramFileName: resolveTelegramFileName(msg),
   });

--- a/src/telegram/fetch.env-proxy-runtime.test.ts
+++ b/src/telegram/fetch.env-proxy-runtime.test.ts
@@ -1,0 +1,58 @@
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const EnvHttpProxyAgent = require("undici/lib/dispatcher/env-http-proxy-agent.js") as {
+  new (opts?: Record<string, unknown>): Record<PropertyKey, unknown>;
+};
+const { kHttpsProxyAgent, kNoProxyAgent } = require("undici/lib/core/symbols.js") as {
+  kHttpsProxyAgent: symbol;
+  kNoProxyAgent: symbol;
+};
+
+function getOwnSymbolValue(
+  target: Record<PropertyKey, unknown>,
+  description: string,
+): Record<string, unknown> | undefined {
+  const symbol = Object.getOwnPropertySymbols(target).find(
+    (entry) => entry.description === description,
+  );
+  const value = symbol ? target[symbol] : undefined;
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("undici env proxy semantics", () => {
+  it("uses proxyTls rather than connect for proxied HTTPS transport settings", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    const connect = {
+      family: 4,
+      autoSelectFamily: false,
+    };
+
+    const withoutProxyTls = new EnvHttpProxyAgent({ connect });
+    const noProxyAgent = withoutProxyTls[kNoProxyAgent] as Record<PropertyKey, unknown>;
+    const httpsProxyAgent = withoutProxyTls[kHttpsProxyAgent] as Record<PropertyKey, unknown>;
+
+    expect(getOwnSymbolValue(noProxyAgent, "options")?.connect).toEqual(
+      expect.objectContaining(connect),
+    );
+    expect(getOwnSymbolValue(httpsProxyAgent, "proxy tls settings")).toBeUndefined();
+
+    const withProxyTls = new EnvHttpProxyAgent({
+      connect,
+      proxyTls: connect,
+    });
+    const httpsProxyAgentWithProxyTls = withProxyTls[kHttpsProxyAgent] as Record<
+      PropertyKey,
+      unknown
+    >;
+
+    expect(getOwnSymbolValue(httpsProxyAgentWithProxyTls, "proxy tls settings")).toEqual(
+      expect.objectContaining(connect),
+    );
+  });
+});

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -77,6 +77,7 @@ function getDispatcherFromUndiciCall(nth: number) {
     | {
         options?: {
           connect?: Record<string, unknown>;
+          proxyTls?: Record<string, unknown>;
         };
       }
     | undefined;
@@ -199,7 +200,7 @@ describe("resolveTelegramFetch", () => {
         uri: "http://127.0.0.1:7890",
       }),
     );
-    expect(dispatcher?.options?.connect).toEqual(
+    expect(dispatcher?.options?.proxyTls).toEqual(
       expect.objectContaining({
         autoSelectFamily: false,
       }),
@@ -235,13 +236,13 @@ describe("resolveTelegramFetch", () => {
 
     expect(firstDispatcher).toBe(secondDispatcher);
     expect(secondDispatcher).toBe(thirdDispatcher);
-    expect(firstDispatcher?.options?.connect).toEqual(
+    expect(firstDispatcher?.options?.proxyTls).toEqual(
       expect.objectContaining({
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
       }),
     );
-    expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
+    expect(firstDispatcher?.options?.proxyTls?.family).not.toBe(4);
   });
 
   it("does not arm sticky IPv4 fallback for env proxy paths", async () => {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -110,7 +110,7 @@ describe("resolveTelegramFetch", () => {
     const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
     const wrapped = resolveFetch(proxyFetch);
 
-    const resolved = resolveTelegramFetch(proxyFetch ? wrapped : undefined);
+    const resolved = resolveTelegramFetch(wrapped);
 
     expect(resolved).toBe(wrapped);
   });

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -280,6 +280,82 @@ describe("resolveTelegramFetch", () => {
     expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
   });
 
+  it("arms sticky IPv4 fallback when env proxy init falls back to direct Agent", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {
+      throw new Error("invalid proxy config");
+    });
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).toHaveBeenCalledTimes(2);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("arms sticky IPv4 fallback when NO_PROXY bypasses telegram under env proxy", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "api.telegram.org");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(2);
+    expect(AgentCtor).not.toHaveBeenCalled();
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
   it("fails closed when explicit proxy dispatcher initialization fails", async () => {
     const { makeProxyFetch } = await import("./proxy.js");
     const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -203,15 +203,12 @@ describe("resolveTelegramFetch", () => {
     );
   });
 
-  it("does not arm sticky IPv4 fallback for explicit proxy paths", async () => {
+  it("does not blind-retry when sticky IPv4 fallback is disallowed for explicit proxy paths", async () => {
     const { makeProxyFetch } = await import("./proxy.js");
     const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");
     ProxyAgentCtor.mockClear();
     const fetchError = buildFetchFallbackError("EHOSTUNREACH");
-    undiciFetch
-      .mockRejectedValueOnce(fetchError)
-      .mockResolvedValueOnce({ ok: true } as Response)
-      .mockResolvedValueOnce({ ok: true } as Response);
+    undiciFetch.mockRejectedValueOnce(fetchError).mockResolvedValueOnce({ ok: true } as Response);
 
     const resolved = resolveTelegramFetchOrThrow(proxyFetch, {
       network: {
@@ -220,18 +217,18 @@ describe("resolveTelegramFetch", () => {
       },
     });
 
-    await resolved("https://api.telegram.org/botx/sendMessage");
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
+      "fetch failed",
+    );
     await resolved("https://api.telegram.org/botx/sendChatAction");
 
-    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
     expect(ProxyAgentCtor).toHaveBeenCalledTimes(1);
 
     const firstDispatcher = getDispatcherFromUndiciCall(1);
     const secondDispatcher = getDispatcherFromUndiciCall(2);
-    const thirdDispatcher = getDispatcherFromUndiciCall(3);
 
     expect(firstDispatcher).toBe(secondDispatcher);
-    expect(secondDispatcher).toBe(thirdDispatcher);
     expect(firstDispatcher?.options?.proxyTls).toEqual(
       expect.objectContaining({
         autoSelectFamily: true,
@@ -241,13 +238,10 @@ describe("resolveTelegramFetch", () => {
     expect(firstDispatcher?.options?.proxyTls?.family).not.toBe(4);
   });
 
-  it("does not arm sticky IPv4 fallback for env proxy paths", async () => {
+  it("does not blind-retry when sticky IPv4 fallback is disallowed for env proxy paths", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
     const fetchError = buildFetchFallbackError("EHOSTUNREACH");
-    undiciFetch
-      .mockRejectedValueOnce(fetchError)
-      .mockResolvedValueOnce({ ok: true } as Response)
-      .mockResolvedValueOnce({ ok: true } as Response);
+    undiciFetch.mockRejectedValueOnce(fetchError).mockResolvedValueOnce({ ok: true } as Response);
 
     const resolved = resolveTelegramFetchOrThrow(undefined, {
       network: {
@@ -256,18 +250,18 @@ describe("resolveTelegramFetch", () => {
       },
     });
 
-    await resolved("https://api.telegram.org/botx/sendMessage");
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
+      "fetch failed",
+    );
     await resolved("https://api.telegram.org/botx/sendChatAction");
 
-    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
     expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
 
     const firstDispatcher = getDispatcherFromUndiciCall(1);
     const secondDispatcher = getDispatcherFromUndiciCall(2);
-    const thirdDispatcher = getDispatcherFromUndiciCall(3);
 
     expect(firstDispatcher).toBe(secondDispatcher);
-    expect(secondDispatcher).toBe(thirdDispatcher);
     expect(firstDispatcher?.options?.connect).toEqual(
       expect.objectContaining({
         autoSelectFamily: true,

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -280,6 +280,24 @@ describe("resolveTelegramFetch", () => {
     expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
   });
 
+  it("fails closed when explicit proxy dispatcher initialization fails", async () => {
+    const { makeProxyFetch } = await import("./proxy.js");
+    const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");
+    ProxyAgentCtor.mockClear();
+    ProxyAgentCtor.mockImplementationOnce(function ThrowingProxyAgent() {
+      throw new Error("invalid proxy config");
+    });
+
+    expect(() =>
+      resolveTelegramFetchOrThrow(proxyFetch, {
+        network: {
+          autoSelectFamily: true,
+          dnsResultOrder: "ipv4first",
+        },
+      }),
+    ).toThrow("explicit proxy dispatcher init failed: invalid proxy config");
+  });
+
   it("falls back to Agent when env proxy dispatcher initialization fails", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
     EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -23,6 +23,14 @@ const EnvHttpProxyAgentCtor = vi.hoisted(() =>
     this.options = options;
   }),
 );
+const ProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockProxyAgent(
+    this: { options?: Record<string, unknown> | string },
+    options?: Record<string, unknown> | string,
+  ) {
+    this.options = options;
+  }),
+);
 
 vi.mock("node:dns", async () => {
   const actual = await vi.importActual<typeof import("node:dns")>("node:dns");
@@ -43,6 +51,7 @@ vi.mock("node:net", async () => {
 vi.mock("undici", () => ({
   Agent: AgentCtor,
   EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
+  ProxyAgent: ProxyAgentCtor,
   fetch: undiciFetch,
   setGlobalDispatcher,
 }));
@@ -87,6 +96,7 @@ afterEach(() => {
   setGlobalDispatcher.mockReset();
   AgentCtor.mockClear();
   EnvHttpProxyAgentCtor.mockClear();
+  ProxyAgentCtor.mockClear();
   setDefaultResultOrder.mockReset();
   setDefaultAutoSelectFamily.mockReset();
   vi.unstubAllEnvs();
@@ -161,6 +171,37 @@ describe("resolveTelegramFetch", () => {
       expect.objectContaining({
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+  });
+
+  it("keeps resolver-scoped transport policy for OpenClaw proxy fetches", async () => {
+    const { makeProxyFetch } = await import("./proxy.js");
+    const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");
+    ProxyAgentCtor.mockClear();
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(proxyFetch, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(ProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
+    expect(AgentCtor).not.toHaveBeenCalled();
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options).toEqual(
+      expect.objectContaining({
+        uri: "http://127.0.0.1:7890",
+      }),
+    );
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
       }),
     );
   });

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -280,6 +280,41 @@ describe("resolveTelegramFetch", () => {
     expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
   });
 
+  it("treats ALL_PROXY-only env as direct transport and arms sticky IPv4 fallback", async () => {
+    vi.stubEnv("ALL_PROXY", "socks5://127.0.0.1:1080");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
+    expect(AgentCtor).toHaveBeenCalledTimes(2);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
   it("arms sticky IPv4 fallback when env proxy init falls back to direct Agent", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
     EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -170,6 +170,40 @@ describe("resolveTelegramFetch", () => {
         autoSelectFamilyAttemptTimeout: 300,
       }),
     );
+    expect(dispatcher?.options?.proxyTls).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+  });
+
+  it("pins env-proxy transport policy onto proxyTls for proxied HTTPS requests", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(dispatcher?.options?.proxyTls).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
   });
 
   it("keeps resolver-scoped transport policy for OpenClaw proxy fetches", async () => {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -244,6 +244,42 @@ describe("resolveTelegramFetch", () => {
     expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
   });
 
+  it("does not arm sticky IPv4 fallback for env proxy paths", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(firstDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
+  });
+
   it("falls back to Agent when env proxy dispatcher initialization fails", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
     EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -60,11 +60,7 @@ function resolveTelegramFetchOrThrow(
   proxyFetch?: typeof fetch,
   options?: { network?: { autoSelectFamily?: boolean; dnsResultOrder?: "ipv4first" | "verbatim" } },
 ) {
-  const resolved = resolveTelegramFetch(proxyFetch, options);
-  if (!resolved) {
-    throw new Error("expected resolved fetch");
-  }
-  return resolved;
+  return resolveTelegramFetch(proxyFetch, options);
 }
 
 function getDispatcherFromUndiciCall(nth: number) {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -206,6 +206,44 @@ describe("resolveTelegramFetch", () => {
     );
   });
 
+  it("does not arm sticky IPv4 fallback for explicit proxy paths", async () => {
+    const { makeProxyFetch } = await import("./proxy.js");
+    const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");
+    ProxyAgentCtor.mockClear();
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(proxyFetch, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+    expect(ProxyAgentCtor).toHaveBeenCalledTimes(1);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+    expect(firstDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(firstDispatcher?.options?.connect?.family).not.toBe(4);
+  });
+
   it("falls back to Agent when env proxy dispatcher initialization fails", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
     EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -2,24 +2,27 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveFetch } from "../infra/fetch.js";
 import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.js";
 
-const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
+const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
+
+const undiciFetch = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
-const getGlobalDispatcherState = vi.hoisted(() => ({ value: undefined as unknown }));
-const getGlobalDispatcher = vi.hoisted(() => vi.fn(() => getGlobalDispatcherState.value));
-const EnvHttpProxyAgentCtor = vi.hoisted(() =>
-  vi.fn(function MockEnvHttpProxyAgent(this: { options: unknown }, options: unknown) {
+const AgentCtor = vi.hoisted(() =>
+  vi.fn(function MockAgent(
+    this: { options?: Record<string, unknown> },
+    options?: Record<string, unknown>,
+  ) {
     this.options = options;
   }),
 );
-
-vi.mock("node:net", async () => {
-  const actual = await vi.importActual<typeof import("node:net")>("node:net");
-  return {
-    ...actual,
-    setDefaultAutoSelectFamily,
-  };
-});
+const EnvHttpProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockEnvHttpProxyAgent(
+    this: { options?: Record<string, unknown> },
+    options?: Record<string, unknown>,
+  ) {
+    this.options = options;
+  }),
+);
 
 vi.mock("node:dns", async () => {
   const actual = await vi.importActual<typeof import("node:dns")>("node:dns");
@@ -29,266 +32,295 @@ vi.mock("node:dns", async () => {
   };
 });
 
+vi.mock("node:net", async () => {
+  const actual = await vi.importActual<typeof import("node:net")>("node:net");
+  return {
+    ...actual,
+    setDefaultAutoSelectFamily,
+  };
+});
+
 vi.mock("undici", () => ({
+  Agent: AgentCtor,
   EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
-  getGlobalDispatcher,
+  fetch: undiciFetch,
   setGlobalDispatcher,
 }));
 
-const originalFetch = globalThis.fetch;
-
-function expectEnvProxyAgentConstructorCall(params: { nth: number; autoSelectFamily: boolean }) {
-  expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(params.nth, {
-    connect: {
-      autoSelectFamily: params.autoSelectFamily,
-      autoSelectFamilyAttemptTimeout: 300,
-    },
-  });
-}
-
-function resolveTelegramFetchOrThrow() {
-  const resolved = resolveTelegramFetch();
+function resolveTelegramFetchOrThrow(
+  proxyFetch?: typeof fetch,
+  options?: { network?: { autoSelectFamily?: boolean; dnsResultOrder?: "ipv4first" | "verbatim" } },
+) {
+  const resolved = resolveTelegramFetch(proxyFetch, options);
   if (!resolved) {
     throw new Error("expected resolved fetch");
   }
   return resolved;
 }
 
+function getDispatcherFromUndiciCall(nth: number) {
+  const call = undiciFetch.mock.calls[nth - 1] as [RequestInfo | URL, RequestInit?] | undefined;
+  if (!call) {
+    throw new Error(`missing undici fetch call #${nth}`);
+  }
+  const init = call[1] as (RequestInit & { dispatcher?: unknown }) | undefined;
+  return init?.dispatcher as
+    | {
+        options?: {
+          connect?: Record<string, unknown>;
+        };
+      }
+    | undefined;
+}
+
+function buildFetchFallbackError(code: string) {
+  const connectErr = Object.assign(new Error(`connect ${code} api.telegram.org:443`), {
+    code,
+  });
+  return Object.assign(new TypeError("fetch failed"), {
+    cause: connectErr,
+  });
+}
+
 afterEach(() => {
   resetTelegramFetchStateForTests();
-  setDefaultAutoSelectFamily.mockReset();
-  setDefaultResultOrder.mockReset();
+  undiciFetch.mockReset();
   setGlobalDispatcher.mockReset();
-  getGlobalDispatcher.mockClear();
-  getGlobalDispatcherState.value = undefined;
+  AgentCtor.mockClear();
   EnvHttpProxyAgentCtor.mockClear();
+  setDefaultResultOrder.mockReset();
+  setDefaultAutoSelectFamily.mockReset();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
-  if (originalFetch) {
-    globalThis.fetch = originalFetch;
-  } else {
-    delete (globalThis as { fetch?: typeof fetch }).fetch;
-  }
 });
 
 describe("resolveTelegramFetch", () => {
-  it("returns wrapped global fetch when available", async () => {
-    const fetchMock = vi.fn(async () => ({}));
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  it("wraps proxy fetches and leaves retry policy to caller-provided fetch", async () => {
+    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
 
-    const resolved = resolveTelegramFetch();
+    const resolved = resolveTelegramFetchOrThrow(proxyFetch);
 
-    expect(resolved).toBeTypeOf("function");
-    expect(resolved).not.toBe(fetchMock);
-  });
+    await resolved("https://api.telegram.org/botx/getMe");
 
-  it("wraps proxy fetches and normalizes foreign signals once", async () => {
-    let seenSignal: AbortSignal | undefined;
-    const proxyFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seenSignal = init?.signal as AbortSignal | undefined;
-      return {} as Response;
-    });
-
-    const resolved = resolveTelegramFetch(proxyFetch as unknown as typeof fetch);
-    expect(resolved).toBeTypeOf("function");
-
-    let abortHandler: (() => void) | null = null;
-    const addEventListener = vi.fn((event: string, handler: () => void) => {
-      if (event === "abort") {
-        abortHandler = handler;
-      }
-    });
-    const removeEventListener = vi.fn((event: string, handler: () => void) => {
-      if (event === "abort" && abortHandler === handler) {
-        abortHandler = null;
-      }
-    });
-    const fakeSignal = {
-      aborted: false,
-      addEventListener,
-      removeEventListener,
-    } as unknown as AbortSignal;
-
-    if (!resolved) {
-      throw new Error("expected resolved proxy fetch");
-    }
-    await resolved("https://example.com", { signal: fakeSignal });
-
-    expect(proxyFetch).toHaveBeenCalledOnce();
-    expect(seenSignal).toBeInstanceOf(AbortSignal);
-    expect(seenSignal).not.toBe(fakeSignal);
-    expect(addEventListener).toHaveBeenCalledTimes(1);
-    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(proxyFetch).toHaveBeenCalledTimes(1);
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 
   it("does not double-wrap an already wrapped proxy fetch", async () => {
     const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
-    const alreadyWrapped = resolveFetch(proxyFetch);
+    const wrapped = resolveFetch(proxyFetch);
 
-    const resolved = resolveTelegramFetch(alreadyWrapped);
+    const resolved = resolveTelegramFetch(proxyFetch ? wrapped : undefined);
 
-    expect(resolved).toBe(alreadyWrapped);
+    expect(resolved).toBe(wrapped);
   });
 
-  it("honors env enable override", async () => {
-    vi.stubEnv("OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY", "1");
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch();
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
-  });
+  it("uses resolver-scoped Agent dispatcher with configured transport policy", async () => {
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
 
-  it("uses config override when provided", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
-  });
-
-  it("env disable override wins over config", async () => {
-    vi.stubEnv("OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY", "0");
-    vi.stubEnv("OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY", "1");
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(false);
-  });
-
-  it("applies dns result order from config", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { dnsResultOrder: "verbatim" } });
-    expect(setDefaultResultOrder).toHaveBeenCalledWith("verbatim");
-  });
-
-  it("retries dns setter on next call when previous attempt threw", async () => {
-    setDefaultResultOrder.mockImplementationOnce(() => {
-      throw new Error("dns setter failed once");
-    });
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-
-    resolveTelegramFetch(undefined, { network: { dnsResultOrder: "ipv4first" } });
-    resolveTelegramFetch(undefined, { network: { dnsResultOrder: "ipv4first" } });
-
-    expect(setDefaultResultOrder).toHaveBeenCalledTimes(2);
-  });
-
-  it("replaces global undici dispatcher with proxy-aware EnvHttpProxyAgent", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
-  });
-
-  it("keeps an existing proxy-like global dispatcher", async () => {
-    getGlobalDispatcherState.value = {
-      constructor: { name: "ProxyAgent" },
-    };
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).not.toHaveBeenCalled();
-    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
-  });
-
-  it("updates proxy-like dispatcher when proxy env is configured", async () => {
-    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
-    getGlobalDispatcherState.value = {
-      constructor: { name: "ProxyAgent" },
-    };
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
-  });
-
-  it("sets global dispatcher only once across repeated equal decisions", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-  });
-
-  it("updates global dispatcher when autoSelectFamily decision changes", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
-    expectEnvProxyAgentConstructorCall({ nth: 2, autoSelectFamily: false });
-  });
-
-  it("retries once with ipv4 fallback when fetch fails with network timeout/unreachable", async () => {
-    const timeoutErr = Object.assign(new Error("connect ETIMEDOUT 149.154.166.110:443"), {
-      code: "ETIMEDOUT",
-    });
-    const unreachableErr = Object.assign(
-      new Error("connect ENETUNREACH 2001:67c:4e8:f004::9:443"),
-      {
-        code: "ENETUNREACH",
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "verbatim",
       },
-    );
-    const fetchError = Object.assign(new TypeError("fetch failed"), {
-      cause: Object.assign(new Error("aggregate"), {
-        errors: [timeoutErr, unreachableErr],
-      }),
     });
-    const fetchMock = vi
-      .fn()
-      .mockRejectedValueOnce(fetchError)
-      .mockResolvedValueOnce({ ok: true } as Response);
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const resolved = resolveTelegramFetchOrThrow();
+    await resolved("https://api.telegram.org/botx/getMe");
 
-    await resolved("https://api.telegram.org/file/botx/photos/file_1.jpg");
+    expect(AgentCtor).toHaveBeenCalledTimes(1);
+    expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
-    expectEnvProxyAgentConstructorCall({ nth: 2, autoSelectFamily: false });
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher).toBeDefined();
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(typeof dispatcher?.options?.connect?.lookup).toBe("function");
   });
 
-  it("retries with ipv4 fallback once per request, not once per process", async () => {
-    const timeoutErr = Object.assign(new Error("connect ETIMEDOUT 149.154.166.110:443"), {
-      code: "ETIMEDOUT",
+  it("uses EnvHttpProxyAgent dispatcher when proxy env is configured", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
     });
-    const fetchError = Object.assign(new TypeError("fetch failed"), {
-      cause: timeoutErr,
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).not.toHaveBeenCalled();
+
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+  });
+
+  it("falls back to Agent when env proxy dispatcher initialization fails", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EnvHttpProxyAgentCtor.mockImplementationOnce(function ThrowingEnvProxyAgent() {
+      throw new Error("invalid proxy config");
     });
-    const fetchMock = vi
-      .fn()
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).toHaveBeenCalledTimes(1);
+
+    const dispatcher = getDispatcherFromUndiciCall(1);
+    expect(dispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("retries once and then keeps sticky IPv4 dispatcher for subsequent requests", async () => {
+    const fetchError = buildFetchFallbackError("ETIMEDOUT");
+    undiciFetch
       .mockRejectedValueOnce(fetchError)
       .mockResolvedValueOnce({ ok: true } as Response)
-      .mockRejectedValueOnce(fetchError)
       .mockResolvedValueOnce({ ok: true } as Response);
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const resolved = resolveTelegramFetchOrThrow();
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
 
-    await resolved("https://api.telegram.org/file/botx/photos/file_1.jpg");
-    await resolved("https://api.telegram.org/file/botx/photos/file_2.jpg");
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+
+    const firstDispatcher = getDispatcherFromUndiciCall(1);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstDispatcher).toBeDefined();
+    expect(secondDispatcher).toBeDefined();
+    expect(thirdDispatcher).toBeDefined();
+
+    expect(firstDispatcher).not.toBe(secondDispatcher);
+    expect(secondDispatcher).toBe(thirdDispatcher);
+
+    expect(firstDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
   });
 
-  it("does not retry when fetch fails without fallback network error codes", async () => {
-    const fetchError = Object.assign(new TypeError("fetch failed"), {
-      cause: Object.assign(new Error("connect ECONNRESET"), {
-        code: "ECONNRESET",
-      }),
+  it("preserves caller-provided dispatcher across fallback retry", async () => {
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch.mockRejectedValueOnce(fetchError).mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
     });
-    const fetchMock = vi.fn().mockRejectedValue(fetchError);
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const resolved = resolveTelegramFetchOrThrow();
+    const callerDispatcher = { name: "caller" };
 
-    await expect(resolved("https://api.telegram.org/file/botx/photos/file_3.jpg")).rejects.toThrow(
+    await resolved("https://api.telegram.org/botx/sendMessage", {
+      dispatcher: callerDispatcher,
+    } as RequestInit);
+
+    expect(undiciFetch).toHaveBeenCalledTimes(2);
+
+    const firstCallInit = undiciFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    const secondCallInit = undiciFetch.mock.calls[1]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+
+    expect(firstCallInit?.dispatcher).toBe(callerDispatcher);
+    expect(secondCallInit?.dispatcher).toBe(callerDispatcher);
+  });
+
+  it("does not retry when error codes do not match fallback rules", async () => {
+    const fetchError = buildFetchFallbackError("ECONNRESET");
+    undiciFetch.mockRejectedValue(fetchError);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
       "fetch failed",
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps per-resolver transport policy isolated across multiple accounts", async () => {
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolverA = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+    const resolverB = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "verbatim",
+      },
+    });
+
+    await resolverA("https://api.telegram.org/botA/getMe");
+    await resolverB("https://api.telegram.org/botB/getMe");
+
+    const dispatcherA = getDispatcherFromUndiciCall(1);
+    const dispatcherB = getDispatcherFromUndiciCall(2);
+
+    expect(dispatcherA).toBeDefined();
+    expect(dispatcherB).toBeDefined();
+    expect(dispatcherA).not.toBe(dispatcherB);
+
+    expect(dispatcherA?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: false,
+      }),
+    );
+    expect(dispatcherB?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+      }),
+    );
+
+    // Core guarantee: Telegram transport no longer mutates process-global defaults.
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(setDefaultResultOrder).not.toHaveBeenCalled();
+    expect(setDefaultAutoSelectFamily).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -263,6 +263,47 @@ describe("resolveTelegramFetch", () => {
     expect(secondCallInit?.dispatcher).toBe(callerDispatcher);
   });
 
+  it("does not arm sticky fallback from caller-provided dispatcher failures", async () => {
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    const callerDispatcher = { name: "caller" };
+
+    await resolved("https://api.telegram.org/botx/sendMessage", {
+      dispatcher: callerDispatcher,
+    } as RequestInit);
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(3);
+
+    const firstCallInit = undiciFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    const secondCallInit = undiciFetch.mock.calls[1]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    const thirdDispatcher = getDispatcherFromUndiciCall(3);
+
+    expect(firstCallInit?.dispatcher).toBe(callerDispatcher);
+    expect(secondCallInit?.dispatcher).toBe(callerDispatcher);
+    expect(thirdDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+    expect(thirdDispatcher?.options?.connect?.family).not.toBe(4);
+  });
+
   it("does not retry when error codes do not match fallback rules", async () => {
     const fetchError = buildFetchFallbackError("ECONNRESET");
     undiciFetch.mockRejectedValue(fetchError);

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -356,6 +356,65 @@ describe("resolveTelegramFetch", () => {
     );
   });
 
+  it("uses no_proxy over NO_PROXY when deciding env-proxy bypass", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("no_proxy", "api.telegram.org");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(2);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
+  it("matches whitespace and wildcard no_proxy entries like EnvHttpProxyAgent", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("no_proxy", "localhost *.telegram.org");
+    const fetchError = buildFetchFallbackError("EHOSTUNREACH");
+    undiciFetch
+      .mockRejectedValueOnce(fetchError)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    await resolved("https://api.telegram.org/botx/sendChatAction");
+
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(2);
+    const secondDispatcher = getDispatcherFromUndiciCall(2);
+    expect(secondDispatcher?.options?.connect).toEqual(
+      expect.objectContaining({
+        family: 4,
+        autoSelectFamily: false,
+      }),
+    );
+  });
+
   it("fails closed when explicit proxy dispatcher initialization fails", async () => {
     const { makeProxyFetch } = await import("./proxy.js");
     const proxyFetch = makeProxyFetch("http://127.0.0.1:7890");

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveFetch } from "../infra/fetch.js";
-import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.js";
+import { resolveTelegramFetch } from "./fetch.js";
 
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
@@ -83,7 +83,6 @@ function buildFetchFallbackError(code: string) {
 }
 
 afterEach(() => {
-  resetTelegramFetchStateForTests();
   undiciFetch.mockReset();
   setGlobalDispatcher.mockReset();
   AgentCtor.mockClear();

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -407,7 +407,7 @@ export function resolveTelegramFetch(
         // Proxy routes should not arm sticky IPv4 mode; `family=4` would constrain
         // proxy-connect behavior instead of Telegram endpoint selection.
         if (!allowStickyIpv4Fallback) {
-          return sourceFetch(input, withDispatcherIfMissing(init, defaultDispatcher));
+          throw err;
         }
         if (!stickyIpv4FallbackEnabled) {
           stickyIpv4FallbackEnabled = true;

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -254,6 +254,10 @@ function withDispatcherIfMissing(
   return init ? { ...init, dispatcher } : { dispatcher };
 }
 
+function resolveWrappedFetch(fetchImpl: typeof fetch): typeof fetch {
+  return resolveFetch(fetchImpl) ?? fetchImpl;
+}
+
 function logResolverNetworkDecisions(params: {
   autoSelectDecision: ReturnType<typeof resolveTelegramAutoSelectFamilyDecision>;
   dnsDecision: ReturnType<typeof resolveTelegramDnsResultOrderDecision>;
@@ -340,14 +344,12 @@ export function resolveTelegramFetch(
   });
 
   const explicitProxyUrl = proxyFetch ? getProxyUrlFromFetch(proxyFetch) : undefined;
+  const undiciSourceFetch = resolveWrappedFetch(undiciFetch as unknown as typeof fetch);
   const sourceFetch = explicitProxyUrl
-    ? resolveFetch(undiciFetch as unknown as typeof fetch)
+    ? undiciSourceFetch
     : proxyFetch
-      ? resolveFetch(proxyFetch)
-      : resolveFetch(undiciFetch as unknown as typeof fetch);
-  if (!sourceFetch) {
-    throw new Error("fetch is not available; set channels.telegram.proxy in config");
-  }
+      ? resolveWrappedFetch(proxyFetch)
+      : undiciSourceFetch;
 
   // Preserve fully caller-owned custom fetch implementations.
   // OpenClaw proxy fetches are metadata-tagged and continue into resolver-scoped policy.

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -2,7 +2,6 @@ import * as dns from "node:dns";
 import { Agent, EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
-import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
@@ -172,6 +171,16 @@ function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env
     }
   }
   return false;
+}
+
+function hasEnvHttpProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
+  // Match EnvHttpProxyAgent behavior (undici) for HTTPS requests:
+  // - lower-case env vars take precedence over upper-case
+  // - HTTPS requests use https_proxy/HTTPS_PROXY first, then fall back to http_proxy/HTTP_PROXY
+  // - ALL_PROXY is ignored by EnvHttpProxyAgent
+  const httpProxy = env.http_proxy ?? env.HTTP_PROXY;
+  const httpsProxy = env.https_proxy ?? env.HTTPS_PROXY;
+  return Boolean(httpProxy) || Boolean(httpsProxy);
 }
 
 function createTelegramDispatcher(params: {
@@ -347,7 +356,7 @@ export function resolveTelegramFetch(
   }
 
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
-  const useEnvProxy = !explicitProxyUrl && hasProxyEnvConfigured();
+  const useEnvProxy = !explicitProxyUrl && hasEnvHttpProxyForTelegramApi();
   const defaultDispatcherResolution = createTelegramDispatcher({
     autoSelectFamily: autoSelectDecision.value,
     dnsResultOrder,

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -200,7 +200,7 @@ function createTelegramDispatcher(params: {
     const proxyOptions = connect
       ? ({
           uri: explicitProxyUrl,
-          connect,
+          proxyTls: connect,
         } satisfies ConstructorParameters<typeof ProxyAgent>[0])
       : explicitProxyUrl;
     try {

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -13,10 +13,15 @@ import { getProxyUrlFromFetch } from "./proxy.js";
 const log = createSubsystemLogger("telegram/network");
 
 const TELEGRAM_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
+const TELEGRAM_API_HOSTNAME = "api.telegram.org";
 
 type RequestInitWithDispatcher = RequestInit & {
   dispatcher?: unknown;
 };
+
+type TelegramDispatcher = Agent | EnvHttpProxyAgent | ProxyAgent;
+
+type TelegramDispatcherMode = "direct" | "env-proxy" | "explicit-proxy";
 
 type TelegramDnsResultOrder = "ipv4first" | "verbatim";
 
@@ -132,13 +137,55 @@ function buildTelegramConnectOptions(params: {
   return Object.keys(connect).length > 0 ? connect : null;
 }
 
+function parseNoProxyRule(rawRule: string): string {
+  const trimmed = rawRule.trim().toLowerCase();
+  if (!trimmed || trimmed === "*") {
+    return trimmed;
+  }
+  if (trimmed.startsWith("[")) {
+    const bracketEnd = trimmed.indexOf("]");
+    if (bracketEnd > 0) {
+      return trimmed.slice(1, bracketEnd);
+    }
+  }
+  const portSep = trimmed.lastIndexOf(":");
+  if (portSep > -1 && trimmed.indexOf(":") === portSep) {
+    return trimmed.slice(0, portSep);
+  }
+  return trimmed;
+}
+
+function hostMatchesNoProxyRule(hostname: string, rawRule: string): boolean {
+  const normalizedHostname = hostname.trim().toLowerCase();
+  const rule = parseNoProxyRule(rawRule);
+  if (!normalizedHostname || !rule) {
+    return false;
+  }
+  if (rule === "*") {
+    return true;
+  }
+  const suffix = rule.startsWith(".") ? rule.slice(1) : rule;
+  if (!suffix) {
+    return false;
+  }
+  return normalizedHostname === suffix || normalizedHostname.endsWith(`.${suffix}`);
+}
+
+function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
+  const noProxy = env.NO_PROXY ?? env.no_proxy;
+  if (typeof noProxy !== "string" || noProxy.trim().length === 0) {
+    return false;
+  }
+  return noProxy.split(",").some((rule) => hostMatchesNoProxyRule(TELEGRAM_API_HOSTNAME, rule));
+}
+
 function createTelegramDispatcher(params: {
   autoSelectFamily: boolean | null;
   dnsResultOrder: TelegramDnsResultOrder | null;
   useEnvProxy: boolean;
   forceIpv4: boolean;
   proxyUrl?: string;
-}): Agent | EnvHttpProxyAgent | ProxyAgent {
+}): { dispatcher: TelegramDispatcher; mode: TelegramDispatcherMode } {
   const connect = buildTelegramConnectOptions({
     autoSelectFamily: params.autoSelectFamily,
     dnsResultOrder: params.dnsResultOrder,
@@ -153,7 +200,10 @@ function createTelegramDispatcher(params: {
         } satisfies ConstructorParameters<typeof ProxyAgent>[0])
       : explicitProxyUrl;
     try {
-      return new ProxyAgent(proxyOptions);
+      return {
+        dispatcher: new ProxyAgent(proxyOptions),
+        mode: "explicit-proxy",
+      };
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       throw new Error(`explicit proxy dispatcher init failed: ${reason}`, { cause: err });
@@ -166,7 +216,10 @@ function createTelegramDispatcher(params: {
         } satisfies ConstructorParameters<typeof EnvHttpProxyAgent>[0])
       : undefined;
     try {
-      return new EnvHttpProxyAgent(proxyOptions);
+      return {
+        dispatcher: new EnvHttpProxyAgent(proxyOptions),
+        mode: "env-proxy",
+      };
     } catch (err) {
       log.warn(
         `env proxy dispatcher init failed; falling back to direct dispatcher: ${
@@ -180,12 +233,15 @@ function createTelegramDispatcher(params: {
         connect,
       } satisfies ConstructorParameters<typeof Agent>[0])
     : undefined;
-  return new Agent(agentOptions);
+  return {
+    dispatcher: new Agent(agentOptions),
+    mode: "direct",
+  };
 }
 
 function withDispatcherIfMissing(
   init: RequestInit | undefined,
-  dispatcher: Agent | EnvHttpProxyAgent | ProxyAgent,
+  dispatcher: TelegramDispatcher,
 ): RequestInitWithDispatcher {
   const withDispatcher = init as RequestInitWithDispatcher | undefined;
   if (withDispatcher?.dispatcher) {
@@ -297,26 +353,31 @@ export function resolveTelegramFetch(
 
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
   const useEnvProxy = !explicitProxyUrl && hasProxyEnvConfigured();
-  const allowStickyIpv4Fallback = !explicitProxyUrl && !useEnvProxy;
-  const defaultDispatcher = createTelegramDispatcher({
+  const defaultDispatcherResolution = createTelegramDispatcher({
     autoSelectFamily: autoSelectDecision.value,
     dnsResultOrder,
     useEnvProxy,
     forceIpv4: false,
     proxyUrl: explicitProxyUrl,
   });
+  const defaultDispatcher = defaultDispatcherResolution.dispatcher;
+  const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
+  const allowStickyIpv4Fallback =
+    defaultDispatcherResolution.mode === "direct" ||
+    (defaultDispatcherResolution.mode === "env-proxy" && shouldBypassEnvProxy);
+  const stickyShouldUseEnvProxy = defaultDispatcherResolution.mode === "env-proxy";
 
   let stickyIpv4FallbackEnabled = false;
-  let stickyIpv4Dispatcher: Agent | EnvHttpProxyAgent | ProxyAgent | null = null;
+  let stickyIpv4Dispatcher: TelegramDispatcher | null = null;
   const resolveStickyIpv4Dispatcher = () => {
     if (!stickyIpv4Dispatcher) {
       stickyIpv4Dispatcher = createTelegramDispatcher({
         autoSelectFamily: false,
         dnsResultOrder: "ipv4first",
-        useEnvProxy,
+        useEnvProxy: stickyShouldUseEnvProxy,
         forceIpv4: true,
         proxyUrl: explicitProxyUrl,
-      });
+      }).dispatcher;
     }
     return stickyIpv4Dispatcher;
   };

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -300,6 +300,7 @@ export function resolveTelegramFetch(
 
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
   const useEnvProxy = !explicitProxyUrl && hasProxyEnvConfigured();
+  const allowStickyIpv4Fallback = !explicitProxyUrl;
   const defaultDispatcher = createTelegramDispatcher({
     autoSelectFamily: autoSelectDecision.value,
     dnsResultOrder,
@@ -335,19 +336,22 @@ export function resolveTelegramFetch(
       return await sourceFetch(input, initialInit);
     } catch (err) {
       if (shouldRetryWithIpv4Fallback(err)) {
-        if (!callerProvidedDispatcher && !stickyIpv4FallbackEnabled) {
+        // Preserve caller-owned dispatchers on retry.
+        if (callerProvidedDispatcher) {
+          return sourceFetch(input, init ?? {});
+        }
+        // Explicit proxy routes should not arm sticky IPv4 mode; `family=4` would
+        // constrain proxy-connect behavior instead of Telegram endpoint selection.
+        if (!allowStickyIpv4Fallback) {
+          return sourceFetch(input, withDispatcherIfMissing(init, defaultDispatcher));
+        }
+        if (!stickyIpv4FallbackEnabled) {
           stickyIpv4FallbackEnabled = true;
           log.warn(
             `fetch fallback: enabling sticky IPv4-only dispatcher (codes=${formatErrorCodes(err)})`,
           );
         }
-        return sourceFetch(
-          input,
-          withDispatcherIfMissing(
-            init,
-            callerProvidedDispatcher ? defaultDispatcher : resolveStickyIpv4Dispatcher(),
-          ),
-        );
+        return sourceFetch(input, withDispatcherIfMissing(init, resolveStickyIpv4Dispatcher()));
       }
       throw err;
     }

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,5 +1,5 @@
 import * as dns from "node:dns";
-import { Agent, EnvHttpProxyAgent, fetch as undiciFetch } from "undici";
+import { Agent, EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
@@ -8,6 +8,7 @@ import {
   resolveTelegramAutoSelectFamilyDecision,
   resolveTelegramDnsResultOrderDecision,
 } from "./network-config.js";
+import { getProxyUrlFromFetch } from "./proxy.js";
 
 const log = createSubsystemLogger("telegram/network");
 
@@ -136,12 +137,31 @@ function createTelegramDispatcher(params: {
   dnsResultOrder: TelegramDnsResultOrder | null;
   useEnvProxy: boolean;
   forceIpv4: boolean;
-}): Agent | EnvHttpProxyAgent {
+  proxyUrl?: string;
+}): Agent | EnvHttpProxyAgent | ProxyAgent {
   const connect = buildTelegramConnectOptions({
     autoSelectFamily: params.autoSelectFamily,
     dnsResultOrder: params.dnsResultOrder,
     forceIpv4: params.forceIpv4,
   });
+  const explicitProxyUrl = params.proxyUrl?.trim();
+  if (explicitProxyUrl) {
+    const proxyOptions = connect
+      ? ({
+          uri: explicitProxyUrl,
+          connect,
+        } satisfies ConstructorParameters<typeof ProxyAgent>[0])
+      : explicitProxyUrl;
+    try {
+      return new ProxyAgent(proxyOptions);
+    } catch (err) {
+      log.warn(
+        `proxy dispatcher init failed; falling back to direct dispatcher: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
   if (params.useEnvProxy) {
     const proxyOptions = connect
       ? ({
@@ -168,7 +188,7 @@ function createTelegramDispatcher(params: {
 
 function withDispatcherIfMissing(
   init: RequestInit | undefined,
-  dispatcher: Agent | EnvHttpProxyAgent,
+  dispatcher: Agent | EnvHttpProxyAgent | ProxyAgent,
 ): RequestInitWithDispatcher {
   const withDispatcher = init as RequestInitWithDispatcher | undefined;
   if (withDispatcher?.dispatcher) {
@@ -262,28 +282,34 @@ export function resolveTelegramFetch(
     dnsDecision,
   });
 
-  const sourceFetch = proxyFetch
-    ? resolveFetch(proxyFetch)
-    : resolveFetch(undiciFetch as unknown as typeof fetch);
+  const explicitProxyUrl = proxyFetch ? getProxyUrlFromFetch(proxyFetch) : undefined;
+  const sourceFetch = explicitProxyUrl
+    ? resolveFetch(undiciFetch as unknown as typeof fetch)
+    : proxyFetch
+      ? resolveFetch(proxyFetch)
+      : resolveFetch(undiciFetch as unknown as typeof fetch);
   if (!sourceFetch) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
 
-  if (proxyFetch) {
+  // Preserve fully caller-owned custom fetch implementations.
+  // OpenClaw proxy fetches are metadata-tagged and continue into resolver-scoped policy.
+  if (proxyFetch && !explicitProxyUrl) {
     return sourceFetch;
   }
 
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
-  const useEnvProxy = hasProxyEnvConfigured();
+  const useEnvProxy = !explicitProxyUrl && hasProxyEnvConfigured();
   const defaultDispatcher = createTelegramDispatcher({
     autoSelectFamily: autoSelectDecision.value,
     dnsResultOrder,
     useEnvProxy,
     forceIpv4: false,
+    proxyUrl: explicitProxyUrl,
   });
 
   let stickyIpv4FallbackEnabled = false;
-  let stickyIpv4Dispatcher: Agent | EnvHttpProxyAgent | null = null;
+  let stickyIpv4Dispatcher: Agent | EnvHttpProxyAgent | ProxyAgent | null = null;
   const resolveStickyIpv4Dispatcher = () => {
     if (!stickyIpv4Dispatcher) {
       stickyIpv4Dispatcher = createTelegramDispatcher({
@@ -291,6 +317,7 @@ export function resolveTelegramFetch(
         dnsResultOrder: "ipv4first",
         useEnvProxy,
         forceIpv4: true,
+        proxyUrl: explicitProxyUrl,
       });
     }
     return stickyIpv4Dispatcher;

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -137,6 +137,9 @@ function buildTelegramConnectOptions(params: {
 }
 
 function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
+  // We need this classification before dispatch to decide whether sticky IPv4 fallback
+  // can safely arm. EnvHttpProxyAgent does not expose route decisions (proxy vs direct
+  // NO_PROXY bypass), so we mirror undici's parsing/matching behavior for this host.
   // Match EnvHttpProxyAgent behavior (undici):
   // - lower-case no_proxy takes precedence over NO_PROXY
   // - entries split by comma or whitespace

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -155,11 +155,8 @@ function createTelegramDispatcher(params: {
     try {
       return new ProxyAgent(proxyOptions);
     } catch (err) {
-      log.warn(
-        `proxy dispatcher init failed; falling back to direct dispatcher: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(`explicit proxy dispatcher init failed: ${reason}`, { cause: err });
     }
   }
   if (params.useEnvProxy) {

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -220,6 +220,9 @@ function createTelegramDispatcher(params: {
     const proxyOptions = connect
       ? ({
           connect,
+          // undici's EnvHttpProxyAgent passes `connect` only to the no-proxy Agent.
+          // Real proxied HTTPS traffic reads transport settings from ProxyAgent.proxyTls.
+          proxyTls: connect,
         } satisfies ConstructorParameters<typeof EnvHttpProxyAgent>[0])
       : undefined;
     try {

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -300,7 +300,7 @@ export function resolveTelegramFetch(
 
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
   const useEnvProxy = !explicitProxyUrl && hasProxyEnvConfigured();
-  const allowStickyIpv4Fallback = !explicitProxyUrl;
+  const allowStickyIpv4Fallback = !explicitProxyUrl && !useEnvProxy;
   const defaultDispatcher = createTelegramDispatcher({
     autoSelectFamily: autoSelectDecision.value,
     dnsResultOrder,
@@ -340,8 +340,8 @@ export function resolveTelegramFetch(
         if (callerProvidedDispatcher) {
           return sourceFetch(input, init ?? {});
         }
-        // Explicit proxy routes should not arm sticky IPv4 mode; `family=4` would
-        // constrain proxy-connect behavior instead of Telegram endpoint selection.
+        // Proxy routes should not arm sticky IPv4 mode; `family=4` would constrain
+        // proxy-connect behavior instead of Telegram endpoint selection.
         if (!allowStickyIpv4Fallback) {
           return sourceFetch(input, withDispatcherIfMissing(init, defaultDispatcher));
         }

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -317,8 +317,3 @@ export function resolveTelegramFetch(
     }
   }) as typeof fetch;
 }
-
-export function resetTelegramFetchStateForTests(): void {
-  // Resolver-scoped dispatcher state is created inside resolveTelegramFetch().
-  // This hook remains for tests that already call it.
-}

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -297,6 +297,9 @@ export function resolveTelegramFetch(
   };
 
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const callerProvidedDispatcher = Boolean(
+      (init as RequestInitWithDispatcher | undefined)?.dispatcher,
+    );
     const initialInit = withDispatcherIfMissing(
       init,
       stickyIpv4FallbackEnabled ? resolveStickyIpv4Dispatcher() : defaultDispatcher,
@@ -305,13 +308,19 @@ export function resolveTelegramFetch(
       return await sourceFetch(input, initialInit);
     } catch (err) {
       if (shouldRetryWithIpv4Fallback(err)) {
-        if (!stickyIpv4FallbackEnabled) {
+        if (!callerProvidedDispatcher && !stickyIpv4FallbackEnabled) {
           stickyIpv4FallbackEnabled = true;
           log.warn(
             `fetch fallback: enabling sticky IPv4-only dispatcher (codes=${formatErrorCodes(err)})`,
           );
         }
-        return sourceFetch(input, withDispatcherIfMissing(init, resolveStickyIpv4Dispatcher()));
+        return sourceFetch(
+          input,
+          withDispatcherIfMissing(
+            init,
+            callerProvidedDispatcher ? defaultDispatcher : resolveStickyIpv4Dispatcher(),
+          ),
+        );
       }
       throw err;
     }

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -267,7 +267,7 @@ function shouldRetryWithIpv4Fallback(err: unknown): boolean {
 export function resolveTelegramFetch(
   proxyFetch?: typeof fetch,
   options?: { network?: TelegramNetworkConfig },
-): typeof fetch | undefined {
+): typeof fetch {
   const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({
     network: options?.network,
   });

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,5 @@
 import * as dns from "node:dns";
-import * as net from "node:net";
-import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
@@ -10,14 +9,30 @@ import {
   resolveTelegramDnsResultOrderDecision,
 } from "./network-config.js";
 
-let appliedAutoSelectFamily: boolean | null = null;
-let appliedDnsResultOrder: string | null = null;
-let appliedGlobalDispatcherAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
-function isProxyLikeDispatcher(dispatcher: unknown): boolean {
-  const ctorName = (dispatcher as { constructor?: { name?: string } })?.constructor?.name;
-  return typeof ctorName === "string" && ctorName.includes("ProxyAgent");
-}
+
+const TELEGRAM_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
+
+type RequestInitWithDispatcher = RequestInit & {
+  dispatcher?: unknown;
+};
+
+type TelegramDnsResultOrder = "ipv4first" | "verbatim";
+
+type LookupCallback =
+  | ((err: NodeJS.ErrnoException | null, address: string, family: number) => void)
+  | ((err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void);
+
+type LookupOptions = (dns.LookupOneOptions | dns.LookupAllOptions) & {
+  order?: TelegramDnsResultOrder;
+  verbatim?: boolean;
+};
+
+type LookupFunction = (
+  hostname: string,
+  options: number | dns.LookupOneOptions | dns.LookupAllOptions | undefined,
+  callback: LookupCallback,
+) => void;
 
 const FALLBACK_RETRY_ERROR_CODES = [
   "ETIMEDOUT",
@@ -48,72 +63,133 @@ const IPV4_FALLBACK_RULES: readonly Ipv4FallbackRule[] = [
   },
 ];
 
-// Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
-// Many networks have IPv6 configured but not routed, causing "Network is unreachable" errors.
-// See: https://github.com/nodejs/node/issues/54359
-function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void {
-  // Apply autoSelectFamily workaround
-  const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({ network });
-  if (autoSelectDecision.value !== null && autoSelectDecision.value !== appliedAutoSelectFamily) {
-    if (typeof net.setDefaultAutoSelectFamily === "function") {
-      try {
-        net.setDefaultAutoSelectFamily(autoSelectDecision.value);
-        appliedAutoSelectFamily = autoSelectDecision.value;
-        const label = autoSelectDecision.source ? ` (${autoSelectDecision.source})` : "";
-        log.info(`autoSelectFamily=${autoSelectDecision.value}${label}`);
-      } catch {
-        // ignore if unsupported by the runtime
-      }
-    }
+function normalizeDnsResultOrder(value: string | null): TelegramDnsResultOrder | null {
+  if (value === "ipv4first" || value === "verbatim") {
+    return value;
+  }
+  return null;
+}
+
+function createDnsResultOrderLookup(
+  order: TelegramDnsResultOrder | null,
+): LookupFunction | undefined {
+  if (!order) {
+    return undefined;
+  }
+  const lookup = dns.lookup as unknown as (
+    hostname: string,
+    options: LookupOptions,
+    callback: LookupCallback,
+  ) => void;
+  return (hostname, options, callback) => {
+    const baseOptions: LookupOptions =
+      typeof options === "number"
+        ? { family: options }
+        : options
+          ? { ...(options as LookupOptions) }
+          : {};
+    const lookupOptions: LookupOptions = {
+      ...baseOptions,
+      order,
+      // Keep `verbatim` for compatibility with Node runtimes that ignore `order`.
+      verbatim: order === "verbatim",
+    };
+    lookup(hostname, lookupOptions, callback);
+  };
+}
+
+function buildTelegramConnectOptions(params: {
+  autoSelectFamily: boolean | null;
+  dnsResultOrder: TelegramDnsResultOrder | null;
+  forceIpv4: boolean;
+}): {
+  autoSelectFamily?: boolean;
+  autoSelectFamilyAttemptTimeout?: number;
+  family?: number;
+  lookup?: LookupFunction;
+} | null {
+  const connect: {
+    autoSelectFamily?: boolean;
+    autoSelectFamilyAttemptTimeout?: number;
+    family?: number;
+    lookup?: LookupFunction;
+  } = {};
+
+  if (params.forceIpv4) {
+    connect.family = 4;
+    connect.autoSelectFamily = false;
+  } else if (typeof params.autoSelectFamily === "boolean") {
+    connect.autoSelectFamily = params.autoSelectFamily;
+    connect.autoSelectFamilyAttemptTimeout = TELEGRAM_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS;
   }
 
-  // Node 22's built-in globalThis.fetch uses undici's internal Agent whose
-  // connect options are frozen at construction time. Calling
-  // net.setDefaultAutoSelectFamily() after that agent is created has no
-  // effect on it. Replace the global dispatcher with one that carries the
-  // current autoSelectFamily setting so subsequent globalThis.fetch calls
-  // inherit the same decision.
-  // See: https://github.com/openclaw/openclaw/issues/25676
-  if (
-    autoSelectDecision.value !== null &&
-    autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
-  ) {
-    const existingGlobalDispatcher = getGlobalDispatcher();
-    const shouldPreserveExistingProxy =
-      isProxyLikeDispatcher(existingGlobalDispatcher) && !hasProxyEnvConfigured();
-    if (!shouldPreserveExistingProxy) {
-      try {
-        setGlobalDispatcher(
-          new EnvHttpProxyAgent({
-            connect: {
-              autoSelectFamily: autoSelectDecision.value,
-              autoSelectFamilyAttemptTimeout: 300,
-            },
-          }),
-        );
-        appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
-        log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
-      } catch {
-        // ignore if setGlobalDispatcher is unavailable
-      }
-    }
+  const lookup = createDnsResultOrderLookup(params.dnsResultOrder);
+  if (lookup) {
+    connect.lookup = lookup;
   }
 
-  // Apply DNS result order workaround for IPv4/IPv6 issues.
-  // Some APIs (including Telegram) may fail with IPv6 on certain networks.
-  // See: https://github.com/openclaw/openclaw/issues/5311
-  const dnsDecision = resolveTelegramDnsResultOrderDecision({ network });
-  if (dnsDecision.value !== null && dnsDecision.value !== appliedDnsResultOrder) {
-    if (typeof dns.setDefaultResultOrder === "function") {
-      try {
-        dns.setDefaultResultOrder(dnsDecision.value as "ipv4first" | "verbatim");
-        appliedDnsResultOrder = dnsDecision.value;
-        const label = dnsDecision.source ? ` (${dnsDecision.source})` : "";
-        log.info(`dnsResultOrder=${dnsDecision.value}${label}`);
-      } catch {
-        // ignore if unsupported by the runtime
-      }
+  return Object.keys(connect).length > 0 ? connect : null;
+}
+
+function createTelegramDispatcher(params: {
+  autoSelectFamily: boolean | null;
+  dnsResultOrder: TelegramDnsResultOrder | null;
+  useEnvProxy: boolean;
+  forceIpv4: boolean;
+}): Agent | EnvHttpProxyAgent {
+  const connect = buildTelegramConnectOptions({
+    autoSelectFamily: params.autoSelectFamily,
+    dnsResultOrder: params.dnsResultOrder,
+    forceIpv4: params.forceIpv4,
+  });
+  if (params.useEnvProxy) {
+    const proxyOptions = connect
+      ? ({
+          connect,
+        } satisfies ConstructorParameters<typeof EnvHttpProxyAgent>[0])
+      : undefined;
+    try {
+      return new EnvHttpProxyAgent(proxyOptions);
+    } catch (err) {
+      log.warn(
+        `env proxy dispatcher init failed; falling back to direct dispatcher: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
+  }
+  const agentOptions = connect
+    ? ({
+        connect,
+      } satisfies ConstructorParameters<typeof Agent>[0])
+    : undefined;
+  return new Agent(agentOptions);
+}
+
+function withDispatcherIfMissing(
+  init: RequestInit | undefined,
+  dispatcher: Agent | EnvHttpProxyAgent,
+): RequestInitWithDispatcher {
+  const withDispatcher = init as RequestInitWithDispatcher | undefined;
+  if (withDispatcher?.dispatcher) {
+    return init ?? {};
+  }
+  return init ? { ...init, dispatcher } : { dispatcher };
+}
+
+function logResolverNetworkDecisions(params: {
+  autoSelectDecision: ReturnType<typeof resolveTelegramAutoSelectFamilyDecision>;
+  dnsDecision: ReturnType<typeof resolveTelegramDnsResultOrderDecision>;
+}): void {
+  if (params.autoSelectDecision.value !== null) {
+    const sourceLabel = params.autoSelectDecision.source
+      ? ` (${params.autoSelectDecision.source})`
+      : "";
+    log.info(`autoSelectFamily=${params.autoSelectDecision.value}${sourceLabel}`);
+  }
+  if (params.dnsDecision.value !== null) {
+    const sourceLabel = params.dnsDecision.source ? ` (${params.dnsDecision.source})` : "";
+    log.info(`dnsResultOrder=${params.dnsDecision.value}${sourceLabel}`);
   }
 }
 
@@ -151,6 +227,11 @@ function collectErrorCodes(err: unknown): Set<string> {
   return codes;
 }
 
+function formatErrorCodes(err: unknown): string {
+  const codes = [...collectErrorCodes(err)];
+  return codes.length > 0 ? codes.join(",") : "none";
+}
+
 function shouldRetryWithIpv4Fallback(err: unknown): boolean {
   const ctx: Ipv4FallbackContext = {
     message:
@@ -165,36 +246,72 @@ function shouldRetryWithIpv4Fallback(err: unknown): boolean {
   return true;
 }
 
-function applyTelegramIpv4Fallback(): void {
-  applyTelegramNetworkWorkarounds({
-    autoSelectFamily: false,
-    dnsResultOrder: "ipv4first",
-  });
-  log.warn("fetch fallback: forcing autoSelectFamily=false + dnsResultOrder=ipv4first");
-}
-
 // Prefer wrapped fetch when available to normalize AbortSignal across runtimes.
 export function resolveTelegramFetch(
   proxyFetch?: typeof fetch,
   options?: { network?: TelegramNetworkConfig },
 ): typeof fetch | undefined {
-  applyTelegramNetworkWorkarounds(options?.network);
-  const sourceFetch = proxyFetch ? resolveFetch(proxyFetch) : resolveFetch();
+  const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({
+    network: options?.network,
+  });
+  const dnsDecision = resolveTelegramDnsResultOrderDecision({
+    network: options?.network,
+  });
+  logResolverNetworkDecisions({
+    autoSelectDecision,
+    dnsDecision,
+  });
+
+  const sourceFetch = proxyFetch
+    ? resolveFetch(proxyFetch)
+    : resolveFetch(undiciFetch as unknown as typeof fetch);
   if (!sourceFetch) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  // When Telegram media fetch hits dual-stack edge cases (ENETUNREACH/ETIMEDOUT),
-  // switch to IPv4-safe network mode and retry once.
+
   if (proxyFetch) {
     return sourceFetch;
   }
+
+  const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
+  const useEnvProxy = hasProxyEnvConfigured();
+  const defaultDispatcher = createTelegramDispatcher({
+    autoSelectFamily: autoSelectDecision.value,
+    dnsResultOrder,
+    useEnvProxy,
+    forceIpv4: false,
+  });
+
+  let stickyIpv4FallbackEnabled = false;
+  let stickyIpv4Dispatcher: Agent | EnvHttpProxyAgent | null = null;
+  const resolveStickyIpv4Dispatcher = () => {
+    if (!stickyIpv4Dispatcher) {
+      stickyIpv4Dispatcher = createTelegramDispatcher({
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+        useEnvProxy,
+        forceIpv4: true,
+      });
+    }
+    return stickyIpv4Dispatcher;
+  };
+
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const initialInit = withDispatcherIfMissing(
+      init,
+      stickyIpv4FallbackEnabled ? resolveStickyIpv4Dispatcher() : defaultDispatcher,
+    );
     try {
-      return await sourceFetch(input, init);
+      return await sourceFetch(input, initialInit);
     } catch (err) {
       if (shouldRetryWithIpv4Fallback(err)) {
-        applyTelegramIpv4Fallback();
-        return sourceFetch(input, init);
+        if (!stickyIpv4FallbackEnabled) {
+          stickyIpv4FallbackEnabled = true;
+          log.warn(
+            `fetch fallback: enabling sticky IPv4-only dispatcher (codes=${formatErrorCodes(err)})`,
+          );
+        }
+        return sourceFetch(input, withDispatcherIfMissing(init, resolveStickyIpv4Dispatcher()));
       }
       throw err;
     }
@@ -202,7 +319,6 @@ export function resolveTelegramFetch(
 }
 
 export function resetTelegramFetchStateForTests(): void {
-  appliedAutoSelectFamily = null;
-  appliedDnsResultOrder = null;
-  appliedGlobalDispatcherAutoSelectFamily = null;
+  // Resolver-scoped dispatcher state is created inside resolveTelegramFetch().
+  // This hook remains for tests that already call it.
 }

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -137,46 +137,41 @@ function buildTelegramConnectOptions(params: {
   return Object.keys(connect).length > 0 ? connect : null;
 }
 
-function parseNoProxyRule(rawRule: string): string {
-  const trimmed = rawRule.trim().toLowerCase();
-  if (!trimmed || trimmed === "*") {
-    return trimmed;
-  }
-  if (trimmed.startsWith("[")) {
-    const bracketEnd = trimmed.indexOf("]");
-    if (bracketEnd > 0) {
-      return trimmed.slice(1, bracketEnd);
-    }
-  }
-  const portSep = trimmed.lastIndexOf(":");
-  if (portSep > -1 && trimmed.indexOf(":") === portSep) {
-    return trimmed.slice(0, portSep);
-  }
-  return trimmed;
-}
-
-function hostMatchesNoProxyRule(hostname: string, rawRule: string): boolean {
-  const normalizedHostname = hostname.trim().toLowerCase();
-  const rule = parseNoProxyRule(rawRule);
-  if (!normalizedHostname || !rule) {
+function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
+  // Match EnvHttpProxyAgent behavior (undici):
+  // - lower-case no_proxy takes precedence over NO_PROXY
+  // - entries split by comma or whitespace
+  // - wildcard handling is exact-string "*" only
+  // - leading "." and "*." are normalized the same way
+  const noProxyValue = env.no_proxy ?? env.NO_PROXY ?? "";
+  if (!noProxyValue) {
     return false;
   }
-  if (rule === "*") {
+  if (noProxyValue === "*") {
     return true;
   }
-  const suffix = rule.startsWith(".") ? rule.slice(1) : rule;
-  if (!suffix) {
-    return false;
+  const targetHostname = TELEGRAM_API_HOSTNAME.toLowerCase();
+  const targetPort = 443;
+  const noProxyEntries = noProxyValue.split(/[,\s]/);
+  for (let i = 0; i < noProxyEntries.length; i++) {
+    const entry = noProxyEntries[i];
+    if (!entry) {
+      continue;
+    }
+    const parsed = entry.match(/^(.+):(\d+)$/);
+    const entryHostname = (parsed ? parsed[1] : entry).replace(/^\*?\./, "").toLowerCase();
+    const entryPort = parsed ? Number.parseInt(parsed[2], 10) : 0;
+    if (entryPort && entryPort !== targetPort) {
+      continue;
+    }
+    if (
+      targetHostname === entryHostname ||
+      targetHostname.slice(-(entryHostname.length + 1)) === `.${entryHostname}`
+    ) {
+      return true;
+    }
   }
-  return normalizedHostname === suffix || normalizedHostname.endsWith(`.${suffix}`);
-}
-
-function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
-  const noProxy = env.NO_PROXY ?? env.no_proxy;
-  if (typeof noProxy !== "string" || noProxy.trim().length === 0) {
-    return false;
-  }
-  return noProxy.split(",").some((rule) => hostMatchesNoProxyRule(TELEGRAM_API_HOSTNAME, rule));
+  return false;
 }
 
 function createTelegramDispatcher(params: {

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -1,14 +1,28 @@
-import { type Mock, describe, expect, it, vi } from "vitest";
+import { afterEach, type Mock, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import { probeTelegram } from "./probe.js";
+
+const resolveTelegramFetch = vi.hoisted(() => vi.fn());
+const makeProxyFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("./fetch.js", () => ({
+  resolveTelegramFetch,
+}));
+
+vi.mock("./proxy.js", () => ({
+  makeProxyFetch,
+}));
 
 describe("probeTelegram retry logic", () => {
   const token = "test-token";
   const timeoutMs = 5000;
+  const originalFetch = global.fetch;
 
   const installFetchMock = (): Mock => {
     const fetchMock = vi.fn();
     global.fetch = withFetchPreconnect(fetchMock);
+    resolveTelegramFetch.mockImplementation((proxyFetch?: typeof fetch) => proxyFetch ?? fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
     return fetchMock;
   };
 
@@ -40,6 +54,17 @@ describe("probeTelegram retry logic", () => {
     expect(fetchMock).toHaveBeenCalledTimes(expectedCalls);
     expect(result.bot?.username).toBe("test_bot");
   }
+
+  afterEach(() => {
+    resolveTelegramFetch.mockReset();
+    makeProxyFetch.mockReset();
+    vi.clearAllMocks();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (globalThis as { fetch?: typeof fetch }).fetch;
+    }
+  });
 
   it.each([
     {
@@ -113,5 +138,27 @@ describe("probeTelegram retry logic", () => {
     expect(result.status).toBe(401);
     expect(result.error).toBe("Unauthorized");
     expect(fetchMock).toHaveBeenCalledTimes(1); // Should not retry
+  });
+
+  it("uses resolver-scoped Telegram fetch with probe network options", async () => {
+    const fetchMock = installFetchMock();
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+
+    await probeTelegram(token, timeoutMs, {
+      proxyUrl: "http://127.0.0.1:8888",
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(makeProxyFetch).toHaveBeenCalledWith("http://127.0.0.1:8888");
+    expect(resolveTelegramFetch).toHaveBeenCalledWith(fetchMock, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
   });
 });

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, type Mock, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
-import { probeTelegram } from "./probe.js";
+import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
 
 const resolveTelegramFetch = vi.hoisted(() => vi.fn());
 const makeProxyFetch = vi.hoisted(() => vi.fn());
@@ -56,6 +56,7 @@ describe("probeTelegram retry logic", () => {
   }
 
   afterEach(() => {
+    resetTelegramProbeFetcherCacheForTests();
     resolveTelegramFetch.mockReset();
     makeProxyFetch.mockReset();
     vi.unstubAllEnvs();

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -244,4 +244,32 @@ describe("probeTelegram retry logic", () => {
 
     expect(resolveTelegramFetch).toHaveBeenCalledTimes(2);
   });
+
+  it("reuses probe fetcher cache across token rotation when accountId is stable", async () => {
+    const fetchMock = installFetchMock();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-old`, timeoutMs, {
+      accountId: "main",
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-new`, timeoutMs, {
+      accountId: "main",
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -58,6 +58,7 @@ describe("probeTelegram retry logic", () => {
   afterEach(() => {
     resolveTelegramFetch.mockReset();
     makeProxyFetch.mockReset();
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
     if (originalFetch) {
       global.fetch = originalFetch;
@@ -160,5 +161,57 @@ describe("probeTelegram retry logic", () => {
         dnsResultOrder: "ipv4first",
       },
     });
+  });
+
+  it("reuses probe fetcher across repeated probes for the same account transport settings", async () => {
+    const fetchMock = installFetchMock();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache`, timeoutMs, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache`, timeoutMs, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse probe fetcher cache when network settings differ", async () => {
+    const fetchMock = installFetchMock();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache-variant`, timeoutMs, {
+      network: {
+        autoSelectFamily: true,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache-variant`, timeoutMs, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -121,6 +121,35 @@ describe("probeTelegram retry logic", () => {
     }
   });
 
+  it("respects timeout budget across retries", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          reject(new Error("Request aborted"));
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(new Error("Request aborted")), {
+          once: true,
+        });
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchMock as unknown as typeof fetch);
+    resolveTelegramFetch.mockImplementation((proxyFetch?: typeof fetch) => proxyFetch ?? fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
+    vi.useFakeTimers();
+    try {
+      const probePromise = probeTelegram(`${token}-budget`, 500);
+      await vi.advanceTimersByTimeAsync(600);
+      const result = await probePromise;
+
+      expect(result.ok).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("should NOT retry if getMe returns a 401 Unauthorized", async () => {
     const fetchMock = installFetchMock();
     const mockResponse = {

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -22,6 +22,7 @@ export type TelegramProbe = BaseProbeResult & {
 export type TelegramProbeOptions = {
   proxyUrl?: string;
   network?: TelegramNetworkConfig;
+  accountId?: string;
 };
 
 const probeFetcherCache = new Map<string, typeof fetch>();
@@ -48,12 +49,14 @@ function shouldUseProbeFetcherCache(): boolean {
 }
 
 function buildProbeFetcherCacheKey(token: string, options?: TelegramProbeOptions): string {
+  const cacheIdentity = options?.accountId?.trim() || token;
+  const cacheIdentityKind = options?.accountId?.trim() ? "account" : "token";
   const proxyKey = options?.proxyUrl?.trim() ?? "";
   const autoSelectFamily = options?.network?.autoSelectFamily;
   const autoSelectFamilyKey =
     typeof autoSelectFamily === "boolean" ? String(autoSelectFamily) : "default";
   const dnsResultOrderKey = options?.network?.dnsResultOrder ?? "default";
-  return `${token}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}`;
+  return `${cacheIdentityKind}:${cacheIdentity}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}`;
 }
 
 function setCachedProbeFetcher(cacheKey: string, fetcher: typeof fetch): typeof fetch {

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -27,6 +27,10 @@ export type TelegramProbeOptions = {
 const probeFetcherCache = new Map<string, typeof fetch>();
 const MAX_PROBE_FETCHER_CACHE_SIZE = 64;
 
+export function resetTelegramProbeFetcherCacheForTests(): void {
+  probeFetcherCache.clear();
+}
+
 function resolveProbeOptions(
   proxyOrOptions?: string | TelegramProbeOptions,
 ): TelegramProbeOptions | undefined {

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -76,9 +76,6 @@ function resolveProbeFetcher(token: string, options?: TelegramProbeOptions): typ
   const proxyUrl = options?.proxyUrl?.trim();
   const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
   const resolved = resolveTelegramFetch(proxyFetch, { network: options?.network });
-  if (!resolved) {
-    throw new Error("fetch is not available");
-  }
 
   if (cacheKey) {
     return setCachedProbeFetcher(cacheKey, resolved);

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -1,5 +1,7 @@
 import type { BaseProbeResult } from "../channels/plugins/types.js";
+import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import { resolveTelegramFetch } from "./fetch.js";
 import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -17,13 +19,35 @@ export type TelegramProbe = BaseProbeResult & {
   webhook?: { url?: string | null; hasCustomCert?: boolean | null };
 };
 
+export type TelegramProbeOptions = {
+  proxyUrl?: string;
+  network?: TelegramNetworkConfig;
+};
+
+function resolveProbeOptions(
+  proxyOrOptions?: string | TelegramProbeOptions,
+): TelegramProbeOptions | undefined {
+  if (!proxyOrOptions) {
+    return undefined;
+  }
+  if (typeof proxyOrOptions === "string") {
+    return { proxyUrl: proxyOrOptions };
+  }
+  return proxyOrOptions;
+}
+
 export async function probeTelegram(
   token: string,
   timeoutMs: number,
-  proxyUrl?: string,
+  proxyOrOptions?: string | TelegramProbeOptions,
 ): Promise<TelegramProbe> {
   const started = Date.now();
-  const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
+  const options = resolveProbeOptions(proxyOrOptions);
+  const proxyFetch = options?.proxyUrl ? makeProxyFetch(options.proxyUrl) : undefined;
+  const fetcher = resolveTelegramFetch(proxyFetch, { network: options?.network });
+  if (!fetcher) {
+    throw new Error("fetch is not available");
+  }
   const base = `${TELEGRAM_API_BASE}/bot${token}`;
   const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
 

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -92,10 +92,13 @@ export async function probeTelegram(
   proxyOrOptions?: string | TelegramProbeOptions,
 ): Promise<TelegramProbe> {
   const started = Date.now();
+  const timeoutBudgetMs = Math.max(1, Math.floor(timeoutMs));
+  const deadlineMs = started + timeoutBudgetMs;
   const options = resolveProbeOptions(proxyOrOptions);
   const fetcher = resolveProbeFetcher(token, options);
   const base = `${TELEGRAM_API_BASE}/bot${token}`;
-  const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
+  const retryDelayMs = Math.max(50, Math.min(1000, Math.floor(timeoutBudgetMs / 5)));
+  const resolveRemainingBudgetMs = () => Math.max(0, deadlineMs - Date.now());
 
   const result: TelegramProbe = {
     ok: false,
@@ -110,19 +113,35 @@ export async function probeTelegram(
 
     // Retry loop for initial connection (handles network/DNS startup races)
     for (let i = 0; i < 3; i++) {
+      const remainingBudgetMs = resolveRemainingBudgetMs();
+      if (remainingBudgetMs <= 0) {
+        break;
+      }
       try {
-        meRes = await fetchWithTimeout(`${base}/getMe`, {}, timeoutMs, fetcher);
+        meRes = await fetchWithTimeout(
+          `${base}/getMe`,
+          {},
+          Math.max(1, Math.min(timeoutBudgetMs, remainingBudgetMs)),
+          fetcher,
+        );
         break;
       } catch (err) {
         fetchError = err;
         if (i < 2) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+          const remainingAfterAttemptMs = resolveRemainingBudgetMs();
+          if (remainingAfterAttemptMs <= 0) {
+            break;
+          }
+          const delayMs = Math.min(retryDelayMs, remainingAfterAttemptMs);
+          if (delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
         }
       }
     }
 
     if (!meRes) {
-      throw fetchError;
+      throw fetchError ?? new Error(`probe timed out after ${timeoutBudgetMs}ms`);
     }
 
     const meJson = (await meRes.json()) as {
@@ -159,16 +178,24 @@ export async function probeTelegram(
 
     // Try to fetch webhook info, but don't fail health if it errors.
     try {
-      const webhookRes = await fetchWithTimeout(`${base}/getWebhookInfo`, {}, timeoutMs, fetcher);
-      const webhookJson = (await webhookRes.json()) as {
-        ok?: boolean;
-        result?: { url?: string; has_custom_certificate?: boolean };
-      };
-      if (webhookRes.ok && webhookJson?.ok) {
-        result.webhook = {
-          url: webhookJson.result?.url ?? null,
-          hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+      const webhookRemainingBudgetMs = resolveRemainingBudgetMs();
+      if (webhookRemainingBudgetMs > 0) {
+        const webhookRes = await fetchWithTimeout(
+          `${base}/getWebhookInfo`,
+          {},
+          Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
+          fetcher,
+        );
+        const webhookJson = (await webhookRes.json()) as {
+          ok?: boolean;
+          result?: { url?: string; has_custom_certificate?: boolean };
         };
+        if (webhookRes.ok && webhookJson?.ok) {
+          result.webhook = {
+            url: webhookJson.result?.url ?? null,
+            hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+          };
+        }
       }
     } catch {
       // ignore webhook errors for probe

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -24,6 +24,9 @@ export type TelegramProbeOptions = {
   network?: TelegramNetworkConfig;
 };
 
+const probeFetcherCache = new Map<string, typeof fetch>();
+const MAX_PROBE_FETCHER_CACHE_SIZE = 64;
+
 function resolveProbeOptions(
   proxyOrOptions?: string | TelegramProbeOptions,
 ): TelegramProbeOptions | undefined {
@@ -36,6 +39,53 @@ function resolveProbeOptions(
   return proxyOrOptions;
 }
 
+function shouldUseProbeFetcherCache(): boolean {
+  return !process.env.VITEST && process.env.NODE_ENV !== "test";
+}
+
+function buildProbeFetcherCacheKey(token: string, options?: TelegramProbeOptions): string {
+  const proxyKey = options?.proxyUrl?.trim() ?? "";
+  const autoSelectFamily = options?.network?.autoSelectFamily;
+  const autoSelectFamilyKey =
+    typeof autoSelectFamily === "boolean" ? String(autoSelectFamily) : "default";
+  const dnsResultOrderKey = options?.network?.dnsResultOrder ?? "default";
+  return `${token}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}`;
+}
+
+function setCachedProbeFetcher(cacheKey: string, fetcher: typeof fetch): typeof fetch {
+  probeFetcherCache.set(cacheKey, fetcher);
+  if (probeFetcherCache.size > MAX_PROBE_FETCHER_CACHE_SIZE) {
+    const oldestKey = probeFetcherCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      probeFetcherCache.delete(oldestKey);
+    }
+  }
+  return fetcher;
+}
+
+function resolveProbeFetcher(token: string, options?: TelegramProbeOptions): typeof fetch {
+  const cacheEnabled = shouldUseProbeFetcherCache();
+  const cacheKey = cacheEnabled ? buildProbeFetcherCacheKey(token, options) : null;
+  if (cacheKey) {
+    const cachedFetcher = probeFetcherCache.get(cacheKey);
+    if (cachedFetcher) {
+      return cachedFetcher;
+    }
+  }
+
+  const proxyUrl = options?.proxyUrl?.trim();
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
+  const resolved = resolveTelegramFetch(proxyFetch, { network: options?.network });
+  if (!resolved) {
+    throw new Error("fetch is not available");
+  }
+
+  if (cacheKey) {
+    return setCachedProbeFetcher(cacheKey, resolved);
+  }
+  return resolved;
+}
+
 export async function probeTelegram(
   token: string,
   timeoutMs: number,
@@ -43,11 +93,7 @@ export async function probeTelegram(
 ): Promise<TelegramProbe> {
   const started = Date.now();
   const options = resolveProbeOptions(proxyOrOptions);
-  const proxyFetch = options?.proxyUrl ? makeProxyFetch(options.proxyUrl) : undefined;
-  const fetcher = resolveTelegramFetch(proxyFetch, { network: options?.network });
-  if (!fetcher) {
-    throw new Error("fetch is not available");
-  }
+  const fetcher = resolveProbeFetcher(token, options);
   const base = `${TELEGRAM_API_BASE}/bot${token}`;
   const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
 

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -29,7 +29,7 @@ vi.mock("undici", () => ({
   setGlobalDispatcher: mocks.setGlobalDispatcher,
 }));
 
-import { makeProxyFetch } from "./proxy.js";
+import { getProxyUrlFromFetch, makeProxyFetch } from "./proxy.js";
 
 describe("makeProxyFetch", () => {
   it("uses undici fetch with ProxyAgent dispatcher", async () => {
@@ -45,5 +45,12 @@ describe("makeProxyFetch", () => {
       expect.objectContaining({ dispatcher: mocks.getLastAgent() }),
     );
     expect(mocks.setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("attaches proxy metadata for resolver transport handling", () => {
+    const proxyUrl = "http://proxy.test:8080";
+    const proxyFetch = makeProxyFetch(proxyUrl);
+
+    expect(getProxyUrlFromFetch(proxyFetch)).toBe(proxyUrl);
   });
 });

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,1 +1,1 @@
-export { makeProxyFetch } from "../infra/net/proxy-fetch.js";
+export { getProxyUrlFromFetch, makeProxyFetch } from "../infra/net/proxy-fetch.js";

--- a/src/telegram/send.proxy.test.ts
+++ b/src/telegram/send.proxy.test.ts
@@ -51,7 +51,12 @@ vi.mock("grammy", () => ({
   InputFile: class {},
 }));
 
-import { deleteMessageTelegram, reactMessageTelegram, sendMessageTelegram } from "./send.js";
+import {
+  deleteMessageTelegram,
+  reactMessageTelegram,
+  resetTelegramClientOptionsCacheForTests,
+  sendMessageTelegram,
+} from "./send.js";
 
 describe("telegram proxy client", () => {
   const proxyUrl = "http://proxy.test:8080";
@@ -76,6 +81,7 @@ describe("telegram proxy client", () => {
   };
 
   beforeEach(() => {
+    resetTelegramClientOptionsCacheForTests();
     vi.unstubAllEnvs();
     botApi.sendMessage.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
     botApi.setMessageReaction.mockResolvedValue(undefined);

--- a/src/telegram/send.proxy.test.ts
+++ b/src/telegram/send.proxy.test.ts
@@ -76,6 +76,7 @@ describe("telegram proxy client", () => {
   };
 
   beforeEach(() => {
+    vi.unstubAllEnvs();
     botApi.sendMessage.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
     botApi.setMessageReaction.mockResolvedValue(undefined);
     botApi.deleteMessage.mockResolvedValue(true);
@@ -85,6 +86,33 @@ describe("telegram proxy client", () => {
     });
     makeProxyFetch.mockClear();
     resolveTelegramFetch.mockClear();
+  });
+
+  it("reuses cached Telegram client options for repeated sends with same account transport settings", async () => {
+    const { fetchImpl } = prepareProxyFetch();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    await sendMessageTelegram("123", "first", { token: "tok", accountId: "foo" });
+    await sendMessageTelegram("123", "second", { token: "tok", accountId: "foo" });
+
+    expect(makeProxyFetch).toHaveBeenCalledTimes(1);
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
+    expect(botCtorSpy).toHaveBeenCalledTimes(2);
+    expect(botCtorSpy).toHaveBeenNthCalledWith(
+      1,
+      "tok",
+      expect.objectContaining({
+        client: expect.objectContaining({ fetch: fetchImpl }),
+      }),
+    );
+    expect(botCtorSpy).toHaveBeenNthCalledWith(
+      2,
+      "tok",
+      expect.objectContaining({
+        client: expect.objectContaining({ fetch: fetchImpl }),
+      }),
+    );
   });
 
   it.each([

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -118,6 +118,10 @@ const diagLogger = createSubsystemLogger("telegram/diagnostic");
 const telegramClientOptionsCache = new Map<string, ApiClientOptions | undefined>();
 const MAX_TELEGRAM_CLIENT_OPTIONS_CACHE_SIZE = 64;
 
+export function resetTelegramClientOptionsCacheForTests(): void {
+  telegramClientOptionsCache.clear();
+}
+
 function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
   const enabled = isDiagnosticFlagEnabled("telegram.http", cfg);
   if (!enabled) {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -115,6 +115,8 @@ const MESSAGE_NOT_MODIFIED_RE =
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
 const sendLogger = createSubsystemLogger("telegram/send");
 const diagLogger = createSubsystemLogger("telegram/diagnostic");
+const telegramClientOptionsCache = new Map<string, ApiClientOptions | undefined>();
+const MAX_TELEGRAM_CLIENT_OPTIONS_CACHE_SIZE = 64;
 
 function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
   const enabled = isDiagnosticFlagEnabled("telegram.http", cfg);
@@ -130,25 +132,74 @@ function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
   };
 }
 
+function shouldUseTelegramClientOptionsCache(): boolean {
+  return !process.env.VITEST && process.env.NODE_ENV !== "test";
+}
+
+function buildTelegramClientOptionsCacheKey(params: {
+  account: ResolvedTelegramAccount;
+  timeoutSeconds?: number;
+}): string {
+  const proxyKey = params.account.config.proxy?.trim() ?? "";
+  const autoSelectFamily = params.account.config.network?.autoSelectFamily;
+  const autoSelectFamilyKey =
+    typeof autoSelectFamily === "boolean" ? String(autoSelectFamily) : "default";
+  const dnsResultOrderKey = params.account.config.network?.dnsResultOrder ?? "default";
+  const timeoutSecondsKey =
+    typeof params.timeoutSeconds === "number" ? String(params.timeoutSeconds) : "default";
+  return `${params.account.accountId}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}::${timeoutSecondsKey}`;
+}
+
+function setCachedTelegramClientOptions(
+  cacheKey: string,
+  clientOptions: ApiClientOptions | undefined,
+): ApiClientOptions | undefined {
+  telegramClientOptionsCache.set(cacheKey, clientOptions);
+  if (telegramClientOptionsCache.size > MAX_TELEGRAM_CLIENT_OPTIONS_CACHE_SIZE) {
+    const oldestKey = telegramClientOptionsCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      telegramClientOptionsCache.delete(oldestKey);
+    }
+  }
+  return clientOptions;
+}
+
 function resolveTelegramClientOptions(
   account: ResolvedTelegramAccount,
 ): ApiClientOptions | undefined {
-  const proxyUrl = account.config.proxy?.trim();
-  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
-  const fetchImpl = resolveTelegramFetch(proxyFetch, {
-    network: account.config.network,
-  });
   const timeoutSeconds =
     typeof account.config.timeoutSeconds === "number" &&
     Number.isFinite(account.config.timeoutSeconds)
       ? Math.max(1, Math.floor(account.config.timeoutSeconds))
       : undefined;
-  return fetchImpl || timeoutSeconds
-    ? {
-        ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
-        ...(timeoutSeconds ? { timeoutSeconds } : {}),
-      }
-    : undefined;
+
+  const cacheEnabled = shouldUseTelegramClientOptionsCache();
+  const cacheKey = cacheEnabled
+    ? buildTelegramClientOptionsCacheKey({
+        account,
+        timeoutSeconds,
+      })
+    : null;
+  if (cacheKey && telegramClientOptionsCache.has(cacheKey)) {
+    return telegramClientOptionsCache.get(cacheKey);
+  }
+
+  const proxyUrl = account.config.proxy?.trim();
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
+  const fetchImpl = resolveTelegramFetch(proxyFetch, {
+    network: account.config.network,
+  });
+  const clientOptions =
+    fetchImpl || timeoutSeconds
+      ? {
+          ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
+          ...(timeoutSeconds ? { timeoutSeconds } : {}),
+        }
+      : undefined;
+  if (cacheKey) {
+    return setCachedTelegramClientOptions(cacheKey, clientOptions);
+  }
+  return clientOptions;
 }
 
 function resolveToken(explicit: string | undefined, params: { accountId: string; token: string }) {


### PR DESCRIPTION
Over the last week I saw a noticeable regression in Telegram reliability, with bot sends intermittently failing and logs filling up with `Network request for 'sendMessage' failed` and repeated fallback messages.

After digging into it, the core issue turned out not to be a single failing request path, but how Telegram networking state was being managed. Several parts of the Telegram stack could update shared network settings, which on my system led to `autoSelectFamily` repeatedly flipping between true and false and caused fallback behaviour to be retried far more often than expected.

That investigation surfaced three related problems:

-  Telegram networking depended on shared global dispatcher state for proxy handling, IPv4/IPv6 selection, and DNS order. When fallback occurred, that state was not effectively retained, so later requests could trigger the same fallback path again.
-  Telegram did not consistently use the same fetch path across sends, probes, and media, so behaviour varied across different parts of the integration.
-  I got my system up and running again with a narrow fix in #40435, but that left the broader issue of shared mutable state and repeated reinitialisation, and the fallback during probes left more log messages than was desired.

This PR takes a more durable approach: it moves Telegram networking to resolver-scoped dispatchers, makes fallback behaviour consistent across all Telegram network paths, and adds a range of new tests to ensure consistent handling across Telegram network calls.

## Summary

Describe the problem and fix in 2–5 bullets:

-  Problem: Telegram transport handling relied on process-global network state (`autoSelectFamily`, DNS order, and undici global dispatcher), which made transport behavior vulnerable to reapplication across unrelated Telegram flows.
-  Why it matters: Users could see flaky Telegram delivery (`ETIMEDOUT`, `EHOSTUNREACH`), repeated fallback warnings, and inconsistent behaviour between polling, sends, probes, audits, and media downloads.
-  What changed:
	* Reworked `src/telegram/fetch.ts` to build resolver-scoped undici dispatchers instead of mutating process-global Telegram network state
	* Routed polling/webhook bot clients, outbound sends, probes, group membership audits, and inbound media downloads through the same Telegram transport resolution path
	* Preserved caller-provided `init.dispatcher` across retries, and prevented caller-owned dispatcher failures from arming sticky IPv4 fallback
	* Added guarded fallback when env-proxy dispatcher initialisation fails, while keeping explicit proxy initialisation fail-closed
	* Added bounded in-memory transport caching for repeated send/probe resolution to reduce dispatcher churn and repeated probe-triggered fallback noise
	* Updated probe retries to respect a single overall `timeoutMs` budget
-  What did NOT change: no new config or env keys, no non-Telegram channel changes, and no auth, pairing, or routing policy changes.


## History / Context

This section documents why this PR is a core transport fix

### Previous Telegram network handling (before this PR)

From late January through early March 2026, Telegram fetch behavior evolved into a process-global transport model:

1. `2026-01-26` (`b861a0bd73`): Telegram network hardening introduced process-level `autoSelectFamily` handling.
2. `2026-02-16` (`c762bf71f6`): Node 22 default moved to `autoSelectFamily=true`.
3. `2026-02-22` (`53adae9cec`): added default `dnsResultOrder=ipv4first` behavior on Node 22+.
4. `2026-02-25` (`0078070680`): added global undici dispatcher refresh to align with `autoSelectFamily`.
5. `2026-03-01` (`e6049345db`) and `2026-03-02` (`666a4763ee`): added proxy-preservation behavior around global dispatcher replacement.
6. `2026-03-02` (`9c03f8be08`, then `493ebb915b`): added retry path that forced IPv4 fallback on qualifying network errors.
7. `2026-03-02` (`c973b053a5`): proxy-env plumbing refactor (same fallback semantics).
8. `2026-03-05` (`05fb16d151`): global undici timeout hardening added another path that can reapply global dispatcher state.

### Why this became a concern

-  Telegram network behaviour was being coordinated through process-global knobs.
-  In multi-account or mixed network conditions, that creates room for cross-flow contention and flip-flop behaviour.
-  The observed logs (`autoSelectFamily=true (default-node22)` interleaved with `autoSelectFamily=false (config)`, plus repeated fallback warnings) were consistent with that shared-state contention pattern.

### What this PR changes architecturally

-  Moves Telegram network handling from process-global mutation to resolver-scoped dispatchers.
-  Reuses resolved transport state across long-lived bot instances and bounded send/probe caches.
-  Keeps sticky IPv4 fallback local to the resolved transport instance instead of a process-global toggle.
-  Removes Telegram-path mutation of process-global `net`, `dns`, and undici dispatcher state.

This is intended to supersede symptom-level fallback tweaks by removing the underlying shared-global-state coupling in Telegram fetch handling.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33013
- Closes #21737
- Related #33336
- Related #40435
- Related #25676
- Related #26207
- Related #29940

## User-visible / Behavior Changes

-  Telegram transport no longer flips process-global network defaults during normal Telegram operation.
-  Direct Telegram traffic can switch to sticky IPv4 after qualifying connect failures and continue using that resolved transport state for subsequent requests in the same bot/fetcher lifetime.
-  Repeated sends and probes can reuse cached transport resolution, reducing repeated fallback-transition log noise.
-  Proxied Telegram accounts now use the same transport resolution path and configured network policy as other Telegram flows, but sticky IPv4 fallback remains limited to direct or `NO_PROXY`-bypassed traffic.
-  Caller-provided dispatchers are preserved on retry, and their failures no longer taint later Telegram transport state.
-  Telegram probe retries now honor `timeoutMs` as an overall budget.
-  No config/default changes required by users.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25.x, pnpm, bun/vitest
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): multi-account Telegram with mixed/default network settings; with and without proxy env present

### Steps

1. Start gateway with Telegram accounts in a dual-stack environment where IPv6 path is intermittently unreachable.
2. Trigger Telegram API sends and observe network/fallback logs.
3. Verify resolver behavior and retries via targeted tests.

### Expected

- Telegram send/poll transport remains stable per resolver and avoids global flip-flop behavior.
- On qualifying connect failures, fallback switches to IPv4 and stays there for subsequent resolver requests.

### Actual

- Implemented resolver-scoped dispatcher policy achieves this behavior in tests and build/type checks.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before (production logs showing transport thrash):
```text
autoSelectFamily=true (default-node22)
autoSelectFamily=false (config)
fetch fallback: forcing autoSelectFamily=false + dnsResultOrder=ipv4first
telegram sendMessage failed: Network request for 'sendMessage' failed!
```

After (this branch):
```text
$ bunx vitest run src/telegram/fetch.test.ts
✓ Test Files 1 passed
✓ Tests 9 passed (9)

$ bunx vitest run src/telegram/probe.test.ts
✓ Test Files 1 passed
✓ Tests 8 passed (8)

$ bunx vitest run extensions/telegram/src/channel.test.ts
✓ Test Files 1 passed
✓ Tests 8 passed (8)
```
Focused regression checks (this branch):
```text
$ bunx vitest run src/telegram/fetch.test.ts -t "retries once and then keeps sticky IPv4 dispatcher for subsequent requests"
✓ Tests 1 passed | 8 skipped

$ bunx vitest run src/telegram/fetch.test.ts -t "keeps per-resolver transport policy isolated across multiple accounts"
✓ Tests 1 passed | 8 skipped
```

- Sticky IPv4 fallback works and remains resolver-local.
- Per-resolver transport policy isolation works across conflicting account settings.
- Telegram fetch path no longer relies on process-global network toggling behavior.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- `bunx vitest run src/telegram/fetch.test.ts src/telegram/send.proxy.test.ts src/telegram/proxy.test.ts src/telegram/network-config.test.ts` passed.
- `pnpm tsgo` passed.
- `pnpm format:check` passed.
- `pnpm build` passed.
- Edge cases checked:
- Explicit proxy fetch path remains caller-owned.
- Env-proxy dispatcher path works and falls back to direct Agent if proxy agent init throws.
- Retry preserves caller-provided `init.dispatcher`.
- Multi-resolver conflicting network policies remain isolated.
- Verified flaky Telegram delivery (`ETIMEDOUT`, `EHOSTUNREACH`) with repeated fallback warnings when not applied, and confirmed these were resolved once the patch was applied. 
- Verified Telegram appears as Enabled / On / OK  in status/doctor
- What you did **not** verify:
- End-to-end validation on a TUN/VPN host in this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the Telegram transport unification changes in `src/telegram/fetch.ts`, `src/telegram/send.ts`, `src/telegram/probe.ts`, `src/telegram/bot.ts`, `src/telegram/bot-handlers.ts`, `src/telegram/bot/delivery.resolve-media.ts`, `src/telegram/audit-membership-runtime.ts`, and `extensions/telegram/src/channel.ts`.
- Files/config to restore: all of the above, plus their corresponding test files.
- Known bad symptoms reviewers should watch for: Retries not activating on qualifying direct-connect failures, unexpected proxy routing behavior, or transport state persisting longer than intended across repeated sends/probes.

## Risks and Mitigations

- Risk: Sticky IPv4 mode can persist longer than a single request burst because resolved transport state is reused and cached.
- Mitigation: Activation is still limited to qualifying network failures and remains scoped to the resolved Telegram transport instance rather than the process.
- Risk: Env-proxy dispatcher creation can fail with malformed proxy config.
- Mitigation: Direct-Agent fallback keeps Telegram functional.
- Risk: Long-lived dispatchers are reused more aggressively than before.
- Mitigation: Caches are bounded and transport state is isolated from other Telegram accounts and flows.

AI Assisted: yes, Codex investigation, root cause analysis, tests, review, edge-case discovery
