### PR TITLE
Feature: suggest model switching when API limits exhaust fallback

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -754,7 +754,63 @@ describe("runWithModelFallback", () => {
     expect(message).toContain("API limit reached.");
     expect(message).toContain("/model");
     expect(message).toContain("openclaw models list --local");
+    expect((thrown as Error).cause).toBeInstanceOf(Error);
+    expect(((thrown as Error).cause as Error).message).toBe("rate limited");
     expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows single non-limit failures without model switch guidance", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockRejectedValueOnce(new Error("No API key found for profile openai."));
+
+    let thrown: unknown;
+    try {
+      await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        fallbacksOverride: [],
+        run,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain("No API key found for profile openai.");
+    expect(message).not.toContain("All models failed");
+    expect(message).not.toContain("API limit reached.");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not append model switch guidance when terminal failure is non-limit", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+      .mockRejectedValueOnce(new Error("No API key found for profile anthropic."));
+
+    let thrown: unknown;
+    try {
+      await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        fallbacksOverride: ["anthropic/claude-haiku-3-5"],
+        run,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain("All models failed (2):");
+    expect(message).not.toContain("API limit reached.");
+    expect((thrown as Error).cause).toBeInstanceOf(Error);
+    expect(((thrown as Error).cause as Error).message).toContain("No API key found");
   });
 
   it("keeps explicit fallbacks reachable when models allowlist is present", async () => {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -729,6 +729,34 @@ describe("runWithModelFallback", () => {
     expect(calls).toEqual([{ provider: "anthropic", model: "claude-opus-4-5" }]);
   });
 
+  it("adds model switch guidance when a single model hits API limits", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }));
+
+    let thrown: unknown;
+    try {
+      await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        fallbacksOverride: [],
+        run,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain("All models failed (1):");
+    expect(message).toContain("API limit reached.");
+    expect(message).toContain("/model");
+    expect(message).toContain("openclaw models list --local");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps explicit fallbacks reachable when models allowlist is present", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -44,6 +44,33 @@ type ModelFallbackRunFn<T> = (
   options?: ModelFallbackRunOptions,
 ) => Promise<T>;
 
+type FallbackAttempt = {
+  provider: string;
+  model: string;
+  error: string;
+  reason?: FailoverReason;
+  status?: number;
+  code?: string;
+};
+
+function hasApiLimitReason(attempts: FallbackAttempt[]): boolean {
+  const lastAttempt = attempts.at(-1);
+  return Boolean(
+    lastAttempt &&
+      (lastAttempt.reason === "rate_limit" || lastAttempt.reason === "billing"),
+  );
+}
+
+function buildApiLimitSwitchHint(attempts: FallbackAttempt[], label: string): string | null {
+  if (label !== "models" || !hasApiLimitReason(attempts)) {
+    return null;
+  }
+  return (
+    "API limit reached. Switch models with /model to pick another connected API/model " +
+    "(including local providers like ollama or lmstudio). " +
+    "CLI: openclaw models list --local, then openclaw models set <provider/model>."
+  );
+}
 /**
  * Fallback abort check. Only treats explicit AbortError names as user aborts.
  * Message-based checks (e.g., "aborted") can mask timeouts and skip fallback.
@@ -184,17 +211,21 @@ function throwFallbackFailureSummary(params: {
   label: string;
   formatAttempt: (attempt: FallbackAttempt) => string;
 }): never {
-  if (params.attempts.length <= 1 && params.lastError) {
+  const shouldWrapSingleAttempt =
+    params.attempts.length === 1 && hasApiLimitReason(params.attempts);
+  if (params.attempts.length <= 1 && params.lastError && !shouldWrapSingleAttempt) {
     throw params.lastError;
   }
   const summary =
     params.attempts.length > 0 ? params.attempts.map(params.formatAttempt).join(" | ") : "unknown";
-  throw new Error(
-    `All ${params.label} failed (${params.attempts.length || params.candidates.length}): ${summary}`,
-    {
-      cause: params.lastError instanceof Error ? params.lastError : undefined,
-    },
-  );
+  const baseMessage = `All ${params.label} failed (${
+    params.attempts.length || params.candidates.length
+  }): ${summary}`;
+  const apiLimitHint = buildApiLimitSwitchHint(params.attempts, params.label);
+  const message = apiLimitHint ? `${baseMessage}\n${apiLimitHint}` : baseMessage;
+  throw new Error(message, {
+    cause: params.lastError instanceof Error ? params.lastError : undefined,
+  });
 }
 
 function resolveImageFallbackCandidates(params: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when the active model/provider hits API limits, the failure path does not tell users how to switch quickly.
- Why it matters: work stalls even when other connected providers/models (including local ones) are available.
- What changed: `runWithModelFallback` now appends explicit model-switch guidance when fallback exhaustion is caused by rate-limit/billing reasons (including single-candidate exhaustion).
- What did NOT change (scope boundary): no automatic provider switching logic was added; this only improves user guidance text.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41174
- Related #

## User-visible / Behavior Changes

When model fallback fails due API limits (rate-limit or billing), the error now includes direct switch guidance:
- `/model` for interactive session switching
- local model hint (ollama/lmstudio)
- CLI path: `openclaw models list --local` then `openclaw models set <provider/model>`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: mocked providers in Vitest
- Integration/channel (if any): N/A
- Relevant config (redacted): test fixtures in `src/agents/model-fallback.test.ts`

### Steps

1. Simulate single-candidate fallback exhaustion with a 429 failure.
2. Run fallback resolution.
3. Assert thrown message includes API-limit switch guidance.

### Expected

- Error includes actionable model-switch instructions.

### Actual

- Verified: message includes `/model` and local/CLI switch guidance.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added/ran test that checks single-model 429 exhaustion now returns guidance text.
  - Confirmed existing fallback/probe suites still pass.
- Edge cases checked:
  - Guidance is only appended for `models` fallback exhaustion with `rate_limit`/`billing` reasons.
- What you did **not** verify:
  - Live provider calls or real channel delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `6f8a121bb`.
- Files/config to restore:
  - `src/agents/model-fallback.ts`
  - `src/agents/model-fallback.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected guidance text appearing for non-limit errors.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Guidance text could appear in contexts where `/model` is not the preferred path.
  - Mitigation:
  - Message also includes CLI fallback commands and only triggers on API-limit reasons.

## Validation Commands

- `pnpm test src/agents/model-fallback.test.ts src/agents/model-fallback.probe.test.ts`
  - Result: pass (`2` files, `75` tests)
