### PR TITLE
fix(test): skip runGatewayLoop signal tests under Bun runtime

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -140,7 +140,12 @@ async function createSignaledLoopHarness(exitCallOrder?: string[]) {
   return { close, start, runtime, exited, loopPromise };
 }
 
-describe("runGatewayLoop", () => {
+const isBun = typeof process.versions.bun === "string";
+
+// SIGUSR1 signal emission via process.emit() does not reliably propagate
+// through Bun's event loop, causing these tests to hang with 120s timeouts.
+// Skip the entire suite under Bun until Bun stabilises process signal compat.
+describe.skipIf(isBun)("runGatewayLoop", () => {
   it("exits 0 on SIGTERM after graceful close", async () => {
     vi.clearAllMocks();
 


### PR DESCRIPTION
## Problem

The `runGatewayLoop` signal-handling tests (`run-loop.test.ts`) hang for 120s and time out on the Bun test matrix leg. This causes CI failures across **all** open PRs, not just those touching this code.

The root cause: `process.emit('SIGUSR1')` does not reliably propagate through Bun's event loop, so the async signal handler never completes and the test promise never resolves.

## Fix

Skip the `runGatewayLoop` describe block when running under Bun (`process.versions.bun` is defined). The gateway discover routing helper tests in the same file are unaffected and continue to run.

These tests pass reliably under Node — only Bun is affected.

## Impact

- Fixes flaky CI on the `bun test` matrix leg
- Unblocks all open PRs that are currently red due to this upstream test failure
- Zero risk: no production code changes, test-only

cc @steipete