### PR TITLE
Allow negative Telegram groupAllowFrom IDs

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -1,15 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { normalizeAllowFrom } from "./bot-access.js";
+import { normalizeAllowFrom, resolveSenderAllowMatch } from "./bot-access.js";
 
-describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
-    const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
+describe("telegram/bot-access", () => {
+  it("accepts negative Telegram group IDs in allowlists", () => {
+    const normalized = normalizeAllowFrom([-1003890514701, " tg:-12345 ", "*"]);
 
-    expect(result).toEqual({
-      entries: ["745123456"],
-      hasWildcard: false,
+    expect(normalized).toEqual({
+      entries: ["-1003890514701", "-12345"],
+      hasWildcard: true,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: [],
     });
+  });
+
+  it("matches negative sender IDs against normalized allowlists", () => {
+    const allow = normalizeAllowFrom(["-1003890514701"]);
+
+    expect(
+      resolveSenderAllowMatch({
+        allow,
+        senderId: "-1003890514701",
+      }),
+    ).toEqual({
+      allowed: true,
+      matchKey: "-1003890514701",
+      matchSource: "id",
+    });
+  });
+
+  it("still rejects non-numeric allowlist entries", () => {
+    const normalized = normalizeAllowFrom(["@username", "abc123"]);
+
+    expect(normalized.entries).toEqual([]);
+    expect(normalized.invalidEntries).toEqual(["@username", "abc123"]);
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
Fixes #40444

## Summary

Telegram supergroup and group chat IDs are negative integers, but the Telegram allowlist normalizer only accepted unsigned digits. That caused `groupAllowFrom` entries such as `-100...` to be treated as invalid and silently blocked allowlisted group traffic.

This change updates the Telegram allowlist normalizer to accept signed numeric IDs and adds regression coverage for:

- negative group IDs in `groupAllowFrom`
- matching negative sender IDs against the normalized allowlist
- preserving rejection of non-numeric entries

## Verification

```bash
pnpm vitest run src/telegram/bot-access.test.ts
```
