### PR TITLE
fix(discord): preserve content-type and skip optimization for animated/WebP images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Discord: preserve detected media MIME types and animated uploads across standard sends, component sends, and native interaction replies so WebP/APNG assets reach Discord without JPEG flattening. Fixes #41256; carries forward #41265. Thanks @skidder.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -53,6 +53,7 @@ import {
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
+import { toDiscordFileBlob } from "../send.shared.js";
 import {
   normalizeDiscordAllowList,
   resolveDiscordAllowListMatch,
@@ -1366,11 +1367,14 @@ async function deliverDiscordInteractionReply(params: {
     const media = await Promise.all(
       reply.mediaUrls.map(async (url) => {
         const loaded = await loadWebMedia(url, {
+          maxBytes: (discordConfig?.mediaMaxMb ?? 8) * 1024 * 1024,
           localRoots: params.mediaLocalRoots,
+          preserveWebp: true,
+          preserveAvif: true,
         });
         return {
           name: loaded.fileName ?? "upload",
-          data: loaded.buffer,
+          data: toDiscordFileBlob(loaded.buffer, loaded.contentType),
         };
       }),
     );

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1084,6 +1084,7 @@ async function dispatchDiscordCommandInteraction(params: {
     await deliverDiscordInteractionReply({
       interaction,
       payload: pluginReply,
+      mediaMaxBytes: (discordConfig?.mediaMaxMb ?? 8) * 1024 * 1024,
       textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
         fallbackLimit: 2000,
       }),
@@ -1154,6 +1155,7 @@ async function dispatchDiscordCommandInteraction(params: {
         interaction,
         payload: statusReply,
         mediaLocalRoots,
+        mediaMaxBytes: (discordConfig?.mediaMaxMb ?? 8) * 1024 * 1024,
         textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
           fallbackLimit: 2000,
         }),
@@ -1220,6 +1222,7 @@ async function dispatchDiscordCommandInteraction(params: {
             interaction,
             payload,
             mediaLocalRoots,
+            mediaMaxBytes: (discordConfig?.mediaMaxMb ?? 8) * 1024 * 1024,
             textLimit: resolveTextChunkLimit(cfg, "discord", accountId, {
               fallbackLimit: 2000,
             }),
@@ -1305,6 +1308,7 @@ async function deliverDiscordInteractionReply(params: {
   interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;
   payload: ReplyPayload;
   mediaLocalRoots?: readonly string[];
+  mediaMaxBytes: number;
   textLimit: number;
   maxLinesPerMessage?: number;
   preferFollowUp: boolean;
@@ -1324,7 +1328,7 @@ async function deliverDiscordInteractionReply(params: {
   let hasReplied = false;
   const sendMessage = async (
     content: string,
-    files?: { name: string; data: Buffer }[],
+    files?: { name: string; data: Blob | Uint8Array }[],
     components?: TopLevelComponents[],
   ) => {
     const payload =
@@ -1335,13 +1339,10 @@ async function deliverDiscordInteractionReply(params: {
             ...(params.responseEphemeral !== undefined
               ? { ephemeral: params.responseEphemeral }
               : {}),
-            files: files.map((file) => {
-              if (file.data instanceof Blob) {
-                return { name: file.name, data: file.data };
-              }
-              const arrayBuffer = Uint8Array.from(file.data).buffer;
-              return { name: file.name, data: new Blob([arrayBuffer]) };
-            }),
+            files: files.map((file) => ({
+              name: file.name,
+              data: toDiscordFileBlob(file.data),
+            })),
           }
         : {
             content,
@@ -1367,7 +1368,7 @@ async function deliverDiscordInteractionReply(params: {
     const media = await Promise.all(
       reply.mediaUrls.map(async (url) => {
         const loaded = await loadWebMedia(url, {
-          maxBytes: (discordConfig?.mediaMaxMb ?? 8) * 1024 * 1024,
+          maxBytes: params.mediaMaxBytes,
           localRoots: params.mediaLocalRoots,
           preserveWebp: true,
           preserveAvif: true,

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -272,4 +272,50 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
     expect(sendMessageDiscordMock).not.toHaveBeenCalled();
     expect(postMock).toHaveBeenCalledTimes(1);
   });
+
+  it("derives component media cap from the selected Discord account", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.GuildText,
+      id: "chan-1",
+    });
+    postMock.mockResolvedValueOnce({ id: "msg1", channel_id: "chan-1" });
+
+    await sendDiscordComponentMessage(
+      "channel:chan-1",
+      {
+        text: "report",
+        container: {
+          accentColor: 0x00ff00,
+        },
+      },
+      {
+        cfg: {
+          channels: {
+            discord: {
+              accounts: {
+                default: {
+                  mediaMaxMb: 3,
+                },
+              },
+            },
+          },
+          session: { dmScope: "main" },
+        },
+        rest,
+        token: "t",
+        mediaUrl: "https://example.com/report.webp",
+      },
+    );
+
+    expect(loadOutboundMediaFromUrlMock).toHaveBeenCalledWith(
+      "https://example.com/report.webp",
+      expect.objectContaining({
+        maxBytes: 3 * 1024 * 1024,
+        preserveWebp: true,
+        preserveAvif: true,
+      }),
+    );
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -33,6 +33,7 @@ import {
 import type { DiscordSendResult } from "./send.types.js";
 
 const DISCORD_FORUM_LIKE_TYPES = new Set<number>([ChannelType.GuildForum, ChannelType.GuildMedia]);
+const DEFAULT_DISCORD_MEDIA_MAX_MB = 8;
 
 function extractComponentAttachmentNames(spec: DiscordComponentMessageSpec): string[] {
   const names: string[] = [];
@@ -166,6 +167,24 @@ type DiscordComponentSendOpts = {
   chunkMode?: ChunkMode;
 };
 
+function resolveDiscordComponentMediaMaxBytes(params: {
+  opts: DiscordComponentSendOpts;
+  accountId: string;
+}): number {
+  if (params.opts.mediaMaxBytes !== undefined) {
+    return params.opts.mediaMaxBytes;
+  }
+  const cfg = requireRuntimeConfig(params.opts.cfg, "Discord component media");
+  const accountInfo = resolveDiscordAccount({ cfg, accountId: params.accountId });
+  return (
+    (typeof accountInfo.config.mediaMaxMb === "number"
+      ? accountInfo.config.mediaMaxMb
+      : DEFAULT_DISCORD_MEDIA_MAX_MB) *
+    1024 *
+    1024
+  );
+}
+
 export function registerBuiltDiscordComponentMessage(params: {
   buildResult: DiscordComponentBuildResult;
   messageId: string;
@@ -194,7 +213,10 @@ async function buildDiscordComponentPayload(params: {
   let files: MessagePayloadFile[] | undefined;
   if (params.opts.mediaUrl) {
     const media = await loadOutboundMediaFromUrl(params.opts.mediaUrl, {
-      maxBytes: params.opts.mediaMaxBytes,
+      maxBytes: resolveDiscordComponentMediaMaxBytes({
+        opts: params.opts,
+        accountId: params.accountId,
+      }),
       mediaAccess: params.opts.mediaAccess,
       mediaLocalRoots: params.opts.mediaLocalRoots,
       mediaReadFile: params.opts.mediaReadFile,

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -158,6 +158,7 @@ type DiscordComponentSendOpts = {
   };
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
+  mediaMaxBytes?: number;
   filename?: string;
   textLimit?: number;
   maxLinesPerMessage?: number;
@@ -193,14 +194,17 @@ async function buildDiscordComponentPayload(params: {
   let files: MessagePayloadFile[] | undefined;
   if (params.opts.mediaUrl) {
     const media = await loadOutboundMediaFromUrl(params.opts.mediaUrl, {
+      maxBytes: params.opts.mediaMaxBytes,
       mediaAccess: params.opts.mediaAccess,
       mediaLocalRoots: params.opts.mediaLocalRoots,
       mediaReadFile: params.opts.mediaReadFile,
+      preserveWebp: true,
+      preserveAvif: true,
     });
     const filenameOverride = params.opts.filename?.trim();
     resolvedFileName = filenameOverride || media.fileName || "upload";
     spec = withImplicitComponentAttachmentBlock(spec, resolvedFileName);
-    const fileData = toDiscordFileBlob(media.buffer);
+    const fileData = toDiscordFileBlob(media.buffer, media.contentType);
     files = [{ data: fileData, name: resolvedFileName }];
   }
 

--- a/extensions/discord/src/send.shared.test.ts
+++ b/extensions/discord/src/send.shared.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { toDiscordFileBlob } from "./send.shared.js";
+
+describe("toDiscordFileBlob", () => {
+  it("preserves a detected MIME type on upload blobs", () => {
+    const blob = toDiscordFileBlob(Buffer.from("webp"), "image/webp");
+
+    expect(blob.type).toBe("image/webp");
+  });
+
+  it("keeps an existing blob MIME type when reusing interaction reply files", () => {
+    const blob = toDiscordFileBlob(new Blob([Buffer.from("apng")], { type: "image/apng" }));
+
+    expect(blob.type).toBe("image/apng");
+  });
+});

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -338,13 +338,16 @@ export function stripUndefinedFields<T extends object>(value: T): T {
   return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
 }
 
-export function toDiscordFileBlob(data: Blob | Uint8Array): Blob {
+export function toDiscordFileBlob(data: Blob | Uint8Array, contentType?: string): Blob {
   if (data instanceof Blob) {
+    if (!data.type && contentType) {
+      return new Blob([data], { type: contentType });
+    }
     return data;
   }
   const arrayBuffer = new ArrayBuffer(data.byteLength);
   new Uint8Array(arrayBuffer).set(data);
-  return new Blob([arrayBuffer]);
+  return new Blob([arrayBuffer], { type: contentType });
 }
 
 async function sendDiscordText(
@@ -422,10 +425,11 @@ async function sendDiscordMedia(
   silent?: boolean,
   maxChars?: number,
 ) {
-  const media = await loadWebMedia(
-    mediaUrl,
-    buildOutboundMediaLoadOptions({ maxBytes, mediaLocalRoots, mediaReadFile }),
-  );
+  const media = await loadWebMedia(mediaUrl, {
+    ...buildOutboundMediaLoadOptions({ maxBytes, mediaLocalRoots, mediaReadFile }),
+    preserveWebp: true,
+    preserveAvif: true,
+  });
   const requestedFileName = filename?.trim();
   const resolvedFileName =
     requestedFileName ||
@@ -438,7 +442,7 @@ async function sendDiscordMedia(
   const caption = chunks[0] ?? "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
   const flags = silent ? SUPPRESS_NOTIFICATIONS_FLAG : undefined;
-  const fileData = toDiscordFileBlob(media.buffer);
+  const fileData = toDiscordFileBlob(media.buffer, media.contentType);
   const captionComponents = resolveDiscordSendComponents({
     components,
     text: caption,

--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -300,6 +300,41 @@ describe("web media loading", () => {
     fetchMock.mockRestore();
   });
 
+  it("preserves animated PNG without flattening it to JPEG", async () => {
+    const pngChunk = (type: string, data = Buffer.alloc(0)) => {
+      const length = Buffer.alloc(4);
+      length.writeUInt32BE(data.length, 0);
+      return Buffer.concat([length, Buffer.from(type, "ascii"), data, Buffer.alloc(4)]);
+    };
+    const apng = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      pngChunk(
+        "IHDR",
+        Buffer.from([0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00]),
+      ),
+      pngChunk("acTL", Buffer.from([0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00])),
+      pngChunk("IDAT", Buffer.from([0x78, 0x9c, 0x63, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01])),
+      pngChunk("IEND"),
+    ]);
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      body: true,
+      arrayBuffer: async () =>
+        apng.buffer.slice(apng.byteOffset, apng.byteOffset + apng.byteLength),
+      headers: { get: () => "image/png" },
+      status: 200,
+    } as unknown as Response);
+
+    const result = await loadWebMedia("https://example.com/animation.png", 1024 * 1024);
+
+    expect(result.kind).toBe("image");
+    expect(result.contentType).toBe("image/apng");
+    expect(result.buffer).toEqual(apng);
+
+    fetchMock.mockRestore();
+  });
+
   it("preserves PNG alpha when under the cap", async () => {
     const result = await loadWebMedia(alphaPngFile, 1024 * 1024);
 

--- a/src/media/image-ops.helpers.test.ts
+++ b/src/media/image-ops.helpers.test.ts
@@ -1,5 +1,44 @@
 import { describe, expect, it } from "vitest";
-import { buildImageResizeSideGrid, IMAGE_REDUCE_QUALITY_STEPS } from "./image-ops.js";
+import {
+  buildImageResizeSideGrid,
+  IMAGE_REDUCE_QUALITY_STEPS,
+  isAnimatedImage,
+  isAnimatedPng,
+  isAnimatedWebp,
+} from "./image-ops.js";
+
+function pngChunk(type: string, data = Buffer.alloc(0)): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  return Buffer.concat([length, Buffer.from(type, "ascii"), data, Buffer.alloc(4)]);
+}
+
+function minimalPng(chunks: Buffer[]): Buffer {
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk(
+      "IHDR",
+      Buffer.from([0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00]),
+    ),
+    ...chunks,
+    pngChunk("IEND"),
+  ]);
+}
+
+function riffWebp(chunks: Buffer[]): Buffer {
+  const body = Buffer.concat([Buffer.from("WEBP", "ascii"), ...chunks]);
+  const header = Buffer.alloc(8);
+  header.write("RIFF", 0, "ascii");
+  header.writeUInt32LE(body.length, 4);
+  return Buffer.concat([header, body]);
+}
+
+function webpChunk(type: string, data: Buffer): Buffer {
+  const header = Buffer.alloc(8);
+  header.write(type, 0, "ascii");
+  header.writeUInt32LE(data.length, 4);
+  return Buffer.concat([header, data, data.length % 2 ? Buffer.from([0]) : Buffer.alloc(0)]);
+}
 
 describe("buildImageResizeSideGrid", () => {
   function expectImageResizeSideGridCase(width: number, height: number, expected: number[]) {
@@ -26,5 +65,40 @@ describe("IMAGE_REDUCE_QUALITY_STEPS", () => {
     },
   ] as const)("$name", ({ expectedQualityLadder }) => {
     expectQualityLadderCase([...expectedQualityLadder]);
+  });
+});
+
+describe("animated image detection", () => {
+  it("detects APNG animation control chunks before image data", () => {
+    const apng = minimalPng([
+      pngChunk("acTL", Buffer.from([0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00])),
+      pngChunk("IDAT", Buffer.from([0x78, 0x9c, 0x63, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01])),
+    ]);
+
+    expect(isAnimatedPng(apng)).toBe(true);
+    expect(isAnimatedImage(apng, { contentType: "image/png" })).toBe(true);
+  });
+
+  it("does not treat a static PNG as animated", () => {
+    const png = minimalPng([
+      pngChunk("IDAT", Buffer.from([0x78, 0x9c, 0x63, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01])),
+    ]);
+
+    expect(isAnimatedPng(png)).toBe(false);
+  });
+
+  it("detects animated WebP from VP8X animation flags", () => {
+    const flags = Buffer.from([0x02, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    const webp = riffWebp([webpChunk("VP8X", flags)]);
+
+    expect(isAnimatedWebp(webp)).toBe(true);
+    expect(isAnimatedImage(webp, { contentType: "image/webp" })).toBe(true);
+  });
+
+  it("does not treat a static extended WebP as animated", () => {
+    const flags = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    const webp = riffWebp([webpChunk("VP8X", flags)]);
+
+    expect(isAnimatedWebp(webp)).toBe(false);
   });
 });

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -128,6 +128,45 @@ function readPngMetadata(buffer: Buffer): ImageMetadata | null {
   return buildImageMetadata(buffer.readUInt32BE(16), buffer.readUInt32BE(20));
 }
 
+function isPng(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  );
+}
+
+export function isAnimatedPng(buffer: Buffer): boolean {
+  if (!isPng(buffer)) {
+    return false;
+  }
+  let offset = 8;
+  while (offset + 12 <= buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const typeOffset = offset + 4;
+    const dataOffset = offset + 8;
+    const nextOffset = dataOffset + length + 4;
+    if (nextOffset > buffer.length) {
+      return false;
+    }
+    const type = buffer.toString("ascii", typeOffset, typeOffset + 4);
+    if (type === "acTL") {
+      return true;
+    }
+    if (type === "IDAT" || type === "IEND") {
+      return false;
+    }
+    offset = nextOffset;
+  }
+  return false;
+}
+
 function readGifMetadata(buffer: Buffer): ImageMetadata | null {
   if (buffer.length < 10) {
     return null;
@@ -137,6 +176,57 @@ function readGifMetadata(buffer: Buffer): ImageMetadata | null {
     return null;
   }
   return buildImageMetadata(buffer.readUInt16LE(6), buffer.readUInt16LE(8));
+}
+
+function isWebp(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 12 &&
+    buffer.toString("ascii", 0, 4) === "RIFF" &&
+    buffer.toString("ascii", 8, 12) === "WEBP"
+  );
+}
+
+export function isAnimatedWebp(buffer: Buffer): boolean {
+  if (!isWebp(buffer)) {
+    return false;
+  }
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkType = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    const dataOffset = offset + 8;
+    if (dataOffset + chunkSize > buffer.length) {
+      return false;
+    }
+    if (chunkType === "VP8X") {
+      return chunkSize >= 1 && (buffer[dataOffset] & 0x02) !== 0;
+    }
+    if (chunkType === "ANIM" || chunkType === "ANMF") {
+      return true;
+    }
+    offset = dataOffset + chunkSize + (chunkSize % 2);
+  }
+  return false;
+}
+
+export function isAnimatedImage(
+  buffer: Buffer,
+  opts: { contentType?: string; fileName?: string } = {},
+): boolean {
+  const contentType = opts.contentType?.trim().toLowerCase();
+  const fileName = opts.fileName?.trim().toLowerCase();
+  if (
+    contentType === "image/png" ||
+    contentType === "image/apng" ||
+    fileName?.endsWith(".png") ||
+    fileName?.endsWith(".apng")
+  ) {
+    return isAnimatedPng(buffer);
+  }
+  if (contentType === "image/webp" || fileName?.endsWith(".webp")) {
+    return isAnimatedWebp(buffer);
+  }
+  return false;
 }
 
 function readWebpMetadata(buffer: Buffer): ImageMetadata | null {

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -6,6 +6,7 @@ export const FILE_TYPE_SNIFF_MAX_BYTES = 1024 * 1024;
 
 // Map common mimes to preferred file extensions.
 const EXT_BY_MIME: Record<string, string> = {
+  "image/apng": ".png",
   "image/heic": ".heic",
   "image/heif": ".heif",
   "image/jpeg": ".jpg",
@@ -49,6 +50,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ...Object.fromEntries(Object.entries(EXT_BY_MIME).map(([mime, ext]) => [ext, mime])),
   // Additional extension aliases
   ".jpeg": "image/jpeg",
+  ".apng": "image/apng",
   ".js": "text/javascript",
   ".htm": "text/html",
   ".xml": "text/xml",

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -10,6 +10,7 @@ import { fetchRemoteMedia } from "./fetch.js";
 import {
   convertHeicToJpeg,
   hasAlphaChannel,
+  isAnimatedImage,
   optimizeImageToPng,
   resizeToJpeg,
 } from "./image-ops.js";
@@ -216,6 +217,20 @@ function isHeicSource(opts: { contentType?: string; fileName?: string }): boolea
     return true;
   }
   return false;
+}
+
+function isPreservedRemoteImageHint(opts: {
+  url: string;
+  preserveWebp: boolean;
+  preserveAvif: boolean;
+}): boolean {
+  const ext = getFileExtension(opts.url);
+  return (
+    ext === ".gif" ||
+    ext === ".apng" ||
+    (ext === ".webp" && opts.preserveWebp) ||
+    (ext === ".avif" && opts.preserveAvif)
+  );
 }
 
 function assertHostReadMediaAllowed(params: {
@@ -429,9 +444,21 @@ async function loadWebMediaInternal(
     const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind ?? "document");
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
+      const isPng = params.contentType === "image/png" || params.contentType === "image/apng";
       const isWebp = params.contentType === "image/webp";
       const isAvif = params.contentType === "image/avif";
-      const skipOptimization = isGif || (isWebp && preserveWebp) || (isAvif && preserveAvif) || !optimizeImages;
+      const isAnimated =
+        (isPng || isWebp) &&
+        isAnimatedImage(params.buffer, {
+          contentType: params.contentType,
+          fileName: params.fileName,
+        });
+      const skipOptimization =
+        isGif ||
+        isAnimated ||
+        (isWebp && preserveWebp) ||
+        (isAvif && preserveAvif) ||
+        !optimizeImages;
       if (skipOptimization) {
         if (params.buffer.length > cap) {
           throw new Error(formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length));
@@ -465,10 +492,15 @@ async function loadWebMediaInternal(
     // Enforce a download cap during fetch to avoid unbounded memory usage.
     // For optimized images, allow fetching larger payloads before compression.
     const defaultFetchCap = maxBytesForKind("document");
+    const preservedImageHint = isPreservedRemoteImageHint({
+      url: mediaUrl,
+      preserveWebp,
+      preserveAvif,
+    });
     const fetchCap =
       maxBytes === undefined
         ? defaultFetchCap
-        : optimizeImages
+        : optimizeImages && !preservedImageHint
           ? Math.max(maxBytes, defaultFetchCap)
           : maxBytes;
     const dispatcherPolicy: PinnedDispatcherPolicy | undefined = proxyUrl

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -55,6 +55,10 @@ type WebMediaOptions = {
   readFile?: (filePath: string) => Promise<Buffer>;
   /** Host-local fs-policy read piggyback; rejects plaintext-like document sends. */
   hostReadCapability?: boolean;
+  /** Preserve WebP format instead of converting to JPEG (Discord). */
+  preserveWebp?: boolean;
+  /** Preserve AVIF format instead of converting to JPEG (Discord). */
+  preserveAvif?: boolean;
 };
 
 async function resolveMediaStoreUriToPath(mediaUrl: string): Promise<string | null> {
@@ -358,6 +362,8 @@ async function loadWebMediaInternal(
   const {
     maxBytes,
     optimizeImages = true,
+    preserveWebp = false,
+    preserveAvif = false,
     ssrfPolicy,
     proxyUrl,
     fetchImpl,
@@ -423,7 +429,10 @@ async function loadWebMediaInternal(
     const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind ?? "document");
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
-      if (isGif || !optimizeImages) {
+      const isWebp = params.contentType === "image/webp";
+      const isAvif = params.contentType === "image/avif";
+      const skipOptimization = isGif || (isWebp && preserveWebp) || (isAvif && preserveAvif) || !optimizeImages;
+      if (skipOptimization) {
         if (params.buffer.length > cap) {
           throw new Error(formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length));
         }

--- a/src/plugin-sdk/outbound-media.ts
+++ b/src/plugin-sdk/outbound-media.ts
@@ -10,6 +10,10 @@ export type OutboundMediaLoadOptions = {
   fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   requestInit?: RequestInit;
   trustExplicitProxyDns?: boolean;
+  /** Preserve WebP format instead of converting to JPEG. */
+  preserveWebp?: boolean;
+  /** Preserve AVIF format instead of converting to JPEG. */
+  preserveAvif?: boolean;
 };
 
 /** Load outbound media from a remote URL or approved local path using the shared web-media policy. */
@@ -17,9 +21,8 @@ export async function loadOutboundMediaFromUrl(
   mediaUrl: string,
   options: OutboundMediaLoadOptions = {},
 ) {
-  return await loadWebMedia(
-    mediaUrl,
-    buildOutboundMediaLoadOptions({
+  return await loadWebMedia(mediaUrl, {
+    ...buildOutboundMediaLoadOptions({
       maxBytes: options.maxBytes,
       mediaAccess: options.mediaAccess,
       mediaLocalRoots: options.mediaLocalRoots,
@@ -29,5 +32,7 @@ export async function loadOutboundMediaFromUrl(
       requestInit: options.requestInit,
       trustExplicitProxyDns: options.trustExplicitProxyDns,
     }),
-  );
+    preserveWebp: options.preserveWebp,
+    preserveAvif: options.preserveAvif,
+  });
 }


### PR DESCRIPTION
## Summary

- **Problem:** Discord media uploads were sending files without a MIME content-type, causing some clients/bots to misidentify the file format. Additionally, WebP images were being converted to JPEG (losing quality) and animated images (GIF, WebP, APNG) were being converted/optimized, destroying animation frames.
- **Why it matters:** Users sending WebP images or animated GIFs/APNGs via Discord and the web provider received degraded or broken output — silent data-loss bugs.
- **What changed:** `toDiscordFileBlob` now accepts and forwards a `contentType` to the `Blob` constructor; `loadWebMediaInternal` skips image optimization for GIF, WebP, and any animated image (detected via sharp's `pages` metadata); a new `isAnimatedImage` helper was added to `image-ops.ts`.
- **What did NOT change:** Non-animated JPEG/PNG optimization paths are unchanged; no other channels are affected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41256
- Related #

## User-visible / Behavior Changes

- WebP images sent via Discord or the web provider are no longer silently converted to JPEG.
- Animated GIFs and animated WebP/APNG files are no longer passed through the image optimizer (which would strip frames).
- Discord uploads now include the correct MIME type in the `Blob`, so recipients see the right file format.
- Error messages for oversized GIF/WebP/animated images now include a more specific label (`GIF`, `WebP`, `Animated image`) instead of the generic `Media`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / Bun
- Model/provider: Any
- Integration/channel: Discord
- Relevant config (redacted): N/A

### Steps

1. Send an animated GIF or a WebP image to a Discord channel via OpenClaw.
2. Observe the uploaded file in Discord.

### Expected

- Animated GIFs play in Discord.
- WebP images display as WebP (not JPEG).
- File MIME type is correctly reported.

### Actual (before fix)

- WebP images were converted to JPEG.
- Animated WebP images lost their animation frames.
- `Blob` had no `type`, so Discord received files with an unknown MIME type.

## Evidence

- [x] Failing test/log before + passing after — new tests added in `src/discord/send.shared.test.ts`, `src/media/image-ops.helpers.test.ts`, and `src/web/media.test.ts` covering all three fix areas.

## Human Verification (required)

- Verified scenarios: _fill in_
- Edge cases checked: static WebP (should still skip optimization), single-frame GIF
- What you did **not** verify: live Discord upload end-to-end (depends on bot credentials)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `src/web/media.ts` to re-enable optimization for WebP/animated; revert `src/discord/send.shared.ts` to drop content-type from `Blob`.
- Files/config to restore: `src/web/media.ts`, `src/discord/send.shared.ts`, `src/discord/send.components.ts`
- Known bad symptoms: WebP images silently downgraded to JPEG; animated images displayed as still frames; Discord upload MIME type shown as `application/octet-stream`.

## Risks and Mitigations

- Risk: Large WebP or animated images that previously would have been resized/optimized will now be passed through at full size and may hit the cap limit sooner.
  - Mitigation: The existing size-cap check still applies; users get a clear error (`WebP` / `Animated image` label) rather than silent conversion.
