### PR TITLE
fix: include current time in system prompt for /new and /reset

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -3,6 +3,7 @@ import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
+import { resolveCronStyleNow } from "./current-time.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { EmbeddedSandboxInfo } from "./pi-embedded-runner/types.js";
@@ -98,7 +99,11 @@ function buildTimeSection(params: { userTimezone?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const { timeLine } = resolveCronStyleNow(
+    { agents: { defaults: { userTimezone: params.userTimezone } } },
+    Date.now(),
+  );
+  return ["## Current Date & Time", timeLine, ""];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {


### PR DESCRIPTION
## Summary
- Add actual timestamp to the time section so models can accurately greet with correct time-of-day (morning/evening)
- Previously only included timezone without actual time, causing models to guess

## Fixes
- Fixes #38782

## Test plan
- [ ] Start new session with `agents.defaults.userTimezone` set
- [ ] Run `/new` or `/reset`
- [ ] Verify greeting uses correct time-of-day

🤖 Generated with [Claude Code](https://claude.com/claude-code)