### PR TITLE
feat(reply): provider-neutral low-thinking hint for simple adaptive turns

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,13 +1,19 @@
 import crypto from "node:crypto";
-import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext, TemplateContext } from "../templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { buildCommandContext } from "./commands.js";
+import type { InlineDirectives } from "./directive-handling.js";
+import type { createModelSelectionState } from "./model-selection.js";
+import type { TypingController } from "./typing.js";
+import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
   isEmbeddedPiRunStreaming,
   resolveEmbeddedSessionLane,
 } from "../../agents/pi-embedded.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveGroupSessionKey,
   resolveSessionFilePath,
@@ -21,7 +27,6 @@ import { normalizeMainKey } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
 import { buildInboundMediaNote } from "../media-note.js";
-import type { MsgContext, TemplateContext } from "../templating.js";
 import {
   type ElevatedLevel,
   formatXHighModelHint,
@@ -32,22 +37,18 @@ import {
   type VerboseLevel,
 } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runReplyAgent } from "./agent-runner.js";
 import { applySessionHints } from "./body.js";
-import type { buildCommandContext } from "./commands.js";
-import type { InlineDirectives } from "./directive-handling.js";
 import { buildGroupChatContext, buildGroupIntro } from "./groups.js";
 import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./inbound-meta.js";
-import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
 import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
+import { maybeHintLowThinkingForSimpleTurn } from "./simple-task-thinking.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
-import type { TypingController } from "./typing.js";
 import { appendUntrustedContext } from "./untrusted-context.js";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
@@ -409,6 +410,12 @@ export async function runPreparedReply(
       }
     }
   }
+
+  resolvedThinkLevel = maybeHintLowThinkingForSimpleTurn({
+    resolvedThinkLevel,
+    hasExplicitThinkDirective: directives.hasThinkDirective,
+    baseBodyTrimmedRaw,
+  });
   if (resetTriggered && command.isAuthorizedSender) {
     await sendResetSessionNotice({
       ctx,

--- a/src/auto-reply/reply/simple-task-thinking.test.ts
+++ b/src/auto-reply/reply/simple-task-thinking.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { isSimpleTaskTurn, maybeHintLowThinkingForSimpleTurn } from "./simple-task-thinking.js";
+
+describe("isSimpleTaskTurn", () => {
+  it("returns true for short single-line prompts", () => {
+    expect(isSimpleTaskTurn("what's the weather in sf?")).toBe(true);
+    expect(isSimpleTaskTurn("status")).toBe(true);
+  });
+
+  it("returns false for multiline prompts", () => {
+    expect(isSimpleTaskTurn("first do x\nthen do y")).toBe(false);
+  });
+
+  it("returns false for structured/code-like prompts", () => {
+    expect(isSimpleTaskTurn('parse this JSON: {"a":1}')).toBe(false);
+    expect(isSimpleTaskTurn("```ts\nconsole.log('x')\n```")).toBe(false);
+    expect(isSimpleTaskTurn("see https://example.com and summarize")).toBe(false);
+  });
+
+  it("returns false for long prompts", () => {
+    expect(
+      isSimpleTaskTurn(
+        "Please help me draft a detailed migration plan for replacing our deployment system across environments with phased rollout and risk analysis.",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("maybeHintLowThinkingForSimpleTurn", () => {
+  it("downgrades adaptive to low for simple turns", () => {
+    expect(
+      maybeHintLowThinkingForSimpleTurn({
+        resolvedThinkLevel: "adaptive",
+        hasExplicitThinkDirective: false,
+        baseBodyTrimmedRaw: "status",
+      }),
+    ).toBe("low");
+  });
+
+  it("preserves explicit think directives", () => {
+    expect(
+      maybeHintLowThinkingForSimpleTurn({
+        resolvedThinkLevel: "adaptive",
+        hasExplicitThinkDirective: true,
+        baseBodyTrimmedRaw: "status",
+      }),
+    ).toBe("adaptive");
+  });
+
+  it("preserves non-adaptive levels", () => {
+    expect(
+      maybeHintLowThinkingForSimpleTurn({
+        resolvedThinkLevel: "high",
+        hasExplicitThinkDirective: false,
+        baseBodyTrimmedRaw: "status",
+      }),
+    ).toBe("high");
+  });
+});

--- a/src/auto-reply/reply/simple-task-thinking.test.ts
+++ b/src/auto-reply/reply/simple-task-thinking.test.ts
@@ -24,6 +24,36 @@ describe("isSimpleTaskTurn", () => {
       ),
     ).toBe(false);
   });
+
+  it("returns false when word count exceeds MAX_SIMPLE_WORDS (20) even if under char limit", () => {
+    // Construct a prompt with 21 short words but short enough to stay under 140 chars
+    const twentyOneWords = "a b c d e f g h i j k l m n o p q r s t u";
+    expect(twentyOneWords.split(/\s+/).length).toBe(21);
+    expect(twentyOneWords.length).toBeLessThan(140);
+    expect(isSimpleTaskTurn(twentyOneWords)).toBe(false);
+  });
+
+  it("returns true at exactly MAX_SIMPLE_WORDS (20 words)", () => {
+    const twentyWords = "a b c d e f g h i j k l m n o p q r s t";
+    expect(twentyWords.split(/\s+/).length).toBe(20);
+    expect(isSimpleTaskTurn(twentyWords)).toBe(true);
+  });
+
+  it("returns false when prompt contains '{' (object/code hint)", () => {
+    expect(isSimpleTaskTurn("try calling run { check }")).toBe(false);
+  });
+
+  it("returns false when prompt contains '}' (object/code hint)", () => {
+    expect(isSimpleTaskTurn("close the block }")).toBe(false);
+  });
+
+  it("returns false when prompt contains '=>' (arrow function)", () => {
+    expect(isSimpleTaskTurn("use fn => result")).toBe(false);
+  });
+
+  it("returns false when prompt contains '$(' (shell substitution)", () => {
+    expect(isSimpleTaskTurn("run $(date) please")).toBe(false);
+  });
 });
 
 describe("maybeHintLowThinkingForSimpleTurn", () => {

--- a/src/auto-reply/reply/simple-task-thinking.ts
+++ b/src/auto-reply/reply/simple-task-thinking.ts
@@ -1,0 +1,66 @@
+import type { ThinkLevel } from "../thinking.js";
+
+const MAX_SIMPLE_CHARS = 140;
+const MAX_SIMPLE_WORDS = 20;
+
+function countWords(input: string): number {
+  return input.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * Heuristic: identify short, low-complexity user turns where low thinking effort
+ * is typically sufficient.
+ */
+export function isSimpleTaskTurn(rawBody: string): boolean {
+  const body = rawBody.trim();
+  if (!body) {
+    return false;
+  }
+
+  if (body.length > MAX_SIMPLE_CHARS) {
+    return false;
+  }
+  if (countWords(body) > MAX_SIMPLE_WORDS) {
+    return false;
+  }
+
+  // Multi-line prompts usually indicate richer context or instructions.
+  if (body.includes("\n")) {
+    return false;
+  }
+
+  // Code/structured hints likely need more deliberate reasoning.
+  if (
+    body.includes("```") ||
+    body.includes("{") ||
+    body.includes("}") ||
+    body.includes("=>") ||
+    body.includes("$(") ||
+    /https?:\/\//i.test(body)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Use low thinking for simple turns when the resolved level is adaptive.
+ *
+ * This is a hinting optimization only:
+ * - never overrides explicit `/think` directives
+ * - never changes provider/model
+ */
+export function maybeHintLowThinkingForSimpleTurn(params: {
+  resolvedThinkLevel: ThinkLevel;
+  hasExplicitThinkDirective: boolean;
+  baseBodyTrimmedRaw: string;
+}): ThinkLevel {
+  if (params.hasExplicitThinkDirective) {
+    return params.resolvedThinkLevel;
+  }
+  if (params.resolvedThinkLevel !== "adaptive") {
+    return params.resolvedThinkLevel;
+  }
+  return isSimpleTaskTurn(params.baseBodyTrimmedRaw) ? "low" : params.resolvedThinkLevel;
+}


### PR DESCRIPTION
Closes #35457

Adds a lightweight simple-turn heuristic that hints `thinkLevel=low` for short, low-complexity turns when resolved level is adaptive.