### PR TITLE
fix(doctor): suppress orphan transcript warning for qmd sessions

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -158,6 +158,37 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
   });
 
+  it("suppresses orphan transcript warnings when QMD session indexing is enabled", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tempHome,
+        },
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          sessions: {
+            enabled: true,
+          },
+        },
+      },
+    };
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
+    const confirmSkipInNonInteractive = vi.fn(async () => false);
+
+    await noteStateIntegrity(cfg, { confirmSkipInNonInteractive });
+
+    expect(stateIntegrityText()).not.toContain("orphan transcript file");
+    expect(confirmSkipInNonInteractive).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("orphan transcript file"),
+      }),
+    );
+  });
+
   it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {
     const cfg: OpenClawConfig = {};
     writeSessionStore(cfg, {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -16,6 +16,7 @@ import {
   resolveStorePath,
 } from "../config/sessions.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { note } from "../terminal/note.js";
 import { shortenHomePath } from "../utils.js";
@@ -102,6 +103,11 @@ function countJsonlLines(filePath: string): number {
   } catch {
     return 0;
   }
+}
+
+function shouldSuppressOrphanTranscriptWarning(cfg: OpenClawConfig, agentId: string): boolean {
+  const memoryBackend = resolveMemoryBackendConfig({ cfg, agentId });
+  return memoryBackend.backend === "qmd" && memoryBackend.qmd?.sessions.enabled === true;
 }
 
 function findOtherStateDirs(stateDir: string): string[] {
@@ -490,6 +496,7 @@ export async function noteStateIntegrity(
   const displayStoreDir = shortenHomePath(storeDir);
   const displayConfigPath = configPath ? shortenHomePath(configPath) : undefined;
   const requireOAuthDir = shouldRequireOAuthDir(cfg, env);
+  const suppressOrphanTranscriptWarning = shouldSuppressOrphanTranscriptWarning(cfg, agentId);
   const cloudSyncedStateDir = detectMacCloudSyncedStateDir(stateDir);
   const linuxSdBackedStateDir = detectLinuxSdBackedStateDir(stateDir);
 
@@ -769,7 +776,7 @@ export async function noteStateIntegrity(
       .filter((entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name))
       .map((entry) => path.resolve(path.join(sessionsDir, entry.name)))
       .filter((filePath) => !referencedTranscriptPaths.has(filePath));
-    if (orphanTranscriptPaths.length > 0) {
+    if (orphanTranscriptPaths.length > 0 && !suppressOrphanTranscriptWarning) {
       warnings.push(
         `- Found ${orphanTranscriptPaths.length} orphan transcript file(s) in ${displaySessionsDir}. They are not referenced by sessions.json and can consume disk over time.`,
       );


### PR DESCRIPTION
## Summary
- suppress the orphan transcript warning when QMD session indexing is enabled
- skip the orphan archive prompt in that mode so doctor does not suggest deleting QMD-backed transcript history
- add regression coverage for the QMD session-indexing path

## Reproduction
1. Enable QMD session indexing with `memory.backend = "qmd"` and `memory.qmd.sessions.enabled = true`
2. Keep transcript files under the sessions directory that are not referenced by `sessions.json`
3. Run `openclaw doctor`
4. Before this change, doctor warns that these files are orphaned and suggests archiving them even though QMD still indexes them

## Verification
- `pnpm exec vitest run src/commands/doctor-state-integrity.test.ts`
- `pnpm exec vitest run src/commands/doctor-state-integrity.test.ts src/commands/doctor-memory-search.test.ts`
- `pnpm exec oxfmt --check src/commands/doctor-state-integrity.ts src/commands/doctor-state-integrity.test.ts`
- `pnpm exec oxlint src/commands/doctor-state-integrity.ts src/commands/doctor-state-integrity.test.ts`

Fixes #40584
