### PR TITLE
fix(gateway): allow spawnedBy on ACP sessions

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -263,6 +263,13 @@ describe("gateway sessions patch", () => {
     expect(entry.spawnedBy).toBe(MAIN_SESSION_KEY);
   });
 
+  test("rejects spawnedBy on unsupported sessions with the updated scope hint", async () => {
+    const result = await runPatch({
+      patch: { key: MAIN_SESSION_KEY, spawnedBy: ACP_SESSION_KEY },
+    });
+    expectPatchError(result, "spawnedBy is only supported for subagent:* and acp:* sessions");
+  });
+
   test("rejects spawnDepth on non-subagent sessions", async () => {
     const result = await runPatch({
       patch: { key: MAIN_SESSION_KEY, spawnDepth: 1 },

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -5,6 +5,7 @@ import { applySessionsPatchToStore } from "./sessions-patch.js";
 
 const SUBAGENT_MODEL = "synthetic/hf:moonshotai/Kimi-K2.5";
 const KIMI_SUBAGENT_KEY = "agent:kimi:subagent:child";
+const ACP_SESSION_KEY = "agent:codex:acp:session-1";
 const MAIN_SESSION_KEY = "agent:main:main";
 const EMPTY_CFG = {} as OpenClawConfig;
 
@@ -250,6 +251,16 @@ describe("gateway sessions patch", () => {
       }),
     );
     expect(entry.spawnDepth).toBe(2);
+  });
+
+  test("accepts spawnedBy for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: ACP_SESSION_KEY,
+        patch: { key: ACP_SESSION_KEY, spawnedBy: MAIN_SESSION_KEY },
+      }),
+    );
+    expect(entry.spawnedBy).toBe(MAIN_SESSION_KEY);
   });
 
   test("rejects spawnDepth on non-subagent sessions", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -19,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
+  isAcpSessionKey,
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
@@ -97,7 +98,7 @@ export async function applySessionsPatchToStore(params: {
       if (!trimmed) {
         return invalid("invalid spawnedBy: empty");
       }
-      if (!isSubagentSessionKey(storeKey)) {
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
         return invalid("spawnedBy is only supported for subagent:* sessions");
       }
       if (existing?.spawnedBy && existing.spawnedBy !== trimmed) {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -99,7 +99,7 @@ export async function applySessionsPatchToStore(params: {
         return invalid("invalid spawnedBy: empty");
       }
       if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
-        return invalid("spawnedBy is only supported for subagent:* sessions");
+        return invalid("spawnedBy is only supported for subagent:* and acp:* sessions");
       }
       if (existing?.spawnedBy && existing.spawnedBy !== trimmed) {
         return invalid("spawnedBy cannot be changed once set");


### PR DESCRIPTION
Fixes #40800

## Summary

- allow `sessions.patch` to persist `spawnedBy` for ACP session keys
- add a regression test covering `agent:<id>:acp:*` sessions in `sessions-patch`
- keep `spawnDepth` scoped to subagent sessions only

## Root cause

`spawnAcpDirect()` persists `spawnedBy` through `sessions.patch`, but `applySessionsPatchToStore()` only accepted `spawnedBy` on `subagent:*` keys. ACP child sessions use `agent:<id>:acp:*`, so the patch was rejected with `spawnedBy is only supported for subagent:* sessions`.

## Testing

- `PATH=/opt/homebrew/opt/node@23/bin:$PATH pnpm --dir /Users/zhangxuanyang/Desktop/DDDDAO/openclaw/worktrees/fix-acp-spawnedby-regression exec vitest run src/gateway/sessions-patch.test.ts src/agents/acp-spawn.test.ts`
