### PR TITLE
fix(discord): dedupe inbound messages by message id

### DIFF
--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -17,7 +17,8 @@ vi.mock("./message-handler.process.js", () => ({
   processDiscordMessage: processDiscordMessageMock,
 }));
 
-const { createDiscordMessageHandler, resetDiscordInboundMessageDedupe } = await import("./message-handler.js");
+const { createDiscordMessageHandler, resetDiscordInboundMessageDedupe } =
+  await import("./message-handler.js");
 
 function createDeferred<T = void>() {
   let resolve: (value: T | PromiseLike<T>) => void = () => {};
@@ -114,12 +115,16 @@ describe("createDiscordMessageHandler queue behavior", () => {
 
     const handler = createDiscordMessageHandler(createDiscordHandlerParams());
 
-    await expect(handler(createMessageData("dup-1") as never, {} as never)).resolves.toBeUndefined();
+    await expect(
+      handler(createMessageData("dup-1") as never, {} as never),
+    ).resolves.toBeUndefined();
     await vi.waitFor(() => {
       expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
     });
 
-    await expect(handler(createMessageData("dup-1") as never, {} as never)).resolves.toBeUndefined();
+    await expect(
+      handler(createMessageData("dup-1") as never, {} as never),
+    ).resolves.toBeUndefined();
     await Promise.resolve();
 
     expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);

--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDiscordHandlerParams,
   createDiscordPreflightContext,
@@ -17,7 +17,7 @@ vi.mock("./message-handler.process.js", () => ({
   processDiscordMessage: processDiscordMessageMock,
 }));
 
-const { createDiscordMessageHandler } = await import("./message-handler.js");
+const { createDiscordMessageHandler, resetDiscordInboundMessageDedupe } = await import("./message-handler.js");
 
 function createDeferred<T = void>() {
   let resolve: (value: T | PromiseLike<T>) => void = () => {};
@@ -83,6 +83,10 @@ async function createLifecycleStopScenario(params: {
 }
 
 describe("createDiscordMessageHandler queue behavior", () => {
+  beforeEach(() => {
+    resetDiscordInboundMessageDedupe();
+  });
+
   it("resets busy counters when the handler is created", () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
@@ -96,6 +100,30 @@ describe("createDiscordMessageHandler queue behavior", () => {
         busy: false,
       }),
     );
+  });
+
+  it("drops duplicate inbound Discord messages with the same message id", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    preflightDiscordMessageMock.mockImplementation(
+      async (params: { data: { channel_id: string } }) =>
+        createPreflightContext(params.data.channel_id),
+    );
+    processDiscordMessageMock.mockResolvedValue(undefined);
+
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
+
+    await expect(handler(createMessageData("dup-1") as never, {} as never)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    await expect(handler(createMessageData("dup-1") as never, {} as never)).resolves.toBeUndefined();
+    await Promise.resolve();
+
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
   });
 
   it("returns immediately and tracks busy status while queued runs execute", async () => {

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -5,6 +5,7 @@ import {
 } from "../../channels/inbound-debounce-policy.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import { danger } from "../../globals.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import { buildDiscordInboundJob } from "./inbound-job.js";
 import { createDiscordInboundWorker } from "./inbound-worker.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
@@ -29,6 +30,37 @@ type DiscordMessageHandlerParams = Omit<
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
 };
+
+const discordInboundMessageDedupe = createDedupeCache({
+  ttlMs: 2 * 60_000,
+  maxSize: 10_000,
+});
+
+export function resetDiscordInboundMessageDedupe(): void {
+  discordInboundMessageDedupe.clear();
+}
+
+function buildDiscordInboundMessageDedupeKey(params: {
+  accountId?: string;
+  data: DiscordMessageEvent;
+}): string | null {
+  const messageId = params.data.message?.id?.trim() || params.data.id?.trim();
+  const authorId = params.data.message?.author?.id ?? params.data.author?.id;
+  const channelId = resolveDiscordMessageChannelId({
+    message: params.data.message,
+    eventChannelId: params.data.channel_id,
+  });
+  if (!messageId || !channelId) {
+    return null;
+  }
+  return JSON.stringify([
+    "discord-inbound",
+    params.accountId ?? "",
+    channelId,
+    authorId ?? "",
+    messageId,
+  ]);
+}
 
 export function createDiscordMessageHandler(
   params: DiscordMessageHandlerParams,
@@ -172,6 +204,17 @@ export function createDiscordMessageHandler(
       const msgAuthorId = data.message?.author?.id ?? data.author?.id;
       if (params.botUserId && msgAuthorId === params.botUserId) {
         return;
+      }
+
+      const dedupeKey = buildDiscordInboundMessageDedupeKey({
+        accountId: params.accountId,
+        data,
+      });
+      if (dedupeKey && discordInboundMessageDedupe.peek(dedupeKey)) {
+        return;
+      }
+      if (dedupeKey) {
+        discordInboundMessageDedupe.check(dedupeKey);
       }
 
       await debouncer.enqueue({ data, client, abortSignal: options?.abortSignal });

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -213,11 +213,12 @@ export function createDiscordMessageHandler(
       if (dedupeKey && discordInboundMessageDedupe.peek(dedupeKey)) {
         return;
       }
+
+      await debouncer.enqueue({ data, client, abortSignal: options?.abortSignal });
+
       if (dedupeKey) {
         discordInboundMessageDedupe.check(dedupeKey);
       }
-
-      await debouncer.enqueue({ data, client, abortSignal: options?.abortSignal });
     } catch (err) {
       params.runtime.error?.(danger(`handler failed: ${String(err)}`));
     }


### PR DESCRIPTION
## Summary
This PR prevents duplicate processing of the same Discord inbound message by adding a short-TTL dedupe guard keyed by Discord `message.id` before the message enters the debounce queue.

## Problem
OpenClaw already has duplicate protection in later stages (for example queued follow-up handling, and more general inbound dedupe at dispatch time), but a duplicate Discord event can still be admitted earlier in the pipeline.

In practice, this can happen when the same Discord message is replayed/re-injected into an active session path (observed around model switching in a live local deployment). When that happens, the same physical Discord message may enter processing twice.

The result can be:
- duplicate session processing for the same inbound message
- duplicate visible replies, or
- user-visible behavior that only gets suppressed later by downstream safeguards

## Fix
Add a lightweight inbound dedupe cache in `src/discord/monitor/message-handler.ts` keyed by:
- accountId
- channelId
- authorId
- message.id

This guard runs **before** `debouncer.enqueue(...)`, so a duplicate Discord message never consumes debounce capacity and never re-enters the downstream processing path.

## Why this approach
- Preserves the existing debounce behavior (`accountId + channelId + authorId`) for normal short-burst message coalescing
- Adds a stricter idempotency barrier specifically for duplicate physical Discord messages
- Fixes the bug earlier in the pipeline instead of relying on downstream `NO_REPLY` / duplicate suppression behavior

## Tests
Added a test in `src/discord/monitor/message-handler.queue.test.ts` to verify that two inbound Discord events with the same `message.id` are only processed once.

Validated locally with:
```bash
npx vitest run src/discord/monitor/message-handler.queue.test.ts --config vitest.channels.config.ts
```

## Related
- Relates to #37844
- Relates to #29868

## Notes
This PR intentionally keeps scope small and focused on Discord inbound idempotency. If maintainers want a second session-level guard as defense-in-depth for model-switch replay paths, that can be proposed separately.
