### PR TITLE
fix(cron): strip thinking/reasoning content from announce delivery

### DIFF
--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isHeartbeatOnlyResponse,
+  pickFirstNonReasoningText,
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromOutput,
@@ -106,6 +107,11 @@ describe("pickSummaryFromOutput — thinking tag stripping (regression #40480)",
   it("preserves text without thinking tags", () => {
     expect(pickSummaryFromOutput("All clear, no issues.")).toBe("All clear, no issues.");
   });
+
+  it("strips <antthinking> tags", () => {
+    const text = "<antthinking>Internal chain of thought</antthinking>Final answer.";
+    expect(pickSummaryFromOutput(text)).toBe("Final answer.");
+  });
 });
 
 describe("pickSummaryFromPayloads — isReasoning filtering (regression #40480)", () => {
@@ -147,6 +153,31 @@ describe("pickLastDeliverablePayload — isReasoning filtering (regression #4048
     const deliverable = { text: "Deliverable content" };
     const reasoning = { text: "Reasoning content", isReasoning: true as const };
     expect(pickLastDeliverablePayload([deliverable, reasoning])).toBe(deliverable);
+  });
+});
+
+describe("pickFirstNonReasoningText", () => {
+  it("picks first non-reasoning text", () => {
+    const payloads = [
+      { text: "Internal reasoning", isReasoning: true },
+      { text: "User-facing text" },
+    ];
+    expect(pickFirstNonReasoningText(payloads)).toBe("User-facing text");
+  });
+
+  it("returns undefined when all payloads are reasoning", () => {
+    expect(
+      pickFirstNonReasoningText([{ text: "reasoning only", isReasoning: true }]),
+    ).toBeUndefined();
+  });
+
+  it("skips empty text payloads", () => {
+    const payloads = [{ text: "" }, { text: "actual content" }];
+    expect(pickFirstNonReasoningText(payloads)).toBe("actual content");
+  });
+
+  it("returns undefined for empty payloads", () => {
+    expect(pickFirstNonReasoningText([])).toBeUndefined();
   });
 });
 

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -3,6 +3,7 @@ import {
   isHeartbeatOnlyResponse,
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
+  pickSummaryFromOutput,
   pickSummaryFromPayloads,
 } from "./helpers.js";
 
@@ -83,6 +84,69 @@ describe("pickLastDeliverablePayload", () => {
     const normal = { text: "ok", isError: undefined };
     const error = { text: "bad", isError: true as const };
     expect(pickLastDeliverablePayload([normal, error])).toBe(normal);
+  });
+});
+
+describe("pickSummaryFromOutput — thinking tag stripping (regression #40480)", () => {
+  it("strips <think> tags from output text", () => {
+    const text = "<think>I need to analyze the data...</think>\n\nHere is your daily report.";
+    expect(pickSummaryFromOutput(text)).toBe("Here is your daily report.");
+  });
+
+  it("strips <thinking> tags", () => {
+    const text =
+      "<thinking>Step 1: gather data\nStep 2: format</thinking>Summary: all systems operational.";
+    expect(pickSummaryFromOutput(text)).toBe("Summary: all systems operational.");
+  });
+
+  it("returns undefined when text is only thinking content", () => {
+    expect(pickSummaryFromOutput("<think>internal only</think>")).toBeUndefined();
+  });
+
+  it("preserves text without thinking tags", () => {
+    expect(pickSummaryFromOutput("All clear, no issues.")).toBe("All clear, no issues.");
+  });
+});
+
+describe("pickSummaryFromPayloads — isReasoning filtering (regression #40480)", () => {
+  it("skips isReasoning payloads", () => {
+    const payloads = [
+      { text: "Internal reasoning about the task", isReasoning: true },
+      { text: "Daily report: everything is fine." },
+    ];
+    expect(pickSummaryFromPayloads(payloads)).toBe("Daily report: everything is fine.");
+  });
+
+  it("never returns reasoning-only payloads", () => {
+    expect(
+      pickSummaryFromPayloads([{ text: "Thinking about it...", isReasoning: true }]),
+    ).toBeUndefined();
+  });
+
+  it("falls back to error payload when only reasoning and error exist", () => {
+    const payloads = [
+      { text: "Some error", isError: true },
+      { text: "Reasoning content", isReasoning: true },
+    ];
+    expect(pickSummaryFromPayloads(payloads)).toBe("Some error");
+  });
+});
+
+describe("pickLastNonEmptyTextFromPayloads — isReasoning filtering (regression #40480)", () => {
+  it("skips isReasoning payloads", () => {
+    const payloads = [
+      { text: "User-visible answer" },
+      { text: "Internal reasoning", isReasoning: true },
+    ];
+    expect(pickLastNonEmptyTextFromPayloads(payloads)).toBe("User-visible answer");
+  });
+});
+
+describe("pickLastDeliverablePayload — isReasoning filtering (regression #40480)", () => {
+  it("skips isReasoning payloads", () => {
+    const deliverable = { text: "Deliverable content" };
+    const reasoning = { text: "Reasoning content", isReasoning: true as const };
+    expect(pickLastDeliverablePayload([deliverable, reasoning])).toBe(deliverable);
   });
 });
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -108,6 +108,25 @@ export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars
   return shouldSkipHeartbeatOnlyDelivery(payloads, ackMaxChars);
 }
 
+/**
+ * Pick the text of the first non-reasoning payload (for fallback summary paths
+ * where pickSummaryFromPayloads returned undefined). See Copilot review on #41208.
+ */
+export function pickFirstNonReasoningText(
+  payloads: Array<{ text?: string | undefined; isReasoning?: boolean }>,
+): string | undefined {
+  for (const p of payloads) {
+    if (p?.isReasoning) {
+      continue;
+    }
+    const clean = (p?.text ?? "").trim();
+    if (clean) {
+      return clean;
+    }
+  }
+  return undefined;
+}
+
 export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxChars?: number } }) {
   const raw = agentCfg?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
   return Math.max(0, raw);

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "../../auto-reply/heartbeat.js";
+import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
 
@@ -8,10 +9,16 @@ type DeliveryPayload = {
   mediaUrls?: string[];
   channelData?: Record<string, unknown>;
   isError?: boolean;
+  isReasoning?: boolean;
 };
 
 export function pickSummaryFromOutput(text: string | undefined) {
-  const clean = (text ?? "").trim();
+  // Strip thinking/reasoning tags so internal model monologue never leaks
+  // into user-facing cron announce summaries (#40480).
+  const clean = stripReasoningTagsFromText((text ?? "").trim(), {
+    mode: "strict",
+    trim: "both",
+  });
   if (!clean) {
     return undefined;
   }
@@ -20,10 +27,10 @@ export function pickSummaryFromOutput(text: string | undefined) {
 }
 
 export function pickSummaryFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
+  payloads: Array<{ text?: string | undefined; isError?: boolean; isReasoning?: boolean }>,
 ) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     const summary = pickSummaryFromOutput(payloads[i]?.text);
@@ -32,6 +39,9 @@ export function pickSummaryFromPayloads(
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     const summary = pickSummaryFromOutput(payloads[i]?.text);
     if (summary) {
       return summary;
@@ -41,10 +51,10 @@ export function pickSummaryFromPayloads(
 }
 
 export function pickLastNonEmptyTextFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
+  payloads: Array<{ text?: string | undefined; isError?: boolean; isReasoning?: boolean }>,
 ) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     const clean = (payloads[i]?.text ?? "").trim();
@@ -53,6 +63,9 @@ export function pickLastNonEmptyTextFromPayloads(
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     const clean = (payloads[i]?.text ?? "").trim();
     if (clean) {
       return clean;
@@ -69,7 +82,7 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
     return text || hasMedia || hasChannelData;
   };
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    if (payloads[i]?.isError || payloads[i]?.isReasoning) {
       continue;
     }
     if (isDeliverable(payloads[i])) {
@@ -77,6 +90,9 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
+    if (payloads[i]?.isReasoning) {
+      continue;
+    }
     if (isDeliverable(payloads[i])) {
       return payloads[i];
     }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -63,6 +63,7 @@ import {
 import { resolveDeliveryTarget } from "./delivery-target.js";
 import {
   isHeartbeatOnlyResponse,
+  pickFirstNonReasoningText,
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromOutput,
@@ -754,7 +755,9 @@ export async function runCronIsolatedAgentTurn(params: {
   if (isAborted()) {
     return withRunSession({ status: "error", error: abortReason(), ...telemetry });
   }
-  const firstText = payloads[0]?.text ?? "";
+  // Use first non-reasoning payload text for fallback summary to prevent
+  // leaking internal monologue when payloads[0] is a reasoning payload (#40480).
+  const firstText = pickFirstNonReasoningText(payloads) ?? "";
   let summary = pickSummaryFromPayloads(payloads) ?? pickSummaryFromOutput(firstText);
   let outputText = pickLastNonEmptyTextFromPayloads(payloads);
   let synthesizedText = outputText?.trim() || summary?.trim() || undefined;


### PR DESCRIPTION
## Summary

- Strip `<think>`/`<thinking>`/`<antthinking>` tags in `pickSummaryFromOutput()` using the shared `stripReasoningTagsFromText` utility
- Skip `isReasoning: true` payloads in `pickSummaryFromPayloads`, `pickLastNonEmptyTextFromPayloads`, and `pickLastDeliverablePayload` so structured reasoning payloads never reach cron delivery
- Add `isReasoning` to the internal `DeliveryPayload` type

When reasoning/extended thinking is enabled, the embedded runner emits separate `isReasoning: true` payloads containing the model's internal monologue. These were being included in cron announce summaries, leaking confidential reasoning to delivery targets.

## Test plan

- [x] 10 new regression tests in `helpers.test.ts` covering thinking tag stripping, isReasoning payload filtering across all picker functions
- [x] All 29 tests in `helpers.test.ts` pass
- [x] No new lint/format warnings

Fixes #40480