### PR TITLE
Test: make next-run presenter assertion locale-aware

### DIFF
--- a/test/ui.presenter-next-run.test.ts
+++ b/test/ui.presenter-next-run.test.ts
@@ -10,7 +10,8 @@ describe("formatNextRun", () => {
   it("includes weekday and relative time", () => {
     const ts = Date.UTC(2026, 1, 23, 15, 0, 0);
     const out = formatNextRun(ts);
-    expect(out).toMatch(/^[A-Za-z]{3}, /);
+    const weekday = new Date(ts).toLocaleDateString(undefined, { weekday: "short" });
+    expect(out.startsWith(`${weekday}, `)).toBe(true);
     expect(out).toContain("(");
     expect(out).toContain(")");
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `formatNextRun` uses locale-dependent weekday formatting, but its test expected only English 3-letter weekdays.
- Why it matters: on non-English locales (for example `zh-CN`), the test fails even though runtime behavior is correct.
- What changed: updated the test to compute the expected weekday with the current locale and assert a locale-aware prefix.
- What did NOT change (scope boundary): no runtime formatting logic was changed; this PR only fixes test brittleness.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none)
- Related # (none)

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `LC_ALL=zh_CN.UTF-8`, `LANG=zh_CN.UTF-8`

### Steps

1. Run `LC_ALL=zh_CN.UTF-8 LANG=zh_CN.UTF-8 pnpm -s vitest test/ui.presenter-next-run.test.ts` before this fix.
2. Observe failure because output weekday is localized (for example `周一`) but test requires `/^[A-Za-z]{3}, /`.
3. Run the same command after this fix.

### Expected

- Test should pass regardless of system locale.

### Actual

- Test now passes in both default locale and `zh_CN.UTF-8` locale.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm -s vitest test/ui.presenter-next-run.test.ts` (pass)
  - `LC_ALL=zh_CN.UTF-8 LANG=zh_CN.UTF-8 pnpm -s vitest test/ui.presenter-next-run.test.ts` (pass)
- Edge cases checked:
  - locale-dependent short weekday output no longer causes false negatives.
- What you did **not** verify:
  - full repository test/build health (there are unrelated pre-existing failures outside this change).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `63cd98c48`.
- Files/config to restore:
  - `test/ui.presenter-next-run.test.ts`
- Known bad symptoms reviewers should watch for:
  - locale-specific test regressions in `formatNextRun` assertions.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Test still relies on host locale formatting behavior by design.
  - Mitigation:
    - Expected prefix is derived from the same locale path as the formatter, removing English-only assumptions.
