### PR TITLE
fix: recover from invalid fallback temp dir by removing and recreating

### DIFF
--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -94,6 +94,7 @@ function resolveWithMocks(params: {
   fallbackLstatSync?: NonNullable<TmpDirOptions["lstatSync"]>;
   accessSync?: NonNullable<TmpDirOptions["accessSync"]>;
   chmodSync?: NonNullable<TmpDirOptions["chmodSync"]>;
+  rmSync?: NonNullable<TmpDirOptions["rmSync"]>;
   warn?: NonNullable<TmpDirOptions["warn"]>;
   uid?: number;
   tmpdirPath?: string;
@@ -102,6 +103,7 @@ function resolveWithMocks(params: {
   const fallbackPath = fallbackTmp(uid);
   const accessSync = params.accessSync ?? vi.fn();
   const chmodSync = params.chmodSync ?? vi.fn();
+  const rmSync = params.rmSync ?? vi.fn();
   const warn = params.warn ?? vi.fn();
   const wrappedLstatSync = vi.fn((target: string) => {
     if (target === POSIX_OPENCLAW_TMP_DIR) {
@@ -123,6 +125,7 @@ function resolveWithMocks(params: {
     chmodSync,
     lstatSync: wrappedLstatSync,
     mkdirSync,
+    rmSync,
     getuid,
     tmpdir,
     warn,
@@ -197,7 +200,55 @@ describe("resolvePreferredOpenClawTmpDir", () => {
     expectFallsBackToOsTmpDir({ lstatSync: vi.fn(() => makeDirStat({ mode: 0o40777 })) });
   });
 
-  it("throws when fallback path is a symlink", () => {
+  it("removes and recreates fallback dir owned by a different user", () => {
+    const lstatSync = symlinkTmpDirLstat();
+    let removed = false;
+    // First call: dir exists but owned by different user (uid 999).
+    // After remove+recreate: dir is now owned by current user (uid 501).
+    const fallbackLstatSync = vi.fn(() => {
+      if (removed) {
+        return secureDirStat(501);
+      }
+      return makeDirStat({ uid: 999 });
+    });
+    const rmSync = vi.fn(() => {
+      removed = true;
+    });
+    const warn = vi.fn();
+
+    const fb = fallbackTmp();
+    const accessSync = vi.fn();
+    const chmodSync = vi.fn();
+    const mkdirSync = vi.fn();
+    const getuid = vi.fn(() => 501);
+    const tmpdir = vi.fn(() => "/var/fallback");
+
+    const resolved = resolvePreferredOpenClawTmpDir({
+      accessSync,
+      chmodSync,
+      lstatSync: vi.fn((target: string) => {
+        if (target === POSIX_OPENCLAW_TMP_DIR) {
+          return lstatSync(target);
+        }
+        if (target === fb) {
+          return fallbackLstatSync(target);
+        }
+        return secureDirStat(501);
+      }),
+      mkdirSync,
+      rmSync,
+      getuid,
+      tmpdir,
+      warn,
+    });
+
+    expect(resolved).toBe(fb);
+    expect(rmSync).toHaveBeenCalledWith(fb, { recursive: true, force: true });
+    expect(mkdirSync).toHaveBeenCalledWith(fb, { recursive: true, mode: 0o700 });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("replaced invalid temp dir"));
+  });
+
+  it("throws when fallback path is a symlink and remove-recreate also fails", () => {
     const lstatSync = symlinkTmpDirLstat();
     const fallbackLstatSync = vi.fn(() => makeDirStat({ isSymbolicLink: true, mode: 0o120777 }));
 

--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -245,6 +245,7 @@ describe("resolvePreferredOpenClawTmpDir", () => {
     expect(resolved).toBe(fb);
     expect(rmSync).toHaveBeenCalledWith(fb, { recursive: true, force: true });
     expect(mkdirSync).toHaveBeenCalledWith(fb, { recursive: true, mode: 0o700 });
+    expect(chmodSync).toHaveBeenCalledWith(fb, 0o700);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("replaced invalid temp dir"));
   });
 

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -15,6 +15,7 @@ type ResolvePreferredOpenClawTmpDirOptions = {
     uid?: number;
   };
   mkdirSync?: (path: string, opts: { recursive: boolean; mode?: number }) => void;
+  rmSync?: (path: string, opts: { recursive: boolean; force: boolean }) => void;
   getuid?: () => number | undefined;
   tmpdir?: () => string;
   warn?: (message: string) => void;
@@ -38,6 +39,7 @@ export function resolvePreferredOpenClawTmpDir(
   const chmodSync = options.chmodSync ?? fs.chmodSync;
   const lstatSync = options.lstatSync ?? fs.lstatSync;
   const mkdirSync = options.mkdirSync ?? fs.mkdirSync;
+  const rmSync = options.rmSync ?? fs.rmSync;
   const warn = options.warn ?? ((message: string) => console.warn(message));
   const getuid =
     options.getuid ??
@@ -116,6 +118,17 @@ export function resolvePreferredOpenClawTmpDir(
     }
   };
 
+  const tryRemoveAndRecreate = (dirPath: string): boolean => {
+    try {
+      rmSync(dirPath, { recursive: true, force: true });
+      mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+      chmodSync(dirPath, 0o700);
+      return resolveDirState(dirPath) === "available";
+    } catch {
+      return false;
+    }
+  };
+
   const ensureTrustedFallbackDir = (): string => {
     const fallbackPath = fallback();
     const state = resolveDirState(fallbackPath);
@@ -124,6 +137,14 @@ export function resolvePreferredOpenClawTmpDir(
     }
     if (state === "invalid") {
       if (tryRepairWritableBits(fallbackPath)) {
+        return fallbackPath;
+      }
+      // Repair failed — attempt to remove and recreate the directory.
+      // This handles cases where the dir was left by a previous install
+      // under a different uid or with unsafe permissions (e.g. after
+      // reinstall, Docker leftover, or uid remapping).
+      if (tryRemoveAndRecreate(fallbackPath)) {
+        warn(`[openclaw] replaced invalid temp dir: ${fallbackPath}`);
         return fallbackPath;
       }
       throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackPath}`);

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -122,6 +122,13 @@ export function resolvePreferredOpenClawTmpDir(
     try {
       rmSync(dirPath, { recursive: true, force: true });
       mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+      // Guard against symlink race: verify the path is a real directory
+      // (not a symlink) before applying chmod in shared temp parents.
+      const st = lstatSync(dirPath);
+      if (st.isSymbolicLink()) {
+        rmSync(dirPath, { recursive: true, force: true });
+        return false;
+      }
       chmodSync(dirPath, 0o700);
       return resolveDirState(dirPath) === "available";
     } catch {


### PR DESCRIPTION
## Problem

When the fallback OpenClaw temp dir exists but has wrong ownership or unsafe permissions (e.g. after reinstall, Docker leftover, or uid remapping), the code threw `Unsafe fallback OpenClaw temp dir` with no recovery path, causing a startup crash.

This affects users who:
- Reinstalled OpenClaw under a different user
- Had leftover temp dirs from Docker/container runs
- Experienced uid remapping between installs

## Fix

Add a `tryRemoveAndRecreate` recovery step in `ensureTrustedFallbackDir`. When the fallback dir is invalid and permission repair fails, the code now:

1. Removes the invalid directory (`rmSync` with `recursive: true, force: true`)
2. Recreates it with secure permissions (`0o700`)
3. Validates the new directory is available
4. Only throws if remove-and-recreate also fails

This is safe because the fallback dir lives in the user's own `os.tmpdir()` directory, so they have permission to remove and recreate it.

## Changes

- `src/infra/tmp-openclaw-dir.ts`: Add `rmSync` option and `tryRemoveAndRecreate` helper
- `src/infra/tmp-openclaw-dir.test.ts`: Add test for remove-and-recreate recovery path; update `resolveWithMocks` to support `rmSync`

## Tests

All 12 tests pass (11 existing + 1 new).

Closes #40975