### PR TITLE
fix: guard estimateMessageCharsCached against null/undefined messages

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
@@ -1,0 +1,92 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
+import {
+  createMessageCharEstimateCache,
+  estimateContextChars,
+  estimateMessageCharsCached,
+} from "./tool-result-char-estimator.js";
+
+function makeUser(text: string): AgentMessage {
+  return castAgentMessage({
+    role: "user",
+    content: text,
+    timestamp: Date.now(),
+  });
+}
+
+describe("estimateMessageCharsCached", () => {
+  it("returns a positive estimate for a valid message", () => {
+    const cache = createMessageCharEstimateCache();
+    const msg = makeUser("hello world");
+    expect(estimateMessageCharsCached(msg, cache)).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for null", () => {
+    const cache = createMessageCharEstimateCache();
+    expect(estimateMessageCharsCached(null as unknown as AgentMessage, cache)).toBe(0);
+  });
+
+  it("returns 0 for undefined", () => {
+    const cache = createMessageCharEstimateCache();
+    expect(estimateMessageCharsCached(undefined as unknown as AgentMessage, cache)).toBe(0);
+  });
+
+  it("returns 0 for a non-object primitive", () => {
+    const cache = createMessageCharEstimateCache();
+    expect(estimateMessageCharsCached(42 as unknown as AgentMessage, cache)).toBe(0);
+  });
+
+  it("caches the estimate on second call", () => {
+    const cache = createMessageCharEstimateCache();
+    const msg = makeUser("cached test");
+    const first = estimateMessageCharsCached(msg, cache);
+    const second = estimateMessageCharsCached(msg, cache);
+    expect(first).toBe(second);
+    expect(first).toBeGreaterThan(0);
+  });
+});
+
+describe("estimateContextChars", () => {
+  it("sums estimates for valid messages", () => {
+    const cache = createMessageCharEstimateCache();
+    const messages = [makeUser("one"), makeUser("two")];
+    const total = estimateContextChars(messages, cache);
+    expect(total).toBeGreaterThan(0);
+  });
+
+  it("skips null entries without crashing", () => {
+    const cache = createMessageCharEstimateCache();
+    const messages = [
+      makeUser("valid"),
+      null as unknown as AgentMessage,
+      makeUser("also valid"),
+    ];
+    const total = estimateContextChars(messages, cache);
+    expect(total).toBeGreaterThan(0);
+  });
+
+  it("skips undefined entries without crashing", () => {
+    const cache = createMessageCharEstimateCache();
+    const messages = [
+      undefined as unknown as AgentMessage,
+      makeUser("valid"),
+    ];
+    const total = estimateContextChars(messages, cache);
+    expect(total).toBeGreaterThan(0);
+  });
+
+  it("handles an entirely null/undefined array", () => {
+    const cache = createMessageCharEstimateCache();
+    const messages = [
+      null as unknown as AgentMessage,
+      undefined as unknown as AgentMessage,
+    ];
+    expect(estimateContextChars(messages, cache)).toBe(0);
+  });
+
+  it("handles an empty array", () => {
+    const cache = createMessageCharEstimateCache();
+    expect(estimateContextChars([], cache)).toBe(0);
+  });
+});

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
@@ -57,31 +57,21 @@ describe("estimateContextChars", () => {
 
   it("skips null entries without crashing", () => {
     const cache = createMessageCharEstimateCache();
-    const messages = [
-      makeUser("valid"),
-      null as unknown as AgentMessage,
-      makeUser("also valid"),
-    ];
+    const messages = [makeUser("valid"), null as unknown as AgentMessage, makeUser("also valid")];
     const total = estimateContextChars(messages, cache);
     expect(total).toBeGreaterThan(0);
   });
 
   it("skips undefined entries without crashing", () => {
     const cache = createMessageCharEstimateCache();
-    const messages = [
-      undefined as unknown as AgentMessage,
-      makeUser("valid"),
-    ];
+    const messages = [undefined as unknown as AgentMessage, makeUser("valid")];
     const total = estimateContextChars(messages, cache);
     expect(total).toBeGreaterThan(0);
   });
 
   it("handles an entirely null/undefined array", () => {
     const cache = createMessageCharEstimateCache();
-    const messages = [
-      null as unknown as AgentMessage,
-      undefined as unknown as AgentMessage,
-    ];
+    const messages = [null as unknown as AgentMessage, undefined as unknown as AgentMessage];
     expect(estimateContextChars(messages, cache)).toBe(0);
   });
 

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -145,6 +145,9 @@ export function estimateMessageCharsCached(
   msg: AgentMessage,
   cache: MessageCharEstimateCache,
 ): number {
+  if (msg == null || typeof msg !== "object") {
+    return 0;
+  }
   const hit = cache.get(msg);
   if (hit !== undefined) {
     return hit;
@@ -158,7 +161,9 @@ export function estimateContextChars(
   messages: AgentMessage[],
   cache: MessageCharEstimateCache,
 ): number {
-  return messages.reduce((sum, msg) => sum + estimateMessageCharsCached(msg, cache), 0);
+  return messages
+    .filter((m): m is AgentMessage => m != null)
+    .reduce((sum, msg) => sum + estimateMessageCharsCached(msg, cache), 0);
 }
 
 export function invalidateMessageCharsCacheEntry(


### PR DESCRIPTION
## Summary

- Problem: After upgrading to v2026.3.7, orphaned `null`/`undefined` entries can appear in the session message array, causing `TypeError: Invalid value used as weak map key` in `estimateMessageCharsCached()` and crashing active sessions.
- Why it matters: Sessions become unrecoverable — users must `/clear` or create new sessions.
- What changed: Added null/type guards in `estimateMessageCharsCached()` and a `.filter()` in `estimateContextChars()` to skip null entries before reduce.
- What did NOT change (scope boundary): No changes to compaction logic itself, message array construction, or any other estimator functions.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related #35146 (null guard for thinking/text char estimation by @Sid-Qin)
- Related #35143 (null guard for thinking-tag promotion by @Sid-Qin)

## User-visible / Behavior Changes

None — defensive guard only. Valid inputs produce identical output. Invalid (null/undefined) inputs now return 0 instead of crashing.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Debian 12, kernel 6.1.0)
- Runtime: Node.js v22.22.0
- OpenClaw: v2026.3.7
- Model/provider: Anthropic Claude (but provider-independent)

### Steps

1. Run a long session on v2026.3.7 that triggers auto-compaction
2. After compaction, orphaned null/undefined entries remain in the message array
3. Next call to `estimateContextChars()` crashes with `TypeError: Invalid value used as weak map key`

### Expected

- Compaction completes, session continues normally

### Actual

- `TypeError` crash in `estimateMessageCharsCached` — session becomes unrecoverable

```
TypeError: Invalid value used as weak map key
    at WeakMap.get (<anonymous>)
    at estimateMessageCharsCached (compact-B247y5Qt.js:15277)
    at compact-B247y5Qt.js:15285
    at Array.reduce (<anonymous>)
    at estimateContextChars (compact-B247y5Qt.js:15285)
```

## Evidence

- [x] Failing test/log before + passing after

Test file `tool-result-char-estimator.test.ts` added with 9 test cases covering null, undefined, primitive, mixed-array, and empty-array inputs.

## Human Verification (required)

- Verified scenarios: Applied as a production hotfix to `dist/compact-B247y5Qt.js` on v2026.3.7 — sessions stable for 2+ hours after patching, no more compaction crashes.
- Edge cases checked: null, undefined, primitive (number), fully-null array, empty array, mixed array with valid + null entries.
- What you did NOT verify: Did not run full `pnpm build && pnpm check && pnpm test` (source-level fix verified against production runtime behavior).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit.
- Known bad symptoms: If reverted, sessions on v2026.3.7+ with orphaned null messages will crash during char estimation.

## Risks and Mitigations

- Risk: The `.filter()` in `estimateContextChars` creates a new array on each call.
  - Mitigation: This function is not in a hot loop — called during compaction threshold checks, not per-token. Allocation cost is negligible.

---

> 🤖 This PR was drafted with AI assistance (OpenClaw/Claude).
> Testing: Production-verified hotfix + new unit tests.
> The author understands and can explain all changes.
