### PR TITLE
fix(ui): auto-load usage data on tab open

### DIFF
--- a/test/ui/app-settings.usage.test.ts
+++ b/test/ui/app-settings.usage.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Tab } from "../../ui/src/ui/navigation.ts";
+
+const loadUsageMock = vi.hoisted(() => vi.fn(async () => undefined));
+const storageMock = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  return {
+    clear: vi.fn(() => store.clear()),
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => store.delete(key)),
+    setItem: vi.fn((key: string, value: string) => store.set(key, String(value))),
+    get length() {
+      return store.size;
+    },
+  };
+});
+
+vi.mock("../../ui/src/ui/controllers/usage.ts", () => ({
+  loadUsage: loadUsageMock,
+}));
+
+vi.stubGlobal("localStorage", storageMock as unknown as Storage);
+vi.stubGlobal("sessionStorage", storageMock as unknown as Storage);
+
+const { setTabFromRoute } = await import("../../ui/src/ui/app-settings.ts");
+
+type SettingsHost = Parameters<typeof setTabFromRoute>[0] & {
+  debugPollInterval: number | null;
+  logsPollInterval: number | null;
+};
+
+const createHost = (tab: Tab, overrides: Partial<SettingsHost> = {}): SettingsHost => ({
+  settings: {
+    gatewayUrl: "",
+    token: "",
+    sessionKey: "main",
+    lastActiveSessionKey: "main",
+    theme: "system",
+    chatFocusMode: false,
+    chatShowThinking: true,
+    splitRatio: 0.6,
+    navCollapsed: false,
+    navGroupsCollapsed: {},
+  },
+  theme: "system",
+  themeResolved: "dark",
+  applySessionKey: "main",
+  sessionKey: "main",
+  tab,
+  connected: true,
+  chatHasAutoScrolled: false,
+  logsAtBottom: false,
+  eventLog: [],
+  eventLogBuffer: [],
+  basePath: "",
+  themeMedia: null,
+  themeMediaHandler: null,
+  logsPollInterval: null,
+  debugPollInterval: null,
+  ...overrides,
+});
+
+describe("usage tab refresh", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads usage data when the route switches to the usage tab", async () => {
+    const host = createHost("chat");
+
+    setTabFromRoute(host, "usage");
+    await vi.waitFor(() => expect(loadUsageMock).toHaveBeenCalledTimes(1));
+    expect(loadUsageMock).toHaveBeenCalledWith(host);
+  });
+});

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -26,6 +26,7 @@ import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { loadSkills } from "./controllers/skills.ts";
+import { loadUsage } from "./controllers/usage.ts";
 import {
   inferBasePathFromPathname,
   normalizeBasePath,
@@ -192,6 +193,9 @@ export async function refreshActiveTab(host: SettingsHost) {
   }
   if (host.tab === "sessions") {
     await loadSessions(host as unknown as OpenClawApp);
+  }
+  if (host.tab === "usage") {
+    await loadUsage(host as unknown as OpenClawApp);
   }
   if (host.tab === "cron") {
     await loadCron(host);


### PR DESCRIPTION
## Summary

- Problem: the Control UI `Usage` page only loaded data after clicking `Refresh`, so entering the tab showed empty charts and tables every time
- Why it matters: usage data looked broken even though the gateway already had the session data available
- What changed: wired the `usage` tab into `refreshActiveTab()` and added a regression test that verifies switching into the tab triggers `loadUsage()`
- What did NOT change (scope boundary): this does not change usage query parameters, chart rendering, or the manual `Refresh` behavior itself

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Control UI / Web UI

## Linked Issue/PR

- Closes #41049

## User-visible / Behavior Changes

The Control UI `Usage` tab now loads session usage data automatically when the user opens the tab instead of waiting for a manual refresh.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps
1. Open the Control UI and navigate to `Usage`.
2. Observe the initial tab load.
3. Verify usage data requests fire immediately without clicking `Refresh`.

### Expected
- The `Usage` tab auto-loads data on entry.
- The existing `Refresh` button still works as before.

### Actual (before fix)
- The tab rendered empty until the user clicked `Refresh`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets

Passing verification:
- `pnpm exec vitest run test/ui/app-settings.usage.test.ts`
- `pnpm exec oxlint ui/src/ui/app-settings.ts test/ui/app-settings.usage.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/app-settings.ts test/ui/app-settings.usage.test.ts`
- `pnpm build`

## Human Verification (required)

- Verified scenarios: route switch into `usage` now triggers `loadUsage()` through `refreshActiveTab()`
- Edge cases checked: other existing tab refresh branches remain untouched; disconnected route handling still uses the existing `connected` gate before refresh
- What you did **not** verify: no manual browser session was run against a live gateway in this environment

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous tab-refresh behavior
- Files/config to restore: `ui/src/ui/app-settings.ts`, `test/ui/app-settings.usage.test.ts`
- Known bad symptoms reviewers should watch for: the `Usage` tab still opening empty until manual refresh, or repeated usage reloads when switching tabs

## Risks and Mitigations

- Risk: automatically loading the tab could trigger an unexpected request on every usage-tab entry
  - Mitigation: this follows the same `refreshActiveTab()` pattern already used by the other data tabs and only runs when the tab is selected
