### PR TITLE
fix(telegram): accept negative group IDs in groupAllowFrom allowlist

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,25 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
+  it("accepts positive sender IDs and negative group/supergroup chat IDs", () => {
     const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
 
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["-1001234567890", "-100999", "745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone"],
+    });
+  });
+
+  it("rejects non-numeric entries but accepts negative IDs", () => {
+    const result = normalizeAllowFrom(["-1003890514701", "123456789", "@badentry", "tg:-999"]);
+
+    expect(result).toEqual({
+      entries: ["-1003890514701", "123456789", "-999"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@badentry"],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -1,9 +1,9 @@
-import type { AllowlistMatch } from "../channels/allowlist-match.js";
 import {
   firstDefined,
   isSenderIdAllowed,
   mergeDmAllowFromSources,
 } from "../channels/allow-from.js";
+import type { AllowlistMatch } from "../channels/allowlist-match.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export type NormalizedAllowFrom = {

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -1,9 +1,9 @@
+import type { AllowlistMatch } from "../channels/allowlist-match.js";
 import {
   firstDefined,
   isSenderIdAllowed,
   mergeDmAllowFromSources,
 } from "../channels/allow-from.js";
-import type { AllowlistMatch } from "../channels/allowlist-match.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export type NormalizedAllowFrom = {
@@ -44,11 +44,12 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  // Telegram supergroup/group IDs are always negative integers; allow leading minus.
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

Fixes #40444

Telegram supergroup and group chat IDs are always negative integers (e.g., `-1001234567890`). The `normalizeAllowFrom` function in `bot-access.ts` validated entries with `^\d+$`, which rejects any value with a leading `-`, making `groupPolicy: "allowlist"` completely non-functional for Telegram groups.

- Change validation regex from `^\d+$` to `^-?\d+$` in both the `invalidEntries` filter and the `ids` filter
- Update tests to reflect correct behavior: negative IDs are now valid entries; only non-numeric entries like `@username` remain invalid

## Test plan

- [x] `pnpm test src/telegram/bot-access.test.ts` — 2 tests pass
- [ ] Manually set `groupAllowFrom: [-1001234567890]` + `groupPolicy: "allowlist"` and verify group messages are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)