### PR TITLE
fix(ios): use plain Text during streaming to eliminate markdown flicker [AI-assisted]

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -515,18 +515,30 @@ private extension View {
 @MainActor
 struct ChatStreamingAssistantBubble: View {
     let text: String
-    let markdownVariant: ChatMarkdownVariant
     let showsAssistantTrace: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            ChatAssistantTextBody(
-                text: self.text,
-                markdownVariant: self.markdownVariant,
-                includesThinking: self.showsAssistantTrace)
+            // Use plain Text during streaming to avoid re-parsing the full markdown
+            // tree on every token (StructuredText layout thrash → flicker).
+            // The final committed message re-renders with full markdown via ChatAssistantTextBody.
+            Text(self.visibleText)
+                .font(.system(size: 14))
+                .foregroundStyle(OpenClawChatTheme.assistantText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
         }
         .padding(12)
         .assistantBubbleContainerStyle()
+    }
+
+    /// Returns only the non-thinking text for display during streaming.
+    /// Thinking blocks are never shown during streaming regardless of showsAssistantTrace —
+    /// they appear only in the final committed message via ChatAssistantTextBody.
+    private var visibleText: String {
+        AssistantTextParser.segments(from: self.text, includeThinking: false)
+            .map(\.text)
+            .joined(separator: "\n\n")
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -219,7 +219,6 @@ public struct OpenClawChatView: View {
         {
             ChatStreamingAssistantBubble(
                 text: text,
-                markdownVariant: self.markdownVariant,
                 showsAssistantTrace: self.showsAssistantTrace)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }


### PR DESCRIPTION
## Problem

`ChatStreamingAssistantBubble` was calling `ChatAssistantTextBody` on every token update. `ChatAssistantTextBody` uses Textual's `StructuredText`, which re-parses the full markdown AST and re-lays out the entire bubble each time. On fast streams this causes visible layout thrash and flicker.

## Fix

Replace the streaming view with a plain SwiftUI `Text` view. Stable during streaming. Once complete, the message commits and `ChatMessageBody` re-renders via `ChatAssistantTextBody` with full markdown — same as before.

Matches the pattern used by ChatGPT and Claude.ai mobile.

## Before / After

| Before | After |
|--------|-------|
| StructuredText re-parses full markdown AST on every token → layout thrash / flicker | Plain Text during stream → stable bubble → snaps to formatted markdown on commit |

> **Screenshots:** This is a streaming animation issue — flicker only manifests during live token delivery, not capturable in a static screenshot. Verify by running the app and triggering any streaming response.

## Changes

- `ChatStreamingAssistantBubble`: replace `ChatAssistantTextBody` with plain `Text` + `visibleText` computed property
- `visibleText` uses `includeThinking: false` unconditionally — thinking blocks are never shown mid-stream; `showsAssistantTrace` applies only to the final committed render via `ChatAssistantTextBody`
- Removed dead `markdownVariant` property from `ChatStreamingAssistantBubble` and its call site in `ChatView`
- No new dependencies

## Testing

- `swift build` on OpenClawKit: clean (0 errors, 0 warnings)
- Single commit, cherry-picked onto latest `upstream/main`
- Degree: **lightly tested** (build verified; live streaming test requires running gateway)

## Bot Review

Greptile flagged two issues — both addressed in this commit:

1. ✅ **`showsAssistantTrace` logic contradiction** — fixed: `includeThinking: false` is now unconditional. Thinking blocks are never displayed during streaming regardless of the flag.
2. ✅ **Unused `markdownVariant` property** — removed from struct and call site.

## AI Disclosure 🤖

Built with **Claude Sonnet 4.6** via OpenClaw. Approach reviewed and understood by human author. Bot feedback addressed before requesting review.