### PR TITLE
fix(config): accept requiresOpenAiAnthropicToolPayload in model compat schema

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -315,6 +315,7 @@ describe("model compat config schema", () => {
                   requiresAssistantAfterToolResult: false,
                   requiresThinkingAsText: false,
                   requiresMistralToolIds: false,
+                  requiresOpenAiAnthropicToolPayload: true,
                 },
               },
             ],

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -198,6 +198,7 @@ export const ModelCompatSchema = z
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
     requiresMistralToolIds: z.boolean().optional(),
+    requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
Summary
- Accepts `models.providers.*.models[].compat.requiresOpenAiAnthropicToolPayload` during strict config validation.

Why
- Some config generation paths can persist this compat flag. When the schema rejects it as an unknown key, the CLI can fail to start with a strict validation error.

What did NOT change
- No runtime behavior changes; this only updates config schema validation + a schema test.

Tests (local)
- `pnpm format:check`
- `pnpm tsgo`
- `pnpm build`
- `pnpm test src/config/config-misc.test.ts`

Evidence
- Updated schema test to cover the compat flag: `src/config/config-misc.test.ts`

AI-assisted: yes.