### PR TITLE
feat: pluggable web search providers via plugin API

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -545,11 +545,20 @@ function resolvePluginSearchProvider(
   if (!registry || registry.searchProviders.length === 0) {
     return null;
   }
-  // Explicit match by provider id
+  // Explicit match by provider id (case-insensitive to match Zod-validated config)
   if (raw) {
-    const match = registry.searchProviders.find((entry) => entry.provider.id === raw);
+    const match = registry.searchProviders.find(
+      (entry) => entry.provider.id.trim().toLowerCase() === raw,
+    );
     if (match) {
       return match.provider;
+    }
+    // Warn when a non-built-in provider id doesn't resolve to any plugin
+    const builtIn = new Set(SEARCH_PROVIDERS as readonly string[]);
+    if (!builtIn.has(raw)) {
+      logVerbose(
+        `web_search: provider "${raw}" is not registered as a plugin provider, falling back to built-in resolution`,
+      );
     }
   }
   // Auto-detect: try each plugin provider's isAvailable()
@@ -1902,7 +1911,13 @@ function createPluginSearchTool(
             })),
           }),
           ...(result.content && { content: wrapWebContent(result.content) }),
-          ...(result.citations && { citations: result.citations }),
+          ...(result.citations && {
+            citations: result.citations.map((c) =>
+              typeof c === "string"
+                ? c
+                : { ...c, title: c.title ? wrapWebContent(c.title) : undefined },
+            ),
+          }),
         };
         writeCache(SEARCH_CACHE, cacheKey, payload, cacheTtlMs);
         return jsonResult(payload);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -564,11 +564,17 @@ function resolvePluginSearchProvider(
   // Auto-detect: try each plugin provider's isAvailable()
   if (!raw) {
     for (const entry of registry.searchProviders) {
-      if (entry.provider.isAvailable?.(config)) {
+      try {
+        if (entry.provider.isAvailable?.(config)) {
+          logVerbose(
+            `web_search: no provider configured, auto-detected plugin provider "${entry.provider.id}"`,
+          );
+          return entry.provider;
+        }
+      } catch {
         logVerbose(
-          `web_search: no provider configured, auto-detected plugin provider "${entry.provider.id}"`,
+          `web_search: plugin provider "${entry.provider.id}" isAvailable() threw, skipping`,
         );
-        return entry.provider;
       }
     }
   }
@@ -1883,14 +1889,13 @@ function createPluginSearchTool(
         return jsonResult({ error: "missing_query", message: "query is required" });
       }
 
-      const cacheKey = normalizeCacheKey(`${pluginProvider.id}:${query}`);
-      const cached = readCache(SEARCH_CACHE, cacheKey, cacheTtlMs);
-      if (cached) {
-        return jsonResult(cached);
-      }
-
       const maxResults = readNumberParam(params, "count", { integer: true }) ??
         search?.maxResults ?? DEFAULT_SEARCH_COUNT;
+      const cacheKey = normalizeCacheKey(`${pluginProvider.id}:${query}:${maxResults}`);
+      const cached = readCache(SEARCH_CACHE, cacheKey, cacheTtlMs);
+      if (cached) {
+        return jsonResult(cached.value);
+      }
       const started = Date.now();
 
       try {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -3,6 +3,8 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import { logVerbose } from "../../globals.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import type { SearchProviderPlugin } from "../../plugins/types.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import type { AnyAgentTool } from "./common.js";
@@ -529,6 +531,39 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       "web_search (perplexity) needs an API key. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY in the Gateway environment, or configure tools.web.search.perplexity.apiKey.",
     docs: "https://docs.openclaw.ai/tools/web",
   };
+}
+
+function resolvePluginSearchProvider(
+  search?: WebSearchConfig,
+  config?: OpenClawConfig,
+): SearchProviderPlugin | null {
+  const raw =
+    search && "provider" in search && typeof search.provider === "string"
+      ? search.provider.trim().toLowerCase()
+      : "";
+  const registry = getActivePluginRegistry();
+  if (!registry || registry.searchProviders.length === 0) {
+    return null;
+  }
+  // Explicit match by provider id
+  if (raw) {
+    const match = registry.searchProviders.find((entry) => entry.provider.id === raw);
+    if (match) {
+      return match.provider;
+    }
+  }
+  // Auto-detect: try each plugin provider's isAvailable()
+  if (!raw) {
+    for (const entry of registry.searchProviders) {
+      if (entry.provider.isAvailable?.(config)) {
+        logVerbose(
+          `web_search: no provider configured, auto-detected plugin provider "${entry.provider.id}"`,
+        );
+        return entry.provider;
+      }
+    }
+  }
+  return null;
 }
 
 function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {
@@ -1801,6 +1836,87 @@ async function runWebSearch(params: {
   return payload;
 }
 
+function createPluginSearchTool(
+  pluginProvider: SearchProviderPlugin,
+  search: WebSearchConfig | undefined,
+  config?: OpenClawConfig,
+): AnyAgentTool {
+  const cacheTtlMs = resolveCacheTtlMs(search?.cacheTtlMinutes);
+  const timeoutSeconds = resolveTimeoutSeconds(search?.timeoutSeconds);
+  const description =
+    pluginProvider.description ??
+    `Search the web using ${pluginProvider.name}. Returns titles, URLs, and descriptions for research.`;
+
+  return {
+    label: "Web Search",
+    name: "web_search",
+    description,
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query" }),
+      count: Type.Optional(
+        Type.Number({ description: "Number of results (1-10)", minimum: 1, maximum: 10 }),
+      ),
+    }),
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const query = readStringParam(params, "query", { required: true });
+      if (!query) {
+        return jsonResult({ error: "missing_query", message: "query is required" });
+      }
+
+      const cacheKey = normalizeCacheKey(`${pluginProvider.id}:${query}`);
+      const cached = readCache(SEARCH_CACHE, cacheKey, cacheTtlMs);
+      if (cached) {
+        return jsonResult(cached);
+      }
+
+      const maxResults = readNumberParam(params, "count", { integer: true }) ??
+        search?.maxResults ?? DEFAULT_SEARCH_COUNT;
+      const started = Date.now();
+
+      try {
+        const result = await pluginProvider.search({
+          query,
+          maxResults,
+          timeoutMs: timeoutSeconds * 1000,
+          config,
+        });
+
+        const payload = {
+          query,
+          provider: pluginProvider.id,
+          count: result.results?.length ?? 0,
+          tookMs: Date.now() - started,
+          externalContent: {
+            untrusted: true,
+            source: "web_search",
+            provider: pluginProvider.id,
+            wrapped: true,
+          },
+          ...(result.results && {
+            results: result.results.map((r) => ({
+              title: wrapWebContent(r.title),
+              url: r.url,
+              description: r.description ? wrapWebContent(r.description) : undefined,
+              published: r.published,
+            })),
+          }),
+          ...(result.content && { content: wrapWebContent(result.content) }),
+          ...(result.citations && { citations: result.citations }),
+        };
+        writeCache(SEARCH_CACHE, cacheKey, payload, cacheTtlMs);
+        return jsonResult(payload);
+      } catch (err) {
+        return jsonResult({
+          error: "search_failed",
+          provider: pluginProvider.id,
+          message: String(err),
+        });
+      }
+    },
+  };
+}
+
 export function createWebSearchTool(options?: {
   config?: OpenClawConfig;
   sandboxed?: boolean;
@@ -1808,6 +1924,12 @@ export function createWebSearchTool(options?: {
   const search = resolveSearchConfig(options?.config);
   if (!resolveSearchEnabled({ search, sandboxed: options?.sandboxed })) {
     return null;
+  }
+
+  // Check plugin-registered search providers first.
+  const pluginProvider = resolvePluginSearchProvider(search, options?.config);
+  if (pluginProvider) {
+    return createPluginSearchTool(pluginProvider, search, options?.config);
   }
 
   const provider = resolveSearchProvider(search);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1845,6 +1845,16 @@ async function runWebSearch(params: {
   return payload;
 }
 
+function sanitizeUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.href;
+    }
+  } catch {}
+  return undefined;
+}
+
 function createPluginSearchTool(
   pluginProvider: SearchProviderPlugin,
   search: WebSearchConfig | undefined,
@@ -1903,20 +1913,28 @@ function createPluginSearchTool(
             wrapped: true,
           },
           ...(result.results && {
-            results: result.results.map((r) => ({
-              title: wrapWebContent(r.title),
-              url: r.url,
-              description: r.description ? wrapWebContent(r.description) : undefined,
-              published: r.published,
-            })),
+            results: result.results
+              .filter((r) => sanitizeUrl(r.url))
+              .map((r) => ({
+                title: wrapWebContent(r.title),
+                url: sanitizeUrl(r.url)!,
+                description: r.description ? wrapWebContent(r.description) : undefined,
+                published: r.published,
+              })),
           }),
           ...(result.content && { content: wrapWebContent(result.content) }),
           ...(result.citations && {
-            citations: result.citations.map((c) =>
-              typeof c === "string"
-                ? c
-                : { ...c, title: c.title ? wrapWebContent(c.title) : undefined },
-            ),
+            citations: result.citations
+              .map((c) => {
+                if (typeof c === "string") {
+                  return sanitizeUrl(c);
+                }
+                const url = sanitizeUrl(c.url);
+                return url
+                  ? { ...c, url, title: c.title ? wrapWebContent(c.title) : undefined }
+                  : undefined;
+              })
+              .filter(Boolean),
           }),
         };
         writeCache(SEARCH_CACHE, cacheKey, payload, cacheTtlMs);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1855,10 +1855,25 @@ function sanitizeUrl(url: string): string | undefined {
   try {
     const parsed = new URL(url);
     if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      // Strip embedded credentials (user:pass@host) to avoid leaking secrets.
+      parsed.username = "";
+      parsed.password = "";
       return parsed.href;
     }
   } catch {}
   return undefined;
+}
+
+const MAX_PLUGIN_DESCRIPTION_LENGTH = 200;
+
+/** Strip control chars and cap length so plugin descriptions stay safe for LLM tool metadata. */
+function sanitizePluginDescription(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  const cleaned = raw.replace(/[\x00-\x1f\x7f]/g, " ").trim();
+  if (cleaned.length <= MAX_PLUGIN_DESCRIPTION_LENGTH) {
+    return cleaned;
+  }
+  return cleaned.slice(0, MAX_PLUGIN_DESCRIPTION_LENGTH).trimEnd() + "…";
 }
 
 function createPluginSearchTool(
@@ -1868,9 +1883,8 @@ function createPluginSearchTool(
 ): AnyAgentTool {
   const cacheTtlMs = resolveCacheTtlMs(search?.cacheTtlMinutes);
   const timeoutSeconds = resolveTimeoutSeconds(search?.timeoutSeconds);
-  const description =
-    pluginProvider.description ??
-    `Search the web using ${pluginProvider.name}. Returns titles, URLs, and descriptions for research.`;
+  const fallback = `Search the web using ${pluginProvider.name}. Returns titles, URLs, and descriptions for research.`;
+  const description = sanitizePluginDescription(pluginProvider.description ?? fallback);
 
   return {
     label: "Web Search",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -441,8 +441,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). */
-      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+      /** Search provider. Built-in: "brave", "gemini", "grok", "kimi", "perplexity". Plugin providers use their registered id. */
+      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | (string & {});
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -269,6 +269,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.string().regex(/^[a-z][a-z0-9_-]*$/, "custom provider id"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -245,6 +245,7 @@ function createPluginRecord(params: {
     cliCommands: [],
     services: [],
     commands: [],
+    searchProviderIds: [],
     httpRoutes: 0,
     hookCount: 0,
     configSchema: params.configSchema,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -467,7 +467,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   };
 
   const registerSearchProvider = (record: PluginRecord, provider: SearchProviderPlugin) => {
-    const id = typeof provider?.id === "string" ? provider.id.trim() : "";
+    const id = typeof provider?.id === "string" ? provider.id.trim().toLowerCase() : "";
     if (!id) {
       pushDiagnostic({
         level: "error",
@@ -490,7 +490,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     record.searchProviderIds.push(id);
     registry.searchProviders.push({
       pluginId: record.id,
-      provider,
+      provider: { ...provider, id },
       source: record.source,
     });
   };

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -41,6 +41,7 @@ import type {
   PluginHookName,
   PluginHookHandlerMap,
   PluginHookRegistration as TypedPluginHookRegistration,
+  SearchProviderPlugin,
 } from "./types.js";
 
 export type PluginToolRegistration = {
@@ -99,6 +100,12 @@ export type PluginCommandRegistration = {
   source: string;
 };
 
+export type PluginSearchProviderRegistration = {
+  pluginId: string;
+  provider: SearchProviderPlugin;
+  source: string;
+};
+
 export type PluginRecord = {
   id: string;
   name: string;
@@ -119,6 +126,7 @@ export type PluginRecord = {
   cliCommands: string[];
   services: string[];
   commands: string[];
+  searchProviderIds: string[];
   httpRoutes: number;
   hookCount: number;
   configSchema: boolean;
@@ -138,6 +146,7 @@ export type PluginRegistry = {
   cliRegistrars: PluginCliRegistration[];
   services: PluginServiceRegistration[];
   commands: PluginCommandRegistration[];
+  searchProviders: PluginSearchProviderRegistration[];
   diagnostics: PluginDiagnostic[];
 };
 
@@ -178,6 +187,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     cliRegistrars: [],
     services: [],
     commands: [],
+    searchProviders: [],
     diagnostics: [],
   };
 }
@@ -456,6 +466,35 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  const registerSearchProvider = (record: PluginRecord, provider: SearchProviderPlugin) => {
+    const id = typeof provider?.id === "string" ? provider.id.trim() : "";
+    if (!id) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "search provider registration missing id",
+      });
+      return;
+    }
+    const existing = registry.searchProviders.find((entry) => entry.provider.id === id);
+    if (existing) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `search provider already registered: ${id} (${existing.pluginId})`,
+      });
+      return;
+    }
+    record.searchProviderIds.push(id);
+    registry.searchProviders.push({
+      pluginId: record.id,
+      provider,
+      source: record.source,
+    });
+  };
+
   const registerCli = (
     record: PluginRecord,
     registrar: OpenClawPluginCliRegistrar,
@@ -596,6 +635,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerHttpRoute: (params) => registerHttpRoute(record, params),
       registerChannel: (registration) => registerChannel(record, registration),
       registerProvider: (provider) => registerProvider(record, provider),
+      registerSearchProvider: (provider) => registerSearchProvider(record, provider),
       registerGatewayMethod: (method, handler) => registerGatewayMethod(record, method, handler),
       registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       registerService: (service) => registerService(record, service),
@@ -614,6 +654,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerTool,
     registerChannel,
     registerProvider,
+    registerSearchProvider,
     registerGatewayMethod,
     registerCli,
     registerService,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -466,6 +466,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  // Built-in search provider IDs that plugins must not shadow.
+  const BUILTIN_SEARCH_PROVIDER_IDS = new Set(["brave", "gemini", "grok", "kimi", "perplexity"]);
+
   const registerSearchProvider = (record: PluginRecord, provider: SearchProviderPlugin) => {
     const id = typeof provider?.id === "string" ? provider.id.trim().toLowerCase() : "";
     if (!id) {
@@ -474,6 +477,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         pluginId: record.id,
         source: record.source,
         message: "search provider registration missing id",
+      });
+      return;
+    }
+    if (BUILTIN_SEARCH_PROVIDER_IDS.has(id)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `search provider id "${id}" conflicts with a built-in provider`,
       });
       return;
     }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -131,6 +131,52 @@ export type ProviderPlugin = {
   refreshOAuth?: (cred: OAuthCredential) => Promise<OAuthCredential>;
 };
 
+/**
+ * A plugin-provided web search backend. Registered via `api.registerSearchProvider()`.
+ * The built-in `web_search` tool will delegate to the first matching plugin provider
+ * when `tools.web.search.provider` matches the provider id.
+ */
+export type SearchProviderPlugin = {
+  /** Unique provider id used in config, e.g. "searxng" or "tavily". */
+  id: string;
+  /** Human-readable name shown in logs and tool descriptions. */
+  name: string;
+  /** Tool description override for the LLM (what the search tool does). */
+  description?: string;
+  /**
+   * Execute a search query. Must return normalized results.
+   * Throwing an error will surface it to the agent as a tool error.
+   */
+  search: (params: SearchProviderRequest) => Promise<SearchProviderResult>;
+  /**
+   * Optional auto-detection: return true if this provider is available
+   * (e.g. required env vars or config keys are set). Used when no
+   * explicit provider is configured and the system tries each in turn.
+   */
+  isAvailable?: (config?: OpenClawConfig) => boolean;
+};
+
+export type SearchProviderRequest = {
+  query: string;
+  maxResults?: number;
+  timeoutMs?: number;
+  config?: OpenClawConfig;
+};
+
+export type SearchProviderResult = {
+  /** Web result entries. */
+  results?: Array<{
+    title: string;
+    url: string;
+    description?: string;
+    published?: string;
+  }>;
+  /** AI-synthesized answer (for LLM-backed providers like Perplexity). */
+  content?: string;
+  /** Citation URLs or objects. */
+  citations?: Array<string | { url: string; title?: string }>;
+};
+
 export type OpenClawPluginGatewayMethod = {
   method: string;
   handler: GatewayRequestHandler;
@@ -285,6 +331,8 @@ export type OpenClawPluginApi = {
   registerCli: (registrar: OpenClawPluginCliRegistrar, opts?: { commands?: string[] }) => void;
   registerService: (service: OpenClawPluginService) => void;
   registerProvider: (provider: ProviderPlugin) => void;
+  /** Register a custom web search backend (SearXNG, Tavily, etc.). */
+  registerSearchProvider: (provider: SearchProviderPlugin) => void;
   /**
    * Register a custom command that bypasses the LLM agent.
    * Plugin commands are processed before built-in commands and before agent invocation.


### PR DESCRIPTION
## Summary

Adds a `SearchProviderPlugin` extension point so third-party plugins can register custom web search backends without modifying core. This addresses the long-standing request for extensible search providers (#11399, #2317, #12034) — and follows the maintainer guidance from #11444 to use the plugin system rather than adding providers to core.

The built-in `web_search` tool now checks plugin-registered providers before falling through to built-in ones (Brave, Gemini, Grok, Kimi, Perplexity). Plugin providers implement a simple `search()` interface and get automatic caching, content security wrapping, and error handling for free.

## What changed

### Plugin types (`src/plugins/types.ts`)
New `SearchProviderPlugin` type:
```typescript
type SearchProviderPlugin = {
  id: string;              // e.g. "searxng", "tavily"
  name: string;            // display name
  description?: string;    // tool description override
  search: (params: SearchProviderRequest) => Promise<SearchProviderResult>;
  isAvailable?: (config?: OpenClawConfig) => boolean;  // auto-detection
};
```

### Plugin API (`src/plugins/registry.ts`)
New `api.registerSearchProvider(provider)` method, following the same pattern as `registerProvider()` and `registerChannel()`.

### Web search tool (`src/agents/tools/web-search.ts`)
- `resolvePluginSearchProvider()`: checks registry for matching plugin provider (explicit config match + auto-detect fallback)
- `createPluginSearchTool()`: creates a `web_search` tool backed by the plugin provider, with caching and content wrapping

### Config schema (`src/config/zod-schema.agent-runtime.ts`)
`tools.web.search.provider` now accepts any `[a-z][a-z0-9_-]*` string in addition to the 5 built-in literals. Plugin-specific config goes through the plugin's own config namespace (`plugins.<id>.config`).

## Example plugin

```typescript
// In a plugin's register() function:
api.registerSearchProvider({
  id: "searxng",
  name: "SearXNG",
  description: "Search the web using a self-hosted SearXNG instance.",
  search: async ({ query, maxResults, timeoutMs }) => {
    const baseUrl = api.pluginConfig?.baseUrl ?? process.env.SEARXNG_BASE_URL;
    const url = `${baseUrl}/search?q=${encodeURIComponent(query)}&format=json&number_of_results=${maxResults}`;
    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs ?? 10000) });
    const data = await res.json();
    return {
      results: data.results.map((r) => ({
        title: r.title,
        url: r.url,
        description: r.content,
      })),
    };
  },
  isAvailable: () => Boolean(process.env.SEARXNG_BASE_URL),
});
```

Then configure: `tools.web.search.provider: "searxng"`

## Design decisions

- **Plugin providers take priority over built-in**: if a plugin matches the configured provider id, it wins. This lets plugins override built-in providers if desired.
- **Auto-detection via `isAvailable()`**: when no explicit provider is configured, plugin providers are tried before built-in auto-detection (env var scanning).
- **Config isolation**: plugin-specific settings go through `plugins.<id>.config`, not through `tools.web.search.<id>`. This keeps the core schema stable.
- **Minimal core surface**: the extension point is ~40 lines of type definitions + ~30 lines of registry code + ~80 lines of integration. No existing behavior is changed.

## Test plan

- [ ] Built-in providers (Brave, Gemini, Grok, Kimi, Perplexity) work exactly as before
- [ ] `tools.web.search.provider: "searxng"` resolves to a plugin provider when registered
- [ ] Auto-detection falls through to built-in providers when no plugin is available
- [ ] Plugin search results are cached and wrapped with content security markers
- [ ] Config validation accepts custom provider ids matching `[a-z][a-z0-9_-]*`

Addresses #11399, #2317, #12034