### PR TITLE
Fix leaked function_calls XML in assistant chat replies

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -16,6 +16,7 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
+  stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
 
 const stripTrailingDirective = (text: string): string => {
@@ -173,16 +174,18 @@ export function handleMessageUpdate(
     ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
   }
 
-  const next = ctx
-    .stripBlockTags(ctx.state.deltaBuffer, {
+  const next = stripDowngradedToolCallText(
+    ctx.stripBlockTags(ctx.state.deltaBuffer, {
       thinking: false,
       final: false,
       inlineCode: createInlineCodeState(),
-    })
-    .trim();
+    }),
+  ).trim();
   if (next) {
     const wasThinking = ctx.state.partialBlockState.thinking;
-    const visibleDelta = chunk ? ctx.stripBlockTags(chunk, ctx.state.partialBlockState) : "";
+    const visibleDelta = chunk
+      ? stripDowngradedToolCallText(ctx.stripBlockTags(chunk, ctx.state.partialBlockState))
+      : "";
     if (!wasThinking && ctx.state.partialBlockState.thinking) {
       ctx.state.reasoningStreamOpen = true;
     }

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -279,6 +279,35 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads[1]?.delta).toBe(" world");
   });
 
+  it("suppresses leaked XML function_calls blocks in streaming agent events", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(
+      emit,
+      `<function_calls>
+<invoke name="exec">
+<parameter name="command">which himalaya && himalaya --version</parameter>`,
+    );
+    emitAssistantTextDelta(
+      emit,
+      `</invoke>
+</function_calls>
+Done.`,
+    );
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Done.");
+    expect(payloads[0]?.delta).toBe("Done.");
+    const streamedText = payloads[0]?.text;
+    expect(typeof streamedText).toBe("string");
+    if (typeof streamedText === "string") {
+      expect(streamedText).not.toContain("himalaya");
+      expect(streamedText).not.toContain("function_calls");
+    }
+  });
+
   it("emits agent events on message_end for non-streaming assistant text", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -315,6 +315,48 @@ Arguments: { "command": "git status", "timeout": 120000 }`,
     expect(result).toBe("");
   });
 
+  it("strips XML-style function_calls payloads from assistant text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `<function_calls>
+<invoke name="exec">
+<parameter name="command">which himalaya && himalaya --version</parameter>
+</invoke>
+</function_calls>`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("");
+  });
+
+  it("preserves surrounding text while stripping function_calls payloads", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `Checking now.
+<function_calls>
+<invoke name="exec">
+<parameter name="command">ls -la ~/.openclaw/workspace/skills/himalaya</parameter>
+</invoke>
+</function_calls>
+Done.`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Checking now.\nDone.");
+  });
+
   it("strips multiple downgraded tool calls", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
@@ -536,6 +578,17 @@ describe("stripDowngradedToolCallText", () => {
         name: "mixed tool call and historical context",
         text: `Intro.\n[Tool Call: exec (ID: toolu_1)]\nArguments: { "command": "ls" }\n[Historical context: a different model called tool "read"]`,
         expected: "Intro.",
+      },
+      {
+        name: "xml function_calls block",
+        text: `Before
+<function_calls>
+<invoke name="exec">
+<parameter name="command">cat ~/.config/himalaya/config.toml</parameter>
+</invoke>
+</function_calls>
+After`,
+        expected: "Before\nAfter",
       },
       {
         name: "no markers",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -357,6 +357,22 @@ Done.`,
     expect(result).toBe("Checking now.\nDone.");
   });
 
+  it("strips incomplete parameter tails when function_call wrappers are present", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `<function_call></function_call>\n<parameter name="command">echo secret`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("");
+  });
+
   it("strips multiple downgraded tool calls", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -43,7 +43,11 @@ export function stripDowngradedToolCallText(text: string): string {
   if (!text) {
     return text;
   }
-  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
+  if (
+    !/\[Tool (?:Call|Result)/i.test(text) &&
+    !/\[Historical context/i.test(text) &&
+    !/<\/?\s*function_calls?\b/i.test(text)
+  ) {
     return text;
   }
 
@@ -194,6 +198,33 @@ export function stripDowngradedToolCallText(text: string): string {
 
   // Remove [Historical context: ...] markers (self-contained within brackets).
   cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
+
+  // Strip OpenAI-compatible XML-style function call wrappers that can leak in plain text.
+  // Keep this scoped to explicit function_call markers to avoid clobbering normal XML snippets.
+  const hasFunctionCallXml = /<\/?\s*function_calls?\b/i.test(cleaned);
+  const hasFunctionCallPayload = /<\s*invoke\b|<\s*parameter\b|<\/?\s*function_call\b/i.test(
+    cleaned,
+  );
+  if (hasFunctionCallXml && hasFunctionCallPayload) {
+    // Remove complete function call wrapper blocks first.
+    cleaned = cleaned.replace(
+      /<\s*function_calls?\b[^>]*>[\s\S]*?<\s*\/\s*function_calls?\s*>/gi,
+      "",
+    );
+    // Remove complete single-call blocks used by some providers.
+    cleaned = cleaned.replace(/<\s*function_call\b[^>]*>[\s\S]*?<\s*\/\s*function_call\s*>/gi, "");
+    // Hide incomplete streamed call blocks until they are fully closed.
+    cleaned = cleaned.replace(/<\s*function_calls?\b[^>]*>[\s\S]*$/gi, "");
+    cleaned = cleaned.replace(/<\s*function_call\b[^>]*>[\s\S]*$/gi, "");
+    // Safety net for leaked invoke/parameter payloads in function_call contexts.
+    cleaned = cleaned.replace(/<\s*invoke\b[^>]*>[\s\S]*?<\s*\/\s*invoke\s*>/gi, "");
+    cleaned = cleaned.replace(/<\s*invoke\b[^>]*>[\s\S]*$/gi, "");
+    cleaned = cleaned.replace(/<\s*parameter\b[^>]*>[\s\S]*?<\s*\/\s*parameter\s*>/gi, "");
+    // Remove any remaining wrapper tags.
+    cleaned = cleaned.replace(/<\s*\/?\s*function_calls?\b[^>]*>/gi, "");
+    cleaned = cleaned.replace(/<\s*\/?\s*function_call\b[^>]*>/gi, "");
+    cleaned = cleaned.replace(/[ \t]*\n(?:[ \t]*\n)+/g, "\n");
+  }
 
   return cleaned.trim();
 }

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -202,6 +202,9 @@ export function stripDowngradedToolCallText(text: string): string {
   // Strip OpenAI-compatible XML-style function call wrappers that can leak in plain text.
   // Keep this scoped to explicit function_call markers to avoid clobbering normal XML snippets.
   const hasFunctionCallXml = /<\/?\s*function_calls?\b/i.test(cleaned);
+  // Intentionally computed from the pre-substitution text: once we detect a function_call
+  // wrapper + payload in a chunk, we strip matching payload tags globally for that chunk.
+  // Do not widen this predicate casually; broader matches can over-strip unrelated XML.
   const hasFunctionCallPayload = /<\s*invoke\b|<\s*parameter\b|<\/?\s*function_call\b/i.test(
     cleaned,
   );
@@ -220,6 +223,7 @@ export function stripDowngradedToolCallText(text: string): string {
     cleaned = cleaned.replace(/<\s*invoke\b[^>]*>[\s\S]*?<\s*\/\s*invoke\s*>/gi, "");
     cleaned = cleaned.replace(/<\s*invoke\b[^>]*>[\s\S]*$/gi, "");
     cleaned = cleaned.replace(/<\s*parameter\b[^>]*>[\s\S]*?<\s*\/\s*parameter\s*>/gi, "");
+    cleaned = cleaned.replace(/<\s*parameter\b[^>]*>[\s\S]*$/gi, "");
     // Remove any remaining wrapper tags.
     cleaned = cleaned.replace(/<\s*\/?\s*function_calls?\b[^>]*>/gi, "");
     cleaned = cleaned.replace(/<\s*\/?\s*function_call\b[^>]*>/gi, "");


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: assistant chat replies could surface raw XML-style tool payloads like `<function_calls><invoke ...>` instead of user-facing text.
- Why it matters: this leaks internal command details (including potentially sensitive arguments) and degrades UX.
- What changed: extended downgraded-tool-text sanitization to strip leaked `function_call(s)` XML wrappers, and applied that sanitization to streaming assistant updates before event emission.
- What did NOT change (scope boundary): no changes to tool execution behavior, approvals, or model/tool selection.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41181
- Related #

## User-visible / Behavior Changes

- Chat surfaces no longer show leaked XML tool-call payloads (`<function_calls>`, `<function_call>`, `<invoke>`, `<parameter>`) when those appear in assistant text.
- Streaming assistant events now suppress these leaked blocks, so users see only remaining user-facing text.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A (unit tests)
- Integration/channel (if any): agent streaming/chat event pipeline
- Relevant config (redacted): default test harness config

### Steps

1. Emit assistant text containing leaked XML tool-call blocks (`<function_calls>...<invoke name="exec">...</invoke>...</function_calls>`).
2. Observe extracted assistant text and streamed assistant event payloads.
3. Verify leaked command payloads are removed while surrounding user text remains.

### Expected

- No raw function-call XML payloads in user-facing assistant text/streaming updates.

### Actual

- Sanitizer strips leaked XML function-call blocks; tests assert only clean text is emitted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added/ran extraction tests for XML `function_calls` payload removal.
  - Added/ran streaming event test confirming leaked payload suppression in agent events.
- Edge cases checked:
  - Preserved surrounding text before/after stripped payload blocks.
  - Incomplete streamed XML blocks are suppressed until closed.
- What you did **not** verify:
  - Full end-to-end manual Himalaya skill run in a live chat channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-embedded-utils.ts`
  - `src/agents/pi-embedded-subscribe.handlers.messages.ts`
- Known bad symptoms reviewers should watch for:
  - Legitimate XML snippets containing function-call tags being over-suppressed in assistant text.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: over-filtering legitimate XML documentation text that intentionally includes function-call wrapper tags.
  - Mitigation: filtering is scoped to explicit `function_call(s)` wrapper patterns with payload markers (`invoke`/`parameter`), and covered by focused tests.

## Validation Commands

- `pnpm install` (passed)
- `pnpm exec vitest run src/agents/pi-embedded-utils.test.ts` (passed: 35/35)
- `pnpm exec vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts -t "suppresses leaked XML function_calls blocks"` (passed: 1 test)
- `pnpm exec vitest run src/agents/pi-embedded-utils.test.ts -t "function_calls|xml function_calls block"` (passed: 2 tests)
