### PR TITLE
fix(agents): prefer target agent workspace for spawned runs

### DIFF
--- a/src/agents/spawned-context.test.ts
+++ b/src/agents/spawned-context.test.ts
@@ -49,14 +49,47 @@ describe("resolveSpawnedWorkspaceInheritance", () => {
       config: {},
       requesterSessionKey: "agent:main:subagent:parent",
       explicitWorkspaceDir: " /tmp/explicit ",
+      targetAgentId: "ct-manager",
     });
     expect(resolved).toBe("/tmp/explicit");
+  });
+
+  it("prefers target agent explicit workspace over requester workspace", () => {
+    const resolved = resolveSpawnedWorkspaceInheritance({
+      config: {
+        agents: {
+          list: [
+            { id: "main", workspace: "/tmp/requester" },
+            { id: "ct-manager", workspace: "/tmp/target" },
+          ],
+        },
+      },
+      requesterSessionKey: "agent:main:subagent:parent",
+      targetAgentId: "ct-manager",
+      explicitWorkspaceDir: undefined,
+    });
+    expect(resolved).toBe("/tmp/target");
+  });
+
+  it("falls back to requester workspace when target agent has no explicit workspace", () => {
+    const resolved = resolveSpawnedWorkspaceInheritance({
+      config: {
+        agents: {
+          list: [{ id: "main", workspace: "/tmp/requester" }, { id: "ct-manager" }],
+        },
+      },
+      requesterSessionKey: "agent:main:subagent:parent",
+      targetAgentId: "ct-manager",
+      explicitWorkspaceDir: undefined,
+    });
+    expect(resolved).toBe("/tmp/requester");
   });
 
   it("returns undefined for missing requester context", () => {
     const resolved = resolveSpawnedWorkspaceInheritance({
       config: {},
       requesterSessionKey: undefined,
+      targetAgentId: undefined,
       explicitWorkspaceDir: undefined,
     });
     expect(resolved).toBeUndefined();

--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -72,7 +72,7 @@ export function resolveSpawnedWorkspaceInheritance(params: {
         resolveAgentConfig(params.config, normalizeAgentId(targetAgentId))?.workspace,
       )
     : undefined;
-  if (targetWorkspace && targetAgentId) {
+  if (targetWorkspace) {
     return resolveAgentWorkspaceDir(params.config, normalizeAgentId(targetAgentId));
   }
   const requesterAgentId = params.requesterSessionKey

--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
-import { resolveAgentWorkspaceDir } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 
 export type SpawnedRunMetadata = {
   spawnedBy?: string | null;
@@ -60,10 +60,20 @@ export function resolveSpawnedWorkspaceInheritance(params: {
   config: OpenClawConfig;
   requesterSessionKey?: string;
   explicitWorkspaceDir?: string | null;
+  targetAgentId?: string | null;
 }): string | undefined {
   const explicit = normalizeOptionalText(params.explicitWorkspaceDir);
   if (explicit) {
     return explicit;
+  }
+  const targetAgentId = normalizeOptionalText(params.targetAgentId);
+  const targetWorkspace = targetAgentId
+    ? normalizeOptionalText(
+        resolveAgentConfig(params.config, normalizeAgentId(targetAgentId))?.workspace,
+      )
+    : undefined;
+  if (targetWorkspace && targetAgentId) {
+    return resolveAgentWorkspaceDir(params.config, normalizeAgentId(targetAgentId));
   }
   const requesterAgentId = params.requesterSessionKey
     ? parseAgentSessionKey(params.requesterSessionKey)?.agentId

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -550,6 +550,7 @@ export async function spawnSubagentDirect(
       config: cfg,
       requesterSessionKey: requesterInternalKey,
       explicitWorkspaceDir: toolSpawnMetadata.workspaceDir,
+      targetAgentId,
     }),
   });
 


### PR DESCRIPTION
Summary
- Makes spawned workspace inheritance prefer the target agent's configured workspace over the requester's workspace.
- Keeps explicit workspace overrides highest priority.

Why
- `sessions_spawn(agentId=...)` should inject AGENTS.md / SOUL.md / USER.md from the target agent's own configured workspace when one exists. Today the spawn path falls back to the requester workspace, which breaks per-agent identity and workspace-specific context.

What did NOT change
- No changes to normal non-spawned agent runs.
- No changes to `cwd` semantics.
- No changes to sandbox or workspace permission behavior.

Tests (local)
- `pnpm format:check`
- `pnpm tsgo`
- `pnpm build`
- `pnpm test src/agents/spawned-context.test.ts`

Evidence
- Added unit coverage for target-agent workspace preference, explicit override priority, and requester fallback in `src/agents/spawned-context.test.ts`.

AI-assisted: yes.