### PR TITLE
feat(feishu): enable /focus and /unfocus commands + fix ACP block delivery

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -144,6 +144,8 @@ export function spawnWithResolvedCommand(
     params.stripProviderAuthEnvVars ? listKnownProviderAuthEnvVarNames() : [],
   );
   childEnv.OPENCLAW_SHELL = "acp";
+  // Strip CLAUDECODE env var so spawned ACP processes don't inherit it.
+  delete childEnv.CLAUDECODE;
 
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -897,18 +897,40 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const { monitorFeishuProvider } = await import("./monitor.js");
+      const { createFeishuThreadBindingManager } = await import("./thread-bindings.js");
+      const { resolveThreadBindingSpawnPolicy } = await import("openclaw/plugin-sdk/feishu");
       const account = resolveFeishuAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
       const port = account.config?.webhookPort ?? null;
       ctx.setStatus({ accountId: ctx.accountId, port });
       ctx.log?.info(
         `starting feishu[${ctx.accountId}] (mode: ${account.config?.connectionMode ?? "websocket"})`,
       );
+      // Initialize thread binding manager so /focus can bind sessions to Feishu conversations.
+      const threadBindingPolicy = resolveThreadBindingSpawnPolicy({
+        cfg: ctx.cfg,
+        channel: "feishu",
+        accountId: ctx.accountId,
+        kind: "subagent",
+      });
+      if (threadBindingPolicy.enabled) {
+        createFeishuThreadBindingManager({
+          accountId: ctx.accountId,
+          cfg: ctx.cfg,
+        });
+      }
       return monitorFeishuProvider({
         config: ctx.cfg,
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
         accountId: ctx.accountId,
       });
+    },
+    stopAccount: async (ctx) => {
+      const { getFeishuThreadBindingManager } = await import("./thread-bindings.js");
+      const manager = getFeishuThreadBindingManager(ctx.accountId);
+      if (manager) {
+        manager.stop();
+      }
     },
   },
 };

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -70,6 +70,20 @@ const ChannelHeartbeatVisibilitySchema = z
   .optional();
 
 /**
+ * Thread binding configuration for /focus and session binding features.
+ */
+const ThreadBindingsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    idleHours: z.number().nonnegative().optional(),
+    maxAgeHours: z.number().nonnegative().optional(),
+    spawnSubagentSessions: z.boolean().optional(),
+    spawnAcpSessions: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
  * Dynamic agent creation configuration.
  * When enabled, a new agent is created for each unique DM user.
  */
@@ -182,6 +196,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  threadBindings: ThreadBindingsSchema,
 };
 
 /**

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -366,14 +366,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           let first = true;
 
           if (info?.kind === "block") {
-            // Drop internal block chunks unless we can safely consume them as
-            // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
-              return;
+            if (streamingEnabled && useCard) {
+              startStreaming();
+              if (streamingStartPromise) {
+                await streamingStartPromise;
+              }
             }
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
+            // When streaming is active, the block is consumed via streaming card
+            // update below. Otherwise suppress: block payloads from the normal
+            // inference pipeline are disabled via disableBlockStreaming and should
+            // not leak as plain messages.
+            if (!streaming?.isActive()) {
+              return;
             }
           }
 
@@ -469,8 +473,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       },
     });
 
+  // Feishu suppresses block payloads from the normal inference pipeline
+  // (disableBlockStreaming: true below). Tell ACP dispatch to promote its
+  // block chunks to finals so they reach the user instead of being dropped.
+  const feishuDispatcher = { ...dispatcher, promoteAcpBlocksToFinals: true as const };
+
   return {
-    dispatcher,
+    dispatcher: feishuDispatcher,
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -378,9 +378,18 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "unfocus",
       nativeName: "unfocus",
-      description: "Remove the current thread (Discord) or topic/conversation (Telegram) binding.",
+      description:
+        "Remove the current thread (Discord) or topic/conversation (Telegram, Feishu) binding.",
       textAlias: "/unfocus",
       category: "management",
+      args: [
+        {
+          name: "target",
+          description: "Ignored (unfocus always applies to the current conversation)",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
     }),
     defineChatCommand({
       key: "agents",

--- a/src/auto-reply/reply/channel-context.ts
+++ b/src/auto-reply/reply/channel-context.ts
@@ -24,6 +24,10 @@ export function isTelegramSurface(params: DiscordSurfaceParams): boolean {
   return resolveCommandSurfaceChannel(params) === "telegram";
 }
 
+export function isFeishuSurface(params: DiscordSurfaceParams): boolean {
+  return resolveCommandSurfaceChannel(params) === "feishu";
+}
+
 export function resolveCommandSurfaceChannel(params: DiscordSurfaceParams): string {
   const channel =
     params.ctx.OriginatingChannel ??

--- a/src/auto-reply/reply/commands-subagents-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-focus.test.ts
@@ -401,6 +401,6 @@ describe("/focus, /unfocus, /agents", () => {
   it("/focus rejects unsupported channels", async () => {
     const params = buildCommandTestParams("/focus codex-acp", baseCfg);
     const result = await handleSubagentsCommand(params, true);
-    expect(result?.reply?.text).toContain("only available on Discord and Telegram");
+    expect(result?.reply?.text).toContain("only available on Discord, Telegram, and Feishu");
   });
 });

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -16,17 +16,19 @@ import type { CommandHandlerResult } from "../commands-types.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveChannelAccountId,
   resolveCommandSurfaceChannel,
   resolveDiscordChannelIdForFocus,
+  resolveFeishuConversationId,
   resolveFocusTargetSession,
   resolveTelegramConversationId,
   stopWithText,
 } from "./shared.js";
 
 type FocusBindingContext = {
-  channel: "discord" | "telegram";
+  channel: "discord" | "telegram" | "feishu";
   accountId: string;
   conversationId: string;
   placement: "current" | "child";
@@ -65,6 +67,19 @@ function resolveFocusBindingContext(
       labelNoun: "conversation",
     };
   }
+  if (isFeishuSurface(params)) {
+    const conversationId = resolveFeishuConversationId(params);
+    if (!conversationId) {
+      return null;
+    }
+    return {
+      channel: "feishu",
+      accountId: resolveChannelAccountId(params),
+      conversationId,
+      placement: "current",
+      labelNoun: "conversation",
+    };
+  }
   return null;
 }
 
@@ -73,8 +88,8 @@ export async function handleSubagentsFocusAction(
 ): Promise<CommandHandlerResult> {
   const { params, runs, restTokens } = ctx;
   const channel = resolveCommandSurfaceChannel(params);
-  if (channel !== "discord" && channel !== "telegram") {
-    return stopWithText("⚠️ /focus is only available on Discord and Telegram.");
+  if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    return stopWithText("⚠️ /focus is only available on Discord, Telegram, and Feishu.");
   }
 
   const token = restTokens.join(" ").trim();
@@ -89,7 +104,12 @@ export async function handleSubagentsFocusAction(
     accountId,
   });
   if (!capabilities.adapterAvailable || !capabilities.bindSupported) {
-    const label = channel === "discord" ? "Discord thread" : "Telegram conversation";
+    const label =
+      channel === "discord"
+        ? "Discord thread"
+        : channel === "feishu"
+          ? "Feishu conversation"
+          : "Telegram conversation";
     return stopWithText(`⚠️ ${label} bindings are unavailable for this account.`);
   }
 
@@ -103,6 +123,11 @@ export async function handleSubagentsFocusAction(
     if (channel === "telegram") {
       return stopWithText(
         "⚠️ /focus on Telegram requires a topic context in groups, or a direct-message conversation.",
+      );
+    }
+    if (channel === "feishu") {
+      return stopWithText(
+        "⚠️ /focus on Feishu requires a topic thread in groups, or a direct-message conversation.",
       );
     }
     return stopWithText("⚠️ Could not resolve a Discord channel for /focus.");

--- a/src/auto-reply/reply/commands-subagents/action-unfocus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-unfocus.ts
@@ -3,9 +3,11 @@ import type { CommandHandlerResult } from "../commands-types.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveChannelAccountId,
   resolveCommandSurfaceChannel,
+  resolveFeishuConversationId,
   resolveTelegramConversationId,
   stopWithText,
 } from "./shared.js";
@@ -15,8 +17,8 @@ export async function handleSubagentsUnfocusAction(
 ): Promise<CommandHandlerResult> {
   const { params } = ctx;
   const channel = resolveCommandSurfaceChannel(params);
-  if (channel !== "discord" && channel !== "telegram") {
-    return stopWithText("⚠️ /unfocus is only available on Discord and Telegram.");
+  if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    return stopWithText("⚠️ /unfocus is only available on Discord, Telegram, and Feishu.");
   }
 
   const accountId = resolveChannelAccountId(params);
@@ -30,12 +32,20 @@ export async function handleSubagentsUnfocusAction(
     if (isTelegramSurface(params)) {
       return resolveTelegramConversationId(params);
     }
+    if (isFeishuSurface(params)) {
+      return resolveFeishuConversationId(params);
+    }
     return undefined;
   })();
 
   if (!conversationId) {
     if (channel === "discord") {
       return stopWithText("⚠️ /unfocus must be run inside a Discord thread.");
+    }
+    if (channel === "feishu") {
+      return stopWithText(
+        "⚠️ /unfocus on Feishu requires a topic thread in groups, or a direct-message conversation.",
+      );
     }
     return stopWithText(
       "⚠️ /unfocus on Telegram requires a topic context in groups, or a direct-message conversation.",

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -30,12 +30,14 @@ import {
 } from "../../../shared/subagents-format.js";
 import {
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveCommandSurfaceChannel,
   resolveDiscordAccountId,
   resolveChannelAccountId,
 } from "../channel-context.js";
 import type { CommandHandler, CommandHandlerResult } from "../commands-types.js";
+import { resolveFeishuConversationId } from "../feishu-context.js";
 import {
   formatRunLabel,
   formatRunStatus,
@@ -47,10 +49,12 @@ import { resolveTelegramConversationId } from "../telegram-context.js";
 export { extractAssistantText, stripToolMessages };
 export {
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveCommandSurfaceChannel,
   resolveDiscordAccountId,
   resolveChannelAccountId,
+  resolveFeishuConversationId,
   resolveTelegramConversationId,
 };
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -180,9 +180,13 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     if (kind === "tool") {
       return params.dispatcher.sendToolResult(ttsPayload);
     }
-    if (kind === "block") {
+    if (kind === "block" && !params.dispatcher.promoteAcpBlocksToFinals) {
       return params.dispatcher.sendBlockReply(ttsPayload);
     }
+    // When promoteAcpBlocksToFinals is set, the channel suppresses block
+    // payloads from the normal inference pipeline (e.g. Feishu with
+    // disableBlockStreaming). Promote blocks to finals so they reach the
+    // user through the channel's normal final-reply path.
     return params.dispatcher.sendFinalReply(ttsPayload);
   };
 

--- a/src/auto-reply/reply/feishu-context.ts
+++ b/src/auto-reply/reply/feishu-context.ts
@@ -1,0 +1,75 @@
+type FeishuConversationParams = {
+  ctx: {
+    MessageThreadId?: string | number | null;
+    ChatType?: string;
+    OriginatingTo?: string;
+    To?: string;
+  };
+  command: {
+    to?: string;
+  };
+};
+
+function normalizeFeishuTarget(raw: string): string | null {
+  let trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  // Strip provider prefixes (feishu: / lark:) before target-type prefixes.
+  const providerMatch = /^(feishu|lark):/i.exec(trimmed);
+  if (providerMatch) {
+    trimmed = trimmed.slice(providerMatch[0].length).trim();
+    if (!trimmed) {
+      return null;
+    }
+  }
+  const lowered = trimmed.toLowerCase();
+  // Strip common Feishu target prefixes to get the raw ID.
+  for (const prefix of ["chat:", "group:", "channel:", "user:", "dm:", "open_id:"]) {
+    if (lowered.startsWith(prefix)) {
+      const id = trimmed.slice(prefix.length).trim();
+      return id || null;
+    }
+  }
+  return trimmed;
+}
+
+export function resolveFeishuConversationId(params: FeishuConversationParams): string | undefined {
+  const rawThreadId =
+    params.ctx.MessageThreadId != null ? String(params.ctx.MessageThreadId).trim() : "";
+  const threadId = rawThreadId || undefined;
+  const toCandidates = [
+    typeof params.ctx.OriginatingTo === "string" ? params.ctx.OriginatingTo : "",
+    typeof params.command.to === "string" ? params.command.to : "",
+    typeof params.ctx.To === "string" ? params.ctx.To : "",
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const chatId = toCandidates
+    .map((candidate) => normalizeFeishuTarget(candidate))
+    .find((candidate) => candidate != null && candidate.length > 0);
+  if (!chatId) {
+    return undefined;
+  }
+  if (threadId) {
+    return `${chatId}:topic:${threadId}`;
+  }
+  // Direct messages are always focusable. Use ChatType when available, otherwise
+  // infer from the target prefix: user:ou_* targets are DMs, chat:oc_* are groups.
+  const chatType =
+    typeof params.ctx.ChatType === "string" ? params.ctx.ChatType.trim().toLowerCase() : "";
+  if (chatType === "direct" || chatType === "p2p" || chatType === "private") {
+    return chatId;
+  }
+  // Group chats (oc_ prefix) without a topic should not become globally focused.
+  if (chatType === "group" || chatId.toLowerCase().startsWith("oc_")) {
+    return undefined;
+  }
+  // For unrecognised ChatType, only allow known DM identifiers (ou_ prefix).
+  // Unknown or future chat types default to non-focusable to avoid accidentally
+  // binding group-like conversations.
+  if (chatId.toLowerCase().startsWith("ou_")) {
+    return chatId;
+  }
+  return undefined;
+}

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -81,6 +81,12 @@ export type ReplyDispatcher = {
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
   markComplete: () => void;
+  /** When true, ACP dispatch promotes block payloads to finals so they
+   *  reach the user through the channel's normal final-reply path instead
+   *  of being dropped by a block-suppression filter. Channels that handle
+   *  block payloads natively (e.g. Discord draft streams) should leave this
+   *  unset (defaults to false). */
+  promoteAcpBlocksToFinals?: boolean;
 };
 
 type NormalizeReplyPayloadInternalOptions = Pick<

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -40,6 +40,7 @@ import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
 import { parseDiscordParentChannelFromSessionKey } from "./discord-parent-channel.js";
+import { resolveFeishuConversationId } from "./feishu-context.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import {
@@ -104,6 +105,31 @@ function resolveAcpResetBindingContext(ctx: MsgContext): {
     }
     if (!conversationId) {
       return null;
+    }
+    return {
+      channel: channelRaw,
+      accountId,
+      conversationId,
+      ...(parentConversationId ? { parentConversationId } : {}),
+    };
+  }
+
+  if (channelRaw === "feishu") {
+    const conversationId = resolveFeishuConversationId({
+      ctx: {
+        MessageThreadId: normalizedThreadId || undefined,
+        ChatType: ctx.ChatType || undefined,
+        OriginatingTo: ctx.OriginatingTo || undefined,
+        To: ctx.To || undefined,
+      },
+      command: {},
+    });
+    if (!conversationId) {
+      return null;
+    }
+    let parentConversationId: string | undefined;
+    if (normalizedThreadId && conversationId.includes(":topic:")) {
+      parentConversationId = conversationId.split(":topic:")[0];
     }
     return {
       channel: channelRaw,

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -145,7 +145,19 @@ function resolveAdapterCapabilities(
   };
 }
 
-const ADAPTERS_BY_CHANNEL_ACCOUNT = new Map<string, SessionBindingAdapter>();
+// Use globalThis to share the adapter registry across module-loading boundaries
+// (built dist/ chunks and jiti-loaded extension source may each load this module
+// independently, resulting in separate module-level Maps).
+const GLOBAL_ADAPTERS_KEY = "__openclaw_session_binding_adapters__";
+const ADAPTERS_BY_CHANNEL_ACCOUNT: Map<string, SessionBindingAdapter> =
+  ((globalThis as Record<string, unknown>)[GLOBAL_ADAPTERS_KEY] as
+    | Map<string, SessionBindingAdapter>
+    | undefined) ??
+  (() => {
+    const map = new Map<string, SessionBindingAdapter>();
+    (globalThis as Record<string, unknown>)[GLOBAL_ADAPTERS_KEY] = map;
+    return map;
+  })();
 
 export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void {
   const normalizedAdapter = {

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -87,3 +87,25 @@ export {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "./webhook-memory-guards.js";
 export { applyBasicWebhookRequestGuards } from "./webhook-request-guards.js";
+
+// Thread bindings / session binding adapter support (used by extensions/feishu thread-bindings)
+export {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type BindingTargetKind,
+  type SessionBindingRecord,
+  type SessionBindingBindInput,
+  type SessionBindingUnbindInput,
+} from "../infra/outbound/session-binding-service.js";
+export { resolveStateDir } from "../config/paths.js";
+export { logVerbose } from "../globals.js";
+export { writeJsonFileAtomically } from "./json-store.js";
+export { resolveThreadBindingConversationIdFromBindingId } from "../channels/thread-binding-id.js";
+export { formatThreadBindingDurationLabel } from "../channels/thread-bindings-messages.js";
+export {
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+  resolveThreadBindingSpawnPolicy,
+} from "../channels/thread-bindings-policy.js";
+export { isAcpSessionKey } from "../sessions/session-key-utils.js";
+export { readAcpSessionEntry } from "../acp/runtime/session-meta.js";


### PR DESCRIPTION
## Summary

The core Feishu session binding adapter and subagent hooks were landed in #46819. This PR adds the remaining pieces to make `/focus` fully functional on Feishu:

- **`/focus` and `/unfocus` commands**: Allow Feishu as a valid channel, add `resolveFeishuFocusConversationId` for stable conversation binding (rejects group chats), update command registry
- **ACP block delivery fix**: Add `promoteAcpBlocksToFinals` dispatcher capability so Feishu can opt-in to promoting ACP blocks to finals (needed because Feishu suppresses block streaming), while preserving Discord's native block handling
- **Gateway lifecycle**: Initialize thread binding manager on `startAccount`, clean up on `stopAccount`
- **Config**: Add `threadBindings` schema (enabled, idleHours, maxAgeHours, spawnAcpSessions)
- **Plugin SDK**: Export thread-bindings helpers for Feishu

## Changed files (16 files, +255/-18)

| Area | Files |
|------|-------|
| /focus commands | `action-focus.ts`, `action-unfocus.ts`, `shared.ts`, `feishu-context.ts` (new), `channel-context.ts`, `session.ts`, `commands-registry.data.ts` |
| ACP delivery | `dispatch-acp-delivery.ts`, `reply-dispatcher.ts`, `feishu/reply-dispatcher.ts` |
| Gateway/config | `feishu/channel.ts`, `feishu/config-schema.ts` |
| SDK/misc | `plugin-sdk/feishu.ts`, `session-binding-service.ts`, `acpx/process.ts` |

## Test plan

- [x] `startup-memory` passes (previously failed due to duplicate registration — fixed)
- [x] Typecheck and lint pass
- [ ] `extension-fast (feishu)` — `probe.test.ts` failures are pre-existing on main (zero diff in our PR); only triggered because our PR touches feishu files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>