### PR TITLE
Matrix: replace legacy plugin with new implementation

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -1,4 +1,6 @@
 import { Type } from "@sinclair/typebox";
+import { requiresExplicitMatrixDefaultAccount } from "./account-selection.js";
+import { resolveDefaultMatrixAccountId, resolveMatrixAccount } from "./matrix/accounts.js";
 import {
   createActionGate,
   readNumberParam,
@@ -8,9 +10,7 @@ import {
   type ChannelMessageActionName,
   type ChannelMessageToolDiscovery,
   type ChannelToolSend,
-} from "openclaw/plugin-sdk/matrix";
-import { requiresExplicitMatrixDefaultAccount } from "./account-selection.js";
-import { resolveDefaultMatrixAccountId, resolveMatrixAccount } from "./matrix/accounts.js";
+} from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
 const MATRIX_PLUGIN_HANDLED_ACTIONS = new Set<ChannelMessageActionName>([

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -1,9 +1,4 @@
 import type { Command } from "commander";
-import {
-  formatZonedTimestamp,
-  normalizeAccountId,
-  type ChannelSetupInput,
-} from "openclaw/plugin-sdk/matrix";
 import { resolveMatrixAccount, resolveMatrixAccountConfig } from "./matrix/accounts.js";
 import { withResolvedActionClient, withStartedActionClient } from "./matrix/actions/client.js";
 import { listMatrixOwnDevices, pruneMatrixStaleGatewayDevices } from "./matrix/actions/devices.js";
@@ -27,6 +22,7 @@ import {
   type MatrixDirectRoomCandidate,
 } from "./matrix/direct-management.js";
 import { applyMatrixProfileUpdate, type MatrixProfileUpdateResult } from "./profile-update.js";
+import { formatZonedTimestamp, normalizeAccountId, type ChannelSetupInput } from "./runtime-api.js";
 import { getMatrixRuntime } from "./runtime.js";
 import { maybeBootstrapNewEncryptedMatrixAccount } from "./setup-bootstrap.js";
 import { matrixSetupAdapter } from "./setup-core.js";

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -4,12 +4,8 @@ import {
   DmPolicySchema,
   GroupPolicySchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
-import {
-  buildSecretInputSchema,
-  MarkdownConfigSchema,
-  ToolPolicySchema,
-} from "openclaw/plugin-sdk/matrix";
 import { z } from "zod";
+import { buildSecretInputSchema, MarkdownConfigSchema, ToolPolicySchema } from "./runtime-api.js";
 
 const matrixActionSchema = z
   .object({

--- a/extensions/matrix/src/directory-live.ts
+++ b/extensions/matrix/src/directory-live.ts
@@ -1,7 +1,7 @@
-import type { ChannelDirectoryEntry } from "openclaw/plugin-sdk/matrix";
 import { resolveMatrixAuth } from "./matrix/client.js";
 import { MatrixAuthedHttpClient } from "./matrix/sdk/http-client.js";
 import { isMatrixQualifiedUserId, normalizeMatrixMessagingTarget } from "./matrix/target-ids.js";
+import type { ChannelDirectoryEntry } from "./runtime-api.js";
 
 type MatrixUserResult = {
   user_id?: string;

--- a/extensions/matrix/src/group-mentions.ts
+++ b/extensions/matrix/src/group-mentions.ts
@@ -1,7 +1,7 @@
-import type { ChannelGroupContext, GroupToolPolicyConfig } from "openclaw/plugin-sdk/matrix";
 import { resolveMatrixAccountConfig } from "./matrix/accounts.js";
 import { resolveMatrixRoomConfig } from "./matrix/monitor/rooms.js";
 import { normalizeMatrixResolvableTarget } from "./matrix/target-ids.js";
+import type { ChannelGroupContext, GroupToolPolicyConfig } from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
 function resolveMatrixRoomConfigForGroup(params: ChannelGroupContext) {

--- a/extensions/matrix/src/matrix/account-config.ts
+++ b/extensions/matrix/src/matrix/account-config.ts
@@ -1,5 +1,5 @@
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/matrix";
+import { DEFAULT_ACCOUNT_ID } from "../runtime-api.js";
 import type { CoreConfig, MatrixAccountConfig, MatrixConfig } from "../types.js";
 
 export function resolveMatrixBaseConfig(cfg: CoreConfig): MatrixConfig {

--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -1,12 +1,12 @@
 import {
-  DEFAULT_ACCOUNT_ID,
-  hasConfiguredSecretInput,
-  normalizeAccountId,
-} from "openclaw/plugin-sdk/matrix";
-import {
   resolveConfiguredMatrixAccountIds,
   resolveMatrixDefaultOrOnlyAccountId,
 } from "../account-selection.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  hasConfiguredSecretInput,
+  normalizeAccountId,
+} from "../runtime-api.js";
 import type { CoreConfig, MatrixConfig } from "../types.js";
 import { findMatrixAccountConfig, resolveMatrixBaseConfig } from "./account-config.js";
 import { resolveMatrixConfigForAccount } from "./client.js";

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -1,16 +1,16 @@
 import {
-  DEFAULT_ACCOUNT_ID,
-  isPrivateOrLoopbackHost,
-  normalizeAccountId,
-  normalizeOptionalAccountId,
-  normalizeResolvedSecretInputString,
-} from "openclaw/plugin-sdk/matrix";
-import {
   requiresExplicitMatrixDefaultAccount,
   resolveMatrixDefaultOrOnlyAccountId,
 } from "../../account-selection.js";
 import { resolveMatrixAccountStringValues } from "../../auth-precedence.js";
 import { getMatrixScopedEnvVarNames } from "../../env-vars.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  isPrivateOrLoopbackHost,
+  normalizeAccountId,
+  normalizeOptionalAccountId,
+  normalizeResolvedSecretInputString,
+} from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig } from "../../types.js";
 import {

--- a/extensions/matrix/src/matrix/client/file-sync-store.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.ts
@@ -7,7 +7,7 @@ import {
   type ISyncResponse,
   type IStoredClientOpts,
 } from "matrix-js-sdk";
-import { writeJsonFileAtomically } from "openclaw/plugin-sdk/matrix";
+import { writeJsonFileAtomically } from "../../runtime-api.js";
 import { LogService } from "../sdk/logger.js";
 
 const STORE_VERSION = 1;

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { maybeCreateMatrixMigrationSnapshot, normalizeAccountId } from "openclaw/plugin-sdk/matrix";
 import {
   requiresExplicitMatrixDefaultAccount,
   resolveMatrixDefaultOrOnlyAccountId,
 } from "../../account-selection.js";
+import { maybeCreateMatrixMigrationSnapshot, normalizeAccountId } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import {
   resolveMatrixAccountStorageRoot,

--- a/extensions/matrix/src/matrix/config-update.ts
+++ b/extensions/matrix/src/matrix/config-update.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import { normalizeAccountId } from "openclaw/plugin-sdk/matrix";
+import { normalizeAccountId } from "../runtime-api.js";
 import type { CoreConfig, MatrixConfig } from "../types.js";
 import { findMatrixAccountConfig } from "./account-config.js";
 

--- a/extensions/matrix/src/matrix/credentials.ts
+++ b/extensions/matrix/src/matrix/credentials.ts
@@ -2,11 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
-import { writeJsonFileAtomically } from "openclaw/plugin-sdk/matrix";
 import {
   requiresExplicitMatrixDefaultAccount,
   resolveMatrixDefaultOrOnlyAccountId,
 } from "../account-selection.js";
+import { writeJsonFileAtomically } from "../runtime-api.js";
 import { getMatrixRuntime } from "../runtime.js";
 import {
   resolveMatrixCredentialsDir as resolveSharedMatrixCredentialsDir,

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/matrix";
+import type { RuntimeEnv } from "../runtime-api.js";
 
 const REQUIRED_MATRIX_PACKAGES = ["matrix-js-sdk", "@matrix-org/matrix-sdk-crypto-nodejs"];
 

--- a/extensions/matrix/src/matrix/monitor/ack-config.ts
+++ b/extensions/matrix/src/matrix/monitor/ack-config.ts
@@ -1,4 +1,4 @@
-import { resolveAckReaction, type OpenClawConfig } from "openclaw/plugin-sdk/matrix";
+import { resolveAckReaction, type OpenClawConfig } from "../../runtime-api.js";
 import type { CoreConfig } from "../../types.js";
 import { resolveMatrixAccountConfig } from "../accounts.js";
 

--- a/extensions/matrix/src/matrix/monitor/allowlist.ts
+++ b/extensions/matrix/src/matrix/monitor/allowlist.ts
@@ -2,7 +2,7 @@ import {
   normalizeStringEntries,
   resolveAllowlistMatchByCandidates,
   type AllowlistMatch,
-} from "openclaw/plugin-sdk/matrix";
+} from "../../runtime-api.js";
 
 function normalizeAllowList(list?: Array<string | number>) {
   return normalizeStringEntries(list);

--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -1,4 +1,4 @@
-import type { RuntimeEnv } from "openclaw/plugin-sdk/matrix";
+import type { RuntimeEnv } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixConfig } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";

--- a/extensions/matrix/src/matrix/monitor/config.ts
+++ b/extensions/matrix/src/matrix/monitor/config.ts
@@ -1,3 +1,4 @@
+import { resolveMatrixTargets } from "../../resolve-targets.js";
 import {
   addAllowlistUserEntriesFromConfigEntry,
   buildAllowlistResolutionSummary,
@@ -5,8 +6,7 @@ import {
   patchAllowlistUsersInConfigEntries,
   summarizeMapping,
   type RuntimeEnv,
-} from "openclaw/plugin-sdk/matrix";
-import { resolveMatrixTargets } from "../../resolve-targets.js";
+} from "../../runtime-api.js";
 import type { CoreConfig, MatrixRoomConfig } from "../../types.js";
 import { normalizeMatrixUserId } from "./allowlist.js";
 

--- a/extensions/matrix/src/matrix/monitor/events.ts
+++ b/extensions/matrix/src/matrix/monitor/events.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/matrix";
+import type { PluginRuntime, RuntimeLogger } from "../../runtime-api.js";
 import type { CoreConfig } from "../../types.js";
 import type { MatrixAuth } from "../client.js";
 import { formatMatrixEncryptedEventDisabledWarning } from "../encryption-guidance.js";

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -1,5 +1,5 @@
-import type { RuntimeEnv, RuntimeLogger } from "openclaw/plugin-sdk/matrix";
 import { vi } from "vitest";
+import type { RuntimeEnv, RuntimeLogger } from "../../runtime-api.js";
 import type { MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
 import { createMatrixRoomMessageHandler, type MatrixMonitorHandlerParams } from "./handler.js";

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -11,7 +11,7 @@ import {
   type ReplyPayload,
   type RuntimeEnv,
   type RuntimeLogger,
-} from "openclaw/plugin-sdk/matrix";
+} from "../../runtime-api.js";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import { formatMatrixMediaUnavailableText } from "../media-text.js";
 import { fetchMatrixPollSnapshot } from "../poll-summary.js";

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -7,7 +7,7 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
   type RuntimeEnv,
-} from "openclaw/plugin-sdk/matrix";
+} from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig, ReplyToMode } from "../../types.js";
 import { resolveMatrixAccount } from "../accounts.js";

--- a/extensions/matrix/src/matrix/monitor/legacy-crypto-restore.ts
+++ b/extensions/matrix/src/matrix/monitor/legacy-crypto-restore.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/matrix";
+import { readJsonFileWithFallback, writeJsonFileAtomically } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import { resolveMatrixStoragePaths } from "../client/storage.js";
 import type { MatrixAuth } from "../client/types.js";

--- a/extensions/matrix/src/matrix/monitor/location.ts
+++ b/extensions/matrix/src/matrix/monitor/location.ts
@@ -2,7 +2,7 @@ import {
   formatLocationText,
   toLocationContext,
   type NormalizedLocation,
-} from "openclaw/plugin-sdk/matrix";
+} from "../../runtime-api.js";
 import type { LocationMessageEventContent } from "../sdk.js";
 import { EventType } from "./types.js";
 

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
+import type { PluginRuntime } from "../../runtime-api.js";
 import type { CoreConfig } from "../../types.js";
 import { resolveMatrixAccountConfig } from "../accounts.js";
 import { extractMatrixReactionAnnotation } from "../reaction-common.js";

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -3,7 +3,7 @@ import type {
   OpenClawConfig,
   ReplyPayload,
   RuntimeEnv,
-} from "openclaw/plugin-sdk/matrix";
+} from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
 import { sendMessageMatrix } from "../send.js";

--- a/extensions/matrix/src/matrix/monitor/rooms.ts
+++ b/extensions/matrix/src/matrix/monitor/rooms.ts
@@ -1,4 +1,4 @@
-import { buildChannelKeyCandidates, resolveChannelEntryMatch } from "openclaw/plugin-sdk/matrix";
+import { buildChannelKeyCandidates, resolveChannelEntryMatch } from "../../runtime-api.js";
 import type { MatrixRoomConfig } from "../../types.js";
 
 export type MatrixRoomConfigResolved = {

--- a/extensions/matrix/src/matrix/monitor/route.ts
+++ b/extensions/matrix/src/matrix/monitor/route.ts
@@ -3,7 +3,7 @@ import {
   resolveAgentIdFromSessionKey,
   resolveConfiguredAcpBindingRecord,
   type PluginRuntime,
-} from "openclaw/plugin-sdk/matrix";
+} from "../../runtime-api.js";
 import type { CoreConfig } from "../../types.js";
 
 type MatrixResolvedRoute = ReturnType<PluginRuntime["channel"]["routing"]["resolveAgentRoute"]>;

--- a/extensions/matrix/src/matrix/monitor/startup-verification.ts
+++ b/extensions/matrix/src/matrix/monitor/startup-verification.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/matrix";
+import { readJsonFileWithFallback, writeJsonFileAtomically } from "../../runtime-api.js";
 import type { MatrixConfig } from "../../types.js";
 import { resolveMatrixStoragePaths } from "../client/storage.js";
 import type { MatrixAuth } from "../client/types.js";

--- a/extensions/matrix/src/matrix/monitor/startup.ts
+++ b/extensions/matrix/src/matrix/monitor/startup.ts
@@ -1,4 +1,4 @@
-import type { RuntimeLogger } from "openclaw/plugin-sdk/matrix";
+import type { RuntimeLogger } from "../../runtime-api.js";
 import type { CoreConfig, MatrixConfig } from "../../types.js";
 import type { MatrixAuth } from "../client.js";
 import { updateMatrixAccountConfig } from "../config-update.js";

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -7,7 +7,7 @@
  * - m.poll.end - Closes a poll
  */
 
-import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/matrix";
+import { normalizePollInput, type PollInput } from "../runtime-api.js";
 
 export const M_POLL_START = "m.poll.start" as const;
 export const M_POLL_RESPONSE = "m.poll.response" as const;

--- a/extensions/matrix/src/matrix/probe.ts
+++ b/extensions/matrix/src/matrix/probe.ts
@@ -1,4 +1,4 @@
-import type { BaseProbeResult } from "openclaw/plugin-sdk/matrix";
+import type { BaseProbeResult } from "../runtime-api.js";
 import { createMatrixClient, isBunRuntime } from "./client.js";
 
 export type MatrixProbe = BaseProbeResult & {

--- a/extensions/matrix/src/matrix/sdk/logger.ts
+++ b/extensions/matrix/src/matrix/sdk/logger.ts
@@ -1,5 +1,5 @@
 import { format } from "node:util";
-import { redactSensitiveText, type RuntimeLogger } from "openclaw/plugin-sdk/matrix";
+import { redactSensitiveText, type RuntimeLogger } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 
 export type Logger = {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -1,4 +1,4 @@
-import type { PollInput } from "openclaw/plugin-sdk/matrix";
+import type { PollInput } from "../runtime-api.js";
 import { getMatrixRuntime } from "../runtime.js";
 import type { CoreConfig } from "../types.js";
 import { buildPollStartContent, M_POLL_START } from "./poll-types.js";

--- a/extensions/matrix/src/matrix/thread-bindings.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.ts
@@ -8,7 +8,7 @@ import {
   writeJsonFileAtomically,
   type BindingTargetKind,
   type SessionBindingRecord,
-} from "openclaw/plugin-sdk/matrix";
+} from "../runtime-api.js";
 import { resolveMatrixStoragePaths } from "./client/storage.js";
 import type { MatrixAuth } from "./client/types.js";
 import type { MatrixClient } from "./sdk.js";

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -1,16 +1,4 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import type { DmPolicy } from "openclaw/plugin-sdk/matrix";
-import {
-  addWildcardAllowFrom,
-  formatDocsLink,
-  mergeAllowFromEntries,
-  moveSingleAccountChannelSectionToDefaultAccount,
-  normalizeAccountId,
-  promptChannelAccessConfig,
-  promptAccountId,
-  type RuntimeEnv,
-  type WizardPrompter,
-} from "openclaw/plugin-sdk/matrix";
 import {
   type ChannelSetupDmPolicy,
   type ChannelSetupWizardAdapter,
@@ -31,6 +19,18 @@ import {
 } from "./matrix/config-update.js";
 import { ensureMatrixSdkInstalled, isMatrixSdkAvailable } from "./matrix/deps.js";
 import { resolveMatrixTargets } from "./resolve-targets.js";
+import type { DmPolicy } from "./runtime-api.js";
+import {
+  addWildcardAllowFrom,
+  formatDocsLink,
+  mergeAllowFromEntries,
+  moveSingleAccountChannelSectionToDefaultAccount,
+  normalizeAccountId,
+  promptChannelAccessConfig,
+  promptAccountId,
+  type RuntimeEnv,
+  type WizardPrompter,
+} from "./runtime-api.js";
 import { runMatrixSetupBootstrapAfterConfigWrite } from "./setup-bootstrap.js";
 import type { CoreConfig } from "./types.js";
 

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -1,5 +1,5 @@
-import { resolveOutboundSendDep, type ChannelOutboundAdapter } from "openclaw/plugin-sdk/matrix";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
+import { resolveOutboundSendDep, type ChannelOutboundAdapter } from "./runtime-api.js";
 import { getMatrixRuntime } from "./runtime.js";
 
 export const matrixOutbound: ChannelOutboundAdapter = {

--- a/extensions/matrix/src/profile-update.ts
+++ b/extensions/matrix/src/profile-update.ts
@@ -1,6 +1,6 @@
-import { normalizeAccountId } from "openclaw/plugin-sdk/matrix";
 import { updateMatrixOwnProfile } from "./matrix/actions/profile.js";
 import { updateMatrixAccountConfig, resolveMatrixConfigPath } from "./matrix/config-update.js";
+import { normalizeAccountId } from "./runtime-api.js";
 import { getMatrixRuntime } from "./runtime.js";
 import type { CoreConfig } from "./types.js";
 

--- a/extensions/matrix/src/resolve-targets.ts
+++ b/extensions/matrix/src/resolve-targets.ts
@@ -1,11 +1,11 @@
+import { listMatrixDirectoryGroupsLive, listMatrixDirectoryPeersLive } from "./directory-live.js";
+import { isMatrixQualifiedUserId, normalizeMatrixMessagingTarget } from "./matrix/target-ids.js";
 import type {
   ChannelDirectoryEntry,
   ChannelResolveKind,
   ChannelResolveResult,
   RuntimeEnv,
-} from "openclaw/plugin-sdk/matrix";
-import { listMatrixDirectoryGroupsLive, listMatrixDirectoryPeersLive } from "./directory-live.js";
-import { isMatrixQualifiedUserId, normalizeMatrixMessagingTarget } from "./matrix/target-ids.js";
+} from "./runtime-api.js";
 
 function normalizeLookupQuery(query: string): string {
   return query.trim().toLowerCase();

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -1,5 +1,5 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk/matrix";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+import type { PluginRuntime } from "./runtime-api.js";
 
 const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =
   createPluginRuntimeStore<PluginRuntime>("Matrix runtime not initialized");

--- a/extensions/matrix/src/setup-bootstrap.ts
+++ b/extensions/matrix/src/setup-bootstrap.ts
@@ -1,7 +1,7 @@
-import type { RuntimeEnv } from "openclaw/plugin-sdk/matrix";
 import { hasExplicitMatrixAccountConfig } from "./matrix/account-config.js";
 import { resolveMatrixAccountConfig } from "./matrix/accounts.js";
 import { bootstrapMatrixVerification } from "./matrix/actions/verification.js";
+import type { RuntimeEnv } from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
 export type MatrixSetupVerificationBootstrapResult = {

--- a/extensions/matrix/src/setup-config.ts
+++ b/extensions/matrix/src/setup-config.ts
@@ -1,3 +1,5 @@
+import { resolveMatrixEnvAuthReadiness } from "./matrix/client.js";
+import { updateMatrixAccountConfig } from "./matrix/config-update.js";
 import {
   applyAccountNameToChannelSection,
   DEFAULT_ACCOUNT_ID,
@@ -5,9 +7,7 @@ import {
   normalizeAccountId,
   normalizeSecretInputString,
   type ChannelSetupInput,
-} from "openclaw/plugin-sdk/matrix";
-import { resolveMatrixEnvAuthReadiness } from "./matrix/client.js";
-import { updateMatrixAccountConfig } from "./matrix/config-update.js";
+} from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
 const channel = "matrix" as const;

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -1,12 +1,4 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import {
-  createActionGate,
-  jsonResult,
-  readNumberParam,
-  readReactionParams,
-  readStringArrayParam,
-  readStringParam,
-} from "openclaw/plugin-sdk/matrix";
 import { resolveMatrixAccountConfig } from "./matrix/accounts.js";
 import {
   bootstrapMatrixVerification,
@@ -41,6 +33,14 @@ import {
 } from "./matrix/actions.js";
 import { reactMatrixMessage } from "./matrix/send.js";
 import { applyMatrixProfileUpdate } from "./profile-update.js";
+import {
+  createActionGate,
+  jsonResult,
+  readNumberParam,
+  readReactionParams,
+  readStringArrayParam,
+  readStringParam,
+} from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
 const messageActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages"]);

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -1,4 +1,4 @@
-import type { DmPolicy, GroupPolicy, SecretInput } from "openclaw/plugin-sdk/matrix";
+import type { DmPolicy, GroupPolicy, SecretInput } from "./runtime-api.js";
 export type { DmPolicy, GroupPolicy };
 
 export type ReplyToMode = "off" | "first" | "all";


### PR DESCRIPTION
## Summary

- Problem: the legacy Matrix integration was built on `@vector-im/matrix-bot-sdk`, which was slowing down Matrix feature development and diverging from the SDK surface needed for newer Matrix capabilities.
- Why it matters: moving to the official `matrix-js-sdk` gives us a much stronger foundation for shipping Matrix features faster, especially around encryption, verification, richer event handling, and account-scoped behavior.
- What changed: replaced the legacy Matrix implementation with the new plugin-based Matrix channel under `extensions/matrix`, migrated the runtime to `matrix-js-sdk`, added migration/install guidance and account-scoped Matrix onboarding/config/runtime flows, and kept the supporting shared-core changes needed for the new plugin to operate cleanly on current `main`.
- What did NOT change (scope boundary): this PR is not a general ACP initiative across channels; ACP support in Matrix is new work delivered as part of the new plugin, not the reason for the Matrix migration itself.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Matrix now uses the new plugin implementation from `extensions/matrix` instead of the legacy path.
- The new Matrix plugin is based on the official `matrix-js-sdk` rather than `@vector-im/matrix-bot-sdk`.
- Matrix onboarding, config, verification, storage, and account-scoped runtime behavior are updated to the new plugin model.
- Matrix ACP support is now available in the new plugin, including thread-bound session spawning/focus behavior and ACP session identifier resolution.
- In Matrix top-level rooms/DMs, `--thread here` now explains to use `--thread auto`; inside an existing Matrix thread, `--thread here` still works.
- `/acp sessions` now lists ACP sessions across ACP agent stores instead of falsely showing `(none)` when sessions exist.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation:
  The new Matrix plugin changes the Matrix runtime foundation and introduces the `matrix-js-sdk`-based verification/encryption/event-handling path, along with account-scoped onboarding/config behavior. ACP support is also introduced for Matrix in this new plugin. Risk is concentrated in Matrix-specific auth/runtime behavior and in shared session-binding flows touched to support Matrix ACP correctly. Mitigations in this PR are migration/update guidance, startup/install warnings, account-scoped config resolution, Matrix thread-binding tests, ACP resolution tests, and build/test verification on the rebased branch.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Matrix, ACP/ACPX
- Relevant config (redacted): Matrix plugin enabled; ACP backend `acpx`

### Steps

1. Rebase the Matrix plugin branch onto current `main`.
2. Run the targeted Matrix/ACP regression suite for the new plugin and shared binding logic.
3. Run a full build.

### Expected

- The new Matrix plugin builds on top of current `main`.
- The `matrix-js-sdk`-based Matrix implementation is wired into current plugin/runtime/config surfaces.
- Matrix ACP flows that were added in the new plugin resolve and bind correctly.
- No regressions in the targeted ACP/thread-binding tests.

### Actual

- Targeted Matrix/ACP tests pass.
- Full build passes on the rebased branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: rebased branch onto `origin/main`; verified ACP session-binding service tests, ACP command tests, `/focus` tests, and Matrix thread-binding tests; verified full `pnpm build` succeeds.
- Edge cases checked: ACP shorthand session resolution (`acp:<uuid>` and UUID suffix), Matrix `--thread here` guidance from top-level rooms, ACP sessions listing across ACP agent stores, and the rebased Matrix plugin building cleanly on current `main`.
- What you did **not** verify: live Matrix account/device verification against a real homeserver in this PR workflow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): No
- Config/env changes? (`Yes/No`): Yes
- Migration needed? (`Yes/No`): Yes
- If yes, exact upgrade steps:
  1. Update to a build including this PR.
  2. Install/use the Matrix plugin from `extensions/matrix` / `@openclaw/matrix`.
  3. Follow the Matrix migration/update docs added in this PR.
  4. If using ACP in Matrix, use `--thread auto` from top-level rooms/DMs and `--thread here` only inside existing Matrix threads.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: disable/uninstall the Matrix plugin or revert this PR.
- Files/config to restore: Matrix plugin config, onboarding state, and any prior Matrix integration packaging from before this PR.
- Known bad symptoms reviewers should watch for: Matrix startup/install warnings, failed Matrix verification/bootstrap, Matrix migration issues after switching from the legacy implementation, or ACP sessions in Matrix not binding as expected.

## Risks and Mitigations

- Risk: Matrix migration leaves some installs on outdated config/runtime assumptions.
  - Mitigation: migration docs, startup warnings, account-scoped config handling, and legacy-state helpers are included.
- Risk: switching SDK foundations from `@vector-im/matrix-bot-sdk` to `matrix-js-sdk` changes runtime behavior in subtle Matrix-specific areas.
  - Mitigation: the new plugin adds targeted tests for verification, storage, routing, thread bindings, and startup behavior, and the branch was rebased and rebuilt on top of current `main`.
- Risk: shared ACP/session-binding changes introduced for the new Matrix plugin could affect other channels.
  - Mitigation: resolution changes are additive, targeted tests cover ACP command and `/focus` behavior, and existing gateway resolution still runs first.
