### PR TITLE
Accept web fetch Firecrawl config in the runtime schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,25 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts web fetch firecrawl config overrides", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            readability: true,
+            firecrawl: {
+              apiKey: "fc-test",
+              baseUrl: "https://api.firecrawl.dev",
+              onlyMainContent: true,
+              maxAgeMs: 172800000,
+              timeoutSeconds: 60,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -327,6 +327,18 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
Fixes #27833

## Summary

The runtime/web-fetch implementation, docs, labels, and types already support `tools.web.fetch.firecrawl`, but the runtime config schema still rejected that block as an unrecognized key.

This patch restores the missing schema support so documented Firecrawl overrides validate cleanly. While touching the same schema block, it also restores the adjacent documented `readability` key so the schema matches the published config surface again.

## Changes

- add `tools.web.fetch.readability` to `ToolsWebFetchSchema`
- add `tools.web.fetch.firecrawl` with its documented override fields
- add a config regression test covering Firecrawl config overrides

## Verification

```bash
pnpm exec vitest run src/config/config.schema-regressions.test.ts
```
