### PR TITLE
fix(agents): deduplicate tool_call_ids within a single message

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.normalize-tool-call-ids.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.normalize-tool-call-ids.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolCallIdsInMessage } from "./normalize-tool-call-ids.js";
+
+describe("normalizeToolCallIdsInMessage", () => {
+  it("keeps unique non-empty IDs unchanged", () => {
+    const message = {
+      content: [
+        { type: "toolUse", id: "call_1", name: "exec" },
+        { type: "toolUse", id: "call_2", name: "read" },
+      ],
+    };
+    normalizeToolCallIdsInMessage(message);
+    expect(message.content[0].id).toBe("call_1");
+    expect(message.content[1].id).toBe("call_2");
+  });
+
+  it("assigns fallback IDs to empty tool call blocks", () => {
+    const message = {
+      content: [
+        { type: "toolUse", id: "", name: "exec" },
+        { type: "toolUse", id: "  ", name: "read" },
+      ],
+    };
+    normalizeToolCallIdsInMessage(message);
+    expect(message.content[0].id).toBe("call_auto_1");
+    expect(message.content[1].id).toBe("call_auto_2");
+  });
+
+  it("deduplicates identical tool_call_ids within the same message", () => {
+    // Regression test for #40897: clients like Cursor/Codex can generate
+    // duplicate IDs (e.g. "edit:22") for multiple tool calls in one turn,
+    // causing HTTP 400 from OpenAI-compatible backends.
+    const message = {
+      content: [
+        { type: "toolUse", id: "edit:22", name: "edit" },
+        { type: "toolUse", id: "edit:22", name: "edit" },
+        { type: "toolUse", id: "edit:22", name: "edit" },
+      ],
+    };
+    normalizeToolCallIdsInMessage(message);
+    const ids = message.content.map((b) => b.id);
+    // First occurrence keeps the original ID
+    expect(ids[0]).toBe("edit:22");
+    // Subsequent duplicates get unique fallback IDs
+    expect(ids[1]).not.toBe("edit:22");
+    expect(ids[2]).not.toBe("edit:22");
+    // All IDs are unique
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("handles a mix of duplicates and empty IDs", () => {
+    const message = {
+      content: [
+        { type: "toolUse", id: "abc", name: "exec" },
+        { type: "toolUse", id: "", name: "read" },
+        { type: "toolUse", id: "abc", name: "write" },
+        { type: "toolUse", id: "xyz", name: "edit" },
+        { type: "toolUse", id: "xyz", name: "edit" },
+      ],
+    };
+    normalizeToolCallIdsInMessage(message);
+    const ids = message.content.map((b) => b.id);
+    expect(ids[0]).toBe("abc");
+    expect(ids[3]).toBe("xyz");
+    // All 5 IDs must be unique
+    expect(new Set(ids).size).toBe(5);
+  });
+
+  it("is a no-op for non-tool-use content blocks", () => {
+    const message = {
+      content: [
+        { type: "text", text: "hello" },
+        { type: "toolUse", id: "call_1", name: "exec" },
+      ],
+    };
+    normalizeToolCallIdsInMessage(message);
+    expect(message.content[0]).toEqual({ type: "text", text: "hello" });
+    expect(message.content[1].id).toBe("call_1");
+  });
+
+  it("handles null/undefined message gracefully", () => {
+    expect(() => normalizeToolCallIdsInMessage(null)).not.toThrow();
+    expect(() => normalizeToolCallIdsInMessage(undefined)).not.toThrow();
+    expect(() => normalizeToolCallIdsInMessage({})).not.toThrow();
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -130,6 +130,7 @@ import {
 } from "./compaction-timeout.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
+import { isToolCallBlockType, normalizeToolCallIdsInMessage } from "./normalize-tool-call-ids.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 type PromptBuildHookRunner = {
@@ -290,64 +291,6 @@ function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Se
   }
 
   return trimmed;
-}
-
-function isToolCallBlockType(type: unknown): boolean {
-  return type === "toolCall" || type === "toolUse" || type === "functionCall";
-}
-
-function normalizeToolCallIdsInMessage(message: unknown): void {
-  if (!message || typeof message !== "object") {
-    return;
-  }
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return;
-  }
-
-  const usedIds = new Set<string>();
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const typedBlock = block as { type?: unknown; id?: unknown };
-    if (!isToolCallBlockType(typedBlock.type) || typeof typedBlock.id !== "string") {
-      continue;
-    }
-    const trimmedId = typedBlock.id.trim();
-    if (!trimmedId) {
-      continue;
-    }
-    usedIds.add(trimmedId);
-  }
-
-  let fallbackIndex = 1;
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const typedBlock = block as { type?: unknown; id?: unknown };
-    if (!isToolCallBlockType(typedBlock.type)) {
-      continue;
-    }
-    if (typeof typedBlock.id === "string") {
-      const trimmedId = typedBlock.id.trim();
-      if (trimmedId) {
-        if (typedBlock.id !== trimmedId) {
-          typedBlock.id = trimmedId;
-        }
-        usedIds.add(trimmedId);
-        continue;
-      }
-    }
-
-    let fallbackId = "";
-    while (!fallbackId || usedIds.has(fallbackId)) {
-      fallbackId = `call_auto_${fallbackIndex++}`;
-    }
-    typedBlock.id = fallbackId;
-    usedIds.add(fallbackId);
-  }
 }
 
 function trimWhitespaceFromToolCallNamesInMessage(

--- a/src/agents/pi-embedded-runner/run/normalize-tool-call-ids.ts
+++ b/src/agents/pi-embedded-runner/run/normalize-tool-call-ids.ts
@@ -1,0 +1,79 @@
+/**
+ * Tool-call block type check: covers Anthropic (toolUse), OpenAI (functionCall),
+ * and internal (toolCall) representations.
+ */
+export function isToolCallBlockType(type: unknown): boolean {
+  return type === "toolCall" || type === "toolUse" || type === "functionCall";
+}
+
+/**
+ * Ensure every tool-call block in a message has a unique, non-empty ID.
+ *
+ * - Empty/whitespace-only IDs are replaced with auto-generated fallbacks.
+ * - Duplicate IDs (e.g. two blocks with "edit:22") are deduplicated: the first
+ *   occurrence keeps the original, subsequent duplicates get a fresh ID.
+ *
+ * This prevents HTTP 400 errors from OpenAI-compatible backends that require
+ * unique tool_call_id values within a single request.
+ */
+export function normalizeToolCallIdsInMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  // First pass: collect all existing non-empty IDs so fallback generation
+  // can avoid collisions with any ID already present in the message.
+  const usedIds = new Set<string>();
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; id?: unknown };
+    if (!isToolCallBlockType(typedBlock.type) || typeof typedBlock.id !== "string") {
+      continue;
+    }
+    const trimmedId = typedBlock.id.trim();
+    if (!trimmedId) {
+      continue;
+    }
+    usedIds.add(trimmedId);
+  }
+
+  // Second pass: assign unique IDs. The first occurrence of a non-empty ID
+  // keeps it; subsequent duplicates (e.g. two "edit:22" blocks) get a fresh
+  // auto-generated ID so that every tool_call_id in the message is unique.
+  const assignedIds = new Set<string>();
+  let fallbackIndex = 1;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; id?: unknown };
+    if (!isToolCallBlockType(typedBlock.type)) {
+      continue;
+    }
+    if (typeof typedBlock.id === "string") {
+      const trimmedId = typedBlock.id.trim();
+      if (trimmedId && !assignedIds.has(trimmedId)) {
+        if (typedBlock.id !== trimmedId) {
+          typedBlock.id = trimmedId;
+        }
+        assignedIds.add(trimmedId);
+        usedIds.add(trimmedId);
+        continue;
+      }
+    }
+
+    let fallbackId = "";
+    while (!fallbackId || usedIds.has(fallbackId)) {
+      fallbackId = `call_auto_${fallbackIndex++}`;
+    }
+    typedBlock.id = fallbackId;
+    assignedIds.add(fallbackId);
+    usedIds.add(fallbackId);
+  }
+}


### PR DESCRIPTION
Clients like Cursor and Codex can generate duplicate tool_call_id values (e.g. multiple blocks with id "edit:22") in a single assistant message. OpenAI-compatible backends require every tool_call_id in a request to be unique and return HTTP 400 when duplicates are present.

The existing `normalizeToolCallIdsInMessage` only filled in empty IDs but did not detect or fix duplicates. Now it tracks which IDs have been assigned and replaces subsequent occurrences with unique auto-generated fallback IDs.

The normalization logic has been extracted to its own module (`normalize-tool-call-ids.ts`) so it can be tested independently without pulling in the full agent dependency tree.

Testing: 6 new test cases covering unique IDs, empty IDs, duplicates, mixed scenarios, non-tool blocks, and null/undefined inputs.

Fixes #40897
