### PR TITLE
fix: allow negative group chat IDs in groupAllowFrom

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,73 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
-    const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
-
+  it("accepts positive sender IDs", () => {
+    const result = normalizeAllowFrom(["745123456", "123"]);
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["745123456", "123"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: [],
+    });
+  });
+
+  it("accepts negative Telegram group chat IDs", () => {
+    const result = normalizeAllowFrom(["-1003890514701", " tg:-100999 ", "745123456"]);
+    expect(result).toEqual({
+      entries: ["-1003890514701", "-100999", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("rejects non-numeric strings", () => {
+    const result = normalizeAllowFrom(["@someone", "abc", "12.34"]);
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@someone", "abc", "12.34"],
+    });
+  });
+
+  it("handles wildcard", () => {
+    const result = normalizeAllowFrom(["*", "745123456"]);
+    expect(result).toEqual({
+      entries: ["745123456"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("handles mixed valid and invalid entries", () => {
+    const result = normalizeAllowFrom(["-1001234567890", "745123456", "@someone"]);
+    expect(result).toEqual({
+      entries: ["-1001234567890", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@someone"],
+    });
+  });
+
+  it("returns empty for undefined input", () => {
+    const result = normalizeAllowFrom(undefined);
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: false,
+      invalidEntries: [],
+    });
+  });
+
+  it("strips telegram prefix before validation", () => {
+    const result = normalizeAllowFrom(["telegram:-1001234567890", "tg:745123456"]);
+    expect(result).toEqual({
+      entries: ["-1001234567890", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,12 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  // Allow negative IDs: Telegram group/supergroup chat IDs are always negative
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

- Fix `normalizeAllowFrom` in `src/telegram/bot-access.ts` to accept negative Telegram group/supergroup chat IDs
- Change validation regex from `^\d+$` to `^-?\d+$` so entries like `-1003890514701` are no longer rejected as invalid

Fixes #40444

## Context

Telegram supergroup and group chat IDs are always negative integers (e.g., `-1003890514701`). The `groupAllowFrom` allowlist feature was completely non-functional for Telegram groups because the validation regex `^\d+$` rejected any value containing a leading `-`, causing all group messages to be dropped with `reason: not-allowed`.

## Changes

- `src/telegram/bot-access.ts`: Updated both regex instances in `normalizeAllowFrom` from `^\d+$` to `^-?\d+$`
- `src/telegram/bot-access.test.ts`: Replaced the single test with comprehensive coverage:
  - Positive sender IDs accepted
  - Negative Telegram group chat IDs accepted (e.g., `-1003890514701`)
  - Non-numeric strings still rejected
  - Wildcard handling
  - Mixed valid/invalid entries
  - Undefined input
  - Telegram prefix stripping with negative IDs

## Test plan

- [x] `vitest run src/telegram/bot-access.test.ts` — all 7 tests pass
- [x] Verified negative IDs like `-1003890514701` are accepted
- [x] Verified positive IDs still work
- [x] Verified non-numeric strings (`@someone`, `abc`, `12.34`) are still rejected
- [x] Ran full `src/telegram/` test suite — only pre-existing timer-related failures in `send.test.ts` (unrelated to this change)
