### PR TITLE
fix(heartbeat): do not append workspace path hint to user-configured prompts

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -602,8 +602,7 @@ describe("launchd install", () => {
 
     const plistPath = resolveLaunchAgentPlistPath(env);
     expect(state.dirModes.get(env.HOME!)).toBe(0o755);
-    const expectedLibraryMode = process.platform === "win32" ? 0o777 : 0o755;
-    expect(state.dirModes.get("/Users/test/Library")).toBe(expectedLibraryMode);
+    expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
     expect(state.fileModes.get(plistPath)).toBe(0o600);
   });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -602,7 +602,8 @@ describe("launchd install", () => {
 
     const plistPath = resolveLaunchAgentPlistPath(env);
     expect(state.dirModes.get(env.HOME!)).toBe(0o755);
-    expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
+    const expectedLibraryMode = process.platform === "win32" ? 0o777 : 0o755;
+    expect(state.dirModes.get("/Users/test/Library")).toBe(expectedLibraryMode);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
     expect(state.fileModes.get(plistPath)).toBe(0o600);
   });

--- a/src/infra/heartbeat-runner.custom-prompt.test.ts
+++ b/src/infra/heartbeat-runner.custom-prompt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { appendHeartbeatWorkspacePathHint } from "./heartbeat-runner.js";
+
+describe("appendHeartbeatWorkspacePathHint — user-custom prompt guard", () => {
+  const workspaceDir = "/home/user/.openclaw/workspace";
+
+  it("does not modify a user-configured custom prompt even when it mentions HEARTBEAT.md", () => {
+    const customPrompt =
+      "You are Ash. When you receive a heartbeat, read HEARTBEAT.md from my workspace and execute.";
+    const result = appendHeartbeatWorkspacePathHint(customPrompt, workspaceDir, true);
+    expect(result).toBe(customPrompt);
+  });
+
+  it("appends the workspace hint to the default prompt when no custom prompt is set", () => {
+    const defaultPrompt =
+      "HEARTBEAT TRIGGER. Read HEARTBEAT.md. Execute the highest-priority task.";
+    const result = appendHeartbeatWorkspacePathHint(defaultPrompt, workspaceDir, false);
+    expect(result).toContain("use workspace file");
+    expect(result).toContain("HEARTBEAT.md");
+    expect(result).toContain(workspaceDir);
+  });
+
+  it("returns the prompt unchanged when it does not reference heartbeat.md (default or custom)", () => {
+    const unrelatedPrompt = "Run the daily report and post to Slack.";
+    expect(appendHeartbeatWorkspacePathHint(unrelatedPrompt, workspaceDir, false)).toBe(
+      unrelatedPrompt,
+    );
+    expect(appendHeartbeatWorkspacePathHint(unrelatedPrompt, workspaceDir, true)).toBe(
+      unrelatedPrompt,
+    );
+  });
+
+  it("does not duplicate the hint when already present", () => {
+    const hint = `When reading HEARTBEAT.md, use workspace file ${workspaceDir}/HEARTBEAT.md (exact case). Do not read docs/heartbeat.md.`;
+    const promptWithHint = `HEARTBEAT TRIGGER. Read HEARTBEAT.md.\n${hint}`;
+    const result = appendHeartbeatWorkspacePathHint(promptWithHint, workspaceDir, false);
+    expect(result.split("use workspace file").length).toBe(2); // only one occurrence
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -646,7 +646,18 @@ type HeartbeatPromptResolution = {
   hasCronEvents: boolean;
 };
 
-function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string): string {
+export function appendHeartbeatWorkspacePathHint(
+  prompt: string,
+  workspaceDir: string,
+  isUserCustomPrompt: boolean,
+): string {
+  // Never modify a user-configured prompt. The hint exists to help the default
+  // prompt find the correct HEARTBEAT.md; users who wrote their own prompt
+  // already know where to look and may have intentionally left out the
+  // HEARTBEAT.md reference or pointed to a different file.
+  if (isUserCustomPrompt) {
+    return prompt;
+  }
   if (!/heartbeat\.md/i.test(prompt)) {
     return prompt;
   }
@@ -714,12 +725,22 @@ After completing all due tasks, reply HEARTBEAT_OK.`;
     return { prompt: null, hasExecCompletion: false, hasCronEvents: false };
   }
 
+  const rawUserPrompt = params.heartbeat?.prompt ?? params.cfg.agents?.defaults?.heartbeat?.prompt;
+  const isUserCustomPrompt =
+    !hasExecCompletion &&
+    !hasCronEvents &&
+    typeof rawUserPrompt === "string" &&
+    rawUserPrompt.trim().length > 0;
   const basePrompt = hasExecCompletion
     ? buildExecEventPrompt(execEvents, { deliverToUser: params.canRelayToUser })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
-  const prompt = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
+  const prompt = appendHeartbeatWorkspacePathHint(
+    basePrompt,
+    params.workspaceDir,
+    isUserCustomPrompt,
+  );
 
   return { prompt, hasExecCompletion, hasCronEvents };
 }


### PR DESCRIPTION
Commit 604f22c introduced `appendHeartbeatWorkspacePathHint` to help agents find the correct HEARTBEAT.md when using the built-in default prompt. The hint was appended whenever the prompt mentioned 'heartbeat.md', regardless of whether it was the default or a user-supplied custom prompt.

This breaks user-configured prompts: the appended text may contradict the user's intent, and users who explicitly exclude HEARTBEAT.md references from their prompt cannot prevent the hint from being injected.

Fix: detect whether the heartbeat prompt came from the user's config (non-empty custom string) vs the built-in default, and skip the hint injection for user-authored prompts. Exec/cron event prompts are always generated internally and are never treated as user prompts.

Adds a focused unit test covering the custom-prompt guard, the default-prompt append path, and the no-duplicate guard.

Fixes #40255.

---
AI-assisted (Claude). Fully tested and reviewed.