### PR TITLE
fix(acp): map error states to end_turn instead of unconditional refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Context engine/tests: add bundled-registry regression coverage for cross-chunk resolution, plugin-sdk re-exports, and concurrent chunk registration. (#40460) thanks @dsantoreis.
 - Agents/embedded runner: bound compaction retry waiting and drain embedded runs during SIGUSR1 restart so session lanes recover instead of staying blocked behind compaction. (#40324) thanks @cgdusek.
 - ACP/sessions.patch: allow `spawnedBy` and `spawnDepth` lineage fields on ACP session keys so `sessions_spawn` with `runtime: "acp"` no longer fails during child-session setup. Fixes #40971. (#40995) thanks @xaeon2026.
+- ACP/stop reason mapping: resolve gateway chat `state: "error"` completions as ACP `end_turn` instead of `refusal` so transient backend failures are not surfaced as deliberate refusals. (#41187) thanks @pejmanjohn.
 
 ## 2026.3.8
 

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -1,0 +1,111 @@
+import type { PromptRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import type { EventFrame } from "../gateway/protocol/index.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+type PendingPromptHarness = {
+  agent: AcpGatewayAgent;
+  promptPromise: ReturnType<AcpGatewayAgent["prompt"]>;
+  runId: string;
+};
+
+async function createPendingPromptHarness(): Promise<PendingPromptHarness> {
+  const sessionId = "session-1";
+  const sessionKey = "agent:main:main";
+
+  let runId: string | undefined;
+  const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === "chat.send") {
+      runId = params?.idempotencyKey as string | undefined;
+      return new Promise<never>(() => {});
+    }
+    return {};
+  }) as GatewayClient["request"];
+
+  const sessionStore = createInMemorySessionStore();
+  sessionStore.createSession({
+    sessionId,
+    sessionKey,
+    cwd: "/tmp",
+  });
+
+  const agent = new AcpGatewayAgent(
+    createAcpConnection(),
+    createAcpGateway(request as unknown as GatewayClient["request"]),
+    { sessionStore },
+  );
+  const promptPromise = agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: "hello" }],
+    _meta: {},
+  } as unknown as PromptRequest);
+
+  await vi.waitFor(() => {
+    expect(runId).toBeDefined();
+  });
+
+  return {
+    agent,
+    promptPromise,
+    runId: runId!,
+  };
+}
+
+function createChatEvent(payload: Record<string, unknown>): EventFrame {
+  return {
+    type: "event",
+    event: "chat",
+    payload,
+  } as EventFrame;
+}
+
+describe("acp translator stop reason mapping", () => {
+  it("error state resolves as end_turn, not refusal", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "error",
+        errorMessage: "gateway timeout",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("error state with no errorMessage resolves as end_turn", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "error",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("aborted state resolves as cancelled", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "aborted",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+  });
+});

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -473,7 +473,11 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
     if (state === "error") {
-      this.finishPrompt(pending.sessionId, pending, "refusal");
+      // ACP has no explicit "server_error" stop reason.  Use "end_turn" so clients
+      // do not treat transient backend errors (timeouts, rate-limits) as deliberate
+      // refusals.  TODO: when ChatEventSchema gains a structured errorKind field
+      // (e.g. "refusal" | "timeout" | "rate_limit"), use it to distinguish here.
+      this.finishPrompt(pending.sessionId, pending, "end_turn");
     }
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** `handleChatEvent` maps all gateway `"error"` states to ACP stop reason `"refusal"`. This is semantically wrong — `"refusal"` means the agent deliberately refused (e.g., safety filter), but most errors are transient failures (timeouts, rate limits, API crashes)
- **Why it matters:** Users see "agent refused to respond" in their IDE when the actual problem was a timeout or API error — confusing UX that makes users second-guess their prompts instead of retrying
- **What changed:** Error states now resolve as `"end_turn"` instead of `"refusal"`. Added a TODO noting that proper refusal detection requires a structured `errorKind` field in `ChatEventSchema` (which does not currently exist)
- **What did NOT change:** `"final"` → `"end_turn"/"max_tokens"` mapping, `"aborted"` → `"cancelled"` mapping, delta event handling

### Why not detect refusals heuristically?

The gateway error event schema (`ChatEventSchema`) only carries `errorMessage` (free text from `formatForLog(error)`). There are no structured fields like `reason` or `errorCode` — the schema enforces `additionalProperties: false`. Heuristic substring matching on free text is unreliable and would reintroduce the false-positive problem this PR fixes. The correct path is adding a structured `errorKind` field upstream.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Related: [ACP protocol gap analysis](https://super-agentic.ai/resources/super-posts/openclaw-acp-what-coding-agent-users-need-to-know-about-protocol-gaps)

## User-visible / Behavior Changes

- Gateway errors now report `end_turn` instead of `refusal` to ACP clients

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4 (arm64)
- Runtime: Node v24.13.0

### Steps

1. Start an ACP session via `openclaw acp`
2. Trigger a gateway error (e.g., kill gateway mid-request, misconfigure model)
3. Observe the stop reason reported to the client

### Expected

- Client receives `end_turn`

### Actual (before fix)

- Client receives `refusal`

## Evidence

- [x] Failing test/log before + passing after
- New test file: `src/acp/translator.stop-reason.test.ts` (3 tests: error→end_turn, bare error→end_turn, aborted→cancelled regression guard)
- All 124 existing ACP tests pass with no regressions

## Human Verification

- Verified: All ACP unit tests pass (`pnpm vitest run src/acp/` — 124 tests, 16 files)
- Verified: `ChatEventSchema` uses `additionalProperties: false` — structured error fields cannot exist on error events, confirming heuristic matching would be dead code
- Not verified: End-to-end with a live ACP client (Zed)

## AI-Assisted 🤖

- Initial code generation via Codex CLI, significantly revised during human review
- Testing: fully tested, 3 focused unit tests

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — changes stop reason for errors from `refusal` to `end_turn`. Clients should handle all stop reason values.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- Revert this single commit

## Risks and Mitigations

- **Risk:** If a genuine content-filter refusal surfaces through the error path, it will now report `end_turn` instead of `refusal`
  - **Mitigation:** The gateway does not currently emit structured refusal signals on error events. When `ChatEventSchema` gains an `errorKind` field, this mapping should be updated (noted in TODO comment). Until then, `end_turn` is strictly more correct than the unconditional `refusal` that was there before.