### PR TITLE
gateway: avoid startup race in delivery recovery

### DIFF
--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
 });
 
 describe("delivery recovery target resolution", () => {
-
   it("skips legacy entries without accountId when channel has no configured accounts", () => {
     hoisted.getChannelPlugin.mockReturnValue({
       id: "synologychat",

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const hoisted = vi.hoisted(() => ({
+  normalizeChannelId: vi.fn<(raw?: string | null) => string | null>(),
+  getChannelPlugin: vi.fn(),
+  resolveChannelDefaultAccountId: vi.fn(),
+}));
+
+vi.mock("../channels/plugins/index.js", () => ({
+  normalizeChannelId: hoisted.normalizeChannelId,
+  getChannelPlugin: hoisted.getChannelPlugin,
+  listChannelPlugins: vi.fn(() => []),
+}));
+
+vi.mock("../channels/plugins/helpers.js", () => ({
+  resolveChannelDefaultAccountId: hoisted.resolveChannelDefaultAccountId,
+}));
+
+import { __testing } from "./server.impl.js";
+
+describe("delivery recovery target resolution", () => {
+  beforeEach(() => {
+    hoisted.normalizeChannelId.mockReset();
+    hoisted.getChannelPlugin.mockReset();
+    hoisted.resolveChannelDefaultAccountId.mockReset();
+
+    hoisted.normalizeChannelId.mockImplementation((raw?: string | null) => {
+      if (typeof raw !== "string") {
+        return null;
+      }
+      const trimmed = raw.trim();
+      return trimmed ? trimmed : null;
+    });
+  });
+
+  it("skips legacy entries without accountId when channel has no configured accounts", () => {
+    hoisted.getChannelPlugin.mockReturnValue({
+      id: "synologychat",
+      config: {
+        listAccountIds: () => [],
+      },
+    });
+    hoisted.resolveChannelDefaultAccountId.mockReturnValue("default");
+
+    const targets = __testing.resolvePendingDeliveryRecoveryTargets({
+      pending: [{ channel: "synologychat" }],
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  it("uses configured default account for legacy entries when accounts exist", () => {
+    hoisted.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      config: {
+        listAccountIds: () => ["default", "backup"],
+      },
+    });
+    hoisted.resolveChannelDefaultAccountId.mockReturnValue("default");
+
+    const targets = __testing.resolvePendingDeliveryRecoveryTargets({
+      pending: [{ channel: "whatsapp" }],
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(targets).toEqual([{ channel: "whatsapp", accountId: "default" }]);
+  });
+
+  it("skips explicit stale account ids removed from config", () => {
+    hoisted.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      config: {
+        listAccountIds: () => ["live"],
+      },
+    });
+
+    const targets = __testing.resolvePendingDeliveryRecoveryTargets({
+      pending: [{ channel: "whatsapp", accountId: "removed" }],
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(targets).toEqual([]);
+  });
+});

--- a/src/gateway/server.impl.delivery-recovery.test.ts
+++ b/src/gateway/server.impl.delivery-recovery.test.ts
@@ -19,20 +19,21 @@ vi.mock("../channels/plugins/helpers.js", () => ({
 
 import { __testing } from "./server.impl.js";
 
-describe("delivery recovery target resolution", () => {
-  beforeEach(() => {
-    hoisted.normalizeChannelId.mockReset();
-    hoisted.getChannelPlugin.mockReset();
-    hoisted.resolveChannelDefaultAccountId.mockReset();
+beforeEach(() => {
+  hoisted.normalizeChannelId.mockReset();
+  hoisted.getChannelPlugin.mockReset();
+  hoisted.resolveChannelDefaultAccountId.mockReset();
 
-    hoisted.normalizeChannelId.mockImplementation((raw?: string | null) => {
-      if (typeof raw !== "string") {
-        return null;
-      }
-      const trimmed = raw.trim();
-      return trimmed ? trimmed : null;
-    });
+  hoisted.normalizeChannelId.mockImplementation((raw?: string | null) => {
+    if (typeof raw !== "string") {
+      return null;
+    }
+    const trimmed = raw.trim();
+    return trimmed ? trimmed : null;
   });
+});
+
+describe("delivery recovery target resolution", () => {
 
   it("skips legacy entries without accountId when channel has no configured accounts", () => {
     hoisted.getChannelPlugin.mockReturnValue({
@@ -82,5 +83,28 @@ describe("delivery recovery target resolution", () => {
     });
 
     expect(targets).toEqual([]);
+  });
+});
+
+describe("delivery recovery preflight skip mode", () => {
+  it("skips readiness preflight when OPENCLAW_SKIP_CHANNELS is enabled", () => {
+    expect(
+      __testing.shouldSkipDeliveryRecoveryReadinessPreflight({ OPENCLAW_SKIP_CHANNELS: "1" }),
+    ).toBe(true);
+  });
+
+  it("skips readiness preflight when OPENCLAW_SKIP_PROVIDERS is enabled", () => {
+    expect(
+      __testing.shouldSkipDeliveryRecoveryReadinessPreflight({ OPENCLAW_SKIP_PROVIDERS: "true" }),
+    ).toBe(true);
+  });
+
+  it("does not skip readiness preflight when both flags are disabled", () => {
+    expect(
+      __testing.shouldSkipDeliveryRecoveryReadinessPreflight({
+        OPENCLAW_SKIP_CHANNELS: "0",
+        OPENCLAW_SKIP_PROVIDERS: "false",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -276,13 +276,31 @@ function resolvePendingDeliveryRecoveryTargets(params: {
     if (!plugin) {
       continue;
     }
+
+    const configuredAccountIds = plugin.config
+      .listAccountIds(params.cfg)
+      .map((accountId) => accountId.trim())
+      .filter(Boolean);
+    const configuredAccountSet = new Set(configuredAccountIds);
+
     const accountIdRaw = typeof entry.accountId === "string" ? entry.accountId.trim() : "";
+    if (accountIdRaw && !configuredAccountSet.has(accountIdRaw)) {
+      // Queue may contain stale deliveries for removed accounts. Do not block
+      // startup preflight on targets that can never become ready.
+      continue;
+    }
+
     const accountId =
       accountIdRaw ||
       resolveChannelDefaultAccountId({
         plugin,
         cfg: params.cfg,
+        accountIds: configuredAccountIds,
       });
+    if (!accountId) {
+      continue;
+    }
+
     const key = `${channel}:${accountId}`;
     if (!targets.has(key)) {
       targets.set(key, { channel, accountId });

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -5,7 +5,13 @@ import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
-import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
+import {
+  getChannelPlugin,
+  listChannelPlugins,
+  normalizeChannelId,
+  type ChannelId,
+} from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { isRestartEnabled } from "../config/commands.js";
@@ -75,7 +81,7 @@ import {
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
-import { createChannelManager } from "./server-channels.js";
+import { createChannelManager, type ChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
 import { buildGatewayCronService } from "./server-cron.js";
@@ -206,6 +212,165 @@ function applyGatewayAuthOverridesForStartupPreflight(
       tailscale: mergeGatewayTailscaleConfig(config.gateway?.tailscale, overrides.tailscale),
     },
   };
+}
+
+type PendingDeliveryRecoveryTarget = {
+  channel: ChannelId;
+  accountId: string;
+};
+
+function createAbortError(message: string): Error {
+  const err = new Error(message);
+  err.name = "AbortError";
+  return err;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError("Delivery recovery preflight aborted");
+  }
+}
+
+async function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) {
+    throwIfAborted(signal);
+    return;
+  }
+  if (!signal) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, ms);
+    });
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError("Delivery recovery preflight aborted"));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function resolvePendingDeliveryRecoveryTargets(params: {
+  pending: Array<{ channel?: unknown; accountId?: unknown }>;
+  cfg: OpenClawConfig;
+}): PendingDeliveryRecoveryTarget[] {
+  const targets = new Map<string, PendingDeliveryRecoveryTarget>();
+
+  for (const entry of params.pending) {
+    const channelRaw = typeof entry.channel === "string" ? entry.channel : null;
+    const channel = normalizeChannelId(channelRaw);
+    if (!channel) {
+      continue;
+    }
+    const plugin = getChannelPlugin(channel);
+    if (!plugin) {
+      continue;
+    }
+    const accountIdRaw = typeof entry.accountId === "string" ? entry.accountId.trim() : "";
+    const accountId =
+      accountIdRaw ||
+      resolveChannelDefaultAccountId({
+        plugin,
+        cfg: params.cfg,
+      });
+    const key = `${channel}:${accountId}`;
+    if (!targets.has(key)) {
+      targets.set(key, { channel, accountId });
+    }
+  }
+
+  return [...targets.values()];
+}
+
+function shouldRequireConnectedForRecovery(channel: ChannelId): boolean {
+  // Some channels (e.g. Discord) can send outbound over REST even when runtime
+  // reports connected=false. Restrict the connected gate to channels where
+  // listener/socket readiness is required for outbound delivery.
+  return channel === "whatsapp";
+}
+
+function formatRecoveryTarget(target: PendingDeliveryRecoveryTarget): string {
+  return `${target.channel}:${target.accountId}`;
+}
+
+async function waitForPendingDeliveryChannelReadiness(params: {
+  channelManager: ChannelManager;
+  targets: PendingDeliveryRecoveryTarget[];
+  log: { info: (msg: string) => void; warn: (msg: string) => void };
+  timeoutMs?: number;
+  pollMs?: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const targets = [...params.targets].filter(
+    (target, index, arr) =>
+      index ===
+      arr.findIndex(
+        (item) => item.channel === target.channel && item.accountId === target.accountId,
+      ),
+  );
+  if (targets.length === 0) {
+    return;
+  }
+
+  const timeoutMs = params.timeoutMs ?? 15_000;
+  const pollMs = Math.max(50, params.pollMs ?? 250);
+  const deadline = Date.now() + timeoutMs;
+  const targetLabel = targets.map((target) => formatRecoveryTarget(target)).join(", ");
+
+  params.log.info(
+    `Recovery preflight: waiting for runtime readiness (${targetLabel}), timeout ${timeoutMs}ms`,
+  );
+
+  while (true) {
+    throwIfAborted(params.signal);
+
+    const snapshot = params.channelManager.getRuntimeSnapshot();
+    const waiting: string[] = [];
+
+    for (const target of targets) {
+      const accountMap = snapshot.channelAccounts[target.channel];
+      const account = accountMap?.[target.accountId];
+      if (!account) {
+        waiting.push(formatRecoveryTarget(target));
+        continue;
+      }
+      if (account.enabled === false || account.configured === false) {
+        continue;
+      }
+      if (account.running !== true) {
+        waiting.push(formatRecoveryTarget(target));
+        continue;
+      }
+      if (shouldRequireConnectedForRecovery(target.channel) && account.connected !== true) {
+        waiting.push(formatRecoveryTarget(target));
+      }
+    }
+
+    if (waiting.length === 0) {
+      params.log.info(`Recovery preflight complete: runtime ready for ${targetLabel}`);
+      return;
+    }
+
+    const now = Date.now();
+    if (now >= deadline) {
+      params.log.warn(
+        `Recovery preflight timeout after ${timeoutMs}ms; continuing while waiting on: ${waiting.join(", ")}`,
+      );
+      return;
+    }
+
+    await sleepWithAbort(Math.min(pollMs, Math.max(1, deadline - now)), params.signal);
+  }
 }
 
 export type GatewayServer = {
@@ -765,20 +930,6 @@ export async function startGatewayServer(
     void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
   }
 
-  // Recover pending outbound deliveries from previous crash/restart.
-  if (!minimalTestGateway) {
-    void (async () => {
-      const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
-      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
-      const logRecovery = log.child("delivery-recovery");
-      await recoverPendingDeliveries({
-        deliver: deliverOutboundPayloads,
-        log: logRecovery,
-        cfg: cfgAtStart,
-      });
-    })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
-  }
-
   const execApprovalManager = new ExecApprovalManager();
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
@@ -936,6 +1087,50 @@ export async function startGatewayServer(
     }));
   }
 
+  const deliveryRecoveryAbort = new AbortController();
+
+  // Recover pending outbound deliveries from previous crash/restart.
+  // Run this after sidecars/channels start to avoid racing channel bootstrap
+  // (e.g., WhatsApp listener registration) during startup.
+  if (!minimalTestGateway) {
+    void (async () => {
+      const { loadPendingDeliveries, recoverPendingDeliveries } =
+        await import("../infra/outbound/delivery-queue.js");
+      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
+      const logRecovery = log.child("delivery-recovery");
+      const pending = await loadPendingDeliveries();
+      if (pending.length === 0) {
+        return;
+      }
+
+      const targets = resolvePendingDeliveryRecoveryTargets({ pending, cfg: cfgAtStart });
+      if (targets.length > 0) {
+        await waitForPendingDeliveryChannelReadiness({
+          channelManager,
+          targets,
+          log: logRecovery,
+          signal: deliveryRecoveryAbort.signal,
+        });
+      }
+      if (deliveryRecoveryAbort.signal.aborted) {
+        logRecovery.info("Delivery recovery skipped: gateway shutdown in progress.");
+        return;
+      }
+
+      await recoverPendingDeliveries({
+        deliver: deliverOutboundPayloads,
+        log: logRecovery,
+        cfg: cfgAtStart,
+      });
+    })().catch((err) => {
+      if (err instanceof Error && err.name === "AbortError") {
+        log.info("Delivery recovery aborted: gateway shutdown in progress.");
+        return;
+      }
+      log.error(`Delivery recovery failed: ${String(err)}`);
+    });
+  }
+
   // Run gateway_start plugin hook (fire-and-forget)
   if (!minimalTestGateway) {
     const hookRunner = getGlobalHookRunner();
@@ -1041,6 +1236,7 @@ export async function startGatewayServer(
 
   return {
     close: async (opts) => {
+      deliveryRecoveryAbort.abort();
       // Run gateway_stop plugin hook before shutdown
       await runGlobalGatewayStopSafely({
         event: { reason: opts?.reason ?? "gateway stopping" },

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -326,7 +326,9 @@ function shouldRequireConnectedForRecovery(channel: ChannelId): boolean {
 function shouldSkipDeliveryRecoveryReadinessPreflight(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
-  return isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS);
+  return (
+    isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS)
+  );
 }
 
 function formatRecoveryTarget(target: PendingDeliveryRecoveryTarget): string {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -300,6 +300,12 @@ function resolvePendingDeliveryRecoveryTargets(params: {
     if (!accountId) {
       continue;
     }
+    if (!configuredAccountSet.has(accountId)) {
+      // Avoid creating synthetic readiness targets (e.g. "default") when the
+      // channel has no configured accounts. Those targets can never appear in
+      // channelAccounts and only force the preflight to time out.
+      continue;
+    }
 
     const key = `${channel}:${accountId}`;
     if (!targets.has(key)) {
@@ -390,6 +396,10 @@ async function waitForPendingDeliveryChannelReadiness(params: {
     await sleepWithAbort(Math.min(pollMs, Math.max(1, deadline - now)), params.signal);
   }
 }
+
+export const __testing = {
+  resolvePendingDeliveryRecoveryTargets,
+};
 
 export type GatewayServer = {
   close: (opts?: { reason?: string; restartExpectedMs?: number | null }) => Promise<void>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -35,7 +35,7 @@ import {
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
-import { logAcceptedEnvOption } from "../infra/env.js";
+import { isTruthyEnvValue, logAcceptedEnvOption } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -323,6 +323,12 @@ function shouldRequireConnectedForRecovery(channel: ChannelId): boolean {
   return channel === "whatsapp";
 }
 
+function shouldSkipDeliveryRecoveryReadinessPreflight(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) || isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS);
+}
+
 function formatRecoveryTarget(target: PendingDeliveryRecoveryTarget): string {
   return `${target.channel}:${target.accountId}`;
 }
@@ -399,6 +405,7 @@ async function waitForPendingDeliveryChannelReadiness(params: {
 
 export const __testing = {
   resolvePendingDeliveryRecoveryTargets,
+  shouldSkipDeliveryRecoveryReadinessPreflight,
 };
 
 export type GatewayServer = {
@@ -1132,13 +1139,18 @@ export async function startGatewayServer(
       }
 
       const targets = resolvePendingDeliveryRecoveryTargets({ pending, cfg: cfgAtStart });
-      if (targets.length > 0) {
+      const skipRecoveryReadinessPreflight = shouldSkipDeliveryRecoveryReadinessPreflight();
+      if (targets.length > 0 && !skipRecoveryReadinessPreflight) {
         await waitForPendingDeliveryChannelReadiness({
           channelManager,
           targets,
           log: logRecovery,
           signal: deliveryRecoveryAbort.signal,
         });
+      } else if (targets.length > 0 && skipRecoveryReadinessPreflight) {
+        logRecovery.info(
+          "Recovery preflight skipped: channel startup disabled via OPENCLAW_SKIP_CHANNELS/OPENCLAW_SKIP_PROVIDERS.",
+        );
       }
       if (deliveryRecoveryAbort.signal.aborted) {
         logRecovery.info("Delivery recovery skipped: gateway shutdown in progress.");

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -28,9 +28,31 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-let _currentListener: ActiveWebListener | null = null;
+// Use Symbol keys to prevent build-time token rewrites and ensure isolation across bundled chunks
+const ACTIVE_WEB_LISTENERS_KEY = Symbol.for("openclaw.activeWebListeners");
+const ACTIVE_WEB_CURRENT_LISTENER_KEY = Symbol.for("openclaw.activeWebCurrentListener");
 
-const listeners = new Map<string, ActiveWebListener>();
+type ActiveWebListenerGlobalState = typeof globalThis & {
+  [ACTIVE_WEB_LISTENERS_KEY]?: Map<string, ActiveWebListener>;
+  [ACTIVE_WEB_CURRENT_LISTENER_KEY]?: ActiveWebListener | null;
+};
+
+function getSharedListenersMap(): Map<string, ActiveWebListener> {
+  const state = globalThis as ActiveWebListenerGlobalState;
+  const existing = state[ACTIVE_WEB_LISTENERS_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created = new Map<string, ActiveWebListener>();
+  state[ACTIVE_WEB_LISTENERS_KEY] = created;
+  return created;
+}
+
+const listeners = getSharedListenersMap();
+let _currentListener: ActiveWebListener | null =
+  (globalThis as ActiveWebListenerGlobalState)[ACTIVE_WEB_CURRENT_LISTENER_KEY] ??
+  listeners.get(DEFAULT_ACCOUNT_ID) ??
+  null;
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -75,6 +97,7 @@ export function setActiveWebListener(
   }
   if (id === DEFAULT_ACCOUNT_ID) {
     _currentListener = listener;
+    (globalThis as ActiveWebListenerGlobalState)[ACTIVE_WEB_CURRENT_LISTENER_KEY] = listener;
   }
 }
 


### PR DESCRIPTION
## Summary
- move startup delivery recovery to run after `startGatewaySidecars()` (after channel startup is triggered)
- add a recovery preflight wait that polls channel runtime readiness for channels that actually have queued deliveries
- wait up to 15s for `running` (and `connected` when available, e.g. WhatsApp) before replaying queued deliveries

## Why
At boot, delivery recovery could run before WhatsApp listener registration completed, causing replay attempts to fail with:

`No active WhatsApp Web listener (account: default)`

Then the listener comes up moments later, but replay was already attempted too early.

## Behavior after this change
- if no pending deliveries: no extra startup wait
- if pending deliveries exist: recovery waits briefly for relevant channel runtime readiness, then replays
- if readiness times out, recovery still proceeds (non-blocking startup)

## Validation
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server.health.test.ts`
