### PR TITLE
docs: improve good first issue link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ We are currently prioritizing:
 - **Skills**: For skill contributions, head to [ClawHub](https://clawhub.ai/) — the community hub for OpenClaw skills.
 - **Performance**: Optimizing token usage and compaction logic.
 
-Check the [GitHub Issues](https://github.com/openclaw/openclaw/issues) for "good first issue" labels!
+Check the [good first issues](https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to get started!
 
 ## Maintainers
 


### PR DESCRIPTION
## What & Why
Change the generic GitHub Issues link to a direct filtered link for issues labeled "good first issue". This makes it easier for new contributors to find entry points without manual filtering.
### Before
- Link to all issues requiring manual label filtering
### After
- One-click access to pre-filtered good first issues
## Type of Change
- [x] Documentation improvement
## Checklist
- [x] Change is focused (single concern)
- [x] Description explains what & why
## Testing
- Verified the link works and correctly filters for "good first issue" labeled issues


