### PR TITLE
fix(macOS): use kickstart -k as primary restart method for LaunchAgent

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -134,6 +134,12 @@ export type MediaToolsConfig = {
   models?: MediaUnderstandingModelConfig[];
   /** Max concurrent media understanding runs. */
   concurrency?: number;
+  /**
+   * Max bytes for media files staged into sandbox containers.
+   * Default: 5MB (5 * 1024 * 1024 = 5242880).
+   * Used when copying inbound media into sandbox workspace.
+   */
+  maxBytes?: number;
   image?: MediaUnderstandingConfig;
   audio?: MediaUnderstandingConfig;
   video?: MediaUnderstandingConfig;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -18,6 +18,7 @@ const state = vi.hoisted(() => ({
   listOutput: "",
   printOutput: "",
   bootstrapError: "",
+  kickstartError: "",
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -48,6 +49,13 @@ vi.mock("./exec-file.js", () => ({
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
+    }
+    // kickstart fails only on first call when kickstartError is set
+    if (call[0] === "kickstart" && state.kickstartError) {
+      const kickstartCalls = state.launchctlCalls.filter((c) => c[0] === "kickstart");
+      if (kickstartCalls.length === 1) {
+        return { stdout: "", stderr: state.kickstartError, code: 1 };
+      }
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -304,7 +312,7 @@ describe("launchd install", () => {
     expect(state.fileModes.get(plistPath)).toBe(0o644);
   });
 
-  it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent with kickstart -k as primary method", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
@@ -313,64 +321,60 @@ describe("launchd install", () => {
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
-    const plistPath = resolveLaunchAgentPlistPath(env);
     const serviceId = `${domain}/${label}`;
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === serviceId,
-    );
-    const enableIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "enable" && c[1] === serviceId,
-    );
-    const bootstrapIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
-    );
     const kickstartIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
-    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-    expect(enableIndex).toBeGreaterThanOrEqual(0);
-    expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
+    // Primary path: kickstart -k should be called
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(enableIndex);
-    expect(enableIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
+
+    // No bootout should be called in the happy path
+    const bootoutIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootout");
+    expect(bootoutIndex).toBe(-1);
   });
 
-  it("waits for previous launchd pid to exit before bootstrapping", async () => {
+  it("uses kickstart -k as primary restart method", async () => {
     const env = createDefaultLaunchdEnv();
     state.printOutput = ["state = running", "pid = 4242"].join("\n");
-    const killSpy = vi.spyOn(process, "kill");
-    killSpy
-      .mockImplementationOnce(() => true)
-      .mockImplementationOnce(() => {
-        const err = new Error("no such process") as NodeJS.ErrnoException;
-        err.code = "ESRCH";
-        throw err;
-      });
 
-    vi.useFakeTimers();
-    try {
-      const restartPromise = restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      });
-      await vi.advanceTimersByTimeAsync(250);
-      await restartPromise;
-      expect(killSpy).toHaveBeenCalledWith(4242, 0);
-      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-      const label = "ai.openclaw.gateway";
-      const bootoutIndex = state.launchctlCalls.findIndex(
-        (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
-      );
-      const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
-      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-      expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    } finally {
-      vi.useRealTimers();
-      killSpy.mockRestore();
-    }
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const target = `${domain}/${label}`;
+
+    // Primary path: kickstart -k should be called first
+    const kickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === target,
+    );
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+
+    // No bootout should be called in the happy path
+    const bootoutIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootout");
+    expect(bootoutIndex).toBe(-1);
+  });
+
+  it("falls back to bootstrap when kickstart fails on deregistered service", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.printOutput = ["state = running", "pid = 4242"].join("\n");
+    // Simulate kickstart failure (service deregistered)
+    state.kickstartError = "Could not find service";
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    // Should have called kickstart first, then bootstrap as fallback
+    const kickstartIndex = state.launchctlCalls.findIndex((c) => c[0] === "kickstart");
+    const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
+    expect(kickstartIndex).toBeLessThan(bootstrapIndex);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -352,34 +352,6 @@ function isUnsupportedGuiDomain(detail: string): boolean {
   );
 }
 
-const RESTART_PID_WAIT_TIMEOUT_MS = 10_000;
-const RESTART_PID_WAIT_INTERVAL_MS = 200;
-
-async function sleepMs(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-async function waitForPidExit(pid: number): Promise<void> {
-  if (!Number.isFinite(pid) || pid <= 1) {
-    return;
-  }
-  const deadline = Date.now() + RESTART_PID_WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ESRCH" || code === "EPERM") {
-        return;
-      }
-      return;
-    }
-    await sleepMs(RESTART_PID_WAIT_INTERVAL_MS);
-  }
-}
-
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
@@ -475,25 +447,28 @@ export async function restartLaunchAgent({
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
+  const target = `${domain}/${label}`;
+
+  // Use kickstart -k to kill and restart in one atomic operation.
+  // This avoids the bootout + bootstrap dance which can fail silently on macOS.
+  // kickstart -k kills the process and launchd restarts it immediately.
+  const start = await execLaunchctl(["kickstart", "-k", target]);
+  if (start.code === 0) {
+    try {
+      stdout.write(`${formatLine("Restarted LaunchAgent", label)}\n`);
+    } catch {
+      // ignore write errors
+    }
+    return;
+  }
+
+  // kickstart fails when the service was previously booted out (deregistered from launchd).
+  // Fall back to bootstrap (re-register from plist) + kickstart.
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
 
-  const runtime = await execLaunchctl(["print", `${domain}/${label}`]);
-  const previousPid =
-    runtime.code === 0
-      ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
-      : undefined;
+  // Clear any persisted disabled state before bootstrap
+  await execLaunchctl(["enable", target]);
 
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
-    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
-  }
-  if (typeof previousPid === "number") {
-    await waitForPidExit(previousPid);
-  }
-
-  // launchd can persist "disabled" state after bootout; clear it before bootstrap
-  // (matches the same guard in installLaunchAgent).
-  await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();
@@ -511,9 +486,9 @@ export async function restartLaunchAgent({
     throw new Error(`launchctl bootstrap failed: ${detail}`);
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
-  if (start.code !== 0) {
-    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+  const retry = await execLaunchctl(["kickstart", "-k", target]);
+  if (retry.code !== 0) {
+    throw new Error(`launchctl kickstart failed: ${retry.stderr || retry.stdout}`.trim());
   }
   try {
     stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);


### PR DESCRIPTION
## Summary

- **Problem**: `openclaw gateway restart` on macOS performs `bootout` + `bootstrap`, but `bootstrap` silently fails
- **Impact**: Gateway process is killed and never comes back, requires manual `launchctl load`
- **Fix**: Use `launchctl kickstart -k` as primary method, which kills and restarts in one atomic operation

## Root Cause

The previous implementation used:
1. `bootout` to stop the service
2. `enable` to clear disabled state
3. `bootstrap` to re-register from plist
4. `kickstart` to restart

However, `bootstrap` can fail silently after `bootout`, leaving the service deregistered.

## Solution

Use `kickstart -k` as the primary restart method:
- Kills the process and launchd restarts it immediately
- No unload/load dance
- Falls back to `bootstrap` + `kickstart` only when service is deregistered

## Change Type

- [x] Bug fix

## Linked Issue

Fixes #40905

## Test

- All 22 tests in `launchd.test.ts` passing
- Updated tests to match new implementation

## Verification

```bash
pnpm exec vitest run src/daemon/launchd.test.ts
# ✓ src/daemon/launchd.test.ts (22 tests) 6ms
# Test Files  1 passed
# Tests       22 passed
```

## Workaround (until merged)

Use `launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway` instead of `openclaw gateway restart`.