### PR TITLE
fix: surface specific sub-issue for config validation union errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
+- Config validation: surface the actual offending field for strict-schema union failures in bindings, including top-level unexpected keys on the matching ACP branch. (#40841) Thanks @Hollychou924.
 
 ## 2026.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Config/plugins: let config writes keep disabled plugin entries without forcing required plugin config schemas or crashing raw plugin validation, so slot switches and similar plugin-state updates persist cleanly. (#63296) Thanks @fuller-stack-dev.
 - WhatsApp/outbound queue: drain queued WhatsApp deliveries when the listener reconnects without dropping reconnect-delayed sends after a special TTL or rewriting retry history, so disconnect-window outbound messages can recover once the channel is ready again. (#46299) Thanks @manuel-claw.
 - Tools/web_fetch: add an opt-in `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange` config so fake-IP proxy environments that resolve public sites into `198.18.0.0/15` can use `web_fetch` without weakening the default SSRF block. (#61830) Thanks @xing-xing-coder.
+- Config validation: surface the actual offending field for strict-schema union failures in bindings, including top-level unexpected keys on the matching ACP branch. (#40841) Thanks @Hollychou924.
 
 ## 2026.4.9
 
@@ -63,7 +64,6 @@ Docs: https://docs.openclaw.ai
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
-- Config validation: surface the actual offending field for strict-schema union failures in bindings, including top-level unexpected keys on the matching ACP branch. (#40841) Thanks @Hollychou924.
 
 ## 2026.4.8
 

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -121,4 +121,28 @@ describe("config validation allowed-values metadata", () => {
       });
     }
   });
+
+  it("keeps generic union messaging for mixed scalar-or-object unions", () => {
+    const result = validateConfigObjectRaw({
+      agents: {
+        list: [{ id: "a", model: true }],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).not.toContainEqual({
+        path: "agents.list.0.model",
+        message: "Invalid input: expected string, received boolean",
+      });
+      expect(result.issues).not.toContainEqual({
+        path: "agents.list.0.model",
+        message: "Invalid input: expected object, received boolean",
+      });
+      expect(result.issues).toContainEqual({
+        path: "agents.list.0.model",
+        message: "Invalid input",
+      });
+    }
+  });
 });

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -70,4 +70,55 @@ describe("config validation allowed-values metadata", () => {
       expect(issue?.message).not.toContain("(allowed:");
     }
   });
+
+  it("surfaces specific sub-issue for invalid_union bindings errors instead of generic 'Invalid input'", () => {
+    const result = validateConfigObjectRaw({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "test",
+          match: { channel: "discord", peer: { kind: "direct", id: "123" } },
+          acp: { agent: "claude" },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).not.toContainEqual({
+        path: "bindings.0",
+        message: "Invalid input",
+      });
+      expect(result.issues).toContainEqual({
+        path: "bindings.0.acp",
+        message: 'Unrecognized key: "agent"',
+      });
+    }
+  });
+
+  it("prefers the matching union branch for top-level unexpected keys", () => {
+    const result = validateConfigObjectRaw({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "test",
+          match: { channel: "discord", peer: { kind: "direct", id: "123" } },
+          acp: { mode: "persistent" },
+          extraTopLevel: true,
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).not.toContainEqual({
+        path: "bindings.0.type",
+        message: 'Invalid input: expected "route"',
+      });
+      expect(result.issues).toContainEqual({
+        path: "bindings.0",
+        message: 'Unrecognized key: "extraTopLevel"',
+      });
+    }
+  });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -262,82 +262,59 @@ function collectAllowedValuesFromUnknownIssue(issue: unknown): unknown[] {
   return collection.values;
 }
 
-/**
- * For `invalid_union` issues, Zod wraps branch errors behind a generic
- * "Invalid input" message. Walk the branch errors and pick the most
- * informative sub-issue so the user sees, e.g.:
- *
- *   bindings.2.acp: Unrecognized key: "agent"
- *
- * instead of the opaque:
- *
- *   bindings.2: Invalid input
- *
- * We prefer issues from branches whose `type` discriminator already matches
- * the user input, so a non-matching branch's deeper path does not outrank the
- * real unexpected-key error on the matching branch. We only surface a branch
- * issue when it is actually more specific than the union-level error; for
- * plain scalar unions, a single branch's root-level type error is usually
- * misleading because several branch types may still be valid.
- */
-function extractBestUnionSubIssue(
+function isBindingsIssuePath(pathSegments: readonly ConfigPathSegment[]): boolean {
+  return pathSegments[0] === "bindings" && typeof pathSegments[1] === "number";
+}
+
+function isRouteTypeMismatchIssue(issue: UnknownIssueRecord): boolean {
+  const issuePath = toConfigPathSegments(issue.path);
+  if (issuePath.length !== 1 || issuePath[0] !== "type") {
+    return false;
+  }
+  if (issue.code !== "invalid_value" || !Array.isArray(issue.values)) {
+    return false;
+  }
+  return issue.values.includes("route");
+}
+
+function extractBindingsSpecificUnionIssue(
   record: UnknownIssueRecord,
   parentPath: string,
 ): ConfigValidationIssue | null {
-  const code = typeof record.code === "string" ? record.code : "";
-  if (code !== "invalid_union") {
+  if (!isBindingsIssuePath(toConfigPathSegments(record.path)) || !Array.isArray(record.errors)) {
     return null;
   }
 
-  const branchGroups: UnknownIssueRecord[][] = [];
-  if (Array.isArray(record.unionErrors)) {
-    for (const zodError of record.unionErrors) {
-      const err = toIssueRecord(zodError);
-      if (!err || !Array.isArray(err.issues)) {
-        continue;
-      }
-      branchGroups.push(
-        err.issues.map((issue) => toIssueRecord(issue)).filter(Boolean) as UnknownIssueRecord[],
-      );
-    }
-  }
-  if (Array.isArray(record.errors)) {
-    for (const errGroup of record.errors) {
-      if (!Array.isArray(errGroup)) {
-        continue;
-      }
-      branchGroups.push(
-        errGroup.map((issue) => toIssueRecord(issue)).filter(Boolean) as UnknownIssueRecord[],
-      );
-    }
-  }
-  if (branchGroups.length === 0) {
-    return null;
-  }
+  let matchingBranchIssue: UnknownIssueRecord | null = null;
+  let matchingBranchIsUnrecognized = false;
+  let matchingBranchPathLen = -1;
+  let sawRouteTypeMismatch = false;
 
-  let bestIssue: UnknownIssueRecord | null = null;
-  let bestBranchMatchesDiscriminator = false;
-  let bestIssueIsUnrecognized = false;
-  let bestIssuePathLen = -1;
+  for (const errGroup of record.errors) {
+    if (!Array.isArray(errGroup)) {
+      continue;
+    }
 
-  for (const branch of branchGroups) {
-    let branchMatchesDiscriminator = true;
+    const branch = errGroup
+      .map((issue) => toIssueRecord(issue))
+      .filter(Boolean) as UnknownIssueRecord[];
+    if (branch.length === 0) {
+      continue;
+    }
+
+    if (branch.some((issue) => isRouteTypeMismatchIssue(issue))) {
+      sawRouteTypeMismatch = true;
+      continue;
+    }
+
     let branchBestIssue: UnknownIssueRecord | null = null;
     let branchBestIsUnrecognized = false;
     let branchBestPathLen = -1;
 
     for (const issue of branch) {
-      const issuePath = toConfigPathSegments(issue.path);
       const issueCode = typeof issue.code === "string" ? issue.code : "";
+      const issuePathLen = toConfigPathSegments(issue.path).length;
       const issueIsUnrecognized = issueCode === "unrecognized_keys";
-      const issueIsTypeMismatch =
-        issueCode === "invalid_value" && issuePath.length === 1 && issuePath[0] === "type";
-
-      if (issueIsTypeMismatch) {
-        branchMatchesDiscriminator = false;
-      }
-
-      const issuePathLen = issuePath.length;
       const issueIsBetter =
         issuePathLen > branchBestPathLen
           ? true
@@ -354,36 +331,27 @@ function extractBestUnionSubIssue(
       continue;
     }
 
-    const branchIsBetter =
-      branchMatchesDiscriminator && !bestBranchMatchesDiscriminator
-        ? true
-        : branchMatchesDiscriminator === bestBranchMatchesDiscriminator &&
-            branchBestPathLen > bestIssuePathLen
-          ? true
-          : branchMatchesDiscriminator === bestBranchMatchesDiscriminator &&
-            branchBestPathLen === bestIssuePathLen &&
-            branchBestIsUnrecognized &&
-            !bestIssueIsUnrecognized;
-
-    if (branchIsBetter) {
-      bestIssue = branchBestIssue;
-      bestBranchMatchesDiscriminator = branchMatchesDiscriminator;
-      bestIssueIsUnrecognized = branchBestIsUnrecognized;
-      bestIssuePathLen = branchBestPathLen;
+    if (matchingBranchIssue) {
+      return null;
     }
+
+    matchingBranchIssue = branchBestIssue;
+    matchingBranchIsUnrecognized = branchBestIsUnrecognized;
+    matchingBranchPathLen = branchBestPathLen;
   }
 
-  if (!bestIssue) {
+  if (!sawRouteTypeMismatch || !matchingBranchIssue) {
     return null;
   }
 
-  if (bestIssuePathLen === 0 && !bestIssueIsUnrecognized) {
+  if (matchingBranchPathLen === 0 && !matchingBranchIsUnrecognized) {
     return null;
   }
 
-  const subPath = formatConfigPath(toConfigPathSegments(bestIssue.path));
+  const subPath = formatConfigPath(toConfigPathSegments(matchingBranchIssue.path));
   const fullPath = parentPath && subPath ? `${parentPath}.${subPath}` : parentPath || subPath;
-  const subMessage = typeof bestIssue.message === "string" ? bestIssue.message : "Invalid input";
+  const subMessage =
+    typeof matchingBranchIssue.message === "string" ? matchingBranchIssue.message : "Invalid input";
   return { path: fullPath, message: subMessage };
 }
 
@@ -482,15 +450,16 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
 
   const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
 
-  // For union errors where we could NOT extract useful allowed-values,
-  // try to surface the most specific sub-issue instead of generic "Invalid input".
+  // Bindings use a plain union because legacy route bindings may omit `type`.
+  // When an explicit ACP binding fails strict-object checks, Zod collapses the
+  // useful ACP branch issue behind a generic union-level "Invalid input".
   if (
     record &&
     typeof record.code === "string" &&
     record.code === "invalid_union" &&
     !allowedValuesSummary
   ) {
-    const betterIssue = extractBestUnionSubIssue(record, path);
+    const betterIssue = extractBindingsSpecificUnionIssue(record, path);
     if (betterIssue) {
       return betterIssue;
     }

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -275,7 +275,10 @@ function collectAllowedValuesFromUnknownIssue(issue: unknown): unknown[] {
  *
  * We prefer issues from branches whose `type` discriminator already matches
  * the user input, so a non-matching branch's deeper path does not outrank the
- * real unexpected-key error on the matching branch.
+ * real unexpected-key error on the matching branch. We only surface a branch
+ * issue when it is actually more specific than the union-level error; for
+ * plain scalar unions, a single branch's root-level type error is usually
+ * misleading because several branch types may still be valid.
  */
 function extractBestUnionSubIssue(
   record: UnknownIssueRecord,
@@ -293,7 +296,9 @@ function extractBestUnionSubIssue(
       if (!err || !Array.isArray(err.issues)) {
         continue;
       }
-      branchGroups.push(err.issues.map((issue) => toIssueRecord(issue)).filter(Boolean) as UnknownIssueRecord[]);
+      branchGroups.push(
+        err.issues.map((issue) => toIssueRecord(issue)).filter(Boolean) as UnknownIssueRecord[],
+      );
     }
   }
   if (Array.isArray(record.errors)) {
@@ -326,9 +331,7 @@ function extractBestUnionSubIssue(
       const issueCode = typeof issue.code === "string" ? issue.code : "";
       const issueIsUnrecognized = issueCode === "unrecognized_keys";
       const issueIsTypeMismatch =
-        issueCode === "invalid_value" &&
-        issuePath.length === 1 &&
-        issuePath[0] === "type";
+        issueCode === "invalid_value" && issuePath.length === 1 && issuePath[0] === "type";
 
       if (issueIsTypeMismatch) {
         branchMatchesDiscriminator = false;
@@ -336,9 +339,9 @@ function extractBestUnionSubIssue(
 
       const issuePathLen = issuePath.length;
       const issueIsBetter =
-        issueIsUnrecognized && !branchBestIsUnrecognized
+        issuePathLen > branchBestPathLen
           ? true
-          : issueIsUnrecognized === branchBestIsUnrecognized && issuePathLen > branchBestPathLen;
+          : issuePathLen === branchBestPathLen && issueIsUnrecognized && !branchBestIsUnrecognized;
 
       if (issueIsBetter) {
         branchBestIssue = issue;
@@ -355,12 +358,12 @@ function extractBestUnionSubIssue(
       branchMatchesDiscriminator && !bestBranchMatchesDiscriminator
         ? true
         : branchMatchesDiscriminator === bestBranchMatchesDiscriminator &&
-            branchBestIsUnrecognized &&
-            !bestIssueIsUnrecognized
+            branchBestPathLen > bestIssuePathLen
           ? true
           : branchMatchesDiscriminator === bestBranchMatchesDiscriminator &&
-              branchBestIsUnrecognized === bestIssueIsUnrecognized &&
-              branchBestPathLen > bestIssuePathLen;
+            branchBestPathLen === bestIssuePathLen &&
+            branchBestIsUnrecognized &&
+            !bestIssueIsUnrecognized;
 
     if (branchIsBetter) {
       bestIssue = branchBestIssue;
@@ -371,6 +374,10 @@ function extractBestUnionSubIssue(
   }
 
   if (!bestIssue) {
+    return null;
+  }
+
+  if (bestIssuePathLen === 0 && !bestIssueIsUnrecognized) {
     return null;
   }
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -262,6 +262,124 @@ function collectAllowedValuesFromUnknownIssue(issue: unknown): unknown[] {
   return collection.values;
 }
 
+/**
+ * For `invalid_union` issues, Zod wraps branch errors behind a generic
+ * "Invalid input" message. Walk the branch errors and pick the most
+ * informative sub-issue so the user sees, e.g.:
+ *
+ *   bindings.2.acp: Unrecognized key: "agent"
+ *
+ * instead of the opaque:
+ *
+ *   bindings.2: Invalid input
+ *
+ * We prefer issues from branches whose `type` discriminator already matches
+ * the user input, so a non-matching branch's deeper path does not outrank the
+ * real unexpected-key error on the matching branch.
+ */
+function extractBestUnionSubIssue(
+  record: UnknownIssueRecord,
+  parentPath: string,
+): ConfigValidationIssue | null {
+  const code = typeof record.code === "string" ? record.code : "";
+  if (code !== "invalid_union") {
+    return null;
+  }
+
+  const branchGroups: UnknownIssueRecord[][] = [];
+  if (Array.isArray(record.unionErrors)) {
+    for (const zodError of record.unionErrors) {
+      const err = toIssueRecord(zodError);
+      if (!err || !Array.isArray(err.issues)) {
+        continue;
+      }
+      branchGroups.push(err.issues.map((issue) => toIssueRecord(issue)).filter(Boolean) as UnknownIssueRecord[]);
+    }
+  }
+  if (Array.isArray(record.errors)) {
+    for (const errGroup of record.errors) {
+      if (!Array.isArray(errGroup)) {
+        continue;
+      }
+      branchGroups.push(
+        errGroup.map((issue) => toIssueRecord(issue)).filter(Boolean) as UnknownIssueRecord[],
+      );
+    }
+  }
+  if (branchGroups.length === 0) {
+    return null;
+  }
+
+  let bestIssue: UnknownIssueRecord | null = null;
+  let bestBranchMatchesDiscriminator = false;
+  let bestIssueIsUnrecognized = false;
+  let bestIssuePathLen = -1;
+
+  for (const branch of branchGroups) {
+    let branchMatchesDiscriminator = true;
+    let branchBestIssue: UnknownIssueRecord | null = null;
+    let branchBestIsUnrecognized = false;
+    let branchBestPathLen = -1;
+
+    for (const issue of branch) {
+      const issuePath = toConfigPathSegments(issue.path);
+      const issueCode = typeof issue.code === "string" ? issue.code : "";
+      const issueIsUnrecognized = issueCode === "unrecognized_keys";
+      const issueIsTypeMismatch =
+        issueCode === "invalid_value" &&
+        issuePath.length === 1 &&
+        issuePath[0] === "type";
+
+      if (issueIsTypeMismatch) {
+        branchMatchesDiscriminator = false;
+      }
+
+      const issuePathLen = issuePath.length;
+      const issueIsBetter =
+        issueIsUnrecognized && !branchBestIsUnrecognized
+          ? true
+          : issueIsUnrecognized === branchBestIsUnrecognized && issuePathLen > branchBestPathLen;
+
+      if (issueIsBetter) {
+        branchBestIssue = issue;
+        branchBestIsUnrecognized = issueIsUnrecognized;
+        branchBestPathLen = issuePathLen;
+      }
+    }
+
+    if (!branchBestIssue) {
+      continue;
+    }
+
+    const branchIsBetter =
+      branchMatchesDiscriminator && !bestBranchMatchesDiscriminator
+        ? true
+        : branchMatchesDiscriminator === bestBranchMatchesDiscriminator &&
+            branchBestIsUnrecognized &&
+            !bestIssueIsUnrecognized
+          ? true
+          : branchMatchesDiscriminator === bestBranchMatchesDiscriminator &&
+              branchBestIsUnrecognized === bestIssueIsUnrecognized &&
+              branchBestPathLen > bestIssuePathLen;
+
+    if (branchIsBetter) {
+      bestIssue = branchBestIssue;
+      bestBranchMatchesDiscriminator = branchMatchesDiscriminator;
+      bestIssueIsUnrecognized = branchBestIsUnrecognized;
+      bestIssuePathLen = branchBestPathLen;
+    }
+  }
+
+  if (!bestIssue) {
+    return null;
+  }
+
+  const subPath = formatConfigPath(toConfigPathSegments(bestIssue.path));
+  const fullPath = parentPath && subPath ? `${parentPath}.${subPath}` : parentPath || subPath;
+  const subMessage = typeof bestIssue.message === "string" ? bestIssue.message : "Invalid input";
+  return { path: fullPath, message: subMessage };
+}
+
 function isObjectSecretRefCandidate(value: unknown): boolean {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
@@ -354,7 +472,22 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   const record = toIssueRecord(issue);
   const path = formatConfigPath(toConfigPathSegments(record?.path));
   const message = typeof record?.message === "string" ? record.message : "Invalid input";
+
   const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
+
+  // For union errors where we could NOT extract useful allowed-values,
+  // try to surface the most specific sub-issue instead of generic "Invalid input".
+  if (
+    record &&
+    typeof record.code === "string" &&
+    record.code === "invalid_union" &&
+    !allowedValuesSummary
+  ) {
+    const betterIssue = extractBestUnionSubIssue(record, path);
+    if (betterIssue) {
+      return betterIssue;
+    }
+  }
 
   if (!allowedValuesSummary) {
     return { path, message };


### PR DESCRIPTION
## Problem

When a Zod `.strict()` schema inside a `z.union` rejects an unexpected field, the config validation error was the opaque:

```
bindings.2: Invalid input
```

This caused a 30-minute crash loop (SEV1) because users couldn't identify which field was rejected. The gateway kept exiting code 1 and launchd respawned it every ~11 seconds.

## Root Cause

`z.union([RouteBindingSchema, AcpBindingSchema])` produces an `invalid_union` issue when no branch matches. Zod wraps all branch errors behind a generic `"Invalid input"` message, losing the specific `unrecognized_keys` error that Zod's `.strict()` would normally produce.

## Fix

Added `extractBestUnionSubIssue()` in `mapZodIssueToConfigIssue` that walks union branch errors and picks the sub-issue with the most specific path, preferring `unrecognized_keys` issues. Now produces:

```
bindings.2.acp: Unrecognized key(s) in object: 'agent'
```

This fallback only activates when the existing allowed-values extraction yields nothing, so `update.channel`, `streaming`, and other enum union errors are unchanged.

## Tests

Added test case verifying bindings union errors surface specific field information. All 5 tests pass (including 4 existing tests unchanged).

Fixes #40565