### PR TITLE
fix(cli): warn about agent-level model overrides on config set

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -451,6 +451,65 @@ describe("config cli", () => {
       expect(logOutput).not.toContain("model overrides");
     });
 
+    it("warns for string-style model overrides", async () => {
+      const resolved: OpenClawConfig = {
+        agents: {
+          defaults: { model: { primary: "anthropic/claude-opus-4-6" } },
+          list: [
+            {
+              id: "legacy",
+              name: "Legacy Agent",
+              model: "openai-codex/gpt-5.3-codex" as never,
+            },
+          ],
+        },
+      };
+      mockReadConfigFileSnapshot.mockResolvedValueOnce(
+        buildSnapshot({ resolved, config: resolved }),
+      );
+
+      const { registerConfigCli } = await import("./config-cli.js");
+      const program = new Command();
+      program.exitOverride();
+      registerConfigCli(program);
+
+      await program.parseAsync(
+        ["config", "set", "agents.defaults.model.primary", "openai-codex/gpt-5.4"],
+        { from: "user" },
+      );
+
+      const logOutput = mockLog.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(logOutput).toContain("model overrides");
+      expect(logOutput).toContain("Legacy Agent (id: legacy)");
+      expect(logOutput).toContain("openai-codex/gpt-5.3-codex");
+    });
+
+    it("warns when using bracket notation path", async () => {
+      const resolved: OpenClawConfig = {
+        agents: {
+          defaults: { model: { primary: "anthropic/claude-opus-4-6" } },
+          list: [{ id: "main", name: "Main", model: { primary: "openai-codex/gpt-5.3-codex" } }],
+        },
+      };
+      mockReadConfigFileSnapshot.mockResolvedValueOnce(
+        buildSnapshot({ resolved, config: resolved }),
+      );
+
+      const { registerConfigCli } = await import("./config-cli.js");
+      const program = new Command();
+      program.exitOverride();
+      registerConfigCli(program);
+
+      await program.parseAsync(
+        ["config", "set", "agents.defaults.model[primary]", "openai-codex/gpt-5.4"],
+        { from: "user" },
+      );
+
+      const logOutput = mockLog.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(logOutput).toContain("model overrides");
+      expect(logOutput).toContain("Main (id: main)");
+    });
+
     it("does not warn when setting a non-model config path", async () => {
       const resolved: OpenClawConfig = {
         agents: {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -388,6 +388,93 @@ describe("config cli", () => {
     });
   });
 
+  describe("config set - agent model override warnings", () => {
+    it("warns when setting agents.defaults.model.primary with agent-level overrides", async () => {
+      const resolved: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+          },
+          list: [
+            { id: "main", name: "Main", model: { primary: "openai-codex/gpt-5.3-codex" } },
+            { id: "work", name: "Work Agent", model: { primary: "openai-codex/gpt-5.3-codex" } },
+          ],
+        },
+      };
+      mockReadConfigFileSnapshot.mockResolvedValueOnce(
+        buildSnapshot({ resolved, config: resolved }),
+      );
+
+      const { registerConfigCli } = await import("./config-cli.js");
+      const program = new Command();
+      program.exitOverride();
+      registerConfigCli(program);
+
+      await program.parseAsync(
+        ["config", "set", "agents.defaults.model.primary", "openai-codex/gpt-5.4"],
+        { from: "user" },
+      );
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const logOutput = mockLog.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(logOutput).toContain("agent");
+      expect(logOutput).toContain("model overrides");
+      expect(logOutput).toContain("Main (id: main)");
+      expect(logOutput).toContain("Work Agent (id: work)");
+    });
+
+    it("does not warn when no agent-level model overrides exist", async () => {
+      const resolved: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+          },
+          list: [{ id: "main", name: "Main" }, { id: "work" }],
+        },
+      };
+      mockReadConfigFileSnapshot.mockResolvedValueOnce(
+        buildSnapshot({ resolved, config: resolved }),
+      );
+
+      const { registerConfigCli } = await import("./config-cli.js");
+      const program = new Command();
+      program.exitOverride();
+      registerConfigCli(program);
+
+      await program.parseAsync(
+        ["config", "set", "agents.defaults.model.primary", "openai-codex/gpt-5.4"],
+        { from: "user" },
+      );
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const logOutput = mockLog.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(logOutput).not.toContain("model overrides");
+    });
+
+    it("does not warn when setting a non-model config path", async () => {
+      const resolved: OpenClawConfig = {
+        agents: {
+          list: [{ id: "main", model: { primary: "openai-codex/gpt-5.3-codex" } }],
+        },
+        gateway: { port: 18789 },
+      };
+      mockReadConfigFileSnapshot.mockResolvedValueOnce(
+        buildSnapshot({ resolved, config: resolved }),
+      );
+
+      const { registerConfigCli } = await import("./config-cli.js");
+      const program = new Command();
+      program.exitOverride();
+      registerConfigCli(program);
+
+      await program.parseAsync(["config", "set", "gateway.port", "18790"], { from: "user" });
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const logOutput = mockLog.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(logOutput).not.toContain("model overrides");
+    });
+  });
+
   describe("config unset - issue #6070", () => {
     it("preserves existing config keys when unsetting a value", async () => {
       const resolved: OpenClawConfig = {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -429,9 +429,15 @@ function detectAgentModelOverrides(config: Record<string, unknown>): AgentModelO
   return overrides;
 }
 
-function isDefaultModelPath(path: string): boolean {
-  const normalized = path.toLowerCase();
-  return normalized === "agents.defaults.model" || normalized === "agents.defaults.model.primary";
+const DEFAULT_MODEL_SEGMENTS: string[][] = [
+  ["agents", "defaults", "model"],
+  ["agents", "defaults", "model", "primary"],
+];
+
+function isDefaultModelSegments(segments: PathSegment[]): boolean {
+  return DEFAULT_MODEL_SEGMENTS.some(
+    (target) => segments.length === target.length && segments.every((seg, i) => seg === target[i]),
+  );
 }
 
 export function registerConfigCli(program: Command) {
@@ -488,7 +494,7 @@ export function registerConfigCli(program: Command) {
         await writeConfigFile(next);
         defaultRuntime.log(info(`Updated ${path}. Restart the gateway to apply.`));
 
-        if (isDefaultModelPath(path)) {
+        if (isDefaultModelSegments(parsedPath)) {
           const overrides = detectAgentModelOverrides(next);
           if (overrides.length > 0) {
             defaultRuntime.log("");

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -5,7 +5,7 @@ import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-f
 import { CONFIG_PATH } from "../config/paths.js";
 import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
-import { danger, info, success } from "../globals.js";
+import { danger, info, success, warn } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -392,6 +392,48 @@ export async function runConfigValidate(opts: { json?: boolean; runtime?: Runtim
   }
 }
 
+type AgentModelOverrideInfo = {
+  id: string;
+  name?: string;
+  model: string;
+};
+
+function detectAgentModelOverrides(config: Record<string, unknown>): AgentModelOverrideInfo[] {
+  const agents = config.agents as { list?: unknown[] } | undefined;
+  if (!agents?.list || !Array.isArray(agents.list)) {
+    return [];
+  }
+  const overrides: AgentModelOverrideInfo[] = [];
+  for (const entry of agents.list) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const agent = entry as { id?: string; name?: string; model?: unknown };
+    if (!agent.model) {
+      continue;
+    }
+    const modelStr =
+      typeof agent.model === "string"
+        ? agent.model
+        : typeof agent.model === "object" && agent.model !== null
+          ? ((agent.model as { primary?: string }).primary ?? "")
+          : "";
+    if (modelStr) {
+      overrides.push({
+        id: agent.id ?? "unknown",
+        name: agent.name,
+        model: modelStr,
+      });
+    }
+  }
+  return overrides;
+}
+
+function isDefaultModelPath(path: string): boolean {
+  const normalized = path.toLowerCase();
+  return normalized === "agents.defaults.model" || normalized === "agents.defaults.model.primary";
+}
+
 export function registerConfigCli(program: Command) {
   const cmd = program
     .command("config")
@@ -445,6 +487,28 @@ export function registerConfigCli(program: Command) {
         setAtPath(next, parsedPath, parsedValue);
         await writeConfigFile(next);
         defaultRuntime.log(info(`Updated ${path}. Restart the gateway to apply.`));
+
+        if (isDefaultModelPath(path)) {
+          const overrides = detectAgentModelOverrides(next);
+          if (overrides.length > 0) {
+            defaultRuntime.log("");
+            defaultRuntime.log(
+              warn(
+                `${overrides.length} agent${overrides.length === 1 ? "" : "s"} ha${overrides.length === 1 ? "s" : "ve"} explicit model overrides that take priority over defaults:`,
+              ),
+            );
+            for (const entry of overrides) {
+              const label = entry.name ? `${entry.name} (id: ${entry.id})` : entry.id;
+              defaultRuntime.log(warn(`  - ${label}: ${entry.model}`));
+            }
+            defaultRuntime.log("");
+            defaultRuntime.log(
+              info(
+                "To update all agents, set each agent's model individually or remove agent-level overrides.",
+              ),
+            );
+          }
+        }
       } catch (err) {
         defaultRuntime.error(danger(String(err)));
         defaultRuntime.exit(1);


### PR DESCRIPTION
## Summary

- Problem: `openclaw config set agents.defaults.model.primary <model>` silently succeeds without informing the user that agents with explicit `model` in `agents.list[]` will ignore the new default.
- Why it matters: users changing their default model expect all agents to switch, but agent-level overrides silently take priority. This leads to confusing behavior where `/new` still shows the old model despite the config appearing correct. In practice this caused a 1-hour debugging session chasing phantom issues (stale sessions, process restarts) before discovering the actual cause.
- What changed: after `config set` writes the config, if the path targets `agents.defaults.model` or `agents.defaults.model.primary`, the CLI now checks `agents.list[]` for agents with explicit model overrides and prints a warning listing them.
- What did NOT change (scope boundary): no runtime model resolution changes, no config schema changes, no gateway restart behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #41270

## User-visible / Behavior Changes

Before:
```
$ openclaw config set agents.defaults.model.primary openai-codex/gpt-5.4
✓ Updated agents.defaults.model.primary. Restart the gateway to apply.
```

After:
```
$ openclaw config set agents.defaults.model.primary openai-codex/gpt-5.4
✓ Updated agents.defaults.model.primary. Restart the gateway to apply.

⚠ 2 agents have explicit model overrides that take priority over defaults:
  - Main (id: main): openai-codex/gpt-5.3-codex
  - Work Agent (id: work): openai-codex/gpt-5.3-codex

To update all agents, set each agent's model individually or remove agent-level overrides.
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS Darwin 25.2.0 (Apple Silicon)
- Runtime/container: Node 25.2.1
- Model/provider: openai-codex/gpt-5.4 (target), openai-codex/gpt-5.3-codex (agent overrides)
- Integration/channel: Feishu
- Relevant config (redacted): `agents.defaults.model.primary` + `agents.list[].model.primary`

### Steps

1. Have a config with `agents.list[]` entries that specify explicit `model.primary`.
2. Run `openclaw config set agents.defaults.model.primary <new-model>`.
3. Observe the warning output.

### Expected

- Warning lists agents with explicit model overrides.

### Actual

- Verified: warning is printed with correct agent names, IDs, and model values.

## Evidence

- [x] Failing test/log before + passing after

```
 ✓ src/cli/config-cli.test.ts (24 tests) 105ms
   ✓ config set - agent model override warnings
     ✓ warns when setting agents.defaults.model.primary with agent-level overrides
     ✓ does not warn when no agent-level model overrides exist
     ✓ warns for string-style model overrides
     ✓ warns when using bracket notation path
     ✓ does not warn when setting a non-model config path
```

## Human Verification (required)

- Verified scenarios: warning appears with correct agent list when overrides exist; no warning when agents have no explicit model; no warning for unrelated config paths; bracket notation path triggers warning correctly.
- Edge cases checked: agents with string-style model (`"model": "provider/model"`), agents with object-style model (`"model": { "primary": "..." }`), agents without any model config, bracket notation path (`agents.defaults.model[primary]`).
- What you did **not** verify: full end-to-end with live gateway (change is CLI-only, no gateway interaction).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/cli/config-cli.ts`
- Known bad symptoms: false warnings when agent config shape is unexpected (mitigated by defensive type checks).

## Risks and Mitigations

- Risk: warning output could be noisy if many agents have overrides.
  - Mitigation: warning only triggers for `agents.defaults.model` paths, and lists are typically small (< 10 agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)