### PR TITLE
feat(telegram): add asDocument option to send media as document

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -195,6 +195,7 @@ function buildSendSchema(options: {
     replyTo: Type.Optional(Type.String()),
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),
+    asDocument: Type.Optional(Type.Boolean()),s
     silent: Type.Optional(Type.Boolean()),
     quoteText: Type.Optional(
       Type.String({ description: "Quote text for Telegram reply_parameters" }),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -195,7 +195,7 @@ function buildSendSchema(options: {
     replyTo: Type.Optional(Type.String()),
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),
-    asDocument: Type.Optional(Type.Boolean()),s
+    asDocument: Type.Optional(Type.Boolean()),
     silent: Type.Optional(Type.Boolean()),
     quoteText: Type.Optional(
       Type.String({ description: "Quote text for Telegram reply_parameters" }),

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -246,6 +246,7 @@ export async function handleTelegramAction(
       messageThreadId: messageThreadId ?? undefined,
       quoteText: quoteText ?? undefined,
       asVoice: readBooleanParam(params, "asVoice"),
+      asDocument: readBooleanParam(params, "asDocument"),
       silent: readBooleanParam(params, "silent"),
     });
     return jsonResult({

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -31,6 +31,7 @@ function readTelegramSendParams(params: Record<string, unknown>) {
   const threadId = readStringParam(params, "threadId");
   const buttons = params.buttons;
   const asVoice = readBooleanParam(params, "asVoice");
+  const asDocument = readBooleanParam(params, "asDocument");
   const silent = readBooleanParam(params, "silent");
   const quoteText = readStringParam(params, "quoteText");
   return {
@@ -41,6 +42,7 @@ function readTelegramSendParams(params: Record<string, unknown>) {
     messageThreadId: threadId ?? undefined,
     buttons,
     asVoice,
+    asDocument,
     silent,
     quoteText: quoteText ?? undefined,
   };

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -833,6 +833,32 @@ describe("sendMessageTelegram", () => {
     expect(res.messageId).toBe("9");
   });
 
+  it("routes media to sendDocument when asDocument is true", async () => {
+    mockLoadedMedia({ contentType: "image/png", fileName: "photo.png" });
+    const sendPhoto = vi.fn();
+    const sendDocument = vi.fn().mockResolvedValue({
+      message_id: 99,
+      chat: { id: "123" },
+    });
+    const api = { sendPhoto, sendDocument } as unknown as {
+      sendPhoto: typeof sendPhoto;
+      sendDocument: typeof sendDocument;
+    };
+
+    await sendMessageTelegram("123", "caption", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.png",
+      asDocument: true,
+    });
+
+    expect(sendDocument).toHaveBeenCalledWith("123", expect.anything(), {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
+    expect(sendPhoto).not.toHaveBeenCalled();
+  });
+
   it("routes audio media to sendAudio/sendVoice based on voice compatibility", async () => {
     const cases: Array<{
       name: string;

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -57,6 +57,8 @@ type TelegramSendOpts = {
   asVoice?: boolean;
   /** Send video as video note (voice bubble) instead of regular video. Defaults to false. */
   asVideoNote?: boolean;
+  /** Send media as document (preserves filename, no compression). Defaults to false. */
+  asDocument?: boolean;
   /** Send message silently (no notification). Defaults to false. */
   silent?: boolean;
   /** Message ID to reply to (for threading) */
@@ -640,6 +642,17 @@ export async function sendMessageTelegram(
       );
 
     const mediaSender = (() => {
+      if (opts.asDocument === true) {
+        return {
+          label: "document",
+          sender: (effectiveParams: Record<string, unknown> | undefined) =>
+            api.sendDocument(
+              chatId,
+              file,
+              effectiveParams as Parameters<typeof api.sendDocument>[2],
+            ) as Promise<TelegramMessageLike>,
+        };
+      }
       if (isGif) {
         return {
           label: "animation",


### PR DESCRIPTION
<img width="798" height="448" alt="image" src="https://github.com/user-attachments/assets/5a161b8e-2409-45b9-b40d-e0651432d4dd" />

I want openclaw to have an option to send me uncompressed media in telegram. It should use [sendDocument](https://core.telegram.org/bots/api#senddocument) API instead of sendPhoto/sendVideo.

This PR adds an option to send media files as documents.

AI-assisted, I used Cursor