### PR TITLE
browser/extension: release idle relay connection for cross-profile handoff

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -214,6 +214,11 @@ function onRelayClosed(reason) {
     }
   }
 
+  if (tabs.size === 0) {
+    cancelReconnect()
+    return
+  }
+
   scheduleReconnect()
 }
 
@@ -252,6 +257,26 @@ function cancelReconnect() {
     reconnectTimer = null
   }
   reconnectAttempt = 0
+}
+
+function releaseRelayIfIdle(reason = 'idle') {
+  if (tabs.size > 0) return
+
+  cancelReconnect()
+  relayConnectRequestId = null
+
+  const ws = relayWs
+  if (!ws) return
+
+  if (ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+    return
+  }
+
+  try {
+    ws.close(1000, `idle:${reason}`)
+  } catch {
+    // ignore
+  }
 }
 
 // Re-announce all attached tabs to the relay after reconnect.
@@ -326,6 +351,7 @@ async function reannounceAttachedTabs() {
   }
 
   await persistState()
+  releaseRelayIfIdle('reannounce')
 }
 
 function sendToRelay(payload) {
@@ -569,6 +595,7 @@ async function detachTab(tabId, reason) {
   })
 
   await persistState()
+  releaseRelayIfIdle('detached')
 }
 
 async function connectOrToggleForActiveTab() {
@@ -860,6 +887,7 @@ chrome.tabs.onRemoved.addListener((tabId) => void whenReady(() => {
     }
   }
   void persistState()
+  releaseRelayIfIdle('tab-removed')
 }))
 
 chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => void whenReady(() => {


### PR DESCRIPTION
## Summary
- Release the extension relay websocket when no attached tabs remain.
- Skip reconnect scheduling when there are zero tracked tabs.
- Trigger idle release after detach, tab removal, and reannounce cleanup.

## Why
If relay is not released while idle, Profile A can keep occupying the single extension websocket slot even after users toggle off/close tabs.
Then Profile B cannot take over and shows error badge `!` with `Extension already connected` behavior.

In short: if not released, even after closing on one profile, another profile cannot take over.

## Scope
- `assets/chrome-extension/background.js` only
- No server config/schema changes
- Backward compatible while tabs are attached
