### PR TITLE
fix: GGML Metal shutdown crash, cooldown probe bypass, startup stagger

### DIFF
--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -42,63 +42,7 @@ function expectFallbackUsed(
   expect(result.attempts[0]?.reason).toBe("rate_limit");
 }
 
-function expectPrimaryProbeSuccess(
-  result: { result: unknown },
-  run: {
-    (...args: unknown[]): unknown;
-    mock: { calls: unknown[][] };
-  },
-  expectedResult: unknown,
-) {
-  expect(result.result).toBe(expectedResult);
-  expect(run).toHaveBeenCalledTimes(1);
-  expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
-    allowTransientCooldownProbe: true,
-  });
-}
-
-async function expectProbeFailureFallsBack({
-  reason,
-  probeError,
-}: {
-  reason: "rate_limit" | "overloaded";
-  probeError: Error & { status: number };
-}) {
-  const cfg = makeCfg({
-    agents: {
-      defaults: {
-        model: {
-          primary: "openai/gpt-4.1-mini",
-          fallbacks: ["anthropic/claude-haiku-3-5", "google/gemini-2-flash"],
-        },
-      },
-    },
-  } as Partial<OpenClawConfig>);
-
-  mockedIsProfileInCooldown.mockReturnValue(true);
-  mockedGetSoonestCooldownExpiry.mockReturnValue(1_700_000_000_000 + 30 * 1000);
-  mockedResolveProfilesUnavailableReason.mockReturnValue(reason);
-
-  const run = vi.fn().mockRejectedValueOnce(probeError).mockResolvedValue("fallback-ok");
-
-  const result = await runWithModelFallback({
-    cfg,
-    provider: "openai",
-    model: "gpt-4.1-mini",
-    run,
-  });
-
-  expect(result.result).toBe("fallback-ok");
-  expect(run).toHaveBeenCalledTimes(2);
-  expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini", {
-    allowTransientCooldownProbe: true,
-  });
-  expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
-    allowTransientCooldownProbe: true,
-  });
-}
-
-describe("runWithModelFallback – probe logic", () => {
+describe("runWithModelFallback – cooldown respect", () => {
   let realDateNow: () => number;
   const NOW = 1_700_000_000_000;
 
@@ -154,7 +98,6 @@ describe("runWithModelFallback – probe logic", () => {
 
   it("skips primary model when far from cooldown expiry (30 min remaining)", async () => {
     const cfg = makeCfg();
-    // Cooldown expires in 30 min — well beyond the 2-min margin
     const expiresIn30Min = NOW + 30 * 60 * 1000;
     mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn30Min);
 
@@ -182,51 +125,75 @@ describe("runWithModelFallback – probe logic", () => {
     expect(result.attempts[0]?.reason).toBe("billing");
   });
 
-  it("probes primary model when within 2-min margin of cooldown expiry", async () => {
+  it("skips primary model even when close to cooldown expiry (1 min remaining)", async () => {
     const cfg = makeCfg();
-    // Cooldown expires in 1 minute — within 2-min probe margin
+    // Cooldown expires in 1 minute — still active, no early probing
     const expiresIn1Min = NOW + 60 * 1000;
     mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn1Min);
 
-    const run = vi.fn().mockResolvedValue("probed-ok");
+    const run = vi.fn().mockResolvedValue("ok");
 
     const result = await runPrimaryCandidate(cfg, run);
-    expectPrimaryProbeSuccess(result, run, "probed-ok");
+
+    // No early probing: skip primary and use fallback
+    expectFallbackUsed(result, run);
   });
 
-  it("probes primary model when cooldown already expired", async () => {
+  it("attempts primary model when cooldown already expired (safety valve)", async () => {
     const cfg = makeCfg();
-    // Cooldown expired 5 min ago
+    // Cooldown expired 5 min ago — shouldProbe returns true as safety valve
     const expiredAlready = NOW - 5 * 60 * 1000;
     mockedGetSoonestCooldownExpiry.mockReturnValue(expiredAlready);
 
     const run = vi.fn().mockResolvedValue("recovered");
 
     const result = await runPrimaryCandidate(cfg, run);
-    expectPrimaryProbeSuccess(result, run, "recovered");
+    // Run is called without allowRateLimitCooldownProbe (no longer set)
+    expect(result.result).toBe("recovered");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
   });
 
-  it("attempts non-primary fallbacks during rate-limit cooldown after primary probe failure", async () => {
-    await expectProbeFailureFallsBack({
-      reason: "rate_limit",
-      probeError: Object.assign(new Error("rate limited"), { status: 429 }),
-    });
-  });
+  it("skips all same-provider models when all profiles in cooldown", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "google/gemini-2-flash"],
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
 
-  it("attempts non-primary fallbacks during overloaded cooldown after primary probe failure", async () => {
-    await expectProbeFailureFallsBack({
-      reason: "overloaded",
-      probeError: Object.assign(new Error("service overloaded"), { status: 503 }),
-    });
+    // ALL providers in cooldown
+    mockedIsProfileInCooldown.mockReturnValue(true);
+
+    const almostExpired = NOW + 30 * 1000; // 30s remaining
+    mockedGetSoonestCooldownExpiry.mockReturnValue(almostExpired);
+
+    const run = vi.fn().mockResolvedValue("unreachable");
+
+    // All providers in cooldown — should fail without making any API calls
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toThrow("All models failed");
+
+    expect(run).not.toHaveBeenCalled();
   });
 
   it("throttles probe when called within 30s interval", async () => {
     const cfg = makeCfg();
-    // Cooldown just about to expire (within probe margin)
-    const almostExpired = NOW + 30 * 1000;
-    mockedGetSoonestCooldownExpiry.mockReturnValue(almostExpired);
+    // Cooldown expired — would normally be probe-worthy
+    const expiredAlready = NOW - 5 * 60 * 1000;
+    mockedGetSoonestCooldownExpiry.mockReturnValue(expiredAlready);
 
-    // Simulate a recent probe 10s ago
+    // But a probe happened 10s ago → throttled
     _probeThrottleInternals.lastProbeAttempt.set("openai", NOW - 10_000);
 
     const run = vi.fn().mockResolvedValue("ok");
@@ -237,30 +204,35 @@ describe("runWithModelFallback – probe logic", () => {
     expectFallbackUsed(result, run);
   });
 
-  it("allows probe when 30s have passed since last probe", async () => {
+  it("allows attempt when 30s have passed since last probe and cooldown expired", async () => {
     const cfg = makeCfg();
-    const almostExpired = NOW + 30 * 1000;
-    mockedGetSoonestCooldownExpiry.mockReturnValue(almostExpired);
+    // Cooldown already expired
+    const expiredAlready = NOW - 5 * 60 * 1000;
+    mockedGetSoonestCooldownExpiry.mockReturnValue(expiredAlready);
 
-    // Last probe was 31s ago — should NOT be throttled
+    // Last probe was 31s ago — not throttled
     _probeThrottleInternals.lastProbeAttempt.set("openai", NOW - 31_000);
 
     const run = vi.fn().mockResolvedValue("probed-ok");
 
     const result = await runPrimaryCandidate(cfg, run);
-    expectPrimaryProbeSuccess(result, run, "probed-ok");
+    expect(result.result).toBe("probed-ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
   });
 
   it("handles non-finite soonest safely (treats as probe-worthy)", async () => {
     const cfg = makeCfg();
 
-    // Return Infinity — should be treated as "probe" per the guard
+    // Infinity — not finite, so shouldProbe returns true as safety fallback
     mockedGetSoonestCooldownExpiry.mockReturnValue(Infinity);
 
     const run = vi.fn().mockResolvedValue("ok-infinity");
 
     const result = await runPrimaryCandidate(cfg, run);
-    expectPrimaryProbeSuccess(result, run, "ok-infinity");
+    expect(result.result).toBe("ok-infinity");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
   });
 
   it("handles NaN soonest safely (treats as probe-worthy)", async () => {
@@ -271,7 +243,9 @@ describe("runWithModelFallback – probe logic", () => {
     const run = vi.fn().mockResolvedValue("ok-nan");
 
     const result = await runPrimaryCandidate(cfg, run);
-    expectPrimaryProbeSuccess(result, run, "ok-nan");
+    expect(result.result).toBe("ok-nan");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
   });
 
   it("handles null soonest safely (treats as probe-worthy)", async () => {
@@ -282,7 +256,9 @@ describe("runWithModelFallback – probe logic", () => {
     const run = vi.fn().mockResolvedValue("ok-null");
 
     const result = await runPrimaryCandidate(cfg, run);
-    expectPrimaryProbeSuccess(result, run, "ok-null");
+    expect(result.result).toBe("ok-null");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
   });
 
   it("single candidate skips with rate_limit and exhausts candidates", async () => {
@@ -315,14 +291,15 @@ describe("runWithModelFallback – probe logic", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
-  it("scopes probe throttling by agentDir to avoid cross-agent suppression", async () => {
+  it("respects cooldown per-provider — different providers skip independently", async () => {
     const cfg = makeCfg();
     const almostExpired = NOW + 30 * 1000;
     mockedGetSoonestCooldownExpiry.mockReturnValue(almostExpired);
 
-    const run = vi.fn().mockResolvedValue("probed-ok");
+    const run = vi.fn().mockResolvedValue("ok");
 
-    await runWithModelFallback({
+    // First agent call: openai primary skipped → anthropic fallback used
+    const result1 = await runWithModelFallback({
       cfg,
       provider: "openai",
       model: "gpt-4.1-mini",
@@ -330,7 +307,8 @@ describe("runWithModelFallback – probe logic", () => {
       run,
     });
 
-    await runWithModelFallback({
+    // Second agent call: same behavior for different agent dir
+    const result2 = await runWithModelFallback({
       cfg,
       provider: "openai",
       model: "gpt-4.1-mini",
@@ -338,12 +316,12 @@ describe("runWithModelFallback – probe logic", () => {
       run,
     });
 
-    expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini", {
-      allowTransientCooldownProbe: true,
-    });
-    expect(run).toHaveBeenNthCalledWith(2, "openai", "gpt-4.1-mini", {
-      allowTransientCooldownProbe: true,
-    });
+    // Both should use the fallback (anthropic), not the cooldowned primary (openai)
+    expect(result1.result).toBe("ok");
+    expect(result2.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-haiku-3-5");
+    expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5");
   });
 
   it("skips billing-cooldowned primary when no fallback candidates exist", async () => {
@@ -374,22 +352,21 @@ describe("runWithModelFallback – probe logic", () => {
     ).rejects.toThrow("All models failed");
   });
 
-  it("probes billing-cooldowned primary with fallbacks when near cooldown expiry", async () => {
+  it("skips billing-cooldowned primary even when close to cooldown expiry", async () => {
     const cfg = makeCfg();
-    // Cooldown expires in 1 minute — within 2-min probe margin
+    // Cooldown expires in 1 minute — still active, no early probing
     const expiresIn1Min = NOW + 60 * 1000;
     mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn1Min);
     mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
 
-    const run = vi.fn().mockResolvedValue("billing-probe-ok");
+    const run = vi.fn().mockResolvedValue("ok");
 
     const result = await runPrimaryCandidate(cfg, run);
 
-    expect(result.result).toBe("billing-probe-ok");
+    // No probing during active cooldown — use fallback
+    expect(result.result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
-      allowTransientCooldownProbe: true,
-    });
+    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5");
   });
 
   it("skips billing-cooldowned primary with fallbacks when far from cooldown expiry", async () => {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1149,7 +1149,7 @@ describe("runWithModelFallback", () => {
       return { store, dir: tmpDir };
     }
 
-    it("attempts same-provider fallbacks during rate limit cooldown", async () => {
+    it("skips same-provider fallbacks during rate limit cooldown", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "rate_limit");
       const cfg = makeCfg({
         agents: {
@@ -1162,7 +1162,7 @@ describe("runWithModelFallback", () => {
         },
       });
 
-      const run = vi.fn().mockResolvedValueOnce("sonnet success"); // Fallback succeeds
+      const run = vi.fn().mockResolvedValueOnce("groq success");
 
       const result = await runWithModelFallback({
         cfg,
@@ -1172,41 +1172,10 @@ describe("runWithModelFallback", () => {
         agentDir: dir,
       });
 
-      expect(result.result).toBe("sonnet success");
-      expect(run).toHaveBeenCalledTimes(1); // Primary skipped, fallback attempted
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
-        allowTransientCooldownProbe: true,
-      });
-    });
-
-    it("attempts same-provider fallbacks during overloaded cooldown", async () => {
-      const { dir } = await makeAuthStoreWithCooldown("anthropic", "overloaded");
-      const cfg = makeCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "anthropic/claude-opus-4-6",
-              fallbacks: ["anthropic/claude-sonnet-4-5", "groq/llama-3.3-70b-versatile"],
-            },
-          },
-        },
-      });
-
-      const run = vi.fn().mockResolvedValueOnce("sonnet success");
-
-      const result = await runWithModelFallback({
-        cfg,
-        provider: "anthropic",
-        model: "claude-opus-4-6",
-        run,
-        agentDir: dir,
-      });
-
-      expect(result.result).toBe("sonnet success");
+      // Same-provider fallback (sonnet) also skipped — cooldown is per-account, not per-model
+      expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(1);
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
-        allowTransientCooldownProbe: true,
-      });
+      expect(run).toHaveBeenNthCalledWith(1, "groq", "llama-3.3-70b-versatile");
     });
 
     it("skips same-provider models on auth cooldown but still tries no-profile fallback providers", async () => {
@@ -1265,7 +1234,7 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "groq", "llama-3.3-70b-versatile");
     });
 
-    it("tries cross-provider fallbacks when same provider has rate limit", async () => {
+    it("skips same-provider fallbacks and uses cross-provider when provider has rate limit", async () => {
       // Anthropic in rate limit cooldown, Groq available
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
       const store: AuthProfileStore = {
@@ -1296,10 +1265,7 @@ describe("runWithModelFallback", () => {
         },
       });
 
-      const run = vi
-        .fn()
-        .mockRejectedValueOnce(new Error("Still rate limited")) // Sonnet still fails
-        .mockResolvedValueOnce("groq success"); // Groq works
+      const run = vi.fn().mockResolvedValueOnce("groq success");
 
       const result = await runWithModelFallback({
         cfg,
@@ -1310,11 +1276,9 @@ describe("runWithModelFallback", () => {
       });
 
       expect(result.result).toBe("groq success");
-      expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
-        allowTransientCooldownProbe: true,
-      }); // Rate limit allows attempt
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
+      // Same-provider fallback (sonnet) skipped during active cooldown; only cross-provider (groq) attempted
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run).toHaveBeenNthCalledWith(1, "groq", "llama-3.3-70b-versatile");
     });
   });
 });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -340,7 +340,9 @@ function resolveFallbackCandidates(params: {
 
 const lastProbeAttempt = new Map<string, number>();
 const MIN_PROBE_INTERVAL_MS = 30_000; // 30 seconds between probes per key
-const PROBE_MARGIN_MS = 2 * 60 * 1000;
+// No margin: respect cooldown end time exactly. clearExpiredCooldowns resets
+// profiles once cooldownUntil passes, so the next run proceeds normally.
+const PROBE_MARGIN_MS = 0;
 const PROBE_SCOPE_DELIMITER = "::";
 
 function resolveProbeThrottleKey(provider: string, agentDir?: string): string {
@@ -443,12 +445,11 @@ function resolveCooldownDecision(params: {
     };
   }
 
-  // For primary: try when requested model or when probe allows.
-  // For same-provider fallbacks: only relax cooldown on transient provider
-  // limits, which are often model-scoped and can recover on a sibling model.
-  const shouldAttemptDespiteCooldown =
-    (params.isPrimary && (!params.requestedModel || shouldProbe)) ||
-    (!params.isPrimary && (inferredReason === "rate_limit" || inferredReason === "overloaded"));
+  // Respect cooldown end time: only attempt if the probe check indicates the
+  // cooldown window has passed. With PROBE_MARGIN_MS=0 and clearExpiredCooldowns
+  // running first, this is effectively unreachable — the profile would already be
+  // cleared. Kept as a safety valve for edge-case timing.
+  const shouldAttemptDespiteCooldown = params.isPrimary && shouldProbe;
   if (!shouldAttemptDespiteCooldown) {
     return {
       type: "skip",
@@ -490,7 +491,6 @@ export async function runWithModelFallback<T>(params: {
 
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates[i];
-    let runOptions: ModelFallbackRunOptions | undefined;
     if (authStore) {
       const profileIds = resolveAuthProfileOrder({
         cfg: params.cfg,
@@ -530,13 +530,6 @@ export async function runWithModelFallback<T>(params: {
         if (decision.markProbe) {
           lastProbeAttempt.set(probeThrottleKey, now);
         }
-        if (
-          decision.reason === "rate_limit" ||
-          decision.reason === "overloaded" ||
-          decision.reason === "billing"
-        ) {
-          runOptions = { allowTransientCooldownProbe: true };
-        }
       }
     }
 
@@ -544,7 +537,7 @@ export async function runWithModelFallback<T>(params: {
       run: params.run,
       ...candidate,
       attempts,
-      options: runOptions,
+      options: undefined,
     });
     if ("success" in attemptRun) {
       const notFoundAttempt =

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -21,7 +21,7 @@ import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../../infra/restart-stale-pids.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { defaultRuntime } from "../../runtime.js";
+import { createGatewayRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { forceFreePortAndWait, waitForPortBindable } from "../ports.js";
@@ -420,7 +420,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
 
   try {
     await runGatewayLoop({
-      runtime: defaultRuntime,
+      runtime: createGatewayRuntime(),
       lockPort: port,
       start: async () =>
         await startGatewayServer(port, {

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -31,6 +31,8 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /** Delay in ms between consecutive missed-job executions on startup (default: 10000). */
+  startupStaggerMs?: number;
   /** Override default retry policy for one-shot jobs on transient errors. */
   retry?: CronRetryConfig;
   /**

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -2,6 +2,7 @@ import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import { isCronSystemEvent } from "../../infra/heartbeat-events-filter.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { sleep } from "../../utils.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
 import { shouldEnqueueCronMainSummary } from "../heartbeat-policy.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
@@ -97,6 +98,14 @@ function resolveRunConcurrency(state: CronServiceState): number {
     return 1;
   }
   return Math.max(1, Math.floor(raw));
+}
+
+function resolveStartupStaggerMs(state: CronServiceState): number {
+  const raw = state.deps.cronConfig?.startupStaggerMs;
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(0, Math.floor(raw));
+  }
+  return 10_000;
 }
 function timeoutErrorMessage(): string {
   return "cron: job execution timed out";
@@ -912,8 +921,19 @@ async function executeStartupCatchupPlan(
   state: CronServiceState,
   plan: StartupCatchupPlan,
 ): Promise<TimedCronRunOutcome[]> {
+  const staggerMs = resolveStartupStaggerMs(state);
+  if (plan.candidates.length > 1 && staggerMs > 0) {
+    state.deps.log.info(
+      { count: plan.candidates.length, staggerMs },
+      "cron: staggering missed jobs on startup",
+    );
+  }
+
   const outcomes: TimedCronRunOutcome[] = [];
   for (const candidate of plan.candidates) {
+    if (outcomes.length > 0 && staggerMs > 0) {
+      await sleep(staggerMs);
+    }
     outcomes.push(await runStartupCatchupCandidate(state, candidate));
   }
   return outcomes;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -43,6 +43,23 @@ export const defaultRuntime: RuntimeEnv = {
   },
 };
 
+/**
+ * Runtime that uses process._exit() to skip C++ atexit handlers.
+ * Prevents GGML Metal assertion crashes during gateway shutdown where
+ * ggml_metal_rsets_free races with a background init thread → ggml_abort.
+ * Safe because the gateway completes all cleanup (server close, lock
+ * release, signal removal) before calling exit.
+ */
+export function createGatewayRuntime(): RuntimeEnv {
+  return {
+    ...createRuntimeIo(),
+    exit: (code) => {
+      restoreTerminalState("gateway exit", { resumeStdinIfPaused: false });
+      (process as unknown as { _exit: (code: number) => never })._exit(code);
+    },
+  };
+}
+
 export function createNonExitingRuntime(): RuntimeEnv {
   return {
     ...createRuntimeIo(),


### PR DESCRIPTION
## Summary

- **fix(gateway): use `process._exit()` to prevent GGML Metal crash on shutdown** — SIGTERM triggered C++ atexit handlers where `ggml_metal_rsets_free` raced with background `ggml_metal_rsets_init`, causing SIGABRT. Launchd saw crash exits, backed off retries, and eventually gave up — explaining 8 crash reports and multiple gateway non-recovery incidents since Mar 5. Introduces `createGatewayRuntime()` that uses `process._exit()` to skip atexit handlers.

- **fix(agents): stop probing rate-limited APIs during active cooldown** — Three bypass paths allowed API calls to providers still in cooldown: `PROBE_MARGIN_MS` (2min early probe), non-primary rate_limit bypass, and `allowRateLimitCooldownProbe` flag. All removed. The system now respects the cooldown end time from the first rate limit response. Post-expiry safety-valve probing (throttled to 30s) remains.

- **feat(cron): add startup stagger to spread missed-job burst on restart** — Adds `startupStaggerMs` config option. On gateway restart, missed jobs that fire simultaneously are staggered to avoid saturating rate-limited API providers.

## Test plan

- [x] `model-fallback.test.ts` — 47 tests pass (cooldown skip behavior verified)
- [x] `model-fallback.probe.test.ts` — 25 tests pass (no probing during active cooldown)
- [x] `run-loop.test.ts` — 8 tests pass (gateway runtime abstraction)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)