### PR TITLE
feat(workspace): lint and auto-fix code fences in markdown at write time

### DIFF
--- a/src/agents/markdown-code-fence-lint.test.ts
+++ b/src/agents/markdown-code-fence-lint.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { lintMarkdownCodeFences } from "./markdown-code-fence-lint.js";
+
+describe("lintMarkdownCodeFences", () => {
+  // ---------------------------------------------------------------------------
+  // Already-correct content — no changes
+  // ---------------------------------------------------------------------------
+
+  it("leaves properly fenced TypeScript unchanged", () => {
+    const md = "## Example\n\n```ts\nconst x = 1;\n```\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toBe(md);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("leaves properly fenced shell unchanged", () => {
+    const md = "```sh\n$ npm install\n```\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toBe(md);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("leaves plain prose unchanged", () => {
+    const md = "This is a sentence. Nothing to fence here.\n\nAnother paragraph.\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toBe(md);
+    expect(changes).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Missing language tag — infer and add
+  // ---------------------------------------------------------------------------
+
+  it("adds language tag to a fence with no language", () => {
+    const md = "```\nconst x = require('foo');\n```\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toMatch(/^```ts\n/);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].description).toMatch(/Added missing language tag `ts`/);
+  });
+
+  it("adds 'sh' tag when fence contains a shell command", () => {
+    const md = "```\nnpm install -g openclaw\n```\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toMatch(/^```sh\n/);
+    expect(changes[0].description).toMatch(/`sh`/);
+  });
+
+  it("adds 'python' tag for Python code", () => {
+    const md = "```\ndef hello():\n    print('hi')\n```\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toMatch(/^```python\n/);
+  });
+
+  it("adds 'json' tag for JSON content", () => {
+    const md = '```\n{"key": "value"}\n```\n';
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toMatch(/^```json\n/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unfenced code detection
+  // ---------------------------------------------------------------------------
+
+  it("wraps unfenced shell command", () => {
+    const md = "Run this:\n\n$ npm install openclaw\n\nDone.\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toContain("```sh\n$ npm install openclaw\n```");
+    expect(changes).toHaveLength(1);
+    expect(changes[0].line).toBe(3);
+  });
+
+  it("wraps unfenced TypeScript", () => {
+    const md = "Add this to your file:\n\nconst x = require('openclaw');\n\nThen restart.\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toContain("```ts\nconst x = require('openclaw');\n```");
+    expect(changes).toHaveLength(1);
+  });
+
+  it("wraps multiple consecutive unfenced code lines as one block", () => {
+    const md = "import foo from 'bar';\nconst x = foo();\nexport default x;\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toMatch(/^```ts\nimport foo/);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].description).toMatch(/3 unfenced/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Warn mode — no modification
+  // ---------------------------------------------------------------------------
+
+  it("warn mode reports changes but does not modify content", () => {
+    const md = "```\nconst x = 1;\n```\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md, { mode: "warn" });
+    expect(fixed).toBe(md); // unchanged
+    expect(changes).toHaveLength(1);
+    expect(changes[0].description).toMatch(/Added missing language tag/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Code inside a fence is not double-fenced
+  // ---------------------------------------------------------------------------
+
+  it("does not modify code-looking lines already inside a fence", () => {
+    const md = "```ts\nimport x from 'y';\nconst z = x();\n```\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toBe(md);
+    expect(changes).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tilde fences
+  // ---------------------------------------------------------------------------
+
+  it("handles tilde fences (~~~) and adds language tag", () => {
+    const md = "~~~\nnpm install\n~~~\n";
+    const { fixed, changes } = lintMarkdownCodeFences(md);
+    expect(fixed).toMatch(/^~~~sh\n/);
+    expect(changes).toHaveLength(1);
+  });
+});

--- a/src/agents/markdown-code-fence-lint.ts
+++ b/src/agents/markdown-code-fence-lint.ts
@@ -1,0 +1,192 @@
+/**
+ * markdown-code-fence-lint.ts
+ *
+ * Lint and auto-fix code fences in markdown content at write time.
+ * Related: #37625
+ *
+ * Design:
+ *  - Detects unfenced code blocks and bare code lines
+ *  - Auto-fixes by wrapping with fenced code blocks (default)
+ *  - Infers language tag when missing from an existing fence
+ *  - Skippable per-call via options
+ */
+
+export interface CodeFenceChange {
+  /** Line number (1-indexed) where change starts */
+  line: number;
+  /** Human-readable description of what was changed */
+  description: string;
+}
+
+export interface CodeFenceLintResult {
+  /** Content after fixes applied (same as input when no changes) */
+  fixed: string;
+  /** List of changes made */
+  changes: CodeFenceChange[];
+}
+
+export interface CodeFenceLintOptions {
+  /**
+   * "fix"  — auto-fix issues (default)
+   * "warn" — return changes list but do not modify content
+   */
+  mode?: "fix" | "warn";
+}
+
+// ---------------------------------------------------------------------------
+// Language inference
+// ---------------------------------------------------------------------------
+
+const SHELL_TOKENS = /^(\$|#!|npm |yarn |pnpm |git |curl |wget |cd |ls |mkdir |rm |cp |mv |cat |echo |export |source |sudo |apt |brew |docker )/;
+const TS_TOKENS = /^(const |let |var |function |class |import |export |interface |type |async |await |=>|@)/;
+const PYTHON_TOKENS = /^(def |import |from |class |print\(|if __name__|async def )/;
+const JSON_PATTERN = /^[{[]/;
+
+function inferLanguage(lines: string[]): string {
+  const sample = lines.slice(0, 5).join("\n");
+  const first = lines[0]?.trimStart() ?? "";
+
+  if (SHELL_TOKENS.test(first)) return "sh";
+  if (TS_TOKENS.test(first)) return "ts";
+  if (PYTHON_TOKENS.test(first)) return "python";
+  if (JSON_PATTERN.test(first) && isLikelyJson(sample)) return "json";
+  return "text";
+}
+
+function isLikelyJson(s: string): boolean {
+  try {
+    JSON.parse(s);
+    return true;
+  } catch {
+    // heuristic fallback: contains "key": pattern
+    return /"[^"]+"\s*:/.test(s);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unfenced code detection heuristics
+// ---------------------------------------------------------------------------
+
+/** Returns true if a line looks like bare code that should be fenced. */
+function looksLikeCode(line: string): boolean {
+  const trimmed = line.trimStart();
+  if (!trimmed) return false;
+
+  // Shell prompt or shebang
+  if (/^(\$ |#!\/|npm |yarn |pnpm |git |curl |wget )/.test(trimmed)) return true;
+
+  // TypeScript / JavaScript
+  if (/^(const |let |var |function |class |import |export |interface |type |async |=>)/.test(trimmed)) return true;
+
+  // Python
+  if (/^(def |from [a-z]|class [A-Z]|print\()/.test(trimmed)) return true;
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Core lint pass
+// ---------------------------------------------------------------------------
+
+export function lintMarkdownCodeFences(
+  content: string,
+  options: CodeFenceLintOptions = {},
+): CodeFenceLintResult {
+  const mode = options.mode ?? "fix";
+  const changes: CodeFenceChange[] = [];
+  const inputLines = content.split("\n");
+  const outputLines: string[] = [];
+
+  let i = 0;
+  let inFence = false;
+  let fenceLang = "";
+  let fenceDelimiter = "";
+
+  while (i < inputLines.length) {
+    const raw = inputLines[i];
+    const trimmed = raw.trimStart();
+
+    // Track fence open/close
+    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})(\w*)/);
+    if (fenceMatch) {
+      if (!inFence) {
+        inFence = true;
+        fenceDelimiter = fenceMatch[1];
+        fenceLang = fenceMatch[2];
+
+        // Fix: missing language tag on opening fence
+        if (!fenceLang) {
+          // Collect the fenced block to infer language
+          const blockLines: string[] = [];
+          let j = i + 1;
+          while (j < inputLines.length) {
+            const inner = inputLines[j].trimStart();
+            if (inner.startsWith(fenceDelimiter)) break;
+            blockLines.push(inputLines[j]);
+            j++;
+          }
+          const inferred = inferLanguage(blockLines);
+          const fixed = raw.replace(fenceMatch[1], fenceMatch[1] + inferred);
+          changes.push({
+            line: i + 1,
+            description: `Added missing language tag \`${inferred}\` to code fence`,
+          });
+          outputLines.push(mode === "fix" ? fixed : raw);
+          i++;
+          continue;
+        }
+      } else if (trimmed.startsWith(fenceDelimiter)) {
+        inFence = false;
+        fenceLang = "";
+        fenceDelimiter = "";
+      }
+
+      outputLines.push(raw);
+      i++;
+      continue;
+    }
+
+    // Inside a fence — pass through unchanged
+    if (inFence) {
+      outputLines.push(raw);
+      i++;
+      continue;
+    }
+
+    // Outside a fence — check for unfenced code block (≥2 consecutive matching lines)
+    if (looksLikeCode(trimmed)) {
+      // Collect consecutive code-looking lines
+      const codeLines: string[] = [raw];
+      let j = i + 1;
+      while (j < inputLines.length && looksLikeCode(inputLines[j].trimStart())) {
+        codeLines.push(inputLines[j]);
+        j++;
+      }
+
+      if (codeLines.length >= 1) {
+        const lang = inferLanguage(codeLines.map((l) => l.trimStart()));
+        changes.push({
+          line: i + 1,
+          description: `Wrapped ${codeLines.length} unfenced code line(s) with \`\`\`${lang} fence`,
+        });
+        if (mode === "fix") {
+          outputLines.push("```" + lang);
+          outputLines.push(...codeLines);
+          outputLines.push("```");
+        } else {
+          outputLines.push(...codeLines);
+        }
+        i = j;
+        continue;
+      }
+    }
+
+    outputLines.push(raw);
+    i++;
+  }
+
+  return {
+    fixed: mode === "fix" ? outputLines.join("\n") : content,
+    changes,
+  };
+}


### PR DESCRIPTION
Closes #37625

Adds `lintMarkdownCodeFences()` — a write-time linting pass that ensures markdown code fences are correctly tagged and code blocks are fenced.