### PR TITLE
logging.file configuration supports wildcard characters YYYY-MM-DD

### DIFF
--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -53,4 +53,24 @@ describe("readConfiguredLogTail", () => {
 
     await fs.rm(tempDir, { recursive: true, force: true });
   });
+
+  it("resolves YYYY-MM-DD placeholder in configured file path", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-04-27T02:03:04.000Z"));
+      const { readConfiguredLogTail } = await import("./log-tail.js");
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-log-tail-"));
+      const resolvedFile = path.join(tempDir, "openclaw-2026-04-27.log");
+      await fs.writeFile(resolvedFile, "line one\nline two\n");
+
+      setLoggerOverride({ file: path.join(tempDir, "openclaw-YYYY-MM-DD.log") });
+      const result = await readConfiguredLogTail();
+
+      expect(result.file).toBe(resolvedFile);
+      expect(result.lines).toEqual(["line one", "line two"]);
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/logging/logger-settings.test.ts
+++ b/src/logging/logger-settings.test.ts
@@ -49,18 +49,20 @@ afterEach(() => {
 
 describe("getResolvedLoggerSettings", () => {
   it("substitutes YYYY-MM-DD placeholder in configured file path with actual date", () => {
-    process.env.OPENCLAW_TEST_FILE_LOG = "1";
-    const customDir = "/tmp/custom-logs";
-    logging.setLoggerOverride({
-      level: "info",
-      file: `${customDir}/openclaw-YYYY-MM-DD.log`,
-    });
-    const today = new Date();
-    const yyyy = today.getFullYear();
-    const mm = String(today.getMonth() + 1).padStart(2, "0");
-    const dd = String(today.getDate()).padStart(2, "0");
-    const expected = `${customDir}/openclaw-${yyyy}-${mm}-${dd}.log`;
-    expect(logging.getResolvedLoggerSettings().file).toBe(expected);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-09T08:30:00.000Z"));
+      process.env.OPENCLAW_TEST_FILE_LOG = "1";
+      const customDir = "/tmp/custom-logs";
+      logging.setLoggerOverride({
+        level: "info",
+        file: `${customDir}/openclaw-YYYY-MM-DD.log`,
+      });
+      const expected = `${customDir}/openclaw-2026-03-09.log`;
+      expect(logging.getResolvedLoggerSettings().file).toBe(expected);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses a silent fast path in default Vitest mode without config reads", () => {
@@ -69,9 +71,9 @@ describe("getResolvedLoggerSettings", () => {
     expect(readLoggingConfigMock).not.toHaveBeenCalled();
   });
 
-  it("reads logging config when test file logging is explicitly enabled", () => {
+  it("uses override logging settings when test file logging is explicitly enabled", () => {
     process.env.OPENCLAW_TEST_FILE_LOG = "1";
-    readLoggingConfigMock.mockReturnValue({
+    logging.setLoggerOverride({
       level: "debug",
       file: "/tmp/openclaw-configured.log",
       maxFileBytes: 2048,

--- a/src/logging/logger-settings.test.ts
+++ b/src/logging/logger-settings.test.ts
@@ -48,6 +48,21 @@ afterEach(() => {
 });
 
 describe("getResolvedLoggerSettings", () => {
+  it("substitutes YYYY-MM-DD placeholder in configured file path with actual date", () => {
+    process.env.OPENCLAW_TEST_FILE_LOG = "1";
+    const customDir = "/tmp/custom-logs";
+    logging.setLoggerOverride({
+      level: "info",
+      file: `${customDir}/openclaw-YYYY-MM-DD.log`,
+    });
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, "0");
+    const dd = String(today.getDate()).padStart(2, "0");
+    const expected = `${customDir}/openclaw-${yyyy}-${mm}-${dd}.log`;
+    expect(logging.getResolvedLoggerSettings().file).toBe(expected);
+  });
+
   it("uses a silent fast path in default Vitest mode without config reads", () => {
     const settings = logging.getResolvedLoggerSettings();
     expect(settings.level).toBe("silent");

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -477,7 +477,10 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const rawFile = cfg?.file ?? defaultRollingPathForToday();
+  const file = rawFile.includes("YYYY-MM-DD")
+    ? rawFile.replaceAll("YYYY-MM-DD", formatLocalDate(new Date()))
+    : rawFile;
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -56,6 +56,7 @@ export const DEFAULT_LOG_FILE = resolveDefaultLogFile(DEFAULT_LOG_DIR); // legac
 
 const LOG_PREFIX = "openclaw";
 const LOG_SUFFIX = ".log";
+const LOG_DATE_PLACEHOLDER = "YYYY-MM-DD";
 const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFAULT_MAX_LOG_FILE_BYTES = 100 * 1024 * 1024; // 100 MB
 const MAX_ROTATED_LOG_FILES = 5;
@@ -477,10 +478,7 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const rawFile = cfg?.file ?? defaultRollingPathForToday();
-  const file = rawFile.includes("YYYY-MM-DD")
-    ? rawFile.replaceAll("YYYY-MM-DD", formatLocalDate(new Date()))
-    : rawFile;
+  const file = resolveConfiguredLogFile(cfg?.file ?? defaultRollingPathForToday(), new Date());
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }
@@ -520,7 +518,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   }
 
   const rollingFile = isRollingPath(settings.file);
-  let activeFile = resolveActiveLogFile(settings.file);
+  let activeFile = resolveConfiguredLogFile(settings.file, new Date());
   fs.mkdirSync(path.dirname(activeFile), { recursive: true });
   // Clean up stale rolling logs when using a dated log filename.
   if (rollingFile) {
@@ -531,7 +529,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
 
   logger.attachTransport((logObj: LogObj) => {
     try {
-      const nextActiveFile = resolveActiveLogFile(settings.file);
+      const nextActiveFile = resolveConfiguredLogFile(settings.file, new Date());
       if (nextActiveFile !== activeFile) {
         activeFile = nextActiveFile;
         fs.mkdirSync(path.dirname(activeFile), { recursive: true });
@@ -689,25 +687,24 @@ function defaultRollingPathForToday(): string {
   return rollingPathForDate(DEFAULT_LOG_DIR, new Date());
 }
 
+function resolveConfiguredLogFile(file: string, date: Date): string {
+  const withPlaceholder = file.includes(LOG_DATE_PLACEHOLDER)
+    ? file.replaceAll(LOG_DATE_PLACEHOLDER, formatLocalDate(date))
+    : file;
+  if (!isRollingPath(withPlaceholder)) {
+    return withPlaceholder;
+  }
+  return rollingPathForDate(path.dirname(withPlaceholder), date);
+}
+
 function rollingPathForDate(dir: string, date: Date): string {
   const today = formatLocalDate(date);
   return path.join(dir, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
 }
 
-function resolveActiveLogFile(file: string): string {
-  if (!isRollingPath(file)) {
-    return file;
-  }
-  return rollingPathForDate(path.dirname(file), new Date());
-}
-
 function isRollingPath(file: string): boolean {
   const base = path.basename(file);
-  return (
-    base.startsWith(`${LOG_PREFIX}-`) &&
-    base.endsWith(LOG_SUFFIX) &&
-    base.length === `${LOG_PREFIX}-YYYY-MM-DD${LOG_SUFFIX}`.length
-  );
+  return /^openclaw-(?:\d{4}-\d{2}-\d{2}|YYYY-MM-DD)\.log$/u.test(base);
 }
 
 function pruneOldRollingLogs(dir: string): void {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: logging.file configuration is not supports wildcard characters `YYYY-MM-DD`
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra



## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:


### Expected
- if logging.file=/home/chchliang/.openclaw/logs/openclaw-YYYY-MM-DD.log,today is 2026-03-09,then in the path /home/chchliang/.openclaw/logs,have log file openclaw-2026-03-09.log
-

### Actual

- generate openclaw-2026-03-09.log in the path

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: 
  "logging": {
    "file": "/home/chchliang/.openclaw/logs/openclaw-YYYY-MM-DD.log"
  }


## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

