### PR TITLE
feat: add temporal grouping for sessions in TUI

### DIFF
--- a/src/infra/format-time/format-relative.ts
+++ b/src/infra/format-time/format-relative.ts
@@ -101,12 +101,100 @@ export function formatRelativeTimestamp(
 
   // Fall back to short date display for old timestamps
   try {
+    const tsDate = new Date(timestampMs);
+    const nowDate = new Date();
+    const includeYear = tsDate.getFullYear() !== nowDate.getFullYear();
     return new Intl.DateTimeFormat("en-US", {
       month: "short",
       day: "numeric",
+      ...(includeYear ? { year: "numeric" } : {}),
       ...(options.timezone ? { timeZone: options.timezone } : {}),
-    }).format(new Date(timestampMs));
+    }).format(tsDate);
   } catch {
     return `${day}d ago`;
+  }
+}
+
+export type TemporalBucketOptions = {
+  /** IANA timezone for date comparison. Uses system default if omitted. */
+  timezone?: string;
+  /** Override "now" for testing */
+  now?: number;
+};
+
+/**
+ * Categorize a timestamp into a temporal bucket for grouping.
+ *
+ * Returns one of:
+ * - "Today"
+ * - "Yesterday"
+ * - "Last 7 days"
+ * - "Last 30 days"
+ * - "February 2026" (month + year for older in current year)
+ * - "2025" (just year for previous years)
+ */
+export function getTemporalBucket(
+  timestampMs: number | null | undefined,
+  options?: TemporalBucketOptions,
+): string {
+  if (timestampMs == null || !Number.isFinite(timestampMs)) {
+    return "Unknown";
+  }
+
+  const now = options?.now ?? Date.now();
+  const tz = options?.timezone;
+
+  // Get calendar dates in the target timezone
+  const formatOpts: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    ...(tz ? { timeZone: tz } : {}),
+  };
+  const fmt = new Intl.DateTimeFormat("en-CA", formatOpts); // en-CA gives YYYY-MM-DD
+  const nowDateStr = fmt.format(new Date(now));
+  const tsDateStr = fmt.format(new Date(timestampMs));
+
+  // Same calendar day = Today
+  if (tsDateStr === nowDateStr) {
+    return "Today";
+  }
+
+  // Yesterday: subtract 1 day from now
+  const yesterdayMs = now - 86400000;
+  const yesterdayStr = fmt.format(new Date(yesterdayMs));
+  if (tsDateStr === yesterdayStr) {
+    return "Yesterday";
+  }
+
+  const diffDays = Math.floor((now - timestampMs) / 86400000);
+
+  if (diffDays < 7) {
+    return "Last 7 days";
+  }
+
+  if (diffDays < 30) {
+    return "Last 30 days";
+  }
+
+  // Older: group by month+year or just year
+  const tsDate = new Date(timestampMs);
+
+  const tsYear = parseInt(tsDateStr.slice(0, 4), 10);
+  const nowYear = parseInt(nowDateStr.slice(0, 4), 10);
+
+  if (tsYear !== nowYear) {
+    return String(tsYear);
+  }
+
+  // Same year but >30 days: show month + year
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      month: "long",
+      year: "numeric",
+      ...(tz ? { timeZone: tz } : {}),
+    }).format(tsDate);
+  } catch {
+    return String(tsYear);
   }
 }

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -6,7 +6,7 @@ import {
   formatDurationPrecise,
   formatDurationSeconds,
 } from "./format-duration.js";
-import { formatTimeAgo, formatRelativeTimestamp } from "./format-relative.js";
+import { formatTimeAgo, formatRelativeTimestamp, getTemporalBucket } from "./format-relative.js";
 
 describe("format-duration", () => {
   describe("formatDurationCompact", () => {
@@ -212,6 +212,69 @@ describe("format-relative", () => {
       const result = formatRelativeTimestamp(oldDate, { dateFallback: true });
       // Should be a short date like "Jan 9" not "30d ago"
       expect(result).toMatch(/[A-Z][a-z]{2} \d{1,2}/);
+    });
+
+    it("includes year for cross-year dates with dateFallback", () => {
+      // A date in a different year
+      const lastYear = new Date();
+      lastYear.setFullYear(lastYear.getFullYear() - 1);
+      lastYear.setMonth(11); // December
+      lastYear.setDate(31);
+      const result = formatRelativeTimestamp(lastYear.getTime(), { dateFallback: true });
+      // Should include the year, e.g. "Dec 31, 2025"
+      expect(result).toMatch(/\d{4}/);
+    });
+  });
+
+  describe("getTemporalBucket", () => {
+    // Use a fixed "now" for deterministic tests: 2026-03-09T12:00:00Z
+    const now = new Date("2026-03-09T12:00:00Z").getTime();
+
+    it("returns 'Unknown' for invalid input", () => {
+      expect(getTemporalBucket(null)).toBe("Unknown");
+      expect(getTemporalBucket(undefined)).toBe("Unknown");
+      expect(getTemporalBucket(NaN)).toBe("Unknown");
+    });
+
+    it("returns 'Today' for timestamps from the same calendar day", () => {
+      // 2 hours ago
+      expect(getTemporalBucket(now - 2 * 3600000, { now, timezone: "UTC" })).toBe("Today");
+      // 1 minute ago
+      expect(getTemporalBucket(now - 60000, { now, timezone: "UTC" })).toBe("Today");
+    });
+
+    it("returns 'Yesterday' for timestamps from the previous calendar day", () => {
+      // 26 hours ago (yesterday in UTC)
+      expect(getTemporalBucket(now - 26 * 3600000, { now, timezone: "UTC" })).toBe("Yesterday");
+    });
+
+    it("returns 'Last 7 days' for timestamps 2-6 days ago", () => {
+      // 3 days ago
+      expect(getTemporalBucket(now - 3 * 86400000, { now, timezone: "UTC" })).toBe("Last 7 days");
+      // 5 days ago
+      expect(getTemporalBucket(now - 5 * 86400000, { now, timezone: "UTC" })).toBe("Last 7 days");
+    });
+
+    it("returns 'Last 30 days' for timestamps 7-29 days ago", () => {
+      // 10 days ago
+      expect(getTemporalBucket(now - 10 * 86400000, { now, timezone: "UTC" })).toBe("Last 30 days");
+      // 25 days ago
+      expect(getTemporalBucket(now - 25 * 86400000, { now, timezone: "UTC" })).toBe("Last 30 days");
+    });
+
+    it("returns month + year for older timestamps in the same year", () => {
+      // January 15, 2026
+      const jan15 = new Date("2026-01-15T12:00:00Z").getTime();
+      expect(getTemporalBucket(jan15, { now, timezone: "UTC" })).toBe("January 2026");
+    });
+
+    it("returns just year for timestamps from a different year", () => {
+      // December 25, 2025
+      const dec25 = new Date("2025-12-25T12:00:00Z").getTime();
+      expect(getTemporalBucket(dec25, { now, timezone: "UTC" })).toBe("2025");
+      // 2024
+      const old = new Date("2024-06-15T12:00:00Z").getTime();
+      expect(getTemporalBucket(old, { now, timezone: "UTC" })).toBe("2024");
     });
   });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -6,7 +6,10 @@ import {
   resolveResponseUsageMode,
 } from "../auto-reply/thinking.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
-import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
+import {
+  formatRelativeTimestamp,
+  getTemporalBucket,
+} from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { helpText, parseCommand } from "./commands.js";
 import type { ChatLog } from "./components/chat-log.js";
@@ -185,8 +188,30 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             .join(" "),
         };
       });
-      const selector = createFilterableSelectList(items, 9);
+      // Group items by temporal bucket with separator headers
+      const groupedItems: typeof items = [];
+      let lastBucket = "";
+      for (const item of items) {
+        const session = result.sessions.find((s) => s.key === item.value);
+        const bucket = session?.updatedAt ? getTemporalBucket(session.updatedAt) : "Unknown";
+        if (bucket !== lastBucket) {
+          groupedItems.push({
+            value: `__separator__${bucket}`,
+            label: `── ${bucket} ──`,
+            description: "",
+            searchText: "",
+          });
+          lastBucket = bucket;
+        }
+        groupedItems.push(item);
+      }
+
+      const selector = createFilterableSelectList(groupedItems, 9);
       openSelector(selector, async (value) => {
+        // Skip separator items
+        if (value.startsWith("__separator__")) {
+          return;
+        }
         await setSession(value);
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

Adds temporal grouping to the TUI session selector, similar to how ChatGPT and Claude.ai organize conversation history.

Closes #40994

## Changes

### `src/infra/format-time/format-relative.ts`
- **New function `getTemporalBucket(timestampMs, options?)`** — categorizes a timestamp into one of: Today, Yesterday, Last 7 days, Last 30 days, ${Month} ${Year}, or ${Year}
- Supports timezone-aware bucketing and a `now` override for testing
- **Updated `formatRelativeTimestamp`** — now includes the year for cross-year dates when `dateFallback: true` (e.g. "Dec 31, 2025" instead of "Dec 31")

### `src/tui/tui-command-handlers.ts`
- Session selector now groups items with separator headers (e.g. `── Today ──`, `── Yesterday ──`)
- Separator items are non-selectable (skipped on Enter)

### `src/infra/format-time/format-time.test.ts`
- Tests for `getTemporalBucket` covering all bucket categories
- Test for cross-year date formatting with `dateFallback`

## Testing
- All existing tests pass (`pnpm test:fast`)
- New tests cover temporal bucketing comprehensively