### PR TITLE
fix(telegram): split messages at word boundaries instead of mid-word

### DIFF
--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -312,7 +312,33 @@ function splitMarkdownIRPreserveWhitespace(ir: MarkdownIR, limit: number): Markd
   const chunks: MarkdownIR[] = [];
   let cursor = 0;
   while (cursor < ir.text.length) {
-    const end = Math.min(ir.text.length, cursor + normalizedLimit);
+    const naiveEnd = Math.min(ir.text.length, cursor + normalizedLimit);
+
+    // If we reached the end of the text, take the rest as-is
+    if (naiveEnd >= ir.text.length) {
+      chunks.push({
+        text: ir.text.slice(cursor, naiveEnd),
+        styles: sliceStyleSpans(ir.styles, cursor, naiveEnd),
+        links: sliceLinkSpans(ir.links, cursor, naiveEnd),
+      });
+      break;
+    }
+
+    // Look backward from naiveEnd for a word boundary.
+    // Don't search back more than 25% of the chunk to avoid tiny fragments.
+    const searchFloor = Math.max(cursor + 1, naiveEnd - Math.floor(normalizedLimit * 0.25));
+    let splitAt = -1;
+
+    for (let i = naiveEnd - 1; i >= searchFloor; i--) {
+      const ch = ir.text[i];
+      if (ch === " " || ch === "\n" || ch === "\t" || ch === "\r") {
+        splitAt = i + 1; // split after the whitespace character
+        break;
+      }
+    }
+
+    const end = splitAt > 0 ? splitAt : naiveEnd;
+
     chunks.push({
       text: ir.text.slice(cursor, end),
       styles: sliceStyleSpans(ir.styles, cursor, end),

--- a/src/telegram/format.word-boundary-split.test.ts
+++ b/src/telegram/format.word-boundary-split.test.ts
@@ -64,7 +64,8 @@ describe("splitMarkdownIRPreserveWhitespace – word boundary splitting", () => 
   });
 
   it("preserves markdown formatting across word-boundary splits", () => {
-    const text = "This has **bold text** and _italic_ with a lot more words to push it past the limit";
+    const text =
+      "This has **bold text** and _italic_ with a lot more words to push it past the limit";
     const chunks = markdownToTelegramChunks(text, 40);
 
     const reconstructed = chunks.map((c) => c.text).join("");

--- a/src/telegram/format.word-boundary-split.test.ts
+++ b/src/telegram/format.word-boundary-split.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { markdownToTelegramChunks } from "./format.js";
+
+describe("splitMarkdownIRPreserveWhitespace – word boundary splitting", () => {
+  it("does not split words mid-character (issue #36644)", () => {
+    const text =
+      "Regulatory overhang lifts beta for UK banks and creates investment opportunities in the sector";
+    const chunks = markdownToTelegramChunks(text, 35);
+
+    const reconstructed = chunks.map((c) => c.text).join("");
+    expect(reconstructed).toBe(text);
+
+    // "beta" must appear as a complete word in exactly one chunk
+    const betaChunks = chunks.filter((c) => /\bbeta\b/.test(c.text));
+    expect(betaChunks).toHaveLength(1);
+
+    // No chunk should be a single-letter fragment of "beta"
+    const hasFragment = chunks.some(
+      (c) => c.text.trim() === "b" || c.text.trim() === "e" || c.text.trim() === "ta",
+    );
+    expect(hasFragment).toBe(false);
+  });
+
+  it("splits at whitespace boundaries", () => {
+    const text = "hello world this is a test of word boundary splitting logic";
+    const chunks = markdownToTelegramChunks(text, 20);
+
+    const reconstructed = chunks.map((c) => c.text).join("");
+    expect(reconstructed).toBe(text);
+
+    // Non-final chunks should end at a whitespace boundary
+    for (let i = 0; i < chunks.length - 1; i++) {
+      const chunkText = chunks[i].text;
+      const lastChar = chunkText[chunkText.length - 1];
+      const nextStart = chunks[i + 1].text[0];
+      // Either chunk ends with space or next starts without a partial word continuation
+      expect(lastChar === " " || nextStart === " " || /^\s/.test(chunks[i + 1].text)).toBe(true);
+    }
+  });
+
+  it("falls back to character boundary for a single long word", () => {
+    const longWord = "Supercalifragilisticexpialidocious";
+    const chunks = markdownToTelegramChunks(longWord, 10);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    const reconstructed = chunks.map((c) => c.text).join("");
+    expect(reconstructed).toBe(longWord);
+  });
+
+  it("handles newlines as valid split points", () => {
+    const text = "Line one content\nLine two content\nLine three content";
+    const chunks = markdownToTelegramChunks(text, 20);
+
+    const reconstructed = chunks.map((c) => c.text).join("");
+    expect(reconstructed).toBe(text);
+  });
+
+  it("preserves text exactly when under the limit", () => {
+    const text = "Short text";
+    const chunks = markdownToTelegramChunks(text, 100);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].text).toBe(text);
+  });
+
+  it("preserves markdown formatting across word-boundary splits", () => {
+    const text = "This has **bold text** and _italic_ with a lot more words to push it past the limit";
+    const chunks = markdownToTelegramChunks(text, 40);
+
+    const reconstructed = chunks.map((c) => c.text).join("");
+    expect(reconstructed).toBe(text);
+
+    // HTML should be present on all chunks
+    for (const chunk of chunks) {
+      expect(chunk.html).toBeDefined();
+      expect(typeof chunk.html).toBe("string");
+    }
+  });
+
+  it("handles empty input", () => {
+    const chunks = markdownToTelegramChunks("", 100);
+    expect(chunks).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Long Telegram messages are split at exact character boundaries, breaking words mid-character. Users see fragments like `"...lifts b"` / `"e"` / `"ta for UK banks"` ("beta" split into three separate messages).

Fixes #36644

## Changes

### `src/telegram/format.ts`
- `splitMarkdownIRPreserveWhitespace`: look backward from the naive character-limit split point to find the nearest whitespace (`space`, `\n`, `\t`, `\r`) within 25% of the chunk size
- Fall back to exact character boundary only when no whitespace is found, preventing tiny trailing fragments
- Style spans and link spans continue to be sliced correctly at the new split position

## What Did NOT Change

- `sliceStyleSpans` / `sliceLinkSpans` logic is untouched
- `renderTelegramChunksWithinHtmlLimit` and the HTML-level re-splitting are unchanged
- Messages that fit within the limit are not affected
- Single long words without any whitespace still split at character boundaries (graceful fallback)

## Testing

Added `src/telegram/format.word-boundary-split.test.ts` with 7 tests covering:
- **Word mid-split regression** (exact issue #36644 scenario — "beta" must not be fragmented)
- Whitespace boundary detection across chunks
- Fallback to character boundary for long words without spaces
- Newline as valid split point
- Under-limit passthrough (no split needed)
- Markdown formatting preservation across splits
- Empty input handling

## Validation

```bash
pnpm vitest run src/telegram/format.word-boundary-split.test.ts
pnpm build
pnpm check
```

## CI Note

Fork PR — `secrets`, `build-artifacts`, and `install-smoke` checks may fail due to missing repository secrets. All code-related checks (typecheck, lint, oxfmt, unit tests on Node + Bun + Windows) should pass.