### PR TITLE
fix(errors): recognize Groq tool call validation error format

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -117,6 +117,17 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
+  it("extracts tool name from Groq tool call validation error", () => {
+    // Groq returns this when a model hallucinates a tool not in request.tools.
+    // Without a sandbox cfg, falls through to the raw error path.
+    const msg = makeAssistantError(
+      "tool call validation failed: attempted to call tool 'gog' which was not in request.tools",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).not.toBeUndefined();
+    // Raw error is surfaced as-is (no sandbox rewrite without cfg)
+    expect(result).toContain("gog");
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -472,7 +472,9 @@ export function formatAssistantErrorText(
 
   const unknownTool =
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
-    raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
+    raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i) ??
+    // Groq: "attempted to call tool 'xxx' which was not in request.tools"
+    raw.match(/attempted to call tool\s+["']?([a-z0-9_-]+)["']?\s+which was not in/i);
   if (unknownTool?.[1]) {
     const rewritten = formatSandboxToolPolicyBlockedMessage({
       cfg: opts?.cfg,


### PR DESCRIPTION
## Summary

When using `groq/meta-llama/llama-4-scout-17b-16e-instruct` (and potentially other Groq-hosted models), the model occasionally hallucinates a tool name that was not declared in the request. Groq's server-side validation then returns an error in the format:

```
tool call validation failed: attempted to call tool 'gog' which was not in request.tools
```

The existing `unknownTool` regex patterns in `formatAssistantErrorText` only match:
- `unknown tool: 'xxx'`
- `tool 'xxx' not found` / `tool 'xxx' is not available`

They did **not** match the Groq-specific format, so the tool name was never extracted and the sandbox tool policy blocked message was never surfaced (for sandboxed sessions).

This PR adds a third pattern to cover Groq's error format.

## Test plan

- [ ] Reproduce with `groq/meta-llama/llama-4-scout-17b-16e-instruct` hallucinating a tool name — confirm the error is now parsed and the tool name extracted correctly
- [ ] Verify existing `unknownTool` pattern tests still pass (`pnpm test`)