### PR TITLE
fix: strip leading <session-recap> blocks from user-visible messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - macOS/LaunchAgent install: tighten LaunchAgent directory and plist permissions during install so launchd bootstrap does not fail when the target home path or generated plist inherited group/world-writable modes.
 - Gateway/Control UI: keep dashboard auth tokens in session-scoped browser storage so same-tab refreshes preserve remote token auth without restoring long-lived localStorage token persistence, while scoping tokens to the selected gateway URL and fragment-only bootstrap flow. (#40892) thanks @velvet-shark.
+- Auto-reply/inbound metadata: fix <session-recap> block stripping to require both open and close tags, preserving the original message when the close tag is missing. Fix mid-message recap tags not altering user-authored blank lines in the fast-return path. (#41013)
 
 ## 2026.3.8
 

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -33,6 +33,24 @@ Sender labels:
 example
 <<<END_EXTERNAL_UNTRUSTED_CONTENT id="deadbeefdeadbeef">>>`;
 
+const SESSION_RECAP_BLOCK = `<session-recap>
+<summary>Found 10 recent items across 3 categories</summary>
+<ledger-items count="2">
+  <item path="ledger/2026-03-09.md">
+    <title>ledger/2026-03-09.md</title>
+    <snippet>some snippet</snippet>
+  </item>
+</ledger-items>
+<handoff-items count="1">
+  <item path="handoffs/handoff-2026-03-09-1012">
+    <title>handoff-2026-03-09-1012</title>
+  </item>
+</handoff-items>
+<task-items count="1">
+  <item path="tasks/foo" status="open">foo task</item>
+</task-items>
+</session-recap>`;
+
 describe("stripInboundMetadata", () => {
   it("fast-path: returns same string when no sentinels present", () => {
     const text = "Hello, how are you?";
@@ -117,6 +135,38 @@ Real user content`;
 name: test
 Hello from user`;
     expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  // --- session-recap tests ---
+
+  it("strips a leading <session-recap> block", () => {
+    const input = `${SESSION_RECAP_BLOCK}\n\nWhat should I do today?`;
+    expect(stripInboundMetadata(input)).toBe("What should I do today?");
+  });
+
+  it("strips a leading <session-recap> block with no user text after it", () => {
+    expect(stripInboundMetadata(SESSION_RECAP_BLOCK)).toBe("");
+  });
+
+  it("strips <session-recap> block followed by standard metadata blocks", () => {
+    const input = `${SESSION_RECAP_BLOCK}\n\n${CONV_BLOCK}\n\nHello`;
+    expect(stripInboundMetadata(input)).toBe("Hello");
+  });
+
+  it("does not strip <session-recap> when it appears mid-message", () => {
+    const input = `User message\n\n${SESSION_RECAP_BLOCK}`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("strips leading blank lines before <session-recap> and user content", () => {
+    const input = `\n\n${SESSION_RECAP_BLOCK}\n\nActual user text`;
+    expect(stripInboundMetadata(input)).toBe("Actual user text");
+  });
+
+  it("handles session_recap (underscore variant) open tag", () => {
+    const block = `<session_recap>\n<summary>summary</summary>\n</session_recap>`;
+    const input = `${block}\n\nUser text`;
+    expect(stripInboundMetadata(input)).toBe("User text");
   });
 });
 

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -168,6 +168,16 @@ Hello from user`;
     const input = `${block}\n\nUser text`;
     expect(stripInboundMetadata(input)).toBe("User text");
   });
+
+  it("preserves message when <session-recap> close tag is missing", () => {
+    const input = `<session-recap>\n<summary>no close tag\n\nReal user message`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("does not trim blank lines when <session-recap> is mid-message", () => {
+    const input = `User preamble\n\n${SESSION_RECAP_BLOCK}\n\nUser postamble`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
 });
 
 describe("extractInboundSenderLabel", () => {

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -33,6 +33,11 @@ const SENTINEL_FAST_RE = new RegExp(
     .join("|"),
 );
 
+// Fast-path check for <session-recap> blocks.
+const SESSION_RECAP_QUICK_RE = /<\s*session[-_]recap\b/i;
+const SESSION_RECAP_OPEN_LINE_RE = /^<\s*session[-_]recap\b[^<>]*>\s*$/i;
+const SESSION_RECAP_CLOSE_LINE_RE = /^<\s*\/\s*session[-_]recap\s*>\s*$/i;
+
 function isInboundMetaSentinelLine(line: string): boolean {
   const trimmed = line.trim();
   return INBOUND_META_SENTINELS.some((sentinel) => sentinel === trimmed);
@@ -106,6 +111,31 @@ function stripTrailingUntrustedContextSuffix(lines: string[]): string[] {
 }
 
 /**
+ * Strips a leading <session-recap>…</session-recap> block injected as agent
+ * context scaffolding. These blocks are AI-facing only and must not be visible
+ * in any UI surface.
+ *
+ * The block is only stripped when it appears at the very start of the message
+ * (ignoring leading blank lines). A <session-recap> tag that appears mid-message
+ * is left intact.
+ */
+function stripLeadingSessionRecapBlock(lines: string[]): string[] {
+  let i = 0;
+  // Skip leading blank lines.
+  while (i < lines.length && lines[i]?.trim() === "") i++;
+  if (i >= lines.length) return lines;
+  // Only strip if the first non-blank line is a <session-recap> open tag.
+  if (!SESSION_RECAP_OPEN_LINE_RE.test(lines[i] ?? "")) return lines;
+  i++;
+  // Consume all lines until (and including) the closing </session-recap> tag.
+  while (i < lines.length && !SESSION_RECAP_CLOSE_LINE_RE.test(lines[i] ?? "")) i++;
+  if (i < lines.length) i++; // consume the closing tag line itself
+  // Skip blank lines after the closing tag.
+  while (i < lines.length && lines[i]?.trim() === "") i++;
+  return lines.slice(i);
+}
+
+/**
  * Remove all injected inbound metadata prefix blocks from `text`.
  *
  * Each block has the shape:
@@ -121,11 +151,28 @@ function stripTrailingUntrustedContextSuffix(lines: string[]): string[] {
  * (fast path — zero allocation).
  */
 export function stripInboundMetadata(text: string): string {
-  if (!text || !SENTINEL_FAST_RE.test(text)) {
+  if (!text) return text;
+
+  // Fast-path: if neither standard sentinels nor session-recap are present,
+  // return the original string unchanged (zero allocation).
+  const hasStandardSentinels = SENTINEL_FAST_RE.test(text);
+  const hasSessionRecap = SESSION_RECAP_QUICK_RE.test(text);
+  if (!hasStandardSentinels && !hasSessionRecap) {
     return text;
   }
 
-  const lines = text.split("\n");
+  let lines = text.split("\n");
+
+  // Strip a leading <session-recap> block first so the remaining logic can
+  // operate on a clean prefix.
+  if (hasSessionRecap) {
+    lines = stripLeadingSessionRecapBlock(lines);
+  }
+
+  if (!hasStandardSentinels) {
+    return lines.join("\n").replace(/^\n+/, "").replace(/\n+$/, "");
+  }
+
   const result: string[] = [];
   let inMetaBlock = false;
   let inFencedJson = false;
@@ -178,11 +225,26 @@ export function stripInboundMetadata(text: string): string {
 }
 
 export function stripLeadingInboundMetadata(text: string): string {
-  if (!text || !SENTINEL_FAST_RE.test(text)) {
+  if (!text) return text;
+
+  const hasStandardSentinels = SENTINEL_FAST_RE.test(text);
+  const hasSessionRecap = SESSION_RECAP_QUICK_RE.test(text);
+  if (!hasStandardSentinels && !hasSessionRecap) {
     return text;
   }
 
-  const lines = text.split("\n");
+  let lines = text.split("\n");
+
+  // Strip a leading <session-recap> block first.
+  if (hasSessionRecap) {
+    lines = stripLeadingSessionRecapBlock(lines);
+  }
+
+  if (!hasStandardSentinels) {
+    const strippedNoLeading = stripTrailingUntrustedContextSuffix(lines);
+    return strippedNoLeading.join("\n");
+  }
+
   let index = 0;
 
   while (index < lines.length && lines[index] === "") {

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -129,7 +129,9 @@ function stripLeadingSessionRecapBlock(lines: string[]): string[] {
   i++;
   // Consume all lines until (and including) the closing </session-recap> tag.
   while (i < lines.length && !SESSION_RECAP_CLOSE_LINE_RE.test(lines[i] ?? "")) i++;
-  if (i < lines.length) i++; // consume the closing tag line itself
+  // If no close tag found, preserve original text unchanged.
+  if (i >= lines.length) return lines;
+  i++; // consume the closing tag line itself
   // Skip blank lines after the closing tag.
   while (i < lines.length && lines[i]?.trim() === "") i++;
   return lines.slice(i);
@@ -166,7 +168,14 @@ export function stripInboundMetadata(text: string): string {
   // Strip a leading <session-recap> block first so the remaining logic can
   // operate on a clean prefix.
   if (hasSessionRecap) {
+    const originalLength = lines.length;
     lines = stripLeadingSessionRecapBlock(lines);
+    // If the recap block wasn't actually stripped (e.g. missing close tag,
+    // mid-message tag), and there are no standard sentinels, return the
+    // original text unchanged so we don't alter user-authored blank lines.
+    if (!hasStandardSentinels && lines.length === originalLength) {
+      return text;
+    }
   }
 
   if (!hasStandardSentinels) {
@@ -237,7 +246,13 @@ export function stripLeadingInboundMetadata(text: string): string {
 
   // Strip a leading <session-recap> block first.
   if (hasSessionRecap) {
+    const originalLength = lines.length;
     lines = stripLeadingSessionRecapBlock(lines);
+    // If nothing was actually stripped, and there are no standard sentinels,
+    // return the original text unchanged.
+    if (!hasStandardSentinels && lines.length === originalLength) {
+      return text;
+    }
   }
 
   if (!hasStandardSentinels) {


### PR DESCRIPTION
## Problem

Fixes #40948

`<session-recap>` blocks injected as agent context scaffolding were leaking into the Control UI and TUI as visible user message text. This happened because `stripInboundMetadata()` had no handling for `<session-recap>` — the fast-path returned the string unchanged when no JSON sentinel headers were found.

**Affected surfaces (from the issue):**
- Control UI + Gemini (`google/gemini-3.1-flash-lite-preview`): block rendered visibly in user message bubble
- TUI shell: always rendered visibly, regardless of model

## Solution

Added a `stripLeadingSessionRecapBlock()` helper that removes a `<session-recap>…</session-recap>` block when it appears at the very start of a message. The block is only stripped from the leading position — a `<session-recap>` tag that appears mid-message is left intact.

**Changes to `strip-inbound-meta.ts`:**

1. Add `SESSION_RECAP_QUICK_RE` fast-path check (analogous to `SENTINEL_FAST_RE`)
2. Add `stripLeadingSessionRecapBlock()` that:
   - Skips leading blank lines
   - Checks if the first non-blank line matches `<session-recap>` (or `<session_recap>`, case-insensitive)
   - Consumes all lines up to and including `</session-recap>`
   - Skips blank lines after the closing tag
3. Wire it into both `stripInboundMetadata()` and `stripLeadingInboundMetadata()`

## Tests

Added 6 new test cases covering:
- ✅ Strips leading `<session-recap>` block with user text after it
- ✅ Strips `<session-recap>` block alone (no trailing content)
- ✅ Strips `<session-recap>` followed by standard sentinel metadata blocks
- ✅ Does **not** strip `<session-recap>` when it appears mid-message
- ✅ Handles leading blank lines before the block
- ✅ Handles `session_recap` (underscore variant) open tag

All existing tests pass unchanged.