### PR TITLE
fix: use atomic writes for auth-profiles.json to prevent corruption

### DIFF
--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadJsonFile, saveJsonFile } from "./json-file.js";
+
+describe("saveJsonFile", () => {
+  it("writes valid JSON that can be loaded back", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      const filePath = path.join(dir, "test.json");
+      const data = { version: 1, profiles: { "openai:default": { type: "api_key", key: "sk-test" } } };
+      saveJsonFile(filePath, data);
+      const loaded = loadJsonFile(filePath);
+      expect(loaded).toEqual(data);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates parent directories if they do not exist", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      const filePath = path.join(dir, "nested", "deep", "test.json");
+      saveJsonFile(filePath, { ok: true });
+      expect(fs.existsSync(filePath)).toBe(true);
+      const loaded = loadJsonFile(filePath);
+      expect(loaded).toEqual({ ok: true });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not leave a .tmp file after successful write", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      const filePath = path.join(dir, "test.json");
+      saveJsonFile(filePath, { hello: "world" });
+      expect(fs.existsSync(`${filePath}.tmp`)).toBe(false);
+      expect(fs.existsSync(filePath)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("atomically replaces existing file content", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      const filePath = path.join(dir, "test.json");
+      saveJsonFile(filePath, { version: 1 });
+      saveJsonFile(filePath, { version: 2 });
+      const loaded = loadJsonFile(filePath);
+      expect(loaded).toEqual({ version: 2 });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("file is never empty or partial during overwrite", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      const filePath = path.join(dir, "test.json");
+      const data = { key: "a".repeat(10_000) };
+      saveJsonFile(filePath, data);
+
+      // Overwrite with new data — the file should always be valid JSON
+      const newData = { key: "b".repeat(10_000) };
+      saveJsonFile(filePath, newData);
+
+      const raw = fs.readFileSync(filePath, "utf8");
+      const parsed = JSON.parse(raw);
+      expect(parsed).toEqual(newData);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans up temp file if write fails", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      // Circular reference causes JSON.stringify to throw
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+
+      const filePath = path.join(dir, "test.json");
+      expect(() => saveJsonFile(filePath, circular)).toThrow();
+      expect(fs.existsSync(`${filePath}.tmp`)).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves original file if write to temp fails", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      const filePath = path.join(dir, "test.json");
+      const original = { preserved: true };
+      saveJsonFile(filePath, original);
+
+      // Circular reference causes JSON.stringify to throw
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      expect(() => saveJsonFile(filePath, circular)).toThrow();
+
+      // Original file should be intact
+      const loaded = loadJsonFile(filePath);
+      expect(loaded).toEqual(original);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sets restrictive file permissions (0o600)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+    try {
+      const filePath = path.join(dir, "test.json");
+      saveJsonFile(filePath, { secret: true });
+      const stat = fs.statSync(filePath);
+      // eslint-disable-next-line no-bitwise
+      expect(stat.mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -18,6 +18,19 @@ export function saveJsonFile(pathname: string, data: unknown) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
+  // Atomic write: write to temp file then rename to prevent corruption
+  // from concurrent writes (see #40471).
+  const tmpPath = `${pathname}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, pathname);
+  } catch (err) {
+    // Clean up temp file on failure
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Ignore cleanup errors (temp file may not exist)
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #40471

`auth-profiles.json` gets corrupted when multiple processes (Telegram polling, MQTT agent-chat listener, cron jobs) trigger concurrent auth token refreshes. The non-atomic `writeFileSync` call in `saveJsonFile` allows one process to truncate the file while another is mid-write, producing concatenated/truncated JSON that causes "No API key found" errors.

**Root cause:** `src/infra/json-file.ts` `saveJsonFile()` used `fs.writeFileSync()` directly on the target file — a non-atomic operation that is unsafe under concurrent writes.

**Fix:** Replace the direct write with an atomic write-to-temp-then-rename pattern:
1. Write data to `<path>.tmp` in the same directory
2. Use `fs.renameSync()` to atomically replace the original file (POSIX guarantees `rename` is atomic on the same filesystem)
3. Clean up the temp file if the write fails

Since `saveJsonFile` is the shared utility used by all auth-profiles write sites (`saveAuthProfileStore`, `loadAuthProfileStore`, `loadAuthProfileStoreForAgent`, and other callers like `github-copilot-token.ts`), fixing it here covers all write paths.

## Testing

- Added `src/infra/json-file.test.ts` with 8 tests covering:
  - Roundtrip write/read correctness
  - Parent directory auto-creation
  - No leftover `.tmp` file after success
  - Atomic replacement of existing content
  - No partial/empty file during overwrite
  - Temp file cleanup on write failure (circular JSON)
  - Original file preservation when write fails
  - Restrictive file permissions (0o600)
- All 8 new tests pass
- All 131 existing auth-profiles tests pass (0 regressions)
- All tests for other `saveJsonFile` callers pass (github-copilot-token, store save, runtime snapshot)