### PR TITLE
fix(telegram): accept negative group chat IDs in groupAllowFrom

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
+  it("accepts sender IDs and negative chat IDs (Telegram supergroup IDs)", () => {
     const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
 
     expect(result).toEqual({
-      entries: ["745123456"],
+      entries: ["-1001234567890", "-100999", "745123456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: ["@someone"],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

- **Problem**: Telegram supergroup IDs are always negative (e.g., `-1003890514701`), but the regex `/^\d+$/` rejected negative IDs
- **Impact**: `groupPolicy: "allowlist"` was completely broken for Telegram groups
- **Fix**: Updated regex to `/^-?\d+$/` to accept both positive and negative IDs

## Root Cause

In `src/telegram/bot-access.ts`, the `normalizeAllowFrom` function validated entries with:
```javascript
const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
```

This regex only matched non-negative integers. Telegram group and supergroup IDs are **always negative** (prefixed with `-`), so they always failed this check.

## Change Type

- [x] Bug fix

## Linked Issue

Fixes #40444

## Test

- Updated test to expect negative IDs as valid entries
- All tests passing locally

## Verification

```bash
pnpm exec vitest run src/telegram/bot-access.test.ts
# ✓ src/telegram/bot-access.test.ts (1 test) 2ms
# Test Files  1 passed
# Tests       1 passed
```