### PR TITLE
fix(ui): strip session-recap blocks from visible message rendering

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { extractInboundSenderLabel, stripInboundMetadata } from "./strip-inbound-meta.js";
+import {
+  extractInboundSenderLabel,
+  stripInboundMetadata,
+  stripLeadingInboundMetadata,
+} from "./strip-inbound-meta.js";
 
 const CONV_BLOCK = `Conversation info (untrusted metadata):
 \`\`\`json
@@ -117,6 +121,101 @@ Real user content`;
 name: test
 Hello from user`;
     expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("strips leading <session-recap> block", () => {
+    const input = `<session-recap>
+<summary>Found 10 recent items across 3 categories</summary>
+<ledger-items count="2">
+  <item path="ledger/2026-03-09.md">
+    <title>ledger/2026-03-09.md</title>
+  </item>
+</ledger-items>
+</session-recap>
+
+What is the weather today?`;
+    expect(stripInboundMetadata(input)).toBe("What is the weather today?");
+  });
+
+  it("strips leading <session_recap> (underscore variant) block", () => {
+    const input = `<session_recap>
+<summary>items</summary>
+</session_recap>
+
+Hello`;
+    expect(stripInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("does not strip <session-recap> when it appears mid-message", () => {
+    const input = `Hello\n<session-recap>\nstuff\n</session-recap>\nWorld`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("preserves entire message when <session-recap> is unterminated", () => {
+    const input = `<session-recap>\n<summary>truncated`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("strips inline single-line <session-recap> block", () => {
+    const input = `<session-recap><summary>recap</summary></session-recap>\n\nHello`;
+    expect(stripInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("strips block where closing tag is inline with content", () => {
+    const input = `<session-recap>\n<summary>items</summary></session-recap>\n\nHello`;
+    expect(stripInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("preserves text after inline closing tag on same line", () => {
+    const input = `<session-recap>stuff</session-recap>Hello`;
+    expect(stripInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("strips <session-recap> that appears after sentinel metadata blocks", () => {
+    const input = `${CONV_BLOCK}\n\n<session-recap>\n<summary>recap</summary>\n</session-recap>\n\nUser message`;
+    expect(stripInboundMetadata(input)).toBe("User message");
+  });
+
+  it("preserves indentation in user text after stripping recap block", () => {
+    const input = `<session-recap>stuff</session-recap>\n    indented code`;
+    expect(stripInboundMetadata(input)).toBe("    indented code");
+  });
+});
+
+describe("stripLeadingInboundMetadata", () => {
+  it("strips leading <session-recap> block", () => {
+    const input = `<session-recap>\n<summary>items</summary>\n</session-recap>\n\nHello`;
+    expect(stripLeadingInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("strips leading <session_recap> (underscore variant) block", () => {
+    const input = `<session_recap>\n<summary>items</summary>\n</session_recap>\n\nHello`;
+    expect(stripLeadingInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("does not strip <session-recap> when it appears mid-message", () => {
+    const input = `Hello\n<session-recap>\nstuff\n</session-recap>\nWorld`;
+    expect(stripLeadingInboundMetadata(input)).toBe(input);
+  });
+
+  it("preserves entire message when <session-recap> is unterminated", () => {
+    const input = `<session-recap>\n<summary>truncated`;
+    expect(stripLeadingInboundMetadata(input)).toBe(input);
+  });
+
+  it("strips inline single-line <session-recap> block", () => {
+    const input = `<session-recap>stuff</session-recap>\n\nHello`;
+    expect(stripLeadingInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("preserves text after inline closing tag on same line", () => {
+    const input = `<session-recap>stuff</session-recap>Hello`;
+    expect(stripLeadingInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("strips <session-recap> that appears after sentinel metadata blocks", () => {
+    const input = `${CONV_BLOCK}\n\n<session-recap>\n<summary>recap</summary>\n</session-recap>\n\nUser message`;
+    expect(stripLeadingInboundMetadata(input)).toBe("User message");
   });
 });
 

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -33,6 +33,30 @@ const SENTINEL_FAST_RE = new RegExp(
     .join("|"),
 );
 
+// <session-recap> XML blocks injected as agent context scaffolding.
+const SESSION_RECAP_QUICK_RE = /<\s*session[-_]recap\b/i;
+const SESSION_RECAP_OPEN_RE = /^<\s*session[-_]recap\b[^<>]*>/i;
+const SESSION_RECAP_CLOSE_RE = /<\s*\/\s*session[-_]recap\s*>/i;
+
+function stripLeadingSessionRecapBlock(text: string): string {
+  if (!SESSION_RECAP_QUICK_RE.test(text)) {
+    return text;
+  }
+  const trimmedStart = text.trimStart();
+  if (!SESSION_RECAP_OPEN_RE.test(trimmedStart)) {
+    return text;
+  }
+
+  const closeMatch = SESSION_RECAP_CLOSE_RE.exec(trimmedStart);
+  if (!closeMatch) {
+    // Unterminated block — preserve entire message to avoid data loss.
+    return text;
+  }
+
+  const closeEnd = closeMatch.index + closeMatch[0].length;
+  return trimmedStart.slice(closeEnd).replace(/^\n+/, "");
+}
+
 function isInboundMetaSentinelLine(line: string): boolean {
   const trimmed = line.trim();
   return INBOUND_META_SENTINELS.some((sentinel) => sentinel === trimmed);
@@ -121,7 +145,14 @@ function stripTrailingUntrustedContextSuffix(lines: string[]): string[] {
  * (fast path — zero allocation).
  */
 export function stripInboundMetadata(text: string): string {
-  if (!text || !SENTINEL_FAST_RE.test(text)) {
+  if (!text) {
+    return text;
+  }
+
+  // Strip leading <session-recap> blocks first (before sentinel metadata).
+  text = stripLeadingSessionRecapBlock(text);
+
+  if (!SENTINEL_FAST_RE.test(text)) {
     return text;
   }
 
@@ -174,11 +205,21 @@ export function stripInboundMetadata(text: string): string {
     result.push(line);
   }
 
-  return result.join("\n").replace(/^\n+/, "").replace(/\n+$/, "");
+  // Strip recap blocks that appear after sentinel metadata was removed.
+  let stripped = result.join("\n").replace(/^\n+/, "").replace(/\n+$/, "");
+  stripped = stripLeadingSessionRecapBlock(stripped);
+  return stripped;
 }
 
 export function stripLeadingInboundMetadata(text: string): string {
-  if (!text || !SENTINEL_FAST_RE.test(text)) {
+  if (!text) {
+    return text;
+  }
+
+  // Strip leading <session-recap> blocks before sentinel metadata.
+  text = stripLeadingSessionRecapBlock(text);
+
+  if (!SENTINEL_FAST_RE.test(text)) {
     return text;
   }
 
@@ -221,8 +262,11 @@ export function stripLeadingInboundMetadata(text: string): string {
     }
   }
 
+  // Strip recap blocks that appear after sentinel metadata was removed.
   const strippedRemainder = stripTrailingUntrustedContextSuffix(lines.slice(index));
-  return strippedRemainder.join("\n");
+  let result = strippedRemainder.join("\n");
+  result = stripLeadingSessionRecapBlock(result);
+  return result;
 }
 
 export function extractInboundSenderLabel(text: string): string | null {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -46,4 +46,43 @@ describe("stripAssistantInternalScaffolding", () => {
     const input = ["Hello", "<relevant-memories>", "internal-only"].join("\n");
     expect(stripAssistantInternalScaffolding(input)).toBe("Hello\n");
   });
+
+  it("strips session-recap scaffolding blocks", () => {
+    const input = [
+      "<session-recap>",
+      "<summary>Found 10 recent items</summary>",
+      '<ledger-items count="2">',
+      '  <item path="ledger/2026-03-09.md">test</item>',
+      "</ledger-items>",
+      "</session-recap>",
+      "",
+      "User-visible answer",
+    ].join("\n");
+    expect(stripAssistantInternalScaffolding(input)).toBe("User-visible answer");
+  });
+
+  it("supports session_recap underscore variant", () => {
+    const input = ["<session_recap>", "Internal recap note", "</session_recap>", "Visible"].join(
+      "\n",
+    );
+    expect(stripAssistantInternalScaffolding(input)).toBe("Visible");
+  });
+
+  it("keeps session-recap tags inside fenced code", () => {
+    const input = [
+      "```xml",
+      "<session-recap>",
+      "sample",
+      "</session-recap>",
+      "```",
+      "",
+      "Visible text",
+    ].join("\n");
+    expect(stripAssistantInternalScaffolding(input)).toBe(input);
+  });
+
+  it("hides unfinished session-recap blocks", () => {
+    const input = ["Hello", "<session-recap>", "internal-only"].join("\n");
+    expect(stripAssistantInternalScaffolding(input)).toBe("Hello\n");
+  });
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -4,6 +4,9 @@ import { stripReasoningTagsFromText } from "./reasoning-tags.js";
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
 
+const SESSION_RECAP_TAG_RE = /<\s*(\/?)\s*session[-_]recap\b[^<>]*>/gi;
+const SESSION_RECAP_TAG_QUICK_RE = /<\s*\/?\s*session[-_]recap\b/i;
+
 function stripRelevantMemoriesTags(text: string): string {
   if (!text || !MEMORY_TAG_QUICK_RE.test(text)) {
     return text;
@@ -41,7 +44,45 @@ function stripRelevantMemoriesTags(text: string): string {
   return result;
 }
 
+function stripSessionRecapTags(text: string): string {
+  if (!text || !SESSION_RECAP_TAG_QUICK_RE.test(text)) {
+    return text;
+  }
+  SESSION_RECAP_TAG_RE.lastIndex = 0;
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let lastIndex = 0;
+  let inRecapBlock = false;
+
+  for (const match of text.matchAll(SESSION_RECAP_TAG_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+
+    const isClose = match[1] === "/";
+    if (!inRecapBlock) {
+      result += text.slice(lastIndex, idx);
+      if (!isClose) {
+        inRecapBlock = true;
+      }
+    } else if (isClose) {
+      inRecapBlock = false;
+    }
+
+    lastIndex = idx + match[0].length;
+  }
+
+  if (!inRecapBlock) {
+    result += text.slice(lastIndex);
+  }
+
+  return result;
+}
+
 export function stripAssistantInternalScaffolding(text: string): string {
   const withoutReasoning = stripReasoningTagsFromText(text, { mode: "preserve", trim: "start" });
-  return stripRelevantMemoriesTags(withoutReasoning).trimStart();
+  const withoutMemories = stripRelevantMemoriesTags(withoutReasoning);
+  return stripSessionRecapTags(withoutMemories).trimStart();
 }


### PR DESCRIPTION
## Summary
- Strip `<session-recap>` / `<session_recap>` XML scaffolding blocks from both user message (inbound metadata) and assistant message rendering paths
- These blocks are agent-injected context that should never surface in Control UI or TUI

## Changes
- `src/auto-reply/reply/strip-inbound-meta.ts`: Add `stripLeadingSessionRecapBlock()` and integrate into `stripInboundMetadata()` / `stripLeadingInboundMetadata()` fast paths
- `src/shared/text/assistant-visible-text.ts`: Add `stripSessionRecapTags()` (same pattern as `stripRelevantMemoriesTags`) and integrate into `stripAssistantInternalScaffolding()`
- Tests added for both paths covering: basic stripping, underscore variant, mid-message preservation, code-fenced preservation, unfinished blocks

Closes #40948

## Test plan
- [x] `pnpm test -- --run src/shared/text/assistant-visible-text.test.ts src/auto-reply/reply/strip-inbound-meta.test.ts` — 29 tests pass
- [ ] Manual verification: send a message with `<session-recap>` prefix via Gemini model, confirm block is stripped in Control UI and TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)