### PR TITLE
fix: add google/gemini provider pairing for image tool

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -299,6 +299,21 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("pairs google primary with gemini-3-flash-preview (and fallbacks) when auth exists (regression #41210)", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("GEMINI_API_KEY", "gemini-test");
+      vi.stubEnv("OPENAI_API_KEY", "openai-test");
+      vi.stubEnv("ANTHROPIC_API_KEY", "anthropic-test");
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "google/gemini-3-pro" } } },
+      };
+      expect(resolveImageModelConfigForTool({ cfg, agentDir })).toEqual(
+        createDefaultImageFallbackExpectation("google/gemini-3-flash-preview"),
+      );
+      expect(createImageTool({ config: cfg, agentDir })).not.toBeNull();
+    });
+  });
+
   it("pairs zai primary with glm-4.6v (and fallbacks) when auth exists", async () => {
     await withTempAgentDir(async (agentDir) => {
       vi.stubEnv("ZAI_API_KEY", "zai-test");

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -114,6 +114,8 @@ export function resolveImageModelConfigForTool(params: {
     preferred = `${primary.provider}/MiniMax-VL-01`;
   } else if (providerOk && providerVisionFromConfig) {
     preferred = providerVisionFromConfig;
+  } else if (primary.provider === "google" && providerOk) {
+    preferred = "google/gemini-3-flash-preview";
   } else if (primary.provider === "zai" && providerOk) {
     preferred = "zai/glm-4.6v";
   } else if (primary.provider === "openai" && openaiOk) {


### PR DESCRIPTION
## Summary

- Add missing `google` provider case in `resolveImageModelConfigForTool()` so Google/Gemini users get `google/gemini-3-flash-preview` as the paired image model instead of falling through to the hardcoded `openai/gpt-5-mini` fallback
- The paired model matches `DEFAULT_IMAGE_MODELS["google"]` in `media-understanding/defaults.ts`
- Add regression test verifying Google primary model resolves to `google/gemini-3-flash-preview` with OpenAI/Anthropic fallbacks

Fixes #41210

## Test plan

- [x] Existing image tool tests pass (29/29)
- [x] New test: `pairs google primary with gemini-3-flash-preview (and fallbacks) when auth exists`
- [ ] Manual: configure `agents.defaults.model.primary: "google/gemini-3-pro"` with `GEMINI_API_KEY`, verify `image` tool uses `google/gemini-3-flash-preview`