### PR TITLE
fix(acp): propagate setSessionMode gateway errors to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded runner: bound compaction retry waiting and drain embedded runs during SIGUSR1 restart so session lanes recover instead of staying blocked behind compaction. (#40324) thanks @cgdusek.
 - ACP/sessions.patch: allow `spawnedBy` and `spawnDepth` lineage fields on ACP session keys so `sessions_spawn` with `runtime: "acp"` no longer fails during child-session setup. Fixes #40971. (#40995) thanks @xaeon2026.
 - ACP/stop reason mapping: resolve gateway chat `state: "error"` completions as ACP `end_turn` instead of `refusal` so transient backend failures are not surfaced as deliberate refusals. (#41187) thanks @pejmanjohn.
+- ACP/setSessionMode: propagate gateway `sessions.patch` failures back to ACP clients so rejected mode changes no longer return silent success. (#41185) thanks @pejmanjohn.
 
 ## 2026.3.8
 

--- a/src/acp/translator.set-session-mode.test.ts
+++ b/src/acp/translator.set-session-mode.test.ts
@@ -1,0 +1,61 @@
+import type { SetSessionModeRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+function createSetSessionModeRequest(modeId: string): SetSessionModeRequest {
+  return {
+    sessionId: "session-1",
+    modeId,
+  } as unknown as SetSessionModeRequest;
+}
+
+function createAgentWithSession(request: GatewayClient["request"]) {
+  const sessionStore = createInMemorySessionStore();
+  sessionStore.createSession({
+    sessionId: "session-1",
+    sessionKey: "agent:main:main",
+    cwd: "/tmp",
+  });
+  return new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+    sessionStore,
+  });
+}
+
+describe("acp setSessionMode", () => {
+  it("setSessionMode propagates gateway error", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("gateway rejected mode change");
+    }) as GatewayClient["request"];
+    const agent = createAgentWithSession(request);
+
+    await expect(agent.setSessionMode(createSetSessionModeRequest("high"))).rejects.toThrow(
+      "gateway rejected mode change",
+    );
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      thinkingLevel: "high",
+    });
+  });
+
+  it("setSessionMode succeeds when gateway accepts", async () => {
+    const request = vi.fn(async () => ({ ok: true })) as GatewayClient["request"];
+    const agent = createAgentWithSession(request);
+
+    await expect(agent.setSessionMode(createSetSessionModeRequest("low"))).resolves.toEqual({});
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      thinkingLevel: "low",
+    });
+  });
+
+  it("setSessionMode returns early for empty modeId", async () => {
+    const request = vi.fn(async () => ({ ok: true })) as GatewayClient["request"];
+    const agent = createAgentWithSession(request);
+
+    await expect(agent.setSessionMode(createSetSessionModeRequest(""))).resolves.toEqual({});
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -256,6 +256,7 @@ export class AcpGatewayAgent implements Agent {
       this.log(`setSessionMode: ${session.sessionId} -> ${params.modeId}`);
     } catch (err) {
       this.log(`setSessionMode error: ${String(err)}`);
+      throw err;
     }
     return {};
   }


### PR DESCRIPTION
## Summary

- **Problem:** `setSessionMode` catches gateway errors silently, logs them, and returns success — the IDE never learns the mode change failed
- **Why it matters:** Users switch thinking modes in their IDE, the UI shows success, but the agent keeps responding at the old level. No error, no feedback — invisible misconfiguration
- **What changed:** Added `throw err` in the existing catch block so gateway errors propagate to the ACP client while preserving server-side error logging
- **What did NOT change:** Success path, empty modeId early-return, and logging behavior are all preserved. The only behavioral change is that errors now propagate instead of being swallowed.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Related: [ACP protocol gap analysis](https://super-agentic.ai/resources/super-posts/openclaw-acp-what-coding-agent-users-need-to-know-about-protocol-gaps)

## User-visible / Behavior Changes

- ACP clients (Zed, etc.) will now receive an error when a mode change is rejected by the gateway, instead of silent success

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4 (arm64)
- Runtime: Node v24.13.0

### Steps

1. Create an ACP session via `openclaw acp`
2. Call `setSessionMode` with a mode the gateway rejects
3. Observe the response

### Expected

- Client receives an error indicating the mode change failed

### Actual (before fix)

- Client receives `{}` (empty success response), mode silently unchanged

## Evidence

- [x] Failing test/log before + passing after
- New test file: `src/acp/translator.set-session-mode.test.ts` (3 tests: error propagation, success path, empty modeId guard)
- All 124 existing ACP tests pass with no regressions

## Human Verification

- Verified: All ACP unit tests pass (`pnpm vitest run src/acp/` — 124 tests, 16 files)
- Edge cases: Empty modeId (no-op), valid mode (success), gateway rejection (error propagates with logging preserved)
- Not verified: End-to-end with a live ACP client (Zed) — tested via unit tests only

## AI-Assisted 🤖

- Built with Codex CLI (code generation) + human review
- Fully tested (unit tests written and passing)
- Degree of change: **one line added** — `throw err` in existing catch block

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — clients that did not handle errors before will now see them, which is the correct behavior per ACP spec
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- Revert this single commit
- Known bad symptoms: If a gateway legitimately returns errors that should be suppressed (none known), clients would see unexpected errors

## Risks and Mitigations

- **Risk:** Clients that were not handling setSessionMode errors could surface unexpected errors
  - **Mitigation:** ACP spec expects clients to handle errors on any RPC call. The error was always there — it was just hidden.