### PR TITLE
fix: avoid blank-secret raw redaction expansion in config.get

### DIFF
--- a/src/config/redact-snapshot.raw.test.ts
+++ b/src/config/redact-snapshot.raw.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { replaceSensitiveValuesInRaw } from "./redact-snapshot.raw.js";
+
+describe("replaceSensitiveValuesInRaw", () => {
+  it("ignores blank sensitive values while redacting non-empty secrets", () => {
+    const result = replaceSensitiveValuesInRaw({
+      raw: '{"token":"","password":"top-secret"}',
+      sensitiveValues: ["", "top-secret"],
+      redactedSentinel: "__OPENCLAW_REDACTED__",
+    });
+
+    expect(result).toBe('{"token":"","password":"__OPENCLAW_REDACTED__"}');
+  });
+});

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,10 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  // Skip blank entries: replaceAll("", sentinel) expands every string boundary.
+  const values = [...new Set(params.sensitiveValues.filter((value) => value.length > 0))].toSorted(
+    (a, b) => b.length - a.length,
+  );
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -255,6 +255,25 @@ describe("redactConfigSnapshot", () => {
     expect(result.raw).toContain(REDACTED_SENTINEL);
   });
 
+  it("keeps raw config stable when a sensitive field is blank", () => {
+    const config = {
+      gateway: {
+        auth: {
+          token: "",
+        },
+      },
+      ui: {
+        seamColor: "#0088cc",
+      },
+    };
+    const raw = JSON.stringify(config, null, 2);
+    const snapshot = makeSnapshot(config, raw);
+    const result = redactConfigSnapshot(snapshot, mainSchemaHints);
+
+    expectGatewayAuthFieldValue(result, "token", REDACTED_SENTINEL);
+    expect(result.raw).toBe(raw);
+  });
+
   it("keeps non-sensitive raw fields intact when secret values overlap", () => {
     const config = {
       gateway: {


### PR DESCRIPTION
## Summary
- skip blank sensitive values when redacting raw config text so config.get does not trigger replaceAll("", sentinel)
- keep longest-first raw secret replacement for non-empty values while deduplicating the replacement set
- add regression coverage for the raw helper and the public redactConfigSnapshot path

## Test Plan
- [x] export PATH="/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/TeX/texbin:/Applications/Little Snitch.app/Contents/Components:/Users/zhangxuanyang/.codex/tmp/arg0/codex-arg0t8EsBY:/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/opt/homebrew/opt/postgresql@16/bin:/Users/zhangxuanyang/.bun/bin:/Users/zhangxuanyang/.opencode/bin:/Users/zhangxuanyang/Library/pnpm:/Users/zhangxuanyang/.local/bin:/Users/zhangxuanyang/.antigravity/antigravity/bin:/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/bin:/Users/zhangxuanyang/Library/Application Support/waveterm/bin:/Users/zhangxuanyang/.cargo/bin:/Users/zhangxuanyang/.orbstack/bin:/opt/homebrew/opt/node@20/bin:/Users/zhangxuanyang/.orbstack/bin"; pnpm exec vitest run src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts src/gateway/server.config-patch.test.ts
- [x] export PATH="/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/TeX/texbin:/Applications/Little Snitch.app/Contents/Components:/Users/zhangxuanyang/.codex/tmp/arg0/codex-arg0t8EsBY:/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/opt/homebrew/opt/postgresql@16/bin:/Users/zhangxuanyang/.bun/bin:/Users/zhangxuanyang/.opencode/bin:/Users/zhangxuanyang/Library/pnpm:/Users/zhangxuanyang/.local/bin:/Users/zhangxuanyang/.antigravity/antigravity/bin:/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/bin:/Users/zhangxuanyang/Library/Application Support/waveterm/bin:/Users/zhangxuanyang/.cargo/bin:/Users/zhangxuanyang/.orbstack/bin:/opt/homebrew/opt/node@20/bin:/Users/zhangxuanyang/.orbstack/bin"; pnpm exec oxfmt --check src/config/redact-snapshot.raw.ts src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts
- [x] export PATH="/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/TeX/texbin:/Applications/Little Snitch.app/Contents/Components:/Users/zhangxuanyang/.codex/tmp/arg0/codex-arg0t8EsBY:/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/opt/homebrew/opt/postgresql@16/bin:/Users/zhangxuanyang/.bun/bin:/Users/zhangxuanyang/.opencode/bin:/Users/zhangxuanyang/Library/pnpm:/Users/zhangxuanyang/.local/bin:/Users/zhangxuanyang/.antigravity/antigravity/bin:/Users/zhangxuanyang/.nvm/versions/node/v22.22.1/bin:/Users/zhangxuanyang/Library/Application Support/waveterm/bin:/Users/zhangxuanyang/.cargo/bin:/Users/zhangxuanyang/.orbstack/bin:/opt/homebrew/opt/node@20/bin:/Users/zhangxuanyang/.orbstack/bin"; pnpm exec oxlint src/config/redact-snapshot.raw.ts src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts

Closes #40818