### PR TITLE
fix: allow spawnedBy/spawnDepth for ACP sessions in sessions.patch [AI-assisted]

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -6,6 +6,7 @@ import { applySessionsPatchToStore } from "./sessions-patch.js";
 const SUBAGENT_MODEL = "synthetic/hf:moonshotai/Kimi-K2.5";
 const KIMI_SUBAGENT_KEY = "agent:kimi:subagent:child";
 const MAIN_SESSION_KEY = "agent:main:main";
+const ACP_SESSION_KEY = "agent:main:acp:550e8400-e29b-41d4-a716-446655440000";
 const EMPTY_CFG = {} as OpenClawConfig;
 
 type ApplySessionsPatchArgs = Parameters<typeof applySessionsPatchToStore>[0];
@@ -257,6 +258,33 @@ describe("gateway sessions patch", () => {
       patch: { key: MAIN_SESSION_KEY, spawnDepth: 1 },
     });
     expectPatchError(result, "spawnDepth is only supported");
+  });
+
+  test("sets spawnedBy for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: ACP_SESSION_KEY,
+        patch: { key: ACP_SESSION_KEY, spawnedBy: "agent:main:main" },
+      }),
+    );
+    expect(entry.spawnedBy).toBe("agent:main:main");
+  });
+
+  test("sets spawnDepth for ACP sessions", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        storeKey: ACP_SESSION_KEY,
+        patch: { key: ACP_SESSION_KEY, spawnDepth: 1 },
+      }),
+    );
+    expect(entry.spawnDepth).toBe(1);
+  });
+
+  test("rejects spawnedBy on main sessions", async () => {
+    const result = await runPatch({
+      patch: { key: MAIN_SESSION_KEY, spawnedBy: "agent:main:main" },
+    });
+    expectPatchError(result, "spawnedBy is only supported");
   });
 
   test("normalizes exec/send/group patches", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -19,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
+  isAcpSessionKey,
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
@@ -97,8 +98,8 @@ export async function applySessionsPatchToStore(params: {
       if (!trimmed) {
         return invalid("invalid spawnedBy: empty");
       }
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnedBy is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnedBy is only supported for subagent:* or acp:* sessions");
       }
       if (existing?.spawnedBy && existing.spawnedBy !== trimmed) {
         return invalid("spawnedBy cannot be changed once set");
@@ -114,8 +115,8 @@ export async function applySessionsPatchToStore(params: {
         return invalid("spawnDepth cannot be cleared once set");
       }
     } else if (raw !== undefined) {
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnDepth is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnDepth is only supported for subagent:* or acp:* sessions");
       }
       const numeric = Number(raw);
       if (!Number.isInteger(numeric) || numeric < 0) {


### PR DESCRIPTION
## Summary

- **Problem:** `spawnAcpDirect()` (introduced in PR #40137, v2026.3.8) sets `spawnedBy` on ACP-spawned sessions (`agent:<id>:acp:<uuid>`), but `applySessionsPatchToStore()` only allows `spawnedBy` and `spawnDepth` for `subagent:*` session keys — rejecting ACP sessions with _"spawnedBy is only supported for subagent:* sessions"_.
- **Why it matters:** The `sessions_spawn(runtime:"acp")` tool path is completely broken. Any agent using the tool call (as opposed to the `/acp spawn` command) to spawn ACP sub-agents hits this validation wall.
- **What changed:** Added `isAcpSessionKey()` to the validation guards for both `spawnedBy` and `spawnDepth` in `sessions-patch.ts`, plus 3 test cases covering ACP accept and main-session reject.
- **What did NOT change (scope boundary):** No changes to session key parsing, ACP spawn logic, or the `/acp spawn` command path. The fix is strictly in the gateway validation layer.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #40137 (ACP spawned-session lineage — introduced `spawnedBy` in `spawnAcpDirect`)

## User-visible / Behavior Changes

- `sessions_spawn(runtime:"acp")` tool calls now succeed instead of returning an INVALID_REQUEST error.
- Agents can spawn ACP sub-agents via the tool path (not just the `/acp spawn` command).

## Security Impact (required)

- New permissions/capabilities? `No` — ACP sessions could already be spawned via `/acp spawn`; this just unblocks the equivalent tool path.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Hetzner VPS) / macOS
- Runtime/container: Docker (openclaw gateway v2026.3.8+)
- Integration/channel: Telegram DM (but channel-agnostic)

### Steps

1. Configure an agent with ACP enabled (`plugins.allow: ["acpx"]`)
2. Have the agent call `sessions_spawn(runtime:"acp")` (e.g., spawn a Codex sub-agent)
3. Observe the error: `spawnedBy is only supported for subagent:* sessions`

### Expected

- ACP session is created with `spawnedBy` lineage metadata

### Actual

- `INVALID_REQUEST: spawnedBy is only supported for subagent:* sessions`

## Evidence

- [x] Failing test/log before + passing after
  - Added 3 new test cases in `sessions-patch.test.ts`: ACP `spawnedBy` accept, ACP `spawnDepth` accept, main-session `spawnedBy` reject
  - All 23 tests pass

## Human Verification (required)

- Verified scenarios: Ran `vitest run src/gateway/sessions-patch.test.ts` — 23/23 pass
- Edge cases checked: Confirmed main sessions still reject `spawnedBy`/`spawnDepth`; subagent sessions still accept them
- What you did **not** verify: Live end-to-end ACP spawn on a running gateway (no staging env available)

## AI-Assisted PR

- [x] AI-assisted (Claude Code)
- [x] Fully tested — 3 new test cases, all 23 pass
- [x] I understand what the code does: the fix adds `isAcpSessionKey()` to two validation guards that previously only checked `isSubagentSessionKey()`, allowing ACP session keys to carry `spawnedBy`/`spawnDepth` lineage metadata

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/gateway/sessions-patch.ts`
- Known bad symptoms reviewers should watch for: If `isAcpSessionKey` somehow matches unexpected keys, non-ACP sessions could gain `spawnedBy` — but the function checks for `acp:` prefix specifically

## Risks and Mitigations

- Risk: `isAcpSessionKey` might accept malformed keys
  - Mitigation: Uses the same battle-tested parsing as `isSubagentSessionKey` from `session-key-utils.ts`; both check `parsed?.rest?.startsWith(...)` pattern
