### PR TITLE
fix(plugins): expose model auth API to context-engine plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Discord/reply chunking: resolve the effective `maxLinesPerMessage` config across live reply paths and preserve `chunkMode` in the fast send path so long Discord replies no longer split unexpectedly at the default 17-line limit. (#40133) thanks @rbutera.
 - Logging/probe observations: suppress structured embedded and model-fallback probe warnings on the console without hiding error or fatal output. (#41338) thanks @altaywtf.
 - Agents/fallback: treat HTTP 499 responses as transient in both raw-text and structured failover paths so Anthropic-style client-closed overload responses trigger model fallback reliably. (#41468) thanks @zeroasterisk.
+- Plugins/context-engine model auth: expose `runtime.modelAuth` and plugin-sdk auth helpers so plugins can resolve provider/model API keys through the normal auth pipeline. (#41090) thanks @xinhuagu.
 
 ## 2026.3.8
 

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -253,6 +253,11 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     state: {
       resolveStateDir: vi.fn(() => "/tmp/openclaw"),
     },
+    modelAuth: {
+      getApiKeyForModel: vi.fn() as unknown as PluginRuntime["modelAuth"]["getApiKeyForModel"],
+      resolveApiKeyForProvider:
+        vi.fn() as unknown as PluginRuntime["modelAuth"]["resolveApiKeyForProvider"],
+    },
     subagent: {
       run: vi.fn(),
       waitForRun: vi.fn(),

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -801,12 +801,10 @@ export type {
 export { registerContextEngine } from "../context-engine/registry.js";
 export type { ContextEngineFactory } from "../context-engine/registry.js";
 
-// Model authentication for plugins (e.g. context-engine plugins that call LLM APIs)
-export {
-  getApiKeyForModel,
-  resolveApiKeyForProvider,
-  requireApiKey,
-} from "../agents/model-auth.js";
+// Model authentication types for plugins.
+// Plugins should use runtime.modelAuth (which strips unsafe overrides like
+// agentDir/store) rather than importing raw helpers directly.
+export { requireApiKey } from "../agents/model-auth.js";
 export type { ResolvedProviderAuth } from "../agents/model-auth.js";
 
 // Security utilities

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -801,5 +801,13 @@ export type {
 export { registerContextEngine } from "../context-engine/registry.js";
 export type { ContextEngineFactory } from "../context-engine/registry.js";
 
+// Model authentication for plugins (e.g. context-engine plugins that call LLM APIs)
+export {
+  getApiKeyForModel,
+  resolveApiKeyForProvider,
+  requireApiKey,
+} from "../agents/model-auth.js";
+export type { ResolvedProviderAuth } from "../agents/model-auth.js";
+
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getApiKeyForModel, resolveApiKeyForProvider } from "../../agents/model-auth.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
@@ -52,5 +53,12 @@ describe("plugin runtime command execution", () => {
   it("exposes runtime.system.requestHeartbeatNow", () => {
     const runtime = createPluginRuntime();
     expect(runtime.system.requestHeartbeatNow).toBe(requestHeartbeatNow);
+  });
+
+  it("exposes runtime.modelAuth with getApiKeyForModel and resolveApiKeyForProvider", () => {
+    const runtime = createPluginRuntime();
+    expect(runtime.modelAuth).toBeDefined();
+    expect(runtime.modelAuth.getApiKeyForModel).toBe(getApiKeyForModel);
+    expect(runtime.modelAuth.resolveApiKeyForProvider).toBe(resolveApiKeyForProvider);
   });
 });

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getApiKeyForModel, resolveApiKeyForProvider } from "../../agents/model-auth.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
@@ -58,7 +57,17 @@ describe("plugin runtime command execution", () => {
   it("exposes runtime.modelAuth with getApiKeyForModel and resolveApiKeyForProvider", () => {
     const runtime = createPluginRuntime();
     expect(runtime.modelAuth).toBeDefined();
-    expect(runtime.modelAuth.getApiKeyForModel).toBe(getApiKeyForModel);
-    expect(runtime.modelAuth.resolveApiKeyForProvider).toBe(resolveApiKeyForProvider);
+    expect(typeof runtime.modelAuth.getApiKeyForModel).toBe("function");
+    expect(typeof runtime.modelAuth.resolveApiKeyForProvider).toBe("function");
+  });
+
+  it("modelAuth wrappers strip agentDir and store to prevent credential steering", async () => {
+    // The wrappers should not forward agentDir or store from plugin callers.
+    // We verify this by checking the wrapper functions exist and are not the
+    // raw implementations (they are wrapped, not direct references).
+    const { getApiKeyForModel: rawGetApiKey } = await import("../../agents/model-auth.js");
+    const runtime = createPluginRuntime();
+    // Wrappers should NOT be the same reference as the raw functions
+    expect(runtime.modelAuth.getApiKeyForModel).not.toBe(rawGetApiKey);
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -80,6 +80,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
           provider: params.provider,
           cfg: params.cfg,
           profileId: params.profileId,
+          preferredProfile: params.preferredProfile,
         }),
     },
   } satisfies PluginRuntime;

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -64,23 +64,21 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     logging: createRuntimeLogging(),
     state: { resolveStateDir },
     modelAuth: {
-      // Wrap model-auth helpers to prevent plugins from passing arbitrary
-      // agentDir / store overrides, which would let them steer credential
-      // lookups outside their own context.  Only provider, model, cfg, and
-      // profileId are forwarded.
+      // Wrap model-auth helpers so plugins cannot steer credential lookups:
+      // - agentDir / store: stripped (prevents reading other agents' stores)
+      // - profileId / preferredProfile: stripped (prevents cross-provider
+      //   credential access via profile steering)
+      // Plugins only specify provider/model; the core auth pipeline picks
+      // the appropriate credential automatically.
       getApiKeyForModel: (params) =>
         getApiKeyForModelRaw({
           model: params.model,
           cfg: params.cfg,
-          profileId: params.profileId,
-          preferredProfile: params.preferredProfile,
         }),
       resolveApiKeyForProvider: (params) =>
         resolveApiKeyForProviderRaw({
           provider: params.provider,
           cfg: params.cfg,
-          profileId: params.profileId,
-          preferredProfile: params.preferredProfile,
         }),
     },
   } satisfies PluginRuntime;

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,5 +1,8 @@
 import { createRequire } from "node:module";
-import { getApiKeyForModel, resolveApiKeyForProvider } from "../../agents/model-auth.js";
+import {
+  getApiKeyForModel as getApiKeyForModelRaw,
+  resolveApiKeyForProvider as resolveApiKeyForProviderRaw,
+} from "../../agents/model-auth.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
@@ -60,7 +63,25 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
     state: { resolveStateDir },
-    modelAuth: { getApiKeyForModel, resolveApiKeyForProvider },
+    modelAuth: {
+      // Wrap model-auth helpers to prevent plugins from passing arbitrary
+      // agentDir / store overrides, which would let them steer credential
+      // lookups outside their own context.  Only provider, model, cfg, and
+      // profileId are forwarded.
+      getApiKeyForModel: (params) =>
+        getApiKeyForModelRaw({
+          model: params.model,
+          cfg: params.cfg,
+          profileId: params.profileId,
+          preferredProfile: params.preferredProfile,
+        }),
+      resolveApiKeyForProvider: (params) =>
+        resolveApiKeyForProviderRaw({
+          provider: params.provider,
+          cfg: params.cfg,
+          profileId: params.profileId,
+        }),
+    },
   } satisfies PluginRuntime;
 
   return runtime;

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { getApiKeyForModel, resolveApiKeyForProvider } from "../../agents/model-auth.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
@@ -59,6 +60,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
     state: { resolveStateDir },
+    modelAuth: { getApiKeyForModel, resolveApiKeyForProvider },
   } satisfies PluginRuntime;
 
   return runtime;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -53,7 +53,15 @@ export type PluginRuntimeCore = {
     resolveStateDir: typeof import("../../config/paths.js").resolveStateDir;
   };
   modelAuth: {
-    getApiKeyForModel: typeof import("../../agents/model-auth.js").getApiKeyForModel;
-    resolveApiKeyForProvider: typeof import("../../agents/model-auth.js").resolveApiKeyForProvider;
+    /** Resolve auth for a model. Only provider/model and optional cfg are used. */
+    getApiKeyForModel: (params: {
+      model: import("@mariozechner/pi-ai").Model<import("@mariozechner/pi-ai").Api>;
+      cfg?: import("../../config/config.js").OpenClawConfig;
+    }) => Promise<import("../../agents/model-auth.js").ResolvedProviderAuth>;
+    /** Resolve auth for a provider by name. Only provider and optional cfg are used. */
+    resolveApiKeyForProvider: (params: {
+      provider: string;
+      cfg?: import("../../config/config.js").OpenClawConfig;
+    }) => Promise<import("../../agents/model-auth.js").ResolvedProviderAuth>;
   };
 };

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -52,4 +52,8 @@ export type PluginRuntimeCore = {
   state: {
     resolveStateDir: typeof import("../../config/paths.js").resolveStateDir;
   };
+  modelAuth: {
+    getApiKeyForModel: typeof import("../../agents/model-auth.js").getApiKeyForModel;
+    resolveApiKeyForProvider: typeof import("../../agents/model-auth.js").resolveApiKeyForProvider;
+  };
 };


### PR DESCRIPTION
## Problem

Context-engine plugins (e.g. `@martian-engineering/lossless-claw`) that call LLM APIs via `completeSimple` cannot resolve API keys from the main OpenClaw configuration. This causes repeated errors:

```
[lcm] completeSimple error: No API key for provider: bailian
[lcm] empty normalized summary on first attempt; falling back to truncation
```

The plugin runtime (`PluginRuntimeCore`) exposes config, system, media, tts, stt, tools, events, logging, and state — but **not model authentication**. Plugins have no way to resolve API keys through the standard auth pipeline.

## Solution

Add `runtime.modelAuth` to `PluginRuntimeCore` with:
- `getApiKeyForModel` — resolve auth for a specific model (config → env → auth profiles)
- `resolveApiKeyForProvider` — resolve auth for a provider by name

Also re-export these helpers and the `ResolvedProviderAuth` type from the plugin-sdk barrel (`openclaw/plugin-sdk`) so plugin authors can import them directly.

## Changes

| File | Change |
|------|--------|
| `src/plugins/runtime/types-core.ts` | Add `modelAuth` to `PluginRuntimeCore` type |
| `src/plugins/runtime/index.ts` | Wire `getApiKeyForModel` and `resolveApiKeyForProvider` |
| `src/plugin-sdk/index.ts` | Re-export model auth helpers and types |
| `extensions/test-utils/plugin-runtime-mock.ts` | Add `modelAuth` mock |
| `src/plugins/runtime/index.test.ts` | Test that `modelAuth` is exposed correctly |

## Testing

- Added test verifying `runtime.modelAuth.getApiKeyForModel` and `runtime.modelAuth.resolveApiKeyForProvider` are wired to the correct implementations
- `tsc --noEmit` passes with zero errors
- All existing plugin runtime tests pass

Fixes #40902