### PR TITLE
fix(mattermost): read replyTo param in plugin handleAction send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory flush: forward `memoryFlushWritePath` through `runEmbeddedPiAgent` so memory-triggered flush turns keep the append-only write guard without aborting before tool setup. Follows up on #38574. (#41761) Thanks @frankekn.
 - CI/CodeQL Swift toolchain: select Xcode 26.1 before installing Swift build tools so the CodeQL Swift job uses Swift tools 6.2 on `macos-latest`. (#41787) thanks @BunsDev.
 - Sandbox/subagents: pass the real configured workspace through `sessions_spawn` inheritance when a parent agent runs in a copied-workspace sandbox, so child `/agent` mounts point at the configured workspace instead of the parent sandbox copy. (#40757) Thanks @dsantoreis.
+- Mattermost/plugin send actions: normalize direct `replyTo` fallback handling so threaded plugin sends trim blank IDs and reuse the correct reply target again. (#41176) Thanks @hnykda.
 
 ## 2026.3.8
 

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -214,6 +214,57 @@ describe("mattermostPlugin", () => {
       ]);
       expect(result?.details).toEqual({});
     });
+
+    it("maps replyTo to replyToId for send actions", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: {
+          to: "channel:CHAN1",
+          message: "hello",
+          replyTo: "post-root",
+        },
+        cfg,
+        accountId: "default",
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          accountId: "default",
+          replyToId: "post-root",
+        }),
+      );
+    });
+
+    it("falls back to trimmed replyTo when replyToId is blank", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: {
+          to: "channel:CHAN1",
+          message: "hello",
+          replyToId: "   ",
+          replyTo: " post-root ",
+        },
+        cfg,
+        accountId: "default",
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          accountId: "default",
+          replyToId: "post-root",
+        }),
+      );
+    });
   });
 
   describe("outbound", () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -157,15 +157,9 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     }
 
     const message = typeof params.message === "string" ? params.message : "";
-    // The message tool passes the reply target as "replyTo", not "replyToId".
-    // handleSendAction reads params.replyTo into a local var but never writes
-    // it back, so the plugin handler must check both property names.
-    const replyToId =
-      typeof params.replyToId === "string"
-        ? params.replyToId
-        : typeof params.replyTo === "string"
-          ? params.replyTo
-          : undefined;
+    // Match the shared runner semantics: trim empty reply IDs away before
+    // falling back from replyToId to replyTo on direct plugin calls.
+    const replyToId = readMattermostReplyToId(params);
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =
@@ -208,6 +202,18 @@ const meta = {
   order: 65,
   quickstartAllowFrom: true,
 } as const;
+
+function readMattermostReplyToId(params: Record<string, unknown>): string | undefined {
+  const readNormalizedValue = (value: unknown) => {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  };
+
+  return readNormalizedValue(params.replyToId) ?? readNormalizedValue(params.replyTo);
+}
 
 function normalizeAllowEntry(entry: string): string {
   return entry

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -157,7 +157,15 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     }
 
     const message = typeof params.message === "string" ? params.message : "";
-    const replyToId = typeof params.replyToId === "string" ? params.replyToId : undefined;
+    // The message tool passes the reply target as "replyTo", not "replyToId".
+    // handleSendAction reads params.replyTo into a local var but never writes
+    // it back, so the plugin handler must check both property names.
+    const replyToId =
+      typeof params.replyToId === "string"
+        ? params.replyToId
+        : typeof params.replyTo === "string"
+          ? params.replyTo
+          : undefined;
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =


### PR DESCRIPTION
## Summary

The Mattermost plugin's `handleAction` reads `params.replyToId` for the send action, but the message tool passes the reply target as `params.replyTo`. This causes `message(replyTo=<id>)` to create top-level posts (`root_id: ""`) instead of threaded replies.

## Root cause

1. Message tool sends `replyTo` parameter
2. `handleSendAction` (message-action-runner.ts) reads `params.replyTo` into a local variable `replyToId`
3. `tryHandleWithPluginAction` is called, passing the raw `params` object to the plugin
4. Mattermost plugin's `handleAction` reads `params.replyToId` — which is `undefined` because the property is named `replyTo`, not `replyToId`
5. `sendMessageMattermost` is called with `replyToId: undefined` → post created with empty `root_id`

The core path (non-plugin) works correctly because `executeSendAction` receives the extracted `replyToId` as a separate argument.

## Fix

Check both `params.replyToId` and `params.replyTo` in the Mattermost plugin's send handler.

## Testing

Tested on a self-hosted v2026.3.8 instance:
- Before fix: `message(replyTo=<id>)` → `root_id: ""` (top-level post)
- After fix: `message(replyTo=<id>)` → `root_id: <id>` (threaded reply, confirmed via API and UI)

Fixes #40924