### PR TITLE
fix(config): add missing params field to agents.list[] validation schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory bootstrap: load only one root memory file, preferring `MEMORY.md` and using `memory.md` as a fallback, so case-insensitive Docker mounts no longer inject duplicate memory context. (#26054) Thanks @Lanfei.
 - Agents/OpenAI-compatible compat overrides: respect explicit user `models[].compat` opt-ins for non-native `openai-completions` endpoints so usage-in-streaming capability overrides no longer get forced off when the endpoint actually supports them. (#44432) Thanks @cheapestinference.
 - Agents/Azure OpenAI startup prompts: rephrase the built-in `/new`, `/reset`, and post-compaction startup instruction so Azure OpenAI deployments no longer hit HTTP 400 false positives from the content filter. (#43403) Thanks @xingsy97.
+- Config/validation: accept documented `agents.list[].params` per-agent overrides in strict config validation so `openclaw config validate` no longer rejects runtime-supported `cacheRetention`, `temperature`, and `maxTokens` settings. (#41171) Thanks @atian8179.
 
 ## 2026.3.12
 

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -361,6 +361,33 @@ describe("config strict validation", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("accepts documented agents.list[].params overrides", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            model: "anthropic/claude-opus-4-6",
+            params: {
+              cacheRetention: "none",
+              temperature: 0.4,
+              maxTokens: 8192,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.list?.[0]?.params).toEqual({
+        cacheRetention: "none",
+        temperature: 0.4,
+        maxTokens: 8192,
+      });
+    }
+  });
+
   it("flags legacy config entries without auto-migrating", async () => {
     await withTempHome(async (home) => {
       await writeOpenClawConfig(home, {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -757,6 +757,7 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,
   })


### PR DESCRIPTION
## Problem

`openclaw config validate` rejects `agents.list[].params` even though this field is defined in the `AgentConfig` TypeScript type and documented as a per-agent override for stream parameters like `cacheRetention`, `temperature`, and `maxTokens`.

The root cause is that `AgentEntrySchema` (Zod validation) uses `.strict()` but does not include the `params` field, so any config containing it fails validation.

## Fix

Add `params: z.record(z.string(), z.unknown()).optional()` to `AgentEntrySchema`, matching the existing TypeScript type:

```ts
params?: Record<string, unknown>;
```

One-line change in `src/config/zod-schema.agent-runtime.ts`.

## Testing

Verified the Zod schema change aligns with the existing `AgentConfig` type definition in `src/config/types.agents.ts`.

Fixes #41160