### PR TITLE
Recognize Gemini/Grok/Kimi web search keys in security audit

### DIFF
--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectAttackSurfaceSummaryFindings } from "./audit-extra.sync.js";
+import {
+  collectAttackSurfaceSummaryFindings,
+  collectSmallModelRiskFindings,
+} from "./audit-extra.sync.js";
 import { safeEqualSecret } from "./secret-equal.js";
 
 describe("collectAttackSurfaceSummaryFindings", () => {
@@ -31,6 +34,34 @@ describe("collectAttackSurfaceSummaryFindings", () => {
     const [finding] = collectAttackSurfaceSummaryFindings(cfg);
     expect(finding.detail).toContain("hooks.webhooks: disabled");
     expect(finding.detail).toContain("hooks.internal: disabled");
+  });
+});
+
+describe("collectSmallModelRiskFindings", () => {
+  it("treats gemini search credentials as enabling web_search exposure", () => {
+    const findings = collectSmallModelRiskFindings({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "qwen2.5-7b-instruct",
+          },
+        },
+        tools: {
+          web: {
+            search: {
+              gemini: {
+                apiKey: "gemini-key",
+              },
+            },
+          },
+        },
+      } satisfies OpenClawConfig,
+      env: {},
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.detail).toContain("web_search");
+    expect(findings[0]?.detail).not.toContain("web=[off]");
   });
 });
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,13 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY,
   );
 }
 


### PR DESCRIPTION
Fixes #34509

## Summary

This updates the synchronous security audit so Gemini, Grok, and Kimi web search credentials count as configured web search providers alongside the existing Brave and Perplexity checks.

## What changed

- extend `hasWebSearchKey(...)` to recognize:
  - `tools.web.search.gemini.apiKey`
  - `tools.web.search.grok.apiKey`
  - `tools.web.search.kimi.apiKey`
- add a regression test covering a Gemini-only web search config

## Why

Without this, security audit findings that depend on `isWebSearchEnabled(...)` can report false negatives for Gemini/Grok/Kimi-only configs.

## Verification

```bash
pnpm exec vitest run src/security/audit-extra.sync.test.ts
```
