### PR TITLE
feat(compaction): truncate session JSONL after compaction to prevent unbounded growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,6 @@ Docs: https://docs.openclaw.ai
 - macOS/node service startup: use `openclaw node start/stop --json` from the Mac app instead of the removed `openclaw service node ...` command shape, so current CLI installs expose the full node exec surface again. (#46843) Fixes #43171. Thanks @Br1an67.
 - macOS/launch at login: stop emitting `KeepAlive` for the desktop app launch agent so OpenClaw no longer relaunches immediately after a manual quit while launch at login remains enabled. (#40213) Thanks @stablegenius49.
 - ACP/gateway startup: use direct Telegram and Discord startup/status helpers instead of routing probes through the plugin runtime, and prepend the selected daemon Node bin dir to service PATH so plugin-local installs can still find `npm` and `pnpm`.
-- Agents/compaction: add an opt-in post-compaction session JSONL truncation step that drops summarized transcript entries while preserving the retained branch tail and live session metadata. (#41021) thanks @thirumaleshp.
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
@@ -180,6 +179,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/update: let `openclaw plugins update <npm-spec>` target tracked npm installs by dist-tag or exact version, and preserve the recorded npm spec for later id-based updates. (#49998) Thanks @huntharo.
 - Tests/CLI: reduce command-secret gateway test import pressure while keeping the real protocol payload validator in place, so the isolated lane no longer carries the heavier runtime-web and message-channel graphs. (#50663) Thanks @huntharo.
 - Gateway/plugins: share plugin interactive callback routing and plugin bind approval state across duplicate module graphs so Telegram Codex picker buttons and plugin bind approvals no longer fall through to normal inbound message routing. (#50722) Thanks @huntharo.
+- Agents/compaction: add an opt-in post-compaction session JSONL truncation step that drops summarized transcript entries while preserving the retained branch tail and live session metadata. (#41021) thanks @thirumaleshp.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ Docs: https://docs.openclaw.ai
 - macOS/node service startup: use `openclaw node start/stop --json` from the Mac app instead of the removed `openclaw service node ...` command shape, so current CLI installs expose the full node exec surface again. (#46843) Fixes #43171. Thanks @Br1an67.
 - macOS/launch at login: stop emitting `KeepAlive` for the desktop app launch agent so OpenClaw no longer relaunches immediately after a manual quit while launch at login remains enabled. (#40213) Thanks @stablegenius49.
 - ACP/gateway startup: use direct Telegram and Discord startup/status helpers instead of routing probes through the plugin runtime, and prepend the selected daemon Node bin dir to service PATH so plugin-local installs can still find `npm` and `pnpm`.
+- Agents/compaction: add an opt-in post-compaction session JSONL truncation step that drops summarized transcript entries while preserving the retained branch tail and live session metadata. (#41021) thanks @thirumaleshp.
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -96,6 +96,7 @@ import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-disco
 import { buildModelAliasLines, resolveModelAsync } from "./model.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
+import { truncateSessionAfterCompaction } from "./session-truncation.js";
 import { resolveEmbeddedRunSkillEntries } from "./skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
@@ -1080,6 +1081,25 @@ export async function compactEmbeddedPiSessionDirect(
             );
           } catch (err) {
             log.warn("after_compaction hook failed", {
+              errorMessage: err instanceof Error ? err.message : String(err),
+              errorStack: err instanceof Error ? err.stack : undefined,
+            });
+          }
+        }
+        // Truncate session file to remove compacted entries (#39953)
+        if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction) {
+          try {
+            const truncResult = await truncateSessionAfterCompaction({
+              sessionFile: params.sessionFile,
+            });
+            if (truncResult.truncated) {
+              log.info(
+                `[compaction] post-compaction truncation removed ${truncResult.entriesRemoved} entries ` +
+                  `(sessionKey=${params.sessionKey ?? params.sessionId})`,
+              );
+            }
+          } catch (err) {
+            log.warn("[compaction] post-compaction truncation failed", {
               errorMessage: err instanceof Error ? err.message : String(err),
               errorStack: err instanceof Error ? err.stack : undefined,
             });

--- a/src/agents/pi-embedded-runner/session-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.test.ts
@@ -67,10 +67,13 @@ describe("truncateSessionAfterCompaction", () => {
     const entriesAfter = smAfter.getEntries().length;
     expect(entriesAfter).toBeLessThan(entriesBefore);
 
-    // The branch should contain compaction + post-compaction messages
+    // The branch should contain the firstKeptEntryId message (unsummarized
+    // tail), compaction, and post-compaction messages
     const branchAfter = smAfter.getBranch();
-    expect(branchAfter[0].type).toBe("compaction");
+    // The firstKeptEntryId message is preserved as the new root
+    expect(branchAfter[0].type).toBe("message");
     expect(branchAfter[0].parentId).toBeNull();
+    expect(branchAfter[1].type).toBe("compaction");
 
     // Session context should still work
     const ctx = smAfter.buildSessionContext();
@@ -164,14 +167,14 @@ describe("truncateSessionAfterCompaction", () => {
     const entriesAfter = smAfter.getEntries().length;
     expect(entriesAfter).toBeLessThan(entriesBefore);
 
-    // No message entries should exist before the latest compaction
+    // Only the firstKeptEntryId message should remain before the latest compaction
     const latestCompIdx = branchAfter.findIndex(
       (e) => e.type === "compaction" && e === compactionEntries[compactionEntries.length - 1],
     );
     const messagesBeforeLatest = branchAfter
       .slice(0, latestCompIdx)
       .filter((e) => e.type === "message");
-    expect(messagesBeforeLatest).toHaveLength(0);
+    expect(messagesBeforeLatest).toHaveLength(1);
   });
 
   it("preserves non-message session state during truncation", async () => {
@@ -215,17 +218,18 @@ describe("truncateSessionAfterCompaction", () => {
     expect(types).toContain("session_info");
     expect(types).toContain("compaction");
 
-    // Message entries before compaction should be gone
+    // Only the firstKeptEntryId message should remain before the compaction
+    // (all other messages before it were summarized and removed)
     const branchAfter = smAfter.getBranch();
     const compIdx = branchAfter.findIndex((e) => e.type === "compaction");
     const msgsBefore = branchAfter.slice(0, compIdx).filter((e) => e.type === "message");
-    expect(msgsBefore).toHaveLength(0);
+    expect(msgsBefore).toHaveLength(1);
 
     // Session context should still work
     const ctx = smAfter.buildSessionContext();
     expect(ctx.messages.length).toBeGreaterThan(0);
-    // Model and thinking state should be recoverable
-    expect(ctx.model?.modelId).toBe("claude-sonnet-4-5-20250514");
+    // Non-message state entries are preserved in the truncated file
+    expect(ctx.model).toBeDefined();
     expect(ctx.thinkingLevel).toBe("high");
   });
 
@@ -276,6 +280,43 @@ describe("truncateSessionAfterCompaction", () => {
     const allAfter = smAfter.getEntries();
     const labels = allAfter.filter((e) => e.type === "label");
     expect(labels).toHaveLength(0);
+  });
+
+  it("preserves the firstKeptEntryId unsummarized tail", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+
+    // Build a conversation where firstKeptEntryId is NOT the last message
+    sm.appendMessage({ role: "user", content: "msg1", timestamp: 1 });
+    sm.appendMessage(makeAssistant("resp1", 2));
+    sm.appendMessage({ role: "user", content: "msg2", timestamp: 3 });
+    sm.appendMessage(makeAssistant("resp2", 4));
+
+    const branch = sm.getBranch();
+    // Set firstKeptEntryId to the second message — so msg1 is summarized
+    // but msg2, resp2, and everything after are the unsummarized tail.
+    const firstKeptId = branch[1].id; // "resp1"
+    sm.appendCompaction("Summary of msg1.", firstKeptId, 2000);
+
+    sm.appendMessage({ role: "user", content: "next", timestamp: 5 });
+
+    const sessionFile = sm.getSessionFile()!;
+    const result = await truncateSessionAfterCompaction({ sessionFile });
+
+    expect(result.truncated).toBe(true);
+    // Only msg1 was summarized (1 entry removed)
+    expect(result.entriesRemoved).toBe(1);
+
+    // Verify the unsummarized tail is preserved
+    const smAfter = SessionManager.open(sessionFile);
+    const branchAfter = smAfter.getBranch();
+    const types = branchAfter.map((e) => e.type);
+    // resp1 (firstKeptEntryId), msg2, resp2, compaction, next
+    expect(types).toEqual(["message", "message", "message", "compaction", "message"]);
+
+    // buildSessionContext should include the unsummarized tail
+    const ctx = smAfter.buildSessionContext();
+    expect(ctx.messages.length).toBeGreaterThan(2);
   });
 
   it("preserves unsummarized sibling branches during truncation", async () => {

--- a/src/agents/pi-embedded-runner/session-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it } from "vitest";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import { truncateSessionAfterCompaction } from "./session-truncation.js";
+
+let tmpDir: string;
+
+async function createTmpDir(): Promise<string> {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "session-truncation-test-"));
+  return tmpDir;
+}
+
+afterEach(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+function makeAssistant(text: string, timestamp: number) {
+  return makeAgentAssistantMessage({
+    content: [{ type: "text", text }],
+    timestamp,
+  });
+}
+
+function createSessionWithCompaction(sessionDir: string): string {
+  const sm = SessionManager.create(sessionDir, sessionDir);
+  // Add messages before compaction
+  sm.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+  sm.appendMessage(makeAssistant("hi there", 2));
+  sm.appendMessage({ role: "user", content: "do something", timestamp: 3 });
+  sm.appendMessage(makeAssistant("done", 4));
+
+  // Add compaction (summarizing the above)
+  const branch = sm.getBranch();
+  const firstKeptId = branch[branch.length - 1].id;
+  sm.appendCompaction("Summary of conversation so far.", firstKeptId, 5000);
+
+  // Add messages after compaction
+  sm.appendMessage({ role: "user", content: "next task", timestamp: 5 });
+  sm.appendMessage(makeAssistant("working on it", 6));
+
+  return sm.getSessionFile()!;
+}
+
+describe("truncateSessionAfterCompaction", () => {
+  it("removes entries before compaction and keeps entries after (#39953)", async () => {
+    const dir = await createTmpDir();
+    const sessionFile = createSessionWithCompaction(dir);
+
+    // Verify pre-truncation state
+    const smBefore = SessionManager.open(sessionFile);
+    const entriesBefore = smBefore.getEntries().length;
+    expect(entriesBefore).toBeGreaterThan(5); // 4 messages + compaction + 2 messages
+
+    const result = await truncateSessionAfterCompaction({ sessionFile });
+
+    expect(result.truncated).toBe(true);
+    expect(result.entriesRemoved).toBeGreaterThan(0);
+    expect(result.bytesAfter).toBeLessThan(result.bytesBefore!);
+
+    // Verify post-truncation: file is still a valid session
+    const smAfter = SessionManager.open(sessionFile);
+    const entriesAfter = smAfter.getEntries().length;
+    expect(entriesAfter).toBeLessThan(entriesBefore);
+
+    // The branch should contain compaction + post-compaction messages
+    const branchAfter = smAfter.getBranch();
+    expect(branchAfter[0].type).toBe("compaction");
+    expect(branchAfter[0].parentId).toBeNull();
+
+    // Session context should still work
+    const ctx = smAfter.buildSessionContext();
+    expect(ctx.messages.length).toBeGreaterThan(0);
+  });
+
+  it("skips truncation when no compaction entry exists", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    // appendMessage implicitly creates the session file
+    sm.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sm.appendMessage(makeAssistant("hi", 2));
+    sm.appendMessage({ role: "user", content: "bye", timestamp: 3 });
+    const sessionFile = sm.getSessionFile()!;
+
+    const result = await truncateSessionAfterCompaction({ sessionFile });
+
+    expect(result.truncated).toBe(false);
+    expect(result.reason).toBe("no compaction entry found");
+  });
+
+  it("is idempotent — second truncation is a no-op", async () => {
+    const dir = await createTmpDir();
+    const sessionFile = createSessionWithCompaction(dir);
+
+    const first = await truncateSessionAfterCompaction({ sessionFile });
+    expect(first.truncated).toBe(true);
+
+    // Run again — compaction is now at root, nothing more to remove
+    const second = await truncateSessionAfterCompaction({ sessionFile });
+    expect(second.truncated).toBe(false);
+    expect(second.reason).toBe("compaction already at root");
+  });
+
+  it("archives original file when archivePath is provided (#39953)", async () => {
+    const dir = await createTmpDir();
+    const sessionFile = createSessionWithCompaction(dir);
+    const archivePath = path.join(dir, "archive", "backup.jsonl");
+
+    const result = await truncateSessionAfterCompaction({ sessionFile, archivePath });
+
+    expect(result.truncated).toBe(true);
+    const archiveExists = await fs
+      .stat(archivePath)
+      .then(() => true)
+      .catch(() => false);
+    expect(archiveExists).toBe(true);
+
+    // Archive should be larger than truncated file (it has the full history)
+    const archiveSize = (await fs.stat(archivePath)).size;
+    const truncatedSize = (await fs.stat(sessionFile)).size;
+    expect(archiveSize).toBeGreaterThan(truncatedSize);
+  });
+
+  it("handles multiple compaction cycles (#39953)", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+
+    // First cycle: messages + compaction
+    sm.appendMessage({ role: "user", content: "cycle 1 message 1", timestamp: 1 });
+    sm.appendMessage(makeAssistant("response 1", 2));
+    const branch1 = sm.getBranch();
+    sm.appendCompaction("Summary of cycle 1.", branch1[branch1.length - 1].id, 3000);
+
+    // Second cycle: more messages + another compaction
+    sm.appendMessage({ role: "user", content: "cycle 2 message 1", timestamp: 3 });
+    sm.appendMessage(makeAssistant("response 2", 4));
+    const branch2 = sm.getBranch();
+    sm.appendCompaction("Summary of cycles 1 and 2.", branch2[branch2.length - 1].id, 6000);
+
+    // Post-compaction messages
+    sm.appendMessage({ role: "user", content: "final question", timestamp: 5 });
+
+    const sessionFile = sm.getSessionFile()!;
+    const entriesBefore = sm.getEntries().length;
+
+    const result = await truncateSessionAfterCompaction({ sessionFile });
+
+    expect(result.truncated).toBe(true);
+
+    // Should keep only the latest compaction + entries after it
+    const smAfter = SessionManager.open(sessionFile);
+    const branchAfter = smAfter.getBranch();
+    expect(branchAfter[0].type).toBe("compaction");
+
+    // Only the latest compaction should remain
+    const compactionEntries = branchAfter.filter((e) => e.type === "compaction");
+    expect(compactionEntries).toHaveLength(1);
+
+    const entriesAfter = smAfter.getEntries().length;
+    expect(entriesAfter).toBeLessThan(entriesBefore);
+  });
+});

--- a/src/agents/pi-embedded-runner/session-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.test.ts
@@ -99,10 +99,9 @@ describe("truncateSessionAfterCompaction", () => {
     const first = await truncateSessionAfterCompaction({ sessionFile });
     expect(first.truncated).toBe(true);
 
-    // Run again — compaction is now at root, nothing more to remove
+    // Run again — no message entries left to remove
     const second = await truncateSessionAfterCompaction({ sessionFile });
     expect(second.truncated).toBe(false);
-    expect(second.reason).toBe("compaction already at root");
   });
 
   it("archives original file when archivePath is provided (#39953)", async () => {
@@ -151,16 +150,135 @@ describe("truncateSessionAfterCompaction", () => {
 
     expect(result.truncated).toBe(true);
 
-    // Should keep only the latest compaction + entries after it
+    // Should preserve both compactions (older compactions are non-message state)
+    // but remove the summarized message entries
     const smAfter = SessionManager.open(sessionFile);
     const branchAfter = smAfter.getBranch();
     expect(branchAfter[0].type).toBe("compaction");
 
-    // Only the latest compaction should remain
+    // Both compaction entries are preserved (non-message state is kept)
     const compactionEntries = branchAfter.filter((e) => e.type === "compaction");
-    expect(compactionEntries).toHaveLength(1);
+    expect(compactionEntries).toHaveLength(2);
 
+    // But message entries before the latest compaction were removed
     const entriesAfter = smAfter.getEntries().length;
     expect(entriesAfter).toBeLessThan(entriesBefore);
+
+    // No message entries should exist before the latest compaction
+    const latestCompIdx = branchAfter.findIndex(
+      (e) => e.type === "compaction" && e === compactionEntries[compactionEntries.length - 1],
+    );
+    const messagesBeforeLatest = branchAfter.slice(0, latestCompIdx).filter((e) => e.type === "message");
+    expect(messagesBeforeLatest).toHaveLength(0);
+  });
+
+  it("preserves non-message session state during truncation", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+
+    // Messages before compaction
+    sm.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sm.appendMessage(makeAssistant("hi", 2));
+
+    // Non-message state entries interleaved with messages
+    sm.appendModelChange("anthropic", "claude-sonnet-4-5-20250514");
+    sm.appendThinkingLevelChange("high");
+    sm.appendCustomEntry("my-extension", { key: "value" });
+    sm.appendSessionInfo("my session");
+
+    sm.appendMessage({ role: "user", content: "do task", timestamp: 3 });
+    sm.appendMessage(makeAssistant("done", 4));
+
+    // Compaction summarizing the conversation
+    const branch = sm.getBranch();
+    const firstKeptId = branch[branch.length - 1].id;
+    sm.appendCompaction("Summary.", firstKeptId, 5000);
+
+    // Post-compaction messages
+    sm.appendMessage({ role: "user", content: "next", timestamp: 5 });
+
+    const sessionFile = sm.getSessionFile()!;
+    const result = await truncateSessionAfterCompaction({ sessionFile });
+
+    expect(result.truncated).toBe(true);
+
+    // Verify non-message entries are preserved
+    const smAfter = SessionManager.open(sessionFile);
+    const allAfter = smAfter.getEntries();
+    const types = allAfter.map((e) => e.type);
+
+    expect(types).toContain("model_change");
+    expect(types).toContain("thinking_level_change");
+    expect(types).toContain("custom");
+    expect(types).toContain("session_info");
+    expect(types).toContain("compaction");
+
+    // Message entries before compaction should be gone
+    const branchAfter = smAfter.getBranch();
+    const compIdx = branchAfter.findIndex((e) => e.type === "compaction");
+    const msgsBefore = branchAfter.slice(0, compIdx).filter((e) => e.type === "message");
+    expect(msgsBefore).toHaveLength(0);
+
+    // Session context should still work
+    const ctx = smAfter.buildSessionContext();
+    expect(ctx.messages.length).toBeGreaterThan(0);
+    // Model and thinking state should be recoverable
+    expect(ctx.model?.modelId).toBe("claude-sonnet-4-5-20250514");
+    expect(ctx.thinkingLevel).toBe("high");
+  });
+
+  it("preserves unsummarized sibling branches during truncation", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+
+    // Build main conversation
+    sm.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sm.appendMessage(makeAssistant("hi there", 2));
+
+    // Save a branch point
+    const branchPoint = sm.getBranch();
+    const branchFromId = branchPoint[branchPoint.length - 1].id;
+
+    // Continue main branch
+    sm.appendMessage({ role: "user", content: "do task A", timestamp: 3 });
+    sm.appendMessage(makeAssistant("done A", 4));
+
+    // Create a sibling branch from the earlier point
+    sm.branch(branchFromId);
+    sm.appendMessage({ role: "user", content: "do task B instead", timestamp: 5 });
+    const siblingMsg = sm.appendMessage(makeAssistant("done B", 6));
+
+    // Go back to main branch tip and add compaction there
+    sm.branch(branchFromId);
+    sm.appendMessage({ role: "user", content: "do task A", timestamp: 3 });
+    sm.appendMessage(makeAssistant("done A take 2", 7));
+    const mainBranch = sm.getBranch();
+    const firstKeptId = mainBranch[mainBranch.length - 1].id;
+    sm.appendCompaction("Summary of main branch.", firstKeptId, 5000);
+    sm.appendMessage({ role: "user", content: "next", timestamp: 8 });
+
+    const sessionFile = sm.getSessionFile()!;
+
+    const entriesBefore = sm.getEntries();
+
+    const result = await truncateSessionAfterCompaction({ sessionFile });
+
+    expect(result.truncated).toBe(true);
+
+    // Verify sibling branch is preserved in the full entry list
+    const smAfter = SessionManager.open(sessionFile);
+    const allAfter = smAfter.getEntries();
+
+    // The sibling branch message should still exist
+    const siblingAfter = allAfter.find((e) => e.id === siblingMsg);
+    expect(siblingAfter).toBeDefined();
+
+    // The tree should have entries from both branches
+    const tree = smAfter.getTree();
+    expect(tree.length).toBeGreaterThan(0);
+
+    // Total entries should be less (main branch messages removed) but not zero
+    expect(allAfter.length).toBeGreaterThan(0);
+    expect(allAfter.length).toBeLessThan(entriesBefore.length);
   });
 });

--- a/src/agents/pi-embedded-runner/session-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.test.ts
@@ -233,7 +233,7 @@ describe("truncateSessionAfterCompaction", () => {
     expect(ctx.thinkingLevel).toBe("high");
   });
 
-  it("drops label and branch_summary entries that reference removed messages", async () => {
+  it("drops label entries whose target message was truncated", async () => {
     const dir = await createTmpDir();
     const sm = SessionManager.create(dir, dir);
 
@@ -243,7 +243,7 @@ describe("truncateSessionAfterCompaction", () => {
     sm.appendMessage({ role: "user", content: "do task", timestamp: 3 });
     sm.appendMessage(makeAssistant("done", 4));
 
-    // Get a pre-compaction message ID to attach label to
+    // Capture a pre-compaction message that will be summarized away.
     const branch = sm.getBranch();
     const preCompactionMsgId = branch[1].id; // "hi" message
 
@@ -253,33 +253,25 @@ describe("truncateSessionAfterCompaction", () => {
 
     // Post-compaction messages
     sm.appendMessage({ role: "user", content: "next", timestamp: 5 });
+    sm.appendLabelChange(preCompactionMsgId, "my-label");
 
     const sessionFile = sm.getSessionFile()!;
+    const labelEntry = sm.getEntries().find((entry) => entry.type === "label");
+    expect(labelEntry?.parentId).not.toBe(preCompactionMsgId);
 
-    // Inject a label entry referencing a pre-compaction message into the
-    // raw JSONL before the compaction line (SessionManager has no appendLabel).
-    const lines = (await fs.readFile(sessionFile, "utf-8")).trimEnd().split("\n");
-    const compactionLineIdx = lines.findIndex((l) => l.includes('"compaction"'));
-    const labelLine = JSON.stringify({
-      type: "label",
-      id: "label-001",
-      parentId: preCompactionMsgId,
-      timestamp: 2500,
-      targetId: preCompactionMsgId,
-      label: "my-label",
-    });
-    lines.splice(compactionLineIdx, 0, labelLine);
-    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf-8");
+    const smBefore = SessionManager.open(sessionFile);
+    expect(smBefore.getLabel(preCompactionMsgId)).toBe("my-label");
 
     const result = await truncateSessionAfterCompaction({ sessionFile });
 
     expect(result.truncated).toBe(true);
 
-    // Verify label entry was dropped (its parent message was removed)
+    // Verify label metadata was dropped with the removed target message.
     const smAfter = SessionManager.open(sessionFile);
     const allAfter = smAfter.getEntries();
     const labels = allAfter.filter((e) => e.type === "label");
     expect(labels).toHaveLength(0);
+    expect(smAfter.getLabel(preCompactionMsgId)).toBeUndefined();
   });
 
   it("preserves the firstKeptEntryId unsummarized tail", async () => {

--- a/src/agents/pi-embedded-runner/session-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.test.ts
@@ -168,7 +168,9 @@ describe("truncateSessionAfterCompaction", () => {
     const latestCompIdx = branchAfter.findIndex(
       (e) => e.type === "compaction" && e === compactionEntries[compactionEntries.length - 1],
     );
-    const messagesBeforeLatest = branchAfter.slice(0, latestCompIdx).filter((e) => e.type === "message");
+    const messagesBeforeLatest = branchAfter
+      .slice(0, latestCompIdx)
+      .filter((e) => e.type === "message");
     expect(messagesBeforeLatest).toHaveLength(0);
   });
 

--- a/src/agents/pi-embedded-runner/session-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.test.ts
@@ -229,6 +229,55 @@ describe("truncateSessionAfterCompaction", () => {
     expect(ctx.thinkingLevel).toBe("high");
   });
 
+  it("drops label and branch_summary entries that reference removed messages", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+
+    // Messages before compaction
+    sm.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+    sm.appendMessage(makeAssistant("hi", 2));
+    sm.appendMessage({ role: "user", content: "do task", timestamp: 3 });
+    sm.appendMessage(makeAssistant("done", 4));
+
+    // Get a pre-compaction message ID to attach label to
+    const branch = sm.getBranch();
+    const preCompactionMsgId = branch[1].id; // "hi" message
+
+    // Compaction summarizing the conversation
+    const firstKeptId = branch[branch.length - 1].id;
+    sm.appendCompaction("Summary.", firstKeptId, 5000);
+
+    // Post-compaction messages
+    sm.appendMessage({ role: "user", content: "next", timestamp: 5 });
+
+    const sessionFile = sm.getSessionFile()!;
+
+    // Inject a label entry referencing a pre-compaction message into the
+    // raw JSONL before the compaction line (SessionManager has no appendLabel).
+    const lines = (await fs.readFile(sessionFile, "utf-8")).trimEnd().split("\n");
+    const compactionLineIdx = lines.findIndex((l) => l.includes('"compaction"'));
+    const labelLine = JSON.stringify({
+      type: "label",
+      id: "label-001",
+      parentId: preCompactionMsgId,
+      timestamp: 2500,
+      targetId: preCompactionMsgId,
+      label: "my-label",
+    });
+    lines.splice(compactionLineIdx, 0, labelLine);
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf-8");
+
+    const result = await truncateSessionAfterCompaction({ sessionFile });
+
+    expect(result.truncated).toBe(true);
+
+    // Verify label entry was dropped (its parent message was removed)
+    const smAfter = SessionManager.open(sessionFile);
+    const allAfter = smAfter.getEntries();
+    const labels = allAfter.filter((e) => e.type === "label");
+    expect(labels).toHaveLength(0);
+  });
+
   it("preserves unsummarized sibling branches during truncation", async () => {
     const dir = await createTmpDir();
     const sm = SessionManager.create(dir, dir);

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { SessionEntry } from "@mariozechner/pi-coding-agent";
+import type { CompactionEntry, SessionEntry } from "@mariozechner/pi-coding-agent";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { log } from "./logger.js";
 
@@ -20,12 +20,15 @@ import { log } from "./logger.js";
  *    Note: label and branch_summary entries referencing removed messages are
  *    also dropped to avoid dangling metadata.
  * 3. All entries from sibling branches not covered by the compaction
- * 4. The compaction entry and all entries after it in the current branch
+ * 4. The unsummarized tail: entries from `firstKeptEntryId` through (and
+ *    including) the compaction entry, plus all entries after it
  *
- * Only `message` entries in the current branch that precede the latest
- * compaction are removed — they are the entries the compaction summarized.
- * Entries whose parent was removed are re-parented to the nearest kept
- * ancestor (or become roots).
+ * Only `message` entries in the current branch that precede the compaction's
+ * `firstKeptEntryId` are removed — they are the entries the compaction
+ * actually summarized. Entries from `firstKeptEntryId` onward are preserved
+ * because `buildSessionContext()` expects them when reconstructing the
+ * session. Entries whose parent was removed are re-parented to the nearest
+ * kept ancestor (or become roots).
  */
 export async function truncateSessionAfterCompaction(params: {
   sessionFile: string;
@@ -71,10 +74,21 @@ export async function truncateSessionAfterCompaction(params: {
     return { truncated: false, entriesRemoved: 0, reason: "compaction already at root" };
   }
 
-  // Collect IDs of entries in the current branch that precede the compaction.
-  // These are the candidates for removal (only message-type ones will be removed).
+  // The compaction's firstKeptEntryId marks the start of the "unsummarized
+  // tail" — entries from firstKeptEntryId through the compaction that
+  // buildSessionContext() expects to find when reconstructing the session.
+  // Only entries *before* firstKeptEntryId were actually summarized.
+  const compactionEntry = branch[latestCompactionIdx] as CompactionEntry;
+  const { firstKeptEntryId } = compactionEntry;
+
+  // Collect IDs of entries in the current branch that were actually summarized
+  // (everything before firstKeptEntryId). Entries from firstKeptEntryId through
+  // the compaction are the unsummarized tail and must be preserved.
   const summarizedBranchIds = new Set<string>();
   for (let i = 0; i < latestCompactionIdx; i++) {
+    if (firstKeptEntryId && branch[i].id === firstKeptEntryId) {
+      break; // Everything from here to the compaction is the unsummarized tail
+    }
     summarizedBranchIds.add(branch[i].id);
   }
 

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -149,10 +149,7 @@ export async function truncateSessionAfterCompaction(params: {
   }
 
   // Write truncated file atomically (temp + rename)
-  const lines: string[] = [
-    JSON.stringify(header),
-    ...keptEntries.map((e) => JSON.stringify(e)),
-  ];
+  const lines: string[] = [JSON.stringify(header), ...keptEntries.map((e) => JSON.stringify(e))];
   const content = lines.join("\n") + "\n";
 
   const tmpFile = `${sessionFile}.truncate-tmp`;

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -16,7 +16,9 @@ import { log } from "./logger.js";
  * This function rewrites the file keeping:
  * 1. The session header
  * 2. All non-message session state (custom, model_change, thinking_level_change,
- *    session_info, label, branch_summary, custom_message, compaction entries)
+ *    session_info, custom_message, compaction entries)
+ *    Note: label and branch_summary entries referencing removed messages are
+ *    also dropped to avoid dangling metadata.
  * 3. All entries from sibling branches not covered by the compaction
  * 4. The compaction entry and all entries after it in the current branch
  *
@@ -81,12 +83,27 @@ export async function truncateSessionAfterCompaction(params: {
   const allEntries = sm.getEntries();
 
   // Only remove message-type entries that the compaction actually summarized.
-  // Non-message entries (custom, model_change, thinking_level_change,
-  // session_info, label, branch_summary, custom_message) are preserved even
-  // if they sit in the summarized portion of the branch.
+  // Non-message session state (custom, model_change, thinking_level_change,
+  // session_info, custom_message) is preserved even if it sits in the
+  // summarized portion of the branch.
+  //
+  // label and branch_summary entries that reference removed message IDs are
+  // also dropped to avoid dangling metadata (consistent with the approach in
+  // tool-result-truncation.ts).
   const removedIds = new Set<string>();
   for (const entry of allEntries) {
     if (summarizedBranchIds.has(entry.id) && entry.type === "message") {
+      removedIds.add(entry.id);
+    }
+  }
+
+  // Drop label/branch_summary entries whose parent points to a removed message
+  for (const entry of allEntries) {
+    if (
+      (entry.type === "label" || entry.type === "branch_summary") &&
+      entry.parentId !== null &&
+      removedIds.has(entry.parentId)
+    ) {
       removedIds.add(entry.id);
     }
   }

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { CompactionEntry, SessionEntry } from "@mariozechner/pi-coding-agent";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { log } from "./logger.js";
+
+/**
+ * Truncate a session JSONL file after compaction by removing entries
+ * that are no longer reachable from the current branch.
+ *
+ * After compaction, the session file still contains all historical entries
+ * even though `buildSessionContext()` logically skips entries before
+ * `firstKeptEntryId`. Over many compaction cycles this causes unbounded
+ * file growth (issue #39953).
+ *
+ * This function rewrites the file to keep only:
+ * 1. The session header
+ * 2. The latest compaction entry (re-parented as root)
+ * 3. All entries after the compaction in the current branch
+ */
+export async function truncateSessionAfterCompaction(params: {
+  sessionFile: string;
+  /** Optional path to archive the pre-truncation file. */
+  archivePath?: string;
+}): Promise<TruncationResult> {
+  const { sessionFile } = params;
+
+  let sm: SessionManager;
+  try {
+    sm = SessionManager.open(sessionFile);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log.warn(`[session-truncation] Failed to open session file: ${reason}`);
+    return { truncated: false, entriesRemoved: 0, reason };
+  }
+
+  const header = sm.getHeader();
+  if (!header) {
+    return { truncated: false, entriesRemoved: 0, reason: "missing session header" };
+  }
+
+  const branch = sm.getBranch();
+  if (branch.length === 0) {
+    return { truncated: false, entriesRemoved: 0, reason: "empty session" };
+  }
+
+  // Find the latest compaction entry in the current branch
+  let latestCompactionIdx = -1;
+  for (let i = branch.length - 1; i >= 0; i--) {
+    if (branch[i].type === "compaction") {
+      latestCompactionIdx = i;
+      break;
+    }
+  }
+
+  if (latestCompactionIdx < 0) {
+    return { truncated: false, entriesRemoved: 0, reason: "no compaction entry found" };
+  }
+
+  // Nothing to truncate if compaction is already at root
+  if (latestCompactionIdx === 0) {
+    return { truncated: false, entriesRemoved: 0, reason: "compaction already at root" };
+  }
+
+  const entriesRemoved = latestCompactionIdx;
+  const totalEntriesBefore = sm.getEntries().length;
+
+  // Build the truncated entry list:
+  // compaction entry (re-parented as root) + all entries after it
+  const truncatedEntries: SessionEntry[] = [];
+
+  const compactionEntry = branch[latestCompactionIdx] as CompactionEntry;
+  truncatedEntries.push({ ...compactionEntry, parentId: null });
+
+  for (let i = latestCompactionIdx + 1; i < branch.length; i++) {
+    truncatedEntries.push(branch[i]);
+  }
+
+  // Get file size before truncation
+  let bytesBefore = 0;
+  try {
+    const stat = await fs.stat(sessionFile);
+    bytesBefore = stat.size;
+  } catch {
+    // If stat fails, continue anyway
+  }
+
+  // Archive original file if requested
+  if (params.archivePath) {
+    try {
+      const archiveDir = path.dirname(params.archivePath);
+      await fs.mkdir(archiveDir, { recursive: true });
+      await fs.copyFile(sessionFile, params.archivePath);
+      log.info(`[session-truncation] Archived pre-truncation file to ${params.archivePath}`);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      log.warn(`[session-truncation] Failed to archive: ${reason}`);
+    }
+  }
+
+  // Write truncated file atomically (temp + rename)
+  const lines: string[] = [
+    JSON.stringify(header),
+    ...truncatedEntries.map((e) => JSON.stringify(e)),
+  ];
+  const content = lines.join("\n") + "\n";
+
+  const tmpFile = `${sessionFile}.truncate-tmp`;
+  try {
+    await fs.writeFile(tmpFile, content, "utf-8");
+    await fs.rename(tmpFile, sessionFile);
+  } catch (err) {
+    // Clean up temp file on failure
+    try {
+      await fs.unlink(tmpFile);
+    } catch {
+      // Ignore cleanup errors
+    }
+    const reason = err instanceof Error ? err.message : String(err);
+    log.warn(`[session-truncation] Failed to write truncated file: ${reason}`);
+    return { truncated: false, entriesRemoved: 0, reason };
+  }
+
+  const bytesAfter = Buffer.byteLength(content, "utf-8");
+
+  log.info(
+    `[session-truncation] Truncated session file: ` +
+      `entriesBefore=${totalEntriesBefore} entriesAfter=${truncatedEntries.length} ` +
+      `removed=${entriesRemoved} bytesBefore=${bytesBefore} bytesAfter=${bytesAfter} ` +
+      `reduction=${bytesBefore > 0 ? ((1 - bytesAfter / bytesBefore) * 100).toFixed(1) : "?"}%`,
+  );
+
+  return { truncated: true, entriesRemoved, bytesBefore, bytesAfter };
+}
+
+export type TruncationResult = {
+  truncated: boolean;
+  entriesRemoved: number;
+  bytesBefore?: number;
+  bytesAfter?: number;
+  reason?: string;
+};

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -1,22 +1,29 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { CompactionEntry, SessionEntry } from "@mariozechner/pi-coding-agent";
+import type { SessionEntry } from "@mariozechner/pi-coding-agent";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { log } from "./logger.js";
 
 /**
- * Truncate a session JSONL file after compaction by removing entries
- * that are no longer reachable from the current branch.
+ * Truncate a session JSONL file after compaction by removing only the
+ * message entries that the compaction actually summarized.
  *
  * After compaction, the session file still contains all historical entries
  * even though `buildSessionContext()` logically skips entries before
  * `firstKeptEntryId`. Over many compaction cycles this causes unbounded
  * file growth (issue #39953).
  *
- * This function rewrites the file to keep only:
+ * This function rewrites the file keeping:
  * 1. The session header
- * 2. The latest compaction entry (re-parented as root)
- * 3. All entries after the compaction in the current branch
+ * 2. All non-message session state (custom, model_change, thinking_level_change,
+ *    session_info, label, branch_summary, custom_message, compaction entries)
+ * 3. All entries from sibling branches not covered by the compaction
+ * 4. The compaction entry and all entries after it in the current branch
+ *
+ * Only `message` entries in the current branch that precede the latest
+ * compaction are removed — they are the entries the compaction summarized.
+ * Entries whose parent was removed are re-parented to the nearest kept
+ * ancestor (or become roots).
  */
 export async function truncateSessionAfterCompaction(params: {
   sessionFile: string;
@@ -62,19 +69,62 @@ export async function truncateSessionAfterCompaction(params: {
     return { truncated: false, entriesRemoved: 0, reason: "compaction already at root" };
   }
 
-  const entriesRemoved = latestCompactionIdx;
-  const totalEntriesBefore = sm.getEntries().length;
-
-  // Build the truncated entry list:
-  // compaction entry (re-parented as root) + all entries after it
-  const truncatedEntries: SessionEntry[] = [];
-
-  const compactionEntry = branch[latestCompactionIdx] as CompactionEntry;
-  truncatedEntries.push({ ...compactionEntry, parentId: null });
-
-  for (let i = latestCompactionIdx + 1; i < branch.length; i++) {
-    truncatedEntries.push(branch[i]);
+  // Collect IDs of entries in the current branch that precede the compaction.
+  // These are the candidates for removal (only message-type ones will be removed).
+  const summarizedBranchIds = new Set<string>();
+  for (let i = 0; i < latestCompactionIdx; i++) {
+    summarizedBranchIds.add(branch[i].id);
   }
+
+  // Operate on the full transcript so sibling branches and tree metadata
+  // are not silently dropped.
+  const allEntries = sm.getEntries();
+
+  // Only remove message-type entries that the compaction actually summarized.
+  // Non-message entries (custom, model_change, thinking_level_change,
+  // session_info, label, branch_summary, custom_message) are preserved even
+  // if they sit in the summarized portion of the branch.
+  const removedIds = new Set<string>();
+  for (const entry of allEntries) {
+    if (summarizedBranchIds.has(entry.id) && entry.type === "message") {
+      removedIds.add(entry.id);
+    }
+  }
+
+  if (removedIds.size === 0) {
+    return { truncated: false, entriesRemoved: 0, reason: "no entries to remove" };
+  }
+
+  // Build an id→entry map for walking parent chains during re-parenting.
+  const entryById = new Map<string, SessionEntry>();
+  for (const entry of allEntries) {
+    entryById.set(entry.id, entry);
+  }
+
+  // Keep every entry that was not removed, re-parenting where necessary so
+  // the tree stays connected.
+  const keptEntries: SessionEntry[] = [];
+  for (const entry of allEntries) {
+    if (removedIds.has(entry.id)) {
+      continue;
+    }
+
+    // Walk up the parent chain to find the nearest kept ancestor.
+    let newParentId = entry.parentId;
+    while (newParentId !== null && removedIds.has(newParentId)) {
+      const parent = entryById.get(newParentId);
+      newParentId = parent?.parentId ?? null;
+    }
+
+    if (newParentId !== entry.parentId) {
+      keptEntries.push({ ...entry, parentId: newParentId });
+    } else {
+      keptEntries.push(entry);
+    }
+  }
+
+  const entriesRemoved = removedIds.size;
+  const totalEntriesBefore = allEntries.length;
 
   // Get file size before truncation
   let bytesBefore = 0;
@@ -101,7 +151,7 @@ export async function truncateSessionAfterCompaction(params: {
   // Write truncated file atomically (temp + rename)
   const lines: string[] = [
     JSON.stringify(header),
-    ...truncatedEntries.map((e) => JSON.stringify(e)),
+    ...keptEntries.map((e) => JSON.stringify(e)),
   ];
   const content = lines.join("\n") + "\n";
 
@@ -125,7 +175,7 @@ export async function truncateSessionAfterCompaction(params: {
 
   log.info(
     `[session-truncation] Truncated session file: ` +
-      `entriesBefore=${totalEntriesBefore} entriesAfter=${truncatedEntries.length} ` +
+      `entriesBefore=${totalEntriesBefore} entriesAfter=${keptEntries.length} ` +
       `removed=${entriesRemoved} bytesBefore=${bytesBefore} bytesAfter=${bytesAfter} ` +
       `reduction=${bytesBefore > 0 ? ((1 - bytesAfter / bytesBefore) * 100).toFixed(1) : "?"}%`,
   );

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -111,10 +111,16 @@ export async function truncateSessionAfterCompaction(params: {
     }
   }
 
-  // Drop label/branch_summary entries whose parent points to a removed message
+  // Labels bookmark targetId while parentId just records the leaf when the
+  // label was changed, so targetId determines whether the label is still valid.
+  // Branch summaries still hang off the summarized branch via parentId.
   for (const entry of allEntries) {
+    if (entry.type === "label" && removedIds.has(entry.targetId)) {
+      removedIds.add(entry.id);
+      continue;
+    }
     if (
-      (entry.type === "label" || entry.type === "branch_summary") &&
+      entry.type === "branch_summary" &&
       entry.parentId !== null &&
       removedIds.has(entry.parentId)
     ) {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -390,6 +390,7 @@ const TARGET_KEYS = [
   "agents.defaults.compaction.postCompactionSections",
   "agents.defaults.compaction.timeoutSeconds",
   "agents.defaults.compaction.model",
+  "agents.defaults.compaction.truncateAfterCompaction",
   "agents.defaults.compaction.memoryFlush",
   "agents.defaults.compaction.memoryFlush.enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1050,6 +1050,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Maximum time in seconds allowed for a single compaction operation before it is aborted (default: 900). Increase this for very large sessions that need more time to summarize, or decrease it to fail faster on unresponsive models.",
   "agents.defaults.compaction.model":
     "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
+  "agents.defaults.compaction.truncateAfterCompaction":
+    "When enabled, rewrites the session JSONL file after compaction to remove entries that were summarized. Prevents unbounded file growth in long-running sessions with many compaction cycles. Default: false.",
   "agents.defaults.compaction.memoryFlush":
     "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
   "agents.defaults.compaction.memoryFlush.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -467,6 +467,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.postCompactionSections": "Post-Compaction Context Sections",
   "agents.defaults.compaction.timeoutSeconds": "Compaction Timeout (Seconds)",
   "agents.defaults.compaction.model": "Compaction Model Override",
+  "agents.defaults.compaction.truncateAfterCompaction": "Truncate After Compaction",
   "agents.defaults.compaction.memoryFlush": "Compaction Memory Flush",
   "agents.defaults.compaction.memoryFlush.enabled": "Compaction Memory Flush Enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -342,6 +342,12 @@ export type AgentCompactionConfig = {
   model?: string;
   /** Maximum time in seconds for a single compaction operation (default: 900). */
   timeoutSeconds?: number;
+  /**
+   * Truncate the session JSONL file after compaction to remove entries that
+   * were summarized. Prevents unbounded file growth in long-running sessions.
+   * Default: false (existing behavior preserved).
+   */
+  truncateAfterCompaction?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/plugins/loader.git-path-regression.test.ts
+++ b/src/plugins/loader.git-path-regression.test.ts
@@ -1,18 +1,8 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { __testing } from "./loader.js";
-
-type CreateJiti = typeof import("jiti").createJiti;
-
-let createJitiPromise: Promise<CreateJiti> | undefined;
-
-async function getCreateJiti() {
-  createJitiPromise ??= import("jiti").then(({ createJiti }) => createJiti);
-  return createJitiPromise;
-}
 
 const tempRoots: string[] = [];
 
@@ -39,7 +29,6 @@ describe("plugin loader git path regression", () => {
     const copiedPluginSdkDir = path.join(copiedExtensionRoot, "plugin-sdk");
     mkdirSafe(copiedSourceDir);
     mkdirSafe(copiedPluginSdkDir);
-
     const jitiBaseFile = path.join(copiedSourceDir, "__jiti-base__.mjs");
     fs.writeFileSync(jitiBaseFile, "export {};\n", "utf-8");
     fs.writeFileSync(
@@ -69,29 +58,46 @@ export const copiedRuntimeMarker = {
 `,
       "utf-8",
     );
-
     const copiedChannelRuntime = path.join(copiedExtensionRoot, "src", "channel.runtime.ts");
-    const jitiBaseUrl = pathToFileURL(jitiBaseFile).href;
-    const createJiti = await getCreateJiti();
-    const withoutAlias = createJiti(jitiBaseUrl, {
-      ...__testing.buildPluginLoaderJitiOptions({}),
-      tryNative: false,
+    const script = `
+      import { createJiti } from "jiti";
+      const withoutAlias = createJiti(${JSON.stringify(jitiBaseFile)}, {
+        interopDefault: true,
+        tryNative: false,
+        extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+      });
+      let withoutAliasThrew = false;
+      try {
+        withoutAlias(${JSON.stringify(copiedChannelRuntime)});
+      } catch {
+        withoutAliasThrew = true;
+      }
+      const withAlias = createJiti(${JSON.stringify(jitiBaseFile)}, {
+        interopDefault: true,
+        tryNative: false,
+        extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+        alias: {
+          "openclaw/plugin-sdk/channel-runtime": ${JSON.stringify(copiedChannelRuntimeShim)},
+        },
+      });
+      const mod = withAlias(${JSON.stringify(copiedChannelRuntime)});
+      console.log(JSON.stringify({
+        withoutAliasThrew,
+        marker: mod.copiedRuntimeMarker?.PAIRING_APPROVED_MESSAGE,
+        dep: mod.copiedRuntimeMarker?.resolveOutboundSendDep?.(),
+      }));
+    `;
+    const raw = execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+      cwd: process.cwd(),
+      encoding: "utf-8",
     });
-    // The production loader uses sync Jiti evaluation, so this regression test
-    // should exercise the same seam instead of Jiti's async import helper.
-    expect(() => withoutAlias(copiedChannelRuntime)).toThrow();
-
-    const withAlias = createJiti(jitiBaseUrl, {
-      ...__testing.buildPluginLoaderJitiOptions({
-        "openclaw/plugin-sdk/channel-runtime": copiedChannelRuntimeShim,
-      }),
-      tryNative: false,
-    });
-    expect(withAlias(copiedChannelRuntime)).toMatchObject({
-      copiedRuntimeMarker: {
-        PAIRING_APPROVED_MESSAGE: "paired",
-        resolveOutboundSendDep: expect.any(Function),
-      },
-    });
+    const result = JSON.parse(raw) as {
+      withoutAliasThrew: boolean;
+      marker?: string;
+      dep?: string;
+    };
+    expect(result.withoutAliasThrew).toBe(true);
+    expect(result.marker).toBe("paired");
+    expect(result.dep).toBe("shimmed");
   });
 });


### PR DESCRIPTION
## Summary

- Adds opt-in `truncateAfterCompaction` config option under `agents.defaults.compaction` that rewrites session JSONL files after compaction, removing entries that were summarized
- After compaction, the file is rewritten to keep only: session header + latest compaction entry (re-parented as root) + post-compaction messages
- Supports optional `archivePath` for pre-truncation backup
- Atomic write (temp file + rename) ensures no data loss on failure
- Default `false` — existing behavior is unchanged

## Motivation

Session JSONL files grow indefinitely because compaction appends summaries without removing the entries they summarize. After 10+ compaction cycles, files can reach 7+ MB with 3,800+ lines of stale entries, causing processing timeouts and stuck sessions (#39953).

## Files changed

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/session-truncation.ts` | New — truncation logic using `SessionManager` public API |
| `src/agents/pi-embedded-runner/session-truncation.test.ts` | New — 5 tests (basic truncation, no-op cases, idempotency, archive, multi-cycle) |
| `src/agents/pi-embedded-runner/compact.ts` | Integration — calls truncation after successful compaction when enabled |
| `src/config/types.agent-defaults.ts` | Adds `truncateAfterCompaction` to `AgentCompactionConfig` |
| `src/config/schema.labels.ts` | Label for new config key |
| `src/config/schema.help.ts` | Help text for new config key |
| `src/config/schema.help.quality.test.ts` | Registers new key in help coverage test |

## Test plan

- [x] 5 unit tests passing locally (truncation, no-op, idempotent, archive, multi-cycle)
- [x] Schema help quality tests pass (20 tests)
- [x] oxlint + oxfmt clean
- [ ] CI checks

Fixes #39953
