### PR TITLE
fix(telegram): avoid mid-word message chunking

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramHtml, splitTelegramHtmlChunks } from "./format.js";
+import {
+  markdownToTelegramChunks,
+  markdownToTelegramHtml,
+  splitTelegramHtmlChunks,
+} from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {
@@ -133,5 +137,17 @@ describe("markdownToTelegramHtml", () => {
 
   it("fails loudly when tag overhead leaves no room for text", () => {
     expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
+  });
+});
+
+describe("markdownToTelegramChunks", () => {
+  it("backs up to a word boundary when HTML overflow forces a retry split", () => {
+    const chunks = markdownToTelegramChunks("**beta** zeta", 13);
+
+    expect(chunks).toEqual([
+      { html: "<b>beta</b> ", text: "beta " },
+      { html: "zeta", text: "zeta" },
+    ]);
+    expect(chunks.map((chunk) => chunk.text).join("")).toBe("beta zeta");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: Telegram long-message chunking could split text mid-word in the affected formatting path when HTML expansion forced a retry split after markdown rendering.
- Why it matters: replies become harder to read and look broken on Telegram.
- What changed: I added focused regression coverage and fixed the Telegram chunk boundary logic only where tests showed the gap.
- What did NOT change (scope boundary): I did not refactor Telegram streaming, native commands, or general multi-channel chunking behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36644
- Related # None

## User-visible / Behavior Changes

- Long Telegram replies keep cleaner chunk boundaries in the covered regression path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree, Node v25.2.1, pnpm via `npm exec`
- Model/provider: N/A
- Integration/channel (if any): Telegram bot API formatting path
- Relevant config (redacted): default test configuration

### Steps

1. Run `npm exec --yes pnpm test src/telegram/format.test.ts` with the new `markdownToTelegramChunks("**beta** zeta", 13)` regression case.
2. Observe the pre-fix output chunk `**beta** zeta` as `beta z`, `e`, `ta` because the Telegram HTML retry split used a raw character boundary.
3. Re-run after the fix together with `npm exec --yes pnpm test src/telegram/format.test.ts src/channels/plugins/outbound/telegram.test.ts`.

### Expected

- Retry chunking backs up to a whitespace boundary and keeps the covered Telegram split as `"<b>beta</b>"` then `"zeta"`.

### Actual

- Before the fix, the retry split kept the preceding `z` with the formatted chunk and broke `zeta` into `e` and `ta`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failure with a new `src/telegram/format.test.ts` regression, then confirmed it passes after the fix; re-ran `src/channels/plugins/outbound/telegram.test.ts`; ran `npm exec --yes pnpm check` successfully.
- Edge cases checked: existing Telegram format coverage for links, code, spoilers, blockquotes, and file-reference wrapping still passes; outbound Telegram send tests still pass.
- What you did **not** verify: live Telegram delivery against a real bot/chat.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/telegram/format.ts`, `src/telegram/format.test.ts`
- Known bad symptoms reviewers should watch for: malformed Telegram chunk boundaries, broken HTML chunks, or over-limit sends.

## Risks and Mitigations

- Risk: Telegram retry chunking now backs up and trims boundary whitespace when it finds a safer split point.
  - Mitigation: the change is isolated to the Telegram HTML overflow retry path and is covered by the new regression, existing Telegram format tests, outbound Telegram tests, and `pnpm check`.
