### PR TITLE
fix(acpx): add --experimental-acp flag to built-in Gemini agent command

### DIFF
--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock spawnAndCollect so loadAgentOverrides always returns empty overrides,
+// letting resolveAcpxAgentCommand fall through to the built-in command table.
+vi.mock("./process.js", () => ({
+  spawnAndCollect: vi.fn().mockResolvedValue({ code: 1, stdout: "", stderr: "", error: undefined }),
+}));
+
+import { resolveAcpxAgentCommand } from "./mcp-agent-command.js";
+
+const defaultParams = { acpxCommand: "acpx", cwd: "/tmp" };
+
+describe("built-in agent commands", () => {
+  it("resolves each built-in agent to its expected command", async () => {
+    const expected: Record<string, string> = {
+      codex: "npx @zed-industries/codex-acp",
+      claude: "npx -y @zed-industries/claude-agent-acp",
+      gemini: "gemini --experimental-acp",
+      opencode: "npx -y opencode-ai acp",
+      pi: "npx pi-acp",
+    };
+
+    for (const [agent, command] of Object.entries(expected)) {
+      expect(await resolveAcpxAgentCommand({ ...defaultParams, agent })).toBe(command);
+    }
+  });
+
+  it("gemini command includes --experimental-acp flag for ACP mode", async () => {
+    const cmd = await resolveAcpxAgentCommand({ ...defaultParams, agent: "gemini" });
+    expect(cmd).toContain("--experimental-acp");
+  });
+
+  it("returns raw agent string for unknown agents", async () => {
+    const cmd = await resolveAcpxAgentCommand({ ...defaultParams, agent: "unknown-agent" });
+    expect(cmd).toBe("unknown-agent");
+  });
+
+  it("normalizes agent name case and whitespace", async () => {
+    expect(await resolveAcpxAgentCommand({ ...defaultParams, agent: "Gemini" })).toBe(
+      "gemini --experimental-acp",
+    );
+    expect(await resolveAcpxAgentCommand({ ...defaultParams, agent: " CLAUDE " })).toBe(
+      "npx -y @zed-industries/claude-agent-acp",
+    );
+  });
+});

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
@@ -5,7 +5,7 @@ import { spawnAndCollect, type SpawnCommandOptions } from "./process.js";
 const ACPX_BUILTIN_AGENT_COMMANDS: Record<string, string> = {
   codex: "npx @zed-industries/codex-acp",
   claude: "npx -y @zed-industries/claude-agent-acp",
-  gemini: "gemini",
+  gemini: "gemini --experimental-acp",
   opencode: "npx -y opencode-ai acp",
   pi: "npx pi-acp",
 };


### PR DESCRIPTION
## Summary

The built-in Gemini agent command in `acpx` is registered as plain `gemini`, but Gemini CLI requires `--experimental-acp` to run in ACP mode. Without this flag, ACP session initialization hangs or fails.

**Change:** `gemini` → `gemini --experimental-acp` in the built-in agent command registry.

## Problem

`acpx gemini ...` (and any ACP runtime path using the built-in Gemini agent) fails during session initialization because Gemini CLI starts in normal interactive mode instead of ACP agent mode.

Observed symptoms:
- `sessions_spawn(runtime="acp", agentId="gemini")` hangs at `[client] initialize (running)`
- Upstream callers may see `missing tool result in session history`

## Root Cause

`ACPX_BUILTIN_AGENT_COMMANDS` maps `gemini` to `"gemini"`, but Gemini CLI exposes:

```
--experimental-acp    Starts the agent in ACP mode
```

Without this flag, the CLI runs in normal interactive mode which does not speak ACP protocol.

## Verification

1. **Gemini CLI itself works fine** (not an install/auth issue):
   ```
   gemini -p "reply with exactly: GEMINI_OK"
   ```

2. **Explicit override succeeds:**
   ```
   acpx --verbose --timeout 20 --agent 'gemini --experimental-acp' exec 'reply with exactly: ACP_VERBOSE_OK'
   ```
   Output confirms ACP initialization, session creation, and prompt execution all succeed.

3. **After applying this patch**, `sessions_spawn(runtime="acp", agentId="gemini")` works without any manual override.

## Workaround

Users can work around this without patching:
```
acpx --agent 'gemini --experimental-acp' ...
```

## Test plan

- [ ] `acpx gemini exec 'reply with exactly: GEMINI_OK'` succeeds without `--agent` override
- [ ] Existing `acpx` tests pass (`pnpm test` in `extensions/acpx`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)