### PR TITLE
feat(cron): hierarchical job store — one file per cron job in cron/jobs/ directory

### DIFF
--- a/src/cron/store.dir.test.ts
+++ b/src/cron/store.dir.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for the directory-based cron job store.
+ * Related: #37630
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  hasCronJobsDir,
+  isDisabledFilename,
+  jobIdFromFilename,
+  loadCronStoreDir,
+  migrateCronStoreToDir,
+  removeCronJobFile,
+  saveCronJobFile,
+  saveCronStore,
+  slugifyCronJobName,
+} from "./store.js";
+import type { CronJob } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "oc-cron-test-"));
+}
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: "test-job",
+    name: "Test Job",
+    schedule: { kind: "every", everyMs: 3600000 },
+    payload: { kind: "systemEvent", text: "hello" },
+    sessionTarget: "main",
+    enabled: true,
+    createdAtMs: Date.now(),
+    updatedAtMs: Date.now(),
+    state: "idle",
+    ...overrides,
+  } as CronJob;
+}
+
+// ---------------------------------------------------------------------------
+// Slug / filename helpers
+// ---------------------------------------------------------------------------
+
+describe("slugifyCronJobName", () => {
+  it("lowercases and replaces spaces with dashes", () => {
+    expect(slugifyCronJobName("Daily Brew")).toBe("daily-brew");
+  });
+
+  it("collapses multiple separators", () => {
+    expect(slugifyCronJobName("SEO -- Report!")).toBe("seo-report");
+  });
+
+  it("falls back to raw id for non-slugifiable input", () => {
+    expect(slugifyCronJobName("---")).toBe("---");
+  });
+});
+
+describe("jobIdFromFilename", () => {
+  it("strips .json extension", () => {
+    expect(jobIdFromFilename("seo-report.json")).toBe("seo-report");
+  });
+
+  it("strips _disabled. compound prefix", () => {
+    expect(jobIdFromFilename("_disabled.seo-report.json")).toBe("seo-report");
+  });
+
+  it("strips disabled. prefix", () => {
+    expect(jobIdFromFilename("disabled.seo-report.json")).toBe("seo-report");
+  });
+
+  it("strips single _ prefix", () => {
+    expect(jobIdFromFilename("_seo-report.json")).toBe("seo-report");
+  });
+});
+
+describe("isDisabledFilename", () => {
+  it("returns true for _ prefix", () => {
+    expect(isDisabledFilename("_daily-brew.json")).toBe(true);
+  });
+
+  it("returns true for disabled. prefix", () => {
+    expect(isDisabledFilename("disabled.daily-brew.json")).toBe(true);
+  });
+
+  it("returns false for normal file", () => {
+    expect(isDisabledFilename("daily-brew.json")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasCronJobsDir
+// ---------------------------------------------------------------------------
+
+describe("hasCronJobsDir", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("returns false when jobs/ does not exist", async () => {
+    expect(await hasCronJobsDir(dir)).toBe(false);
+  });
+
+  it("returns true when jobs/ exists", async () => {
+    fs.mkdirSync(path.join(dir, "jobs"));
+    expect(await hasCronJobsDir(dir)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadCronStoreDir
+// ---------------------------------------------------------------------------
+
+describe("loadCronStoreDir", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("returns empty store when jobs/ does not exist", async () => {
+    const store = await loadCronStoreDir(dir);
+    expect(store.jobs).toHaveLength(0);
+  });
+
+  it("loads a single job file", async () => {
+    const jobsDir = path.join(dir, "jobs");
+    fs.mkdirSync(jobsDir);
+    const job = makeJob({ id: "my-job", name: "My Job" });
+    fs.writeFileSync(path.join(jobsDir, "my-job.json"), JSON.stringify(job));
+    const store = await loadCronStoreDir(dir);
+    expect(store.jobs).toHaveLength(1);
+    expect(store.jobs[0].id).toBe("my-job");
+  });
+
+  it("infers id from filename when absent in file", async () => {
+    const jobsDir = path.join(dir, "jobs");
+    fs.mkdirSync(jobsDir);
+    const { id: _id, ...jobWithoutId } = makeJob({ name: "Infer Me" });
+    fs.writeFileSync(path.join(jobsDir, "infer-me.json"), JSON.stringify(jobWithoutId));
+    const store = await loadCronStoreDir(dir);
+    expect(store.jobs[0].id).toBe("infer-me");
+  });
+
+  it("marks _ prefixed files as enabled: false", async () => {
+    const jobsDir = path.join(dir, "jobs");
+    fs.mkdirSync(jobsDir);
+    const job = makeJob({ id: "daily-brew", enabled: true });
+    fs.writeFileSync(path.join(jobsDir, "_daily-brew.json"), JSON.stringify(job));
+    const store = await loadCronStoreDir(dir);
+    expect(store.jobs[0].enabled).toBe(false);
+  });
+
+  it("marks disabled. prefixed files as enabled: false", async () => {
+    const jobsDir = path.join(dir, "jobs");
+    fs.mkdirSync(jobsDir);
+    const job = makeJob({ id: "seo-report", enabled: true });
+    fs.writeFileSync(path.join(jobsDir, "disabled.seo-report.json"), JSON.stringify(job));
+    const store = await loadCronStoreDir(dir);
+    expect(store.jobs[0].enabled).toBe(false);
+  });
+
+  it("ignores non-.json files", async () => {
+    const jobsDir = path.join(dir, "jobs");
+    fs.mkdirSync(jobsDir);
+    fs.writeFileSync(path.join(jobsDir, "README.md"), "# notes");
+    fs.writeFileSync(path.join(jobsDir, "my-job.json"), JSON.stringify(makeJob()));
+    const store = await loadCronStoreDir(dir);
+    expect(store.jobs).toHaveLength(1);
+  });
+
+  it("throws on malformed JSON", async () => {
+    const jobsDir = path.join(dir, "jobs");
+    fs.mkdirSync(jobsDir);
+    fs.writeFileSync(path.join(jobsDir, "bad.json"), "{ not json }}}");
+    await expect(loadCronStoreDir(dir)).rejects.toThrow(/Failed to parse/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveCronJobFile / removeCronJobFile
+// ---------------------------------------------------------------------------
+
+describe("saveCronJobFile", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("creates jobs/ directory and writes file", async () => {
+    const job = makeJob({ id: "my-job", name: "My Job" });
+    await saveCronJobFile(dir, job);
+    const filePath = path.join(dir, "jobs", "my-job.json");
+    expect(fs.existsSync(filePath)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    expect(parsed.id).toBe("my-job");
+  });
+
+  it("slugifies the job name for the filename", async () => {
+    const job = makeJob({ id: "brew-1", name: "Daily Brew" });
+    await saveCronJobFile(dir, job);
+    expect(fs.existsSync(path.join(dir, "jobs", "daily-brew.json"))).toBe(true);
+  });
+});
+
+describe("removeCronJobFile", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("removes the correct job file", async () => {
+    const job = makeJob({ id: "my-job", name: "My Job" });
+    await saveCronJobFile(dir, job);
+    const removed = await removeCronJobFile(dir, "my-job");
+    expect(removed).toBe(true);
+    expect(fs.existsSync(path.join(dir, "jobs", "my-job.json"))).toBe(false);
+  });
+
+  it("returns false when job file not found", async () => {
+    fs.mkdirSync(path.join(dir, "jobs"));
+    expect(await removeCronJobFile(dir, "nonexistent")).toBe(false);
+  });
+
+  it("removes disabled-prefixed files by id", async () => {
+    const jobsDir = path.join(dir, "jobs");
+    fs.mkdirSync(jobsDir);
+    const job = makeJob({ id: "daily-brew" });
+    fs.writeFileSync(path.join(jobsDir, "_daily-brew.json"), JSON.stringify(job));
+    const removed = await removeCronJobFile(dir, "daily-brew");
+    expect(removed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// migrateCronStoreToDir
+// ---------------------------------------------------------------------------
+
+describe("migrateCronStoreToDir", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("splits jobs.json into individual files", async () => {
+    const storePath = path.join(dir, "jobs.json");
+    const jobs = [
+      makeJob({ id: "job-a", name: "Job A" }),
+      makeJob({ id: "job-b", name: "Job B" }),
+    ];
+    await saveCronStore(storePath, { version: 1, jobs });
+    const result = await migrateCronStoreToDir(storePath, dir);
+    expect(result.migrated).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(fs.existsSync(path.join(dir, "jobs", "job-a.json"))).toBe(true);
+    expect(fs.existsSync(path.join(dir, "jobs", "job-b.json"))).toBe(true);
+  });
+
+  it("returns migrated=0 for empty store", async () => {
+    const storePath = path.join(dir, "jobs.json");
+    await saveCronStore(storePath, { version: 1, jobs: [] });
+    const result = await migrateCronStoreToDir(storePath, dir);
+    expect(result.migrated).toBe(0);
+  });
+});

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import JSON5 from "json5";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { CONFIG_DIR } from "../utils.js";
-import type { CronStoreFile } from "./types.js";
+import type { CronJob, CronStoreFile } from "./types.js";
 
 export const DEFAULT_CRON_DIR = path.join(CONFIG_DIR, "cron");
 export const DEFAULT_CRON_STORE_PATH = path.join(DEFAULT_CRON_DIR, "jobs.json");
+/** Directory-based store: one JSON file per job */
+export const DEFAULT_CRON_JOBS_DIR = path.join(DEFAULT_CRON_DIR, "jobs");
 const serializedStoreCache = new Map<string, string>();
 
 export function resolveCronStorePath(storePath?: string) {
@@ -128,4 +130,171 @@ async function renameWithRetry(src: string, dest: string): Promise<void> {
       throw err;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Directory-based store (one file per job)
+// ---------------------------------------------------------------------------
+
+// Order matters: longest prefix first so "_disabled." is matched before "_"
+const DISABLED_PREFIXES = ["_disabled.", "disabled.", "_"];
+
+/**
+ * Slugify a job name or id for use as a filename (no extension).
+ * Falls back to the raw id when slugification produces an empty string.
+ */
+export function slugifyCronJobName(nameOrId: string): string {
+  const slug = nameOrId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || nameOrId;
+}
+
+/**
+ * Derive job id from a filename (strip extension and disabled prefix).
+ * e.g. "_disabled.seo-report.json" → "seo-report"
+ */
+export function jobIdFromFilename(filename: string): string {
+  let base = path.basename(filename, ".json");
+  for (const prefix of DISABLED_PREFIXES) {
+    if (base.startsWith(prefix)) {
+      base = base.slice(prefix.length);
+      break;
+    }
+  }
+  return base;
+}
+
+/**
+ * Returns true when a filename indicates the job should be disabled.
+ */
+export function isDisabledFilename(filename: string): boolean {
+  const base = path.basename(filename);
+  return DISABLED_PREFIXES.some((p) => base.startsWith(p));
+}
+
+/**
+ * Check whether the directory-based store is active for a given cron dir.
+ * It is active when `<cronDir>/jobs/` exists and is a directory.
+ */
+export async function hasCronJobsDir(cronDir: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(path.join(cronDir, "jobs"));
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Load all jobs from a `jobs/` directory.
+ * Each `.json` file in the directory is one job.
+ * Files prefixed with `_` or `disabled.` are loaded with `enabled: false`.
+ * The `id` field is inferred from the filename when absent in the file.
+ */
+export async function loadCronStoreDir(cronDir: string): Promise<CronStoreFile> {
+  const jobsDir = path.join(cronDir, "jobs");
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(jobsDir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as { code?: unknown })?.code === "ENOENT") {
+      return { version: 1, jobs: [] };
+    }
+    throw err;
+  }
+
+  const jobs: CronJob[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const filePath = path.join(jobsDir, entry.name);
+    let raw: string;
+    try {
+      raw = await fs.promises.readFile(filePath, "utf-8");
+    } catch {
+      continue; // skip unreadable files
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON5.parse(raw);
+    } catch (err) {
+      throw new Error(`Failed to parse cron job file ${filePath}: ${String(err)}`, { cause: err });
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    const job = parsed as Record<string, unknown>;
+    // Infer id from filename when absent
+    if (!job.id) {
+      job.id = jobIdFromFilename(entry.name);
+    }
+    // Apply disabled prefix rule
+    if (isDisabledFilename(entry.name)) {
+      job.enabled = false;
+    }
+    jobs.push(job as never as CronJob);
+  }
+  return { version: 1, jobs };
+}
+
+/**
+ * Write a single job to `<cronDir>/jobs/<slug>.json`.
+ * Creates the directory if needed.
+ */
+export async function saveCronJobFile(cronDir: string, job: CronJob): Promise<void> {
+  const jobsDir = path.join(cronDir, "jobs");
+  await fs.promises.mkdir(jobsDir, { recursive: true, mode: 0o700 });
+  const slug = slugifyCronJobName(job.name ?? job.id);
+  const filePath = path.join(jobsDir, `${slug}.json`);
+  const json = JSON.stringify(job, null, 2);
+  const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
+  await fs.promises.chmod(tmp, 0o600).catch(() => undefined);
+  await renameWithRetry(tmp, filePath);
+  await fs.promises.chmod(filePath, 0o600).catch(() => undefined);
+}
+
+/**
+ * Remove a single job file from `<cronDir>/jobs/`.
+ * Matches by job id (inferred from filename) or exact filename slug.
+ * No-ops when the file does not exist.
+ */
+export async function removeCronJobFile(cronDir: string, jobId: string): Promise<boolean> {
+  const jobsDir = path.join(cronDir, "jobs");
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(jobsDir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    if (jobIdFromFilename(entry.name) === jobId) {
+      await fs.promises.unlink(path.join(jobsDir, entry.name)).catch(() => undefined);
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Migrate `jobs.json` → `jobs/*.json` (one file per job).
+ * Existing `jobs/` directory is created if needed.
+ * Returns the number of jobs migrated.
+ */
+export async function migrateCronStoreToDir(
+  storePath: string,
+  cronDir: string,
+): Promise<{ migrated: number; skipped: number }> {
+  const store = await loadCronStore(storePath);
+  let migrated = 0;
+  let skipped = 0;
+  for (const job of store.jobs) {
+    try {
+      await saveCronJobFile(cronDir, job);
+      migrated++;
+    } catch {
+      skipped++;
+    }
+  }
+  return { migrated, skipped };
 }


### PR DESCRIPTION
Closes #37630

## Summary

Adds a directory-based cron job store: `~/.openclaw/cron/jobs/`, where each `.json` file is a single cron job. The existing `jobs.json` still works unchanged — the directory store is purely opt-in.