### PR TITLE
fix(gateway): suppress ciao mDNS assertion errors on network changes

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAbortError, isTransientNetworkError } from "./unhandled-rejections.js";
+import {
+  isAbortError,
+  isCiaoMdnsAssertionError,
+  isTransientNetworkError,
+} from "./unhandled-rejections.js";
 
 describe("isAbortError", () => {
   it("returns true for error with name AbortError", () => {
@@ -179,4 +183,65 @@ describe("isTransientNetworkError", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
   });
+});
+
+describe("isCiaoMdnsAssertionError", () => {
+  it("returns true for IPv4 address change assertion error", () => {
+    const error = Object.assign(
+      new Error("Reached illegal state! IPv4 address changed from undefined to defined!"),
+      { name: "AssertionError", code: "ERR_ASSERTION" },
+    );
+    expect(isCiaoMdnsAssertionError(error)).toBe(true);
+  });
+
+  it("returns true for IPv6 address change assertion error", () => {
+    const error = Object.assign(
+      new Error("Reached illegal state! IPv6 address changed from defined to undefined!"),
+      { name: "AssertionError", code: "ERR_ASSERTION" },
+    );
+    expect(isCiaoMdnsAssertionError(error)).toBe(true);
+  });
+
+  it("returns true for generic 'Reached illegal state' assertion", () => {
+    const error = Object.assign(new Error("Reached illegal state! Network interface changed"), {
+      name: "AssertionError",
+      code: "ERR_ASSERTION",
+    });
+    expect(isCiaoMdnsAssertionError(error)).toBe(true);
+  });
+
+  it("returns true with only name AssertionError", () => {
+    const error = { name: "AssertionError", message: "IPv4 address changed" };
+    expect(isCiaoMdnsAssertionError(error)).toBe(true);
+  });
+
+  it("returns true with only code ERR_ASSERTION", () => {
+    const error = { code: "ERR_ASSERTION", message: "IPv6 address changed" };
+    expect(isCiaoMdnsAssertionError(error)).toBe(true);
+  });
+
+  it("returns false for regular AssertionError without network message", () => {
+    const error = Object.assign(new Error("Some other assertion failed"), {
+      name: "AssertionError",
+      code: "ERR_ASSERTION",
+    });
+    expect(isCiaoMdnsAssertionError(error)).toBe(false);
+  });
+
+  it("returns false for non-assertion errors with similar message", () => {
+    const error = new Error("IPv4 address changed from undefined to defined!");
+    expect(isCiaoMdnsAssertionError(error)).toBe(false);
+  });
+
+  it("returns false for regular errors", () => {
+    expect(isCiaoMdnsAssertionError(new Error("Something went wrong"))).toBe(false);
+    expect(isCiaoMdnsAssertionError(new TypeError("Cannot read property"))).toBe(false);
+  });
+
+  it.each([null, undefined, "string error", 42, { message: "plain object" }])(
+    "returns false for non-ciao input %#",
+    (value) => {
+      expect(isCiaoMdnsAssertionError(value)).toBe(false);
+    },
+  );
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -111,6 +111,30 @@ function extractErrorCodeWithCause(err: unknown): string | undefined {
 }
 
 /**
+ * Checks if an error is a ciao mDNS assertion error (network interface change).
+ * These occur when network interfaces change unexpectedly (WiFi reconnect, sleep/wake)
+ * and should not crash the gateway.
+ */
+export function isCiaoMdnsAssertionError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const name = "name" in err ? String(err.name) : "";
+  const code = "code" in err ? String(err.code) : "";
+  // Match AssertionError with ERR_ASSERTION code
+  if (name !== "AssertionError" && code !== "ERR_ASSERTION") {
+    return false;
+  }
+  const message = "message" in err && typeof err.message === "string" ? err.message : "";
+  // Match ciao's MDNSServer network interface assertion failures
+  return (
+    message.includes("IPv4 address changed") ||
+    message.includes("IPv6 address changed") ||
+    message.includes("Reached illegal state")
+  );
+}
+
+/**
  * Checks if an error is an AbortError.
  * These are typically intentional cancellations (e.g., during shutdown) and shouldn't crash.
  */
@@ -244,6 +268,15 @@ export function installUnhandledRejectionHandler(): void {
     if (isTransientNetworkError(reason)) {
       console.warn(
         "[openclaw] Non-fatal unhandled rejection (continuing):",
+        formatUncaughtError(reason),
+      );
+      return;
+    }
+
+    // ciao mDNS assertion errors during network interface changes should not crash
+    if (isCiaoMdnsAssertionError(reason)) {
+      console.warn(
+        "[openclaw] Suppressed ciao mDNS assertion error (network interface change):",
         formatUncaughtError(reason),
       );
       return;


### PR DESCRIPTION
## Summary

The `@homebridge/ciao` library throws unhandled `AssertionError` when network interfaces change unexpectedly (WiFi reconnect, sleep/wake, IP address assignment). This causes the gateway to crash with exit code 1.

## Changes

- Add `isCiaoMdnsAssertionError()` function to detect ciao mDNS assertion errors
- Handle these errors in the unhandled rejection handler, logging a warning instead of crashing

## Test Plan

- [x] Added 9 unit tests for the new error detection function
- [ ] Manual testing: toggle WiFi/sleep-wake and verify gateway stays running

## Root Cause

```
AssertionError [ERR_ASSERTION]: Reached illegal state! IPv4 address changed from undefined to defined!
    at MDNSServer.handleUpdatedNetworkInterfaces
```

This is a bug in `@homebridge/ciao` v1.3.5 that cannot be fixed upstream, so we handle it gracefully.