### PR TITLE
fix(ios): read IDEProvisioningTeamByIdentifier

### DIFF
--- a/scripts/ios-team-id.sh
+++ b/scripts/ios-team-id.sh
@@ -62,32 +62,67 @@ load_teams_from_xcode_preferences() {
     [[ -z "$team_id" ]] && continue
     append_team "$team_id" "${is_free:-0}" "${team_name:-}"
   done < <(
-    plutil -extract IDEProvisioningTeams json -o - "$plist_path" 2>/dev/null \
-      | "$python_cmd" -c '
+    "$python_cmd" -c '
 import json
+import plistlib
+import subprocess
 import sys
 
+def emit_teams(containers):
+    emitted = 0
+    for teams in containers:
+        if not isinstance(teams, list):
+            continue
+        for team in teams:
+            if not isinstance(team, dict):
+                continue
+            team_id = str(team.get("teamID", "")).strip()
+            if not team_id:
+                continue
+            is_free = "1" if bool(team.get("isFreeProvisioningTeam", False)) else "0"
+            team_name = str(team.get("teamName", "")).replace("\t", " ").strip()
+            print(f"{team_id}\t{is_free}\t{team_name}")
+            emitted += 1
+    return emitted
+
+# Primary: defaults export (handles both IDEProvisioningTeamByIdentifier
+# and IDEProvisioningTeams in a single pass)
 try:
-    data = json.load(sys.stdin)
+    raw = subprocess.run(
+        ["defaults", "export", "com.apple.dt.Xcode", "-"],
+        capture_output=True,
+    ).stdout
+    if raw:
+        data = plistlib.loads(raw)
+        if isinstance(data, dict):
+            containers = []
+            for key in ("IDEProvisioningTeamByIdentifier", "IDEProvisioningTeams"):
+                container = data.get(key)
+                if isinstance(container, dict):
+                    containers.extend(container.values())
+                elif isinstance(container, list):
+                    containers.append(container)
+            if emit_teams(containers) > 0:
+                raise SystemExit(0)
+except SystemExit:
+    raise
 except Exception:
-    raise SystemExit(0)
+    pass
 
-if not isinstance(data, dict):
-    raise SystemExit(0)
-
-for teams in data.values():
-    if not isinstance(teams, list):
-        continue
-    for team in teams:
-        if not isinstance(team, dict):
-            continue
-        team_id = str(team.get("teamID", "")).strip()
-        if not team_id:
-            continue
-        is_free = "1" if bool(team.get("isFreeProvisioningTeam", False)) else "0"
-        team_name = str(team.get("teamName", "")).replace("\t", " ").strip()
-        print(f"{team_id}\t{is_free}\t{team_name}")
-'
+# Fallback: plutil extracts only IDEProvisioningTeams as JSON
+try:
+    result = subprocess.run(
+        ["plutil", "-extract", "IDEProvisioningTeams", "json", "-o", "-",
+         sys.argv[1]],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0 and result.stdout:
+        data = json.loads(result.stdout)
+        if isinstance(data, dict):
+            emit_teams(data.values())
+except Exception:
+    pass
+' "$plist_path"
   )
 }
 

--- a/test/scripts/ios-team-id.test.ts
+++ b/test/scripts/ios-team-id.test.ts
@@ -10,11 +10,44 @@ const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
 const BASH_ARGS = process.platform === "win32" ? [SCRIPT] : ["--noprofile", "--norc", SCRIPT];
 const BASE_PATH = process.env.PATH ?? "/usr/bin:/bin";
 const BASE_LANG = process.env.LANG ?? "C";
+
+/** Fake plist output for `defaults export com.apple.dt.Xcode -` with the
+ *  IDEProvisioningTeamByIdentifier key layout (Xcode 16+). */
+const FAKE_XCODE_TEAMS_PLIST = `\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>IDEProvisioningTeamByIdentifier</key>
+  <dict>
+    <key>dev@example.com</key>
+    <array>
+      <dict>
+        <key>teamID</key>
+        <string>AAAAA11111</string>
+        <key>teamName</key>
+        <string>Alpha Team</string>
+        <key>isFreeProvisioningTeam</key>
+        <true/>
+      </dict>
+      <dict>
+        <key>teamID</key>
+        <string>BBBBB22222</string>
+        <key>teamName</key>
+        <string>Beta Team</string>
+        <key>isFreeProvisioningTeam</key>
+        <false/>
+      </dict>
+    </array>
+  </dict>
+</dict>
+</plist>`;
 let fixtureRoot = "";
 let sharedBinDir = "";
 let sharedHomeDir = "";
 let sharedHomeBinDir = "";
 let sharedFakePythonPath = "";
+let guidanceHomeDir = "";
 const tempDirs: string[] = [];
 const runScriptCache = new Map<string, { ok: boolean; stdout: string; stderr: string }>();
 type TeamCandidate = {
@@ -151,6 +184,12 @@ echo '{}'`,
     await writeExecutable(
       path.join(sharedBinDir, "defaults"),
       `#!/usr/bin/env bash
+if [[ "$1" == "export" && "$2" == "com.apple.dt.Xcode" ]]; then
+  cat <<'PLIST'
+${FAKE_XCODE_TEAMS_PLIST}
+PLIST
+  exit 0
+fi
 if [[ "$3" == "DVTDeveloperAccountManagerAppleIDLists" ]]; then
   echo '(identifier = "dev@example.com";)'
   exit 0
@@ -184,8 +223,26 @@ exit 1`,
     await writeExecutable(
       sharedFakePythonPath,
       `#!/usr/bin/env bash
-printf 'AAAAA11111\\t0\\tAlpha Team\\r\\n'
+printf 'AAAAA11111\\t1\\tAlpha Team\\r\\n'
 printf 'BBBBB22222\\t0\\tBeta Team\\r\\n'`,
+    );
+
+    guidanceHomeDir = path.join(fixtureRoot, "guidance-home");
+    const guidanceHomeBinDir = path.join(guidanceHomeDir, "bin");
+    await mkdir(guidanceHomeBinDir, { recursive: true });
+    await mkdir(path.join(guidanceHomeDir, "Library", "Preferences"), { recursive: true });
+    await writeFile(
+      path.join(guidanceHomeDir, "Library", "Preferences", "com.apple.dt.Xcode.plist"),
+      "",
+    );
+    await writeExecutable(
+      path.join(guidanceHomeBinDir, "defaults"),
+      `#!/usr/bin/env bash
+if [[ "$3" == "DVTDeveloperAccountManagerAppleIDLists" ]]; then
+  echo '(identifier = "dev@example.com";)'
+  exit 0
+fi
+exit 0`,
     );
   });
 
@@ -218,11 +275,11 @@ printf 'BBBBB22222\\t0\\tBeta Team\\r\\n'`,
   it("resolves a fallback team ID from Xcode team listings (smoke)", async () => {
     const fallbackResult = runScript(sharedHomeDir, { IOS_PYTHON_BIN: sharedFakePythonPath });
     expect(fallbackResult.ok).toBe(true);
-    expect(fallbackResult.stdout).toBe("AAAAA11111");
+    expect(fallbackResult.stdout).toBe("BBBBB22222");
   });
 
   it("prints actionable guidance when Xcode account exists but no Team ID is resolvable", async () => {
-    const result = runScript(sharedHomeDir);
+    const result = runScript(guidanceHomeDir);
     expect(result.ok).toBe(false);
     expect(
       result.stderr.includes("An Apple account is signed in to Xcode") ||


### PR DESCRIPTION
> UPDATE: created this PR while trying out the openclaw iOS app. Everything worked out of the box except of `scripts/ios-team-id.sh`. So I thought this tiny fix might be of use. Reg. agents feedback about tests: Didn't wrote tests that execute python code since there were no existing ones that do that.

## Summary

- Problem: `scripts/ios-team-id.sh` only read `IDEProvisioningTeams` and legacy fallbacks. On my local Xcode prefs, the team list is stored under `IDEProvisioningTeamByIdentifier`, so team lookup failed.
- Why it matters: `scripts/ios-configure-signing.sh` then exits with `WARN: Unable to detect an Apple Team ID; keeping existing iOS signing override (if any).`
- What changed: parse exported Xcode prefs for both `IDEProvisioningTeamByIdentifier` and `IDEProvisioningTeams`, and add test coverage for the identifier-key layout.
- What did NOT change (scope boundary): team selection preference order and the existing provisioning-profile / keychain fallbacks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #22773

## User-visible / Behavior Changes

- `scripts/ios-team-id.sh` now resolves team IDs from Xcode prefs that store teams under `IDEProvisioningTeamByIdentifier`.
- `scripts/ios-configure-signing.sh` now succeeds on that prefs layout instead of warning and leaving signing unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local shell
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `IOS_PYTHON_BIN=/usr/bin/python3` for deterministic local repro

### Steps

1. Save the pre-change `scripts/ios-team-id.sh` and `scripts/ios-configure-signing.sh` from `HEAD` to a temp directory and run `IOS_PYTHON_BIN=/usr/bin/python3 .../ios-configure-signing.sh`.
2. Run `IOS_PYTHON_BIN=/usr/bin/python3 scripts/ios-team-id.sh` from this branch.
3. Run `IOS_PYTHON_BIN=/usr/bin/python3 scripts/ios-configure-signing.sh` from this branch.
4. Run `pnpm exec vitest test/scripts/ios-team-id.test.ts`.

### Expected

- Before the fix, the old helper should fail to resolve a team ID on this Xcode prefs layout.
- After the fix, the helper should print the selected Team ID and signing configuration should succeed.
- The regression test should pass.

### Actual

- Before: `WARN: Unable to detect an Apple Team ID; keeping existing iOS signing override (if any).`
- After `scripts/ios-team-id.sh`: `2FD7P95TP8`
- After `scripts/ios-configure-signing.sh`: `iOS signing config already up to date: team=2FD7P95TP8 app=ai.openclaw.ios.test.klem-2fd7p95tp8`
- Test: `pnpm exec vitest test/scripts/ios-team-id.test.ts`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Local Xcode prefs contain `IDEProvisioningTeamByIdentifier` with valid teams.
  - The pre-change helper fails on that prefs layout.
  - The patched helper returns `2FD7P95TP8` on the same machine.
  - `scripts/ios-configure-signing.sh` succeeds with the patched helper.
  - `pnpm exec vitest test/scripts/ios-team-id.test.ts` passes.
- Edge cases checked:
  - Existing team de-duplication stays in place via the unchanged `append_team` logic.
- What you did **not** verify:
  - Physical-device build/install after this script-only change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or set `IOS_DEVELOPMENT_TEAM` explicitly.
- Files/config to restore: `scripts/ios-team-id.sh`
- Known bad symptoms reviewers should watch for: `scripts/ios-team-id.sh` prints no team ID on a machine where `IDEProvisioningTeamByIdentifier` is populated.

## Risks and Mitigations

- Risk: parsing both Xcode prefs keys could surface duplicate team entries.
  - Mitigation: `append_team` already de-duplicates by Team ID before selection.
