### PR TITLE
feat(telegram): add /settings inline keyboard control panel

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -535,6 +535,13 @@ function buildChatCommands(): ChatCommandDefinition[] {
       argsMenu: "auto",
     }),
     defineChatCommand({
+      key: "settings",
+      nativeName: "settings",
+      description: "Open the settings control panel.",
+      scope: "native",
+      category: "management",
+    }),
+    defineChatCommand({
       key: "reset",
       nativeName: "reset",
       description: "Reset the current session.",

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -21,6 +21,7 @@ type DefineChatCommandInput = {
   textAliases?: string[];
   scope?: CommandScope;
   category?: CommandCategory;
+  providers?: string[];
 };
 
 function defineChatCommand(command: DefineChatCommandInput): ChatCommandDefinition {
@@ -43,6 +44,7 @@ function defineChatCommand(command: DefineChatCommandInput): ChatCommandDefiniti
     textAliases: aliases,
     scope,
     category: command.category,
+    providers: command.providers,
   };
 }
 
@@ -540,6 +542,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
       description: "Open the settings control panel.",
       scope: "native",
       category: "management",
+      providers: ["telegram"],
     }),
     defineChatCommand({
       key: "reset",

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -157,7 +157,13 @@ function listNativeSpecsFromCommands(
   provider?: string,
 ): NativeCommandSpec[] {
   return commands
-    .filter((command) => command.scope !== "text" && command.nativeName)
+    .filter(
+      (command) =>
+        command.scope !== "text" &&
+        command.nativeName &&
+        // Skip commands restricted to other providers
+        (!command.providers || !provider || command.providers.includes(provider)),
+    )
     .map((command) => toNativeCommandSpec(command, provider));
 }
 

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -62,6 +62,8 @@ export type ChatCommandDefinition = {
   argsMenu?: CommandArgMenuSpec | "auto";
   scope: CommandScope;
   category?: CommandCategory;
+  /** When set, only register as a native command on the listed providers. */
+  providers?: string[];
 };
 
 export type NativeCommandSpec = {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -13,6 +13,7 @@ import {
 import { resolveStoredModelOverride } from "../auto-reply/reply/model-selection.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
+import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { shouldDebounceTextInbound } from "../channels/inbound-debounce-policy.js";
 import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
 import { loadConfig } from "../config/config.js";
@@ -1103,6 +1104,122 @@ export const registerTelegramHandlers = ({
         return await bot.api.sendMessage(callbackMessage.chat.id, text, params);
       };
 
+      // Settings panel callback handler (cfg_menu, cfg_s_*, cfg_v_*)
+      // Must run before the inlineButtonsScope gates — settings callbacks are
+      // DM-only and have their own auth (fresh config + resolveCommandAuthorization),
+      // so they should not be blocked by inlineButtonsScope=off or scope=group.
+      const settingsCallback = parseSettingsCallbackData(data);
+      if (settingsCallback) {
+        const settingsChatId = callbackMessage.chat.id;
+        const settingsIsGroup =
+          callbackMessage.chat.type === "group" || callbackMessage.chat.type === "supergroup";
+        if (settingsIsGroup) {
+          return;
+        } // DM-only
+        const settingsSenderId = callback.from?.id ? String(callback.from.id) : "";
+        const settingsSenderUsername = callback.from?.username ?? "";
+        // Load fresh config so changes to allowFrom/dmPolicy since handler
+        // registration are respected.
+        const freshCfg = loadConfig();
+        const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
+        const freshAllowFrom = freshTelegramCfg.allowFrom ?? allowFrom;
+        // Resolve storeAllowFrom via event auth context for DM.
+        const settingsEventAuth = await resolveTelegramEventAuthorizationContext({
+          chatId: settingsChatId,
+          isGroup: false,
+          isForum: false,
+          messageThreadId: undefined,
+        });
+        const settingsStoreAllowFrom = settingsEventAuth.storeAllowFrom;
+        const settingsDmAllow = normalizeDmAllowFromWithStore({
+          allowFrom: freshAllowFrom,
+          storeAllowFrom: settingsStoreAllowFrom,
+          dmPolicy: freshTelegramCfg.dmPolicy ?? "pairing",
+        });
+        const settingsDmSenderAllowed = isSenderAllowed({
+          allow: settingsDmAllow,
+          senderId: settingsSenderId,
+          senderUsername: settingsSenderUsername,
+        });
+        // Mirror /settings command handler auth: use resolveCommandAuthorizedFromAuthorizers
+        // so that when no allowlist is configured and access groups are off,
+        // commandAuthorized=true (open access), matching the command handler behavior.
+        const commandsAllowFrom = freshCfg.commands?.allowFrom;
+        const commandsAllowFromConfigured =
+          commandsAllowFrom != null &&
+          typeof commandsAllowFrom === "object" &&
+          (Array.isArray(commandsAllowFrom.telegram) || Array.isArray(commandsAllowFrom["*"]));
+        const useAccessGroups = freshCfg.commands?.useAccessGroups !== false;
+        const settingsCommandAuthorized = commandsAllowFromConfigured
+          ? Boolean(
+              resolveCommandAuthorization({
+                ctx: {
+                  Provider: "telegram",
+                  Surface: "telegram",
+                  OriginatingChannel: "telegram",
+                  AccountId: accountId,
+                  ChatType: "direct",
+                  From: `telegram:${settingsChatId}`,
+                  SenderId: settingsSenderId || undefined,
+                  SenderUsername: settingsSenderUsername || undefined,
+                },
+                cfg: freshCfg,
+                commandAuthorized: false,
+              })?.isAuthorizedSender,
+            )
+          : resolveCommandAuthorizedFromAuthorizers({
+              useAccessGroups,
+              authorizers: [
+                { configured: settingsDmAllow.hasEntries, allowed: settingsDmSenderAllowed },
+              ],
+              modeWhenAccessGroupsOff: "configured",
+            });
+        // Use resolveCommandAuthorization to enforce both commands.allowFrom
+        // and commands.ownerAllowFrom in a single check.
+        const commandsAuth = resolveCommandAuthorization({
+          ctx: {
+            Provider: "telegram",
+            Surface: "telegram",
+            OriginatingChannel: "telegram",
+            AccountId: accountId,
+            ChatType: "direct",
+            From: `telegram:${settingsChatId}`,
+            SenderId: settingsSenderId || undefined,
+            SenderUsername: settingsSenderUsername || undefined,
+          },
+          cfg: freshCfg,
+          commandAuthorized: settingsCommandAuthorized,
+        });
+        if (!commandsAuth.isAuthorizedSender) {
+          return;
+        }
+        if (!resolveChannelConfigWrites({ cfg: freshCfg, channelId: "telegram", accountId })) {
+          await replyToCallbackChat("Config writes are disabled for this account.");
+          return;
+        }
+        await handleSettingsCallback({
+          parsed: settingsCallback,
+          cfg: freshCfg,
+          accountId,
+          telegramCfg: freshTelegramCfg,
+          editMessage: async (text, buttons) => {
+            const keyboard = buildInlineKeyboard(buttons);
+            try {
+              await editCallbackMessage(text, keyboard ? { reply_markup: keyboard } : undefined);
+            } catch (editErr) {
+              const errStr = String(editErr);
+              if (!errStr.includes("message is not modified")) {
+                throw editErr;
+              }
+            }
+          },
+          answerCallback: async (text) => {
+            await replyToCallbackChat(text);
+          },
+        });
+        return;
+      }
+
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
         accountId,
@@ -1324,81 +1441,6 @@ export const registerTelegramHandlers = ({
           return;
         }
 
-        return;
-      }
-
-      // Settings panel callback handler (cfg_menu, cfg_s_*, cfg_v_*)
-      const settingsCallback = parseSettingsCallbackData(data);
-      if (settingsCallback) {
-        if (isGroup) {
-          return;
-        } // DM-only
-        // Load fresh config *before* the auth re-check so that changes to
-        // allowFrom / dmPolicy made since handler registration are respected.
-        const freshCfg = loadConfig();
-        const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
-        const freshAllowFrom = freshTelegramCfg.allowFrom ?? allowFrom;
-        // Re-check sender auth at command level (stricter than callback-scope)
-        // since settings callbacks mutate config.
-        const settingsDmAllow = normalizeDmAllowFromWithStore({
-          allowFrom: freshAllowFrom,
-          storeAllowFrom,
-          dmPolicy: freshTelegramCfg.dmPolicy ?? "pairing",
-        });
-        // When the allowlist has no entries, treat as unauthorized (matching
-        // the /settings command handler which denies empty allowlists when
-        // access-groups gating is enabled).
-        const dmSenderAllowed =
-          settingsDmAllow.hasEntries &&
-          isSenderAllowed({ allow: settingsDmAllow, senderId, senderUsername });
-        // Use resolveCommandAuthorization to enforce both commands.allowFrom
-        // and commands.ownerAllowFrom in a single check.
-        const commandsAuth = resolveCommandAuthorization({
-          ctx: {
-            Provider: "telegram",
-            Surface: "telegram",
-            OriginatingChannel: "telegram",
-            AccountId: accountId,
-            ChatType: "direct",
-            From: `telegram:${chatId}`,
-            SenderId: senderId || undefined,
-            SenderUsername: senderUsername || undefined,
-          },
-          cfg: freshCfg,
-          // When commands.allowFrom is unset, resolveCommandAuthorization
-          // falls back to commandAuthorized && isOwnerForCommands.
-          commandAuthorized: dmSenderAllowed,
-        });
-        if (!commandsAuth.isAuthorizedSender) {
-          return;
-        }
-        if (!resolveChannelConfigWrites({ cfg: freshCfg, channelId: "telegram", accountId })) {
-          await replyToCallbackChat("Config writes are disabled for this account.");
-          return;
-        }
-        await handleSettingsCallback({
-          parsed: settingsCallback,
-          cfg: freshCfg,
-          accountId,
-          telegramCfg: freshTelegramCfg,
-          editMessage: async (text, buttons) => {
-            const keyboard = buildInlineKeyboard(buttons);
-            try {
-              await editCallbackMessage(text, keyboard ? { reply_markup: keyboard } : undefined);
-            } catch (editErr) {
-              const errStr = String(editErr);
-              if (!errStr.includes("message is not modified")) {
-                throw editErr;
-              }
-            }
-          },
-          answerCallback: async (text) => {
-            // Use a follow-up toast via sendMessage since answerCallbackQuery was
-            // already called at the top of the handler. Telegram allows only one
-            // answer per callback query, so we reply inline instead.
-            await replyToCallbackChat(text);
-          },
-        });
         return;
       }
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,6 +1,5 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { resolveCommandAuthorization } from "../auto-reply/command-auth.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
@@ -13,7 +12,6 @@ import {
 import { resolveStoredModelOverride } from "../auto-reply/reply/model-selection.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
-import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { shouldDebounceTextInbound } from "../channels/inbound-debounce-policy.js";
 import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
 import { loadConfig } from "../config/config.js";
@@ -77,6 +75,7 @@ import {
 } from "./model-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
+import { resolveSettingsAuthDecision } from "./settings-auth.js";
 import { parseSettingsCallbackData } from "./settings-buttons.js";
 import { handleSettingsCallback } from "./settings-panel.js";
 
@@ -1106,8 +1105,8 @@ export const registerTelegramHandlers = ({
 
       // Settings panel callback handler (cfg_menu, cfg_s_*, cfg_v_*)
       // Must run before the inlineButtonsScope gates — settings callbacks are
-      // DM-only and have their own auth (fresh config + resolveCommandAuthorization),
-      // so they should not be blocked by inlineButtonsScope=off or scope=group.
+      // DM-only and have their own auth, so they should not be blocked by
+      // inlineButtonsScope=off or scope=group.
       const settingsCallback = parseSettingsCallbackData(data);
       if (settingsCallback) {
         const settingsChatId = callbackMessage.chat.id;
@@ -1118,79 +1117,41 @@ export const registerTelegramHandlers = ({
         } // DM-only
         const settingsSenderId = callback.from?.id ? String(callback.from.id) : "";
         const settingsSenderUsername = callback.from?.username ?? "";
+        // Derive isForum / messageThreadId from the actual callback message so
+        // that topic-specific auth (requireTopic, per-topic allowFrom/dmPolicy
+        // overrides) is enforced identically to the /settings command path.
+        const settingsIsForum = callbackMessage.chat.is_forum === true;
+        const settingsMessageThreadId = callbackMessage.message_thread_id;
         // Load fresh config so changes to allowFrom/dmPolicy since handler
         // registration are respected.
         const freshCfg = loadConfig();
         const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
         const freshAllowFrom = freshTelegramCfg.allowFrom ?? allowFrom;
-        // Resolve storeAllowFrom via event auth context for DM.
+        // Resolve full event auth context from the real callback message,
+        // including groupConfig, topicConfig, dmThreadId, groupAllowOverride,
+        // so per-DM/topic overrides are enforced.
         const settingsEventAuth = await resolveTelegramEventAuthorizationContext({
           chatId: settingsChatId,
           isGroup: false,
-          isForum: false,
-          messageThreadId: undefined,
+          isForum: settingsIsForum,
+          messageThreadId: settingsMessageThreadId,
         });
-        const settingsStoreAllowFrom = settingsEventAuth.storeAllowFrom;
-        const settingsDmAllow = normalizeDmAllowFromWithStore({
-          allowFrom: freshAllowFrom,
-          storeAllowFrom: settingsStoreAllowFrom,
-          dmPolicy: freshTelegramCfg.dmPolicy ?? "pairing",
-        });
-        const settingsDmSenderAllowed = isSenderAllowed({
-          allow: settingsDmAllow,
+        // Use shared auth decision (same function the /settings command path
+        // should use) so command and callback auth are structurally identical.
+        const settingsAuth = resolveSettingsAuthDecision({
+          chatId: settingsChatId,
+          accountId,
           senderId: settingsSenderId,
           senderUsername: settingsSenderUsername,
-        });
-        // Mirror /settings command handler auth: use resolveCommandAuthorizedFromAuthorizers
-        // so that when no allowlist is configured and access groups are off,
-        // commandAuthorized=true (open access), matching the command handler behavior.
-        const commandsAllowFrom = freshCfg.commands?.allowFrom;
-        const commandsAllowFromConfigured =
-          commandsAllowFrom != null &&
-          typeof commandsAllowFrom === "object" &&
-          (Array.isArray(commandsAllowFrom.telegram) || Array.isArray(commandsAllowFrom["*"]));
-        const useAccessGroups = freshCfg.commands?.useAccessGroups !== false;
-        const settingsCommandAuthorized = commandsAllowFromConfigured
-          ? Boolean(
-              resolveCommandAuthorization({
-                ctx: {
-                  Provider: "telegram",
-                  Surface: "telegram",
-                  OriginatingChannel: "telegram",
-                  AccountId: accountId,
-                  ChatType: "direct",
-                  From: `telegram:${settingsChatId}`,
-                  SenderId: settingsSenderId || undefined,
-                  SenderUsername: settingsSenderUsername || undefined,
-                },
-                cfg: freshCfg,
-                commandAuthorized: false,
-              })?.isAuthorizedSender,
-            )
-          : resolveCommandAuthorizedFromAuthorizers({
-              useAccessGroups,
-              authorizers: [
-                { configured: settingsDmAllow.hasEntries, allowed: settingsDmSenderAllowed },
-              ],
-              modeWhenAccessGroupsOff: "configured",
-            });
-        // Use resolveCommandAuthorization to enforce both commands.allowFrom
-        // and commands.ownerAllowFrom in a single check.
-        const commandsAuth = resolveCommandAuthorization({
-          ctx: {
-            Provider: "telegram",
-            Surface: "telegram",
-            OriginatingChannel: "telegram",
-            AccountId: accountId,
-            ChatType: "direct",
-            From: `telegram:${settingsChatId}`,
-            SenderId: settingsSenderId || undefined,
-            SenderUsername: settingsSenderUsername || undefined,
-          },
           cfg: freshCfg,
-          commandAuthorized: settingsCommandAuthorized,
+          allowFrom: freshAllowFrom,
+          effectiveDmPolicy: settingsEventAuth.dmPolicy,
+          storeAllowFrom: settingsEventAuth.storeAllowFrom,
+          dmThreadId: settingsEventAuth.dmThreadId,
+          groupConfig: settingsEventAuth.groupConfig,
+          groupAllowOverride: settingsEventAuth.groupAllowOverride,
         });
-        if (!commandsAuth.isAuthorizedSender) {
+        if (!settingsAuth.authorized) {
           return;
         }
         if (!resolveChannelConfigWrites({ cfg: freshCfg, channelId: "telegram", accountId })) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -33,6 +33,7 @@ import { MediaFetchError } from "../media/fetch.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
+import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   isSenderAllowed,
@@ -74,6 +75,8 @@ import {
 } from "./model-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
+import { parseSettingsCallbackData } from "./settings-buttons.js";
+import { handleSettingsCallback } from "./settings-panel.js";
 
 function isMediaSizeLimitError(err: unknown): boolean {
   const errMsg = String(err);
@@ -1320,6 +1323,44 @@ export const registerTelegramHandlers = ({
           return;
         }
 
+        return;
+      }
+
+      // Settings panel callback handler (cfg_menu, cfg_s_*, cfg_v_*)
+      const settingsCallback = parseSettingsCallbackData(data);
+      if (settingsCallback) {
+        if (isGroup) {
+          return;
+        } // DM-only
+        if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
+          await replyToCallbackChat("Config writes are disabled for this account.");
+          return;
+        }
+        const freshCfg = loadConfig();
+        const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
+        await handleSettingsCallback({
+          parsed: settingsCallback,
+          cfg: freshCfg,
+          accountId,
+          telegramCfg: freshTelegramCfg,
+          editMessage: async (text, buttons) => {
+            const keyboard = buildInlineKeyboard(buttons);
+            try {
+              await editCallbackMessage(text, keyboard ? { reply_markup: keyboard } : undefined);
+            } catch (editErr) {
+              const errStr = String(editErr);
+              if (!errStr.includes("message is not modified")) {
+                throw editErr;
+              }
+            }
+          },
+          answerCallback: async (text) => {
+            // Use a follow-up toast via sendMessage since answerCallbackQuery was
+            // already called at the top of the handler. Telegram allows only one
+            // answer per callback query, so we reply inline instead.
+            await replyToCallbackChat(text);
+          },
+        });
         return;
       }
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1332,6 +1332,19 @@ export const registerTelegramHandlers = ({
         if (isGroup) {
           return;
         } // DM-only
+        // Re-check sender auth at command level (stricter than callback-scope)
+        // since settings callbacks mutate config.
+        const settingsDmAllow = normalizeDmAllowFromWithStore({
+          allowFrom: allowFrom,
+          storeAllowFrom,
+          dmPolicy: telegramCfg.dmPolicy ?? "pairing",
+        });
+        if (
+          settingsDmAllow.hasEntries &&
+          !isSenderAllowed({ allow: settingsDmAllow, senderId, senderUsername })
+        ) {
+          return;
+        }
         if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
           await replyToCallbackChat("Config writes are disabled for this account.");
           return;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1345,8 +1345,11 @@ export const registerTelegramHandlers = ({
           storeAllowFrom,
           dmPolicy: freshTelegramCfg.dmPolicy ?? "pairing",
         });
+        // When the allowlist has no entries, treat as unauthorized (matching
+        // the /settings command handler which denies empty allowlists when
+        // access-groups gating is enabled).
         const dmSenderAllowed =
-          !settingsDmAllow.hasEntries ||
+          settingsDmAllow.hasEntries &&
           isSenderAllowed({ allow: settingsDmAllow, senderId, senderUsername });
         // Use resolveCommandAuthorization to enforce both commands.allowFrom
         // and commands.ownerAllowFrom in a single check.

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1332,12 +1332,17 @@ export const registerTelegramHandlers = ({
         if (isGroup) {
           return;
         } // DM-only
+        // Load fresh config *before* the auth re-check so that changes to
+        // allowFrom / dmPolicy made since handler registration are respected.
+        const freshCfg = loadConfig();
+        const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
+        const freshAllowFrom = freshTelegramCfg.allowFrom ?? allowFrom;
         // Re-check sender auth at command level (stricter than callback-scope)
         // since settings callbacks mutate config.
         const settingsDmAllow = normalizeDmAllowFromWithStore({
-          allowFrom: allowFrom,
+          allowFrom: freshAllowFrom,
           storeAllowFrom,
-          dmPolicy: telegramCfg.dmPolicy ?? "pairing",
+          dmPolicy: freshTelegramCfg.dmPolicy ?? "pairing",
         });
         if (
           settingsDmAllow.hasEntries &&
@@ -1345,12 +1350,10 @@ export const registerTelegramHandlers = ({
         ) {
           return;
         }
-        if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
+        if (!resolveChannelConfigWrites({ cfg: freshCfg, channelId: "telegram", accountId })) {
           await replyToCallbackChat("Config writes are disabled for this account.");
           return;
         }
-        const freshCfg = loadConfig();
-        const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
         await handleSettingsCallback({
           parsed: settingsCallback,
           cfg: freshCfg,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,6 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveCommandAuthorization } from "../auto-reply/command-auth.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
@@ -1337,6 +1338,31 @@ export const registerTelegramHandlers = ({
         const freshCfg = loadConfig();
         const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
         const freshAllowFrom = freshTelegramCfg.allowFrom ?? allowFrom;
+        // Enforce commands.allowFrom when configured (takes priority over DM allowlist).
+        const commandsAllowFrom = freshCfg.commands?.allowFrom;
+        const commandsAllowFromConfigured =
+          commandsAllowFrom != null &&
+          typeof commandsAllowFrom === "object" &&
+          (Array.isArray(commandsAllowFrom.telegram) || Array.isArray(commandsAllowFrom["*"]));
+        if (commandsAllowFromConfigured) {
+          const commandsAuth = resolveCommandAuthorization({
+            ctx: {
+              Provider: "telegram",
+              Surface: "telegram",
+              OriginatingChannel: "telegram",
+              AccountId: accountId,
+              ChatType: "direct",
+              From: `telegram:${chatId}`,
+              SenderId: senderId || undefined,
+              SenderUsername: senderUsername || undefined,
+            },
+            cfg: freshCfg,
+            commandAuthorized: false,
+          });
+          if (!commandsAuth?.isAuthorizedSender) {
+            return;
+          }
+        }
         // Re-check sender auth at command level (stricter than callback-scope)
         // since settings callbacks mutate config.
         const settingsDmAllow = normalizeDmAllowFromWithStore({

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1338,31 +1338,6 @@ export const registerTelegramHandlers = ({
         const freshCfg = loadConfig();
         const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
         const freshAllowFrom = freshTelegramCfg.allowFrom ?? allowFrom;
-        // Enforce commands.allowFrom when configured (takes priority over DM allowlist).
-        const commandsAllowFrom = freshCfg.commands?.allowFrom;
-        const commandsAllowFromConfigured =
-          commandsAllowFrom != null &&
-          typeof commandsAllowFrom === "object" &&
-          (Array.isArray(commandsAllowFrom.telegram) || Array.isArray(commandsAllowFrom["*"]));
-        if (commandsAllowFromConfigured) {
-          const commandsAuth = resolveCommandAuthorization({
-            ctx: {
-              Provider: "telegram",
-              Surface: "telegram",
-              OriginatingChannel: "telegram",
-              AccountId: accountId,
-              ChatType: "direct",
-              From: `telegram:${chatId}`,
-              SenderId: senderId || undefined,
-              SenderUsername: senderUsername || undefined,
-            },
-            cfg: freshCfg,
-            commandAuthorized: false,
-          });
-          if (!commandsAuth?.isAuthorizedSender) {
-            return;
-          }
-        }
         // Re-check sender auth at command level (stricter than callback-scope)
         // since settings callbacks mutate config.
         const settingsDmAllow = normalizeDmAllowFromWithStore({
@@ -1370,10 +1345,28 @@ export const registerTelegramHandlers = ({
           storeAllowFrom,
           dmPolicy: freshTelegramCfg.dmPolicy ?? "pairing",
         });
-        if (
-          settingsDmAllow.hasEntries &&
-          !isSenderAllowed({ allow: settingsDmAllow, senderId, senderUsername })
-        ) {
+        const dmSenderAllowed =
+          !settingsDmAllow.hasEntries ||
+          isSenderAllowed({ allow: settingsDmAllow, senderId, senderUsername });
+        // Use resolveCommandAuthorization to enforce both commands.allowFrom
+        // and commands.ownerAllowFrom in a single check.
+        const commandsAuth = resolveCommandAuthorization({
+          ctx: {
+            Provider: "telegram",
+            Surface: "telegram",
+            OriginatingChannel: "telegram",
+            AccountId: accountId,
+            ChatType: "direct",
+            From: `telegram:${chatId}`,
+            SenderId: senderId || undefined,
+            SenderUsername: senderUsername || undefined,
+          },
+          cfg: freshCfg,
+          // When commands.allowFrom is unset, resolveCommandAuthorization
+          // falls back to commandAuthorized && isOwnerForCommands.
+          commandAuthorized: dmSenderAllowed,
+        });
+        if (!commandsAuth.isAuthorizedSender) {
           return;
         }
         if (!resolveChannelConfigWrites({ cfg: freshCfg, channelId: "telegram", accountId })) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1126,7 +1126,10 @@ export const registerTelegramHandlers = ({
         // registration are respected.
         const freshCfg = loadConfig();
         const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
-        const freshAllowFrom = freshTelegramCfg.allowFrom ?? allowFrom;
+        // Use only the fresh config allowFrom — do NOT fall back to the stale
+        // allowFrom captured at handler registration time, otherwise deleting
+        // the allowlist at runtime silently restores the old entries.
+        const freshAllowFrom = freshTelegramCfg.allowFrom;
         // Resolve full event auth context from the real callback message,
         // including groupConfig, topicConfig, dmThreadId, groupAllowOverride,
         // so per-DM/topic overrides are enforced.

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -16,6 +16,7 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/pr
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { resolveNativeCommandSessionTargets } from "../channels/native-command-session-targets.js";
+import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import { recordInboundSessionMetaSafe } from "../channels/session-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -70,6 +71,7 @@ import {
 } from "./group-access.js";
 import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 import { buildInlineKeyboard } from "./send.js";
+import { buildSettingsCommandResponse } from "./settings-panel.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 
@@ -773,6 +775,90 @@ export const registerTelegramNativeCommands = ({
           }
         });
       }
+
+      // /settings — standalone handler that sends an inline keyboard control panel
+      bot.command("settings", async (ctx: TelegramNativeCommandContext) => {
+        const msg = ctx.message;
+        if (!msg) {
+          return;
+        }
+        if (shouldSkipUpdate(ctx)) {
+          return;
+        }
+        const auth = await resolveTelegramCommandAuth({
+          msg,
+          bot,
+          cfg,
+          accountId,
+          telegramCfg,
+          allowFrom,
+          groupAllowFrom,
+          useAccessGroups,
+          resolveGroupPolicy,
+          resolveTelegramGroupConfig,
+          requireAuth: true,
+        });
+        if (!auth) {
+          return;
+        }
+        if (auth.isGroup) {
+          const threadParams =
+            buildTelegramThreadParams(
+              resolveTelegramThreadSpec({
+                isGroup: true,
+                isForum: auth.isForum,
+                messageThreadId: (msg as { message_thread_id?: number }).message_thread_id,
+              }),
+            ) ?? {};
+          await withTelegramApiErrorLogging({
+            operation: "sendMessage",
+            runtime,
+            fn: () =>
+              bot.api.sendMessage(auth.chatId, "Settings is only available in DMs.", threadParams),
+          });
+          return;
+        }
+        if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
+          const threadParams =
+            buildTelegramThreadParams(
+              resolveTelegramThreadSpec({
+                isGroup: false,
+                isForum: auth.isForum,
+                messageThreadId: (msg as { message_thread_id?: number }).message_thread_id,
+              }),
+            ) ?? {};
+          await withTelegramApiErrorLogging({
+            operation: "sendMessage",
+            runtime,
+            fn: () =>
+              bot.api.sendMessage(
+                auth.chatId,
+                "Config writes are disabled for this account.",
+                threadParams,
+              ),
+          });
+          return;
+        }
+        const { text, buttons } = buildSettingsCommandResponse(telegramCfg);
+        const keyboard = buildInlineKeyboard(buttons);
+        const threadParams =
+          buildTelegramThreadParams(
+            resolveTelegramThreadSpec({
+              isGroup: false,
+              isForum: auth.isForum,
+              messageThreadId: (msg as { message_thread_id?: number }).message_thread_id,
+            }),
+          ) ?? {};
+        await withTelegramApiErrorLogging({
+          operation: "sendMessage",
+          runtime,
+          fn: () =>
+            bot.api.sendMessage(auth.chatId, text, {
+              ...(keyboard ? { reply_markup: keyboard } : {}),
+              ...threadParams,
+            }),
+        });
+      });
 
       for (const pluginCommand of pluginCatalog.commands) {
         bot.command(pluginCommand.command, async (ctx: TelegramNativeCommandContext) => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -19,6 +19,7 @@ import { resolveNativeCommandSessionTargets } from "../channels/native-command-s
 import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import { recordInboundSessionMetaSafe } from "../channels/session-meta.js";
+import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ChannelGroupPolicy } from "../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
@@ -45,6 +46,7 @@ import {
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
@@ -839,7 +841,11 @@ export const registerTelegramNativeCommands = ({
           });
           return;
         }
-        const { text, buttons } = buildSettingsCommandResponse(telegramCfg);
+        // Load fresh config so the menu reflects the current persisted state,
+        // not the snapshot from handler registration time.
+        const freshCfg = loadConfig();
+        const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
+        const { text, buttons } = buildSettingsCommandResponse(freshTelegramCfg);
         const keyboard = buildInlineKeyboard(buttons);
         const threadParams =
           buildTelegramThreadParams(

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -786,48 +786,81 @@ export const registerTelegramNativeCommands = ({
       }
 
       // /settings — standalone handler that sends an inline keyboard control panel
-      bot.command("settings", async (ctx: TelegramNativeCommandContext) => {
-        const msg = ctx.message;
-        if (!msg) {
-          return;
-        }
-        if (shouldSkipUpdate(ctx)) {
-          return;
-        }
-        const auth = await resolveTelegramCommandAuth({
-          msg,
-          bot,
-          cfg,
-          accountId,
-          telegramCfg,
-          allowFrom,
-          groupAllowFrom,
-          useAccessGroups,
-          resolveGroupPolicy,
-          resolveTelegramGroupConfig,
-          requireAuth: true,
-        });
-        if (!auth) {
-          return;
-        }
-        if (auth.isGroup) {
-          const threadParams =
-            buildTelegramThreadParams(
-              resolveTelegramThreadSpec({
-                isGroup: true,
-                isForum: auth.isForum,
-                messageThreadId: (msg as { message_thread_id?: number }).message_thread_id,
-              }),
-            ) ?? {};
-          await withTelegramApiErrorLogging({
-            operation: "sendMessage",
-            runtime,
-            fn: () =>
-              bot.api.sendMessage(auth.chatId, "Settings is only available in DMs.", threadParams),
+      // Only register when native commands are enabled so operators can disable
+      // this config-mutation entry point via channels.telegram.commands.native: false.
+      if (nativeEnabled) {
+        bot.command("settings", async (ctx: TelegramNativeCommandContext) => {
+          const msg = ctx.message;
+          if (!msg) {
+            return;
+          }
+          if (shouldSkipUpdate(ctx)) {
+            return;
+          }
+          const auth = await resolveTelegramCommandAuth({
+            msg,
+            bot,
+            cfg,
+            accountId,
+            telegramCfg,
+            allowFrom,
+            groupAllowFrom,
+            useAccessGroups,
+            resolveGroupPolicy,
+            resolveTelegramGroupConfig,
+            requireAuth: true,
           });
-          return;
-        }
-        if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
+          if (!auth) {
+            return;
+          }
+          if (auth.isGroup) {
+            const threadParams =
+              buildTelegramThreadParams(
+                resolveTelegramThreadSpec({
+                  isGroup: true,
+                  isForum: auth.isForum,
+                  messageThreadId: (msg as { message_thread_id?: number }).message_thread_id,
+                }),
+              ) ?? {};
+            await withTelegramApiErrorLogging({
+              operation: "sendMessage",
+              runtime,
+              fn: () =>
+                bot.api.sendMessage(
+                  auth.chatId,
+                  "Settings is only available in DMs.",
+                  threadParams,
+                ),
+            });
+            return;
+          }
+          if (!resolveChannelConfigWrites({ cfg, channelId: "telegram", accountId })) {
+            const threadParams =
+              buildTelegramThreadParams(
+                resolveTelegramThreadSpec({
+                  isGroup: false,
+                  isForum: auth.isForum,
+                  messageThreadId: (msg as { message_thread_id?: number }).message_thread_id,
+                }),
+              ) ?? {};
+            await withTelegramApiErrorLogging({
+              operation: "sendMessage",
+              runtime,
+              fn: () =>
+                bot.api.sendMessage(
+                  auth.chatId,
+                  "Config writes are disabled for this account.",
+                  threadParams,
+                ),
+            });
+            return;
+          }
+          // Load fresh config so the menu reflects the current persisted state,
+          // not the snapshot from handler registration time.
+          const freshCfg = loadConfig();
+          const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
+          const { text, buttons } = buildSettingsCommandResponse(freshTelegramCfg);
+          const keyboard = buildInlineKeyboard(buttons);
           const threadParams =
             buildTelegramThreadParams(
               resolveTelegramThreadSpec({
@@ -840,38 +873,13 @@ export const registerTelegramNativeCommands = ({
             operation: "sendMessage",
             runtime,
             fn: () =>
-              bot.api.sendMessage(
-                auth.chatId,
-                "Config writes are disabled for this account.",
-                threadParams,
-              ),
+              bot.api.sendMessage(auth.chatId, text, {
+                ...(keyboard ? { reply_markup: keyboard } : {}),
+                ...threadParams,
+              }),
           });
-          return;
-        }
-        // Load fresh config so the menu reflects the current persisted state,
-        // not the snapshot from handler registration time.
-        const freshCfg = loadConfig();
-        const freshTelegramCfg = resolveTelegramAccount({ cfg: freshCfg, accountId }).config;
-        const { text, buttons } = buildSettingsCommandResponse(freshTelegramCfg);
-        const keyboard = buildInlineKeyboard(buttons);
-        const threadParams =
-          buildTelegramThreadParams(
-            resolveTelegramThreadSpec({
-              isGroup: false,
-              isForum: auth.isForum,
-              messageThreadId: (msg as { message_thread_id?: number }).message_thread_id,
-            }),
-          ) ?? {};
-        await withTelegramApiErrorLogging({
-          operation: "sendMessage",
-          runtime,
-          fn: () =>
-            bot.api.sendMessage(auth.chatId, text, {
-              ...(keyboard ? { reply_markup: keyboard } : {}),
-              ...threadParams,
-            }),
         });
-      });
+      }
 
       for (const pluginCommand of pluginCatalog.commands) {
         bot.command(pluginCommand.command, async (ctx: TelegramNativeCommandContext) => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -543,8 +543,15 @@ export const registerTelegramNativeCommands = ({
     if (typeof (bot as unknown as { command?: unknown }).command !== "function") {
       logVerbose("telegram: bot.command unavailable; skipping native handlers");
     } else {
+      // Commands with dedicated handlers below (e.g. /settings) are skipped
+      // in the generic loop to avoid registering two bot.command() handlers
+      // for the same trigger.
+      const dedicatedHandlers = new Set(["settings"]);
       for (const command of nativeCommands) {
         const normalizedCommandName = normalizeTelegramCommandName(command.name);
+        if (dedicatedHandlers.has(normalizedCommandName)) {
+          continue;
+        }
         bot.command(normalizedCommandName, async (ctx: TelegramNativeCommandContext) => {
           const msg = ctx.message;
           if (!msg) {

--- a/src/telegram/settings-auth.test.ts
+++ b/src/telegram/settings-auth.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../auto-reply/command-auth.js", () => ({
+  resolveCommandAuthorization: vi.fn(),
+}));
+
+vi.mock("../channels/command-gating.js", () => ({
+  resolveCommandAuthorizedFromAuthorizers: vi.fn(),
+}));
+
+vi.mock("../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+import { resolveCommandAuthorization } from "../auto-reply/command-auth.js";
+import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSettingsAuthDecision } from "./settings-auth.js";
+
+const mockResolveCommandAuth = vi.mocked(resolveCommandAuthorization);
+const mockResolveFromAuthorizers = vi.mocked(resolveCommandAuthorizedFromAuthorizers);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function baseCfg(overrides?: Partial<OpenClawConfig>): OpenClawConfig {
+  return { ...overrides } as OpenClawConfig;
+}
+
+function baseParams(overrides?: Record<string, unknown>) {
+  return {
+    chatId: 12345 as number,
+    accountId: "default",
+    senderId: "111",
+    senderUsername: "alice",
+    cfg: baseCfg(),
+    allowFrom: undefined as Array<string | number> | undefined,
+    effectiveDmPolicy: "pairing",
+    storeAllowFrom: [] as string[],
+    dmThreadId: undefined as number | undefined,
+    groupConfig: undefined as Record<string, unknown> | undefined,
+    groupAllowOverride: undefined as Array<string | number> | undefined,
+    ...overrides,
+  };
+}
+
+describe("resolveSettingsAuthDecision", () => {
+  describe("requireTopic enforcement", () => {
+    it("denies when requireTopic=true and no dmThreadId", () => {
+      const result = resolveSettingsAuthDecision(
+        baseParams({
+          groupConfig: { requireTopic: true },
+          dmThreadId: undefined,
+        }),
+      );
+      expect(result).toEqual({ authorized: false, reason: "require-topic" });
+    });
+
+    it("proceeds when requireTopic=true and dmThreadId is present", () => {
+      mockResolveFromAuthorizers.mockReturnValue(true);
+      mockResolveCommandAuth.mockReturnValue({ isAuthorizedSender: true } as ReturnType<
+        typeof resolveCommandAuthorization
+      >);
+      const result = resolveSettingsAuthDecision(
+        baseParams({
+          groupConfig: { requireTopic: true },
+          dmThreadId: 42,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+  });
+
+  describe("per-DM/topic allowFrom override", () => {
+    it("uses groupAllowOverride when present instead of account-level allowFrom", () => {
+      // groupAllowOverride restricts to user "222", but sender is "111".
+      // With access groups off and modeWhenAccessGroupsOff=configured,
+      // when an allowlist is configured and sender not on it, should deny.
+      mockResolveFromAuthorizers.mockReturnValue(false);
+      mockResolveCommandAuth.mockReturnValue({ isAuthorizedSender: false } as ReturnType<
+        typeof resolveCommandAuthorization
+      >);
+      const result = resolveSettingsAuthDecision(
+        baseParams({
+          allowFrom: [111], // account-level would allow sender 111
+          groupAllowOverride: [222], // per-DM override restricts to 222 only
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  describe("open access (no allowlist, access groups off)", () => {
+    it("allows when no allowlist is configured and useAccessGroups is false", () => {
+      // When no allowlist entries exist and access groups are off,
+      // resolveCommandAuthorizedFromAuthorizers with modeWhenAccessGroupsOff=configured
+      // returns true (no authorizers configured → open access).
+      mockResolveFromAuthorizers.mockReturnValue(true);
+      mockResolveCommandAuth.mockReturnValue({ isAuthorizedSender: true } as ReturnType<
+        typeof resolveCommandAuthorization
+      >);
+      const result = resolveSettingsAuthDecision(
+        baseParams({
+          cfg: baseCfg({ commands: { useAccessGroups: false } }),
+        }),
+      );
+      expect(result.authorized).toBe(true);
+      // Verify resolveCommandAuthorizedFromAuthorizers was called with correct args
+      expect(mockResolveFromAuthorizers).toHaveBeenCalledWith({
+        useAccessGroups: false,
+        authorizers: expect.arrayContaining([expect.objectContaining({ configured: false })]),
+        modeWhenAccessGroupsOff: "configured",
+      });
+    });
+  });
+
+  describe("empty allowlist (access groups on)", () => {
+    it("denies when allowlist has no entries and access groups are on", () => {
+      // When access groups are on, resolveCommandAuthorizedFromAuthorizers
+      // requires at least one configured+allowed authorizer.
+      mockResolveFromAuthorizers.mockReturnValue(false);
+      mockResolveCommandAuth.mockReturnValue({ isAuthorizedSender: false } as ReturnType<
+        typeof resolveCommandAuthorization
+      >);
+      const result = resolveSettingsAuthDecision(
+        baseParams({
+          cfg: baseCfg({ commands: { useAccessGroups: true } }),
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  describe("commands.allowFrom takes precedence", () => {
+    it("uses commands.allowFrom when configured instead of DM allowlist", () => {
+      const cfg = baseCfg({
+        commands: { allowFrom: { telegram: ["222"] } },
+      });
+      // commands.allowFrom is configured → first resolveCommandAuthorization
+      // is called with commandAuthorized: false; if it returns authorized,
+      // that result is used as the commandAuthorized input.
+      mockResolveCommandAuth
+        .mockReturnValueOnce({ isAuthorizedSender: true } as ReturnType<
+          typeof resolveCommandAuthorization
+        >)
+        .mockReturnValueOnce({ isAuthorizedSender: true } as ReturnType<
+          typeof resolveCommandAuthorization
+        >);
+      const result = resolveSettingsAuthDecision(baseParams({ cfg }));
+      expect(result.authorized).toBe(true);
+      // resolveCommandAuthorizedFromAuthorizers should NOT be called
+      // when commands.allowFrom is configured.
+      expect(mockResolveFromAuthorizers).not.toHaveBeenCalled();
+    });
+
+    it("denies when commands.allowFrom rejects the sender", () => {
+      const cfg = baseCfg({
+        commands: { allowFrom: { telegram: ["999"] } },
+      });
+      mockResolveCommandAuth.mockReturnValue({ isAuthorizedSender: false } as ReturnType<
+        typeof resolveCommandAuthorization
+      >);
+      const result = resolveSettingsAuthDecision(baseParams({ cfg }));
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  describe("ownerAllowFrom enforcement", () => {
+    it("denies when commandAuthorized but ownerAllowFrom rejects", () => {
+      // First call (commands.allowFrom check) would pass, but the final
+      // resolveCommandAuthorization enforces ownerAllowFrom and denies.
+      mockResolveFromAuthorizers.mockReturnValue(true);
+      mockResolveCommandAuth.mockReturnValue({ isAuthorizedSender: false } as ReturnType<
+        typeof resolveCommandAuthorization
+      >);
+      const result = resolveSettingsAuthDecision(baseParams());
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe("not-authorized");
+    });
+  });
+
+  describe("configWrites is NOT checked here (caller responsibility)", () => {
+    it("returns authorized=true regardless of configWrites setting", () => {
+      // configWrites check lives in the caller, not in the shared auth decision.
+      // This test verifies the auth function does not reject based on configWrites.
+      mockResolveFromAuthorizers.mockReturnValue(true);
+      mockResolveCommandAuth.mockReturnValue({ isAuthorizedSender: true } as ReturnType<
+        typeof resolveCommandAuthorization
+      >);
+      const result = resolveSettingsAuthDecision(baseParams());
+      expect(result.authorized).toBe(true);
+    });
+  });
+});

--- a/src/telegram/settings-auth.ts
+++ b/src/telegram/settings-auth.ts
@@ -1,0 +1,120 @@
+import { resolveCommandAuthorization } from "../auto-reply/command-auth.js";
+import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramDirectConfig } from "../config/types.js";
+import { logVerbose } from "../globals.js";
+import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
+
+/**
+ * Shared auth decision for both the /settings command and cfg_* callback paths.
+ *
+ * Accepts the resolved event auth context (from resolveTelegramGroupAllowFromContext
+ * or resolveTelegramEventAuthorizationContext) and produces an allow/deny decision
+ * identical to the command path in resolveTelegramCommandAuth.
+ *
+ * By using a single function for both paths, we guarantee auth parity:
+ * any change to the auth logic automatically applies to commands and callbacks.
+ */
+export function resolveSettingsAuthDecision(params: {
+  chatId: number;
+  accountId: string;
+  senderId: string;
+  senderUsername: string;
+  cfg: OpenClawConfig;
+  allowFrom?: Array<string | number>;
+  // From event auth context (resolveTelegramEventAuthorizationContext output)
+  effectiveDmPolicy: string;
+  storeAllowFrom: string[];
+  dmThreadId?: number;
+  groupConfig?: { requireTopic?: boolean; dmPolicy?: string; allowFrom?: Array<string | number> };
+  groupAllowOverride?: Array<string | number>;
+}): { authorized: boolean; reason?: string } {
+  const {
+    chatId,
+    accountId,
+    senderId,
+    senderUsername,
+    cfg,
+    allowFrom,
+    effectiveDmPolicy,
+    storeAllowFrom,
+    dmThreadId,
+    groupConfig,
+    groupAllowOverride,
+  } = params;
+
+  // Enforce requireTopic for DM-topic deployments (mirrors command path).
+  const requireTopic = (groupConfig as TelegramDirectConfig | undefined)?.requireTopic;
+  if (requireTopic === true && dmThreadId == null) {
+    logVerbose(`Blocked telegram settings in DM ${chatId}: requireTopic=true but no topic present`);
+    return { authorized: false, reason: "require-topic" };
+  }
+
+  // Prefer per-DM/topic allowFrom override (mirrors command path).
+  const dmAllowFrom = groupAllowOverride ?? allowFrom;
+  const dmAllow = normalizeDmAllowFromWithStore({
+    allowFrom: dmAllowFrom,
+    storeAllowFrom,
+    dmPolicy: effectiveDmPolicy,
+  });
+  const dmSenderAllowed = isSenderAllowed({
+    allow: dmAllow,
+    senderId,
+    senderUsername,
+  });
+
+  // Mirror /settings command handler auth: use resolveCommandAuthorizedFromAuthorizers
+  // so that when no allowlist is configured and access groups are off,
+  // commandAuthorized=true (open access).
+  const commandsAllowFrom = cfg.commands?.allowFrom;
+  const commandsAllowFromConfigured =
+    commandsAllowFrom != null &&
+    typeof commandsAllowFrom === "object" &&
+    (Array.isArray(commandsAllowFrom.telegram) || Array.isArray(commandsAllowFrom["*"]));
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+
+  const commandAuthorized = commandsAllowFromConfigured
+    ? Boolean(
+        resolveCommandAuthorization({
+          ctx: {
+            Provider: "telegram",
+            Surface: "telegram",
+            OriginatingChannel: "telegram",
+            AccountId: accountId,
+            ChatType: "direct",
+            From: `telegram:${chatId}`,
+            SenderId: senderId || undefined,
+            SenderUsername: senderUsername || undefined,
+          },
+          cfg,
+          commandAuthorized: false,
+        })?.isAuthorizedSender,
+      )
+    : resolveCommandAuthorizedFromAuthorizers({
+        useAccessGroups,
+        authorizers: [{ configured: dmAllow.hasEntries, allowed: dmSenderAllowed }],
+        modeWhenAccessGroupsOff: "configured",
+      });
+
+  // Enforce both commands.allowFrom and commands.ownerAllowFrom in a single check.
+  const commandsAuth = resolveCommandAuthorization({
+    ctx: {
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      AccountId: accountId,
+      ChatType: "direct",
+      From: `telegram:${chatId}`,
+      SenderId: senderId || undefined,
+      SenderUsername: senderUsername || undefined,
+    },
+    cfg,
+    commandAuthorized,
+  });
+
+  if (!commandsAuth.isAuthorizedSender) {
+    return { authorized: false, reason: "not-authorized" };
+  }
+
+  return { authorized: true };
+}

--- a/src/telegram/settings-buttons.test.ts
+++ b/src/telegram/settings-buttons.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAllowlistView,
+  buildSettingSubmenu,
+  buildSettingsMainMenu,
+  normalizeStreamingDisplay,
+  parseSettingsCallbackData,
+  SETTING_VALUES,
+} from "./settings-buttons.js";
+
+describe("parseSettingsCallbackData", () => {
+  it("returns null for non-settings data", () => {
+    expect(parseSettingsCallbackData("mdl_prov")).toBeNull();
+    expect(parseSettingsCallbackData("")).toBeNull();
+    expect(parseSettingsCallbackData("random_data")).toBeNull();
+  });
+
+  it("parses cfg_menu", () => {
+    expect(parseSettingsCallbackData("cfg_menu")).toEqual({ type: "menu" });
+  });
+
+  it("parses cfg_menu with whitespace", () => {
+    expect(parseSettingsCallbackData("  cfg_menu  ")).toEqual({ type: "menu" });
+  });
+
+  it("parses submenu callbacks", () => {
+    expect(parseSettingsCallbackData("cfg_s_dmpol")).toEqual({
+      type: "submenu",
+      setting: "dmpol",
+    });
+    expect(parseSettingsCallbackData("cfg_s_grppol")).toEqual({
+      type: "submenu",
+      setting: "grppol",
+    });
+    expect(parseSettingsCallbackData("cfg_s_stream")).toEqual({
+      type: "submenu",
+      setting: "stream",
+    });
+  });
+
+  it("parses allowlist submenu callback", () => {
+    expect(parseSettingsCallbackData("cfg_s_allow")).toEqual({
+      type: "submenu",
+      setting: "allow",
+    });
+  });
+
+  it("returns null for invalid submenu setting", () => {
+    expect(parseSettingsCallbackData("cfg_s_invalid")).toBeNull();
+    expect(parseSettingsCallbackData("cfg_s_")).toBeNull();
+  });
+
+  it("parses set-value callbacks", () => {
+    expect(parseSettingsCallbackData("cfg_v_dmpol_open")).toEqual({
+      type: "set",
+      setting: "dmpol",
+      value: "open",
+    });
+    expect(parseSettingsCallbackData("cfg_v_grppol_disabled")).toEqual({
+      type: "set",
+      setting: "grppol",
+      value: "disabled",
+    });
+    expect(parseSettingsCallbackData("cfg_v_stream_block")).toEqual({
+      type: "set",
+      setting: "stream",
+      value: "block",
+    });
+  });
+
+  it("returns null for invalid set-value combinations", () => {
+    // Invalid setting key
+    expect(parseSettingsCallbackData("cfg_v_invalid_open")).toBeNull();
+    // Invalid value for setting
+    expect(parseSettingsCallbackData("cfg_v_dmpol_block")).toBeNull();
+    expect(parseSettingsCallbackData("cfg_v_grppol_pairing")).toBeNull();
+    expect(parseSettingsCallbackData("cfg_v_stream_pairing")).toBeNull();
+  });
+
+  it("returns null for partial cfg_ prefixes", () => {
+    expect(parseSettingsCallbackData("cfg_")).toBeNull();
+    expect(parseSettingsCallbackData("cfg_x")).toBeNull();
+    expect(parseSettingsCallbackData("cfg_v_")).toBeNull();
+  });
+});
+
+describe("callback data byte lengths", () => {
+  it("all callback data strings are under 64 bytes", () => {
+    const allCallbackData = [
+      "cfg_menu",
+      "cfg_s_dmpol",
+      "cfg_s_grppol",
+      "cfg_s_stream",
+      "cfg_s_allow",
+    ];
+    for (const setting of ["dmpol", "grppol", "stream"] as const) {
+      for (const value of SETTING_VALUES[setting]) {
+        allCallbackData.push(`cfg_v_${setting}_${value}`);
+      }
+    }
+    for (const data of allCallbackData) {
+      expect(Buffer.byteLength(data, "utf8")).toBeLessThanOrEqual(64);
+    }
+  });
+});
+
+describe("buildSettingsMainMenu", () => {
+  it("renders current values in text", () => {
+    const result = buildSettingsMainMenu({
+      dmPolicy: "pairing",
+      groupPolicy: "open",
+      streaming: "partial",
+    });
+    expect(result.text).toContain("DM Policy: pairing");
+    expect(result.text).toContain("Group Policy: open");
+    expect(result.text).toContain("Streaming: partial");
+  });
+
+  it("uses defaults for undefined values", () => {
+    const result = buildSettingsMainMenu({});
+    expect(result.text).toContain("DM Policy: pairing");
+    expect(result.text).toContain("Group Policy: open");
+    expect(result.text).toContain("Streaming: partial");
+  });
+
+  it("normalizes streaming boolean to display value", () => {
+    const result = buildSettingsMainMenu({ streaming: "false" });
+    // "false" as string is not a valid streaming mode, falls to default
+    expect(result.text).toContain("Streaming: partial");
+  });
+
+  it("has 2 rows of 2 buttons each", () => {
+    const result = buildSettingsMainMenu({});
+    expect(result.buttons).toHaveLength(2);
+    expect(result.buttons[0]).toHaveLength(2);
+    expect(result.buttons[1]).toHaveLength(2);
+  });
+
+  it("buttons have correct callback data", () => {
+    const result = buildSettingsMainMenu({});
+    const allData = result.buttons.flat().map((b) => b.callback_data);
+    expect(allData).toContain("cfg_s_dmpol");
+    expect(allData).toContain("cfg_s_grppol");
+    expect(allData).toContain("cfg_s_stream");
+    expect(allData).toContain("cfg_s_allow");
+  });
+});
+
+describe("buildSettingSubmenu", () => {
+  it("shows checkmark on current value", () => {
+    const result = buildSettingSubmenu("dmpol", "pairing");
+    expect(result.text).toContain("pairing \u2713");
+    expect(result.text).not.toContain("open \u2713");
+
+    // Button also has checkmark
+    const pairingBtn = result.buttons.flat().find((b) => b.callback_data === "cfg_v_dmpol_pairing");
+    expect(pairingBtn?.text).toContain("\u2713");
+  });
+
+  it("includes back button", () => {
+    const result = buildSettingSubmenu("grppol", "open");
+    const lastRow = result.buttons[result.buttons.length - 1];
+    expect(lastRow).toHaveLength(1);
+    expect(lastRow[0].callback_data).toBe("cfg_menu");
+    expect(lastRow[0].text).toBe("<< Back");
+  });
+
+  it("has one button per value plus back", () => {
+    for (const setting of ["dmpol", "grppol", "stream"] as const) {
+      const result = buildSettingSubmenu(setting, undefined);
+      // Each value gets its own row + 1 back row
+      expect(result.buttons).toHaveLength(SETTING_VALUES[setting].length + 1);
+    }
+  });
+
+  it("normalizes streaming display for checkmark", () => {
+    const result = buildSettingSubmenu("stream", "progress");
+    // "progress" maps to "partial", so partial should have checkmark
+    expect(result.text).toContain("partial \u2713");
+  });
+});
+
+describe("buildAllowlistView", () => {
+  it("shows empty allowlists", () => {
+    const result = buildAllowlistView([], []);
+    expect(result.text).toContain("DM allowlist:");
+    expect(result.text).toContain("(none)");
+    expect(result.text).toContain("Group allowlist:");
+    expect(result.text).toContain("Use /allowlist");
+  });
+
+  it("shows entries", () => {
+    const result = buildAllowlistView(["123", "@user"], ["456"]);
+    expect(result.text).toContain("  123");
+    expect(result.text).toContain("  @user");
+    expect(result.text).toContain("  456");
+  });
+
+  it("truncates long lists", () => {
+    const entries = Array.from({ length: 15 }, (_, i) => String(i));
+    const result = buildAllowlistView(entries, []);
+    expect(result.text).toContain("...and 5 more");
+    // First 10 should be present
+    expect(result.text).toContain("  0");
+    expect(result.text).toContain("  9");
+  });
+
+  it("has back button", () => {
+    const result = buildAllowlistView([], []);
+    expect(result.buttons).toHaveLength(1);
+    expect(result.buttons[0][0].callback_data).toBe("cfg_menu");
+  });
+});
+
+describe("normalizeStreamingDisplay", () => {
+  it("maps boolean true to partial", () => {
+    expect(normalizeStreamingDisplay(true)).toBe("partial");
+  });
+
+  it("maps boolean false to off", () => {
+    expect(normalizeStreamingDisplay(false)).toBe("off");
+  });
+
+  it("maps progress to partial", () => {
+    expect(normalizeStreamingDisplay("progress")).toBe("partial");
+  });
+
+  it("passes through valid string values", () => {
+    expect(normalizeStreamingDisplay("off")).toBe("off");
+    expect(normalizeStreamingDisplay("partial")).toBe("partial");
+    expect(normalizeStreamingDisplay("block")).toBe("block");
+  });
+
+  it("defaults undefined to partial", () => {
+    expect(normalizeStreamingDisplay(undefined)).toBe("partial");
+  });
+});

--- a/src/telegram/settings-buttons.ts
+++ b/src/telegram/settings-buttons.ts
@@ -1,0 +1,230 @@
+/**
+ * Telegram inline button utilities for the /settings control panel.
+ *
+ * Callback data patterns (max 64 bytes for Telegram):
+ * - cfg_menu                  → main settings menu
+ * - cfg_s_{setting}           → submenu (dmpol, grppol, stream, allow)
+ * - cfg_v_{setting}_{value}   → set value (e.g. cfg_v_dmpol_open)
+ */
+
+import type { ButtonRow } from "./model-buttons.js";
+
+export type ParsedSettingsCallback =
+  | { type: "menu" }
+  | { type: "submenu"; setting: SettingKey | "allow" }
+  | { type: "set"; setting: SettingKey; value: string };
+
+export type SettingKey = "dmpol" | "grppol" | "stream";
+
+const SETTINGS_PREFIX = "cfg_";
+
+const VALID_SETTING_KEYS = new Set<string>(["dmpol", "grppol", "stream"]);
+const VALID_SUBMENU_KEYS = new Set<string>(["dmpol", "grppol", "stream", "allow"]);
+
+const SETTING_VALUES: Record<SettingKey, readonly string[]> = {
+  dmpol: ["pairing", "allowlist", "open", "disabled"],
+  grppol: ["open", "allowlist", "disabled"],
+  stream: ["off", "partial", "block"],
+};
+
+const SETTING_LABELS: Record<SettingKey, string> = {
+  dmpol: "DM Policy",
+  grppol: "Group Policy",
+  stream: "Streaming",
+};
+
+const SETTING_DESCRIPTIONS: Record<SettingKey, Record<string, string>> = {
+  dmpol: {
+    pairing: "Unknown senders get a pairing code",
+    allowlist: "Only allow senders in allowFrom",
+    open: "Allow all inbound DMs",
+    disabled: "Ignore all inbound DMs",
+  },
+  grppol: {
+    open: "Groups bypass allowFrom",
+    allowlist: "Only allowed groups/senders",
+    disabled: "Block all group messages",
+  },
+  stream: {
+    off: "No streaming preview",
+    partial: "Edit a single preview message",
+    block: "Stream in chunked updates",
+  },
+};
+
+function isSettingKey(value: string): value is SettingKey {
+  return VALID_SETTING_KEYS.has(value);
+}
+
+/**
+ * Parse a settings callback_data string into a structured object.
+ * Returns null if the data doesn't match a known cfg_ pattern.
+ */
+export function parseSettingsCallbackData(data: string): ParsedSettingsCallback | null {
+  const trimmed = data.trim();
+  if (!trimmed.startsWith(SETTINGS_PREFIX)) {
+    return null;
+  }
+
+  if (trimmed === "cfg_menu") {
+    return { type: "menu" };
+  }
+
+  // cfg_s_{setting} — submenu (includes "allow" for read-only allowlist view)
+  const submenuMatch = trimmed.match(/^cfg_s_([a-z]+)$/);
+  if (submenuMatch) {
+    const setting = submenuMatch[1];
+    if (setting && VALID_SUBMENU_KEYS.has(setting)) {
+      return { type: "submenu", setting: setting as SettingKey | "allow" };
+    }
+    return null;
+  }
+
+  // cfg_v_{setting}_{value} — set value
+  const setMatch = trimmed.match(/^cfg_v_([a-z]+)_([a-z]+)$/);
+  if (setMatch) {
+    const setting = setMatch[1];
+    const value = setMatch[2];
+    if (setting && value && isSettingKey(setting)) {
+      const validValues = SETTING_VALUES[setting];
+      if (validValues.includes(value)) {
+        return { type: "set", setting, value };
+      }
+    }
+    return null;
+  }
+
+  return null;
+}
+
+export type SettingsMenuState = {
+  dmPolicy?: string;
+  groupPolicy?: string;
+  streaming?: string;
+};
+
+/**
+ * Build the main settings menu text and buttons.
+ */
+export function buildSettingsMainMenu(current: SettingsMenuState): {
+  text: string;
+  buttons: ButtonRow[];
+} {
+  const dmPol = current.dmPolicy ?? "pairing";
+  const grpPol = current.groupPolicy ?? "open";
+  const stream = normalizeStreamingDisplay(current.streaming);
+
+  const text = [
+    "Settings",
+    "",
+    `DM Policy: ${dmPol}`,
+    `Group Policy: ${grpPol}`,
+    `Streaming: ${stream}`,
+  ].join("\n");
+
+  const buttons: ButtonRow[] = [
+    [
+      { text: "DM Policy", callback_data: "cfg_s_dmpol" },
+      { text: "Group Policy", callback_data: "cfg_s_grppol" },
+    ],
+    [
+      { text: "Streaming", callback_data: "cfg_s_stream" },
+      { text: "Allowlist", callback_data: "cfg_s_allow" },
+    ],
+  ];
+
+  return { text, buttons };
+}
+
+/**
+ * Build a submenu for a specific setting, showing options with a checkmark on
+ * the current value plus a back button.
+ */
+export function buildSettingSubmenu(
+  setting: SettingKey,
+  currentValue: string | undefined,
+): { text: string; buttons: ButtonRow[] } {
+  const label = SETTING_LABELS[setting];
+  const values = SETTING_VALUES[setting];
+  const descriptions = SETTING_DESCRIPTIONS[setting];
+  const effective = setting === "stream" ? normalizeStreamingDisplay(currentValue) : currentValue;
+
+  const lines = [label, ""];
+  for (const value of values) {
+    const check = value === effective ? " \u2713" : "";
+    const desc = descriptions[value] ?? "";
+    lines.push(`${value}${check} \u2014 ${desc}`);
+  }
+
+  const buttons: ButtonRow[] = [];
+  // One value per row for clarity
+  for (const value of values) {
+    const check = value === effective ? " \u2713" : "";
+    buttons.push([{ text: `${value}${check}`, callback_data: `cfg_v_${setting}_${value}` }]);
+  }
+  buttons.push([{ text: "<< Back", callback_data: "cfg_menu" }]);
+
+  return { text: lines.join("\n"), buttons };
+}
+
+/**
+ * Build a read-only allowlist view showing current DM and group allowlist entries.
+ */
+export function buildAllowlistView(
+  dmEntries: readonly string[],
+  groupEntries: readonly string[],
+): { text: string; buttons: ButtonRow[] } {
+  const MAX_DISPLAY = 10;
+  const lines = ["Allowlist"];
+
+  lines.push("");
+  lines.push("DM allowlist:");
+  if (dmEntries.length === 0) {
+    lines.push("  (none)");
+  } else {
+    const display = dmEntries.slice(0, MAX_DISPLAY);
+    for (const entry of display) {
+      lines.push(`  ${entry}`);
+    }
+    if (dmEntries.length > MAX_DISPLAY) {
+      lines.push(`  ...and ${dmEntries.length - MAX_DISPLAY} more`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Group allowlist:");
+  if (groupEntries.length === 0) {
+    lines.push("  (none)");
+  } else {
+    const display = groupEntries.slice(0, MAX_DISPLAY);
+    for (const entry of display) {
+      lines.push(`  ${entry}`);
+    }
+    if (groupEntries.length > MAX_DISPLAY) {
+      lines.push(`  ...and ${groupEntries.length - MAX_DISPLAY} more`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Use /allowlist to add or remove entries.");
+
+  const buttons: ButtonRow[] = [[{ text: "<< Back", callback_data: "cfg_menu" }]];
+
+  return { text: lines.join("\n"), buttons };
+}
+
+/** Map streaming config values (including legacy booleans) to display values. */
+function normalizeStreamingDisplay(value: string | boolean | undefined): string {
+  if (value === true || value === "progress") {
+    return "partial";
+  }
+  if (value === false) {
+    return "off";
+  }
+  if (typeof value === "string" && ["off", "partial", "block"].includes(value)) {
+    return value;
+  }
+  return "partial"; // default
+}
+
+export { SETTING_VALUES, SETTING_LABELS, normalizeStreamingDisplay };

--- a/src/telegram/settings-panel.test.ts
+++ b/src/telegram/settings-panel.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock heavy config modules to avoid transitive dependency issues in tests
+vi.mock("../config/config.js", () => ({
+  readConfigFileSnapshotForWrite: vi.fn(),
+  validateConfigObjectWithPlugins: vi.fn(),
+  writeConfigFile: vi.fn(),
+}));
+
+vi.mock("../config/config-paths.js", () => ({
+  setConfigValueAtPath: vi.fn(),
+}));
+
+vi.mock("../routing/session-key.js", () => ({
+  normalizeAccountId: (id: string) => id || "default",
+}));
+
+import { setConfigValueAtPath } from "../config/config-paths.js";
+import {
+  readConfigFileSnapshotForWrite,
+  validateConfigObjectWithPlugins,
+  writeConfigFile,
+} from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { TelegramAccountConfig } from "../config/types.telegram.js";
+import type { ParsedSettingsCallback } from "./settings-buttons.js";
+import {
+  buildSettingsCommandResponse,
+  handleSettingsCallback,
+  _resolveConfigPath,
+  _applySettingChange,
+} from "./settings-panel.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("_resolveConfigPath", () => {
+  it("returns base telegram path for default account", () => {
+    expect(_resolveConfigPath("default", "dmpol")).toEqual(["channels", "telegram", "dmPolicy"]);
+    expect(_resolveConfigPath("default", "grppol")).toEqual([
+      "channels",
+      "telegram",
+      "groupPolicy",
+    ]);
+    expect(_resolveConfigPath("default", "stream")).toEqual(["channels", "telegram", "streaming"]);
+  });
+
+  it("returns account-scoped path for named accounts", () => {
+    expect(_resolveConfigPath("prod", "dmpol")).toEqual([
+      "channels",
+      "telegram",
+      "accounts",
+      "prod",
+      "dmPolicy",
+    ]);
+  });
+});
+
+describe("buildSettingsCommandResponse", () => {
+  it("renders main menu with config values", () => {
+    const cfg: TelegramAccountConfig = {
+      dmPolicy: "allowlist",
+      groupPolicy: "disabled",
+      streaming: "block",
+    };
+    const result = buildSettingsCommandResponse(cfg);
+    expect(result.text).toContain("DM Policy: allowlist");
+    expect(result.text).toContain("Group Policy: disabled");
+    expect(result.text).toContain("Streaming: block");
+    expect(result.buttons).toHaveLength(2);
+  });
+
+  it("uses defaults for missing config", () => {
+    const result = buildSettingsCommandResponse({});
+    expect(result.text).toContain("DM Policy: pairing");
+    expect(result.text).toContain("Group Policy: open");
+    expect(result.text).toContain("Streaming: partial");
+  });
+});
+
+describe("handleSettingsCallback", () => {
+  function createMockParams(
+    parsed: ParsedSettingsCallback,
+    telegramCfg: TelegramAccountConfig = {},
+  ) {
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const answerCallback = vi.fn().mockResolvedValue(undefined);
+    return {
+      params: {
+        parsed,
+        cfg: {} as OpenClawConfig,
+        accountId: "default",
+        telegramCfg,
+        editMessage,
+        answerCallback,
+      },
+      editMessage,
+      answerCallback,
+    };
+  }
+
+  it("renders main menu on 'menu' callback", async () => {
+    const { params, editMessage } = createMockParams({ type: "menu" });
+    await handleSettingsCallback(params);
+    expect(editMessage).toHaveBeenCalledOnce();
+    const [text] = editMessage.mock.calls[0];
+    expect(text).toContain("Settings");
+    expect(text).toContain("DM Policy:");
+  });
+
+  it("renders submenu on 'submenu' callback", async () => {
+    const { params, editMessage } = createMockParams(
+      { type: "submenu", setting: "dmpol" },
+      { dmPolicy: "open" },
+    );
+    await handleSettingsCallback(params);
+    expect(editMessage).toHaveBeenCalledOnce();
+    const [text] = editMessage.mock.calls[0];
+    expect(text).toContain("DM Policy");
+    expect(text).toContain("open \u2713");
+  });
+
+  it("renders allowlist view on 'allow' submenu", async () => {
+    const { params, editMessage } = createMockParams(
+      { type: "submenu", setting: "allow" },
+      { allowFrom: [123, "@alice"], groupAllowFrom: [456] },
+    );
+    await handleSettingsCallback(params);
+    expect(editMessage).toHaveBeenCalledOnce();
+    const [text] = editMessage.mock.calls[0];
+    expect(text).toContain("Allowlist");
+    expect(text).toContain("123");
+    expect(text).toContain("@alice");
+    expect(text).toContain("456");
+  });
+
+  it("silently no-ops when value is already set", async () => {
+    const { params, answerCallback, editMessage } = createMockParams(
+      { type: "set", setting: "dmpol", value: "pairing" },
+      { dmPolicy: "pairing" },
+    );
+    await handleSettingsCallback(params);
+    expect(answerCallback).not.toHaveBeenCalled();
+    expect(editMessage).not.toHaveBeenCalled();
+  });
+
+  it("applies config change and re-renders submenu", async () => {
+    const mockSnapshot = {
+      snapshot: {
+        valid: true,
+        resolved: { channels: { telegram: { dmPolicy: "pairing" } } },
+      },
+      writeOptions: {},
+    };
+    vi.mocked(readConfigFileSnapshotForWrite).mockResolvedValue(mockSnapshot as never);
+    vi.mocked(validateConfigObjectWithPlugins).mockReturnValue({
+      ok: true,
+      config: {} as OpenClawConfig,
+      warnings: [],
+    });
+    vi.mocked(writeConfigFile).mockResolvedValue(undefined);
+
+    const { params, editMessage, answerCallback } = createMockParams(
+      { type: "set", setting: "dmpol", value: "open" },
+      { dmPolicy: "pairing" },
+    );
+    await handleSettingsCallback(params);
+    expect(answerCallback).not.toHaveBeenCalled();
+    expect(editMessage).toHaveBeenCalledOnce();
+    const [text] = editMessage.mock.calls[0];
+    expect(text).toContain("open \u2713");
+    expect(setConfigValueAtPath).toHaveBeenCalled();
+    expect(writeConfigFile).toHaveBeenCalled();
+  });
+
+  it("shows error on validation failure", async () => {
+    const mockSnapshot = {
+      snapshot: {
+        valid: true,
+        resolved: { channels: { telegram: {} } },
+      },
+      writeOptions: {},
+    };
+    vi.mocked(readConfigFileSnapshotForWrite).mockResolvedValue(mockSnapshot as never);
+    vi.mocked(validateConfigObjectWithPlugins).mockReturnValue({
+      ok: false,
+      issues: [{ path: "test", message: "Invalid value" }],
+      warnings: [],
+    });
+
+    const { params, editMessage, answerCallback } = createMockParams(
+      { type: "set", setting: "grppol", value: "disabled" },
+      { groupPolicy: "open" },
+    );
+    await handleSettingsCallback(params);
+    expect(answerCallback).toHaveBeenCalledWith("Failed: Invalid value");
+    expect(editMessage).toHaveBeenCalledOnce();
+    const [text] = editMessage.mock.calls[0];
+    expect(text).toContain("\u274c Invalid value");
+    expect(writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("handles config file read errors", async () => {
+    vi.mocked(readConfigFileSnapshotForWrite).mockRejectedValue(new Error("file locked"));
+
+    const { params, answerCallback, editMessage } = createMockParams(
+      { type: "set", setting: "stream", value: "block" },
+      { streaming: "partial" },
+    );
+    await handleSettingsCallback(params);
+    expect(answerCallback).toHaveBeenCalledWith(expect.stringContaining("file locked"));
+    expect(editMessage).toHaveBeenCalledOnce();
+  });
+});

--- a/src/telegram/settings-panel.ts
+++ b/src/telegram/settings-panel.ts
@@ -41,15 +41,12 @@ function resolveConfigPath(accountId: string, setting: SettingKey): string[] {
 }
 
 /** Read the effective value of a setting from the Telegram account config. */
-function readCurrentValue(
-  telegramCfg: TelegramAccountConfig,
-  setting: SettingKey,
-): string | undefined {
+function readCurrentValue(telegramCfg: TelegramAccountConfig, setting: SettingKey): string {
   switch (setting) {
     case "dmpol":
-      return telegramCfg.dmPolicy;
+      return telegramCfg.dmPolicy ?? "pairing";
     case "grppol":
-      return telegramCfg.groupPolicy;
+      return telegramCfg.groupPolicy ?? "open";
     case "stream":
       return normalizeStreamingDisplay(telegramCfg.streaming);
   }

--- a/src/telegram/settings-panel.ts
+++ b/src/telegram/settings-panel.ts
@@ -1,0 +1,173 @@
+/**
+ * Settings panel logic: command response builder, callback handler, config mutation.
+ *
+ * The panel lets Telegram users configure account-level settings via inline
+ * keyboard buttons instead of memorizing /config set paths.
+ */
+
+import { setConfigValueAtPath } from "../config/config-paths.js";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  readConfigFileSnapshotForWrite,
+  validateConfigObjectWithPlugins,
+  writeConfigFile,
+} from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.js";
+import { normalizeAccountId } from "../routing/session-key.js";
+import type { ButtonRow } from "./model-buttons.js";
+import {
+  type ParsedSettingsCallback,
+  type SettingKey,
+  buildAllowlistView,
+  buildSettingSubmenu,
+  buildSettingsMainMenu,
+  normalizeStreamingDisplay,
+} from "./settings-buttons.js";
+
+/** Config path segments for each setting key, per account scope. */
+function resolveConfigPath(accountId: string, setting: SettingKey): string[] {
+  const normalized = normalizeAccountId(accountId);
+  const settingToConfigKey: Record<SettingKey, string> = {
+    dmpol: "dmPolicy",
+    grppol: "groupPolicy",
+    stream: "streaming",
+  };
+  const configKey = settingToConfigKey[setting];
+
+  if (normalized === "default") {
+    return ["channels", "telegram", configKey];
+  }
+  return ["channels", "telegram", "accounts", normalized, configKey];
+}
+
+/** Read the effective value of a setting from the Telegram account config. */
+function readCurrentValue(
+  telegramCfg: TelegramAccountConfig,
+  setting: SettingKey,
+): string | undefined {
+  switch (setting) {
+    case "dmpol":
+      return telegramCfg.dmPolicy;
+    case "grppol":
+      return telegramCfg.groupPolicy;
+    case "stream":
+      return normalizeStreamingDisplay(telegramCfg.streaming);
+  }
+}
+
+export type BuildSettingsCommandResponseResult = {
+  text: string;
+  buttons: ButtonRow[];
+};
+
+/**
+ * Build the initial /settings command response (main menu).
+ */
+export function buildSettingsCommandResponse(
+  telegramCfg: TelegramAccountConfig,
+): BuildSettingsCommandResponseResult {
+  return buildSettingsMainMenu({
+    dmPolicy: telegramCfg.dmPolicy,
+    groupPolicy: telegramCfg.groupPolicy,
+    streaming: normalizeStreamingDisplay(telegramCfg.streaming),
+  });
+}
+
+export type HandleSettingsCallbackParams = {
+  parsed: ParsedSettingsCallback;
+  cfg: OpenClawConfig;
+  accountId: string;
+  telegramCfg: TelegramAccountConfig;
+  editMessage: (text: string, buttons: ButtonRow[]) => Promise<void>;
+  answerCallback: (text: string) => Promise<void>;
+};
+
+/**
+ * Handle a settings callback button press.
+ *
+ * - menu: re-render main menu with current values
+ * - submenu: show setting options with checkmark on current value
+ * - set: apply the config change, re-render submenu with updated checkmark
+ */
+export async function handleSettingsCallback(params: HandleSettingsCallbackParams): Promise<void> {
+  const { parsed, telegramCfg, accountId, editMessage, answerCallback } = params;
+
+  if (parsed.type === "menu") {
+    const { text, buttons } = buildSettingsCommandResponse(telegramCfg);
+    await editMessage(text, buttons);
+    return;
+  }
+
+  if (parsed.type === "submenu") {
+    if (parsed.setting === "allow") {
+      // Allowlist is a read-only submenu — shows current entries
+      const dmEntries = (telegramCfg.allowFrom ?? []).map(String);
+      const groupEntries = (telegramCfg.groupAllowFrom ?? []).map(String);
+      const { text, buttons } = buildAllowlistView(dmEntries, groupEntries);
+      await editMessage(text, buttons);
+      return;
+    }
+    const current = readCurrentValue(telegramCfg, parsed.setting);
+    const { text, buttons } = buildSettingSubmenu(parsed.setting, current);
+    await editMessage(text, buttons);
+    return;
+  }
+
+  if (parsed.type === "set") {
+    const current = readCurrentValue(telegramCfg, parsed.setting);
+    if (current === parsed.value) {
+      // Value already set — no-op. Checkmark is already visible.
+      return;
+    }
+
+    const result = await applySettingChange(accountId, parsed.setting, parsed.value);
+    if (!result.ok) {
+      // Show error inline in the submenu + send a chat message for visibility
+      await answerCallback(`Failed: ${result.error}`);
+      const { text, buttons } = buildSettingSubmenu(parsed.setting, current);
+      await editMessage(`\u274c ${result.error}\n\n${text}`, buttons);
+      return;
+    }
+
+    // Re-render submenu showing updated checkmark (visual confirmation)
+    const { text, buttons } = buildSettingSubmenu(parsed.setting, parsed.value);
+    await editMessage(text, buttons);
+  }
+}
+
+type ApplyResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Apply a setting change to the config file using the async snapshot pipeline:
+ * readConfigFileSnapshotForWrite → clone resolved → mutate → validate → write.
+ */
+async function applySettingChange(
+  accountId: string,
+  setting: SettingKey,
+  value: string,
+): Promise<ApplyResult> {
+  try {
+    const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+    if (!snapshot.valid) {
+      return { ok: false, error: "Config file has validation errors" };
+    }
+
+    const configClone = structuredClone(snapshot.resolved) as Record<string, unknown>;
+    const path = resolveConfigPath(accountId, setting);
+    setConfigValueAtPath(configClone, path, value);
+
+    const validated = validateConfigObjectWithPlugins(configClone);
+    if (!validated.ok) {
+      const firstIssue = validated.issues[0]?.message ?? "Validation failed";
+      return { ok: false, error: firstIssue };
+    }
+
+    await writeConfigFile(validated.config, writeOptions);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+// Export for testing
+export { applySettingChange as _applySettingChange, resolveConfigPath as _resolveConfigPath };


### PR DESCRIPTION
## Problem

Configuring Telegram access control today means editing `openclaw.json` by hand or knowing exact `/config set channels.telegram.dmPolicy open` paths. The settings that matter most — who can DM the bot, which groups are open, whether unknown senders get paired or blocked — are the hardest to discover and the easiest to get wrong.

1. **Access control is invisible** — `dmPolicy`, `groupPolicy`, and `streaming` are the three settings users change most, but there is no in-app surface that shows what they are set to, what the valid options are, or what each option does. A user who wants to switch from pairing mode to an open DM policy has to know the exact config path, the exact string value, and the fact that the change takes effect without a restart.
2. **Errors are silent and destructive** — a typo in a config path silently does nothing; a typo in a value can crash the gateway and kill all channels (see #25007). Users shouldn't need to hand-edit JSON to change who can talk to their bot.
3. **No feedback loop** — after running `/config set`, there's no confirmation of what changed or what the current state is. Users have to run `/config get` separately and parse raw JSON output to verify.

The `/model` command already solved this for model selection with inline keyboard buttons (`model-buttons.ts`). This PR extends the same pattern to the access control and streaming settings that users actually need to configure day-to-day.

## Solution

A `/settings` native command that renders an inline keyboard control panel in Telegram DMs. Users tap buttons to navigate submenus and toggle settings — no config paths to memorize, no JSON to edit.

### Main menu
```
Settings

DM Policy: pairing
Group Policy: open
Streaming: partial

[DM Policy]  [Group Policy]
[Streaming]  [Allowlist]
```

### Submenu (e.g. DM Policy)
```
DM Policy

pairing ✓ — Unknown senders get a pairing code
allowlist — Only allow senders in allowFrom
open — Allow all inbound DMs
disabled — Ignore all inbound DMs

[pairing ✓]
[allowlist]
[open]
[disabled]
[<< Back]
```

Tapping a value applies it immediately and re-renders the submenu with the checkmark moved to the new selection. The allowlist view is read-only (shows current entries, directs to `/allowlist` for mutations).

## Implementation

| File | Purpose |
|------|---------|
| `src/telegram/settings-buttons.ts` (223 LOC) | Pure functions: callback data parsing (`cfg_` prefix, all under 64 bytes), keyboard builders for main menu, submenus with checkmarks, and read-only allowlist view |
| `src/telegram/settings-panel.ts` (175 LOC) | Panel logic: command response builder, callback handler, config mutation via async snapshot pipeline (`readConfigFileSnapshotForWrite` → clone `resolved` → `setConfigValueAtPath` → `validateConfigObjectWithPlugins` → `writeConfigFile`) |
| `src/telegram/settings-auth.ts` (120 LOC) | Shared auth decision function used by both the `/settings` command and `cfg_*` callback paths, guaranteeing auth parity |
| `src/telegram/bot-native-commands.ts` | `/settings` command handler registered as standalone `bot.command("settings", ...)` with auth, DM-only guard, and `configWrites` guard |
| `src/telegram/bot-handlers.ts` | `cfg_` callback dispatch before `inlineButtonsScope` gates, using real callback message context for thread-aware auth |
| `src/auto-reply/commands-registry.data.ts` | Register `settings` as a Telegram-only native management command (`providers: ["telegram"]`) |

### Callback data encoding

Following the `mdl_` pattern from `model-buttons.ts`:

```
cfg_menu                  → main settings menu
cfg_s_{setting}           → submenu (dmpol, grppol, stream, allow)
cfg_v_{setting}_{value}   → set value (e.g. cfg_v_dmpol_open)
```

### Guards

- **DM-only**: groups get an explicit "Settings is only available in DMs" reply
- **Auth**: shared `resolveSettingsAuthDecision` enforcing the full command-level auth chain (requireTopic, per-DM/topic allowFrom overrides, `commands.allowFrom`, `ownerAllowFrom`)
- **Fresh config per callback**: every button press re-reads config from disk — no stale registration-time state
- **configWrites**: respects `channels.telegram.configWrites: false` (both command and callbacks)
- **nativeEnabled**: `/settings` handler only registers when native commands are enabled
- **Account-scoped**: default account writes to `channels.telegram.{key}`, named accounts to `channels.telegram.accounts.{id}.{key}`

### Callback auth hardening

Settings callbacks mutate config, so they require stricter auth than read-only inline buttons. The callback path was hardened across multiple review rounds to reach full parity with the `/settings` command auth:

- Callback handler runs **before** `inlineButtonsScope` gates (settings has its own auth and shouldn't be blocked by `scope=off` or `scope=group`)
- Uses the **actual callback message context** (`isForum`, `messageThreadId`) for thread-aware auth — `requireTopic`, per-topic `allowFrom`, and per-DM `dmPolicy` overrides are all enforced
- Auth logic extracted into `resolveSettingsAuthDecision` (shared between command and callback paths) to eliminate parity drift
- Only uses fresh config values — no fallback to stale registration-time `allowFrom`
- Enforces `commands.allowFrom`, `commands.ownerAllowFrom`, and `useAccessGroups` identically to the command path via `resolveCommandAuthorizedFromAuthorizers` + `resolveCommandAuthorization`

### Settings covered

| Key | Config path | Valid values |
|-----|------------|--------------|
| `dmpol` | `dmPolicy` | pairing, allowlist, open, disabled |
| `grppol` | `groupPolicy` | open, allowlist, disabled |
| `stream` | `streaming` | off, partial, block |

The `progress` streaming alias is hidden (maps to `partial`). Legacy boolean streaming values are normalized for display.

## Scope boundaries

- Account-level settings only (no per-group/per-topic overrides in v1)
- Allowlist is read-only in the panel (add/remove via `/allowlist` text commands)
- `requireMention` is intentionally excluded — it's a per-group setting, not account-level
- No gateway restart needed — `loadConfig()` re-reads from disk on next request

## Related issues

- Partially addresses #16062 — improves Telegram chat UX settings for AI-agent conversations
- Related to #22508 — Telegram inline buttons toast/alert text in `answerCallbackQuery` (this PR uses chat replies for feedback since `answerCallbackQuery` is called immediately before parsing)
- Related to #20564 — instant non-AI inline-button acknowledgement (settings callbacks respond instantly without an agent turn)
- Related to #25007 — reduces risk of config file corruption by providing a validated UI instead of manual JSON editing

## Test plan

- [x] `pnpm check` passes (format, lint, type-check, all custom lints)
- [x] `pnpm test` passes
- [x] 48 new tests across `settings-buttons.test.ts` (28), `settings-panel.test.ts` (11), and `settings-auth.test.ts` (9)
  - Callback data parsing (all patterns including invalid inputs)
  - All callback data strings verified under Telegram's 64-byte limit
  - Keyboard generation (correct buttons, rows, checkmarks)
  - Config mutation flow (mock readConfigFileSnapshot/writeConfigFile)
  - Error handling (validation failure, file read error, no-op tap)
  - Allowlist view (empty, populated, truncation at 10 entries)
  - Streaming display normalization (boolean legacy, progress alias)
  - Auth parity: requireTopic, per-DM/topic allowFrom override, open access, empty allowlist, `commands.allowFrom` precedence, `ownerAllowFrom` enforcement
- [x] Manual: DM the bot `/settings`, verify main menu renders with correct current values
- [x] Manual: Tap a setting (e.g. DM Policy), verify submenu shows options with checkmark
- [x] Manual: Select a new value, verify config file is updated and menu reflects the change
- [x] Manual: Try `/settings` in a group — should get "DM only" message
- [x] Manual: Verify `/settings` respects `configWrites: false`

## AI-assisted

Built with Claude Code. Fully tested (automated + understanding of code verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)