### PR TITLE
fix(config): add missing requiresOpenAiAnthropicToolPayload to compat schema

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -325,6 +325,30 @@ describe("model compat config schema", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts requiresOpenAiAnthropicToolPayload compat field", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          "kimi-coding": {
+            baseUrl: "https://api.kimi.example/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "k2p5",
+                name: "Kimi K2.5",
+                compat: {
+                  requiresOpenAiAnthropicToolPayload: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });
 
 describe("config paths", () => {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -198,6 +198,7 @@ export const ModelCompatSchema = z
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
     requiresMistralToolIds: z.boolean().optional(),
+    requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Problem: `ModelCompatSchema` in `zod-schema.core.ts` uses `.strict()` but is missing the `requiresOpenAiAnthropicToolPayload` field. The configure wizard writes this field for kimi-coding, but config validation rejects it with `Unrecognized key: "requiresOpenAiAnthropicToolPayload"`.
- Why it matters: Users cannot configure Kimi Coding provider — the CLI crashes on save.
- What changed: Added `requiresOpenAiAnthropicToolPayload: z.boolean().optional()` to `ModelCompatSchema`.
- What did NOT change (scope boundary): No runtime behavior change. The field was already defined in the TypeScript `ModelCompatConfig` type and used by the kimi-coding static provider template. Only the Zod validation schema was out of sync.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #40911

## User-visible / Behavior Changes

Users can now configure Kimi Coding provider via `openclaw configure` without hitting a validation crash.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22+
- Model/provider: Kimi Coding (kimi-coding/k2p5)

### Steps

1. Run `openclaw configure`, select Moonshot AI (Kimi K2.5)
2. Enter API key and confirm model selection
3. Observe crash: `Config validation failed: models.providers.kimi-coding.models.0.compat: Unrecognized key: "requiresOpenAiAnthropicToolPayload"`

### Expected

- Config saves successfully

### Actual (before fix)

- CLI crashes with `Unrecognized key` validation error

## Evidence

- [x] Failing test/log before + passing after

The field is defined in the TypeScript type (`ModelCompatConfig` in `types.models.ts` line 29) and used by the static provider template (`models-config.providers.static.ts` line 237), but was missing from the Zod schema. Added a dedicated test case that validates a config with this field.

| Location | Has field? |
|----------|-----------|
| `ModelCompatConfig` type (`types.models.ts:29`) | Yes |
| kimi-coding static template (`models-config.providers.static.ts:237`) | Yes |
| `ModelCompatSchema` Zod schema (`zod-schema.core.ts`) | **No → Yes (this PR)** |

## Human Verification (required)

- Verified scenarios: `vitest run src/config/config-misc.test.ts` — 33 tests pass including new test
- Edge cases checked: Existing compat fields still validate; the new field is optional so omitting it is fine
- What you did **not** verify: Live `openclaw configure` wizard flow (no Kimi API key available)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single-line addition in `zod-schema.core.ts`
- Files/config to restore: `src/config/zod-schema.core.ts`
- Known bad symptoms reviewers should watch for: None — this only relaxes validation to accept a field that was already in use

## Risks and Mitigations

- None. This is a one-line schema addition to match an existing TypeScript type definition.