### PR TITLE
fix(config): include unknown keys in strict schema errors

### DIFF
--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -124,7 +124,18 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
         })
         .join(".")
     : "";
-  const message = typeof record?.message === "string" ? record.message : "Invalid input";
+
+  const code = typeof record?.code === "string" ? record.code : "";
+  const keys = Array.isArray(record?.keys)
+    ? record.keys.filter((k): k is string => typeof k === "string")
+    : [];
+
+  const messageBase = typeof record?.message === "string" ? record.message : "Invalid input";
+  const message =
+    code === "unrecognized_keys" && keys.length > 0
+      ? `${messageBase} (at ${path || "<root>"}: ${keys.join(", ")})`
+      : messageBase;
+
   const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
 
   if (!allowedValuesSummary) {

--- a/src/config/validation.unrecognized-keys-offending-keys.test.ts
+++ b/src/config/validation.unrecognized-keys-offending-keys.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectRaw } from "./validation.js";
+
+describe("validateConfigObjectRaw (unrecognized_keys)", () => {
+  it("includes the offending unknown keys in the returned issue message", () => {
+    // Intentionally provide unknown keys at the root and under a known object.
+    // We only assert that the message includes the key names, not the exact wording,
+    // to keep this test robust across Zod version message tweaks.
+    const result = validateConfigObjectRaw({
+      gateway: { bind: "loopback", totallyNotARealGatewayKey: true },
+      totallyNotARealRootKey: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    const messages = result.issues.map((iss) => iss.message).join("\n");
+    expect(messages).toContain("totallyNotARealGatewayKey");
+    expect(messages).toContain("totallyNotARealRootKey");
+  });
+});


### PR DESCRIPTION
Summary
- Improves config validation error messages for strict Zod schemas (`unrecognized_keys`) by including the offending unknown keys and their config location.

Why
- "Unrecognized key" errors are hard to act on when they don’t say *which* keys were rejected and *where* they were found.

What did NOT change
- No config semantics changed; this is error reporting only.

Tests (local)
- `pnpm format:check`
- `pnpm tsgo`
- `pnpm build`
- `pnpm test src/config/validation.unrecognized-keys-offending-keys.test.ts`

Evidence
- New regression test asserts unknown key names are present in the strict validation error message:
  - `src/config/validation.unrecognized-keys-offending-keys.test.ts`

AI-assisted: yes.