### PR TITLE
fix(compaction): return user-friendly reason when safeguard cancels compaction

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -702,7 +702,11 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       log.warn(
         "Compaction safeguard: cancelling compaction with no real conversation messages to summarize.",
       );
-      return { cancel: true };
+      return {
+        cancel: true,
+        reason:
+          "No conversation messages to summarize — session contains only system/tool traffic. This is normal for fresh sessions or after /reset.",
+      };
     }
     const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
     const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);


### PR DESCRIPTION
## What this fixes

When compaction triggers on a fresh session (or after `/reset`), it previously failed with the message 'Compaction cancelled' and no actionable reason. The underlying cause was the compaction safeguard hook returning `{ cancel: true }` without a `reason` field.

## Changes

- Add `reason` field to the cancel response in `compaction-safeguard.ts`
- New message: "No conversation messages to summarize — session contains only system/tool traffic. This is normal for fresh sessions or after /reset."

## Impact

- Users get actionable feedback instead of silent failure
- No change to compaction logic, only UX improvement
- Especially helpful for sessions started via `/new` or `/reset`

Fixes #41100