### PR TITLE
gateway: prevent macOS idle sleep while the gateway is running

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process";
+import os from "node:os";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
@@ -16,6 +18,40 @@ import {
 import { createRestartIterationHook } from "../../process/restart-recovery.js";
 import type { defaultRuntime } from "../../runtime.js";
 
+/**
+ * Spawns `caffeinate -i` on macOS to prevent the system from idle-sleeping
+ * while the gateway is running. Returns a cleanup function that kills the
+ * caffeinate process when the gateway shuts down.
+ *
+ * macOS suspends TCP connections during sleep, which causes the Telegram
+ * long-polling loop to stall until the system wakes up. `caffeinate -i`
+ * prevents idle sleep without affecting display or user-initiated sleep.
+ */
+function spawnCaffeinate(): (() => void) | null {
+  if (os.platform() !== "darwin") {
+    return null;
+  }
+  try {
+    // -i: prevent idle sleep  -w <pid>: exit when the given process exits
+    const child = spawn("caffeinate", ["-i", "-w", String(process.pid)], {
+      detached: false,
+      stdio: "ignore",
+    });
+    child.unref();
+    gatewayLog.info("caffeinate started: system will not idle-sleep while gateway is running");
+    return () => {
+      try {
+        child.kill();
+      } catch {
+        // ignore cleanup errors
+      }
+    };
+  } catch {
+    gatewayLog.warn("caffeinate not available; system may sleep and interrupt Telegram polling");
+    return null;
+  }
+}
+
 const gatewayLog = createSubsystemLogger("gateway");
 
 type GatewayRunSignalAction = "stop" | "restart";
@@ -25,6 +61,7 @@ export async function runGatewayLoop(params: {
   runtime: typeof defaultRuntime;
   lockPort?: number;
 }) {
+  const stopCaffeinate = spawnCaffeinate();
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
@@ -196,6 +233,7 @@ export async function runGatewayLoop(params: {
       });
     }
   } finally {
+    stopCaffeinate?.();
     await releaseLockIfHeld();
     cleanupSignals();
   }


### PR DESCRIPTION
## Summary

- Problem: on macOS, idle sleep can suspend long-lived TCP connections while the gateway is running.
- Why it matters: suspended connections can stall always-on local workflows such as Telegram long polling until the machine wakes again.
- What changed: the gateway now starts `caffeinate -i -w <pid>` on macOS and cleans it up when the gateway exits.
- What did NOT change: display sleep, user-initiated sleep behavior, config formats, and non-macOS platforms remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28317

## User-visible / Behavior Changes

On macOS, running the gateway now prevents idle sleep while the gateway process is alive.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw dev checkout
- Model/provider: N/A
- Integration/channel (if any): gateway runtime
- Relevant config (redacted): local gateway mode

### Steps

1. Start the gateway on macOS.
2. Confirm the macOS-only helper launches `caffeinate` tied to the gateway PID.
3. Stop the gateway and confirm cleanup runs.

### Expected

- The system does not enter idle sleep while the gateway is running.
- The helper exits when the gateway exits.

### Actual

- The gateway starts and cleans up a macOS-only `caffeinate` helper process.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: helper starts on Darwin; cleanup path runs on shutdown.
- Edge cases checked: non-Darwin path is a no-op by inspection.
- What you did **not** verify: long-duration overnight idle-sleep behavior under every macOS power configuration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/cli/gateway-cli/run-loop.ts`
- Known bad symptoms reviewers should watch for: unexpected macOS-only process lifecycle issues around gateway startup/shutdown.

## Risks and Mitigations

- Risk: macOS users may see unwanted power-behavior changes while the gateway runs.
  - Mitigation: the behavior is intentionally limited to macOS, uses `-i` only, and stops with the gateway lifecycle.
