### PR TITLE
fix(tui): strip tagged thinking from string content

### DIFF
--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -90,3 +90,33 @@ export function stripReasoningTagsFromText(
 
   return applyTrim(result, trimMode);
 }
+
+export function extractReasoningTagsFromText(text: string): string {
+  if (!text || !QUICK_TAG_RE.test(text)) {
+    return "";
+  }
+
+  const codeRegions = findCodeRegions(text);
+  THINKING_TAG_RE.lastIndex = 0;
+  let result = "";
+  let lastIndex = 0;
+  let inThinking = false;
+
+  for (const match of text.matchAll(THINKING_TAG_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+    if (inThinking) {
+      result += text.slice(lastIndex, idx);
+    }
+    inThinking = match[1] !== "/";
+    lastIndex = idx + match[0].length;
+  }
+
+  if (inThinking) {
+    result += text.slice(lastIndex);
+  }
+
+  return applyTrim(result, "both");
+}

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -78,6 +78,27 @@ describe("extractTextFromMessage", () => {
     expect(text).toBe("[thinking]\nponder\n\nhello");
   });
 
+  it("hides tagged reasoning in string content when thinking is disabled", () => {
+    const text = extractTextFromMessage({
+      role: "assistant",
+      content: "<think>hidden chain of thought</think>Visible answer",
+    });
+
+    expect(text).toBe("Visible answer");
+  });
+
+  it("surfaces tagged reasoning separately from string content when thinking is enabled", () => {
+    const text = extractTextFromMessage(
+      {
+        role: "assistant",
+        content: "<think>hidden chain of thought</think>Visible answer",
+      },
+      { includeThinking: true },
+    );
+
+    expect(text).toBe("[thinking]\nhidden chain of thought\n\nVisible answer");
+  });
+
   it("sanitizes ANSI and control chars from string content", () => {
     const text = extractTextFromMessage({
       role: "assistant",
@@ -178,6 +199,15 @@ describe("extractThinkingFromMessage", () => {
 
     expect(text).toBe("alpha\nbeta");
   });
+
+  it("collects tagged reasoning from string content", () => {
+    const text = extractThinkingFromMessage({
+      role: "assistant",
+      content: "<think>alpha</think>Visible answer",
+    });
+
+    expect(text).toBe("alpha");
+  });
 });
 
 describe("extractContentFromMessage", () => {
@@ -191,6 +221,15 @@ describe("extractContentFromMessage", () => {
     });
 
     expect(text).toBe("hello");
+  });
+
+  it("strips tagged reasoning from string content", () => {
+    const text = extractContentFromMessage({
+      role: "assistant",
+      content: "<think>alpha</think>Visible answer",
+    });
+
+    expect(text).toBe("Visible answer");
   });
 
   it("renders error text when stopReason is error and content is not an array", () => {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,5 +1,9 @@
 import { formatRawAssistantErrorForUi } from "../agents/pi-embedded-helpers.js";
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import {
+  extractReasoningTagsFromText,
+  stripReasoningTagsFromText,
+} from "../shared/text/reasoning-tags.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
@@ -239,6 +243,18 @@ function collectSanitizedBlockStrings(params: {
   return parts;
 }
 
+function resolveTaggedStringContentParts(content: string): {
+  thinkingText: string;
+  contentText: string;
+} {
+  return {
+    thinkingText: sanitizeRenderableText(extractReasoningTagsFromText(content)).trim(),
+    contentText: sanitizeRenderableText(
+      stripReasoningTagsFromText(content, { mode: "strict", trim: "both" }),
+    ).trim(),
+  };
+}
+
 /**
  * Extract ONLY thinking blocks from message content.
  * Model-agnostic: returns empty string if no thinking blocks exist.
@@ -250,7 +266,7 @@ export function extractThinkingFromMessage(message: unknown): string {
   }
   const { content } = resolved;
   if (typeof content === "string") {
-    return "";
+    return resolveTaggedStringContentParts(content).thinkingText;
   }
   const parts = collectSanitizedBlockStrings({
     content,
@@ -272,7 +288,7 @@ export function extractContentFromMessage(message: unknown): string {
   const { record, content } = resolved;
 
   if (typeof content === "string") {
-    return sanitizeRenderableText(content).trim();
+    return resolveTaggedStringContentParts(content).contentText;
   }
 
   const parts = collectSanitizedBlockStrings({
@@ -288,7 +304,12 @@ export function extractContentFromMessage(message: unknown): string {
 
 function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean }): string {
   if (typeof content === "string") {
-    return sanitizeRenderableText(content).trim();
+    const parts = resolveTaggedStringContentParts(content);
+    return composeThinkingAndContent({
+      thinkingText: opts?.includeThinking ? parts.thinkingText : "",
+      contentText: parts.contentText,
+      showThinking: opts?.includeThinking ?? false,
+    });
   }
   if (!Array.isArray(content)) {
     return "";


### PR DESCRIPTION
Fixes #40736

## Summary

- strip inline `<think>...</think>` reasoning tags from TUI string content when thinking display is off
- surface tagged reasoning separately in TUI when thinking display is on
- add regression coverage for tagged-string assistant payloads in `tui-formatters`

## Root cause

TUI already handled structured reasoning blocks when assistant messages arrived as `content: [{ type: "thinking" }, { type: "text" }]`.

But some providers send reasoning inline inside plain string content using `<think>...</think>` tags. In that path, `extractContentFromMessage()` treated the whole string as visible text, so the raw reasoning leaked into the TUI even when `showThinking` was disabled.

## Testing

- `PATH=/opt/homebrew/opt/node@23/bin:$PATH pnpm --dir /Users/zhangxuanyang/Desktop/DDDDAO/openclaw/worktrees/fix-tui-thinking-tag-leak exec vitest run src/tui/tui-formatters.test.ts src/tui/tui-stream-assembler.test.ts src/shared/text/reasoning-tags.test.ts`
