### PR TITLE
fix(outbound): preserve indentation in parsed reply payloads

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1219,6 +1219,28 @@ describe("normalizeOutboundPayloadsForJson", () => {
           },
         ],
       },
+      {
+        input: [{ text: "START\n  alpha\n    beta\n  gamma\nEND" }],
+        expected: [
+          {
+            text: "START\n  alpha\n    beta\n  gamma\nEND",
+            mediaUrl: null,
+            mediaUrls: undefined,
+            channelData: undefined,
+          },
+        ],
+      },
+      {
+        input: [{ text: "[[reply_to_current]]\nSTART\n  alpha\n    beta\n  gamma\nEND" }],
+        expected: [
+          {
+            text: "START\n  alpha\n    beta\n  gamma\nEND",
+            mediaUrl: null,
+            mediaUrls: undefined,
+            channelData: undefined,
+          },
+        ],
+      },
     ]);
 
     for (const testCase of cases) {

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -50,4 +50,15 @@ describe("splitMediaFromOutput", () => {
     const result = splitMediaFromOutput("MEDIA:screenshot");
     expect(result.mediaUrls).toBeUndefined();
   });
+
+  it("preserves indentation for plain text without media tokens", () => {
+    const input = "START\n  alpha\n    beta\n  gamma\nEND";
+    expect(splitMediaFromOutput(input)).toEqual({ text: input });
+  });
+
+  it("preserves indentation after stripping media tokens", () => {
+    const result = splitMediaFromOutput("MEDIA:https://x.test/a.png\n  hello\n    world");
+    expect(result.mediaUrls).toEqual(["https://x.test/a.png"]);
+    expect(result.text).toBe("  hello\n    world");
+  });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -215,30 +215,22 @@ export function splitMediaFromOutput(raw: string): {
 
     pieces.push(line.slice(cursor));
 
-    const cleanedLine = pieces
-      .join("")
-      .replace(/[ \t]{2,}/g, " ")
-      .trim();
+    const cleanedLine = pieces.join("");
 
     // If the line becomes empty, drop it.
-    if (cleanedLine) {
+    if (cleanedLine.trim()) {
       keptLines.push(cleanedLine);
     }
     lineOffset += line.length + 1; // +1 for newline
   }
 
-  let cleanedText = keptLines
-    .join("\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/[ \t]{2,}/g, " ")
-    .replace(/\n{2,}/g, "\n")
-    .trim();
+  let cleanedText = keptLines.join("\n");
 
   // Detect and strip [[audio_as_voice]] tag
   const audioTagResult = parseAudioTag(cleanedText);
   const hasAudioAsVoice = audioTagResult.audioAsVoice;
   if (audioTagResult.hadTag) {
-    cleanedText = audioTagResult.text.replace(/\n{2,}/g, "\n").trim();
+    cleanedText = audioTagResult.text.trim();
   }
 
   if (media.length === 0) {

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
@@ -55,5 +56,20 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toEqual(input);
+  });
+});
+
+describe("parseInlineDirectives", () => {
+  test("preserves multiline indentation after stripping reply tags", () => {
+    const input = "[[reply_to_current]]\nSTART\n  alpha\n    beta\n  gamma\nEND";
+    const result = parseInlineDirectives(input, {
+      currentMessageId: "msg-1",
+      stripReplyTags: true,
+    });
+
+    expect(result.text).toBe("START\n  alpha\n    beta\n  gamma\nEND");
+    expect(result.replyToId).toBe("msg-1");
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.hasReplyTag).toBe(true);
   });
 });

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -72,4 +72,17 @@ describe("parseInlineDirectives", () => {
     expect(result.replyToCurrent).toBe(true);
     expect(result.hasReplyTag).toBe(true);
   });
+
+  test("does not add artificial leading spaces when stripping directives on later lines", () => {
+    const input = "first line\n[[reply_to_current]]second line\n[[audio_as_voice]]third line";
+    const result = parseInlineDirectives(input, {
+      currentMessageId: "msg-1",
+      stripReplyTags: true,
+      stripAudioTag: true,
+    });
+
+    expect(result.text).toBe("first line\nsecond line\nthird line");
+    expect(result.replyToId).toBe("msg-1");
+    expect(result.audioAsVoice).toBe(true);
+  });
 });

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -17,11 +17,11 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
-function normalizeDirectiveWhitespace(text: string): string {
-  return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+function collapseSingleLineDirectiveWhitespace(text: string): string {
+  if (text.includes("\n")) {
+    return text;
+  }
+  return text.replace(/[^\S\n]+/g, " ");
 }
 
 type StripInlineDirectiveTagsResult = {
@@ -98,7 +98,7 @@ export function parseInlineDirectives(
   }
   if (!text.includes("[[")) {
     return {
-      text: normalizeDirectiveWhitespace(text),
+      text,
       audioAsVoice: false,
       replyToCurrent: false,
       hasAudioTag: false,
@@ -132,7 +132,7 @@ export function parseInlineDirectives(
     return stripReplyTags ? " " : match;
   });
 
-  cleaned = normalizeDirectiveWhitespace(cleaned);
+  cleaned = collapseSingleLineDirectiveWhitespace(cleaned.trim());
 
   const replyToId =
     lastExplicitId ?? (sawCurrent ? currentMessageId?.trim() || undefined : undefined);

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -17,8 +17,22 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
+function getDirectiveReplacement(source: string, offset: number, length: number): string {
+  const previous = offset > 0 ? source[offset - 1] : "";
+  const next = source[offset + length] ?? "";
+  const touchesLeadingWhitespace = previous === "" || /\s/.test(previous);
+  const touchesTrailingWhitespace = next === "" || /\s/.test(next);
+
+  // Avoid placeholder spaces when a stripped directive already sits on a
+  // whitespace boundary. That prevents fake indentation on later lines while
+  // still preserving inline word separation when a tag appears inside prose.
+  return touchesLeadingWhitespace || touchesTrailingWhitespace ? "" : " ";
+}
+
 function collapseSingleLineDirectiveWhitespace(text: string): string {
   if (text.includes("\n")) {
+    // Multiline directive stripping should keep meaningful indentation intact,
+    // but still drop trailing horizontal whitespace introduced right before a newline.
     return text.replace(/[ \t]+\n/g, "\n");
   }
   return text.replace(/[^\S\n]+/g, " ");
@@ -113,13 +127,13 @@ export function parseInlineDirectives(
   let sawCurrent = false;
   let lastExplicitId: string | undefined;
 
-  cleaned = cleaned.replace(AUDIO_TAG_RE, (match) => {
+  cleaned = cleaned.replace(AUDIO_TAG_RE, (match, offset, source) => {
     audioAsVoice = true;
     hasAudioTag = true;
-    return stripAudioTag ? " " : match;
+    return stripAudioTag ? getDirectiveReplacement(source, offset, match.length) : match;
   });
 
-  cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined) => {
+  cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined, offset, source) => {
     hasReplyTag = true;
     if (idRaw === undefined) {
       sawCurrent = true;
@@ -129,7 +143,7 @@ export function parseInlineDirectives(
         lastExplicitId = id;
       }
     }
-    return stripReplyTags ? " " : match;
+    return stripReplyTags ? getDirectiveReplacement(source, offset, match.length) : match;
   });
 
   cleaned = collapseSingleLineDirectiveWhitespace(cleaned.trim());

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -19,7 +19,7 @@ const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]
 
 function collapseSingleLineDirectiveWhitespace(text: string): string {
   if (text.includes("\n")) {
-    return text;
+    return text.replace(/[ \t]+\n/g, "\n");
   }
   return text.replace(/[^\S\n]+/g, " ");
 }


### PR DESCRIPTION
## Problem

Indented assistant output could be generated correctly, but lose its indentation before it reached the final outbound payload.

This was easiest to see through `openclaw agent --json`, where plain indented text and fenced code blocks could come back flattened even though the model output itself was correct.

## Root cause

The issue was not JSON formatting itself. The flattening happened earlier in the shared outbound reply-parsing path.

Two places were normalizing whitespace too aggressively while stripping directives/media metadata:

- `parseInlineDirectives(...)` normalized text even when no inline tags were present
- `splitMediaFromOutput(...)` collapsed indentation in the remaining body text while extracting media/audio directives

That meant indentation-sensitive output could be rewritten before the final payload was assembled.

## What changed

This keeps the fix narrow and focused on preserving meaningful body indentation:

- text without inline tags now stays unchanged instead of going through directive whitespace normalization
- after stripping reply/audio tags, multiline text keeps its original indentation
- trailing horizontal whitespace introduced directly before a newline by tag stripping is still removed
- media/audio extraction no longer rewrites the remaining multiline body by collapsing indentation or compressing spacing
- focused regressions were added for plain indented text, reply-tagged multiline text, direct helper-level multiline tag stripping, and indented text that remains after `MEDIA:` extraction

Single-line cleanup still collapses extra horizontal whitespace, so existing inline tag behavior in normal prose stays intact.

## Why this approach

The goal here is to preserve indentation without changing reply/media/audio extraction semantics.

This avoids turning the fix into a broader whitespace refactor and keeps the behavioral change limited to the part that was actually causing the bug: rewriting multiline body text during outbound parsing.

## Validation

### Human Verification

- reproduced the flattening in a local installed OpenClaw build via `openclaw agent --json`
- applied the same logic through the source patch in this PR and confirmed the affected outbound paths preserve indentation

### Automated Verification

- `pnpm vitest run src/utils/directive-tags.test.ts src/auto-reply/reply.directive.parse.test.ts src/media/parse.test.ts src/infra/outbound/outbound.test.ts src/auto-reply/reply/reply-utils.test.ts`

## Risk

Low. The change is limited to outbound directive/media parsing behavior and keeps existing reply/media/audio semantics intact.

## Security Impact

None.

Closes #41215.
