### PR TITLE
fix(telegram): accept negative group/supergroup IDs in groupAllowFrom

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -2,14 +2,80 @@ import { describe, expect, it } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
 describe("normalizeAllowFrom", () => {
-  it("accepts sender IDs and keeps negative chat IDs invalid", () => {
-    const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
+  it("accepts positive sender IDs", () => {
+    const result = normalizeAllowFrom(["745123456", "123"]);
+
+    expect(result).toEqual({
+      entries: ["745123456", "123"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("accepts negative Telegram group/supergroup IDs (regression #40444)", () => {
+    const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456"]);
+
+    expect(result).toEqual({
+      entries: ["-1001234567890", "-100999", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("rejects non-numeric entries", () => {
+    const result = normalizeAllowFrom(["@someone", "abc", "12.34", ""]);
+
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@someone", "abc", "12.34"],
+    });
+  });
+
+  it("handles wildcard entry", () => {
+    const result = normalizeAllowFrom(["*", "745123456"]);
 
     expect(result).toEqual({
       entries: ["745123456"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("strips telegram/tg prefix before validation", () => {
+    const result = normalizeAllowFrom(["telegram:123", "tg:-100999", "TG:456"]);
+
+    expect(result).toEqual({
+      entries: ["123", "-100999", "456"],
       hasWildcard: false,
       hasEntries: true,
-      invalidEntries: ["-1001234567890", "-100999", "@someone"],
+      invalidEntries: [],
+    });
+  });
+
+  it("handles numeric input alongside string input", () => {
+    const result = normalizeAllowFrom([745123456, -1001234567890, "999"]);
+
+    expect(result).toEqual({
+      entries: ["745123456", "-1001234567890", "999"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: [],
+    });
+  });
+
+  it("returns empty state for undefined input", () => {
+    const result = normalizeAllowFrom(undefined);
+
+    expect(result).toEqual({
+      entries: [],
+      hasWildcard: false,
+      hasEntries: false,
+      invalidEntries: [],
     });
   });
 });

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
## Summary

- Fix `normalizeAllowFrom()` regex from `^\d+$` to `^-?\d+$` to accept negative Telegram group/supergroup chat IDs
- Telegram supergroup IDs are always negative (e.g. `-1001234567890`), and anonymous admin messages use the group's negative ID as the sender
- The previous regex silently rejected all negative IDs, making `groupAllowFrom` completely non-functional for group-level filtering

## Test plan

- [x] Updated `bot-access.test.ts` with 7 test cases covering: positive IDs, negative IDs, non-numeric rejection, wildcard, prefix stripping, numeric input, and undefined input
- [x] Existing `allow-from.test.ts` (8 tests) still pass
- [x] `pnpm check` passes

Fixes #40444