### PR TITLE
fix(media): preserve under-cap PNG

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -188,7 +188,7 @@ describe("web media loading", () => {
     const result = await loadWebMedia(tinyPngWrongExtFile, 1024 * 1024);
 
     expect(result.kind).toBe("image");
-    expect(result.contentType).toBe("image/jpeg");
+    expect(result.contentType).toBe("image/png");
   });
 
   it("normalizes HEIC local files to JPEG output", async () => {
@@ -342,6 +342,7 @@ describe("web media loading", () => {
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
+    expect(result.fileName).toBe(path.basename(fallbackPngFile, ".png") + ".jpg");
     expect(result.buffer.length).toBeLessThanOrEqual(fallbackPngCap);
   });
 });

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -212,6 +212,14 @@ async function optimizeImageWithFallback(params: {
 }): Promise<OptimizedImage> {
   const { buffer, cap, meta } = params;
   const isPng = meta?.contentType === "image/png" || meta?.fileName?.toLowerCase().endsWith(".png");
+  if (isPng && buffer.length <= cap) {
+    return {
+      buffer,
+      optimizedSize: buffer.length,
+      resizeSide: 0,
+      format: "png",
+    };
+  }
   const hasAlpha = isPng && (await hasAlphaChannel(buffer));
 
   if (hasAlpha) {
@@ -268,10 +276,7 @@ async function loadWebMediaInternal(
     }
 
     const contentType = optimized.format === "png" ? "image/png" : "image/jpeg";
-    const fileName =
-      optimized.format === "jpeg" && meta && isHeicSource(meta)
-        ? toJpegFileName(meta.fileName)
-        : meta?.fileName;
+    const fileName = optimized.format === "jpeg" ? toJpegFileName(meta?.fileName) : meta?.fileName;
 
     return {
       buffer: optimized.buffer,


### PR DESCRIPTION
## Summary
- preserve PNG images when they are already under the size cap instead of forcing PNG->JPEG conversion in `loadWebMedia`
- keep output filenames consistent with encoded data by renaming any JPEG-converted image to `.jpg`
- update `src/web/media.test.ts` to assert non-alpha under-cap PNGs remain PNG and JPEG fallback paths produce `.jpg` filenames

## Test plan
- [x] `corepack pnpm --dir /home/vesko/Workspace/openclaw exec vitest run src/web/media.test.ts`
- [x] Verify local diff affects only `src/web/media.ts` and `src/web/media.test.ts`

Made with [Cursor](https://cursor.com)