### PR TITLE
feat(feishu): auto-resolve tool account id from channel origin

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -20,6 +20,7 @@ import {
 import { getFeishuRuntime } from "./runtime.js";
 import {
   createFeishuToolClient,
+  resolveFeishuToolDefaultAccountId,
   resolveAnyEnabledFeishuToolsConfig,
   resolveFeishuToolAccount,
 } from "./tool-account.js";
@@ -1261,7 +1262,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   if (toolsCfg.doc) {
     api.registerTool(
       (ctx) => {
-        const defaultAccountId = ctx.agentAccountId;
+        const defaultAccountId = resolveFeishuToolDefaultAccountId(ctx, accounts);
         const trustedRequesterOpenId =
           ctx.messageChannel === "feishu" ? ctx.requesterSenderId?.trim() || undefined : undefined;
         return {

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -2,7 +2,11 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
-import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import {
+  createFeishuToolClient,
+  resolveFeishuToolDefaultAccountId,
+  resolveAnyEnabledFeishuToolsConfig,
+} from "./tool-account.js";
 import {
   jsonToolResult,
   toolExecutionErrorResult,
@@ -185,7 +189,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
 
   api.registerTool(
     (ctx) => {
-      const defaultAccountId = ctx.agentAccountId;
+      const defaultAccountId = resolveFeishuToolDefaultAccountId(ctx, accounts);
       return {
         name: "feishu_drive",
         label: "Feishu Drive",

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -2,7 +2,11 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
-import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import {
+  createFeishuToolClient,
+  resolveFeishuToolDefaultAccountId,
+  resolveAnyEnabledFeishuToolsConfig,
+} from "./tool-account.js";
 import {
   jsonToolResult,
   toolExecutionErrorResult,
@@ -134,7 +138,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
 
   api.registerTool(
     (ctx) => {
-      const defaultAccountId = ctx.agentAccountId;
+      const defaultAccountId = resolveFeishuToolDefaultAccountId(ctx, accounts);
       return {
         name: "feishu_perm",
         label: "Feishu Perm",

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,5 +1,5 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
@@ -67,4 +67,17 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.scopes = merged.scopes || cfg.scopes;
   }
   return merged;
+}
+
+export function resolveFeishuToolDefaultAccountId(
+  ctx: Pick<OpenClawPluginToolContext, "agentAccountId" | "messageChannel">,
+  accounts: ResolvedFeishuAccount[],
+): string | undefined {
+  if (ctx.agentAccountId && accounts.some((a) => a.accountId === ctx.agentAccountId)) {
+    return ctx.agentAccountId;
+  }
+  if (ctx.messageChannel && accounts.some((a) => a.accountId === ctx.messageChannel)) {
+    return ctx.messageChannel;
+  }
+  return undefined;
 }

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,7 +1,11 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import {
+  createFeishuToolClient,
+  resolveFeishuToolDefaultAccountId,
+  resolveAnyEnabledFeishuToolsConfig,
+} from "./tool-account.js";
 import {
   jsonToolResult,
   toolExecutionErrorResult,
@@ -173,7 +177,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
 
   api.registerTool(
     (ctx) => {
-      const defaultAccountId = ctx.agentAccountId;
+      const defaultAccountId = resolveFeishuToolDefaultAccountId(ctx, accounts);
       return {
         name: "feishu_wiki",
         label: "Feishu Wiki",


### PR DESCRIPTION
**What does this PR do?**
This PR enhances the Feishu/Lark plugin tools (such as `feishu_wiki`, `feishu_doc`, `feishu_drive`, and `feishu_perm`) to automatically resolve the correct `accountId` by falling back to the `messageChannel` (e.g., `"lark"` or `"feishu"`) if the channel name matches a configured account ID.

**Why is this needed?**
Currently, in a multi-account setup (e.g., configuring both Feishu domestic and Larksuite international accounts), if the LLM calls a tool without explicitly specifying the `accountId` parameter, the system defaults to the first account in the configuration.
If a user is interacting via the Lark channel but the default account is Feishu, the tool call fails with an `HTTP 400` error due to domain/credential mismatch.

By intelligently falling back to `ctx.messageChannel`, the tools seamlessly inherit the credentials of the channel the user is currently using, eliminating the need for rigid `defaultAccount` configurations and improving the LLM's out-of-the-box success rate.

**Changes made:**
- **Added Helper**: Introduced `resolveFeishuToolDefaultAccountId` in `tool-account.ts`. This safely checks if `ctx.agentAccountId` or `ctx.messageChannel` exists in the configured `accounts` list.
- **Updated Tool Registrations**: Replaced the static `const defaultAccountId = ctx.agentAccountId;` with the new helper across `wiki.ts`, `docx.ts`, `drive.ts`, and `perm.ts`.

**Testing & Safety:**
- **Verified Fallback**: Tools correctly fallback to use the `"lark"` account credentials when the message originates from the Lark channel.
- **Strict Guards**: The fallback is safely guarded by `accounts.some(a => a.accountId === ctx.messageChannel)`. This prevents irrelevant channels (e.g., `"telegram"` or `"discord"`) from triggering a false fallback, ensuring zero side-effects for other platforms.