### PR TITLE
fix(config): deduplicate config validation warnings to prevent log flooding

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -84,6 +84,7 @@ const OPEN_DM_POLICY_ALLOW_FROM_RE =
 
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
+const loggedConfigWarnings = new Set<string>();
 
 type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
 
@@ -766,7 +767,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
               `- ${sanitizeTerminalText(iss.path || "<root>")}: ${sanitizeTerminalText(iss.message)}`,
           )
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        const warningKey = `${configPath}:${details}`;
+        if (!loggedConfigWarnings.has(warningKey)) {
+          loggedConfigWarnings.add(warningKey);
+          deps.logger.warn(`Config warnings:\\n${details}`);
+        }
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyTalkConfigNormalization(


### PR DESCRIPTION
## Summary
- Config validation warnings were logged on every config reload cycle without deduplication, flooding logs with identical warning blocks
- Added a `loggedConfigWarnings` set (mirroring the existing `loggedInvalidConfigs` error dedup pattern on line 753) to skip re-logging identical warnings
- The dedup key includes both the config path and warning details, so changed warnings after a config edit are still logged

## Change Type
Bug fix — prevents log flooding from repeated identical config validation warnings

## Scope
`src/config/io.ts` — added warning deduplication guard (6-line change)

## Security Impact
None

Closes #40404

🤖 Generated with [Claude Code](https://claude.com/claude-code)