### PR TITLE
fix: serve remote and data URL avatars in Control UI

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -65,7 +65,7 @@ describe("handleControlUiHttpRequest", () => {
     resolveAvatar: Parameters<typeof handleControlUiAvatarRequest>[2]["resolveAvatar"];
     basePath?: string;
   }) {
-    const { res, end } = makeMockHttpResponse();
+    const { res, setHeader, end } = makeMockHttpResponse();
     const handled = handleControlUiAvatarRequest(
       { url: params.url, method: params.method } as IncomingMessage,
       res,
@@ -74,7 +74,7 @@ describe("handleControlUiHttpRequest", () => {
         resolveAvatar: params.resolveAvatar,
       },
     );
-    return { res, end, handled };
+    return { res, setHeader, end, handled };
   }
 
   async function writeAssetFile(rootPath: string, filename: string, contents: string) {
@@ -216,6 +216,43 @@ describe("handleControlUiHttpRequest", () => {
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("redirects to remote avatar URL (regression #41201)", () => {
+    const { res, setHeader, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "remote", url: "https://example.com/avatar.png" }),
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(302);
+    expect(setHeader).toHaveBeenCalledWith("Location", "https://example.com/avatar.png");
+    expect(end).toHaveBeenCalledWith();
+  });
+
+  it("serves data URL avatar bytes directly (regression #41201)", () => {
+    const b64 = Buffer.from("fake-png-bytes").toString("base64");
+    const dataUrl = `data:image/png;base64,${b64}`;
+    const { res, setHeader, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "data", url: dataUrl }),
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(setHeader).toHaveBeenCalledWith("Content-Type", "image/png");
+    const body = end.mock.calls[0]?.[0] as Buffer | undefined;
+    expect(body).toBeInstanceOf(Buffer);
+    expect(body?.toString()).toBe("fake-png-bytes");
+  });
+
+  it("returns 404 for malformed data URL avatar", () => {
+    const { res, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "data", url: "data:not-valid" }),
+    });
+    expectNotFoundResponse({ handled, res, end });
   });
 
   it("rejects avatar symlink paths from resolver", async () => {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -246,6 +246,31 @@ describe("handleControlUiHttpRequest", () => {
     expect(body?.toString()).toBe("fake-png-bytes");
   });
 
+  it("serves data URL avatar with extra parameters (charset)", () => {
+    const b64 = Buffer.from("param-png-bytes").toString("base64");
+    const dataUrl = `data:image/png;charset=utf-8;base64,${b64}`;
+    const { res, setHeader, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "data", url: dataUrl }),
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(setHeader).toHaveBeenCalledWith("Content-Type", "image/png");
+    const body = end.mock.calls[0]?.[0] as Buffer | undefined;
+    expect(body?.toString()).toBe("param-png-bytes");
+  });
+
+  it("returns 404 for non-image MIME type data URL avatar (defence-in-depth)", () => {
+    const b64 = Buffer.from("<script>alert(1)</script>").toString("base64");
+    const { res, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "data", url: `data:text/html;base64,${b64}` }),
+    });
+    expectNotFoundResponse({ handled, res, end });
+  });
+
   it("returns 404 for malformed data URL avatar", () => {
     const { res, end, handled } = runAvatarRequest({
       url: "/avatar/main",
@@ -253,6 +278,33 @@ describe("handleControlUiHttpRequest", () => {
       resolveAvatar: () => ({ kind: "data", url: "data:not-valid" }),
     });
     expectNotFoundResponse({ handled, res, end });
+  });
+
+  it("returns 404 for empty base64 payload in data URL avatar", () => {
+    const { res, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "data", url: "data:image/png;base64,!!!!" }),
+    });
+    expectNotFoundResponse({ handled, res, end });
+  });
+
+  it("handles HEAD request for data URL avatar without sending body", () => {
+    const b64 = Buffer.from("head-test-bytes").toString("base64");
+    const dataUrl = `data:image/png;base64,${b64}`;
+    const { res, setHeader, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "HEAD",
+      resolveAvatar: () => ({ kind: "data", url: dataUrl }),
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(setHeader).toHaveBeenCalledWith("Content-Type", "image/png");
+    expect(setHeader).toHaveBeenCalledWith(
+      "Content-Length",
+      String(Buffer.from(b64, "base64").length),
+    );
+    expect(end).toHaveBeenCalledWith();
   });
 
   it("rejects avatar symlink paths from resolver", async () => {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -289,6 +289,30 @@ describe("handleControlUiHttpRequest", () => {
     expectNotFoundResponse({ handled, res, end });
   });
 
+  it("returns 404 for base64 with trailing invalid characters", () => {
+    const { res, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "data", url: "data:image/png;base64,Zm9v!!!!" }),
+    });
+    expectNotFoundResponse({ handled, res, end });
+  });
+
+  it("serves data URL avatar with case-insensitive scheme", () => {
+    const b64 = Buffer.from("case-test").toString("base64");
+    const dataUrl = `DATA:image/png;base64,${b64}`;
+    const { res, setHeader, end, handled } = runAvatarRequest({
+      url: "/avatar/main",
+      method: "GET",
+      resolveAvatar: () => ({ kind: "data", url: dataUrl }),
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(setHeader).toHaveBeenCalledWith("Content-Type", "image/png");
+    const body = end.mock.calls[0]?.[0] as Buffer | undefined;
+    expect(body?.toString()).toBe("case-test");
+  });
+
   it("handles HEAD request for data URL avatar without sending body", () => {
     const b64 = Buffer.from("head-test-bytes").toString("base64");
     const dataUrl = `data:image/png;base64,${b64}`;

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -208,7 +208,8 @@ export function handleControlUiAvatarRequest(
   if (resolved.kind === "data") {
     // Decode data URL and serve the bytes directly (#41201).
     // Accept parameterized data URLs (e.g. data:image/png;charset=utf-8;base64,...).
-    const match = resolved.url.match(/^data:([^,]*);base64,(.+)$/);
+    // Case-insensitive scheme to match avatar resolution (isAvatarDataUrl uses /^data:/i).
+    const match = resolved.url.match(/^data:([^,]*);base64,(.+)$/i);
     if (!match) {
       respondControlUiNotFound(res);
       return true;
@@ -218,6 +219,12 @@ export function handleControlUiAvatarRequest(
       (mediaTypeAndParams?.split(";", 1)[0] || "").trim() || "application/octet-stream";
     // Defence-in-depth: only serve image MIME types from the avatar endpoint.
     if (!mimeType.startsWith("image/")) {
+      respondControlUiNotFound(res);
+      return true;
+    }
+    // Reject base64 payloads containing invalid characters (Buffer.from silently
+    // skips them, which would serve corrupt data as a valid avatar).
+    if (!/^[A-Za-z0-9+/]*={0,2}$/.test(b64)) {
       respondControlUiNotFound(res);
       return true;
     }

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -198,6 +198,29 @@ export function handleControlUiAvatarRequest(
   }
 
   const resolved = opts.resolveAvatar(agentId);
+  if (resolved.kind === "remote") {
+    // Redirect the browser to the external avatar URL (#41201).
+    res.statusCode = 302;
+    res.setHeader("Location", resolved.url);
+    res.end();
+    return true;
+  }
+  if (resolved.kind === "data") {
+    // Decode data URL and serve the bytes directly (#41201).
+    const match = resolved.url.match(/^data:([^;]+);base64,(.+)$/);
+    if (match) {
+      const [, mimeType, b64] = match;
+      const buf = Buffer.from(b64, "base64");
+      res.statusCode = 200;
+      res.setHeader("Content-Type", mimeType ?? "application/octet-stream");
+      res.setHeader("Content-Length", String(buf.length));
+      res.setHeader("Cache-Control", "private, max-age=300");
+      res.end(buf);
+    } else {
+      respondControlUiNotFound(res);
+    }
+    return true;
+  }
   if (resolved.kind !== "local") {
     respondControlUiNotFound(res);
     return true;

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -207,17 +207,39 @@ export function handleControlUiAvatarRequest(
   }
   if (resolved.kind === "data") {
     // Decode data URL and serve the bytes directly (#41201).
-    const match = resolved.url.match(/^data:([^;]+);base64,(.+)$/);
-    if (match) {
-      const [, mimeType, b64] = match;
-      const buf = Buffer.from(b64, "base64");
-      res.statusCode = 200;
-      res.setHeader("Content-Type", mimeType ?? "application/octet-stream");
-      res.setHeader("Content-Length", String(buf.length));
-      res.setHeader("Cache-Control", "private, max-age=300");
-      res.end(buf);
-    } else {
+    // Accept parameterized data URLs (e.g. data:image/png;charset=utf-8;base64,...).
+    const match = resolved.url.match(/^data:([^,]*);base64,(.+)$/);
+    if (!match) {
       respondControlUiNotFound(res);
+      return true;
+    }
+    const [, mediaTypeAndParams, b64] = match;
+    const mimeType =
+      (mediaTypeAndParams?.split(";", 1)[0] || "").trim() || "application/octet-stream";
+    // Defence-in-depth: only serve image MIME types from the avatar endpoint.
+    if (!mimeType.startsWith("image/")) {
+      respondControlUiNotFound(res);
+      return true;
+    }
+    // Estimate decoded size before allocating to enforce AVATAR_MAX_BYTES.
+    const estimatedBytes = Math.ceil((b64.length * 3) / 4);
+    if (estimatedBytes > AVATAR_MAX_BYTES) {
+      respondControlUiNotFound(res);
+      return true;
+    }
+    const buf = Buffer.from(b64, "base64");
+    if (buf.length === 0) {
+      respondControlUiNotFound(res);
+      return true;
+    }
+    res.statusCode = 200;
+    res.setHeader("Content-Type", mimeType);
+    res.setHeader("Content-Length", String(buf.length));
+    res.setHeader("Cache-Control", "private, max-age=300");
+    if (req.method === "HEAD") {
+      res.end();
+    } else {
+      res.end(buf);
     }
     return true;
   }


### PR DESCRIPTION
## Summary

- `handleControlUiAvatarRequest()` rejected all non-local avatar kinds (`remote`, `data`) with a 404 response, causing broken avatar images in the Control UI when avatars are configured as HTTP URLs or data URIs
- Remote avatars (`kind: "remote"`) now receive a 302 redirect to the external URL
- Data URL avatars (`kind: "data"`) are decoded from base64 and served inline with the correct MIME type
- Malformed data URLs still return 404

Fixes #41201

## Test plan

- [x] Existing control-ui HTTP tests pass (24/24)
- [x] New: `redirects to remote avatar URL (regression #41201)`
- [x] New: `serves data URL avatar bytes directly (regression #41201)`
- [x] New: `returns 404 for malformed data URL avatar`
- [ ] Manual: set avatar via `openclaw agents set-identity --avatar https://example.com/avatar.png`, verify Control UI displays it