### PR TITLE
Fix Discord inbound dedupe across auto-thread reroutes

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -278,6 +278,53 @@ describe("inbound dedupe", () => {
       ),
     ).toBe(true);
   });
+
+  it("dedupes discord replays even when auto-thread routing changes the target", () => {
+    resetInboundDedupe();
+    const first: MsgContext = {
+      Provider: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "channel:parent-1",
+      To: "channel:parent-1",
+      From: "discord:channel:parent-1",
+      GroupSpace: "guild-1",
+      GroupChannel: "#general",
+      MessageSid: "1480599840105959566",
+      SessionKey: "agent:main:main",
+    };
+    const replay: MsgContext = {
+      ...first,
+      OriginatingTo: "channel:thread-99",
+      To: "channel:thread-99",
+      From: "discord:channel:thread-99",
+      MessageThreadId: "thread-99",
+    };
+    expect(shouldSkipDuplicateInbound(first, { now: 100 })).toBe(false);
+    expect(shouldSkipDuplicateInbound(replay, { now: 200 })).toBe(true);
+  });
+
+  it("does not dedupe discord messages from different source channels", () => {
+    resetInboundDedupe();
+    const base: MsgContext = {
+      Provider: "discord",
+      OriginatingChannel: "discord",
+      MessageSid: "1480599840105959566",
+      SessionKey: "agent:main:main",
+      GroupSpace: "guild-1",
+    };
+    expect(
+      shouldSkipDuplicateInbound(
+        { ...base, GroupChannel: "#general", OriginatingTo: "channel:1" },
+        { now: 100 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldSkipDuplicateInbound(
+        { ...base, GroupChannel: "#random", OriginatingTo: "channel:2" },
+        { now: 200 },
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("createInboundDebouncer", () => {

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -12,9 +12,41 @@ const inboundDedupeCache = createDedupeCache({
 });
 
 const normalizeProvider = (value?: string | null) => value?.trim().toLowerCase() || "";
+const normalizeValue = (value?: string | null) => value?.trim() || "";
 
-const resolveInboundPeerId = (ctx: MsgContext) =>
-  ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
+function resolveDiscordInboundPeerId(ctx: MsgContext): string {
+  if (ctx.ChatType === "direct") {
+    const senderId = normalizeValue(ctx.SenderId);
+    if (senderId) {
+      return `dm:${senderId}`;
+    }
+  }
+  const groupSpace = normalizeValue(ctx.GroupSpace);
+  const groupChannel = normalizeValue(ctx.GroupChannel);
+  if (groupSpace || groupChannel) {
+    return `guild:${groupSpace}|channel:${groupChannel}`;
+  }
+  return "";
+}
+
+function resolveInboundPeerId(ctx: MsgContext, provider: string): string | undefined {
+  if (provider === "discord") {
+    const discordPeerId = resolveDiscordInboundPeerId(ctx);
+    if (discordPeerId) {
+      return discordPeerId;
+    }
+  }
+  return ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
+}
+
+function resolveInboundThreadScope(ctx: MsgContext, provider: string): string {
+  if (provider === "discord") {
+    return "";
+  }
+  return ctx.MessageThreadId !== undefined && ctx.MessageThreadId !== null
+    ? String(ctx.MessageThreadId)
+    : "";
+}
 
 function resolveInboundDedupeSessionScope(ctx: MsgContext): string {
   const sessionKey =
@@ -39,16 +71,13 @@ export function buildInboundDedupeKey(ctx: MsgContext): string | null {
   if (!provider || !messageId) {
     return null;
   }
-  const peerId = resolveInboundPeerId(ctx);
+  const peerId = resolveInboundPeerId(ctx, provider);
   if (!peerId) {
     return null;
   }
   const sessionScope = resolveInboundDedupeSessionScope(ctx);
   const accountId = ctx.AccountId?.trim() ?? "";
-  const threadId =
-    ctx.MessageThreadId !== undefined && ctx.MessageThreadId !== null
-      ? String(ctx.MessageThreadId)
-      : "";
+  const threadId = resolveInboundThreadScope(ctx, provider);
   return [provider, accountId, sessionScope, peerId, threadId, messageId].filter(Boolean).join("|");
 }
 


### PR DESCRIPTION
## Summary
- make inbound dedupe use a stable Discord source peer derived from DM sender or guild/channel metadata instead of mutable reply-routing targets
- ignore Discord thread ids in the inbound dedupe key so the same source message is still deduped after auto-thread reroutes
- add regression tests covering Discord auto-thread replays and cross-channel safety

## Testing
- `npx vitest run src/auto-reply/inbound.test.ts`
