### PR TITLE
fix(config): accept discord agentComponents schema

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -22,6 +22,9 @@ const gatewayLog = {
   error: vi.fn(),
 };
 
+const LOOP_SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
+type LoopSignal = (typeof LOOP_SIGNALS)[number];
+
 vi.mock("../../infra/gateway-lock.js", () => ({
   acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
 }));
@@ -47,10 +50,7 @@ vi.mock("../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => gatewayLog,
 }));
 
-function removeNewSignalListeners(
-  signal: NodeJS.Signals,
-  existing: Set<(...args: unknown[]) => void>,
-) {
+function removeNewSignalListeners(signal: LoopSignal, existing: Set<(...args: unknown[]) => void>) {
   for (const listener of process.listeners(signal)) {
     const fn = listener as (...args: unknown[]) => void;
     if (!existing.has(fn)) {
@@ -59,20 +59,42 @@ function removeNewSignalListeners(
   }
 }
 
-async function withIsolatedSignals(run: () => Promise<void>) {
-  const beforeSigterm = new Set(
-    process.listeners("SIGTERM") as Array<(...args: unknown[]) => void>,
-  );
-  const beforeSigint = new Set(process.listeners("SIGINT") as Array<(...args: unknown[]) => void>);
-  const beforeSigusr1 = new Set(
-    process.listeners("SIGUSR1") as Array<(...args: unknown[]) => void>,
-  );
+function addedSignalListener(
+  signal: LoopSignal,
+  existing: Set<(...args: unknown[]) => void>,
+): (() => void) | null {
+  const listeners = process.listeners(signal) as Array<(...args: unknown[]) => void>;
+  for (let i = listeners.length - 1; i >= 0; i -= 1) {
+    const listener = listeners[i];
+    if (listener && !existing.has(listener)) {
+      return listener as () => void;
+    }
+  }
+  return null;
+}
+
+async function withIsolatedSignals(
+  run: (helpers: { captureSignal: (signal: LoopSignal) => () => void }) => Promise<void>,
+) {
+  const existingListeners = Object.fromEntries(
+    LOOP_SIGNALS.map((signal) => [
+      signal,
+      new Set(process.listeners(signal) as Array<(...args: unknown[]) => void>),
+    ]),
+  ) as Record<LoopSignal, Set<(...args: unknown[]) => void>>;
+  const captureSignal = (signal: LoopSignal) => {
+    const listener = addedSignalListener(signal, existingListeners[signal]);
+    if (!listener) {
+      throw new Error(`expected new ${signal} listener`);
+    }
+    return () => listener();
+  };
   try {
-    await run();
+    await run({ captureSignal });
   } finally {
-    removeNewSignalListeners("SIGTERM", beforeSigterm);
-    removeNewSignalListeners("SIGINT", beforeSigint);
-    removeNewSignalListeners("SIGUSR1", beforeSigusr1);
+    for (const signal of LOOP_SIGNALS) {
+      removeNewSignalListeners(signal, existingListeners[signal]);
+    }
   }
 }
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -75,6 +75,20 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts channels.discord.agentComponents.enabled", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects unsafe iMessage remoteHost", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1437,6 +1437,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow subagent spawns with thread=true to auto-create and bind Discord threads (default: false; opt-in). Set true to enable thread-bound subagent spawns for this account/channel.",
   "channels.discord.threadBindings.spawnAcpSessions":
     "Allow /acp spawn to auto-create and bind Discord threads for ACP sessions (default: false; opt-in). Set true to enable thread-bound ACP spawns for this account/channel.",
+  "channels.discord.agentComponents.enabled":
+    "Enable agent-controlled interactive Discord components such as buttons and select menus (default: true). Set per account via channels.discord.accounts.<id>.agentComponents.enabled.",
   "channels.discord.ui.components.accentColor":
     "Accent color for Discord component containers (hex). Set per account via channels.discord.accounts.<id>.ui.components.accentColor.",
   "channels.discord.voice.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -714,6 +714,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.discord.threadBindings.maxAgeHours": "Discord Thread Binding Max Age (hours)",
   "channels.discord.threadBindings.spawnSubagentSessions": "Discord Thread-Bound Subagent Spawn",
   "channels.discord.threadBindings.spawnAcpSessions": "Discord Thread-Bound ACP Spawn",
+  "channels.discord.agentComponents.enabled": "Discord Agent Components Enabled",
   "channels.discord.ui.components.accentColor": "Discord Component Accent Color",
   "channels.discord.intents.presence": "Discord Presence Intent",
   "channels.discord.intents.guildMembers": "Discord Guild Members Intent",

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -474,6 +474,12 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    agentComponents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     ui: DiscordUiSchema,
     slashCommand: z
       .object({


### PR DESCRIPTION
## Summary
- accept `channels.discord.agentComponents.enabled` in the strict Discord config schema
- add a config regression test
- add schema label/help metadata for the new config key

## Why
Issue #35564 reports schema/type drift:
- `agentComponents` already exists in `DiscordAccountConfig`
- runtime code already reads `discordCfg.agentComponents`
- strict Zod validation rejected the field because the schema omitted it

This patch keeps the schema aligned with the existing type and runtime behavior without changing runtime logic.

## Validation
- `pnpm exec vitest run --config vitest.unit.config.ts src/config/config.schema-regressions.test.ts`
- `pnpm exec oxfmt --check src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts src/config/schema.labels.ts src/config/schema.help.ts`

Closes #35564
