### PR TITLE
feat(tts): add MiniMax TTS provider integration

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,12 +9,13 @@ title: "Text-to-Speech"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, or Edge TTS.
+OpenClaw can convert outbound replies into audio using ElevenLabs, MiniMax, OpenAI, or Edge TTS.
 It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubble.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
+- **MiniMax** (primary or fallback provider; strong Chinese/multilingual support)
 - **OpenAI** (primary or fallback provider; also used for summaries)
 - **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
 
@@ -32,9 +33,10 @@ does not publish limits, so assume similar or lower limits. citeturn0searc
 
 ## Optional keys
 
-If you want OpenAI or ElevenLabs:
+If you want OpenAI, ElevenLabs, or MiniMax:
 
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
+- `MINIMAX_API_KEY`
 - `OPENAI_API_KEY`
 
 Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
@@ -50,6 +52,7 @@ so that provider must also be authenticated if you enable summaries.
 - [OpenAI Audio API reference](https://platform.openai.com/docs/api-reference/audio)
 - [ElevenLabs Text to Speech](https://elevenlabs.io/docs/api-reference/text-to-speech)
 - [ElevenLabs Authentication](https://elevenlabs.io/docs/api-reference/authentication)
+- [MiniMax Text to Audio (T2A)](https://platform.minimax.io/docs/api-reference/speech-t2a-http)
 - [node-edge-tts](https://github.com/SchneeHertz/node-edge-tts)
 - [Microsoft Speech output formats](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech#audio-outputs)
 
@@ -112,6 +115,28 @@ Full schema is in [Gateway configuration](/gateway/configuration).
           useSpeakerBoost: true,
           speed: 1.0,
         },
+      },
+    },
+  },
+}
+```
+
+### MiniMax primary (Chinese/multilingual)
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "minimax",
+      minimax: {
+        apiKey: "minimax_api_key", // pragma: allowlist secret
+        model: "speech-2.8-hd",
+        voiceId: "Chinese (Mandarin)_Lyrical_Voice",
+        speed: 1.0,
+        vol: 1.0,
+        pitch: 0,
+        languageBoost: "auto",
       },
     },
   },
@@ -205,9 +230,9 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
+- `provider`: `"elevenlabs"`, `"minimax"`, `"openai"`, or `"edge"` (fallback is automatic).
 - If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
-  otherwise `edge`.
+  then `minimax` (if key), otherwise `edge`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
@@ -215,7 +240,7 @@ Then run:
 - `maxTextLength`: hard cap for TTS input (chars). `/tts audio` fails if exceeded.
 - `timeoutMs`: request timeout (ms).
 - `prefsPath`: override the local prefs JSON path (provider/limit/summary).
-- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `OPENAI_API_KEY`).
+- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `MINIMAX_API_KEY`, `OPENAI_API_KEY`).
 - `elevenlabs.baseUrl`: override ElevenLabs API base URL.
 - `openai.baseUrl`: override the OpenAI TTS endpoint.
   - Resolution order: `messages.tts.openai.baseUrl` -> `OPENAI_TTS_BASE_URL` -> `https://api.openai.com/v1`
@@ -236,6 +261,14 @@ Then run:
 - `edge.saveSubtitles`: write JSON subtitles alongside the audio file.
 - `edge.proxy`: proxy URL for Edge TTS requests.
 - `edge.timeoutMs`: request timeout override (ms).
+- `minimax.baseUrl`: override MiniMax API base URL (default `https://api.minimax.io`).
+- `minimax.model`: T2A model (`speech-2.8-hd`, `speech-2.8-turbo`, etc.).
+- `minimax.voiceId`: system voice or cloned voice ID.
+- `minimax.speed`: `0.5..2.0` (1.0 = normal).
+- `minimax.vol`: `(0, 10]` (1.0 = normal volume).
+- `minimax.pitch`: `-12..12` (0 = original pitch).
+- `minimax.emotion`: optional emotion (`happy`, `sad`, `angry`, `calm`, etc.).
+- `minimax.languageBoost`: language hint (`auto`, `Chinese`, `English`, etc.).
 
 ## Model-driven overrides (default on)
 
@@ -260,7 +293,7 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (`openai` | `elevenlabs` | `edge`, requires `allowProvider: true`)
+- `provider` (`openai` | `elevenlabs` | `minimax` | `edge`, requires `allowProvider: true`)
 - `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
 - `model` (OpenAI TTS model or ElevenLabs model id)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
@@ -327,7 +360,9 @@ These override `messages.tts.*` for that host.
     guaranteed Opus voice notes. citeturn1search1
   - If the configured Edge output format fails, OpenClaw retries with MP3.
 
-OpenAI/ElevenLabs formats are fixed; Telegram expects Opus for voice-note UX.
+- **MiniMax**: MP3 at 32kHz / 128kbps (all channels).
+
+OpenAI/ElevenLabs/MiniMax formats are fixed; Telegram expects Opus for voice-note UX.
 
 ## Auto-TTS behavior
 

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -421,7 +421,7 @@
           },
           "provider": {
             "type": "string",
-            "enum": ["openai", "elevenlabs", "edge"]
+            "enum": ["openai", "elevenlabs", "minimax", "edge"]
           },
           "summaryModel": {
             "type": "string"
@@ -565,6 +565,45 @@
                 "type": "integer",
                 "minimum": 1000,
                 "maximum": 120000
+              }
+            }
+          },
+          "minimax": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "apiKey": {
+                "type": "string"
+              },
+              "baseUrl": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "voiceId": {
+                "type": "string"
+              },
+              "speed": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 2
+              },
+              "vol": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "maximum": 10
+              },
+              "pitch": {
+                "type": "integer",
+                "minimum": -12,
+                "maximum": 12
+              },
+              "emotion": {
+                "type": "string"
+              },
+              "languageBoost": {
+                "type": "string"
               }
             }
           },

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -56,7 +56,8 @@ function ttsUsage(): ReplyPayload {
       `**Providers:**\n` +
       `• edge — Free, fast (default)\n` +
       `• openai — High quality (requires API key)\n` +
-      `• elevenlabs — Premium voices (requires API key)\n\n` +
+      `• elevenlabs — Premium voices (requires API key)\n` +
+      `• minimax — Chinese/multilingual (requires API key)\n\n` +
       `**Text Limit (default: 1500, max: 4096):**\n` +
       `When text exceeds the limit:\n` +
       `• Summary ON: AI summarizes, then generates audio\n` +
@@ -161,6 +162,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     if (!args.trim()) {
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
+      const hasMinimax = Boolean(resolveTtsApiKey(config, "minimax"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
       return {
         shouldContinue: false,
@@ -170,14 +172,20 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `Primary: ${currentProvider}\n` +
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
+            `MiniMax key: ${hasMinimax ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Usage: /tts provider openai | elevenlabs | minimax | edge`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "edge" &&
+      requested !== "minimax"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,6 +1,6 @@
 import type { SecretInput } from "./types.secrets.js";
 
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "minimax";
 
 export type TtsMode = "final" | "all";
 
@@ -75,6 +75,18 @@ export type TtsConfig = {
     saveSubtitles?: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  /** MiniMax T2A configuration. */
+  minimax?: {
+    apiKey?: SecretInput;
+    baseUrl?: string;
+    model?: string;
+    voiceId?: string;
+    speed?: number;
+    vol?: number;
+    pitch?: number;
+    emotion?: string;
+    languageBoost?: string;
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -355,7 +355,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "minimax"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -421,6 +421,20 @@ export const TtsConfigSchema = z
         saveSubtitles: z.boolean().optional(),
         proxy: z.string().optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
+      })
+      .strict()
+      .optional(),
+    minimax: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        model: z.string().optional(),
+        voiceId: z.string().optional(),
+        speed: z.number().min(0.5).max(2).optional(),
+        vol: z.number().gt(0).max(10).optional(),
+        pitch: z.number().int().min(-12).max(12).optional(),
+        emotion: z.string().optional(),
+        languageBoost: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../../config/config.js";
 import {
+  MINIMAX_TTS_MODELS,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   getTtsProvider,
@@ -38,6 +39,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         prefsPath,
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
+        hasMinimaxKey: Boolean(resolveTtsApiKey(config, "minimax")),
         edgeEnabled: isTtsProviderConfigured(config, "edge"),
       });
     } catch (err) {
@@ -100,13 +102,18 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (
+      provider !== "openai" &&
+      provider !== "elevenlabs" &&
+      provider !== "edge" &&
+      provider !== "minimax"
+    ) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          "Invalid provider. Use openai, elevenlabs, minimax, or edge.",
         ),
       );
       return;
@@ -140,6 +147,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
             name: "ElevenLabs",
             configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
             models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
+          },
+          {
+            id: "minimax",
+            name: "MiniMax",
+            configured: Boolean(resolveTtsApiKey(config, "minimax")),
+            models: [...MINIMAX_TTS_MODELS],
           },
           {
             id: "edge",

--- a/src/secrets/runtime-config-collectors-tts.ts
+++ b/src/secrets/runtime-config-collectors-tts.ts
@@ -43,4 +43,19 @@ export function collectTtsApiKeyAssignments(params: {
       },
     });
   }
+  const minimax = params.tts.minimax;
+  if (isRecord(minimax)) {
+    collectSecretInputAssignment({
+      value: minimax.apiKey,
+      path: `${params.pathPrefix}.minimax.apiKey`,
+      expected: "string",
+      defaults: params.defaults,
+      context: params.context,
+      active: params.active,
+      inactiveReason: params.inactiveReason,
+      apply: (value) => {
+        minimax.apiKey = value;
+      },
+    });
+  }
 }

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -151,7 +151,12 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "edge" ||
+              rawValue === "minimax"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);
@@ -655,6 +660,124 @@ export async function openaiTTS(params: {
     }
 
     return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export const MINIMAX_TTS_MODELS = [
+  "speech-2.8-hd",
+  "speech-2.8-turbo",
+  "speech-2.6-hd",
+  "speech-2.6-turbo",
+  "speech-02-hd",
+  "speech-02-turbo",
+] as const;
+
+export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io";
+
+function normalizeMinimaxBaseUrl(baseUrl?: string): string {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return DEFAULT_MINIMAX_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+type MinimaxTtsResponse = {
+  data?: { audio?: string; status?: number };
+  base_resp?: { status_code?: number; status_msg?: string };
+  extra_info?: { audio_format?: string };
+};
+
+export async function minimaxTTS(params: {
+  text: string;
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  voiceId: string;
+  audioFormat: string;
+  sampleRate: number;
+  bitrate: number;
+  speed: number;
+  vol: number;
+  pitch: number;
+  emotion?: string;
+  languageBoost?: string;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const {
+    text,
+    apiKey,
+    baseUrl,
+    model,
+    voiceId,
+    audioFormat,
+    sampleRate,
+    bitrate,
+    speed,
+    vol,
+    pitch,
+    emotion,
+    languageBoost,
+    timeoutMs,
+  } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const body: Record<string, unknown> = {
+      model,
+      text,
+      stream: false,
+      output_format: "hex",
+      voice_setting: {
+        voice_id: voiceId,
+        speed,
+        vol,
+        pitch,
+        ...(emotion ? { emotion } : {}),
+      },
+      audio_setting: {
+        sample_rate: sampleRate,
+        bitrate,
+        format: audioFormat,
+        channel: 1,
+      },
+    };
+    if (languageBoost) {
+      body.language_boost = languageBoost;
+    }
+
+    const url = `${normalizeMinimaxBaseUrl(baseUrl)}/v1/t2a_v2`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`MiniMax T2A API error (${response.status})`);
+    }
+
+    const json = (await response.json()) as MinimaxTtsResponse;
+    if (json.base_resp?.status_code !== 0) {
+      throw new Error(
+        `MiniMax T2A error: ${json.base_resp?.status_msg ?? "unknown"} (code ${json.base_resp?.status_code})`,
+      );
+    }
+
+    const hexAudio = json.data?.audio;
+    if (!hexAudio) {
+      throw new Error("MiniMax T2A returned empty audio data");
+    }
+
+    return Buffer.from(hexAudio, "hex");
   } finally {
     clearTimeout(timeout);
   }

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -56,6 +56,7 @@ const {
   isValidOpenAIModel,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
+  MINIMAX_TTS_MODELS,
   parseTtsDirectives,
   resolveModelOverridePolicy,
   summarizeText,
@@ -471,6 +472,7 @@ describe("tts", () => {
             OPENAI_API_KEY: "test-openai-key",
             ELEVENLABS_API_KEY: undefined,
             XI_API_KEY: undefined,
+            MINIMAX_API_KEY: undefined,
           },
           prefsPath: "/tmp/tts-prefs-openai.json",
           expected: "openai",
@@ -480,6 +482,7 @@ describe("tts", () => {
             OPENAI_API_KEY: undefined,
             ELEVENLABS_API_KEY: "test-elevenlabs-key",
             XI_API_KEY: undefined,
+            MINIMAX_API_KEY: undefined,
           },
           prefsPath: "/tmp/tts-prefs-elevenlabs.json",
           expected: "elevenlabs",
@@ -489,6 +492,17 @@ describe("tts", () => {
             OPENAI_API_KEY: undefined,
             ELEVENLABS_API_KEY: undefined,
             XI_API_KEY: undefined,
+            MINIMAX_API_KEY: "test-minimax-key",
+          },
+          prefsPath: "/tmp/tts-prefs-minimax.json",
+          expected: "minimax",
+        },
+        {
+          env: {
+            OPENAI_API_KEY: undefined,
+            ELEVENLABS_API_KEY: undefined,
+            XI_API_KEY: undefined,
+            MINIMAX_API_KEY: undefined,
           },
           prefsPath: "/tmp/tts-prefs-edge.json",
           expected: "edge",
@@ -502,6 +516,92 @@ describe("tts", () => {
           expect(provider).toBe(testCase.expected);
         });
       }
+    });
+  });
+
+  describe("resolveTtsConfig – minimax defaults", () => {
+    const baseCfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: { tts: {} },
+    };
+
+    it("resolves default MiniMax config", () => {
+      const config = resolveTtsConfig(baseCfg);
+      expect(config.minimax.baseUrl).toBe("https://api.minimax.io");
+      expect(config.minimax.model).toBe("speech-2.8-hd");
+      expect(config.minimax.voiceId).toBe("English_Graceful_Lady");
+      expect(config.minimax.speed).toBe(1.0);
+      expect(config.minimax.vol).toBe(1.0);
+      expect(config.minimax.pitch).toBe(0);
+      expect(config.minimax.emotion).toBeUndefined();
+      expect(config.minimax.languageBoost).toBeUndefined();
+    });
+
+    it("applies user-specified MiniMax config overrides", () => {
+      const cfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: {
+            minimax: {
+              baseUrl: "https://custom.minimax.io",
+              model: "speech-2.8-turbo",
+              voiceId: "Chinese (Mandarin)_Lyrical_Voice",
+              speed: 1.5,
+              vol: 2.0,
+              pitch: 3,
+              emotion: "happy",
+              languageBoost: "Chinese",
+            },
+          },
+        },
+      };
+      const config = resolveTtsConfig(cfg);
+      expect(config.minimax.baseUrl).toBe("https://custom.minimax.io");
+      expect(config.minimax.model).toBe("speech-2.8-turbo");
+      expect(config.minimax.voiceId).toBe("Chinese (Mandarin)_Lyrical_Voice");
+      expect(config.minimax.speed).toBe(1.5);
+      expect(config.minimax.vol).toBe(2.0);
+      expect(config.minimax.pitch).toBe(3);
+      expect(config.minimax.emotion).toBe("happy");
+      expect(config.minimax.languageBoost).toBe("Chinese");
+    });
+
+    it("resolves MiniMax API key from config", () => {
+      const cfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: {
+            minimax: {
+              apiKey: "minimax-key-from-config",
+            },
+          },
+        },
+      };
+      const config = resolveTtsConfig(cfg);
+      expect(config.minimax.apiKey).toBe("minimax-key-from-config");
+    });
+
+    it("resolves MiniMax API key from env var", () => {
+      const key = "minimax-key-from-env";
+      withEnv({ MINIMAX_API_KEY: key }, () => {
+        const config = resolveTtsConfig(baseCfg);
+        expect(tts.resolveTtsApiKey(config, "minimax")).toBe(key);
+      });
+    });
+
+    it("includes expected MiniMax TTS model list", () => {
+      expect(MINIMAX_TTS_MODELS).toContain("speech-2.8-hd");
+      expect(MINIMAX_TTS_MODELS).toContain("speech-2.8-turbo");
+      expect(MINIMAX_TTS_MODELS.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  describe("parseTtsDirectives – minimax provider", () => {
+    it("accepts minimax as provider override", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Hello [[tts:provider=minimax]] world";
+      const result = parseTtsDirectives(input, policy);
+      expect(result.overrides.provider).toBe("minimax");
     });
   });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -35,6 +35,9 @@ import {
   isValidOpenAIModel,
   isValidOpenAIVoice,
   isValidVoiceId,
+  DEFAULT_MINIMAX_BASE_URL,
+  MINIMAX_TTS_MODELS,
+  minimaxTTS,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   openaiTTS,
@@ -42,7 +45,7 @@ import {
   scheduleCleanup,
   summarizeText,
 } from "./tts-core.js";
-export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
+export { MINIMAX_TTS_MODELS, OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TTS_MAX_LENGTH = 1500;
@@ -57,6 +60,12 @@ const DEFAULT_OPENAI_VOICE = "alloy";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+
+const DEFAULT_MINIMAX_MODEL = "speech-2.8-hd";
+const DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady";
+const DEFAULT_MINIMAX_SPEED = 1.0;
+const DEFAULT_MINIMAX_VOL = 1.0;
+const DEFAULT_MINIMAX_PITCH = 0;
 
 const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   stability: 0.5,
@@ -82,9 +91,14 @@ const DEFAULT_OUTPUT = {
   voiceCompatible: false,
 };
 
+const MINIMAX_OUTPUT = {
+  default: { format: "mp3" as const, sampleRate: 32000, bitrate: 128000 },
+};
+
 const TELEPHONY_OUTPUT = {
   openai: { format: "pcm" as const, sampleRate: 24000 },
   elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
+  minimax: { format: "pcm" as const, sampleRate: 24000 },
 };
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);
@@ -130,6 +144,17 @@ export type ResolvedTtsConfig = {
     saveSubtitles: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  minimax: {
+    apiKey?: string;
+    baseUrl: string;
+    model: string;
+    voiceId: string;
+    speed: number;
+    vol: number;
+    pitch: number;
+    emotion?: string;
+    languageBoost?: string;
   };
   prefsPath?: string;
   maxTextLength: number;
@@ -318,6 +343,20 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       proxy: raw.edge?.proxy?.trim() || undefined,
       timeoutMs: raw.edge?.timeoutMs,
     },
+    minimax: {
+      apiKey: normalizeResolvedSecretInputString({
+        value: raw.minimax?.apiKey,
+        path: "messages.tts.minimax.apiKey",
+      }),
+      baseUrl: raw.minimax?.baseUrl?.trim() || DEFAULT_MINIMAX_BASE_URL,
+      model: raw.minimax?.model?.trim() || DEFAULT_MINIMAX_MODEL,
+      voiceId: raw.minimax?.voiceId?.trim() || DEFAULT_MINIMAX_VOICE_ID,
+      speed: raw.minimax?.speed ?? DEFAULT_MINIMAX_SPEED,
+      vol: raw.minimax?.vol ?? DEFAULT_MINIMAX_VOL,
+      pitch: raw.minimax?.pitch ?? DEFAULT_MINIMAX_PITCH,
+      emotion: raw.minimax?.emotion?.trim() || undefined,
+      languageBoost: raw.minimax?.languageBoost?.trim() || undefined,
+    },
     prefsPath: raw.prefsPath,
     maxTextLength: raw.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
     timeoutMs: raw.timeoutMs ?? DEFAULT_TIMEOUT_MS,
@@ -456,6 +495,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "minimax")) {
+    return "minimax";
+  }
   return "edge";
 }
 
@@ -523,10 +565,13 @@ export function resolveTtsApiKey(
   if (provider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (provider === "minimax") {
+    return config.minimax.apiKey || process.env.MINIMAX_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "minimax", "edge"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -660,6 +705,7 @@ export async function textToSpeech(params: {
       }
 
       let audioBuffer: Buffer;
+      let providerOutputFormat: string;
       if (provider === "elevenlabs") {
         const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
         const modelIdOverride = params.overrides?.elevenlabs?.modelId;
@@ -683,6 +729,26 @@ export async function textToSpeech(params: {
           voiceSettings,
           timeoutMs: config.timeoutMs,
         });
+        providerOutputFormat = output.elevenlabs;
+      } else if (provider === "minimax") {
+        const mmOutput = MINIMAX_OUTPUT.default;
+        audioBuffer = await minimaxTTS({
+          text: params.text,
+          apiKey,
+          baseUrl: config.minimax.baseUrl,
+          model: config.minimax.model,
+          voiceId: config.minimax.voiceId,
+          audioFormat: mmOutput.format,
+          sampleRate: mmOutput.sampleRate,
+          bitrate: mmOutput.bitrate,
+          speed: config.minimax.speed,
+          vol: config.minimax.vol,
+          pitch: config.minimax.pitch,
+          emotion: config.minimax.emotion,
+          languageBoost: config.minimax.languageBoost,
+          timeoutMs: config.timeoutMs,
+        });
+        providerOutputFormat = mmOutput.format;
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
@@ -695,6 +761,7 @@ export async function textToSpeech(params: {
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
         });
+        providerOutputFormat = output.openai;
       }
 
       const latencyMs = Date.now() - providerStart;
@@ -702,7 +769,8 @@ export async function textToSpeech(params: {
       const tempRoot = resolvePreferredOpenClawTmpDir();
       mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
       const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-      const audioPath = path.join(tempDir, `voice-${Date.now()}${output.extension}`);
+      const ext = provider === "minimax" ? ".mp3" : output.extension;
+      const audioPath = path.join(tempDir, `voice-${Date.now()}${ext}`);
       writeFileSync(audioPath, audioBuffer);
       scheduleCleanup(tempDir);
 
@@ -711,8 +779,8 @@ export async function textToSpeech(params: {
         audioPath,
         latencyMs,
         provider,
-        outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
-        voiceCompatible: output.voiceCompatible,
+        outputFormat: providerOutputFormat,
+        voiceCompatible: provider === "minimax" ? false : output.voiceCompatible,
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));
@@ -769,6 +837,35 @@ export async function textToSpeechTelephony(params: {
           applyTextNormalization: config.elevenlabs.applyTextNormalization,
           languageCode: config.elevenlabs.languageCode,
           voiceSettings: config.elevenlabs.voiceSettings,
+          timeoutMs: config.timeoutMs,
+        });
+
+        return {
+          success: true,
+          audioBuffer,
+          latencyMs: Date.now() - providerStart,
+          provider,
+          outputFormat: output.format,
+          sampleRate: output.sampleRate,
+        };
+      }
+
+      if (provider === "minimax") {
+        const output = TELEPHONY_OUTPUT.minimax;
+        const audioBuffer = await minimaxTTS({
+          text: params.text,
+          apiKey,
+          baseUrl: config.minimax.baseUrl,
+          model: config.minimax.model,
+          voiceId: config.minimax.voiceId,
+          audioFormat: output.format,
+          sampleRate: output.sampleRate,
+          bitrate: 128000,
+          speed: config.minimax.speed,
+          vol: config.minimax.vol,
+          pitch: config.minimax.pitch,
+          emotion: config.minimax.emotion,
+          languageBoost: config.minimax.languageBoost,
           timeoutMs: config.timeoutMs,
         });
 
@@ -961,6 +1058,7 @@ export const _test = {
   isValidOpenAIModel,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
+  MINIMAX_TTS_MODELS,
   parseTtsDirectives,
   resolveModelOverridePolicy,
   summarizeText,


### PR DESCRIPTION
## Summary

Add MiniMax as a new TTS provider alongside OpenAI, ElevenLabs, and Edge TTS.

- Implement `minimaxTTS()` core function calling MiniMax T2A v2 HTTP API with Bearer auth and hex-decoded audio response
- Extend `TtsProvider` type, Zod schema, and all wiring (config resolution, auto-detection, fallback chain, textToSpeech, textToSpeechTelephony)
- Add `/tts provider minimax` command support and `MINIMAX_API_KEY` secret collection
- Update voice-call extension plugin config enum
- Add 8 unit tests covering config parsing, API key resolution, model list, and directive overrides
- Update `docs/tts.md` with MiniMax examples, field reference, output formats, and API links

MiniMax TTS supports 300+ system voices, 40 languages, emotion control, and speed/volume/pitch adjustment — especially suited for Chinese and multilingual scenarios.

## Configuration

```json5
{
  messages: {
    tts: {
      provider: "minimax",
      minimax: {
        model: "speech-2.8-hd",
        voiceId: "Chinese (Mandarin)_Lyrical_Voice",
        languageBoost: "auto",
      },
    },
  },
}
```

Or simply set `MINIMAX_API_KEY` env var — MiniMax will be auto-detected in the fallback chain (openai > elevenlabs > **minimax** > edge).

## Test plan

- [x] 8 new unit tests pass (`vitest run src/tts/tts.test.ts`)
- [x] Lint check passes (0 warnings, 0 errors)
- [ ] Manual test with real MiniMax API key
- [ ] Verify Telegram voice-note bubble works with MiniMax MP3 output
