### PR TITLE
feat(feishu): add /focus support for ACP session binding

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuSubagentHooks } from "./src/subagent-hooks.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuSubagentHooks(api);
   },
 };
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -161,6 +161,17 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         chunkMode: { type: "string", enum: ["length", "newline"] },
         mediaMaxMb: { type: "number", minimum: 0 },
         renderMode: { type: "string", enum: ["auto", "raw", "card"] },
+        threadBindings: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            enabled: { type: "boolean" },
+            idleHours: { type: "number", minimum: 0 },
+            maxAgeHours: { type: "number", minimum: 0 },
+            spawnSubagentSessions: { type: "boolean" },
+            spawnAcpSessions: { type: "boolean" },
+          },
+        },
         accounts: {
           type: "object",
           additionalProperties: {
@@ -352,12 +363,40 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const { monitorFeishuProvider } = await import("./monitor.js");
+      const { createFeishuThreadBindingManager } = await import("./thread-bindings.js");
+      const {
+        resolveThreadBindingSpawnPolicy,
+        resolveThreadBindingIdleTimeoutMsForChannel,
+        resolveThreadBindingMaxAgeMsForChannel,
+      } = await import("openclaw/plugin-sdk/feishu");
       const account = resolveFeishuAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
       const port = account.config?.webhookPort ?? null;
       ctx.setStatus({ accountId: ctx.accountId, port });
       ctx.log?.info(
         `starting feishu[${ctx.accountId}] (mode: ${account.config?.connectionMode ?? "websocket"})`,
       );
+      // Initialize thread binding manager so /focus can bind sessions to Feishu conversations.
+      const threadBindingPolicy = resolveThreadBindingSpawnPolicy({
+        cfg: ctx.cfg,
+        channel: "feishu",
+        accountId: ctx.accountId,
+        kind: "subagent",
+      });
+      if (threadBindingPolicy.enabled) {
+        createFeishuThreadBindingManager({
+          accountId: ctx.accountId,
+          idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
+            cfg: ctx.cfg,
+            channel: "feishu",
+            accountId: ctx.accountId,
+          }),
+          maxAgeMs: resolveThreadBindingMaxAgeMsForChannel({
+            cfg: ctx.cfg,
+            channel: "feishu",
+            accountId: ctx.accountId,
+          }),
+        });
+      }
       return monitorFeishuProvider({
         config: ctx.cfg,
         runtime: ctx.runtime,

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -63,6 +63,20 @@ const ChannelHeartbeatVisibilitySchema = z
   .optional();
 
 /**
+ * Thread binding configuration for /focus and session binding features.
+ */
+const ThreadBindingsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    idleHours: z.number().nonnegative().optional(),
+    maxAgeHours: z.number().nonnegative().optional(),
+    spawnSubagentSessions: z.boolean().optional(),
+    spawnAcpSessions: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
  * Dynamic agent creation configuration.
  * When enabled, a new agent is created for each unique DM user.
  */
@@ -174,6 +188,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  threadBindings: ThreadBindingsSchema,
 };
 
 /**

--- a/extensions/feishu/src/subagent-hooks.ts
+++ b/extensions/feishu/src/subagent-hooks.ts
@@ -1,0 +1,106 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { resolveFeishuAccount } from "./accounts.js";
+import { getFeishuThreadBindingManager } from "./thread-bindings.js";
+
+export function registerFeishuSubagentHooks(api: OpenClawPluginApi) {
+  const resolveThreadBindingFlags = (accountId?: string) => {
+    const account = resolveFeishuAccount({
+      cfg: api.config,
+      accountId,
+    });
+    const baseThreadBindings = (api.config.channels?.feishu as Record<string, unknown> | undefined)
+      ?.threadBindings as Record<string, unknown> | undefined;
+    const accountConfig = (api.config.channels?.feishu as Record<string, unknown> | undefined)
+      ?.accounts as Record<string, Record<string, unknown> | undefined> | undefined;
+    const accountThreadBindings = accountConfig?.[account.accountId]?.threadBindings as
+      | Record<string, unknown>
+      | undefined;
+    return {
+      enabled:
+        (accountThreadBindings?.enabled as boolean | undefined) ??
+        (baseThreadBindings?.enabled as boolean | undefined) ??
+        (api.config.session?.threadBindings?.enabled as boolean | undefined) ??
+        true,
+      spawnSubagentSessions:
+        (accountThreadBindings?.spawnSubagentSessions as boolean | undefined) ??
+        (baseThreadBindings?.spawnSubagentSessions as boolean | undefined) ??
+        true,
+    };
+  };
+
+  api.on("subagent_spawning", async (event) => {
+    if (!event.threadRequested) {
+      return;
+    }
+    const channel = event.requester?.channel?.trim().toLowerCase();
+    if (channel !== "feishu") {
+      return;
+    }
+    const threadBindingFlags = resolveThreadBindingFlags(event.requester?.accountId);
+    if (!threadBindingFlags.enabled) {
+      return {
+        status: "error" as const,
+        error:
+          "Feishu thread bindings are disabled (set channels.feishu.threadBindings.enabled=true to override for this account, or session.threadBindings.enabled=true globally).",
+      };
+    }
+    if (!threadBindingFlags.spawnSubagentSessions) {
+      return {
+        status: "error" as const,
+        error:
+          "Feishu thread-bound subagent spawns are disabled for this account (set channels.feishu.threadBindings.spawnSubagentSessions=true to enable).",
+      };
+    }
+    // Feishu doesn't automatically create topic threads for subagent sessions
+    // like Discord does, so we only support "current" placement via /focus.
+    return;
+  });
+
+  api.on("subagent_ended", (event) => {
+    const manager = getFeishuThreadBindingManager(event.accountId);
+    if (!manager) {
+      return;
+    }
+    manager.unbindBySessionKey({
+      targetSessionKey: event.targetSessionKey,
+      reason: event.reason,
+      sendFarewell: false,
+    });
+  });
+
+  api.on("subagent_delivery_target", (event) => {
+    if (!event.expectsCompletionMessage) {
+      return;
+    }
+    const requesterChannel = event.requesterOrigin?.channel?.trim().toLowerCase();
+    if (requesterChannel !== "feishu") {
+      return;
+    }
+    const requesterAccountId = event.requesterOrigin?.accountId?.trim();
+    const manager = getFeishuThreadBindingManager(requesterAccountId);
+    if (!manager) {
+      return;
+    }
+    const bindings = manager.listBySessionKey(event.childSessionKey);
+    if (bindings.length === 0) {
+      return;
+    }
+
+    let binding: (typeof bindings)[number] | undefined;
+    if (bindings.length === 1) {
+      binding = bindings[0];
+    } else if (requesterAccountId) {
+      binding = bindings.find((entry) => entry.accountId === requesterAccountId);
+    }
+    if (!binding) {
+      return;
+    }
+    return {
+      origin: {
+        channel: "feishu",
+        accountId: binding.accountId,
+        to: binding.conversationId,
+      },
+    };
+  });
+}

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -1,0 +1,625 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type BindingTargetKind,
+  type SessionBindingRecord,
+  resolveStateDir,
+  logVerbose,
+  writeJsonFileAtomically,
+  resolveThreadBindingConversationIdFromBindingId,
+  formatThreadBindingDurationLabel,
+} from "openclaw/plugin-sdk/feishu";
+
+const DEFAULT_THREAD_BINDING_IDLE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_THREAD_BINDING_MAX_AGE_MS = 0;
+const THREAD_BINDINGS_SWEEP_INTERVAL_MS = 60_000;
+const STORE_VERSION = 1;
+
+type FeishuBindingTargetKind = "subagent" | "acp";
+
+export type FeishuThreadBindingRecord = {
+  accountId: string;
+  conversationId: string;
+  targetKind: FeishuBindingTargetKind;
+  targetSessionKey: string;
+  agentId?: string;
+  label?: string;
+  boundBy?: string;
+  boundAt: number;
+  lastActivityAt: number;
+  idleTimeoutMs?: number;
+  maxAgeMs?: number;
+};
+
+type StoredFeishuBindingState = {
+  version: number;
+  bindings: FeishuThreadBindingRecord[];
+};
+
+export type FeishuThreadBindingManager = {
+  accountId: string;
+  shouldPersistMutations: () => boolean;
+  getIdleTimeoutMs: () => number;
+  getMaxAgeMs: () => number;
+  getByConversationId: (conversationId: string) => FeishuThreadBindingRecord | undefined;
+  listBySessionKey: (targetSessionKey: string) => FeishuThreadBindingRecord[];
+  listBindings: () => FeishuThreadBindingRecord[];
+  touchConversation: (conversationId: string, at?: number) => FeishuThreadBindingRecord | null;
+  unbindConversation: (params: {
+    conversationId: string;
+    reason?: string;
+    sendFarewell?: boolean;
+  }) => FeishuThreadBindingRecord | null;
+  unbindBySessionKey: (params: {
+    targetSessionKey: string;
+    reason?: string;
+    sendFarewell?: boolean;
+  }) => FeishuThreadBindingRecord[];
+  stop: () => void;
+};
+
+const MANAGERS_BY_ACCOUNT_ID = new Map<string, FeishuThreadBindingManager>();
+const BINDINGS_BY_ACCOUNT_CONVERSATION = new Map<string, FeishuThreadBindingRecord>();
+
+function normalizeDurationMs(raw: unknown, fallback: number): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return fallback;
+  }
+  return Math.max(0, Math.floor(raw));
+}
+
+function normalizeConversationId(raw: unknown): string | undefined {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed || undefined;
+}
+
+function resolveBindingKey(params: { accountId: string; conversationId: string }): string {
+  return `${params.accountId}:${params.conversationId}`;
+}
+
+function toSessionBindingTargetKind(raw: FeishuBindingTargetKind): BindingTargetKind {
+  return raw === "subagent" ? "subagent" : "session";
+}
+
+function toFeishuTargetKind(raw: BindingTargetKind): FeishuBindingTargetKind {
+  return raw === "subagent" ? "subagent" : "acp";
+}
+
+function resolveEffectiveBindingExpiresAt(params: {
+  record: FeishuThreadBindingRecord;
+  defaultIdleTimeoutMs: number;
+  defaultMaxAgeMs: number;
+}): number | undefined {
+  const idleTimeoutMs =
+    typeof params.record.idleTimeoutMs === "number"
+      ? Math.max(0, Math.floor(params.record.idleTimeoutMs))
+      : params.defaultIdleTimeoutMs;
+  const maxAgeMs =
+    typeof params.record.maxAgeMs === "number"
+      ? Math.max(0, Math.floor(params.record.maxAgeMs))
+      : params.defaultMaxAgeMs;
+
+  const inactivityExpiresAt =
+    idleTimeoutMs > 0
+      ? Math.max(params.record.lastActivityAt, params.record.boundAt) + idleTimeoutMs
+      : undefined;
+  const maxAgeExpiresAt = maxAgeMs > 0 ? params.record.boundAt + maxAgeMs : undefined;
+
+  if (inactivityExpiresAt != null && maxAgeExpiresAt != null) {
+    return Math.min(inactivityExpiresAt, maxAgeExpiresAt);
+  }
+  return inactivityExpiresAt ?? maxAgeExpiresAt;
+}
+
+function toSessionBindingRecord(
+  record: FeishuThreadBindingRecord,
+  defaults: { idleTimeoutMs: number; maxAgeMs: number },
+): SessionBindingRecord {
+  return {
+    bindingId: resolveBindingKey({
+      accountId: record.accountId,
+      conversationId: record.conversationId,
+    }),
+    targetSessionKey: record.targetSessionKey,
+    targetKind: toSessionBindingTargetKind(record.targetKind),
+    conversation: {
+      channel: "feishu",
+      accountId: record.accountId,
+      conversationId: record.conversationId,
+    },
+    status: "active",
+    boundAt: record.boundAt,
+    expiresAt: resolveEffectiveBindingExpiresAt({
+      record,
+      defaultIdleTimeoutMs: defaults.idleTimeoutMs,
+      defaultMaxAgeMs: defaults.maxAgeMs,
+    }),
+    metadata: {
+      agentId: record.agentId,
+      label: record.label,
+      boundBy: record.boundBy,
+      lastActivityAt: record.lastActivityAt,
+      idleTimeoutMs:
+        typeof record.idleTimeoutMs === "number"
+          ? Math.max(0, Math.floor(record.idleTimeoutMs))
+          : defaults.idleTimeoutMs,
+      maxAgeMs:
+        typeof record.maxAgeMs === "number"
+          ? Math.max(0, Math.floor(record.maxAgeMs))
+          : defaults.maxAgeMs,
+    },
+  };
+}
+
+function fromSessionBindingInput(params: {
+  accountId: string;
+  input: {
+    targetSessionKey: string;
+    targetKind: BindingTargetKind;
+    conversationId: string;
+    metadata?: Record<string, unknown>;
+  };
+}): FeishuThreadBindingRecord {
+  const now = Date.now();
+  const metadata = params.input.metadata ?? {};
+  const existing = BINDINGS_BY_ACCOUNT_CONVERSATION.get(
+    resolveBindingKey({
+      accountId: params.accountId,
+      conversationId: params.input.conversationId,
+    }),
+  );
+
+  const record: FeishuThreadBindingRecord = {
+    accountId: params.accountId,
+    conversationId: params.input.conversationId,
+    targetKind: toFeishuTargetKind(params.input.targetKind),
+    targetSessionKey: params.input.targetSessionKey,
+    agentId:
+      typeof metadata.agentId === "string" && metadata.agentId.trim()
+        ? metadata.agentId.trim()
+        : existing?.agentId,
+    label:
+      typeof metadata.label === "string" && metadata.label.trim()
+        ? metadata.label.trim()
+        : existing?.label,
+    boundBy:
+      typeof metadata.boundBy === "string" && metadata.boundBy.trim()
+        ? metadata.boundBy.trim()
+        : existing?.boundBy,
+    boundAt: now,
+    lastActivityAt: now,
+  };
+
+  if (typeof metadata.idleTimeoutMs === "number" && Number.isFinite(metadata.idleTimeoutMs)) {
+    record.idleTimeoutMs = Math.max(0, Math.floor(metadata.idleTimeoutMs));
+  } else if (typeof existing?.idleTimeoutMs === "number") {
+    record.idleTimeoutMs = existing.idleTimeoutMs;
+  }
+
+  if (typeof metadata.maxAgeMs === "number" && Number.isFinite(metadata.maxAgeMs)) {
+    record.maxAgeMs = Math.max(0, Math.floor(metadata.maxAgeMs));
+  } else if (typeof existing?.maxAgeMs === "number") {
+    record.maxAgeMs = existing.maxAgeMs;
+  }
+
+  return record;
+}
+
+function resolveBindingsPath(accountId: string, env: NodeJS.ProcessEnv = process.env): string {
+  const stateDir = resolveStateDir(env, os.homedir);
+  return path.join(stateDir, "feishu", `thread-bindings-${accountId}.json`);
+}
+
+function summarizeLifecycleForLog(
+  record: FeishuThreadBindingRecord,
+  defaults: {
+    idleTimeoutMs: number;
+    maxAgeMs: number;
+  },
+) {
+  const idleTimeoutMs =
+    typeof record.idleTimeoutMs === "number" ? record.idleTimeoutMs : defaults.idleTimeoutMs;
+  const maxAgeMs = typeof record.maxAgeMs === "number" ? record.maxAgeMs : defaults.maxAgeMs;
+  const idleLabel = formatThreadBindingDurationLabel(Math.max(0, Math.floor(idleTimeoutMs)));
+  const maxAgeLabel = formatThreadBindingDurationLabel(Math.max(0, Math.floor(maxAgeMs)));
+  return `idle=${idleLabel} maxAge=${maxAgeLabel}`;
+}
+
+function loadBindingsFromDisk(accountId: string): FeishuThreadBindingRecord[] {
+  const filePath = resolveBindingsPath(accountId);
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as StoredFeishuBindingState;
+    if (parsed?.version !== STORE_VERSION || !Array.isArray(parsed.bindings)) {
+      return [];
+    }
+    const bindings: FeishuThreadBindingRecord[] = [];
+    for (const entry of parsed.bindings) {
+      const conversationId = normalizeConversationId(entry?.conversationId);
+      const targetSessionKey =
+        typeof entry?.targetSessionKey === "string" ? entry.targetSessionKey.trim() : "";
+      const targetKind = entry?.targetKind === "subagent" ? "subagent" : "acp";
+      if (!conversationId || !targetSessionKey) {
+        continue;
+      }
+      const boundAt =
+        typeof entry?.boundAt === "number" && Number.isFinite(entry.boundAt)
+          ? Math.floor(entry.boundAt)
+          : Date.now();
+      const lastActivityAt =
+        typeof entry?.lastActivityAt === "number" && Number.isFinite(entry.lastActivityAt)
+          ? Math.floor(entry.lastActivityAt)
+          : boundAt;
+      const record: FeishuThreadBindingRecord = {
+        accountId,
+        conversationId,
+        targetSessionKey,
+        targetKind,
+        boundAt,
+        lastActivityAt,
+      };
+      if (typeof entry?.idleTimeoutMs === "number" && Number.isFinite(entry.idleTimeoutMs)) {
+        record.idleTimeoutMs = Math.max(0, Math.floor(entry.idleTimeoutMs));
+      }
+      if (typeof entry?.maxAgeMs === "number" && Number.isFinite(entry.maxAgeMs)) {
+        record.maxAgeMs = Math.max(0, Math.floor(entry.maxAgeMs));
+      }
+      if (typeof entry?.agentId === "string" && entry.agentId.trim()) {
+        record.agentId = entry.agentId.trim();
+      }
+      if (typeof entry?.label === "string" && entry.label.trim()) {
+        record.label = entry.label.trim();
+      }
+      if (typeof entry?.boundBy === "string" && entry.boundBy.trim()) {
+        record.boundBy = entry.boundBy.trim();
+      }
+      bindings.push(record);
+    }
+    return bindings;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code !== "ENOENT") {
+      logVerbose(`feishu thread bindings load failed (${accountId}): ${String(err)}`);
+    }
+    return [];
+  }
+}
+
+async function persistBindingsToDisk(params: {
+  accountId: string;
+  persist: boolean;
+}): Promise<void> {
+  if (!params.persist) {
+    return;
+  }
+  const bindings = [...BINDINGS_BY_ACCOUNT_CONVERSATION.values()].filter(
+    (entry) => entry.accountId === params.accountId,
+  );
+  const payload: StoredFeishuBindingState = {
+    version: STORE_VERSION,
+    bindings,
+  };
+  await writeJsonFileAtomically(resolveBindingsPath(params.accountId), payload);
+}
+
+function normalizeTimestampMs(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return Date.now();
+  }
+  return Math.max(0, Math.floor(raw));
+}
+
+function shouldExpireByIdle(params: {
+  now: number;
+  record: FeishuThreadBindingRecord;
+  defaultIdleTimeoutMs: number;
+}): boolean {
+  const idleTimeoutMs =
+    typeof params.record.idleTimeoutMs === "number"
+      ? Math.max(0, Math.floor(params.record.idleTimeoutMs))
+      : params.defaultIdleTimeoutMs;
+  if (idleTimeoutMs <= 0) {
+    return false;
+  }
+  return (
+    params.now >= Math.max(params.record.lastActivityAt, params.record.boundAt) + idleTimeoutMs
+  );
+}
+
+function shouldExpireByMaxAge(params: {
+  now: number;
+  record: FeishuThreadBindingRecord;
+  defaultMaxAgeMs: number;
+}): boolean {
+  const maxAgeMs =
+    typeof params.record.maxAgeMs === "number"
+      ? Math.max(0, Math.floor(params.record.maxAgeMs))
+      : params.defaultMaxAgeMs;
+  if (maxAgeMs <= 0) {
+    return false;
+  }
+  return params.now >= params.record.boundAt + maxAgeMs;
+}
+
+export function createFeishuThreadBindingManager(
+  params: {
+    accountId?: string;
+    persist?: boolean;
+    idleTimeoutMs?: number;
+    maxAgeMs?: number;
+    enableSweeper?: boolean;
+  } = {},
+): FeishuThreadBindingManager {
+  const accountId = normalizeAccountId(params.accountId);
+  const existing = MANAGERS_BY_ACCOUNT_ID.get(accountId);
+  if (existing) {
+    return existing;
+  }
+
+  const persist = params.persist ?? true;
+  const idleTimeoutMs = normalizeDurationMs(
+    params.idleTimeoutMs,
+    DEFAULT_THREAD_BINDING_IDLE_TIMEOUT_MS,
+  );
+  const maxAgeMs = normalizeDurationMs(params.maxAgeMs, DEFAULT_THREAD_BINDING_MAX_AGE_MS);
+
+  const loaded = loadBindingsFromDisk(accountId);
+  for (const entry of loaded) {
+    const key = resolveBindingKey({
+      accountId,
+      conversationId: entry.conversationId,
+    });
+    BINDINGS_BY_ACCOUNT_CONVERSATION.set(key, {
+      ...entry,
+      accountId,
+    });
+  }
+
+  const listBindingsForAccount = () =>
+    [...BINDINGS_BY_ACCOUNT_CONVERSATION.values()].filter((entry) => entry.accountId === accountId);
+
+  let sweepTimer: NodeJS.Timeout | null = null;
+
+  const manager: FeishuThreadBindingManager = {
+    accountId,
+    shouldPersistMutations: () => persist,
+    getIdleTimeoutMs: () => idleTimeoutMs,
+    getMaxAgeMs: () => maxAgeMs,
+    getByConversationId: (conversationIdRaw) => {
+      const conversationId = normalizeConversationId(conversationIdRaw);
+      if (!conversationId) {
+        return undefined;
+      }
+      return BINDINGS_BY_ACCOUNT_CONVERSATION.get(
+        resolveBindingKey({
+          accountId,
+          conversationId,
+        }),
+      );
+    },
+    listBySessionKey: (targetSessionKeyRaw) => {
+      const targetSessionKey = targetSessionKeyRaw.trim();
+      if (!targetSessionKey) {
+        return [];
+      }
+      return listBindingsForAccount().filter(
+        (entry) => entry.targetSessionKey === targetSessionKey,
+      );
+    },
+    listBindings: () => listBindingsForAccount(),
+    touchConversation: (conversationIdRaw, at) => {
+      const conversationId = normalizeConversationId(conversationIdRaw);
+      if (!conversationId) {
+        return null;
+      }
+      const key = resolveBindingKey({ accountId, conversationId });
+      const existing = BINDINGS_BY_ACCOUNT_CONVERSATION.get(key);
+      if (!existing) {
+        return null;
+      }
+      const nextRecord: FeishuThreadBindingRecord = {
+        ...existing,
+        lastActivityAt: normalizeTimestampMs(at ?? Date.now()),
+      };
+      BINDINGS_BY_ACCOUNT_CONVERSATION.set(key, nextRecord);
+      void persistBindingsToDisk({ accountId, persist: manager.shouldPersistMutations() });
+      return nextRecord;
+    },
+    unbindConversation: (unbindParams) => {
+      const conversationId = normalizeConversationId(unbindParams.conversationId);
+      if (!conversationId) {
+        return null;
+      }
+      const key = resolveBindingKey({ accountId, conversationId });
+      const removed = BINDINGS_BY_ACCOUNT_CONVERSATION.get(key) ?? null;
+      if (!removed) {
+        return null;
+      }
+      BINDINGS_BY_ACCOUNT_CONVERSATION.delete(key);
+      void persistBindingsToDisk({ accountId, persist: manager.shouldPersistMutations() });
+      return removed;
+    },
+    unbindBySessionKey: (unbindParams) => {
+      const targetSessionKey = unbindParams.targetSessionKey.trim();
+      if (!targetSessionKey) {
+        return [];
+      }
+      const removed: FeishuThreadBindingRecord[] = [];
+      for (const entry of listBindingsForAccount()) {
+        if (entry.targetSessionKey !== targetSessionKey) {
+          continue;
+        }
+        const key = resolveBindingKey({
+          accountId,
+          conversationId: entry.conversationId,
+        });
+        BINDINGS_BY_ACCOUNT_CONVERSATION.delete(key);
+        removed.push(entry);
+      }
+      if (removed.length > 0) {
+        void persistBindingsToDisk({ accountId, persist: manager.shouldPersistMutations() });
+      }
+      return removed;
+    },
+    stop: () => {
+      if (sweepTimer) {
+        clearInterval(sweepTimer);
+        sweepTimer = null;
+      }
+      unregisterSessionBindingAdapter({ channel: "feishu", accountId });
+      const existingManager = MANAGERS_BY_ACCOUNT_ID.get(accountId);
+      if (existingManager === manager) {
+        MANAGERS_BY_ACCOUNT_ID.delete(accountId);
+      }
+    },
+  };
+
+  registerSessionBindingAdapter({
+    channel: "feishu",
+    accountId,
+    capabilities: {
+      placements: ["current"],
+    },
+    bind: async (input) => {
+      if (input.conversation.channel !== "feishu") {
+        return null;
+      }
+      if (input.placement === "child") {
+        return null;
+      }
+      const conversationId = normalizeConversationId(input.conversation.conversationId);
+      const targetSessionKey = input.targetSessionKey.trim();
+      if (!conversationId || !targetSessionKey) {
+        return null;
+      }
+      const record = fromSessionBindingInput({
+        accountId,
+        input: {
+          targetSessionKey,
+          targetKind: input.targetKind,
+          conversationId,
+          metadata: input.metadata,
+        },
+      });
+      BINDINGS_BY_ACCOUNT_CONVERSATION.set(
+        resolveBindingKey({ accountId, conversationId }),
+        record,
+      );
+      void persistBindingsToDisk({ accountId, persist: manager.shouldPersistMutations() });
+      logVerbose(
+        `feishu: bound conversation ${conversationId} -> ${targetSessionKey} (${summarizeLifecycleForLog(
+          record,
+          { idleTimeoutMs, maxAgeMs },
+        )})`,
+      );
+      return toSessionBindingRecord(record, { idleTimeoutMs, maxAgeMs });
+    },
+    listBySession: (targetSessionKeyRaw) => {
+      const targetSessionKey = targetSessionKeyRaw.trim();
+      if (!targetSessionKey) {
+        return [];
+      }
+      return manager
+        .listBySessionKey(targetSessionKey)
+        .map((entry) => toSessionBindingRecord(entry, { idleTimeoutMs, maxAgeMs }));
+    },
+    resolveByConversation: (ref) => {
+      if (ref.channel !== "feishu") {
+        return null;
+      }
+      const conversationId = normalizeConversationId(ref.conversationId);
+      if (!conversationId) {
+        return null;
+      }
+      const record = manager.getByConversationId(conversationId);
+      return record ? toSessionBindingRecord(record, { idleTimeoutMs, maxAgeMs }) : null;
+    },
+    touch: (bindingId, at) => {
+      const conversationId = resolveThreadBindingConversationIdFromBindingId({
+        accountId,
+        bindingId,
+      });
+      if (!conversationId) {
+        return;
+      }
+      manager.touchConversation(conversationId, at);
+    },
+    unbind: async (input) => {
+      if (input.targetSessionKey?.trim()) {
+        const removed = manager.unbindBySessionKey({
+          targetSessionKey: input.targetSessionKey,
+          reason: input.reason,
+          sendFarewell: false,
+        });
+        return removed.map((entry) => toSessionBindingRecord(entry, { idleTimeoutMs, maxAgeMs }));
+      }
+      const conversationId = resolveThreadBindingConversationIdFromBindingId({
+        accountId,
+        bindingId: input.bindingId,
+      });
+      if (!conversationId) {
+        return [];
+      }
+      const removed = manager.unbindConversation({
+        conversationId,
+        reason: input.reason,
+        sendFarewell: false,
+      });
+      return removed ? [toSessionBindingRecord(removed, { idleTimeoutMs, maxAgeMs })] : [];
+    },
+  });
+
+  const sweeperEnabled = params.enableSweeper !== false;
+  if (sweeperEnabled) {
+    sweepTimer = setInterval(() => {
+      const now = Date.now();
+      for (const record of listBindingsForAccount()) {
+        const idleExpired = shouldExpireByIdle({
+          now,
+          record,
+          defaultIdleTimeoutMs: idleTimeoutMs,
+        });
+        const maxAgeExpired = shouldExpireByMaxAge({
+          now,
+          record,
+          defaultMaxAgeMs: maxAgeMs,
+        });
+        if (!idleExpired && !maxAgeExpired) {
+          continue;
+        }
+        manager.unbindConversation({
+          conversationId: record.conversationId,
+          reason: idleExpired ? "idle-expired" : "max-age-expired",
+          sendFarewell: false,
+        });
+      }
+    }, THREAD_BINDINGS_SWEEP_INTERVAL_MS);
+    sweepTimer.unref?.();
+  }
+
+  MANAGERS_BY_ACCOUNT_ID.set(accountId, manager);
+  return manager;
+}
+
+export function getFeishuThreadBindingManager(
+  accountId?: string,
+): FeishuThreadBindingManager | null {
+  return MANAGERS_BY_ACCOUNT_ID.get(normalizeAccountId(accountId)) ?? null;
+}
+
+export const __testing = {
+  resetFeishuThreadBindingsForTests() {
+    for (const manager of MANAGERS_BY_ACCOUNT_ID.values()) {
+      manager.stop();
+    }
+    MANAGERS_BY_ACCOUNT_ID.clear();
+    BINDINGS_BY_ACCOUNT_CONVERSATION.clear();
+  },
+};

--- a/src/auto-reply/reply/channel-context.ts
+++ b/src/auto-reply/reply/channel-context.ts
@@ -24,6 +24,10 @@ export function isTelegramSurface(params: DiscordSurfaceParams): boolean {
   return resolveCommandSurfaceChannel(params) === "telegram";
 }
 
+export function isFeishuSurface(params: DiscordSurfaceParams): boolean {
+  return resolveCommandSurfaceChannel(params) === "feishu";
+}
+
 export function resolveCommandSurfaceChannel(params: DiscordSurfaceParams): string {
   const channel =
     params.ctx.OriginatingChannel ??

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -16,17 +16,19 @@ import type { CommandHandlerResult } from "../commands-types.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveChannelAccountId,
   resolveCommandSurfaceChannel,
   resolveDiscordChannelIdForFocus,
+  resolveFeishuConversationId,
   resolveFocusTargetSession,
   resolveTelegramConversationId,
   stopWithText,
 } from "./shared.js";
 
 type FocusBindingContext = {
-  channel: "discord" | "telegram";
+  channel: "discord" | "telegram" | "feishu";
   accountId: string;
   conversationId: string;
   placement: "current" | "child";
@@ -65,6 +67,19 @@ function resolveFocusBindingContext(
       labelNoun: "conversation",
     };
   }
+  if (isFeishuSurface(params)) {
+    const conversationId = resolveFeishuConversationId(params);
+    if (!conversationId) {
+      return null;
+    }
+    return {
+      channel: "feishu",
+      accountId: resolveChannelAccountId(params),
+      conversationId,
+      placement: "current",
+      labelNoun: "conversation",
+    };
+  }
   return null;
 }
 
@@ -73,8 +88,8 @@ export async function handleSubagentsFocusAction(
 ): Promise<CommandHandlerResult> {
   const { params, runs, restTokens } = ctx;
   const channel = resolveCommandSurfaceChannel(params);
-  if (channel !== "discord" && channel !== "telegram") {
-    return stopWithText("⚠️ /focus is only available on Discord and Telegram.");
+  if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    return stopWithText("⚠️ /focus is only available on Discord, Telegram, and Feishu.");
   }
 
   const token = restTokens.join(" ").trim();
@@ -89,7 +104,12 @@ export async function handleSubagentsFocusAction(
     accountId,
   });
   if (!capabilities.adapterAvailable || !capabilities.bindSupported) {
-    const label = channel === "discord" ? "Discord thread" : "Telegram conversation";
+    const label =
+      channel === "discord"
+        ? "Discord thread"
+        : channel === "feishu"
+          ? "Feishu conversation"
+          : "Telegram conversation";
     return stopWithText(`⚠️ ${label} bindings are unavailable for this account.`);
   }
 
@@ -103,6 +123,11 @@ export async function handleSubagentsFocusAction(
     if (channel === "telegram") {
       return stopWithText(
         "⚠️ /focus on Telegram requires a topic context in groups, or a direct-message conversation.",
+      );
+    }
+    if (channel === "feishu") {
+      return stopWithText(
+        "⚠️ /focus on Feishu requires a topic thread in groups, or a direct-message conversation.",
       );
     }
     return stopWithText("⚠️ Could not resolve a Discord channel for /focus.");

--- a/src/auto-reply/reply/commands-subagents/action-unfocus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-unfocus.ts
@@ -3,9 +3,11 @@ import type { CommandHandlerResult } from "../commands-types.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveChannelAccountId,
   resolveCommandSurfaceChannel,
+  resolveFeishuConversationId,
   resolveTelegramConversationId,
   stopWithText,
 } from "./shared.js";
@@ -15,8 +17,8 @@ export async function handleSubagentsUnfocusAction(
 ): Promise<CommandHandlerResult> {
   const { params } = ctx;
   const channel = resolveCommandSurfaceChannel(params);
-  if (channel !== "discord" && channel !== "telegram") {
-    return stopWithText("⚠️ /unfocus is only available on Discord and Telegram.");
+  if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    return stopWithText("⚠️ /unfocus is only available on Discord, Telegram, and Feishu.");
   }
 
   const accountId = resolveChannelAccountId(params);
@@ -30,12 +32,20 @@ export async function handleSubagentsUnfocusAction(
     if (isTelegramSurface(params)) {
       return resolveTelegramConversationId(params);
     }
+    if (isFeishuSurface(params)) {
+      return resolveFeishuConversationId(params);
+    }
     return undefined;
   })();
 
   if (!conversationId) {
     if (channel === "discord") {
       return stopWithText("⚠️ /unfocus must be run inside a Discord thread.");
+    }
+    if (channel === "feishu") {
+      return stopWithText(
+        "⚠️ /unfocus on Feishu requires a topic thread in groups, or a direct-message conversation.",
+      );
     }
     return stopWithText(
       "⚠️ /unfocus on Telegram requires a topic context in groups, or a direct-message conversation.",

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -27,12 +27,14 @@ import {
 } from "../../../shared/subagents-format.js";
 import {
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveCommandSurfaceChannel,
   resolveDiscordAccountId,
   resolveChannelAccountId,
 } from "../channel-context.js";
 import type { CommandHandler, CommandHandlerResult } from "../commands-types.js";
+import { resolveFeishuConversationId } from "../feishu-context.js";
 import {
   formatRunLabel,
   formatRunStatus,
@@ -44,10 +46,12 @@ import { resolveTelegramConversationId } from "../telegram-context.js";
 export { extractAssistantText, stripToolMessages };
 export {
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveCommandSurfaceChannel,
   resolveDiscordAccountId,
   resolveChannelAccountId,
+  resolveFeishuConversationId,
   resolveTelegramConversationId,
 };
 

--- a/src/auto-reply/reply/feishu-context.ts
+++ b/src/auto-reply/reply/feishu-context.ts
@@ -1,0 +1,54 @@
+type FeishuConversationParams = {
+  ctx: {
+    MessageThreadId?: string | number | null;
+    OriginatingTo?: string;
+    To?: string;
+  };
+  command: {
+    to?: string;
+  };
+};
+
+function normalizeFeishuTarget(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const lowered = trimmed.toLowerCase();
+  // Strip common Feishu target prefixes to get the raw ID.
+  for (const prefix of ["chat:", "group:", "channel:", "user:", "dm:", "open_id:"]) {
+    if (lowered.startsWith(prefix)) {
+      const id = trimmed.slice(prefix.length).trim();
+      return id || null;
+    }
+  }
+  return trimmed;
+}
+
+export function resolveFeishuConversationId(params: FeishuConversationParams): string | undefined {
+  const rawThreadId =
+    params.ctx.MessageThreadId != null ? String(params.ctx.MessageThreadId).trim() : "";
+  const threadId = rawThreadId || undefined;
+  const toCandidates = [
+    typeof params.ctx.OriginatingTo === "string" ? params.ctx.OriginatingTo : "",
+    typeof params.command.to === "string" ? params.command.to : "",
+    typeof params.ctx.To === "string" ? params.ctx.To : "",
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const chatId = toCandidates
+    .map((candidate) => normalizeFeishuTarget(candidate))
+    .find((candidate) => candidate != null && candidate.length > 0);
+  if (!chatId) {
+    return undefined;
+  }
+  if (threadId) {
+    return `${chatId}:topic:${threadId}`;
+  }
+  // Group chats (oc_ prefix) without a topic should not become globally focused.
+  if (chatId.startsWith("oc_")) {
+    return undefined;
+  }
+  // DM conversations (ou_ prefix or other IDs) are allowed.
+  return chatId;
+}

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -80,3 +80,23 @@ export {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "./webhook-memory-guards.js";
 export { applyBasicWebhookRequestGuards } from "./webhook-request-guards.js";
+
+// Thread bindings / session binding adapter support (used by extensions/feishu thread-bindings)
+export {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type BindingTargetKind,
+  type SessionBindingRecord,
+  type SessionBindingBindInput,
+  type SessionBindingUnbindInput,
+} from "../infra/outbound/session-binding-service.js";
+export { resolveStateDir } from "../config/paths.js";
+export { logVerbose } from "../globals.js";
+export { writeJsonFileAtomically } from "./json-store.js";
+export { resolveThreadBindingConversationIdFromBindingId } from "../channels/thread-binding-id.js";
+export { formatThreadBindingDurationLabel } from "../channels/thread-bindings-messages.js";
+export {
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+  resolveThreadBindingSpawnPolicy,
+} from "../channels/thread-bindings-policy.js";


### PR DESCRIPTION
## Summary

- Add `/focus` and `/unfocus` command support for Feishu, enabling ACP session binding to Feishu conversations (DMs and group topic threads).
- Implement `SessionBindingAdapter` for Feishu with full binding lifecycle (bind, unbind, touch, resolve, sweep), disk persistence, and idle/max-age expiration.
- Register subagent hooks (`subagent_spawning`, `subagent_ended`, `subagent_delivery_target`) for Feishu thread binding management.
- Add `threadBindings` configuration schema to Feishu channel config.

## Details

Previously `/focus` was hardcoded to only support Discord and Telegram. This PR:

1. **`extensions/feishu/src/thread-bindings.ts`** (new): Full `SessionBindingAdapter` implementation following the Telegram pattern — per-account binding manager with disk persistence under `state/feishu-thread-bindings-{accountId}.json`, idle/max-age sweeper, and conversation ID resolution.

2. **`extensions/feishu/src/subagent-hooks.ts`** (new): Subagent lifecycle hooks — gates spawning on config flags, cleans up bindings on session end, routes delivery targets to bound Feishu conversations.

3. **`src/auto-reply/reply/feishu-context.ts`** (new): `resolveFeishuConversationId()` — extracts conversation ID from Feishu message context. Group topics become `chatId:topic:threadId`, DMs (`ou_` prefix) return the ID directly, group chats without topics (`oc_` prefix) return `undefined` (not focusable).

4. **`src/plugin-sdk/feishu.ts`**: Added exports needed by the extension (`registerSessionBindingAdapter`, `resolveStateDir`, `logVerbose`, `writeJsonFileAtomically`, thread binding policy/ID/message helpers).

5. **`src/auto-reply/reply/commands-subagents/action-focus.ts`**: Extended channel check to include `"feishu"`, added Feishu case to `resolveFocusBindingContext()`.

6. **`src/auto-reply/reply/commands-subagents/action-unfocus.ts`**: Extended channel check to include `"feishu"`, added Feishu conversation ID resolution.

7. **`extensions/feishu/src/channel.ts`**: Gateway `startAccount` now initializes thread binding manager when enabled. Added `threadBindings` to JSON config schema.

8. **`extensions/feishu/index.ts`**: Registered subagent hooks via `registerFeishuSubagentHooks(api)`.

## Test plan

- [x] `pnpm build` compiles successfully
- [x] `pnpm test` — 872/872 test files pass
- [x] `pnpm check` (lint) — clean
- [x] `pnpm tsgo` (typecheck) — clean
- [x] `pnpm format` — clean
- [ ] Manual test: `/focus` in a Feishu DM binds ACP session to that conversation
- [ ] Manual test: `/focus` in a Feishu group topic thread binds ACP session
- [ ] Manual test: `/focus` in a group chat without topic returns appropriate error
- [ ] Manual test: `/unfocus` removes the binding
- [ ] Manual test: idle/max-age expiration sweeps bindings correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)