### PR TITLE
fix(kimi-coding): exclude from thinking signature preservation to prevent turn-2 crashes

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -38,6 +38,10 @@ const OPENAI_MODEL_APIS = new Set([
   "openai-codex-responses",
 ]);
 
+// kimi-coding (Moonshot) cannot handle re-sent thinking signatures and crashes.
+// Exclude it from Anthropic signature preservation even though it uses anthropic-messages API.
+const ANTHROPIC_API_SIGNATURE_EXCLUDED_PROVIDERS = new Set(["kimi-coding"]);
+
 function isOpenAiApi(modelApi?: string | null): boolean {
   if (!modelApi) {
     return false;
@@ -83,7 +87,9 @@ export function resolveTranscriptPolicy(params: {
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
   // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({ provider, modelId });
+  const dropThinkingBlocks =
+    shouldDropThinkingBlocksForModel({ provider, modelId }) ||
+    ANTHROPIC_API_SIGNATURE_EXCLUDED_PROVIDERS.has(provider);
 
   const needsNonImageSanitize =
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;
@@ -112,7 +118,10 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: isAnthropic && preservesAnthropicThinkingSignatures(provider),
+    preserveSignatures:
+      isAnthropic &&
+      preservesAnthropicThinkingSignatures(provider) &&
+      !ANTHROPIC_API_SIGNATURE_EXCLUDED_PROVIDERS.has(provider),
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Summary

- **Problem**: kimi-coding/k2p5 sessions crash on turn 2+ with `Unexpected non-whitespace character after JSON`
- **Root Cause**: Thinking signatures from turn 1 are forwarded back to Moonshot API, which cannot handle them
- **Impact**: All kimi-coding users blocked; sessions fail immediately after turn 1
- **Fix**: Exclude kimi-coding from Anthropic signature preservation

## Root Cause Analysis

Commit `909f26a26` (v2026.3.7) changed `transcript-policy.ts`:
```diff
-  preserveSignatures: false,
+  preserveSignatures: isAnthropic,
```

Since kimi-coding sets `modelApi: "anthropic-messages"`, `isAnthropic` evaluates to `true`.
This causes thinking signatures to be preserved and forwarded back to Moonshot API on turn 2.

Moonshot's API cannot handle re-sent thinking signatures and returns malformed SSE,
crashing the session with:
```
Unexpected non-whitespace character after JSON at position 51
```

## Change Type

- [x] Bug fix (regression)

## Linked Issue

Fixes #41016

## Test

No existing tests for kimi-coding transcript policy. Manual testing required:
1. Configure agent with model `kimi-coding/k2p5`
2. Enable `thinking: low` or higher
3. Send message that triggers tool call on turn 1
4. Verify session advances past turn 1 without error

## Verification

```bash
# Check that kimi-coding is excluded from signature preservation
node -e "
const policy = require('./src/agents/transcript-policy.js');
const result = policy.resolveTranscriptPolicy({
  provider: 'kimi-coding',
  modelApi: 'anthropic-messages',
  modelId: 'k2p5'
});
console.log('preserveSignatures:', result.preserveSignatures);
console.log('Expected: false');
"
```

Expected output:
```
preserveSignatures: false
Expected: false
```

## Security Note

This fix only affects kimi-coding provider. All other Anthropic-family providers
(Claude, Bedrock) continue to preserve thinking signatures as intended.