### PR TITLE
feat(infra): add active turn tracker to recover from silent failures after gateway restart

### DIFF
--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -1,3 +1,4 @@
+import { clearActiveTurn, writeActiveTurn } from "../../infra/active-turns.js";
 import {
   diagnosticLogger as diag,
   logMessageQueued,
@@ -216,6 +217,7 @@ export function setActiveEmbeddedRun(
   if (!sessionId.startsWith("probe-")) {
     diag.debug(`run registered: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
   }
+  writeActiveTurn(sessionId, sessionKey ?? sessionId);
 }
 
 export function clearActiveEmbeddedRun(
@@ -225,6 +227,7 @@ export function clearActiveEmbeddedRun(
 ) {
   if (ACTIVE_EMBEDDED_RUNS.get(sessionId) === handle) {
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
+    clearActiveTurn(sessionId);
     logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "run_completed" });
     if (!sessionId.startsWith("probe-")) {
       diag.debug(`run cleared: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);

--- a/src/gateway/server-active-turn-recovery.ts
+++ b/src/gateway/server-active-turn-recovery.ts
@@ -1,3 +1,4 @@
+import { isEmbeddedPiRunActive } from "../agents/pi-embedded-runner/runs.js";
 import { resolveAnnounceTargetFromKey } from "../agents/tools/sessions-send-helpers.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.js";
@@ -34,6 +35,15 @@ export async function recoverInterruptedTurns(_params: { deps: CliDeps }): Promi
 
   let recovered = 0;
   for (const marker of markers) {
+    // Skip markers for runs that are currently active — a message received
+    // during the startup delay may have already created a live run. Removing
+    // its marker would make the active turn invisible to crash recovery and
+    // the stuck-turn watchdog.
+    if (isEmbeddedPiRunActive(marker.sessionId)) {
+      log.info(`skipping live run: sessionId=${marker.sessionId}`);
+      continue;
+    }
+
     // Always clear the marker first (consume-then-process pattern) to prevent
     // infinite retry loops if the gateway crashes again during recovery.
     await removeActiveTurnMarker(marker.sessionId);

--- a/src/gateway/server-active-turn-recovery.ts
+++ b/src/gateway/server-active-turn-recovery.ts
@@ -115,7 +115,3 @@ async function deliverRecoveryNotification(sessionKey: string): Promise<void> {
     enqueueSystemEvent(`Active turn recovery failed: ${String(err)}`, { sessionKey });
   }
 }
-
-export function shouldRecoverInterruptedTurns(): boolean {
-  return !process.env.VITEST && process.env.NODE_ENV !== "test";
-}

--- a/src/gateway/server-active-turn-recovery.ts
+++ b/src/gateway/server-active-turn-recovery.ts
@@ -1,0 +1,121 @@
+import { resolveAnnounceTargetFromKey } from "../agents/tools/sessions-send-helpers.js";
+import { normalizeChannelId } from "../channels/plugins/index.js";
+import type { CliDeps } from "../cli/deps.js";
+import { parseSessionThreadInfo } from "../config/sessions/delivery-info.js";
+import { loadActiveTurnMarkers, removeActiveTurnMarker } from "../infra/active-turns.js";
+import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
+import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
+import { resolveOutboundTarget } from "../infra/outbound/targets.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/delivery-context.js";
+import { loadSessionEntry } from "./session-utils.js";
+
+const log = createSubsystemLogger("active-turn-recovery");
+
+const RECOVERY_MESSAGE =
+  "I was interrupted while processing your message. Could you please resend your last message?";
+
+/**
+ * On gateway startup, check for active turn markers left behind by a
+ * previous crash or unclean restart. For each stale marker, deliver a
+ * notification to the user so they know to resend their message.
+ *
+ * Follows the same delivery resolution chain as
+ * {@link scheduleRestartSentinelWake} in `server-restart-sentinel.ts`.
+ */
+export async function recoverInterruptedTurns(_params: { deps: CliDeps }): Promise<number> {
+  const markers = await loadActiveTurnMarkers();
+  if (markers.length === 0) {
+    return 0;
+  }
+
+  log.info(`found ${markers.length} interrupted turn(s) — starting recovery`);
+
+  let recovered = 0;
+  for (const marker of markers) {
+    // Always clear the marker first (consume-then-process pattern) to prevent
+    // infinite retry loops if the gateway crashes again during recovery.
+    await removeActiveTurnMarker(marker.sessionId);
+
+    try {
+      await deliverRecoveryNotification(marker.sessionKey);
+      recovered += 1;
+      log.info(`recovered interrupted turn: sessionKey=${marker.sessionKey}`);
+    } catch (err) {
+      log.warn(
+        `failed to deliver recovery notification: sessionKey=${marker.sessionKey} err=${String(err)}`,
+      );
+    }
+  }
+
+  log.info(`active turn recovery complete: ${recovered}/${markers.length} recovered`);
+  return recovered;
+}
+
+async function deliverRecoveryNotification(sessionKey: string): Promise<void> {
+  const { baseSessionKey, threadId: sessionThreadId } = parseSessionThreadInfo(sessionKey);
+
+  const { cfg, entry } = loadSessionEntry(sessionKey);
+  const parsedTarget = resolveAnnounceTargetFromKey(baseSessionKey ?? sessionKey);
+
+  let sessionDeliveryContext = deliveryContextFromSession(entry);
+  if (!sessionDeliveryContext && baseSessionKey && baseSessionKey !== sessionKey) {
+    const { entry: baseEntry } = loadSessionEntry(baseSessionKey);
+    sessionDeliveryContext = deliveryContextFromSession(baseEntry);
+  }
+
+  const origin = mergeDeliveryContext(sessionDeliveryContext, parsedTarget ?? undefined);
+
+  const channelRaw = origin?.channel;
+  const channel = channelRaw ? normalizeChannelId(channelRaw) : null;
+  const to = origin?.to;
+  if (!channel || !to) {
+    enqueueSystemEvent(RECOVERY_MESSAGE, { sessionKey });
+    return;
+  }
+
+  const resolved = resolveOutboundTarget({
+    channel,
+    to,
+    cfg,
+    accountId: origin?.accountId,
+    mode: "implicit",
+  });
+  if (!resolved.ok) {
+    enqueueSystemEvent(RECOVERY_MESSAGE, { sessionKey });
+    return;
+  }
+
+  const threadId =
+    parsedTarget?.threadId ??
+    sessionThreadId ??
+    (origin?.threadId != null ? String(origin.threadId) : undefined);
+
+  // Slack uses replyToId (thread_ts) for threading, not threadId.
+  const isSlack = channel === "slack";
+  const replyToId = isSlack && threadId != null && threadId !== "" ? String(threadId) : undefined;
+  const resolvedThreadId = isSlack ? undefined : threadId;
+
+  const outboundSession = buildOutboundSessionContext({ cfg, sessionKey });
+
+  try {
+    await deliverOutboundPayloads({
+      cfg,
+      channel,
+      to: resolved.to,
+      accountId: origin?.accountId,
+      replyToId,
+      threadId: resolvedThreadId,
+      payloads: [{ text: RECOVERY_MESSAGE }],
+      session: outboundSession,
+      bestEffort: true,
+    });
+  } catch (err) {
+    enqueueSystemEvent(`Active turn recovery failed: ${String(err)}`, { sessionKey });
+  }
+}
+
+export function shouldRecoverInterruptedTurns(): boolean {
+  return !process.env.VITEST && process.env.NODE_ENV !== "test";
+}

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -189,15 +189,21 @@ export async function startGatewaySidecars(params: {
 
   // Recover interrupted turns left behind by a previous crash or unclean restart.
   // Runs after sentinel wake (750ms) to avoid duplicate notifications.
+  // The watchdog starts unconditionally via .finally() so it runs even if
+  // recovery rejects unexpectedly.
   if (!process.env.VITEST && process.env.NODE_ENV !== "test") {
     setTimeout(() => {
-      void import("./server-active-turn-recovery.js").then(({ recoverInterruptedTurns }) => {
-        void recoverInterruptedTurns({ deps: params.deps }).then(() => {
+      void import("./server-active-turn-recovery.js")
+        .then(({ recoverInterruptedTurns }) => recoverInterruptedTurns({ deps: params.deps }))
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.warn(`[active-turn-recovery] startup recovery failed: ${String(err)}`);
+        })
+        .finally(() => {
           void import("../infra/stuck-turn-watchdog.js").then(({ startStuckTurnWatchdog }) => {
             startStuckTurnWatchdog({ deps: params.deps });
           });
         });
-      });
     }, 1500);
   }
 

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -187,5 +187,19 @@ export async function startGatewaySidecars(params: {
     }, 750);
   }
 
+  // Recover interrupted turns left behind by a previous crash or unclean restart.
+  // Runs after sentinel wake (750ms) to avoid duplicate notifications.
+  if (!process.env.VITEST && process.env.NODE_ENV !== "test") {
+    setTimeout(() => {
+      void import("./server-active-turn-recovery.js").then(({ recoverInterruptedTurns }) => {
+        void recoverInterruptedTurns({ deps: params.deps }).then(() => {
+          void import("../infra/stuck-turn-watchdog.js").then(({ startStuckTurnWatchdog }) => {
+            startStuckTurnWatchdog({ deps: params.deps });
+          });
+        });
+      });
+    }, 1500);
+  }
+
   return { browserControl, pluginServices };
 }

--- a/src/infra/active-turns-crash-scenarios.test.ts
+++ b/src/infra/active-turns-crash-scenarios.test.ts
@@ -149,7 +149,28 @@ describe("active-turns crash scenarios", () => {
     expect(markers.length).toBe(0);
   });
 
-  it("Scenario 8: marker file has valid JSON but missing fields", async () => {
+  it("Scenario 8: clear from old turn does not delete new turn marker", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    // Turn A starts.
+    writeActiveTurn("sess-race", "key-A", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Turn A ends — clearActiveTurn fires (fire-and-forget).
+    clearActiveTurn("sess-race", env);
+
+    // Turn B starts immediately for the same session before clear runs.
+    writeActiveTurn("sess-race", "key-B", env);
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Turn B's marker should survive — not deleted by turn A's clear.
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(1);
+    expect(markers[0].sessionKey).toBe("key-B");
+  });
+
+  it("Scenario 9: marker file has valid JSON but missing fields", async () => {
     const { env, stateDir } = makeTempEnv();
     cleanup = stateDir;
 

--- a/src/infra/active-turns-crash-scenarios.test.ts
+++ b/src/infra/active-turns-crash-scenarios.test.ts
@@ -1,0 +1,168 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __testing_resolveActiveTurnsDir,
+  clearActiveTurn,
+  loadActiveTurnMarkers,
+  removeActiveTurnMarker,
+  writeActiveTurn,
+} from "./active-turns.js";
+
+function makeTempEnv(): { env: NodeJS.ProcessEnv; stateDir: string } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-scenario-"));
+  return { env: { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv, stateDir };
+}
+
+describe("active-turns crash scenarios", () => {
+  let cleanup: string | undefined;
+
+  afterEach(() => {
+    if (cleanup) {
+      fs.rmSync(cleanup, { recursive: true, force: true });
+    }
+  });
+
+  it("Scenario 1: gateway crash mid-turn — marker survives", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    // Simulate: agent starts processing a turn.
+    writeActiveTurn("crash-sess-1", "agent:main:telegram:dm:123", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Simulate: process crashes (clearActiveTurn never called).
+    // On next startup, marker should still be on disk.
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(1);
+    expect(markers[0].sessionId).toBe("crash-sess-1");
+    expect(markers[0].sessionKey).toBe("agent:main:telegram:dm:123");
+  });
+
+  it("Scenario 2: clean completion — marker removed", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("clean-sess", "key-clean", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Simulate: response delivered, run completes normally.
+    clearActiveTurn("clean-sess", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(0);
+  });
+
+  it("Scenario 3: multiple concurrent turns — one crashes, others complete", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("turn-a", "key-a", env);
+    writeActiveTurn("turn-b", "key-b", env);
+    writeActiveTurn("turn-c", "key-c", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // turn-b completes normally.
+    clearActiveTurn("turn-b", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Simulate crash: turn-a and turn-c still pending.
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(2);
+    const ids = markers.map((m) => m.sessionId).toSorted();
+    expect(ids).toEqual(["turn-a", "turn-c"]);
+  });
+
+  it("Scenario 4: recovery consume-then-process — marker cleared before delivery", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("recover-1", "key-r1", env);
+    writeActiveTurn("recover-2", "key-r2", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Simulate recovery: consume markers first (like recoverInterruptedTurns).
+    const markers = await loadActiveTurnMarkers(env);
+    for (const marker of markers) {
+      await removeActiveTurnMarker(marker.sessionId, env);
+    }
+
+    // All markers cleared even before "delivery" attempt.
+    const remaining = await loadActiveTurnMarkers(env);
+    expect(remaining.length).toBe(0);
+  });
+
+  it("Scenario 5: crash during recovery — markers already consumed won't re-send", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("rr-1", "key-rr1", env);
+    writeActiveTurn("rr-2", "key-rr2", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // First recovery pass: consume rr-1.
+    await loadActiveTurnMarkers(env);
+    await removeActiveTurnMarker("rr-1", env);
+    // Simulate: crash during rr-2 delivery.
+
+    // Second recovery pass after second restart.
+    const markers2 = await loadActiveTurnMarkers(env);
+    expect(markers2.length).toBe(1);
+    expect(markers2[0].sessionId).toBe("rr-2");
+    // rr-1 was already consumed — not re-processed.
+  });
+
+  it("Scenario 6: run replaced (same sessionId, new handle) — marker updated", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("replace-sess", "key-old", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Same sessionId, different sessionKey (run replaced).
+    writeActiveTurn("replace-sess", "key-new", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(1);
+    expect(markers[0].sessionKey).toBe("key-new");
+  });
+
+  it("Scenario 7: rapid write-clear cycle — no stale marker left", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    // Rapid fire: write and clear quickly.
+    for (let i = 0; i < 10; i++) {
+      writeActiveTurn(`rapid-${i}`, `key-${i}`, env);
+    }
+    await new Promise((r) => setTimeout(r, 300));
+
+    for (let i = 0; i < 10; i++) {
+      clearActiveTurn(`rapid-${i}`, env);
+    }
+    await new Promise((r) => setTimeout(r, 300));
+
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(0);
+  });
+
+  it("Scenario 8: marker file has valid JSON but missing fields", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    const dir = __testing_resolveActiveTurnsDir(env);
+    fs.mkdirSync(dir, { recursive: true });
+    // Valid JSON but missing sessionId.
+    fs.writeFileSync(path.join(dir, "bad-fields.json"), JSON.stringify({ foo: "bar" }));
+    writeActiveTurn("good-one", "key-good", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const markers = await loadActiveTurnMarkers(env);
+    // Only the valid marker should be returned.
+    expect(markers.length).toBe(1);
+    expect(markers[0].sessionId).toBe("good-one");
+  });
+});

--- a/src/infra/active-turns.test.ts
+++ b/src/infra/active-turns.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __testing_resolveActiveTurnsDir,
+  clearActiveTurn,
+  loadActiveTurnMarkers,
+  removeActiveTurnMarker,
+  writeActiveTurn,
+} from "./active-turns.js";
+
+function makeTempEnv(): { env: NodeJS.ProcessEnv; stateDir: string } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "active-turns-test-"));
+  return { env: { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv, stateDir };
+}
+
+describe("active-turns", () => {
+  let cleanup: string | undefined;
+
+  beforeEach(() => {
+    cleanup = undefined;
+  });
+
+  afterEach(() => {
+    if (cleanup) {
+      fs.rmSync(cleanup, { recursive: true, force: true });
+    }
+  });
+
+  it("writeActiveTurn creates a marker file", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("sess-1", "agent:main:telegram:dm:123", env);
+    // Wait for fire-and-forget async write to complete.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const dir = __testing_resolveActiveTurnsDir(env);
+    const files = fs.readdirSync(dir);
+    expect(files.length).toBe(1);
+    expect(files[0]).toBe("sess-1.json");
+
+    const content = JSON.parse(fs.readFileSync(path.join(dir, files[0]), "utf-8"));
+    expect(content.sessionId).toBe("sess-1");
+    expect(content.sessionKey).toBe("agent:main:telegram:dm:123");
+    expect(typeof content.startedAt).toBe("number");
+  });
+
+  it("clearActiveTurn removes the marker file", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("sess-2", "key-2", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const dir = __testing_resolveActiveTurnsDir(env);
+    expect(fs.readdirSync(dir).length).toBe(1);
+
+    clearActiveTurn("sess-2", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(fs.readdirSync(dir).length).toBe(0);
+  });
+
+  it("clearActiveTurn does not throw for missing files", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    // Should not throw.
+    clearActiveTurn("nonexistent", env);
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it("loadActiveTurnMarkers returns all valid markers", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("s1", "key-1", env);
+    writeActiveTurn("s2", "key-2", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(2);
+    const ids = markers.map((m) => m.sessionId).toSorted();
+    expect(ids).toEqual(["s1", "s2"]);
+  });
+
+  it("loadActiveTurnMarkers returns empty array when dir does not exist", async () => {
+    const env = { OPENCLAW_STATE_DIR: "/tmp/nonexistent-dir-12345" } as NodeJS.ProcessEnv;
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers).toEqual([]);
+  });
+
+  it("loadActiveTurnMarkers skips corrupt files", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    const dir = __testing_resolveActiveTurnsDir(env);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "bad.json"), "not-json{{{");
+    writeActiveTurn("good", "key-good", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(1);
+    expect(markers[0].sessionId).toBe("good");
+  });
+
+  it("writeActiveTurn skips probe sessions", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("probe-health", "probe-key", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const dir = __testing_resolveActiveTurnsDir(env);
+    const exists = fs.existsSync(dir);
+    if (exists) {
+      expect(fs.readdirSync(dir).length).toBe(0);
+    }
+  });
+
+  it("removeActiveTurnMarker removes a specific marker", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("s1", "key-1", env);
+    writeActiveTurn("s2", "key-2", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    await removeActiveTurnMarker("s1", env);
+
+    const markers = await loadActiveTurnMarkers(env);
+    expect(markers.length).toBe(1);
+    expect(markers[0].sessionId).toBe("s2");
+  });
+
+  it("sanitizes sessionId with path separators", async () => {
+    const { env, stateDir } = makeTempEnv();
+    cleanup = stateDir;
+
+    writeActiveTurn("a/b\\c:d", "key-path", env);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const dir = __testing_resolveActiveTurnsDir(env);
+    const files = fs.readdirSync(dir);
+    expect(files.length).toBe(1);
+    // Should not contain path separators in filename.
+    expect(files[0]).not.toMatch(/[/\\:]/);
+  });
+});

--- a/src/infra/active-turns.ts
+++ b/src/infra/active-turns.ts
@@ -11,6 +11,16 @@ const ACTIVE_TURNS_DIRNAME = "active-turns";
  */
 const pendingWrites = new Map<string, Promise<void>>();
 
+/**
+ * Monotonically increasing write generation per session. Each writeActiveTurn
+ * call bumps the generation so that a stale clearActiveTurn (from a previous
+ * turn) can detect that a newer write happened and skip the unlink.
+ */
+const writeGenerations = new Map<string, number>();
+
+/** Monotonic counter for unique temp file names within a single process. */
+let tmpCounter = 0;
+
 export type ActiveTurnMarker = {
   sessionId: string;
   sessionKey: string;
@@ -41,10 +51,16 @@ export function writeActiveTurn(
   }
   const marker: ActiveTurnMarker = { sessionId, sessionKey, startedAt: Date.now() };
   const filePath = resolveMarkerPath(sessionId, env);
+  // Bump write generation so stale clears from a previous turn can detect
+  // that a newer write happened and skip the unlink.
+  const gen = (writeGenerations.get(sessionId) ?? 0) + 1;
+  writeGenerations.set(sessionId, gen);
   const writePromise = (async () => {
     const dir = path.dirname(filePath);
     await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-    const tmp = `${filePath}.${process.pid}.tmp`;
+    // Use a unique temp path per write to avoid races when two rapid writes
+    // for the same session share the same tmp file.
+    const tmp = `${filePath}.${process.pid}.${tmpCounter++}.tmp`;
     await fs.promises.writeFile(tmp, JSON.stringify(marker, null, 2), {
       encoding: "utf-8",
       mode: 0o600,
@@ -73,7 +89,19 @@ export function clearActiveTurn(sessionId: string, env?: NodeJS.ProcessEnv): voi
   }
   const filePath = resolveMarkerPath(sessionId, env);
   const pending = pendingWrites.get(sessionId);
-  const doUnlink = () => fs.promises.unlink(filePath).catch(() => {});
+  // Capture the current write generation. If a newer writeActiveTurn fires
+  // between now and when the unlink runs, the generation will have changed
+  // and we must skip the unlink to avoid deleting the newer marker.
+  const genAtClear = writeGenerations.get(sessionId) ?? 0;
+  const doUnlink = () => {
+    const currentGen = writeGenerations.get(sessionId) ?? 0;
+    if (currentGen !== genAtClear) {
+      // A newer write started after this clear was issued — do not delete
+      // the marker that belongs to the new run.
+      return Promise.resolve();
+    }
+    return fs.promises.unlink(filePath).catch(() => {});
+  };
   if (pending) {
     void pending.then(doUnlink);
   } else {

--- a/src/infra/active-turns.ts
+++ b/src/infra/active-turns.ts
@@ -4,6 +4,13 @@ import { resolveStateDir } from "../config/paths.js";
 
 const ACTIVE_TURNS_DIRNAME = "active-turns";
 
+/**
+ * Track pending write promises per session so that clearActiveTurn can wait
+ * for the write to finish before unlinking, preventing the race where unlink
+ * fires before rename completes and leaves a stale marker on disk.
+ */
+const pendingWrites = new Map<string, Promise<void>>();
+
 export type ActiveTurnMarker = {
   sessionId: string;
   sessionKey: string;
@@ -34,7 +41,7 @@ export function writeActiveTurn(
   }
   const marker: ActiveTurnMarker = { sessionId, sessionKey, startedAt: Date.now() };
   const filePath = resolveMarkerPath(sessionId, env);
-  void (async () => {
+  const writePromise = (async () => {
     const dir = path.dirname(filePath);
     await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
     const tmp = `${filePath}.${process.pid}.tmp`;
@@ -46,19 +53,32 @@ export function writeActiveTurn(
   })().catch(() => {
     // Best-effort — never block the hot path.
   });
+  pendingWrites.set(sessionId, writePromise);
+  void writePromise.finally(() => {
+    // Only clean up if this is still the latest write for this session.
+    if (pendingWrites.get(sessionId) === writePromise) {
+      pendingWrites.delete(sessionId);
+    }
+  });
 }
 
 /**
  * Remove an active turn marker from disk. Fire-and-forget — never throws.
+ * Waits for any pending write to finish first so the unlink doesn't race
+ * ahead of the atomic rename.
  */
 export function clearActiveTurn(sessionId: string, env?: NodeJS.ProcessEnv): void {
   if (sessionId.startsWith("probe-")) {
     return;
   }
   const filePath = resolveMarkerPath(sessionId, env);
-  void fs.promises.unlink(filePath).catch(() => {
-    // Best-effort — silently ignore ENOENT or other errors.
-  });
+  const pending = pendingWrites.get(sessionId);
+  const doUnlink = () => fs.promises.unlink(filePath).catch(() => {});
+  if (pending) {
+    void pending.then(doUnlink);
+  } else {
+    void doUnlink();
+  }
 }
 
 /**
@@ -82,7 +102,13 @@ export async function loadActiveTurnMarkers(env?: NodeJS.ProcessEnv): Promise<Ac
     try {
       const raw = await fs.promises.readFile(filePath, "utf-8");
       const parsed = JSON.parse(raw) as ActiveTurnMarker;
-      if (parsed && typeof parsed.sessionId === "string" && typeof parsed.sessionKey === "string") {
+      if (
+        parsed &&
+        typeof parsed.sessionId === "string" &&
+        typeof parsed.sessionKey === "string" &&
+        typeof parsed.startedAt === "number" &&
+        Number.isFinite(parsed.startedAt)
+      ) {
         markers.push(parsed);
       }
     } catch {

--- a/src/infra/active-turns.ts
+++ b/src/infra/active-turns.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+const ACTIVE_TURNS_DIRNAME = "active-turns";
+
+export type ActiveTurnMarker = {
+  sessionId: string;
+  sessionKey: string;
+  startedAt: number;
+};
+
+function resolveActiveTurnsDir(env?: NodeJS.ProcessEnv): string {
+  return path.join(resolveStateDir(env), ACTIVE_TURNS_DIRNAME);
+}
+
+function resolveMarkerPath(sessionId: string, env?: NodeJS.ProcessEnv): string {
+  // Sanitize sessionId to prevent path traversal.
+  const safe = sessionId.replaceAll(/[/\\:]/g, "_");
+  return path.join(resolveActiveTurnsDir(env), `${safe}.json`);
+}
+
+/**
+ * Persist an active turn marker to disk. Fire-and-forget — never throws.
+ * Skipped for probe sessions (health checks).
+ */
+export function writeActiveTurn(
+  sessionId: string,
+  sessionKey: string,
+  env?: NodeJS.ProcessEnv,
+): void {
+  if (sessionId.startsWith("probe-")) {
+    return;
+  }
+  const marker: ActiveTurnMarker = { sessionId, sessionKey, startedAt: Date.now() };
+  const filePath = resolveMarkerPath(sessionId, env);
+  void (async () => {
+    const dir = path.dirname(filePath);
+    await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+    const tmp = `${filePath}.${process.pid}.tmp`;
+    await fs.promises.writeFile(tmp, JSON.stringify(marker, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    await fs.promises.rename(tmp, filePath);
+  })().catch(() => {
+    // Best-effort — never block the hot path.
+  });
+}
+
+/**
+ * Remove an active turn marker from disk. Fire-and-forget — never throws.
+ */
+export function clearActiveTurn(sessionId: string, env?: NodeJS.ProcessEnv): void {
+  if (sessionId.startsWith("probe-")) {
+    return;
+  }
+  const filePath = resolveMarkerPath(sessionId, env);
+  void fs.promises.unlink(filePath).catch(() => {
+    // Best-effort — silently ignore ENOENT or other errors.
+  });
+}
+
+/**
+ * Load all active turn markers from disk.
+ * Used at startup to detect interrupted turns and by the stuck turn watchdog.
+ */
+export async function loadActiveTurnMarkers(env?: NodeJS.ProcessEnv): Promise<ActiveTurnMarker[]> {
+  const dir = resolveActiveTurnsDir(env);
+  let files: string[];
+  try {
+    files = await fs.promises.readdir(dir);
+  } catch {
+    return [];
+  }
+  const markers: ActiveTurnMarker[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".json")) {
+      continue;
+    }
+    const filePath = path.join(dir, file);
+    try {
+      const raw = await fs.promises.readFile(filePath, "utf-8");
+      const parsed = JSON.parse(raw) as ActiveTurnMarker;
+      if (parsed && typeof parsed.sessionId === "string" && typeof parsed.sessionKey === "string") {
+        markers.push(parsed);
+      }
+    } catch {
+      // Skip corrupt or inaccessible files.
+    }
+  }
+  return markers;
+}
+
+/**
+ * Remove a specific marker by sessionId (synchronous path resolution, async delete).
+ * Unlike clearActiveTurn, this returns a promise for use in recovery flows.
+ */
+export async function removeActiveTurnMarker(
+  sessionId: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<void> {
+  const filePath = resolveMarkerPath(sessionId, env);
+  await fs.promises.unlink(filePath).catch(() => {});
+}
+
+export { resolveActiveTurnsDir as __testing_resolveActiveTurnsDir };

--- a/src/infra/stuck-turn-watchdog.test.ts
+++ b/src/infra/stuck-turn-watchdog.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActiveTurnMarker } from "./active-turns.js";
+
+// Mock active-turns before importing watchdog.
+const mockLoadMarkers = vi.fn<() => Promise<ActiveTurnMarker[]>>().mockResolvedValue([]);
+const mockRemoveMarker = vi.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+vi.mock("./active-turns.js", () => ({
+  loadActiveTurnMarkers: (...args: unknown[]) => mockLoadMarkers(...(args as [])),
+  removeActiveTurnMarker: (id: string) => mockRemoveMarker(id),
+}));
+
+// Mock embedded runs.
+const mockIsActive = vi.fn<(id: string) => boolean>().mockReturnValue(false);
+const mockAbort = vi.fn<(id: string) => boolean>().mockReturnValue(true);
+vi.mock("../agents/pi-embedded-runner/runs.js", () => ({
+  isEmbeddedPiRunActive: (id: string) => mockIsActive(id),
+  abortEmbeddedPiRun: (id: string) => mockAbort(id),
+}));
+
+// Mock logger.
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const { startStuckTurnWatchdog } = await import("./stuck-turn-watchdog.js");
+
+describe("stuck-turn-watchdog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does nothing when no markers exist", async () => {
+    mockLoadMarkers.mockResolvedValue([]);
+    const handle = startStuckTurnWatchdog({
+      deps: {} as never,
+      checkIntervalMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockAbort).not.toHaveBeenCalled();
+    handle.stop();
+  });
+
+  it("cleans stale markers (no in-memory run)", async () => {
+    mockLoadMarkers.mockResolvedValue([
+      { sessionId: "stale-1", sessionKey: "key-1", startedAt: Date.now() - 5000 },
+    ]);
+    mockIsActive.mockReturnValue(false);
+
+    const handle = startStuckTurnWatchdog({
+      deps: {} as never,
+      checkIntervalMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockRemoveMarker).toHaveBeenCalledWith("stale-1");
+    expect(mockAbort).not.toHaveBeenCalled();
+    handle.stop();
+  });
+
+  it("aborts turns exceeding abort threshold", async () => {
+    const now = Date.now();
+    mockLoadMarkers.mockResolvedValue([
+      { sessionId: "stuck-1", sessionKey: "key-1", startedAt: now - 1_300_000 },
+    ]);
+    mockIsActive.mockReturnValue(true);
+
+    const handle = startStuckTurnWatchdog({
+      deps: {} as never,
+      checkIntervalMs: 1000,
+      abortAfterMs: 1_200_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockAbort).toHaveBeenCalledWith("stuck-1");
+    handle.stop();
+  });
+
+  it("does not abort turns within warn threshold", async () => {
+    const now = Date.now();
+    mockLoadMarkers.mockResolvedValue([
+      { sessionId: "ok-1", sessionKey: "key-1", startedAt: now - 300_000 },
+    ]);
+    mockIsActive.mockReturnValue(true);
+
+    const handle = startStuckTurnWatchdog({
+      deps: {} as never,
+      checkIntervalMs: 1000,
+      warnAfterMs: 600_000,
+      abortAfterMs: 1_200_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockAbort).not.toHaveBeenCalled();
+    handle.stop();
+  });
+
+  it("stop() clears the interval", async () => {
+    const handle = startStuckTurnWatchdog({
+      deps: {} as never,
+      checkIntervalMs: 1000,
+    });
+    handle.stop();
+
+    mockLoadMarkers.mockResolvedValue([{ sessionId: "s1", sessionKey: "k1", startedAt: 0 }]);
+    mockIsActive.mockReturnValue(true);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockLoadMarkers).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/stuck-turn-watchdog.ts
+++ b/src/infra/stuck-turn-watchdog.ts
@@ -1,0 +1,95 @@
+import { isEmbeddedPiRunActive, abortEmbeddedPiRun } from "../agents/pi-embedded-runner/runs.js";
+import type { CliDeps } from "../cli/deps.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { loadActiveTurnMarkers, removeActiveTurnMarker } from "./active-turns.js";
+
+const log = createSubsystemLogger("stuck-turn-watchdog");
+
+/** Default: check every 2 minutes. */
+const DEFAULT_CHECK_INTERVAL_MS = 120_000;
+/** Warn after 10 minutes. */
+const DEFAULT_WARN_AFTER_MS = 600_000;
+/** Abort after 20 minutes. */
+const DEFAULT_ABORT_AFTER_MS = 1_200_000;
+
+export type StuckTurnWatchdogHandle = {
+  stop: () => void;
+};
+
+/**
+ * Start a periodic watchdog that detects agent turns running abnormally long.
+ *
+ * On each tick the watchdog scans active turn markers on disk:
+ * - Marker exists but no in-memory run → stale leftover, clean it up.
+ * - Active run older than `abortAfterMs` → abort the run.
+ * - Active run older than `warnAfterMs` → log a warning.
+ */
+export function startStuckTurnWatchdog(params: {
+  deps: CliDeps;
+  checkIntervalMs?: number;
+  warnAfterMs?: number;
+  abortAfterMs?: number;
+}): StuckTurnWatchdogHandle {
+  const checkIntervalMs = params.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
+  const warnAfterMs = params.warnAfterMs ?? DEFAULT_WARN_AFTER_MS;
+  const abortAfterMs = params.abortAfterMs ?? DEFAULT_ABORT_AFTER_MS;
+
+  const timer = setInterval(() => {
+    void checkStuckTurns({ warnAfterMs, abortAfterMs }).catch((err) => {
+      log.warn(`watchdog tick failed: ${String(err)}`);
+    });
+  }, checkIntervalMs);
+
+  // Prevent the interval from keeping the process alive during shutdown.
+  if (timer.unref) {
+    timer.unref();
+  }
+
+  log.info(
+    `started (checkInterval=${checkIntervalMs}ms warn=${warnAfterMs}ms abort=${abortAfterMs}ms)`,
+  );
+
+  return {
+    stop: () => {
+      clearInterval(timer);
+      log.info("stopped");
+    },
+  };
+}
+
+async function checkStuckTurns(opts: { warnAfterMs: number; abortAfterMs: number }): Promise<void> {
+  const markers = await loadActiveTurnMarkers();
+  if (markers.length === 0) {
+    return;
+  }
+
+  const now = Date.now();
+  for (const marker of markers) {
+    const elapsed = now - marker.startedAt;
+    const isActive = isEmbeddedPiRunActive(marker.sessionId);
+
+    if (!isActive) {
+      // Stale marker: the in-memory run is gone (process restarted or run
+      // completed but clearActiveTurn failed). Clean it up silently.
+      await removeActiveTurnMarker(marker.sessionId);
+      log.info(`cleaned stale marker: sessionId=${marker.sessionId}`);
+      continue;
+    }
+
+    if (elapsed >= opts.abortAfterMs) {
+      log.warn(
+        `aborting stuck turn: sessionId=${marker.sessionId} sessionKey=${marker.sessionKey} elapsed=${elapsed}ms`,
+      );
+      abortEmbeddedPiRun(marker.sessionId);
+      // The abort triggers clearActiveEmbeddedRun which calls clearActiveTurn,
+      // so we do not need to remove the marker here.
+      continue;
+    }
+
+    if (elapsed >= opts.warnAfterMs) {
+      log.warn(
+        `stuck turn detected: sessionId=${marker.sessionId} sessionKey=${marker.sessionKey} elapsed=${elapsed}ms`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

When the gateway restarts (crash, SIGUSR1, or compaction failure), in-flight embedded PI runs are lost because `ACTIVE_EMBEDDED_RUNS` is an in-memory Map. This leaves users in a silent state where the bot never responds until the user sends a new message.

This PR adds a 2-layer defense:

1. **Disk-backed active turn tracker** (`src/infra/active-turns.ts`) — writes marker files to `~/.openclaw/active-turns/{sessionId}.json` when a turn starts, removes them when it completes. On startup, `server-active-turn-recovery.ts` scans for stale markers and sends a recovery message to the user via the same delivery resolution chain used by the restart sentinel.

2. **Stuck turn watchdog** (`src/infra/stuck-turn-watchdog.ts`) — periodic check (every 2 minutes) that cross-references disk markers against in-memory runs. Cleans orphaned markers (disk exists but no in-memory run) and aborts turns stuck >20 minutes.

### Design decisions

- **Fire-and-forget writes**: marker I/O never blocks the hot path (async write, sync-free on the streaming path)
- **Atomic writes**: tmp file + rename to prevent partial reads
- **Consume-then-process**: markers are cleared before delivery attempt to prevent infinite retry loops
- **Probe session filtering**: sessions with `probe-` prefix are skipped (health checks)
- **Follows existing patterns**: reuses the same delivery context resolution chain as `server-restart-sentinel.ts`
- **Dynamic imports in startup**: avoids oxfmt stripping unused static imports

### Files changed

| File | Change |
|------|--------|
| `src/infra/active-turns.ts` | New — marker file I/O (write/clear/load/remove) |
| `src/infra/stuck-turn-watchdog.ts` | New — periodic watchdog with configurable thresholds |
| `src/gateway/server-active-turn-recovery.ts` | New — startup recovery that delivers notification to interrupted users |
| `src/agents/pi-embedded-runner/runs.ts` | Modified — hooks `writeActiveTurn` / `clearActiveTurn` into set/clear lifecycle |
| `src/gateway/server-startup.ts` | Modified — wires recovery + watchdog on startup (dynamic import, test-guarded) |
| `src/infra/active-turns.test.ts` | New — 9 unit tests |
| `src/infra/active-turns-crash-scenarios.test.ts` | New — 8 crash scenario tests |
| `src/infra/stuck-turn-watchdog.test.ts` | New — 5 watchdog tests |

## Test plan

- [x] 22 tests covering unit, crash scenarios, and watchdog behavior
- [x] Crash recovery: marker survives process exit, detected on next startup
- [x] Clean completion: marker removed, no false positive recovery
- [x] Concurrent turns: independent tracking per session
- [x] Rapid write-clear cycles: no stale markers left behind
- [x] Watchdog cleans orphaned markers and aborts stuck turns
- [x] Probe sessions excluded from tracking
- [ ] Manual: kill gateway mid-conversation, restart, verify recovery message delivered
- [ ] Manual: trigger compaction failure, verify watchdog detects and aborts