### PR TITLE
fix(exec): warn when allow-always cannot persist patterns for shell builtins

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -11,7 +11,7 @@ import {
 } from "../infra/exec-approvals.js";
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
-import { logInfo } from "../logger.js";
+import { logInfo, logWarn } from "../logger.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
@@ -217,6 +217,11 @@ export async function processGatewayAllowlist(
             env: params.env,
             platform: process.platform,
           });
+          if (patterns.length === 0) {
+            logWarn(
+              "exec: allow-always could not persist any allowlist patterns (command may contain only shell builtins like cd, export, etc.)",
+            );
+          }
           for (const pattern of patterns) {
             if (pattern) {
               addAllowlistEntry(approvals.file, params.agentId, pattern);

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -451,6 +451,11 @@ async function executeSystemRunPhase(
         env: phase.env,
         platform: process.platform,
       });
+      if (patterns.length === 0) {
+        logWarn(
+          "exec: allow-always could not persist any allowlist patterns (command may contain only shell builtins like cd, export, etc.)",
+        );
+      }
       for (const pattern of patterns) {
         if (pattern) {
           addAllowlistEntry(phase.approvals.file, phase.agentId, pattern);


### PR DESCRIPTION
## Summary
- When a user approves a command with "allow-always" that contains only shell builtins (like `cd`, `export`, `source`), no allowlist patterns can be resolved because builtins have no binary path
- Previously this failed silently — the user saw a success confirmation but the allowlist was not updated, causing re-prompts on subsequent invocations
- Now logs a warning via `logWarn()` when `resolveAllowAlwaysPatterns()` returns zero patterns, making the failure visible

## Change Type
Bug fix — makes silent failure visible with a diagnostic warning

## Scope
`src/agents/bash-tools.exec-host-gateway.ts` — added empty-patterns warning
`src/node-host/invoke-system-run.ts` — added empty-patterns warning (same pattern)

## Security Impact
None — logging only, no behavioral change to allowlist logic

Closes #40478

🤖 Generated with [Claude Code](https://claude.com/claude-code)