### PR TITLE
Fix LINE doctor warnings for file-backed credentials

### DIFF
--- a/extensions/line/src/channel.startup.test.ts
+++ b/extensions/line/src/channel.startup.test.ts
@@ -129,3 +129,54 @@ describe("linePlugin gateway.startAccount", () => {
     await task;
   });
 });
+
+describe("linePlugin status", () => {
+  it("does not report missing token or secret when snapshot came from file-backed config", async () => {
+    const snapshot = await linePlugin.status?.buildAccountSnapshot?.({
+      account: {
+        accountId: "default",
+        name: "Default",
+        enabled: true,
+        channelAccessToken: "token-from-file",
+        channelSecret: "secret-from-file",
+        tokenSource: "file",
+        config: {} as ResolvedLineAccount["config"],
+      } as never,
+      cfg: {} as OpenClawConfig,
+      runtime: undefined,
+      probe: undefined,
+      audit: undefined,
+    });
+
+    expect(snapshot?.configured).toBe(true);
+    expect(linePlugin.status?.collectStatusIssues?.([snapshot as never])).toEqual([]);
+  });
+
+  it("keeps per-field warnings when only one credential is missing", async () => {
+    const snapshot = await linePlugin.status?.buildAccountSnapshot?.({
+      account: {
+        accountId: "default",
+        name: "Default",
+        enabled: true,
+        channelAccessToken: "   ",
+        channelSecret: "secret-from-file",
+        tokenSource: "file",
+        config: {} as ResolvedLineAccount["config"],
+      } as never,
+      cfg: {} as OpenClawConfig,
+      runtime: undefined,
+      probe: undefined,
+      audit: undefined,
+    });
+
+    expect(snapshot?.configured).toBe(false);
+    expect(linePlugin.status?.collectStatusIssues?.([snapshot as never])).toEqual([
+      {
+        channel: "line",
+        accountId: "default",
+        kind: "config",
+        message: "LINE channel access token not configured",
+      },
+    ]);
+  });
+});

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -569,7 +569,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       const issues: ChannelStatusIssue[] = [];
       for (const account of accounts) {
         const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
-        if (!account.channelAccessToken?.trim()) {
+        if (account.channelAccessTokenConfigured === false) {
           issues.push({
             channel: "line",
             accountId,
@@ -577,7 +577,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             message: "LINE channel access token not configured",
           });
         }
-        if (!account.channelSecret?.trim()) {
+        if (account.channelSecretConfigured === false) {
           issues.push({
             channel: "line",
             accountId,
@@ -605,6 +605,8 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       });
       return {
         ...base,
+        channelAccessTokenConfigured: Boolean(account.channelAccessToken?.trim()),
+        channelSecretConfigured: Boolean(account.channelSecret?.trim()),
         tokenSource: account.tokenSource,
         mode: "webhook",
       };


### PR DESCRIPTION
Fixes #10428

## Summary

This fixes a false-positive LINE doctor/status warning path where file-backed credentials were resolved correctly, but the account snapshot dropped the per-field token/secret presence information and `collectStatusIssues(...)` treated both values as missing.

## What changed

- persist token/secret configured booleans in the LINE status snapshot
- use those booleans when building LINE config warnings
- add regression tests for:
  - file-backed credentials producing no warnings
  - partial credentials still producing the correct per-field warning

## Verification

```bash
pnpm exec vitest run extensions/line/src/channel.startup.test.ts --config vitest.extensions.config.ts
```
