### PR TITLE
fix(logging): include model and provider in overload/error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/global hook runner: harden singleton state handling so shared global hook runner reuse does not leak or corrupt runner state across executions. (#40184) Thanks @vincentkoc.
 - Agents/fallback: recognize Poe `402 You've used up your points!` billing errors so configured model fallbacks trigger instead of surfacing the raw provider error. (#42278) Thanks @CryUshio.
 - Telegram/outbound HTML sends: chunk long HTML-mode messages, preserve plain-text fallback and silent-delivery params across retries, and cut over to plain text when HTML chunk planning cannot safely preserve the full message. (#42240) thanks @obviyus.
+- Agents/embedded overload logs: include the failing model and provider in error-path console output, with lifecycle regression coverage for the rendered and sanitized `consoleMessage`. (#41236) thanks @jiarung.
 
 ## 2026.3.8
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -70,7 +70,7 @@ describe("handleAgentEnd", () => {
     });
   });
 
-  it("attaches raw provider error metadata without changing the console message", () => {
+  it("attaches raw provider error metadata and includes model/provider in console output", () => {
     const ctx = createContext({
       role: "assistant",
       stopReason: "error",
@@ -91,7 +91,33 @@ describe("handleAgentEnd", () => {
       error: "The AI service is temporarily overloaded. Please try again in a moment.",
       failoverReason: "overloaded",
       providerErrorType: "overloaded_error",
+      consoleMessage:
+        "embedded run agent end: runId=run-1 isError=true model=claude-test provider=anthropic error=The AI service is temporarily overloaded. Please try again in a moment.",
     });
+  });
+
+  it("sanitizes model and provider before writing consoleMessage", () => {
+    const ctx = createContext({
+      role: "assistant",
+      stopReason: "error",
+      provider: "anthropic\u001b]8;;https://evil.test\u0007",
+      model: "claude\tsonnet\n4",
+      errorMessage: "connection refused",
+      content: [{ type: "text", text: "" }],
+    });
+
+    handleAgentEnd(ctx);
+
+    const warn = vi.mocked(ctx.log.warn);
+    const meta = warn.mock.calls[0]?.[1];
+    expect(meta).toMatchObject({
+      consoleMessage:
+        "embedded run agent end: runId=run-1 isError=true model=claude sonnet 4 provider=anthropic]8;;https://evil.test error=connection refused",
+    });
+    expect(meta?.consoleMessage).not.toContain("\n");
+    expect(meta?.consoleMessage).not.toContain("\r");
+    expect(meta?.consoleMessage).not.toContain("\t");
+    expect(meta?.consoleMessage).not.toContain("\u001b");
   });
 
   it("redacts logged error text before emitting lifecycle events", () => {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -48,6 +48,8 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     const safeErrorText =
       buildTextObservationFields(errorText).textPreview ?? "LLM request failed.";
     const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
+    const safeModel = sanitizeForConsole(lastAssistant.model) ?? "unknown";
+    const safeProvider = sanitizeForConsole(lastAssistant.provider) ?? "unknown";
     ctx.log.warn("embedded run agent end", {
       event: "embedded_run_agent_end",
       tags: ["error_handling", "lifecycle", "agent_end", "assistant_error"],
@@ -55,10 +57,10 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       isError: true,
       error: safeErrorText,
       failoverReason,
-      provider: lastAssistant.provider,
       model: lastAssistant.model,
+      provider: lastAssistant.provider,
       ...observedError,
-      consoleMessage: `embedded run agent end: runId=${safeRunId} isError=true error=${safeErrorText}`,
+      consoleMessage: `embedded run agent end: runId=${safeRunId} isError=true model=${safeModel} provider=${safeProvider} error=${safeErrorText}`,
     });
     emitAgentEvent({
       runId: ctx.params.runId,


### PR DESCRIPTION
When an embedded agent run ends with an error (e.g. overloaded_error), the warn log now includes the model and provider that triggered the error.

Before:
  embedded run agent end: runId=xxx isError=true error=The AI service is temporarily overloaded...

After:
  embedded run agent end: runId=xxx isError=true model=claude-sonnet-4-6 provider=anthropic error=The AI service is temporarily overloaded...

This makes it easy to correlate which model/provider is failing without needing to cross-reference token-usage.json.

## Summary

Describe the problem and fix in 2–5 bullets:

 - Problem: When an overloaded_error occurs, the gateway warn log only records runId and the error message — no model
 or provider info. Developers must manually cross-reference token-usage.json to identify which model failed.
 - Why it matters: When multiple models are active (primary + fallbacks), it's impossible to tell at a glance which
 model/provider triggered the overload, making it hard to decide whether to switch providers or reorder fallbacks.
 - What changed: Added model= and provider= fields to the warn log in handleAgentEnd(), read directly from the
 existing lastAssistant object — no extra API calls or I/O required.
 - What did NOT change: Error handling flow, emitAgentEvent payload, FailoverError trigger logic, any public API
 surface, and existing test coverage are all untouched. Pure observability improvement.


## Change Type (select all)

- [ ] Bug fix
- [ 0 ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ 0 ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: 5.4.0-216-generic 20.04.6 LTS (Focal Fossa) UBUNTU
- Runtime/container: runtime
- Model/provider: claude/chatgpt
- Integration/channel (if any): no
- Relevant config (redacted): no

### Steps
n/a
### Expected

-

### Actual
n/a
-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

 Build passed locally (npm run build). TypeScript typecheck shows no errors in the modified file. Pre-existing type errors in extensions/diagnostics-otel and extensions/diffs are unrelated to this change.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

none
