### PR TITLE
fix(discord): preserve thread session binding

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -441,6 +441,38 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls[1]?.threadId).toBe("requester-thread");
   });
 
+  it("allows current-thread ACP spawns when the binding adapter advertises only current placement", async () => {
+    hoisted.sessionBindingCapabilitiesMock.mockReset().mockReturnValue({
+      adapterAvailable: true,
+      bindSupported: true,
+      unbindSupported: true,
+      placements: ["current"],
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Continue the investigation",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:requester-thread",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "current",
+      }),
+    );
+  });
+
   it("does not inline delivery for fresh oneshot ACP runs", async () => {
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -317,7 +317,7 @@ describe("spawnAcpDirect", () => {
       });
   });
 
-  it("spawns ACP session, binds a new thread, and dispatches initial task", async () => {
+  it("spawns ACP session from a parent channel, binds a new thread, and dispatches initial task", async () => {
     const result = await spawnAcpDirect(
       {
         task: "Investigate flaky tests",
@@ -330,7 +330,6 @@ describe("spawnAcpDirect", () => {
         agentChannel: "discord",
         agentAccountId: "default",
         agentTo: "channel:parent-channel",
-        agentThreadId: "requester-thread",
       },
     );
 
@@ -373,6 +372,73 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls).toHaveLength(2);
     expect(transcriptCalls[0]?.threadId).toBeUndefined();
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
+  });
+
+  it("reuses the current Discord thread when spawning from an existing thread", async () => {
+    hoisted.sessionBindingBindMock
+      .mockReset()
+      .mockImplementation(
+        async (input: {
+          placement?: string;
+          targetSessionKey: string;
+          conversation: { accountId: string; conversationId: string };
+          metadata?: Record<string, unknown>;
+        }) =>
+          createSessionBinding({
+            targetSessionKey: input.targetSessionKey,
+            conversation: {
+              channel: "discord",
+              accountId: input.conversation.accountId,
+              conversationId:
+                input.placement === "current" ? input.conversation.conversationId : "child-thread",
+              parentConversationId: "parent-channel",
+            },
+            metadata: {
+              boundBy:
+                typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+              agentId: "codex",
+              webhookId: "wh-1",
+            },
+          }),
+      );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Continue the investigation",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:requester-thread",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "current",
+        conversation: expect.objectContaining({
+          conversationId: "requester-thread",
+        }),
+      }),
+    );
+
+    const agentCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "agent");
+    expect(agentCall?.params?.to).toBe("channel:requester-thread");
+    expect(agentCall?.params?.threadId).toBe("requester-thread");
+
+    const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
+      (call: unknown[]) => call[0] as { threadId?: string },
+    );
+    expect(transcriptCalls).toHaveLength(2);
+    expect(transcriptCalls[1]?.threadId).toBe("requester-thread");
   });
 
   it("does not inline delivery for fresh oneshot ACP runs", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -277,7 +277,7 @@ function prepareAcpThreadBinding(params: {
       error: `Thread bindings are unavailable for ${policy.channel}.`,
     };
   }
-  if (!capabilities.bindSupported || !capabilities.placements.includes("child")) {
+  if (!capabilities.bindSupported) {
     return {
       ok: false,
       error: `Thread bindings do not support ACP thread spawn for ${policy.channel}.`,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -30,6 +30,7 @@ import { resolveConversationIdFromTargets } from "../infra/outbound/conversation
 import {
   getSessionBindingService,
   isSessionBindingError,
+  type SessionBindingPlacement,
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -112,6 +113,7 @@ type PreparedAcpThreadBinding = {
   channel: string;
   accountId: string;
   conversationId: string;
+  placement: SessionBindingPlacement;
 };
 
 function resolveSpawnMode(params: {
@@ -291,6 +293,14 @@ function prepareAcpThreadBinding(params: {
       error: `Could not resolve a ${policy.channel} conversation for ACP thread spawn.`,
     };
   }
+  const placement: SessionBindingPlacement =
+    policy.channel === "discord" && params.threadId != null ? "current" : "child";
+  if (!capabilities.placements.includes(placement)) {
+    return {
+      ok: false,
+      error: `Thread bindings do not support ACP thread spawn for ${policy.channel}.`,
+    };
+  }
 
   return {
     ok: true,
@@ -298,6 +308,7 @@ function prepareAcpThreadBinding(params: {
       channel: policy.channel,
       accountId: policy.accountId,
       conversationId,
+      placement,
     },
   };
 }
@@ -443,7 +454,7 @@ export async function spawnAcpDirect(
           accountId: preparedBinding.accountId,
           conversationId: preparedBinding.conversationId,
         },
-        placement: "child",
+        placement: preparedBinding.placement,
         metadata: {
           threadName: resolveThreadBindingThreadName({
             agentId: targetAgentId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord ACP `sessions_spawn(thread=true)` regressed when invoked from an existing thread because the spawn path always requested a child binding.
- Why it matters: follow-up messages stayed in the original thread while the ACP session was bound to a different thread, so thread continuity broke and replies looked unbound.
- What changed: I added a focused regression test for ACP spawns from an existing Discord thread and changed only the ACP spawn binding path to reuse the current thread in that case.
- What did NOT change (scope boundary): I did not refactor unrelated Discord mention gating, auto-thread creation, native command routing, or outbound send behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38272
- Related #40895

## User-visible / Behavior Changes

- Discord thread replies keep the expected session binding again when `sessions_spawn(runtime="acp", thread=true)` is invoked from an existing Discord thread.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node.js + pnpm workspace test run
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): `channels.discord.threadBindings.enabled=true`, `channels.discord.threadBindings.spawnAcpSessions=true`

### Steps

1. Create a Discord thread and enter that thread context.
2. Invoke `sessions_spawn` with `runtime: "acp"`, `mode: "session"`, and `thread: true`.
3. Send follow-up messages in the same Discord thread.

### Expected

- The ACP session stays bound to the current Discord thread, and follow-up messages continue that bound session.

### Actual

- Before this patch the ACP spawn path requested a child binding, so the session bound to a different thread and follow-up messages in the original thread did not route to the intended session.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the regression in `src/agents/acp-spawn.test.ts` with a failing test, then confirmed the same test passes after the fix; re-ran Discord monitor regression tests to confirm existing binding lifecycle/context behavior still passes.
- Edge cases checked: ACP spawn from a parent channel still creates a child thread; ACP spawn from an existing Discord thread now reuses that thread.
- What you did **not** verify: no live Discord manual run against a real bot account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit and restart the Discord-connected gateway.
- Files/config to restore: `src/agents/acp-spawn.ts`
- Known bad symptoms reviewers should watch for: thread replies bind to the wrong session, or thread continuity breaks after the patch.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: parent-channel ACP thread spawns could accidentally stop creating child threads.
- Mitigation: kept the existing parent-channel regression coverage and narrowed the new logic to Discord requests that already carry a thread id.
