### PR TITLE
fix(web-search): respect baseUrl config for Perplexity Search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ Docs: https://docs.openclaw.ai
 - Android/chat: theme the thinking dropdown and TLS trust dialogs explicitly so popup surfaces match the active app theme instead of falling back to mismatched Material defaults.
 - Group mention gating: reject invalid and unsafe nested-repetition `mentionPatterns`, reuse the shared safe config-regex compiler across mention stripping and detection, and cache strip-time regex compilation so noisy groups avoid repeated recompiles.
 - Browser/profiles: drop the auto-created `chrome-relay` browser profile; users who need the Chrome extension relay must now create their own profile via `openclaw browser create-profile`. (#46596) Fixes #45777. Thanks @odysseus0.
+- Configure/startup: move outbound send-deps resolution into a lightweight helper so `openclaw configure` no longer stalls after the banner while eagerly loading channel plugins. (#46301) thanks @scoootscooob.
+- **Web Search**: respect `tools.web.search.perplexity.baseUrl` config for Perplexity Search API, fixing 401 errors for OpenRouter proxy users. (#40867)
+
+### Fixes
+
+- Slack/interactive replies: preserve `channelData.slack.blocks` through live DM delivery and preview-finalized edits so Block Kit button and select directives render instead of falling back to raw text. Thanks @vincentkoc.
 - CI/channel test routing: move the built-in channel suites into `test:channels` and keep them out of `test:extensions`, so extension CI no longer fails after the channel migration while targeted test routing still sends Slack, Signal, and iMessage suites to the right lane. (#46066) Thanks @scoootscooob.
 - Docs/Mintlify: fix MDX marker syntax on Perplexity, Model Providers, Moonshot, and exec approvals pages so local docs preview no longer breaks rendering or leaves stale pages unpublished. (#46695) Thanks @velvet-shark.
 - Gateway/config validation: stop treating the implicit default memory slot as a required explicit plugin config, so startup no longer fails with `plugins.slots.memory: plugin not found: memory-core` when `memory-core` was only inferred. (#47494) Thanks @ngutman.


### PR DESCRIPTION
## Summary

- **Problem**: Since v2026.3.7, `tools.web.search.perplexity.baseUrl` configuration was silently ignored
- **Impact**: OpenRouter proxy users received 401 errors because requests always went to `api.perplexity.ai`
- **Fix**: Add `baseUrl` parameter to `runPerplexitySearchApi` and use configured endpoint

## Root Cause

In v2026.3.7, the implementation was refactored to use Perplexity's native `/search` API with a hardcoded endpoint:

```javascript
const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
// ...
url: PERPLEXITY_SEARCH_ENDPOINT, // baseUrl from config was never used
```

This ignored the `baseUrl` configuration, breaking OpenRouter proxy support.

## Change Type

- [x] Bug fix

## Linked Issue

Fixes #40822

## Test

- All 43 tests in `web-tools.enabled-defaults.test.ts` passing
- No new tests needed (existing tests cover the functionality)

## Verification

```bash
pnpm exec vitest run src/agents/tools/web-tools.enabled-defaults.test.ts
# ✓ src/agents/tools/web-tools.enabled-defaults.test.ts (43 tests) 290ms
# Test Files  1 passed
# Tests       43 passed
```

## Changes

1. Added `baseUrl` parameter to `runPerplexitySearchApi` function
2. Use configured `baseUrl` instead of hardcoded `PERPLEXITY_SEARCH_ENDPOINT`
3. Fallback to `PERPLEXITY_DIRECT_BASE_URL` when no baseUrl is configured