### PR TITLE
feat(extensions): add A2A cross-network agent-to-agent extension

### DIFF
--- a/extensions/a2a/index.test.ts
+++ b/extensions/a2a/index.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("a2a plugin", () => {
+  it("has correct metadata", () => {
+    expect(plugin.id).toBe("a2a");
+    expect(plugin.name).toBe("A2A Gateway");
+    expect(plugin.description).toContain("A2A");
+  });
+
+  it("has a config schema with parse method", () => {
+    expect(plugin.configSchema).toBeDefined();
+    expect(typeof plugin.configSchema.parse).toBe("function");
+  });
+
+  it("does not register anything when disabled", () => {
+    const registerHttpHandler = vi.fn();
+    const registerTool = vi.fn();
+    const registerGatewayMethod = vi.fn();
+    const registerService = vi.fn();
+    const registerCli = vi.fn();
+
+    plugin.register({
+      id: "a2a",
+      name: "A2A Gateway",
+      description: "test",
+      source: "test",
+      pluginConfig: { enabled: false },
+      config: {},
+      runtime: {} as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      registerTool,
+      registerHook: vi.fn(),
+      registerHttpHandler,
+      registerHttpRoute: vi.fn(),
+      registerChannel: vi.fn(),
+      registerGatewayMethod,
+      registerCli,
+      registerService,
+      registerProvider: vi.fn(),
+      registerCommand: vi.fn(),
+      resolvePath: (input: string) => input,
+      on: vi.fn(),
+    });
+
+    expect(registerHttpHandler).not.toHaveBeenCalled();
+    expect(registerTool).not.toHaveBeenCalled();
+    expect(registerGatewayMethod).not.toHaveBeenCalled();
+    expect(registerService).not.toHaveBeenCalled();
+    expect(registerCli).not.toHaveBeenCalled();
+  });
+
+  it("registers all components when enabled", () => {
+    const registerHttpHandler = vi.fn();
+    const registerTool = vi.fn();
+    const registerGatewayMethod = vi.fn();
+    const registerService = vi.fn();
+    const registerCli = vi.fn();
+
+    plugin.register({
+      id: "a2a",
+      name: "A2A Gateway",
+      description: "test",
+      source: "test",
+      pluginConfig: { enabled: true },
+      config: {},
+      runtime: {} as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      registerTool,
+      registerHook: vi.fn(),
+      registerHttpHandler,
+      registerHttpRoute: vi.fn(),
+      registerChannel: vi.fn(),
+      registerGatewayMethod,
+      registerCli,
+      registerService,
+      registerProvider: vi.fn(),
+      registerCommand: vi.fn(),
+      resolvePath: (input: string) => input,
+      on: vi.fn(),
+    });
+
+    // HTTP handler
+    expect(registerHttpHandler).toHaveBeenCalledTimes(1);
+
+    // 2 tools: a2a_discover, a2a_send
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    const toolNames = registerTool.mock.calls.map(
+      (c: unknown[]) => (c[1] as { name: string }).name,
+    );
+    expect(toolNames).toContain("a2a_discover");
+    expect(toolNames).toContain("a2a_send");
+
+    // Gateway methods: a2a.card, a2a.peers.list, a2a.peers.discover, a2a.peers.send, a2a.peers.check
+    expect(registerGatewayMethod).toHaveBeenCalledTimes(5);
+    const methodNames = registerGatewayMethod.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(methodNames).toContain("a2a.card");
+    expect(methodNames).toContain("a2a.peers.list");
+    expect(methodNames).toContain("a2a.peers.discover");
+    expect(methodNames).toContain("a2a.peers.send");
+    expect(methodNames).toContain("a2a.peers.check");
+
+    // Service
+    expect(registerService).toHaveBeenCalledTimes(1);
+
+    // CLI
+    expect(registerCli).toHaveBeenCalledTimes(1);
+    const cliCall = registerCli.mock.calls[0] as unknown[];
+    expect((cliCall[1] as { commands: string[] }).commands).toEqual(["a2a"]);
+  });
+
+  it("warns when bearer auth enabled but no token", () => {
+    const warnFn = vi.fn();
+
+    plugin.register({
+      id: "a2a",
+      name: "A2A Gateway",
+      description: "test",
+      source: "test",
+      pluginConfig: { enabled: true, auth: { mode: "bearer" } },
+      config: {},
+      runtime: {} as never,
+      logger: { info: vi.fn(), warn: warnFn, error: vi.fn() },
+      registerTool: vi.fn(),
+      registerHook: vi.fn(),
+      registerHttpHandler: vi.fn(),
+      registerHttpRoute: vi.fn(),
+      registerChannel: vi.fn(),
+      registerGatewayMethod: vi.fn(),
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      registerProvider: vi.fn(),
+      registerCommand: vi.fn(),
+      resolvePath: (input: string) => input,
+      on: vi.fn(),
+    });
+
+    expect(warnFn).toHaveBeenCalledWith(
+      expect.stringContaining("bearer auth enabled but no token"),
+    );
+  });
+});

--- a/extensions/a2a/index.ts
+++ b/extensions/a2a/index.ts
@@ -1,0 +1,190 @@
+/**
+ * OpenClaw A2A Gateway Plugin
+ *
+ * Implements the Google A2A v0.3.0 protocol, enabling cross-network
+ * agent-to-agent communication. Mounts onto the existing Gateway HTTP
+ * server — no separate port needed.
+ *
+ * Endpoints:
+ *   GET  /.well-known/agent-card.json  → Agent Card (discovery)
+ *   POST /a2a/jsonrpc                  → A2A JSON-RPC (message/send, tasks/get)
+ *
+ * Agent tools:
+ *   a2a_discover  → fetch a remote agent's capabilities
+ *   a2a_send      → send a message to a remote A2A agent
+ *
+ * Gateway methods:
+ *   a2a.card        → get local Agent Card
+ *   a2a.peers.list  → list configured peers
+ *
+ * CLI commands:
+ *   openclaw a2a status    → plugin status summary
+ *   openclaw a2a card      → print Agent Card JSON
+ *   openclaw a2a peers     → list configured peers
+ *   openclaw a2a discover  → fetch remote Agent Card
+ *   openclaw a2a send      → send message to remote peer
+ *   openclaw a2a check     → check peer health
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { registerA2ACli } from "./src/cli.js";
+import { checkPeerHealth, fetchAgentCard, sendMessageToPeer } from "./src/client.js";
+import { parseA2AConfig, a2aConfigSchema } from "./src/config.js";
+import { createA2AServer } from "./src/server.js";
+import { createA2ADiscoverTool, createA2ASendTool } from "./src/tools/a2a-tools.js";
+
+const a2aPlugin = {
+  id: "a2a",
+  name: "A2A Gateway",
+  description: "Google A2A v0.3.0 protocol gateway — cross-network agent-to-agent communication",
+  configSchema: a2aConfigSchema,
+
+  register(api: OpenClawPluginApi) {
+    const cfg = parseA2AConfig(api.pluginConfig);
+
+    if (!cfg.enabled) {
+      api.logger.info(
+        "[a2a] plugin disabled (set plugins.entries.a2a.config.enabled = true to activate)",
+      );
+      return;
+    }
+
+    // Warn if bearer mode but no token
+    if (cfg.auth.mode === "bearer" && !cfg.auth.token) {
+      api.logger.warn(
+        "[a2a] bearer auth enabled but no token configured — inbound requests will be accepted without auth. " +
+          "Set plugins.entries.a2a.config.auth.token to secure the endpoint.",
+      );
+    }
+
+    // Resolve state directory for task persistence
+    const stateDir = api.resolvePath("~/.openclaw/state/a2a");
+
+    // Read gateway auth token from config (for local agent dispatch)
+    const gatewayCfg = api.config as Record<string, unknown>;
+    const gatewayAuth = (gatewayCfg.gateway as Record<string, unknown> | undefined)?.auth as
+      | Record<string, unknown>
+      | undefined;
+    const gatewayAuthToken = typeof gatewayAuth?.token === "string" ? gatewayAuth.token : undefined;
+
+    // Create A2A server
+    const server = createA2AServer(cfg, stateDir, api.logger, gatewayAuthToken);
+
+    // ① Mount A2A endpoints on Gateway HTTP (no extra port)
+    api.registerHttpHandler(server.handleRequest);
+
+    // ② Register agent tools
+    api.registerTool(createA2ADiscoverTool(cfg), { name: "a2a_discover" });
+    api.registerTool(createA2ASendTool(cfg, api), { name: "a2a_send" });
+
+    // ③ Gateway methods for CLI / Web UI
+    api.registerGatewayMethod("a2a.card", async ({ respond }) => {
+      respond(true, { agentCard: server.agentCard });
+    });
+
+    api.registerGatewayMethod("a2a.peers.list", async ({ respond }) => {
+      const peers = cfg.peers.map((p) => ({
+        name: p.name,
+        agentCardUrl: p.agentCardUrl,
+        hasAuth: !!p.auth,
+      }));
+      respond(true, { peers });
+    });
+
+    api.registerGatewayMethod("a2a.peers.discover", async ({ params, respond }) => {
+      try {
+        const name = typeof params?.name === "string" ? params.name.trim() : "";
+        const url = typeof params?.url === "string" ? params.url.trim() : "";
+        const peer = cfg.peers.find((p) => p.name.toLowerCase() === name.toLowerCase());
+
+        const cardUrl = peer?.agentCardUrl ?? url;
+        if (!cardUrl) {
+          respond(false, { error: "name or url required" });
+          return;
+        }
+
+        const card = await fetchAgentCard(cardUrl, peer?.auth);
+        respond(true, { agentCard: card });
+      } catch (err) {
+        respond(false, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+
+    api.registerGatewayMethod("a2a.peers.send", async ({ params, respond }) => {
+      try {
+        const name = typeof params?.name === "string" ? params.name.trim() : "";
+        const message = typeof params?.message === "string" ? params.message.trim() : "";
+        const agentId = typeof params?.agentId === "string" ? params.agentId.trim() : undefined;
+
+        if (!name || !message) {
+          respond(false, { error: "name and message required" });
+          return;
+        }
+
+        const peer = cfg.peers.find((p) => p.name.toLowerCase() === name.toLowerCase());
+        if (!peer) {
+          respond(false, { error: `peer "${name}" not found in config` });
+          return;
+        }
+
+        const result = await sendMessageToPeer({
+          peer,
+          message,
+          agentId,
+          blocking: true,
+          timeoutMs: cfg.timeouts.agentResponseMs,
+        });
+        respond(true, result);
+      } catch (err) {
+        respond(false, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+
+    api.registerGatewayMethod("a2a.peers.check", async ({ params, respond }) => {
+      try {
+        const name = typeof params?.name === "string" ? params.name.trim() : "";
+        const targets = name
+          ? cfg.peers.filter((p) => p.name.toLowerCase() === name.toLowerCase())
+          : cfg.peers;
+
+        if (targets.length === 0) {
+          respond(false, { error: name ? `peer "${name}" not found` : "no peers configured" });
+          return;
+        }
+
+        const results = await Promise.all(targets.map((p) => checkPeerHealth(p)));
+        respond(true, { results });
+      } catch (err) {
+        respond(false, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+
+    // ④ Background service — task cleanup
+    api.registerService({
+      id: "a2a",
+      start: async () => {
+        server.start();
+      },
+      stop: async () => {
+        server.stop();
+      },
+    });
+
+    // ⑤ CLI subcommands — `openclaw a2a <subcommand>`
+    api.registerCli(({ program }) => registerA2ACli({ program, config: cfg, logger: api.logger }), {
+      commands: ["a2a"],
+    });
+
+    api.logger.info(
+      `[a2a] plugin registered — card: "${cfg.card.name}", peers: ${cfg.peers.length}`,
+    );
+  },
+};
+
+export default a2aPlugin;

--- a/extensions/a2a/openclaw.plugin.json
+++ b/extensions/a2a/openclaw.plugin.json
@@ -1,0 +1,103 @@
+{
+  "id": "a2a",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean" },
+      "card": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "version": { "type": "string" },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "description": { "type": "string" },
+                "tags": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          },
+          "defaultInputModes": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "defaultOutputModes": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "auth": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["none", "bearer"]
+          },
+          "token": { "type": "string" }
+        }
+      },
+      "routing": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "defaultAgentId": { "type": "string" }
+        }
+      },
+      "peers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "agentCardUrl": { "type": "string" },
+            "auth": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["bearer"]
+                },
+                "token": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "timeouts": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "agentResponseMs": { "type": "number", "minimum": 0 },
+          "taskRetentionMs": { "type": "number", "minimum": 0 }
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "enabled": { "label": "Enable A2A Gateway" },
+    "card.name": { "label": "Agent Card Name" },
+    "card.description": { "label": "Agent Description" },
+    "card.version": { "label": "Agent Version", "advanced": true },
+    "auth.mode": { "label": "Inbound Auth Mode" },
+    "auth.token": { "label": "Inbound Bearer Token", "sensitive": true },
+    "routing.defaultAgentId": { "label": "Default Agent ID" },
+    "peers": { "label": "Remote Peers", "advanced": true },
+    "timeouts.agentResponseMs": { "label": "Agent Response Timeout (ms)", "advanced": true },
+    "timeouts.taskRetentionMs": { "label": "Task Retention Time (ms)", "advanced": true }
+  }
+}

--- a/extensions/a2a/package.json
+++ b/extensions/a2a/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openclaw/a2a",
+  "version": "2026.3.8",
+  "private": true,
+  "description": "OpenClaw A2A (Agent-to-Agent) protocol gateway — cross-network agent communication",
+  "type": "module",
+  "dependencies": {
+    "@a2a-js/sdk": "^0.3.10",
+    "@sinclair/typebox": "0.34.48"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/a2a/src/agent-card.test.ts
+++ b/extensions/a2a/src/agent-card.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentCard, A2A_PROTOCOL_VERSION, AGENT_CARD_PATHS } from "./agent-card.js";
+import type { A2APluginConfig } from "./config.js";
+
+function createConfig(overrides?: Partial<A2APluginConfig>): A2APluginConfig {
+  return {
+    enabled: true,
+    card: {
+      name: "Test Agent",
+      description: "A test A2A agent",
+      version: "1.0.0",
+      skills: [{ id: "chat", name: "Chat", description: "General chat" }],
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+    },
+    auth: { mode: "none" },
+    routing: { defaultAgentId: "default" },
+    peers: [],
+    timeouts: { agentResponseMs: 300_000, taskRetentionMs: 86_400_000 },
+    ...overrides,
+  };
+}
+
+describe("AGENT_CARD_PATHS", () => {
+  it("includes v0.3.0 standard path", () => {
+    expect(AGENT_CARD_PATHS).toContain("/.well-known/agent-card.json");
+  });
+
+  it("includes legacy v0.2.x alias", () => {
+    expect(AGENT_CARD_PATHS).toContain("/.well-known/agent.json");
+  });
+});
+
+describe("A2A_PROTOCOL_VERSION", () => {
+  it("is 0.3.0", () => {
+    expect(A2A_PROTOCOL_VERSION).toBe("0.3.0");
+  });
+});
+
+describe("buildAgentCard", () => {
+  it("builds a valid Agent Card with correct fields", () => {
+    const cfg = createConfig();
+    const card = buildAgentCard(cfg, "http://127.0.0.1:18789");
+
+    expect(card.name).toBe("Test Agent");
+    expect(card.description).toBe("A test A2A agent");
+    expect(card.version).toBe("1.0.0");
+    expect(card.protocolVersion).toBe("0.3.0");
+    expect(card.url).toBe("http://127.0.0.1:18789/a2a/jsonrpc");
+    expect(card.defaultInputModes).toEqual(["text"]);
+    expect(card.defaultOutputModes).toEqual(["text"]);
+  });
+
+  it("strips trailing slashes from gateway URL", () => {
+    const card = buildAgentCard(createConfig(), "http://example.com:8080///");
+    expect(card.url).toBe("http://example.com:8080/a2a/jsonrpc");
+  });
+
+  it("maps skills correctly", () => {
+    const cfg = createConfig({
+      card: {
+        ...createConfig().card,
+        skills: [
+          { id: "search", name: "Search", description: "Web search", tags: ["search"] },
+          { id: "code", name: "Code", description: "Code gen" },
+        ],
+      },
+    });
+    const card = buildAgentCard(cfg, "http://localhost:18789");
+
+    expect(card.skills).toHaveLength(2);
+    expect(card.skills[0]!.id).toBe("search");
+    expect(card.skills[0]!.tags).toEqual(["search"]);
+    expect(card.skills[1]!.id).toBe("code");
+    expect(card.skills[1]!.tags).toEqual([]); // undefined → []
+  });
+
+  it("sets streaming capability to true", () => {
+    const card = buildAgentCard(createConfig(), "http://localhost:18789");
+    expect(card.capabilities.streaming).toBe(true);
+    expect(card.capabilities.pushNotifications).toBe(false);
+  });
+
+  it("includes security schemes for bearer auth mode", () => {
+    const cfg = createConfig({ auth: { mode: "bearer", token: "secret" } });
+    const card = buildAgentCard(cfg, "http://localhost:18789");
+
+    expect(card.securitySchemes).toBeDefined();
+    expect(card.securitySchemes!.bearer).toBeDefined();
+    expect(card.security).toEqual([{ bearer: [] }]);
+  });
+
+  it("omits security schemes for 'none' auth mode", () => {
+    const cfg = createConfig({ auth: { mode: "none" } });
+    const card = buildAgentCard(cfg, "http://localhost:18789");
+
+    expect(card.securitySchemes).toBeUndefined();
+    expect(card.security).toBeUndefined();
+  });
+});

--- a/extensions/a2a/src/agent-card.ts
+++ b/extensions/a2a/src/agent-card.ts
@@ -1,0 +1,56 @@
+/**
+ * Build an A2A v0.3.0 Agent Card from OpenClaw plugin config.
+ *
+ * The card is served at /.well-known/agent-card.json (v0.3.0 standard path).
+ */
+
+import type { AgentCard, SecurityScheme } from "@a2a-js/sdk";
+import type { A2APluginConfig } from "./config.js";
+
+export const A2A_PROTOCOL_VERSION = "0.3.0";
+
+/** Well-known paths for Agent Card discovery (v0.3.0 + legacy alias). */
+export const AGENT_CARD_PATHS = [
+  "/.well-known/agent-card.json",
+  "/.well-known/agent.json", // legacy v0.2.x alias
+];
+
+/**
+ * Build an Agent Card from plugin config.
+ * @param cfg  Parsed A2A plugin config.
+ * @param gatewayUrl  The externally reachable gateway base URL
+ *                    (e.g. "http://100.10.10.1:18789").
+ */
+export function buildAgentCard(cfg: A2APluginConfig, gatewayUrl: string): AgentCard {
+  const baseUrl = gatewayUrl.replace(/\/+$/, "");
+  const jsonRpcUrl = `${baseUrl}/a2a/jsonrpc`;
+
+  return {
+    name: cfg.card.name,
+    description: cfg.card.description,
+    version: cfg.card.version,
+    protocolVersion: A2A_PROTOCOL_VERSION,
+    url: jsonRpcUrl,
+    skills: cfg.card.skills.map((s) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description,
+      tags: s.tags ?? [],
+    })),
+    capabilities: {
+      pushNotifications: false,
+      streaming: true,
+    },
+    defaultInputModes: cfg.card.defaultInputModes as ("text" | "file" | "data")[],
+    defaultOutputModes: cfg.card.defaultOutputModes as ("text" | "file" | "data")[],
+    // Security schemes (OpenAPI 3.0 style) for bearer auth discovery
+    ...(cfg.auth.mode === "bearer"
+      ? {
+          securitySchemes: {
+            bearer: { type: "http" as const, scheme: "bearer" } as SecurityScheme,
+          },
+          security: [{ bearer: [] }],
+        }
+      : {}),
+  } satisfies AgentCard;
+}

--- a/extensions/a2a/src/cli.ts
+++ b/extensions/a2a/src/cli.ts
@@ -1,0 +1,309 @@
+/**
+ * A2A CLI subcommands — `openclaw a2a <subcommand>`
+ *
+ * Commands:
+ *   status    — show plugin status and Agent Card summary
+ *   card      — print the full Agent Card JSON
+ *   peers     — list configured peers
+ *   discover  — fetch a remote agent's Agent Card
+ *   send      — send a message to a remote A2A peer
+ *   check     — check health of configured peers
+ */
+
+import type { Command } from "commander";
+import { buildAgentCard, A2A_PROTOCOL_VERSION } from "./agent-card.js";
+import { checkPeerHealth, fetchAgentCard, sendMessageToPeer } from "./client.js";
+import type { A2APluginConfig } from "./config.js";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** Print JSON with optional compact mode. */
+function printJson(data: unknown, compact: boolean): void {
+  console.log(JSON.stringify(data, null, compact ? 0 : 2));
+}
+
+/** Format milliseconds into human-readable duration. */
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+// ── Registration ───────────────────────────────────────────────────
+
+export function registerA2ACli(params: {
+  program: Command;
+  config: A2APluginConfig;
+  logger: Logger;
+}): void {
+  const { program, config: cfg, logger } = params;
+
+  const root = program
+    .command("a2a")
+    .description("A2A protocol — cross-network agent-to-agent communication")
+    .addHelpText("after", () => "\nDocs: https://docs.openclaw.ai/extensions/a2a\n");
+
+  // ── a2a status ──────────────────────────────────────────────────
+
+  root
+    .command("status")
+    .description("Show A2A plugin status and Agent Card summary")
+    .action(() => {
+      console.log("A2A Plugin Status");
+      console.log("─".repeat(40));
+      console.log(`  Enabled:          ${cfg.enabled ? "✓ yes" : "✗ no"}`);
+      console.log(`  Protocol:         A2A v${A2A_PROTOCOL_VERSION}`);
+      console.log(`  Agent Name:       ${cfg.card.name}`);
+      console.log(`  Agent Version:    ${cfg.card.version}`);
+      console.log(`  Auth Mode:        ${cfg.auth.mode}`);
+      console.log(`  Auth Token:       ${cfg.auth.token ? "configured" : "not set"}`);
+      console.log(`  Default Agent:    ${cfg.routing.defaultAgentId}`);
+      console.log(`  Skills:           ${cfg.card.skills.map((s) => s.name).join(", ") || "none"}`);
+      console.log(`  Input Modes:      ${cfg.card.defaultInputModes.join(", ")}`);
+      console.log(`  Output Modes:     ${cfg.card.defaultOutputModes.join(", ")}`);
+      console.log(`  Peers:            ${cfg.peers.length}`);
+      console.log(`  Response Timeout: ${formatMs(cfg.timeouts.agentResponseMs)}`);
+      console.log(`  Task Retention:   ${formatMs(cfg.timeouts.taskRetentionMs)}`);
+
+      if (cfg.peers.length > 0) {
+        console.log("");
+        console.log("Configured Peers:");
+        for (const p of cfg.peers) {
+          const authTag = p.auth ? " [auth]" : "";
+          console.log(`  • ${p.name}${authTag}`);
+          console.log(`    ${p.agentCardUrl}`);
+        }
+      }
+    });
+
+  // ── a2a card ────────────────────────────────────────────────────
+
+  root
+    .command("card")
+    .description("Print the full Agent Card JSON")
+    .option("--compact", "Print compact JSON (no indentation)", false)
+    .action((opts: { compact: boolean }) => {
+      // Build the card with a placeholder URL (actual URL depends on runtime gateway port)
+      const gatewayUrl = "http://127.0.0.1:18789";
+      const card = buildAgentCard(cfg, gatewayUrl);
+      printJson(card, opts.compact);
+    });
+
+  // ── a2a peers ───────────────────────────────────────────────────
+
+  root
+    .command("peers")
+    .description("List configured A2A peers")
+    .option("--json", "Output as JSON", false)
+    .action((opts: { json: boolean }) => {
+      if (cfg.peers.length === 0) {
+        if (opts.json) {
+          console.log("[]");
+        } else {
+          console.log("No peers configured.");
+          console.log("Add peers in config: plugins.entries.a2a.config.peers");
+        }
+        return;
+      }
+
+      if (opts.json) {
+        const peers = cfg.peers.map((p) => ({
+          name: p.name,
+          agentCardUrl: p.agentCardUrl,
+          hasAuth: !!p.auth,
+        }));
+        printJson(peers, false);
+        return;
+      }
+
+      console.log(`A2A Peers (${cfg.peers.length}):`);
+      console.log("─".repeat(60));
+      for (const p of cfg.peers) {
+        const authTag = p.auth ? " 🔒" : "";
+        console.log(`  ${p.name}${authTag}`);
+        console.log(`    URL: ${p.agentCardUrl}`);
+      }
+    });
+
+  // ── a2a discover ────────────────────────────────────────────────
+
+  root
+    .command("discover")
+    .description("Fetch a remote agent's Agent Card")
+    .argument("<target>", "Peer name (from config) or Agent Card URL")
+    .option("--compact", "Print compact JSON", false)
+    .action(async (target: string, opts: { compact: boolean }) => {
+      try {
+        // Resolve: peer name or raw URL
+        const peer = cfg.peers.find((p) => p.name.toLowerCase() === target.toLowerCase());
+        const cardUrl = peer?.agentCardUrl ?? target;
+
+        if (!cardUrl.startsWith("http://") && !cardUrl.startsWith("https://")) {
+          if (!peer) {
+            console.error(`Error: "${target}" is not a configured peer and not a valid URL.`);
+            console.error(`Configured peers: ${cfg.peers.map((p) => p.name).join(", ") || "none"}`);
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        console.error(`Fetching Agent Card from ${cardUrl}...`);
+        const card = await fetchAgentCard(cardUrl, peer?.auth);
+        printJson(card, opts.compact);
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+
+  // ── a2a send ────────────────────────────────────────────────────
+
+  root
+    .command("send")
+    .description("Send a message to a remote A2A peer")
+    .requiredOption("-p, --peer <name>", "Peer name (from config)")
+    .requiredOption("-m, --message <text>", "Message to send")
+    .option("--agent-id <id>", "Target agent ID on the remote peer")
+    .option("--async", "Send non-blocking (returns task ID for polling)", false)
+    .option("--timeout <ms>", "Response timeout in milliseconds")
+    .option("--json", "Output raw JSON response", false)
+    .action(
+      async (opts: {
+        peer: string;
+        message: string;
+        agentId?: string;
+        async: boolean;
+        timeout?: string;
+        json: boolean;
+      }) => {
+        try {
+          const peer = cfg.peers.find((p) => p.name.toLowerCase() === opts.peer.toLowerCase());
+          if (!peer) {
+            console.error(`Error: peer "${opts.peer}" not found in config.`);
+            console.error(`Configured peers: ${cfg.peers.map((p) => p.name).join(", ") || "none"}`);
+            process.exitCode = 1;
+            return;
+          }
+
+          const timeoutMs = opts.timeout
+            ? parseInt(opts.timeout, 10)
+            : cfg.timeouts.agentResponseMs;
+          const blocking = !opts.async;
+
+          if (!opts.json) {
+            console.error(`Sending to ${peer.name}${blocking ? " (blocking)" : " (async)"}...`);
+          }
+
+          const result = await sendMessageToPeer({
+            peer,
+            message: opts.message,
+            agentId: opts.agentId,
+            blocking,
+            timeoutMs,
+          });
+
+          if (opts.json) {
+            printJson(result, false);
+            return;
+          }
+
+          // Human-readable output
+          console.log("");
+          if (result.taskId) {
+            console.log(`Task ID: ${result.taskId}`);
+          }
+          console.log(`Status:  ${result.status}`);
+
+          if (result.reply) {
+            console.log("");
+            console.log("Reply:");
+            console.log("─".repeat(40));
+            console.log(result.reply);
+          }
+
+          if (result.error) {
+            console.error(`\nError: ${result.error}`);
+            process.exitCode = 1;
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger.error(`[a2a] send failed: ${msg}`);
+          console.error(`Error: ${msg}`);
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  // ── a2a check ─────────────────────────────────────────────────
+
+  root
+    .command("check")
+    .description("Check health of configured peers")
+    .argument("[name]", "Specific peer to check (checks all if omitted)")
+    .option("--json", "Output as JSON", false)
+    .action(async (name: string | undefined, opts: { json: boolean }) => {
+      const targets = name
+        ? cfg.peers.filter((p) => p.name.toLowerCase() === name.toLowerCase())
+        : cfg.peers;
+
+      if (targets.length === 0) {
+        if (name) {
+          console.error(`Error: peer "${name}" not found in config.`);
+          console.error(`Configured peers: ${cfg.peers.map((p) => p.name).join(", ") || "none"}`);
+        } else {
+          console.error("No peers configured.");
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!opts.json) {
+        console.error(`Checking ${targets.length} peer(s)...`);
+      }
+
+      // Check all peers concurrently
+      const results = await Promise.all(targets.map((p) => checkPeerHealth(p)));
+
+      if (opts.json) {
+        printJson(results, false);
+        return;
+      }
+
+      // Human-readable table
+      console.log("");
+      console.log("Peer Health Check");
+      console.log("─".repeat(60));
+
+      for (const r of results) {
+        const icon = r.reachable ? "✓" : "✗";
+        console.log(`  ${icon} ${r.name} (${r.latencyMs}ms)`);
+        if (r.reachable) {
+          console.log(`    Agent:    ${r.agentName}`);
+          console.log(`    Protocol: ${r.protocolVersion}`);
+          console.log(`    Stream:   ${r.streaming ? "yes" : "no"}`);
+          if (r.skills && r.skills.length > 0) {
+            console.log(`    Skills:   ${r.skills.join(", ")}`);
+          }
+        } else {
+          console.log(`    Error:    ${r.error}`);
+        }
+      }
+
+      const reachable = results.filter((r) => r.reachable).length;
+      console.log("");
+      console.log(`${reachable}/${results.length} peers reachable`);
+
+      if (reachable < results.length) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/extensions/a2a/src/client.test.ts
+++ b/extensions/a2a/src/client.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchAgentCard, sendMessageToPeer, checkPeerHealth } from "./client.js";
+
+// ── Mock fetch globally ──────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  mockFetch.mockReset();
+  vi.unstubAllGlobals();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers({ "content-type": "application/json" }),
+  } as unknown as Response;
+}
+
+const MOCK_AGENT_CARD = {
+  name: "Remote Agent",
+  description: "A remote A2A agent",
+  version: "1.0.0",
+  protocolVersion: "0.3.0",
+  url: "https://remote.example.com/a2a/jsonrpc",
+  skills: [{ id: "chat", name: "Chat", description: "Chat", tags: [] }],
+  capabilities: { streaming: true, pushNotifications: false },
+  defaultInputModes: ["text"],
+  defaultOutputModes: ["text"],
+};
+
+// ── Tests: fetchAgentCard ────────────────────────────────────────────
+
+describe("fetchAgentCard", () => {
+  it("fetches and returns an Agent Card", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const card = await fetchAgentCard("https://remote.example.com/.well-known/agent-card.json");
+
+    expect(card.name).toBe("Remote Agent");
+    expect(card.protocolVersion).toBe("0.3.0");
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it("includes bearer token in request headers", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    await fetchAgentCard("https://remote.example.com/.well-known/agent-card.json", {
+      type: "bearer",
+      token: "my-secret",
+    });
+
+    const callArgs = mockFetch.mock.calls[0]!;
+    const headers = callArgs[1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer my-secret");
+  });
+
+  it("throws on non-200 response", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 404));
+
+    await expect(
+      fetchAgentCard("https://not-found.example.com/.well-known/agent-card.json"),
+    ).rejects.toThrow("Failed to fetch Agent Card");
+  });
+});
+
+// ── Tests: sendMessageToPeer ─────────────────────────────────────────
+
+describe("sendMessageToPeer", () => {
+  const peer = {
+    name: "test-peer",
+    agentCardUrl: "https://remote.example.com/.well-known/agent-card.json",
+  };
+
+  it("sends a blocking message and returns reply", async () => {
+    // First call: fetch Agent Card
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    // Second call: JSON-RPC message/send
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: {
+          id: "task-123",
+          status: {
+            state: "completed",
+            message: {
+              kind: "message",
+              messageId: "msg-1",
+              role: "agent",
+              parts: [{ kind: "text", text: "Hello from remote!" }],
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await sendMessageToPeer({
+      peer,
+      message: "Hello!",
+      blocking: true,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.taskId).toBe("task-123");
+    expect(result.reply).toBe("Hello from remote!");
+  });
+
+  it("includes agent ID in message metadata", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: { id: "task-1", status: { state: "completed" } },
+      }),
+    );
+
+    await sendMessageToPeer({
+      peer,
+      message: "test",
+      agentId: "my-agent",
+    });
+
+    // Check the JSON-RPC body sent to the remote
+    const sendCall = mockFetch.mock.calls[1]!;
+    const body = JSON.parse(sendCall[1]?.body as string);
+    expect(body.params.message.metadata).toEqual({ "openclaw.agentId": "my-agent" });
+  });
+
+  it("handles JSON-RPC error response", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        error: { code: -32000, message: "Agent unavailable" },
+      }),
+    );
+
+    const result = await sendMessageToPeer({ peer, message: "test" });
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("Agent unavailable");
+  });
+
+  it("handles missing task in response", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+
+    const result = await sendMessageToPeer({ peer, message: "test" });
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("No task in response");
+  });
+
+  it("includes bearer auth in JSON-RPC request", async () => {
+    const authPeer = {
+      ...peer,
+      auth: { type: "bearer" as const, token: "peer-secret" },
+    };
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: { id: "task-1", status: { state: "completed" } },
+      }),
+    );
+
+    await sendMessageToPeer({ peer: authPeer, message: "test" });
+
+    // Check auth header on the JSON-RPC call (second fetch)
+    const sendCall = mockFetch.mock.calls[1]!;
+    const headers = sendCall[1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer peer-secret");
+  });
+
+  it("throws when Agent Card has no url", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ...MOCK_AGENT_CARD, url: "" }));
+
+    await expect(sendMessageToPeer({ peer, message: "test" })).rejects.toThrow("no url field");
+  });
+
+  it("extracts reply from artifacts when status message is empty", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: {
+          id: "task-1",
+          status: { state: "completed" },
+          artifacts: [
+            {
+              parts: [{ kind: "text", text: "Artifact reply" }],
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await sendMessageToPeer({ peer, message: "test" });
+    expect(result.reply).toBe("Artifact reply");
+  });
+});
+
+// ── Tests: checkPeerHealth ───────────────────────────────────────────
+
+describe("checkPeerHealth", () => {
+  const peer = {
+    name: "health-peer",
+    agentCardUrl: "https://remote.example.com/.well-known/agent-card.json",
+  };
+
+  it("returns reachable with agent info on success", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const result = await checkPeerHealth(peer);
+
+    expect(result.reachable).toBe(true);
+    expect(result.name).toBe("health-peer");
+    expect(result.agentName).toBe("Remote Agent");
+    expect(result.protocolVersion).toBe("0.3.0");
+    expect(result.streaming).toBe(true);
+    expect(result.skills).toEqual(["Chat"]);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns unreachable with error on failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+    const result = await checkPeerHealth(peer);
+
+    expect(result.reachable).toBe(false);
+    expect(result.name).toBe("health-peer");
+    expect(result.error).toContain("Connection refused");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns unreachable on HTTP error", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 503));
+
+    const result = await checkPeerHealth(peer);
+
+    expect(result.reachable).toBe(false);
+    expect(result.error).toContain("503");
+  });
+});

--- a/extensions/a2a/src/client.ts
+++ b/extensions/a2a/src/client.ts
@@ -1,0 +1,242 @@
+/**
+ * A2A Client — call remote A2A agents.
+ *
+ * Uses @a2a-js/sdk/client for Agent Card discovery and message sending.
+ */
+
+import type { AgentCard, Message, Task } from "@a2a-js/sdk";
+import type { A2APeer } from "./config.js";
+
+// ── Agent Card fetching ────────────────────────────────────────────
+
+/** Fetch an Agent Card from a remote URL. */
+export async function fetchAgentCard(
+  agentCardUrl: string,
+  auth?: { type: "bearer"; token: string },
+): Promise<AgentCard> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (auth?.type === "bearer" && auth.token) {
+    headers.Authorization = `Bearer ${auth.token}`;
+  }
+
+  const res = await fetch(agentCardUrl, { headers, signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch Agent Card from ${agentCardUrl}: ${res.status} ${res.statusText}`,
+    );
+  }
+  return (await res.json()) as AgentCard;
+}
+
+// ── Message sending ────────────────────────────────────────────────
+
+export type SendMessageResult = {
+  taskId?: string;
+  status: string;
+  reply?: string;
+  error?: string;
+};
+
+/**
+ * Send a message to a remote A2A agent via JSON-RPC.
+ * Uses direct fetch (no SDK client dependency) for simplicity.
+ */
+export async function sendMessageToPeer(params: {
+  peer: A2APeer;
+  message: string;
+  agentId?: string;
+  blocking?: boolean;
+  timeoutMs?: number;
+}): Promise<SendMessageResult> {
+  const { peer, message, agentId, blocking = true, timeoutMs = 300_000 } = params;
+
+  // Resolve JSON-RPC endpoint from Agent Card
+  const card = await fetchAgentCard(peer.agentCardUrl, peer.auth);
+  const jsonRpcUrl = card.url;
+  if (!jsonRpcUrl) {
+    throw new Error(`Agent Card for "${peer.name}" has no url field`);
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (peer.auth?.type === "bearer" && peer.auth.token) {
+    headers.Authorization = `Bearer ${peer.auth.token}`;
+  }
+
+  // Build A2A message (v0.3.0 requires kind + messageId)
+  const a2aMessage = {
+    kind: "message" as const,
+    messageId: crypto.randomUUID(),
+    role: "user" as const,
+    parts: [{ kind: "text" as const, text: message }],
+    ...(agentId ? { metadata: { "openclaw.agentId": agentId } } : {}),
+  };
+
+  const rpcRequest = {
+    jsonrpc: "2.0",
+    id: crypto.randomUUID(),
+    method: "message/send",
+    params: {
+      message: a2aMessage,
+      configuration: { blocking },
+    },
+  };
+
+  const res = await fetch(jsonRpcUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(rpcRequest),
+    signal: AbortSignal.timeout(blocking ? timeoutMs : 30_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`A2A JSON-RPC failed: ${res.status} ${res.statusText}`);
+  }
+
+  const rpcResponse = (await res.json()) as {
+    result?: Task;
+    error?: { code: number; message: string };
+  };
+
+  if (rpcResponse.error) {
+    return {
+      status: "error",
+      error: `${rpcResponse.error.code}: ${rpcResponse.error.message}`,
+    };
+  }
+
+  const task = rpcResponse.result;
+  if (!task) {
+    return { status: "error", error: "No task in response" };
+  }
+
+  // If blocking, the reply should be in the final status
+  const replyText = extractReplyFromTask(task);
+
+  // If non-blocking and not yet done, poll
+  if (!blocking && task.status?.state === "working") {
+    return pollUntilDone({ jsonRpcUrl, headers, taskId: task.id, timeoutMs });
+  }
+
+  return {
+    taskId: task.id,
+    status: task.status?.state ?? "unknown",
+    reply: replyText,
+  };
+}
+
+// ── Polling for async tasks ────────────────────────────────────────
+
+async function pollUntilDone(params: {
+  jsonRpcUrl: string;
+  headers: Record<string, string>;
+  taskId: string;
+  timeoutMs: number;
+}): Promise<SendMessageResult> {
+  const { jsonRpcUrl, headers, taskId, timeoutMs } = params;
+  const deadline = Date.now() + timeoutMs;
+  const pollIntervalMs = 2000;
+  const terminalStates = new Set(["completed", "failed", "canceled"]);
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+
+    const rpcRequest = {
+      jsonrpc: "2.0",
+      id: crypto.randomUUID(),
+      method: "tasks/get",
+      params: { id: taskId },
+    };
+
+    const res = await fetch(jsonRpcUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(rpcRequest),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) continue;
+
+    const rpcResponse = (await res.json()) as { result?: Task };
+    const task = rpcResponse.result;
+    if (!task?.status) continue;
+
+    if (terminalStates.has(task.status.state)) {
+      return {
+        taskId: task.id,
+        status: task.status.state,
+        reply: extractReplyFromTask(task),
+      };
+    }
+  }
+
+  return { taskId, status: "timeout", error: "Polling timed out" };
+}
+
+// ── Peer health check ─────────────────────────────────────────────
+
+export type PeerHealthResult = {
+  name: string;
+  reachable: boolean;
+  agentName?: string;
+  protocolVersion?: string;
+  skills?: string[];
+  streaming?: boolean;
+  latencyMs: number;
+  error?: string;
+};
+
+/**
+ * Check if a remote peer is reachable by fetching its Agent Card.
+ * Returns health information including latency and capabilities.
+ */
+export async function checkPeerHealth(peer: A2APeer): Promise<PeerHealthResult> {
+  const start = Date.now();
+  try {
+    const card = await fetchAgentCard(peer.agentCardUrl, peer.auth);
+    const latencyMs = Date.now() - start;
+    return {
+      name: peer.name,
+      reachable: true,
+      agentName: card.name,
+      protocolVersion: card.protocolVersion,
+      skills: card.skills?.map((s) => s.name),
+      streaming: card.capabilities?.streaming ?? false,
+      latencyMs,
+    };
+  } catch (err) {
+    return {
+      name: peer.name,
+      reachable: false,
+      latencyMs: Date.now() - start,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ── Reply extraction ───────────────────────────────────────────────
+
+function extractReplyFromTask(task: Task): string | undefined {
+  // Try status message first
+  const statusMsg = task.status?.message;
+  if (statusMsg?.parts) {
+    const texts = statusMsg.parts
+      .filter((p) => p.kind === "text")
+      .map((p) => ("text" in p ? (p as { text: string }).text : ""));
+    if (texts.length > 0) return texts.join("\n").trim();
+  }
+
+  // Fall back to artifacts
+  if (task.artifacts && task.artifacts.length > 0) {
+    const parts = task.artifacts.flatMap((a) => a.parts ?? []);
+    const texts = parts
+      .filter((p) => p.kind === "text")
+      .map((p) => ("text" in p ? (p as { text: string }).text : ""));
+    if (texts.length > 0) return texts.join("\n").trim();
+  }
+
+  return undefined;
+}

--- a/extensions/a2a/src/config.test.ts
+++ b/extensions/a2a/src/config.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { parseA2AConfig } from "./config.js";
+
+describe("parseA2AConfig", () => {
+  it("returns defaults for empty input", () => {
+    const cfg = parseA2AConfig({});
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.card.name).toBe("OpenClaw Agent");
+    expect(cfg.card.description).toBe("OpenClaw A2A-enabled agent");
+    expect(cfg.card.version).toBe("1.0.0");
+    expect(cfg.card.defaultInputModes).toEqual(["text"]);
+    expect(cfg.card.defaultOutputModes).toEqual(["text"]);
+    expect(cfg.auth.mode).toBe("bearer");
+    expect(cfg.auth.token).toBeUndefined();
+    expect(cfg.routing.defaultAgentId).toBe("default");
+    expect(cfg.peers).toEqual([]);
+    expect(cfg.timeouts.agentResponseMs).toBe(300_000);
+    expect(cfg.timeouts.taskRetentionMs).toBe(86_400_000);
+  });
+
+  it("returns defaults for null/undefined/non-object input", () => {
+    expect(parseA2AConfig(null).enabled).toBe(false);
+    expect(parseA2AConfig(undefined).enabled).toBe(false);
+    expect(parseA2AConfig("string").enabled).toBe(false);
+    expect(parseA2AConfig(42).enabled).toBe(false);
+    expect(parseA2AConfig([]).enabled).toBe(false);
+  });
+
+  it("parses enabled flag", () => {
+    expect(parseA2AConfig({ enabled: true }).enabled).toBe(true);
+    expect(parseA2AConfig({ enabled: false }).enabled).toBe(false);
+    expect(parseA2AConfig({ enabled: "yes" }).enabled).toBe(false); // non-boolean
+  });
+
+  it("parses card fields", () => {
+    const cfg = parseA2AConfig({
+      card: {
+        name: "My Agent",
+        description: "A test agent",
+        version: "2.0.0",
+        defaultInputModes: ["text", "file"],
+        defaultOutputModes: ["data"],
+      },
+    });
+    expect(cfg.card.name).toBe("My Agent");
+    expect(cfg.card.description).toBe("A test agent");
+    expect(cfg.card.version).toBe("2.0.0");
+    expect(cfg.card.defaultInputModes).toEqual(["text", "file"]);
+    expect(cfg.card.defaultOutputModes).toEqual(["data"]);
+  });
+
+  it("provides default skill when none specified", () => {
+    const cfg = parseA2AConfig({});
+    expect(cfg.card.skills).toEqual([
+      { id: "chat", name: "Chat", description: "General-purpose chat" },
+    ]);
+  });
+
+  it("parses custom skills", () => {
+    const cfg = parseA2AConfig({
+      card: {
+        skills: [
+          { id: "search", name: "Search", description: "Web search", tags: ["search", "web"] },
+          { id: "code", name: "Code", description: "Code generation" },
+        ],
+      },
+    });
+    expect(cfg.card.skills).toHaveLength(2);
+    expect(cfg.card.skills[0]!.id).toBe("search");
+    expect(cfg.card.skills[0]!.tags).toEqual(["search", "web"]);
+    expect(cfg.card.skills[1]!.id).toBe("code");
+    expect(cfg.card.skills[1]!.tags).toBeUndefined();
+  });
+
+  it("falls back to default skill for empty/invalid skills array", () => {
+    expect(parseA2AConfig({ card: { skills: [] } }).card.skills).toHaveLength(1);
+    expect(parseA2AConfig({ card: { skills: [{}] } }).card.skills).toHaveLength(1);
+    expect(parseA2AConfig({ card: { skills: "invalid" } }).card.skills).toHaveLength(1);
+  });
+
+  it("parses auth mode 'none'", () => {
+    const cfg = parseA2AConfig({ auth: { mode: "none" } });
+    expect(cfg.auth.mode).toBe("none");
+  });
+
+  it("defaults to bearer auth with no token", () => {
+    const cfg = parseA2AConfig({});
+    expect(cfg.auth.mode).toBe("bearer");
+    expect(cfg.auth.token).toBeUndefined();
+  });
+
+  it("parses bearer auth with token", () => {
+    const cfg = parseA2AConfig({ auth: { mode: "bearer", token: "secret123" } });
+    expect(cfg.auth.mode).toBe("bearer");
+    expect(cfg.auth.token).toBe("secret123");
+  });
+
+  it("trims whitespace from token", () => {
+    const cfg = parseA2AConfig({ auth: { token: "  secret  " } });
+    expect(cfg.auth.token).toBe("secret");
+  });
+
+  it("parses peers", () => {
+    const cfg = parseA2AConfig({
+      peers: [
+        { name: "alice", agentCardUrl: "https://alice.example.com/.well-known/agent-card.json" },
+        {
+          name: "bob",
+          agentCardUrl: "https://bob.example.com/.well-known/agent-card.json",
+          auth: { type: "bearer", token: "bob-secret" },
+        },
+      ],
+    });
+    expect(cfg.peers).toHaveLength(2);
+    expect(cfg.peers[0]!.name).toBe("alice");
+    expect(cfg.peers[0]!.auth).toBeUndefined();
+    expect(cfg.peers[1]!.name).toBe("bob");
+    expect(cfg.peers[1]!.auth).toEqual({ type: "bearer", token: "bob-secret" });
+  });
+
+  it("skips peers with missing name or url", () => {
+    const cfg = parseA2AConfig({
+      peers: [
+        { name: "", agentCardUrl: "https://example.com" },
+        { name: "alice", agentCardUrl: "" },
+        { name: "valid", agentCardUrl: "https://valid.com" },
+        null,
+        42,
+      ],
+    });
+    expect(cfg.peers).toHaveLength(1);
+    expect(cfg.peers[0]!.name).toBe("valid");
+  });
+
+  it("skips peer auth with invalid type", () => {
+    const cfg = parseA2AConfig({
+      peers: [
+        {
+          name: "test",
+          agentCardUrl: "https://test.com",
+          auth: { type: "apikey", token: "key" },
+        },
+      ],
+    });
+    expect(cfg.peers[0]!.auth).toBeUndefined();
+  });
+
+  it("parses routing config", () => {
+    const cfg = parseA2AConfig({ routing: { defaultAgentId: "my-agent" } });
+    expect(cfg.routing.defaultAgentId).toBe("my-agent");
+  });
+
+  it("parses timeout values", () => {
+    const cfg = parseA2AConfig({
+      timeouts: { agentResponseMs: 60_000, taskRetentionMs: 3_600_000 },
+    });
+    expect(cfg.timeouts.agentResponseMs).toBe(60_000);
+    expect(cfg.timeouts.taskRetentionMs).toBe(3_600_000);
+  });
+
+  it("rejects negative timeout values", () => {
+    const cfg = parseA2AConfig({
+      timeouts: { agentResponseMs: -1, taskRetentionMs: -100 },
+    });
+    expect(cfg.timeouts.agentResponseMs).toBe(300_000); // default
+    expect(cfg.timeouts.taskRetentionMs).toBe(86_400_000); // default
+  });
+});

--- a/extensions/a2a/src/config.ts
+++ b/extensions/a2a/src/config.ts
@@ -1,0 +1,190 @@
+/**
+ * A2A plugin configuration types and parser.
+ *
+ * Config path: plugins.entries.a2a.config
+ */
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type A2APeerAuth = {
+  type: "bearer";
+  token: string;
+};
+
+export type A2APeer = {
+  name: string;
+  agentCardUrl: string;
+  auth?: A2APeerAuth;
+};
+
+export type A2ACardSkill = {
+  id: string;
+  name: string;
+  description: string;
+  tags?: string[];
+};
+
+export type A2APluginConfig = {
+  enabled: boolean;
+
+  card: {
+    name: string;
+    description: string;
+    version: string;
+    skills: A2ACardSkill[];
+    defaultInputModes: string[];
+    defaultOutputModes: string[];
+  };
+
+  auth: {
+    mode: "none" | "bearer";
+    token?: string;
+  };
+
+  routing: {
+    defaultAgentId: string;
+  };
+
+  peers: A2APeer[];
+
+  timeouts: {
+    agentResponseMs: number;
+    taskRetentionMs: number;
+  };
+};
+
+// ── Defaults ───────────────────────────────────────────────────────
+
+const DEFAULTS = {
+  enabled: false,
+  cardName: "OpenClaw Agent",
+  cardDescription: "OpenClaw A2A-enabled agent",
+  cardVersion: "1.0.0",
+  defaultInputModes: ["text"] as string[],
+  defaultOutputModes: ["text"] as string[],
+  authMode: "bearer" as const,
+  defaultAgentId: "default",
+  agentResponseMs: 300_000,
+  taskRetentionMs: 86_400_000, // 24h
+} as const;
+
+// ── Parser ─────────────────────────────────────────────────────────
+
+function str(val: unknown, fallback: string): string {
+  return typeof val === "string" && val.trim() ? val.trim() : fallback;
+}
+
+function num(val: unknown, fallback: number): number {
+  return typeof val === "number" && Number.isFinite(val) && val >= 0 ? val : fallback;
+}
+
+function parsePeers(raw: unknown): A2APeer[] {
+  if (!Array.isArray(raw)) return [];
+  const peers: A2APeer[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const name = typeof e.name === "string" ? e.name.trim() : "";
+    const agentCardUrl = typeof e.agentCardUrl === "string" ? e.agentCardUrl.trim() : "";
+    if (!name || !agentCardUrl) continue;
+
+    let auth: A2APeerAuth | undefined;
+    if (e.auth && typeof e.auth === "object") {
+      const a = e.auth as Record<string, unknown>;
+      if (a.type === "bearer" && typeof a.token === "string" && a.token.trim()) {
+        auth = { type: "bearer", token: a.token.trim() };
+      }
+    }
+    peers.push({ name, agentCardUrl, auth });
+  }
+  return peers;
+}
+
+function parseSkills(raw: unknown): A2ACardSkill[] {
+  if (!Array.isArray(raw)) {
+    return [{ id: "chat", name: "Chat", description: "General-purpose chat" }];
+  }
+  const skills: A2ACardSkill[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const id = typeof e.id === "string" ? e.id.trim() : "";
+    const name = typeof e.name === "string" ? e.name.trim() : id;
+    const description = typeof e.description === "string" ? e.description.trim() : "";
+    if (!id) continue;
+    const tags = Array.isArray(e.tags)
+      ? e.tags.filter((t): t is string => typeof t === "string")
+      : undefined;
+    skills.push({ id, name, description, ...(tags ? { tags } : {}) });
+  }
+  return skills.length > 0
+    ? skills
+    : [{ id: "chat", name: "Chat", description: "General-purpose chat" }];
+}
+
+export function parseA2AConfig(raw: unknown): A2APluginConfig {
+  const cfg =
+    raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+
+  const card = (cfg.card ?? {}) as Record<string, unknown>;
+  const auth = (cfg.auth ?? {}) as Record<string, unknown>;
+  const routing = (cfg.routing ?? {}) as Record<string, unknown>;
+  const timeouts = (cfg.timeouts ?? {}) as Record<string, unknown>;
+
+  const authMode = auth.mode === "none" ? "none" : DEFAULTS.authMode;
+  const authToken = typeof auth.token === "string" ? auth.token.trim() : undefined;
+
+  // Warn if bearer mode has no token
+  if (authMode === "bearer" && !authToken) {
+    // Will be logged by the plugin entry — config parser stays pure
+  }
+
+  return {
+    enabled: typeof cfg.enabled === "boolean" ? cfg.enabled : DEFAULTS.enabled,
+
+    card: {
+      name: str(card.name, DEFAULTS.cardName),
+      description: str(card.description, DEFAULTS.cardDescription),
+      version: str(card.version, DEFAULTS.cardVersion),
+      skills: parseSkills(card.skills),
+      defaultInputModes: Array.isArray(card.defaultInputModes)
+        ? card.defaultInputModes.filter((m): m is string => typeof m === "string")
+        : DEFAULTS.defaultInputModes,
+      defaultOutputModes: Array.isArray(card.defaultOutputModes)
+        ? card.defaultOutputModes.filter((m): m is string => typeof m === "string")
+        : DEFAULTS.defaultOutputModes,
+    },
+
+    auth: { mode: authMode, token: authToken },
+
+    routing: {
+      defaultAgentId: str(routing.defaultAgentId, DEFAULTS.defaultAgentId),
+    },
+
+    peers: parsePeers(cfg.peers),
+
+    timeouts: {
+      agentResponseMs: num(timeouts.agentResponseMs, DEFAULTS.agentResponseMs),
+      taskRetentionMs: num(timeouts.taskRetentionMs, DEFAULTS.taskRetentionMs),
+    },
+  };
+}
+
+// ── Config schema for plugin definition ────────────────────────────
+
+export const a2aConfigSchema = {
+  parse(value: unknown): A2APluginConfig {
+    return parseA2AConfig(value);
+  },
+  uiHints: {
+    enabled: { label: "Enable A2A Gateway" },
+    "card.name": { label: "Agent Card Name" },
+    "card.description": { label: "Agent Description" },
+    "auth.mode": { label: "Inbound Auth Mode" },
+    "auth.token": { label: "Inbound Bearer Token", sensitive: true },
+    "routing.defaultAgentId": { label: "Default Agent ID" },
+    peers: { label: "Remote Peers", advanced: true },
+    "timeouts.agentResponseMs": { label: "Agent Response Timeout (ms)", advanced: true },
+    "timeouts.taskRetentionMs": { label: "Task Retention (ms)", advanced: true },
+  },
+};

--- a/extensions/a2a/src/executor.test.ts
+++ b/extensions/a2a/src/executor.test.ts
@@ -1,0 +1,378 @@
+import type { Message } from "@a2a-js/sdk";
+import type { ExecutionEventBus, RequestContext } from "@a2a-js/sdk/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { A2APluginConfig } from "./config.js";
+import { OpenClawAgentExecutor } from "./executor.js";
+
+// ── Mock fetch ───────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  mockFetch.mockReset();
+  vi.unstubAllGlobals();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createConfig(overrides?: Partial<A2APluginConfig>): A2APluginConfig {
+  return {
+    enabled: true,
+    card: {
+      name: "Test",
+      description: "Test",
+      version: "1.0.0",
+      skills: [],
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+    },
+    auth: { mode: "none" },
+    routing: { defaultAgentId: "default" },
+    peers: [],
+    timeouts: { agentResponseMs: 30_000, taskRetentionMs: 86_400_000 },
+    ...overrides,
+  };
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function createEventBus(): ExecutionEventBus & { events: unknown[] } {
+  const events: unknown[] = [];
+  let finishedCalled = false;
+  return {
+    events,
+    publish(event: unknown) {
+      events.push(event);
+    },
+    finished() {
+      finishedCalled = true;
+    },
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+    removeAllListeners: vi.fn(),
+    get _finished() {
+      return finishedCalled;
+    },
+  } as unknown as ExecutionEventBus & { events: unknown[]; _finished: boolean };
+}
+
+function createContext(overrides?: Partial<RequestContext>): RequestContext {
+  return {
+    taskId: "task-1",
+    contextId: "ctx-1",
+    userMessage: {
+      kind: "message",
+      messageId: "msg-1",
+      role: "user",
+      parts: [{ kind: "text", text: "Hello agent!" }],
+    } as Message,
+    ...overrides,
+  } as RequestContext;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+// ── Tests: execute ───────────────────────────────────────────────────
+
+describe("OpenClawAgentExecutor", () => {
+  describe("execute", () => {
+    it("publishes working status, then completed with reply", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "Hello from gateway!" } }],
+        }),
+      );
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      // Should have 2 events: working + completed
+      expect(bus.events).toHaveLength(2);
+
+      const working = bus.events[0] as { kind: string; status: { state: string } };
+      expect(working.kind).toBe("status-update");
+      expect(working.status.state).toBe("working");
+
+      const completed = bus.events[1] as {
+        kind: string;
+        final: boolean;
+        status: { state: string; message: Message };
+      };
+      expect(completed.kind).toBe("status-update");
+      expect(completed.final).toBe(true);
+      expect(completed.status.state).toBe("completed");
+
+      // Check reply text
+      const replyParts = completed.status.message.parts;
+      expect(replyParts).toHaveLength(1);
+      expect((replyParts![0] as { text: string }).text).toBe("Hello from gateway!");
+    });
+
+    it("publishes failed status for empty message", async () => {
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext({
+        userMessage: {
+          kind: "message",
+          messageId: "msg-empty",
+          role: "user",
+          parts: [],
+        } as Message,
+      });
+
+      await executor.execute(ctx, bus);
+
+      expect(bus.events).toHaveLength(1);
+      const event = bus.events[0] as {
+        status: { state: string; message: Message };
+        final: boolean;
+      };
+      expect(event.status.state).toBe("failed");
+      expect(event.final).toBe(true);
+      expect((event.status.message.parts![0] as { text: string }).text).toContain("Empty message");
+    });
+
+    it("publishes failed status on gateway error", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ error: "server error" }, 500));
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      // working + failed
+      expect(bus.events).toHaveLength(2);
+      const failed = bus.events[1] as { status: { state: string } };
+      expect(failed.status.state).toBe("failed");
+    });
+
+    it("publishes failed status when gateway returns empty response", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ choices: [] }));
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      const failed = bus.events[1] as {
+        status: { state: string; message: Message };
+      };
+      expect(failed.status.state).toBe("failed");
+      expect((failed.status.message.parts![0] as { text: string }).text).toContain(
+        "empty response",
+      );
+    });
+
+    it("always calls finished() even on error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      expect((bus as unknown as { _finished: boolean })._finished).toBe(true);
+    });
+
+    it("uses default agent ID from config", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "reply" } }],
+        }),
+      );
+
+      const cfg = createConfig({ routing: { defaultAgentId: "my-custom-agent" } });
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      // Check the fetch call body
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(fetchBody.model).toBe("my-custom-agent");
+    });
+
+    it("uses agent ID from message metadata when present", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "reply" } }],
+        }),
+      );
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext({
+        userMessage: {
+          kind: "message",
+          messageId: "msg-routed",
+          role: "user",
+          parts: [{ kind: "text", text: "Hello" }],
+          metadata: { "openclaw.agentId": "specific-agent" },
+        } as Message,
+      });
+
+      await executor.execute(ctx, bus);
+
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(fetchBody.model).toBe("specific-agent");
+    });
+
+    it("includes gateway auth token in request", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "reply" } }],
+        }),
+      );
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(
+        cfg,
+        "http://127.0.0.1:18789",
+        "gw-secret-token",
+        logger,
+      );
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      const fetchHeaders = mockFetch.mock.calls[0][1].headers;
+      expect(fetchHeaders.Authorization).toBe("Bearer gw-secret-token");
+    });
+
+    it("omits Authorization header when no gateway token", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "reply" } }],
+        }),
+      );
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      const fetchHeaders = mockFetch.mock.calls[0][1].headers;
+      expect(fetchHeaders.Authorization).toBeUndefined();
+    });
+
+    it("calls correct gateway endpoint URL", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "reply" } }],
+        }),
+      );
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://10.0.0.1:9090", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext();
+
+      await executor.execute(ctx, bus);
+
+      expect(mockFetch.mock.calls[0][0]).toBe("http://10.0.0.1:9090/v1/chat/completions");
+    });
+
+    it("extracts text from multiple text parts", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "combined reply" } }],
+        }),
+      );
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext({
+        userMessage: {
+          kind: "message",
+          messageId: "msg-multi",
+          role: "user",
+          parts: [
+            { kind: "text", text: "Line 1" },
+            { kind: "data", data: { key: "value" } },
+            { kind: "text", text: "Line 2" },
+          ],
+        } as Message,
+      });
+
+      await executor.execute(ctx, bus);
+
+      // Should combine text parts
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(fetchBody.messages[0].content).toBe("Line 1\nLine 2");
+    });
+
+    it("sets correct taskId and contextId in events", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          choices: [{ message: { content: "reply" } }],
+        }),
+      );
+
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+      const ctx = createContext({ taskId: "my-task", contextId: "my-ctx" });
+
+      await executor.execute(ctx, bus);
+
+      for (const event of bus.events) {
+        const e = event as { taskId: string; contextId: string };
+        expect(e.taskId).toBe("my-task");
+        expect(e.contextId).toBe("my-ctx");
+      }
+    });
+  });
+
+  describe("cancelTask", () => {
+    it("publishes canceled status and calls finished", async () => {
+      const cfg = createConfig();
+      const executor = new OpenClawAgentExecutor(cfg, "http://127.0.0.1:18789", undefined, logger);
+      const bus = createEventBus();
+
+      await executor.cancelTask("task-cancel-1", bus);
+
+      expect(bus.events).toHaveLength(1);
+      const event = bus.events[0] as {
+        kind: string;
+        taskId: string;
+        final: boolean;
+        status: { state: string };
+      };
+      expect(event.kind).toBe("status-update");
+      expect(event.taskId).toBe("task-cancel-1");
+      expect(event.final).toBe(true);
+      expect(event.status.state).toBe("canceled");
+      expect((bus as unknown as { _finished: boolean })._finished).toBe(true);
+    });
+  });
+});

--- a/extensions/a2a/src/executor.ts
+++ b/extensions/a2a/src/executor.ts
@@ -1,0 +1,176 @@
+/**
+ * OpenClaw AgentExecutor — bridges inbound A2A tasks to OpenClaw agent sessions.
+ *
+ * Uses the Gateway's OpenAI-compatible /v1/chat/completions endpoint to
+ * dispatch messages to the local agent. This avoids relying on internal
+ * PluginRuntime APIs and uses a stable public interface.
+ */
+
+import type { Message, Part } from "@a2a-js/sdk";
+import type { AgentExecutor, RequestContext, ExecutionEventBus } from "@a2a-js/sdk/server";
+import type { A2APluginConfig } from "./config.js";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** Extract plain text from A2A Message parts. */
+function extractText(message: Message): string {
+  if (!message.parts || !Array.isArray(message.parts)) return "";
+  return message.parts
+    .filter((p: Part) => p.kind === "text")
+    .map((p) => ("text" in p ? (p as { text: string }).text : ""))
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Resolve the target OpenClaw agentId for an inbound A2A request.
+ * Checks the standard metadata extension field for routing.
+ */
+function resolveAgentId(message: Message, defaultAgentId: string): string {
+  const meta = message.metadata as Record<string, unknown> | undefined;
+  if (meta && typeof meta["openclaw.agentId"] === "string") {
+    const id = (meta["openclaw.agentId"] as string).trim();
+    if (id) return id;
+  }
+  return defaultAgentId;
+}
+
+/** Build a v0.3.0 Message object for event publishing. */
+function makeMessage(role: "agent" | "user", text: string): Message {
+  return {
+    kind: "message",
+    messageId: crypto.randomUUID(),
+    role,
+    parts: [{ kind: "text", text }],
+  };
+}
+
+// ── Executor ───────────────────────────────────────────────────────
+
+export class OpenClawAgentExecutor implements AgentExecutor {
+  constructor(
+    private readonly cfg: A2APluginConfig,
+    private readonly gatewayBaseUrl: string,
+    private readonly gatewayAuthToken: string | undefined,
+    private readonly log: Logger,
+  ) {}
+
+  async execute(ctx: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    const text = extractText(ctx.userMessage);
+    if (!text) {
+      this.publishFinal(eventBus, ctx, "failed", "Empty message — nothing to process.");
+      return;
+    }
+
+    const agentId = resolveAgentId(ctx.userMessage, this.cfg.routing.defaultAgentId);
+
+    try {
+      // Mark task as working
+      eventBus.publish({
+        kind: "status-update",
+        taskId: ctx.taskId,
+        contextId: ctx.contextId,
+        final: false,
+        status: {
+          state: "working",
+          message: makeMessage("agent", "Processing..."),
+        },
+      });
+
+      // Call local Gateway via OpenAI-compatible endpoint
+      const replyText = await this.callLocalAgent(text, agentId);
+      this.publishFinal(eventBus, ctx, "completed", replyText);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      this.log.error(`[a2a] executor error for task ${ctx.taskId}: ${errMsg}`);
+      this.publishFinal(eventBus, ctx, "failed", `Error: ${errMsg}`);
+    } finally {
+      eventBus.finished();
+    }
+  }
+
+  async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    this.log.info(`[a2a] cancel requested for task ${taskId}`);
+    eventBus.publish({
+      kind: "status-update",
+      taskId,
+      contextId: taskId,
+      final: true,
+      status: { state: "canceled" },
+    });
+    eventBus.finished();
+  }
+
+  // ── Internal ───────────────────────────────────────────────────
+
+  /**
+   * Call the local Gateway's OpenAI-compatible /v1/chat/completions endpoint.
+   * This is a stable public API that handles routing, model selection, etc.
+   */
+  private async callLocalAgent(message: string, agentId: string): Promise<string> {
+    const url = `${this.gatewayBaseUrl}/v1/chat/completions`;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    // Use gateway auth if available
+    if (this.gatewayAuthToken) {
+      headers.Authorization = `Bearer ${this.gatewayAuthToken}`;
+    }
+
+    const body = {
+      model: agentId,
+      messages: [{ role: "user", content: message }],
+      stream: false,
+    };
+
+    const timeoutMs = this.cfg.timeouts.agentResponseMs;
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "");
+      throw new Error(`Gateway returned ${res.status}: ${errBody.slice(0, 200)}`);
+    }
+
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const content = data?.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error("Gateway returned empty response");
+    }
+    return content;
+  }
+
+  private publishFinal(
+    eventBus: ExecutionEventBus,
+    ctx: RequestContext,
+    state: "completed" | "failed",
+    text: string,
+  ): void {
+    eventBus.publish({
+      kind: "status-update",
+      taskId: ctx.taskId,
+      contextId: ctx.contextId,
+      final: true,
+      status: {
+        state,
+        message: makeMessage("agent", text),
+      },
+    });
+  }
+}

--- a/extensions/a2a/src/server.test.ts
+++ b/extensions/a2a/src/server.test.ts
@@ -1,0 +1,240 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import type { A2APluginConfig } from "./config.js";
+import { createA2AServer } from "./server.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createConfig(overrides?: Partial<A2APluginConfig>): A2APluginConfig {
+  return {
+    enabled: true,
+    card: {
+      name: "Test Agent",
+      description: "Test",
+      version: "1.0.0",
+      skills: [{ id: "chat", name: "Chat", description: "Chat" }],
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+    },
+    auth: { mode: "none" },
+    routing: { defaultAgentId: "default" },
+    peers: [],
+    timeouts: { agentResponseMs: 300_000, taskRetentionMs: 86_400_000 },
+    ...overrides,
+  };
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function createReq(method: string, url: string, headers?: Record<string, string>): IncomingMessage {
+  return {
+    method,
+    url,
+    headers: { host: "localhost:18789", ...headers },
+    socket: { remoteAddress: "127.0.0.1" },
+    on: vi.fn(),
+  } as unknown as IncomingMessage;
+}
+
+type MockRes = ServerResponse & {
+  _status: number;
+  _headers: Record<string, string>;
+  _body: string;
+  _ended: boolean;
+};
+
+function createRes(): MockRes {
+  const headers: Record<string, string> = {};
+  let body = "";
+  let ended = false;
+  let status = 200;
+  const res = {
+    get _status() {
+      return status;
+    },
+    get _headers() {
+      return headers;
+    },
+    get _body() {
+      return body;
+    },
+    get _ended() {
+      return ended;
+    },
+    writeHead(s: number, h?: Record<string, string | number>) {
+      status = s;
+      if (h) for (const [k, v] of Object.entries(h)) headers[k.toLowerCase()] = String(v);
+      return res;
+    },
+    setHeader(key: string, value: string) {
+      headers[key.toLowerCase()] = value;
+      return res;
+    },
+    getHeader(key: string) {
+      return headers[key.toLowerCase()];
+    },
+    write(chunk: string) {
+      body += chunk;
+      return true;
+    },
+    end(data?: string) {
+      if (data) body += data;
+      ended = true;
+      return res;
+    },
+    flushHeaders() {},
+  } as unknown as MockRes;
+  return res;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("createA2AServer", () => {
+  it("creates a server with correct agent card", () => {
+    const cfg = createConfig();
+    const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+    expect(server.agentCard.name).toBe("Test Agent");
+    expect(server.agentCard.protocolVersion).toBe("0.3.0");
+    expect(server.agentCard.url).toBe("http://127.0.0.1:18789/a2a/jsonrpc");
+  });
+
+  describe("handleRequest", () => {
+    it("serves Agent Card on GET /.well-known/agent-card.json", async () => {
+      const cfg = createConfig();
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      const req = createReq("GET", "/.well-known/agent-card.json");
+      const res = createRes();
+
+      const handled = await server.handleRequest(req, res);
+
+      expect(handled).toBe(true);
+      expect(res._status).toBe(200);
+      expect(res._headers["content-type"]).toBe("application/json");
+
+      const body = JSON.parse(res._body);
+      expect(body.name).toBe("Test Agent");
+      expect(body.protocolVersion).toBe("0.3.0");
+    });
+
+    it("serves Agent Card on legacy path /.well-known/agent.json", async () => {
+      const cfg = createConfig();
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      const req = createReq("GET", "/.well-known/agent.json");
+      const res = createRes();
+
+      const handled = await server.handleRequest(req, res);
+      expect(handled).toBe(true);
+      expect(res._status).toBe(200);
+    });
+
+    it("returns false for unrelated paths", async () => {
+      const cfg = createConfig();
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      const req = createReq("GET", "/some/other/path");
+      const res = createRes();
+
+      const handled = await server.handleRequest(req, res);
+      expect(handled).toBe(false);
+    });
+
+    it("returns false for GET on JSON-RPC path", async () => {
+      const cfg = createConfig();
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      const req = createReq("GET", "/a2a/jsonrpc");
+      const res = createRes();
+
+      const handled = await server.handleRequest(req, res);
+      expect(handled).toBe(false);
+    });
+
+    it("rejects POST without bearer token when auth configured", async () => {
+      const cfg = createConfig({ auth: { mode: "bearer", token: "secret123" } });
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      // Simulate POST with body
+      const req = createReq("POST", "/a2a/jsonrpc");
+      const res = createRes();
+
+      // Mock request body reading
+      const onMock = req.on as ReturnType<typeof vi.fn>;
+      onMock.mockImplementation((event: string, handler: (data?: Buffer) => void) => {
+        if (event === "end") handler();
+        return req;
+      });
+
+      const handled = await server.handleRequest(req, res);
+      expect(handled).toBe(true);
+      expect(res._status).toBe(401);
+
+      const body = JSON.parse(res._body);
+      expect(body.error.message).toBe("Unauthorized");
+    });
+
+    it("accepts POST with correct bearer token", async () => {
+      const cfg = createConfig({ auth: { mode: "bearer", token: "secret123" } });
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      const req = createReq("POST", "/a2a/jsonrpc", {
+        authorization: "Bearer secret123",
+      });
+      const res = createRes();
+
+      // Mock request body with invalid JSON-RPC (to trigger parse error, but auth should pass)
+      const onMock = req.on as ReturnType<typeof vi.fn>;
+      onMock.mockImplementation((event: string, handler: (data?: Buffer) => void) => {
+        if (event === "data") handler(Buffer.from("not-json"));
+        if (event === "end") handler();
+        return req;
+      });
+
+      const handled = await server.handleRequest(req, res);
+      expect(handled).toBe(true);
+      // Should get parse error (400) not auth error (401)
+      expect(res._status).toBe(400);
+    });
+
+    it("accepts requests when auth mode is none", async () => {
+      const cfg = createConfig({ auth: { mode: "none" } });
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      const req = createReq("POST", "/a2a/jsonrpc");
+      const res = createRes();
+
+      const onMock = req.on as ReturnType<typeof vi.fn>;
+      onMock.mockImplementation((event: string, handler: (data?: Buffer) => void) => {
+        if (event === "data") handler(Buffer.from("{}"));
+        if (event === "end") handler();
+        return req;
+      });
+
+      const handled = await server.handleRequest(req, res);
+      expect(handled).toBe(true);
+      // No 401 — either 200 or 400 from JSON-RPC processing
+      expect(res._status).not.toBe(401);
+    });
+  });
+
+  describe("start/stop", () => {
+    it("starts and stops without error", () => {
+      const cfg = createConfig();
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      expect(() => server.start()).not.toThrow();
+      expect(() => server.stop()).not.toThrow();
+    });
+
+    it("can stop multiple times safely", () => {
+      const cfg = createConfig();
+      const server = createA2AServer(cfg, "/tmp/a2a-test", logger, undefined);
+
+      server.start();
+      expect(() => server.stop()).not.toThrow();
+      expect(() => server.stop()).not.toThrow();
+    });
+  });
+});

--- a/extensions/a2a/src/server.ts
+++ b/extensions/a2a/src/server.ts
@@ -1,0 +1,226 @@
+/**
+ * A2A HTTP Server — handles inbound A2A JSON-RPC requests.
+ *
+ * Mounts onto the existing Gateway HTTP server via registerHttpHandler
+ * (no separate port). Handles:
+ *   - GET  /.well-known/agent-card.json  → Agent Card discovery
+ *   - GET  /.well-known/agent.json       → Legacy v0.2.x alias
+ *   - POST /a2a/jsonrpc                  → A2A JSON-RPC endpoint
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { AgentCard } from "@a2a-js/sdk";
+import { DefaultRequestHandler, JsonRpcTransportHandler } from "@a2a-js/sdk/server";
+import { buildAgentCard, AGENT_CARD_PATHS } from "./agent-card.js";
+import type { A2APluginConfig } from "./config.js";
+import { OpenClawAgentExecutor } from "./executor.js";
+import { FileTaskStore } from "./task-store.js";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const JSON_RPC_PATH = "/a2a/jsonrpc";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+/** Read the full request body as a string. */
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/** Verify inbound bearer token. Returns true if auth passes. */
+function verifyBearerAuth(req: IncomingMessage, cfg: A2APluginConfig): boolean {
+  if (cfg.auth.mode === "none") return true;
+  if (!cfg.auth.token) return true; // no token configured = open
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return false;
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0]!.toLowerCase() !== "bearer") return false;
+
+  return parts[1] === cfg.auth.token;
+}
+
+/** Send a JSON response. */
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const data = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(data),
+  });
+  res.end(data);
+}
+
+/** SSE response headers. */
+const SSE_HEADERS: Record<string, string> = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no", // prevent nginx buffering
+};
+
+/** Write a single SSE event. */
+function writeSseEvent(res: ServerResponse, data: unknown): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+/** Check if client requested SSE via Accept header. */
+function acceptsSSE(req: IncomingMessage): boolean {
+  const accept = req.headers.accept ?? "";
+  return accept.includes("text/event-stream");
+}
+
+// ── Server factory ─────────────────────────────────────────────────
+
+export type A2AServer = {
+  /** registerHttpHandler callback — returns true if request was handled. */
+  handleRequest: (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
+  /** Start background tasks (cleanup timer). */
+  start: () => void;
+  /** Stop background tasks. */
+  stop: () => void;
+  /** Access the generated Agent Card. */
+  agentCard: AgentCard;
+  /** Access the task store. */
+  taskStore: FileTaskStore;
+};
+
+export function createA2AServer(
+  cfg: A2APluginConfig,
+  stateDir: string,
+  log: Logger,
+  gatewayAuthToken: string | undefined,
+): A2AServer {
+  // Resolve gateway URL for Agent Card and executor
+  const gatewayPort = 18789; // default OpenClaw gateway port
+  const gatewayBaseUrl = `http://127.0.0.1:${gatewayPort}`;
+
+  const agentCard = buildAgentCard(cfg, gatewayBaseUrl);
+  const taskStore = new FileTaskStore(stateDir);
+  const executor = new OpenClawAgentExecutor(cfg, gatewayBaseUrl, gatewayAuthToken, log);
+
+  // DefaultRequestHandler: positional args (agentCard, taskStore, executor)
+  const requestHandler = new DefaultRequestHandler(agentCard, taskStore, executor);
+
+  // JsonRpcTransportHandler wraps the request handler for JSON-RPC dispatch
+  const jsonRpcHandler = new JsonRpcTransportHandler(requestHandler);
+
+  // Cleanup timer handle
+  let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+    const pathname = url.pathname;
+
+    // ── Agent Card discovery (public, no auth) ──
+    if (req.method === "GET" && AGENT_CARD_PATHS.includes(pathname)) {
+      log.info(`[a2a] Agent Card requested from ${req.socket.remoteAddress}`);
+      sendJson(res, 200, agentCard);
+      return true;
+    }
+
+    // ── A2A JSON-RPC endpoint ──
+    if (req.method === "POST" && pathname === JSON_RPC_PATH) {
+      if (!verifyBearerAuth(req, cfg)) {
+        log.warn(`[a2a] unauthorized request from ${req.socket.remoteAddress}`);
+        sendJson(res, 401, {
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Unauthorized" },
+          id: null,
+        });
+        return true;
+      }
+
+      try {
+        const body = await readBody(req);
+        const parsed = JSON.parse(body);
+        log.info(`[a2a] JSON-RPC request: ${parsed.method ?? "unknown"}`);
+
+        // Use JsonRpcTransportHandler which routes to the right method
+        const result = await jsonRpcHandler.handle(parsed);
+
+        // handle() can return a Promise or AsyncGenerator
+        if (result && typeof result === "object" && Symbol.asyncIterator in result) {
+          const stream = result as AsyncGenerator;
+          if (acceptsSSE(req)) {
+            // SSE streaming — write each event as it arrives
+            res.writeHead(200, SSE_HEADERS);
+            for await (const chunk of stream) {
+              writeSseEvent(res, chunk);
+            }
+            res.end();
+          } else {
+            // Non-SSE client — collect events and return the last one as JSON
+            let last: unknown = { jsonrpc: "2.0", id: null };
+            for await (const chunk of stream) {
+              last = chunk;
+            }
+            sendJson(res, 200, last);
+          }
+        } else {
+          sendJson(res, 200, result);
+        }
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.error(`[a2a] JSON-RPC error: ${errMsg}`);
+        sendJson(res, 400, {
+          jsonrpc: "2.0",
+          error: { code: -32700, message: "Parse error" },
+          id: null,
+        });
+      }
+      return true;
+    }
+
+    // Not an A2A request
+    return false;
+  };
+
+  const start = (): void => {
+    // Periodic cleanup of expired tasks (every 30 min)
+    cleanupTimer = setInterval(
+      async () => {
+        try {
+          const removed = await taskStore.cleanup(cfg.timeouts.taskRetentionMs);
+          if (removed > 0) {
+            log.info(`[a2a] cleaned up ${removed} expired task(s)`);
+          }
+        } catch (err) {
+          log.error(
+            `[a2a] task cleanup error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      },
+      30 * 60 * 1000,
+    );
+    // Don't block process exit
+    if (cleanupTimer && "unref" in cleanupTimer) {
+      (cleanupTimer as NodeJS.Timeout).unref();
+    }
+
+    log.info(`[a2a] server started — Agent Card: ${agentCard.name}`);
+    log.info(`[a2a] endpoints: GET /.well-known/agent-card.json, POST /a2a/jsonrpc`);
+    if (cfg.peers.length > 0) {
+      log.info(`[a2a] configured peers: ${cfg.peers.map((p) => p.name).join(", ")}`);
+    }
+  };
+
+  const stop = (): void => {
+    if (cleanupTimer) {
+      clearInterval(cleanupTimer);
+      cleanupTimer = null;
+    }
+    log.info("[a2a] server stopped");
+  };
+
+  return { handleRequest, start, stop, agentCard, taskStore };
+}

--- a/extensions/a2a/src/task-store.test.ts
+++ b/extensions/a2a/src/task-store.test.ts
@@ -1,0 +1,152 @@
+import { mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileTaskStore } from "./task-store.js";
+
+describe("FileTaskStore", () => {
+  let stateDir: string;
+  let store: FileTaskStore;
+
+  beforeEach(async () => {
+    stateDir = join(tmpdir(), `a2a-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(stateDir, { recursive: true });
+    store = new FileTaskStore(stateDir);
+  });
+
+  afterEach(async () => {
+    // Cleanup temp directory
+    try {
+      const tasksDir = join(stateDir, "tasks");
+      const files = await readdir(tasksDir).catch(() => []);
+      for (const f of files) {
+        await unlink(join(tasksDir, f)).catch(() => {});
+      }
+    } catch {
+      // ignore
+    }
+  });
+
+  it("creates tasks dir on first operation", async () => {
+    const task = { id: "task-1", status: { state: "working" as const } };
+    await store.save(task as never);
+
+    const tasksDir = join(stateDir, "tasks");
+    const files = await readdir(tasksDir);
+    expect(files).toContain("task-1.json");
+  });
+
+  it("saves and loads a task", async () => {
+    const task = {
+      id: "task-abc",
+      status: { state: "completed" as const },
+      metadata: { updatedAt: new Date().toISOString() },
+    };
+
+    await store.save(task as never);
+    const loaded = await store.load("task-abc");
+
+    expect(loaded).toBeDefined();
+    expect(loaded!.id).toBe("task-abc");
+    expect(loaded!.status!.state).toBe("completed");
+  });
+
+  it("returns undefined for non-existent task", async () => {
+    const loaded = await store.load("does-not-exist");
+    expect(loaded).toBeUndefined();
+  });
+
+  it("overwrites existing task on save", async () => {
+    const task1 = { id: "task-1", status: { state: "working" as const } };
+    const task2 = { id: "task-1", status: { state: "completed" as const } };
+
+    await store.save(task1 as never);
+    await store.save(task2 as never);
+
+    const loaded = await store.load("task-1");
+    expect(loaded!.status!.state).toBe("completed");
+  });
+
+  it("sanitizes task IDs to prevent path traversal", async () => {
+    const task = { id: "../../../etc/passwd", status: { state: "working" as const } };
+    await store.save(task as never);
+
+    // Should not create a file outside tasks dir
+    const tasksDir = join(stateDir, "tasks");
+    const files = await readdir(tasksDir);
+    expect(files.length).toBe(1);
+    // ID should be sanitized
+    expect(files[0]).toMatch(/^[a-zA-Z0-9_-]+\.json$/);
+  });
+
+  describe("cleanup", () => {
+    it("removes completed tasks older than retention", async () => {
+      const oldTimestamp = new Date(Date.now() - 100_000).toISOString();
+      const task = {
+        id: "old-task",
+        status: { state: "completed" as const },
+        metadata: { updatedAt: oldTimestamp },
+      };
+
+      await store.save(task as never);
+      const removed = await store.cleanup(50_000); // 50s retention
+      expect(removed).toBe(1);
+
+      const loaded = await store.load("old-task");
+      expect(loaded).toBeUndefined();
+    });
+
+    it("keeps tasks within retention period", async () => {
+      const recentTimestamp = new Date().toISOString();
+      const task = {
+        id: "recent-task",
+        status: { state: "completed" as const },
+        metadata: { updatedAt: recentTimestamp },
+      };
+
+      await store.save(task as never);
+      const removed = await store.cleanup(86_400_000); // 24h retention
+      expect(removed).toBe(0);
+
+      const loaded = await store.load("recent-task");
+      expect(loaded).toBeDefined();
+    });
+
+    it("keeps tasks in non-terminal states", async () => {
+      const oldTimestamp = new Date(Date.now() - 100_000).toISOString();
+      const task = {
+        id: "working-task",
+        status: { state: "working" as const },
+        metadata: { updatedAt: oldTimestamp },
+      };
+
+      await store.save(task as never);
+      const removed = await store.cleanup(50_000);
+      expect(removed).toBe(0);
+    });
+
+    it("removes failed and canceled tasks", async () => {
+      const old = new Date(Date.now() - 100_000).toISOString();
+
+      await store.save({
+        id: "failed-task",
+        status: { state: "failed" as const },
+        metadata: { updatedAt: old },
+      } as never);
+
+      await store.save({
+        id: "canceled-task",
+        status: { state: "canceled" as const },
+        metadata: { updatedAt: old },
+      } as never);
+
+      const removed = await store.cleanup(50_000);
+      expect(removed).toBe(2);
+    });
+
+    it("returns 0 when tasks dir is empty", async () => {
+      const removed = await store.cleanup(1000);
+      expect(removed).toBe(0);
+    });
+  });
+});

--- a/extensions/a2a/src/task-store.ts
+++ b/extensions/a2a/src/task-store.ts
@@ -1,0 +1,95 @@
+/**
+ * File-backed TaskStore for A2A tasks.
+ *
+ * The @a2a-js/sdk TaskStore interface only requires save() and load().
+ * We add cleanup() for periodic removal of expired tasks.
+ *
+ * Persists each task as a JSON file under {stateDir}/tasks/{taskId}.json
+ * so tasks survive gateway restarts.
+ */
+
+import { readFile, writeFile, readdir, unlink, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { Task } from "@a2a-js/sdk";
+import type { TaskStore } from "@a2a-js/sdk/server";
+
+export class FileTaskStore implements TaskStore {
+  private readonly tasksDir: string;
+  private initialized = false;
+
+  constructor(stateDir: string) {
+    this.tasksDir = join(stateDir, "tasks");
+  }
+
+  private async ensureDir(): Promise<void> {
+    if (this.initialized) return;
+    await mkdir(this.tasksDir, { recursive: true, mode: 0o700 });
+    this.initialized = true;
+  }
+
+  private taskPath(taskId: string): string {
+    // Sanitize taskId to prevent path traversal
+    const safe = taskId.replace(/[^a-zA-Z0-9_-]/g, "_");
+    return join(this.tasksDir, `${safe}.json`);
+  }
+
+  async load(taskId: string): Promise<Task | undefined> {
+    await this.ensureDir();
+    try {
+      const data = await readFile(this.taskPath(taskId), "utf-8");
+      return JSON.parse(data) as Task;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async save(task: Task): Promise<void> {
+    await this.ensureDir();
+    const data = JSON.stringify(task, null, 2);
+    await writeFile(this.taskPath(task.id), data, { mode: 0o600 });
+  }
+
+  /**
+   * Remove completed/canceled/failed tasks older than retentionMs.
+   * Returns the number of tasks cleaned up.
+   */
+  async cleanup(retentionMs: number): Promise<number> {
+    await this.ensureDir();
+    const terminalStates = new Set<string>(["completed", "canceled", "failed"]);
+    let files: string[];
+    try {
+      files = await readdir(this.tasksDir);
+    } catch {
+      return 0;
+    }
+
+    const cutoff = Date.now() - retentionMs;
+    let removed = 0;
+
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const data = await readFile(join(this.tasksDir, file), "utf-8");
+        const task = JSON.parse(data) as Task;
+        if (!task.status || !terminalStates.has(task.status.state)) continue;
+
+        // Use task metadata timestamp if available
+        const updatedAt = task.metadata?.updatedAt;
+        const taskTime =
+          typeof updatedAt === "string"
+            ? new Date(updatedAt).getTime()
+            : typeof updatedAt === "number"
+              ? updatedAt
+              : 0;
+
+        if (taskTime > 0 && taskTime < cutoff) {
+          await unlink(join(this.tasksDir, file));
+          removed++;
+        }
+      } catch {
+        // Skip corrupt files
+      }
+    }
+    return removed;
+  }
+}

--- a/extensions/a2a/src/tools/a2a-tools.test.ts
+++ b/extensions/a2a/src/tools/a2a-tools.test.ts
@@ -1,0 +1,346 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { A2APluginConfig } from "../config.js";
+import { createA2ADiscoverTool, createA2ASendTool } from "./a2a-tools.js";
+
+// ── Mock fetch ───────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  mockFetch.mockReset();
+  vi.unstubAllGlobals();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createConfig(overrides?: Partial<A2APluginConfig>): A2APluginConfig {
+  return {
+    enabled: true,
+    card: {
+      name: "Test",
+      description: "Test",
+      version: "1.0.0",
+      skills: [],
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+    },
+    auth: { mode: "none" },
+    routing: { defaultAgentId: "default" },
+    peers: [
+      {
+        name: "alice",
+        agentCardUrl: "https://alice.example.com/.well-known/agent-card.json",
+      },
+      {
+        name: "bob",
+        agentCardUrl: "https://bob.example.com/.well-known/agent-card.json",
+        auth: { type: "bearer", token: "bob-token" },
+      },
+    ],
+    timeouts: { agentResponseMs: 30_000, taskRetentionMs: 86_400_000 },
+    ...overrides,
+  };
+}
+
+const MOCK_AGENT_CARD = {
+  name: "Remote Agent",
+  description: "A remote agent",
+  version: "1.0.0",
+  protocolVersion: "0.3.0",
+  url: "https://remote.example.com/a2a/jsonrpc",
+  skills: [{ id: "chat", name: "Chat", description: "General chat", tags: [] }],
+  capabilities: { streaming: false },
+  defaultInputModes: ["text"],
+  defaultOutputModes: ["text"],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers({ "content-type": "application/json" }),
+  } as unknown as Response;
+}
+
+const mockApi = {} as never;
+
+// ── Tests: a2a_discover ──────────────────────────────────────────────
+
+describe("a2a_discover tool", () => {
+  it("has correct metadata", () => {
+    const tool = createA2ADiscoverTool(createConfig());
+    expect(tool.name).toBe("a2a_discover");
+    expect(tool.description).toContain("Discover");
+    expect(tool.description).toContain("alice");
+    expect(tool.description).toContain("bob");
+  });
+
+  it("shows 'No peers configured' when peers is empty", () => {
+    const tool = createA2ADiscoverTool(createConfig({ peers: [] }));
+    expect(tool.description).toContain("No peers configured");
+  });
+
+  it("discovers a configured peer by name", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    const result = await tool.execute("call-1", { peer: "alice" });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      peer: "alice",
+      agentCard: { name: "Remote Agent", protocolVersion: "0.3.0" },
+    });
+
+    // Verify the correct URL was called
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://alice.example.com/.well-known/agent-card.json",
+    );
+  });
+
+  it("discovers a configured peer case-insensitively", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    const result = await tool.execute("call-1", { peer: "ALICE" });
+
+    expect(result.details).toMatchObject({ status: "ok", peer: "alice" });
+  });
+
+  it("discovers a peer by raw URL", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    const result = await tool.execute("call-1", {
+      peer: "https://new-agent.example.com/.well-known/agent-card.json",
+    });
+
+    expect(result.details).toMatchObject({ status: "ok" });
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://new-agent.example.com/.well-known/agent-card.json",
+    );
+  });
+
+  it("auto-appends agent-card.json to base URL", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    await tool.execute("call-1", { peer: "http://192.168.1.10:18789" });
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "http://192.168.1.10:18789/.well-known/agent-card.json",
+    );
+  });
+
+  it("auto-appends agent-card.json and strips trailing slashes", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    await tool.execute("call-1", { peer: "http://example.com:8080///" });
+
+    expect(mockFetch.mock.calls[0][0]).toBe("http://example.com:8080/.well-known/agent-card.json");
+  });
+
+  it("returns only selected fields from Agent Card", async () => {
+    const fullCard = {
+      ...MOCK_AGENT_CARD,
+      securitySchemes: { bearer: { type: "http", scheme: "bearer" } },
+      security: [{ bearer: [] }],
+      signatures: [],
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(fullCard));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    const result = await tool.execute("call-1", { peer: "alice" });
+    const card = (result.details as { agentCard: Record<string, unknown> }).agentCard;
+
+    // Should include selected fields
+    expect(card.name).toBe("Remote Agent");
+    expect(card.skills).toBeDefined();
+    // Should not include security/internal fields
+    expect(card).not.toHaveProperty("securitySchemes");
+    expect(card).not.toHaveProperty("security");
+    expect(card).not.toHaveProperty("url");
+  });
+
+  it("returns error on fetch failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    const result = await tool.execute("call-1", { peer: "alice" });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "Connection refused",
+    });
+  });
+
+  it("returns result in content format", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    const result = await tool.execute("call-1", { peer: "alice" });
+
+    // Should have content array with text type
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    // Content text should be valid JSON
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.status).toBe("ok");
+  });
+
+  it("uses peer auth when available", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+
+    const tool = createA2ADiscoverTool(createConfig());
+    await tool.execute("call-1", { peer: "bob" });
+
+    const headers = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer bob-token");
+  });
+});
+
+// ── Tests: a2a_send ──────────────────────────────────────────────────
+
+describe("a2a_send tool", () => {
+  it("has correct metadata", () => {
+    const tool = createA2ASendTool(createConfig(), mockApi);
+    expect(tool.name).toBe("a2a_send");
+    expect(tool.description).toContain("Send a message");
+    expect(tool.description).toContain("alice");
+  });
+
+  it("sends a message to a configured peer", async () => {
+    // Agent Card fetch
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    // JSON-RPC message/send
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: {
+          id: "task-42",
+          status: {
+            state: "completed",
+            message: {
+              kind: "message",
+              messageId: "reply-1",
+              role: "agent",
+              parts: [{ kind: "text", text: "Got your message!" }],
+            },
+          },
+        },
+      }),
+    );
+
+    const tool = createA2ASendTool(createConfig(), mockApi);
+    const result = await tool.execute("call-1", {
+      peer: "alice",
+      message: "Hello Alice!",
+    });
+
+    expect(result.details).toMatchObject({
+      peer: "alice",
+      status: "completed",
+      taskId: "task-42",
+      reply: "Got your message!",
+    });
+  });
+
+  it("includes agentId in the request when provided", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: { id: "task-1", status: { state: "completed" } },
+      }),
+    );
+
+    const tool = createA2ASendTool(createConfig(), mockApi);
+    await tool.execute("call-1", {
+      peer: "alice",
+      message: "Hello",
+      agentId: "special-agent",
+    });
+
+    // Check the JSON-RPC body
+    const rpcBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(rpcBody.params.message.metadata).toEqual({
+      "openclaw.agentId": "special-agent",
+    });
+  });
+
+  it("returns error on send failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network timeout"));
+
+    const tool = createA2ASendTool(createConfig(), mockApi);
+    const result = await tool.execute("call-1", {
+      peer: "alice",
+      message: "Hello",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      peer: "alice",
+      error: "Network timeout",
+    });
+  });
+
+  it("sends to a raw URL peer", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: { id: "task-1", status: { state: "completed" } },
+      }),
+    );
+
+    const tool = createA2ASendTool(createConfig(), mockApi);
+    const result = await tool.execute("call-1", {
+      peer: "http://192.168.1.50:18789",
+      message: "Hello raw peer",
+    });
+
+    // Agent Card URL should have been auto-constructed
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "http://192.168.1.50:18789/.well-known/agent-card.json",
+    );
+    expect(result.details).toMatchObject({ status: "completed" });
+  });
+
+  it("uses configured timeout", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(MOCK_AGENT_CARD));
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        result: { id: "task-1", status: { state: "completed" } },
+      }),
+    );
+
+    const cfg = createConfig({
+      timeouts: { agentResponseMs: 60_000, taskRetentionMs: 86_400_000 },
+    });
+    const tool = createA2ASendTool(cfg, mockApi);
+    await tool.execute("call-1", { peer: "alice", message: "test" });
+
+    // The send call (2nd fetch) should use blocking timeout
+    const sendCallOpts = mockFetch.mock.calls[1][1];
+    // AbortSignal.timeout is used internally by sendMessageToPeer
+    expect(sendCallOpts.signal).toBeDefined();
+  });
+
+  it("has parameters schema with required fields", () => {
+    const tool = createA2ASendTool(createConfig(), mockApi);
+    const schema = tool.parameters;
+
+    expect(schema.properties).toHaveProperty("peer");
+    expect(schema.properties).toHaveProperty("message");
+    expect(schema.properties).toHaveProperty("agentId");
+    expect(schema.required).toContain("peer");
+    expect(schema.required).toContain("message");
+    // agentId should be optional
+    expect(schema.required).not.toContain("agentId");
+  });
+});

--- a/extensions/a2a/src/tools/a2a-tools.ts
+++ b/extensions/a2a/src/tools/a2a-tools.ts
@@ -1,0 +1,138 @@
+/**
+ * Agent tools for A2A communication.
+ *
+ * Provides two tools that OpenClaw agents can use:
+ *   - a2a_discover: fetch a remote agent's Agent Card
+ *   - a2a_send: send a message to a remote A2A agent
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { fetchAgentCard, sendMessageToPeer } from "../client.js";
+import type { A2APluginConfig, A2APeer } from "../config.js";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const jsonResult = (payload: unknown) => ({
+  content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+  details: payload,
+});
+
+/**
+ * Resolve a peer name to its config entry.
+ * Accepts either a configured peer name (case-insensitive) or a raw URL.
+ */
+function resolvePeer(cfg: A2APluginConfig, nameOrUrl: string): A2APeer {
+  // Try matching configured peer name
+  const match = cfg.peers.find((p) => p.name.toLowerCase() === nameOrUrl.toLowerCase());
+  if (match) return match;
+
+  // Treat as raw URL — auto-append agent-card.json if needed
+  let url = nameOrUrl.trim();
+  if (url && !url.includes("agent-card.json") && !url.includes("agent.json")) {
+    url = url.replace(/\/+$/, "") + "/.well-known/agent-card.json";
+  }
+
+  return { name: nameOrUrl, agentCardUrl: url };
+}
+
+// ── a2a_discover ───────────────────────────────────────────────────
+
+export function createA2ADiscoverTool(cfg: A2APluginConfig) {
+  return {
+    name: "a2a_discover",
+    label: "A2A Discover",
+    description: [
+      "Discover a remote A2A agent by fetching its Agent Card.",
+      "Returns the agent's name, description, skills, and capabilities.",
+      cfg.peers.length > 0
+        ? `Configured peers: ${cfg.peers.map((p) => p.name).join(", ")}.`
+        : "No peers configured — provide a URL.",
+    ].join(" "),
+    parameters: Type.Object({
+      peer: Type.String({
+        description:
+          "Peer name (from config) or base URL of the remote agent " +
+          "(e.g. 'http://100.10.10.2:18789')",
+      }),
+    }),
+    async execute(_toolCallId: string, params: { peer: string }) {
+      try {
+        const peer = resolvePeer(cfg, params.peer);
+        const card = await fetchAgentCard(peer.agentCardUrl, peer.auth);
+        return jsonResult({
+          status: "ok",
+          peer: peer.name,
+          agentCard: {
+            name: card.name,
+            description: card.description,
+            version: card.version,
+            protocolVersion: card.protocolVersion,
+            skills: card.skills,
+            defaultInputModes: card.defaultInputModes,
+            defaultOutputModes: card.defaultOutputModes,
+          },
+        });
+      } catch (err) {
+        return jsonResult({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  };
+}
+
+// ── a2a_send ───────────────────────────────────────────────────────
+
+export function createA2ASendTool(cfg: A2APluginConfig, _api: OpenClawPluginApi) {
+  return {
+    name: "a2a_send",
+    label: "A2A Send",
+    description: [
+      "Send a message to a remote A2A agent and get the response.",
+      "Use a2a_discover first to check available peers and their skills.",
+      cfg.peers.length > 0
+        ? `Configured peers: ${cfg.peers.map((p) => p.name).join(", ")}.`
+        : "No peers configured — provide a URL.",
+    ].join(" "),
+    parameters: Type.Object({
+      peer: Type.String({
+        description: "Peer name (from config) or base URL of the remote agent",
+      }),
+      message: Type.String({
+        description: "The message to send to the remote agent",
+      }),
+      agentId: Type.Optional(
+        Type.String({
+          description: "Target a specific agent ID on the remote server (optional)",
+        }),
+      ),
+    }),
+    async execute(
+      _toolCallId: string,
+      params: { peer: string; message: string; agentId?: string },
+    ) {
+      try {
+        const peer = resolvePeer(cfg, params.peer);
+        const result = await sendMessageToPeer({
+          peer,
+          message: params.message,
+          agentId: params.agentId,
+          blocking: true,
+          timeoutMs: cfg.timeouts.agentResponseMs,
+        });
+        return jsonResult({
+          peer: peer.name,
+          ...result,
+        });
+      } catch (err) {
+        return jsonResult({
+          status: "error",
+          peer: params.peer,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,15 @@ importers:
         specifier: ^0.10.0
         version: 0.10.0
 
+  extensions/a2a:
+    dependencies:
+      '@a2a-js/sdk':
+        specifier: ^0.3.10
+        version: 0.3.10(@grpc/grpc-js@1.14.3)(express@5.2.1)
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+
   extensions/acpx:
     dependencies:
       acpx:
@@ -531,6 +540,21 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
+
+  '@a2a-js/sdk@0.3.10':
+    resolution: {integrity: sha512-t6w5ctnwJkSOMRl6M9rn95C1FTHCPqixxMR0yWXtzhZXEnF6mF1NAK0CfKlG3cz+tcwTxkmn287QZC3t9XPgrA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.10.2
+      '@grpc/grpc-js': ^1.11.0
+      express: ^4.21.2 || ^5.1.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+      '@grpc/grpc-js':
+        optional: true
+      express:
+        optional: true
 
   '@agentclientprotocol/sdk@0.14.1':
     resolution: {integrity: sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==}
@@ -6081,6 +6105,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@a2a-js/sdk@0.3.10(@grpc/grpc-js@1.14.3)(express@5.2.1)':
+    dependencies:
+      uuid: 11.1.0
+    optionalDependencies:
+      '@grpc/grpc-js': 1.14.3
+      express: 5.2.1
 
   '@agentclientprotocol/sdk@0.14.1(zod@4.3.6)':
     dependencies:

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -268,6 +268,12 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       'do not call `message` with `action=thread-create`; use `sessions_spawn` (`runtime: "acp"`, `thread: true`) as the single thread creation path',
     );
+    expect(prompt).toContain(
+      "Put the first concrete coding instruction into `sessions_spawn.task`; do not create an idle ACP session and plan to bootstrap it later with `sessions_send`.",
+    );
+    expect(prompt).toContain(
+      "Do not infer `not executed` from missing immediate stream output alone; if the task expects file or directory outputs, verify those target paths before concluding execution failed.",
+    );
   });
 
   it("omits ACP harness guidance when ACP is disabled", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -449,6 +449,8 @@ export function buildAgentSystemPrompt(params: {
           'On Discord, default ACP harness requests to thread-bound persistent sessions (`thread: true`, `mode: "session"`) unless the user asks otherwise.',
           "Set `agentId` explicitly unless `acp.defaultAgent` is configured, and do not route ACP harness requests through `subagents`/`agents_list` or local PTY exec flows.",
           'For ACP harness thread spawns, do not call `message` with `action=thread-create`; use `sessions_spawn` (`runtime: "acp"`, `thread: true`) as the single thread creation path.',
+          "Put the first concrete coding instruction into `sessions_spawn.task`; do not create an idle ACP session and plan to bootstrap it later with `sessions_send`.",
+          "Do not infer `not executed` from missing immediate stream output alone; if the task expects file or directory outputs, verify those target paths before concluding execution failed.",
         ]
       : []),
     "Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).",


### PR DESCRIPTION
## Summary

- Add `extensions/a2a` plugin implementing [Google A2A v0.3.0 protocol](https://github.com/a2aproject/a2a-spec) (Linux Foundation standard) for cross-network agent-to-agent communication
- Built as a pure plugin with **zero core changes** — uses only Plugin SDK APIs (`registerHttpHandler`, `registerTool`, `registerGatewayMethod`, `registerService`, `registerCli`)
- Enables any A2A-compliant agent to discover and communicate with OpenClaw agents, and vice versa

### What's included

**Server (inbound):**
- Agent Card discovery at `/.well-known/agent-card.json` (v0.3.0 standard + v0.2.x legacy alias)
- JSON-RPC endpoint at `/a2a/jsonrpc` — `message/send` + `message/stream` (SSE)
- Bearer token authentication with OpenAPI 3.0 security scheme declaration
- File-backed task persistence with configurable retention + auto-cleanup
- Bridges inbound tasks to local OpenClaw agent via Gateway `/v1/chat/completions`

**Client (outbound):**
- `a2a_discover` tool — discover remote agent capabilities via Agent Card
- `a2a_send` tool — send messages to remote A2A peers (blocking or async)
- Peer health checks with latency measurement and capability detection
- Configurable peer list with per-peer authentication

**CLI commands:**
- `openclaw a2a status` — plugin status summary
- `openclaw a2a card` — print Agent Card JSON
- `openclaw a2a peers` — list configured peers
- `openclaw a2a discover <target>` — fetch remote Agent Card
- `openclaw a2a send -p <peer> -m <message>` — send message to peer
- `openclaw a2a check [name]` — health check peers

**Gateway methods:**
- `a2a.card`, `a2a.peers.list`, `a2a.peers.discover`, `a2a.peers.send`, `a2a.peers.check`

### Architecture

```
External A2A Agent                        OpenClaw Gateway
       │                                        │
       │  GET /.well-known/agent-card.json       │
       ├────────────────────────────────────────▶│ agent-card.ts
       │                                        │
       │  POST /a2a/jsonrpc (message/send)       │
       ├────────────────────────────────────────▶│ server.ts → executor.ts
       │                                        │    └─▶ /v1/chat/completions
       │  ◀── SSE events (message/stream)        │
       │                                        │
       │                                        │
Local Agent                                     │
       │  a2a_discover / a2a_send tools          │
       ├────────────────────────────────────────▶│ client.ts → Remote Agent
```

### Configuration example

```yaml
plugins:
  entries:
    a2a:
      config:
        enabled: true
        card:
          name: "My OpenClaw Agent"
          description: "A helpful AI assistant"
        auth:
          mode: bearer
          token: "your-secret-token"
        peers:
          - name: alice
            agentCardUrl: "https://alice.example.com/.well-known/agent-card.json"
            auth:
              type: bearer
              token: "alice-token"
```

### Dependencies

- `@a2a-js/sdk@^0.3.10` — Official A2A JavaScript SDK
- `@sinclair/typebox@0.34.48` — JSON Schema for tool parameters (already used by core)

## Test plan

- [x] `pnpm tsgo` — zero type errors (extensions/a2a)
- [x] `pnpm format` — passes formatting check
- [x] `pnpm test -- --run extensions/a2a` — **95 tests across 8 files, all passing**
  - config parsing (17 tests): defaults, edge cases, peers, auth, skills, timeouts
  - agent-card building (9 tests): fields, URL handling, capabilities, security
  - task-store (10 tests): CRUD, path traversal, cleanup retention
  - server (10 tests): Agent Card discovery, routing, bearer auth, lifecycle
  - client (13 tests): fetchAgentCard, sendMessageToPeer, checkPeerHealth
  - executor (13 tests): full execute flow, error handling, agent routing, auth
  - tools (18 tests): discover + send tools, peer resolution, schema validation
  - plugin registration (5 tests): metadata, enable/disable, component wiring