### PR TITLE
feat(feishu): support index parameter for doc insert action

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -35,9 +35,17 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("insert"),
     doc_token: Type.String({ description: "Document token" }),
     content: Type.String({ description: "Markdown content to insert" }),
-    after_block_id: Type.String({
-      description: "Insert content after this block ID. Use list_blocks to find block IDs.",
-    }),
+    after_block_id: Type.Optional(
+      Type.String({
+        description: "Insert content after this block ID. Use list_blocks to find block IDs.",
+      }),
+    ),
+    index: Type.Optional(
+      Type.Number({
+        description:
+          "Insert position (0-based index among document root children). 0 = beginning. Used when after_block_id is not provided.",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("create"),

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -875,41 +875,47 @@ async function insertDoc(
   client: Lark.Client,
   docToken: string,
   markdown: string,
-  afterBlockId: string,
+  afterBlockId: string | undefined,
   maxBytes: number,
   logger?: Logger,
+  index?: number,
 ) {
-  const blockInfo = await client.docx.documentBlock.get({
-    path: { document_id: docToken, block_id: afterBlockId },
-  });
-  if (blockInfo.code !== 0) throw new Error(blockInfo.msg);
+  let parentId = docToken;
+  let insertIndex = index ?? 0;
 
-  const parentId = blockInfo.data?.block?.parent_id ?? docToken;
-
-  // Paginate through all children to reliably locate after_block_id.
-  // documentBlockChildren.get returns up to 200 children per page; large
-  // parents require multiple requests.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block type
-  const items: any[] = [];
-  let pageToken: string | undefined;
-  do {
-    const childrenRes = await client.docx.documentBlockChildren.get({
-      path: { document_id: docToken, block_id: parentId },
-      params: pageToken ? { page_token: pageToken } : {},
+  if (afterBlockId) {
+    const blockInfo = await client.docx.documentBlock.get({
+      path: { document_id: docToken, block_id: afterBlockId },
     });
-    if (childrenRes.code !== 0) throw new Error(childrenRes.msg);
-    items.push(...(childrenRes.data?.items ?? []));
-    pageToken = childrenRes.data?.page_token ?? undefined;
-  } while (pageToken);
+    if (blockInfo.code !== 0) throw new Error(blockInfo.msg);
 
-  const blockIndex = items.findIndex((item) => item.block_id === afterBlockId);
-  if (blockIndex === -1) {
-    throw new Error(
-      `after_block_id "${afterBlockId}" was not found among the children of parent block "${parentId}". ` +
-        `Use list_blocks to verify the block ID.`,
-    );
+    parentId = blockInfo.data?.block?.parent_id ?? docToken;
+
+    // Paginate through all children to reliably locate after_block_id.
+    // documentBlockChildren.get returns up to 200 children per page; large
+    // parents require multiple requests.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block type
+    const items: any[] = [];
+    let pageToken: string | undefined;
+    do {
+      const childrenRes = await client.docx.documentBlockChildren.get({
+        path: { document_id: docToken, block_id: parentId },
+        params: pageToken ? { page_token: pageToken } : {},
+      });
+      if (childrenRes.code !== 0) throw new Error(childrenRes.msg);
+      items.push(...(childrenRes.data?.items ?? []));
+      pageToken = childrenRes.data?.page_token ?? undefined;
+    } while (pageToken);
+
+    const blockIndex = items.findIndex((item) => item.block_id === afterBlockId);
+    if (blockIndex === -1) {
+      throw new Error(
+        `after_block_id "${afterBlockId}" was not found among the children of parent block "${parentId}". ` +
+          `Use list_blocks to verify the block ID.`,
+      );
+    }
+    insertIndex = blockIndex + 1;
   }
-  const insertIndex = blockIndex + 1;
 
   logger?.info?.("feishu_doc: Converting markdown...");
   const { blocks, firstLevelBlockIds } = await chunkedConvertMarkdown(client, markdown);
@@ -1306,6 +1312,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       p.after_block_id,
                       getMediaMaxBytes(p, defaultAccountId),
                       api.logger,
+                      p.index,
                     ),
                   );
                 case "create":


### PR DESCRIPTION
## Problem

The `feishu_doc(action: "insert")` tool requires `after_block_id` as a mandatory parameter. This makes it impossible to insert content at the very beginning of a document — there is no block to reference when you want to prepend content before the first block.

This is a common need when building documents in reverse-chronological order (e.g., daily diaries with newest entries first).

## Solution

- Make `after_block_id` optional
- Add an optional `index` parameter (0-based position among document root children, default: 0 = beginning)
- When `after_block_id` is provided, behavior is exactly the same as before (fully backward compatible)
- When `after_block_id` is omitted, use `index` to determine insert position

The underlying Feishu Descendant API (`documentBlockDescendant.create`) already supports the `index` parameter. This change simply exposes it through the tool schema.

## Changes

- `extensions/feishu/src/doc-schema.ts`: `after_block_id` → optional, added `index` parameter
- `extensions/feishu/src/docx.ts`: `insertDoc` function handles both modes; call site passes `p.index`

## Testing

Tested locally on a live Feishu document:
- `feishu_doc(action: "insert", index: 0, ...)` — successfully inserts at document beginning ✅
- `feishu_doc(action: "insert", after_block_id: "xxx", ...)` — existing behavior unchanged ✅