### PR TITLE
feat: raise CLI watchdog no-output timeout caps (3 min → 30 min)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- CLI/watchdog: increase resume and fresh watchdog timeout defaults (min 3→5 min, max 10→30 min, resume max 3→30 min) to reduce premature timeouts on slower or heavily-loaded agents. (#41022)
+
 ### Breaking
 
 ### Fixes

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -55,7 +55,7 @@ describe("resolveCliBackendConfig reliability merge", () => {
     // Ensure defaults are retained when only one field is overridden.
     expect(resolved?.config.reliability?.watchdog?.resume?.noOutputTimeoutRatio).toBe(0.3);
     expect(resolved?.config.reliability?.watchdog?.resume?.minMs).toBe(60_000);
-    expect(resolved?.config.reliability?.watchdog?.resume?.maxMs).toBe(180_000);
+    expect(resolved?.config.reliability?.watchdog?.resume?.maxMs).toBe(1_800_000);
     expect(resolved?.config.reliability?.watchdog?.fresh?.noOutputTimeoutRatio).toBe(0.8);
   });
 });

--- a/src/agents/cli-watchdog-defaults.ts
+++ b/src/agents/cli-watchdog-defaults.ts
@@ -2,12 +2,12 @@ export const CLI_WATCHDOG_MIN_TIMEOUT_MS = 1_000;
 
 export const CLI_FRESH_WATCHDOG_DEFAULTS = {
   noOutputTimeoutRatio: 0.8,
-  minMs: 180_000,
-  maxMs: 600_000,
+  minMs: 300_000,
+  maxMs: 1_800_000,
 } as const;
 
 export const CLI_RESUME_WATCHDOG_DEFAULTS = {
   noOutputTimeoutRatio: 0.3,
   minMs: 60_000,
-  maxMs: 180_000,
+  maxMs: 1_800_000,
 } as const;


### PR DESCRIPTION
## Problem

Fixes #40982

`CLI_RESUME_WATCHDOG_DEFAULTS.maxMs` was hardcoded to `180_000` ms (3 minutes), silently killing long-running agent requests mid-flight even when the session timeout was set much higher. `CLI_FRESH_WATCHDOG_DEFAULTS.minMs` was also 180 s, meaning the watchdog would almost always fire at ~3 min regardless of operator intent.

## Changes

| Constant | Before | After |
|---|---|---|
| `CLI_FRESH_WATCHDOG_DEFAULTS.minMs` | 180 s | 300 s |
| `CLI_FRESH_WATCHDOG_DEFAULTS.maxMs` | 600 s | 1800 s |
| `CLI_RESUME_WATCHDOG_DEFAULTS.maxMs` | 180 s | 1800 s |

`CLI_RESUME_WATCHDOG_DEFAULTS.minMs` is left at 60 s — resumed sessions have shorter expected idle windows and the existing minimum is appropriate.

## Why these values

- **30 min (1800 s)** as the new `maxMs` matches typical long-running code review, build, or generation tasks. It's a practical upper bound without being infinite.
- **5 min (300 s)** as the fresh `minMs` gives a more reasonable floor — tasks that genuinely stall for 5 minutes are likely stuck, those that need 10–15 minutes of uninterrupted work are not.

The issue also proposes a config knob (`maxMs: 0 | null` = no cap) as a follow-up; that's a separate change and not included here.