### PR TITLE
fix(hooks): pass sessionFile and sessionKey in after_compaction hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ Docs: https://docs.openclaw.ai
 - Auth/login lockout recovery: clear stale `auth_permanent` and `billing` disabled state for all profiles matching the target provider when `openclaw models auth login` is invoked, so users locked out by expired or revoked OAuth tokens can recover by re-authenticating instead of waiting for the cooldown timer to expire. (#43057)
 - Auto-reply/context-engine compaction: persist the exact embedded-run metadata compaction count for main and followup runner session accounting, so metadata-only auto-compactions no longer undercount multi-compaction runs. (#42629) thanks @uf-hy.
 - Auth/Codex CLI reuse: sync reused Codex CLI credentials into the supported `openai-codex:default` OAuth profile instead of reviving the deprecated `openai-codex:codex-cli` slot, so doctor cleanup no longer loops. (#45353) thanks @Gugu-sugar.
+- Hooks/after_compaction: forward `sessionFile` for direct/manual compaction events and add `sessionFile` plus `sessionKey` to wired auto-compaction hook context so plugins receive the session metadata already declared in the hook types. (#40781) Thanks @jarimustonen.
 
 ## 2026.3.12
 

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -529,6 +529,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
         messageCount: 1,
         tokenCount: 10,
         compactedCount: 1,
+        sessionFile: "/tmp/session.jsonl",
       },
       expect.objectContaining({ sessionKey: "agent:main:session-1", messageProvider: "telegram" }),
     );

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1039,6 +1039,7 @@ export async function compactEmbeddedPiSessionDirect(
                 messageCount: messageCountAfter,
                 tokenCount: tokensAfter,
                 compactedCount,
+                sessionFile: params.sessionFile,
               },
               {
                 sessionId: params.sessionId,

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -80,8 +80,9 @@ export function handleAutoCompactionEnd(
           {
             messageCount: ctx.params.session.messages?.length ?? 0,
             compactedCount: ctx.getCompactionCount(),
+            sessionFile: ctx.params.session.sessionFile,
           },
-          {},
+          { sessionKey: ctx.params.sessionKey },
         )
         .catch((err) => {
           ctx.log.warn(`after_compaction hook failed: ${String(err)}`);

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -39,11 +39,20 @@ describe("compaction hook wiring", () => {
   function createCompactionEndCtx(params: {
     runId: string;
     messages?: unknown[];
+    sessionFile?: string;
+    sessionKey?: string;
     compactionCount?: number;
     withRetryHooks?: boolean;
   }) {
     return {
-      params: { runId: params.runId, session: { messages: params.messages ?? [] } },
+      params: {
+        runId: params.runId,
+        sessionKey: params.sessionKey,
+        session: {
+          messages: params.messages ?? [],
+          sessionFile: params.sessionFile,
+        },
+      },
       state: { compactionInFlight: true },
       log: { debug: vi.fn(), warn: vi.fn() },
       maybeResolveCompactionWait: vi.fn(),
@@ -107,6 +116,8 @@ describe("compaction hook wiring", () => {
     const ctx = createCompactionEndCtx({
       runId: "r2",
       messages: [1, 2],
+      sessionFile: "/tmp/session.jsonl",
+      sessionKey: "agent:main:web-xyz",
       compactionCount: 1,
     });
 
@@ -122,13 +133,16 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.runner.runAfterCompaction).toHaveBeenCalledTimes(1);
 
     const afterCalls = hookMocks.runner.runAfterCompaction.mock.calls as unknown as Array<
-      [unknown]
+      [unknown, unknown]
     >;
     const event = afterCalls[0]?.[0] as
-      | { messageCount?: number; compactedCount?: number }
+      | { messageCount?: number; compactedCount?: number; sessionFile?: string }
       | undefined;
     expect(event?.messageCount).toBe(2);
     expect(event?.compactedCount).toBe(1);
+    expect(event?.sessionFile).toBe("/tmp/session.jsonl");
+    const hookCtx = afterCalls[0]?.[1] as { sessionKey?: string } | undefined;
+    expect(hookCtx?.sessionKey).toBe("agent:main:web-xyz");
     expect(ctx.incrementCompactionCount).toHaveBeenCalledTimes(1);
     expect(ctx.maybeResolveCompactionWait).toHaveBeenCalledTimes(1);
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

- Problem: `after_compaction` hook was missing `sessionFile` and `sessionKey` fields that the type system (`PluginHookAfterCompactionEvent`) declares available
- Why it matters: Plugins listening to `after_compaction` cannot identify which session file was compacted or which session key triggered it
- What changed: Auto-compaction handler now passes `sessionFile` + `sessionKey`; manual compaction now passes `sessionFile`
- What did NOT change (scope boundary): `before_compaction` hook, compaction logic itself, plugin API surface

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: type definition in `src/plugins/types.ts` (`PluginHookAfterCompactionEvent.sessionFile`)

## User-visible / Behavior Changes

Plugins receiving the `after_compaction` hook now get `sessionFile` and `sessionKey` fields that were previously missing/undefined.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun
- Model/provider: N/A (hook wiring only)
- Integration/channel (if any): Telegram (for human test)

### Steps

1. Register a plugin that listens to `after_compaction`
2. Trigger compaction (auto or manual)
3. Observe the event object

### Expected

- `event.sessionFile` contains the session file path
- `ctx.sessionKey` contains the session key

### Actual (before fix)

- `event.sessionFile` was `undefined`
- `ctx.sessionKey` was `undefined` (auto-compaction) or present (manual)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Unit tests updated in `wired-hooks-compaction.test.ts` and `compact.hooks.test.ts` to assert the new fields. All 12 compaction hook tests pass.

## Human Verification (required)

I tested and verified this with a specifically tailored test plugin. This does not cover any edge cases. Rather it shows that the file name is provided and also that I didn't observe any regression.

```js
/** Temporary debug plugin — logs after_compaction event to verify sessionFile/sessionKey fields. */
export default {
  id: "compaction-debug",
  name: "Compaction Debug",
  register(api) {
    api.on("after_compaction", (event, ctx) => {
      api.logger.info(
        `[compaction-debug] after_compaction: sessionFile=${event.sessionFile ?? "(undefined)"}, sessionKey=${ctx.sessionKey ?? "(undefined)"}, messageCount=${event.messageCount}, compactedCount=${event.compactedCount}`,
      );
    });
  },
};
```

- Verified scenarios: auto-compaction with Telegram bot
- Edge cases checked: None specifically
- What you did **not** verify: manual compaction path (`/compact` command), edge cases with missing sessionFile

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: `after_compaction` hook receiving unexpected fields (should not happen as type already declares them)

## Risks and Mitigations

None. Additive change passing already-in-scope values to an already-typed hook event.