### PR TITLE
fix(agents): strip malformed `required` from tool schemas

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,17 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { normalizeToolParameters } from "./pi-tools.schema.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function makeTool(params?: Record<string, unknown>): AnyAgentTool {
+  return {
+    name: "test_tool",
+    description: "test",
+    label: "Test",
+    execute: () => Promise.resolve({ content: [], details: undefined }),
+    ...(params !== undefined ? { parameters: params } : {}),
+  } as AnyAgentTool;
+}
 
 describe("normalizeToolParameters", () => {
   it("strips top-level required: null", () => {
-    const tool = {
-      name: "test_tool",
-      description: "test",
-      parameters: {
-        type: "object",
-        properties: { foo: { type: "string" } },
-        required: null,
-      },
-    };
+    const tool = makeTool({
+      type: "object",
+      properties: { foo: { type: "string" } },
+      required: null,
+    });
     const result = normalizeToolParameters(tool);
     const params = result.parameters as Record<string, unknown>;
     expect(params).not.toHaveProperty("required");
@@ -20,52 +27,40 @@ describe("normalizeToolParameters", () => {
   });
 
   it("preserves valid required array", () => {
-    const tool = {
-      name: "test_tool",
-      description: "test",
-      parameters: {
-        type: "object",
-        properties: { foo: { type: "string" } },
-        required: ["foo"],
-      },
-    };
+    const tool = makeTool({
+      type: "object",
+      properties: { foo: { type: "string" } },
+      required: ["foo"],
+    });
     const result = normalizeToolParameters(tool);
     const params = result.parameters as Record<string, unknown>;
     expect(params.required).toEqual(["foo"]);
   });
 
   it("strips required: undefined-like values (non-array)", () => {
-    const tool = {
-      name: "test_tool",
-      description: "test",
-      parameters: {
-        type: "object",
-        properties: { bar: { type: "number" } },
-        required: "bar",
-      },
-    };
+    const tool = makeTool({
+      type: "object",
+      properties: { bar: { type: "number" } },
+      required: "bar",
+    });
     const result = normalizeToolParameters(tool);
     const params = result.parameters as Record<string, unknown>;
     expect(params).not.toHaveProperty("required");
   });
 
   it("handles required: null with Gemini provider", () => {
-    const tool = {
-      name: "test_tool",
-      description: "test",
-      parameters: {
-        type: "object",
-        properties: { foo: { type: "string" } },
-        required: null,
-      },
-    };
+    const tool = makeTool({
+      type: "object",
+      properties: { foo: { type: "string" } },
+      required: null,
+    });
     const result = normalizeToolParameters(tool, { modelProvider: "google" });
     const params = result.parameters as Record<string, unknown>;
     expect(params).not.toHaveProperty("required");
   });
 
   it("returns tool unchanged when parameters is absent", () => {
-    const tool = { name: "test_tool", description: "test" };
+    const tool = makeTool();
     const result = normalizeToolParameters(tool);
     expect(result).toEqual(tool);
   });

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -59,6 +59,27 @@ describe("normalizeToolParameters", () => {
     expect(params).not.toHaveProperty("required");
   });
 
+  it("strips nested required: null inside properties for Gemini provider", () => {
+    const tool = makeTool({
+      type: "object",
+      properties: {
+        address: {
+          type: "object",
+          properties: { street: { type: "string" } },
+          required: null,
+        },
+      },
+      required: ["address"],
+    });
+    const result = normalizeToolParameters(tool, { modelProvider: "google" });
+    const props = (result.parameters as Record<string, unknown>).properties as Record<
+      string,
+      unknown
+    >;
+    expect(props.address).not.toHaveProperty("required");
+    expect((result.parameters as Record<string, unknown>).required).toEqual(["address"]);
+  });
+
   it("returns tool unchanged when parameters is absent", () => {
     const tool = makeTool();
     const result = normalizeToolParameters(tool);

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+
+describe("normalizeToolParameters", () => {
+  it("strips top-level required: null", () => {
+    const tool = {
+      name: "test_tool",
+      description: "test",
+      parameters: {
+        type: "object",
+        properties: { foo: { type: "string" } },
+        required: null,
+      },
+    };
+    const result = normalizeToolParameters(tool);
+    const params = result.parameters as Record<string, unknown>;
+    expect(params).not.toHaveProperty("required");
+    expect(params.type).toBe("object");
+    expect(params.properties).toEqual({ foo: { type: "string" } });
+  });
+
+  it("preserves valid required array", () => {
+    const tool = {
+      name: "test_tool",
+      description: "test",
+      parameters: {
+        type: "object",
+        properties: { foo: { type: "string" } },
+        required: ["foo"],
+      },
+    };
+    const result = normalizeToolParameters(tool);
+    const params = result.parameters as Record<string, unknown>;
+    expect(params.required).toEqual(["foo"]);
+  });
+
+  it("strips required: undefined-like values (non-array)", () => {
+    const tool = {
+      name: "test_tool",
+      description: "test",
+      parameters: {
+        type: "object",
+        properties: { bar: { type: "number" } },
+        required: "bar",
+      },
+    };
+    const result = normalizeToolParameters(tool);
+    const params = result.parameters as Record<string, unknown>;
+    expect(params).not.toHaveProperty("required");
+  });
+
+  it("handles required: null with Gemini provider", () => {
+    const tool = {
+      name: "test_tool",
+      description: "test",
+      parameters: {
+        type: "object",
+        properties: { foo: { type: "string" } },
+        required: null,
+      },
+    };
+    const result = normalizeToolParameters(tool, { modelProvider: "google" });
+    const params = result.parameters as Record<string, unknown>;
+    expect(params).not.toHaveProperty("required");
+  });
+
+  it("returns tool unchanged when parameters is absent", () => {
+    const tool = { name: "test_tool", description: "test" };
+    const result = normalizeToolParameters(tool);
+    expect(result).toEqual(tool);
+  });
+});

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -75,6 +75,14 @@ export function normalizeToolParameters(
     return tool;
   }
 
+  // Some schema generators (e.g. TypeBox) emit `required: null` instead of
+  // omitting the field. Providers like Bailian/GLM reject this with
+  // "got null, want array". Strip it early so every downstream path benefits.
+  if ("required" in schema && !Array.isArray(schema.required)) {
+    const { required: _, ...rest } = schema;
+    return normalizeToolParameters({ ...tool, parameters: rest }, options);
+  }
+
   // Provider quirks:
   // - Gemini rejects several JSON Schema keywords, so we scrub those.
   // - OpenAI rejects function tool schemas unless the *top-level* is `type: "object"`.

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -78,7 +78,7 @@ export function normalizeToolParameters(
   // Some schema generators (e.g. TypeBox) emit `required: null` instead of
   // omitting the field. Providers like Bailian/GLM reject this with
   // "got null, want array". Strip it early so every downstream path benefits.
-  if ("required" in schema && !Array.isArray(schema.required)) {
+  if (Object.hasOwn(schema, "required") && !Array.isArray(schema.required)) {
     const { required: _, ...rest } = schema;
     return normalizeToolParameters({ ...tool, parameters: rest }, options);
   }

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -340,6 +340,9 @@ function cleanSchemaForGeminiWithDefs(
       cleaned[key] = value.map((variant) =>
         cleanSchemaForGeminiWithDefs(variant, nextDefs, refStack),
       );
+    } else if (key === "required" && !Array.isArray(value)) {
+      // Drop malformed `required` (e.g. null) so providers don't reject the schema.
+      continue;
     } else {
       cleaned[key] = value;
     }


### PR DESCRIPTION
## Summary

- Problem: Some schema generators (e.g. TypeBox) emit `required: null` instead of omitting the field. Providers like Bailian GLM-5 reject this outright with `at '/required': got null, want array`.
- Why it matters: Tool calling is completely broken for any provider that validates `required` must be an array (OpenAPI spec mandates this).
- What changed: `normalizeToolParameters()` now strips non-array `required` values early, before any provider-specific cleaning runs. The Gemini schema-cleaning loop also guards against non-array `required`.
- What did NOT change (scope boundary): Valid `required` arrays pass through unchanged. No changes to union flattening, provider detection, or any other schema normalization logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #40568

## User-visible / Behavior Changes

Tool calling with providers that enforce strict JSON Schema validation (e.g. Bailian GLM-5) now works correctly when tool schemas contain `required: null`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: Bailian GLM-5 (or any provider with strict `required` validation)
- Integration/channel (if any): N/A
- Relevant config (redacted): Tool with `required: null` in its JSON Schema

### Steps

1. Configure a tool whose schema generator emits `required: null` (e.g. TypeBox with an optional-only object)
2. Send a tool-calling request to Bailian GLM-5
3. Observe the error: `at '/required': got null, want array`

### Expected

- Tool call succeeds; `required: null` is silently stripped before sending to the provider

### Actual (before fix)

- Provider rejects the schema with `got null, want array`

## Evidence

- [x] Failing test/log before + passing after

| Test | What it verifies |
|------|-----------------|
| `strips top-level required: null` | Core fix: `required: null` is removed from schema |
| `preserves valid required array` | No regression: valid `["foo"]` arrays survive |
| `strips required: undefined-like values (non-array)` | Edge case: string `required` also stripped |
| `handles required: null with Gemini provider` | Gemini path also handles the fix |
| `returns tool unchanged when parameters is absent` | No-op path is unaffected |

## Human Verification (required)

- Verified scenarios: All 5 unit tests pass; `required: null`, valid array, string value, Gemini provider, absent parameters
- Edge cases checked: `required: "bar"` (non-array non-null), missing `parameters` entirely
- What you did **not** verify: Live Bailian GLM-5 API call (no access to the provider)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/pi-tools.schema.ts`, `src/agents/schema/clean-for-gemini.ts`
- Known bad symptoms reviewers should watch for: Tool schemas losing their `required` field when it should be present (would show as all parameters becoming optional)

## Risks and Mitigations

- Risk: Recursive call in `normalizeToolParameters` for `required: null` schemas
  - Mitigation: Recursion depth is always 1 — the stripped schema no longer has `required` in it, so the guard condition is not hit again