### PR TITLE
fix(feishu): support union_id fallback for @mention detection in multi-bot groups

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -451,15 +451,27 @@ function formatSubMessageContent(content: string, contentType: string): string {
   }
 }
 
-function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
-  if (!botOpenId) return false;
+function checkBotMentioned(
+  event: FeishuMessageEvent,
+  botOpenId?: string,
+  botUnionId?: string,
+): boolean {
+  if (!botOpenId && !botUnionId) return false;
   // Check for @all (@_all in Feishu) — treat as mentioning every bot
   const rawContent = event.message.content ?? "";
   if (rawContent.includes("@_all")) return true;
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
-    // Rely on Feishu mention IDs; display names can vary by alias/context.
-    return mentions.some((m) => m.id.open_id === botOpenId);
+    // Feishu open_id is app-scoped: the same bot has different open_ids in different apps.
+    // WebSocket push events may deliver mention open_ids scoped to a different app context,
+    // causing open_id matching to fail when multiple bots share the same group.
+    // union_id is globally unique across apps for the same entity, so we use it as a
+    // fallback to ensure correct @mention detection in multi-bot group scenarios.
+    return mentions.some(
+      (m) =>
+        (botOpenId && m.id.open_id === botOpenId) ||
+        (botUnionId && m.id.union_id === botUnionId),
+    );
   }
   // Post (rich text) messages may have empty message.mentions when they contain docs/paste
   if (event.message.message_type === "post") {
@@ -772,9 +784,10 @@ export function parseFeishuMessageEvent(
   event: FeishuMessageEvent,
   botOpenId?: string,
   _botName?: string,
+  botUnionId?: string,
 ): FeishuMessageContext {
   const rawContent = parseMessageContent(event.message.content, event.message.message_type);
-  const mentionedBot = checkBotMentioned(event, botOpenId);
+  const mentionedBot = checkBotMentioned(event, botOpenId, botUnionId);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
   // Strip the bot's own mention so slash commands like @Bot /help retain
   // the leading /. This applies in both p2p *and* group contexts — the
@@ -864,11 +877,12 @@ export async function handleFeishuMessage(params: {
   event: FeishuMessageEvent;
   botOpenId?: string;
   botName?: string;
+  botUnionId?: string;
   runtime?: RuntimeEnv;
   chatHistories?: Map<string, HistoryEntry[]>;
   accountId?: string;
 }): Promise<void> {
-  const { cfg, event, botOpenId, botName, runtime, chatHistories, accountId } = params;
+  const { cfg, event, botOpenId, botName, botUnionId, runtime, chatHistories, accountId } = params;
 
   // Resolve account with merged config
   const account = resolveFeishuAccount({ cfg, accountId });
@@ -891,7 +905,7 @@ export async function handleFeishuMessage(params: {
     return;
   }
 
-  let ctx = parseFeishuMessageEvent(event, botOpenId, botName);
+  let ctx = parseFeishuMessageEvent(event, botOpenId, botName, botUnionId);
   const isGroup = ctx.chatType === "group";
   const isDirect = !isGroup;
   const senderUserId = event.sender.sender_id.user_id?.trim() || undefined;

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -20,7 +20,7 @@ import {
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
-import { botNames, botOpenIds } from "./monitor.state.js";
+import { botNames, botOpenIds, botUnionIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
@@ -248,6 +248,7 @@ function registerEventHandlers(
         event,
         botOpenId: botOpenIds.get(accountId),
         botName: botNames.get(accountId),
+        botUnionId: botUnionIds.get(accountId),
         runtime,
         chatHistories,
         accountId,
@@ -432,6 +433,7 @@ function registerEventHandlers(
           event: syntheticEvent,
           botOpenId: myBotId,
           botName: botNames.get(accountId),
+          botUnionId: botUnionIds.get(accountId),
           runtime,
           chatHistories,
           accountId,
@@ -486,7 +488,7 @@ function registerEventHandlers(
 }
 
 export type BotOpenIdSource =
-  | { kind: "prefetched"; botOpenId?: string; botName?: string }
+  | { kind: "prefetched"; botOpenId?: string; botName?: string; botUnionId?: string }
   | { kind: "fetch" };
 
 export type MonitorSingleAccountParams = {
@@ -505,17 +507,23 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const botOpenIdSource = params.botOpenIdSource ?? { kind: "fetch" };
   const botIdentity =
     botOpenIdSource.kind === "prefetched"
-      ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
+      ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName, botUnionId: botOpenIdSource.botUnionId }
       : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
   const botOpenId = botIdentity.botOpenId;
   const botName = botIdentity.botName?.trim();
+  const botUnionId = botIdentity.botUnionId?.trim();
   botOpenIds.set(accountId, botOpenId ?? "");
   if (botName) {
     botNames.set(accountId, botName);
   } else {
     botNames.delete(accountId);
   }
-  log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
+  if (botUnionId) {
+    botUnionIds.set(accountId, botUnionId);
+  } else {
+    botUnionIds.delete(accountId);
+  }
+  log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}${botUnionId ? ` (union_id: ${botUnionId})` : ""}`);
 
   const connectionMode = account.config.connectionMode ?? "websocket";
   if (connectionMode === "webhook" && !account.verificationToken?.trim()) {

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -13,6 +13,7 @@ type FetchBotOpenIdOptions = {
 export type FeishuMonitorBotIdentity = {
   botOpenId?: string;
   botName?: string;
+  botUnionId?: string;
 };
 
 function isTimeoutErrorMessage(message: string | undefined): boolean {
@@ -39,7 +40,7 @@ export async function fetchBotIdentityForMonitor(
     abortSignal: options.abortSignal,
   });
   if (result.ok) {
-    return { botOpenId: result.botOpenId, botName: result.botName };
+    return { botOpenId: result.botOpenId, botName: result.botName, botUnionId: result.botUnionId };
   }
 
   if (options.abortSignal?.aborted || isAbortErrorMessage(result.error)) {

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -12,6 +12,7 @@ export const wsClients = new Map<string, Lark.WSClient>();
 export const httpServers = new Map<string, http.Server>();
 export const botOpenIds = new Map<string, string>();
 export const botNames = new Map<string, string>();
+export const botUnionIds = new Map<string, string>();
 
 export const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 export const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
@@ -142,6 +143,7 @@ export function stopFeishuMonitorState(accountId?: string): void {
     }
     botOpenIds.delete(accountId);
     botNames.delete(accountId);
+    botUnionIds.delete(accountId);
     return;
   }
 
@@ -152,4 +154,5 @@ export function stopFeishuMonitorState(accountId?: string): void {
   httpServers.clear();
   botOpenIds.clear();
   botNames.clear();
+  botUnionIds.clear();
 }

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -20,8 +20,8 @@ export type ProbeFeishuOptions = {
 type FeishuBotInfoResponse = {
   code: number;
   msg?: string;
-  bot?: { bot_name?: string; open_id?: string };
-  data?: { bot?: { bot_name?: string; open_id?: string } };
+  bot?: { bot_name?: string; open_id?: string; union_id?: string };
+  data?: { bot?: { bot_name?: string; open_id?: string; union_id?: string } };
 };
 
 function setCachedProbeResult(

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -134,6 +134,7 @@ export async function probeFeishu(
         appId: creds.appId,
         botName: bot?.bot_name,
         botOpenId: bot?.open_id,
+        botUnionId: bot?.union_id,
       },
       PROBE_SUCCESS_TTL_MS,
     );

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -64,6 +64,7 @@ export type FeishuProbeResult = BaseProbeResult<string> & {
   appId?: string;
   botName?: string;
   botOpenId?: string;
+  botUnionId?: string;
 };
 
 export type FeishuMediaInfo = {


### PR DESCRIPTION
## Problem

When multiple Feishu bot accounts share the same group, @mentioning a specific bot is not recognized. The bot logs `message in group ... did not mention bot` and silently ignores the message.

**Root cause:** Feishu `open_id` is app-scoped — the same bot entity has different `open_id` values depending on which app's context is used. WebSocket push events deliver mention `open_id`s that may be scoped to a different app's context than the receiving bot, causing `checkBotMentioned()` to always return `false`.

Confirmed by querying the same message with different app tokens — each returns a different `open_id` for the same mentioned bot.

## Changes

This PR adds the missing `union_id` field to the `FeishuBotInfoResponse` type in `probe.ts`, completing the multi-bot mention fix:

- `probe.ts`: Add `union_id` to `FeishuBotInfoResponse` type
- `types.ts`: Add `botUnionId` to `FeishuProbeResult`
- `monitor.state.ts`: Add `botUnionIds` map
- `monitor.account.ts`: Store and pass `botUnionId` to message handlers
- `bot.ts`: `checkBotMentioned()` now falls back to `union_id` matching when `open_id` doesn't match

**Note:** This PR has been closed — further investigation found that `bot/v3/info` does not actually return `union_id`, so this approach is incomplete. See issue #40768 for details.

Closes #40768