### PR TITLE
feat: self-escalation tool for model handoff

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -28,6 +28,35 @@ Related:
 - `agents.defaults.imageModel` is used **only when** the primary model can’t accept images.
 - Per-agent defaults can override `agents.defaults.model` via `agents.list[].model` plus bindings (see [/concepts/multi-agent](/concepts/multi-agent)).
 
+## Self-escalation
+
+When a lighter model (e.g. Haiku or Sonnet) encounters a task that needs deeper
+reasoning, it can hand off to a more capable model mid-turn. Set the
+`escalation` field to enable this:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+        escalation: "bedrock/eu.anthropic.claude-opus-4-6",
+      },
+    },
+  },
+}
+```
+
+When `escalation` is set and the current model is not the escalation target,
+the model receives an `escalate` tool. If the model determines the task is too
+complex, it calls this tool as its first action. The agent loop then re-runs the
+same prompt on the escalation model.
+
+- Escalation is one-shot per turn to prevent loops.
+- No latency is added to messages that don't escalate.
+- Per-agent escalation targets are supported via `agents.list[].model.escalation`
+  and fall back to the global default.
+
 ## Quick model policy
 
 - Set your primary to the strongest latest-generation model available to you.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -877,6 +877,7 @@ export async function runEmbeddedPiAgent(
             prompt,
             images: params.images,
             disableTools: params.disableTools,
+            disableEscalation: params.disableEscalation,
             provider,
             modelId,
             model: effectiveModel,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -89,6 +89,7 @@ import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
+import { createEscalateTool, resolveEscalationModel } from "../../tools/escalate-tool.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -885,6 +886,22 @@ export async function runEmbeddedAttempt(
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
         });
+
+    // Self-escalation: register the escalate tool when an escalation model is configured
+    // and the current model is NOT the escalation target.
+    const escalationModel = resolveEscalationModel(params.config, sessionAgentId);
+    const escalationEnabled =
+      !!escalationModel &&
+      !params.disableTools &&
+      !params.disableEscalation &&
+      `${normalizeProviderId(params.provider)}/${params.modelId}` !== escalationModel.ref;
+    if (escalationEnabled) {
+      const escalateTool = createEscalateTool({
+        sessionKey: params.sessionKey ?? params.sessionId,
+      });
+      toolsRaw.push(escalateTool);
+    }
+
     const toolsEnabled = supportsModelTools(params.model);
     const tools = sanitizeToolsForGoogle({
       tools: toolsEnabled ? toolsRaw : [],
@@ -995,11 +1012,22 @@ export async function runEmbeddedAttempt(
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
 
+    // Augment extra system prompt with escalation guidance when the escalate tool is available
+    // and the model actually supports tools (otherwise the tool was dropped by sanitizeToolsForGoogle).
+    let effectiveExtraSystemPrompt = params.extraSystemPrompt;
+    if (escalationEnabled && toolsEnabled) {
+      const escalationHint =
+        "If a task requires deep reasoning, complex analysis, multi-step debugging, creative writing, or you are uncertain about factual accuracy, use the escalate tool IMMEDIATELY as your first action — do not generate any text first.";
+      effectiveExtraSystemPrompt = effectiveExtraSystemPrompt
+        ? `${effectiveExtraSystemPrompt}\n\n${escalationHint}`
+        : escalationHint;
+    }
+
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
-      extraSystemPrompt: params.extraSystemPrompt,
+      extraSystemPrompt: effectiveExtraSystemPrompt,
       ownerNumbers: params.ownerNumbers,
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -71,6 +71,8 @@ export type RunEmbeddedPiAgentParams = {
   clientTools?: ClientToolDefinition[];
   /** Disable built-in tools for this run (LLM-only mode). */
   disableTools?: boolean;
+  /** Skip self-escalation tool registration. Set for call paths that don't consume pendingEscalations. */
+  disableEscalation?: boolean;
   provider?: string;
   model?: string;
   authProfileId?: string;

--- a/src/agents/tools/escalate-tool.test.ts
+++ b/src/agents/tools/escalate-tool.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeProviderId } from "../model-selection.js";
+import { createEscalateTool, pendingEscalations, resolveEscalationModel } from "./escalate-tool.js";
+
+afterEach(() => {
+  pendingEscalations.clear();
+});
+
+describe("createEscalateTool", () => {
+  it("sets pendingEscalations entry without aborting", async () => {
+    const tool = createEscalateTool({
+      sessionKey: "test-session",
+    });
+
+    expect(tool.name).toBe("escalate");
+
+    await tool.execute("call-1", { reason: "complex reasoning needed" });
+
+    expect(pendingEscalations.has("test-session")).toBe(true);
+    expect(pendingEscalations.get("test-session")?.reason).toBe("complex reasoning needed");
+  });
+
+  it("returns a JSON result indicating escalation", async () => {
+    const tool = createEscalateTool({
+      sessionKey: "s1",
+    });
+
+    const result = await tool.execute("call-2", { reason: "needs deeper analysis" });
+    expect(result).toBeDefined();
+  });
+});
+
+describe("resolveEscalationModel", () => {
+  it("parses a valid provider/model ref", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig;
+
+    const result = resolveEscalationModel(cfg);
+    expect(result).toEqual({
+      provider: "amazon-bedrock",
+      model: "claude-opus-4-6",
+      ref: "amazon-bedrock/claude-opus-4-6",
+    });
+  });
+
+  it("returns undefined when config is undefined", () => {
+    expect(resolveEscalationModel(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when model config is a string", () => {
+    const cfg = {
+      agents: { defaults: { model: "bedrock/claude-haiku" } },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toBeUndefined();
+  });
+
+  it("returns undefined when escalation field is missing", () => {
+    const cfg = {
+      agents: { defaults: { model: { primary: "bedrock/claude-haiku" } } },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toBeUndefined();
+  });
+
+  it("returns undefined when escalation ref has no slash", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "no-slash-model" } } },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toBeUndefined();
+  });
+
+  it("returns undefined when escalation ref starts with slash", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "/model-only" } } },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toBeUndefined();
+  });
+
+  it("returns undefined for empty or whitespace ref", () => {
+    expect(
+      resolveEscalationModel({
+        agents: { defaults: { model: { escalation: "" } } },
+      } as OpenClawConfig),
+    ).toBeUndefined();
+
+    expect(
+      resolveEscalationModel({
+        agents: { defaults: { model: { escalation: "   " } } },
+      } as OpenClawConfig),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when model segment is empty (trailing slash)", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "bedrock/" } } },
+    } as OpenClawConfig;
+
+    expect(resolveEscalationModel(cfg)).toBeUndefined();
+  });
+
+  it("trims whitespace and normalizes provider", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "  bedrock/claude-opus-4-6  " } } },
+    } as OpenClawConfig;
+
+    const result = resolveEscalationModel(cfg);
+    expect(result).toEqual({
+      provider: "amazon-bedrock",
+      model: "claude-opus-4-6",
+      ref: "amazon-bedrock/claude-opus-4-6",
+    });
+  });
+
+  it("handles refs with multiple slashes (model id contains slash)", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { escalation: "bedrock/eu.anthropic.claude-opus-4-6" } },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveEscalationModel(cfg);
+    expect(result).toEqual({
+      provider: "amazon-bedrock",
+      model: "eu.anthropic.claude-opus-4-6",
+      ref: "amazon-bedrock/eu.anthropic.claude-opus-4-6",
+    });
+  });
+
+  it("prefers per-agent escalation over global default", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { escalation: "bedrock/claude-opus-4-6" } },
+        list: [{ id: "my-agent", model: { escalation: "openai/gpt-4o" } }],
+      },
+    } as OpenClawConfig;
+
+    const result = resolveEscalationModel(cfg, "my-agent");
+    expect(result).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+      ref: "openai/gpt-4o",
+    });
+  });
+
+  it("falls back to global default when agent has no escalation", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { escalation: "bedrock/claude-opus-4-6" } },
+        list: [{ id: "my-agent", model: { primary: "openai/gpt-4o-mini" } }],
+      },
+    } as OpenClawConfig;
+
+    const result = resolveEscalationModel(cfg, "my-agent");
+    expect(result).toEqual({
+      provider: "amazon-bedrock",
+      model: "claude-opus-4-6",
+      ref: "amazon-bedrock/claude-opus-4-6",
+    });
+  });
+
+  it("falls back to global default when agentId is not in config", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { escalation: "bedrock/claude-opus-4-6" } },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveEscalationModel(cfg, "nonexistent-agent");
+    expect(result).toEqual({
+      provider: "amazon-bedrock",
+      model: "claude-opus-4-6",
+      ref: "amazon-bedrock/claude-opus-4-6",
+    });
+  });
+});
+
+describe("escalation identity check (tool suppression for escalation model)", () => {
+  // Mirrors the condition in attempt.ts that prevents the escalation target
+  // from receiving the escalate tool (which would cause infinite loops).
+  const isEscalationTarget = (provider: string, modelId: string, escalationRef: string) =>
+    `${normalizeProviderId(provider)}/${modelId}` === escalationRef;
+
+  it("skips escalate tool when current model matches escalation target", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig;
+
+    const resolved = resolveEscalationModel(cfg)!;
+    expect(isEscalationTarget("amazon-bedrock", "claude-opus-4-6", resolved.ref)).toBe(true);
+  });
+
+  it("skips escalate tool when provider alias normalizes to match", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig;
+
+    const resolved = resolveEscalationModel(cfg)!;
+    // "bedrock" normalizes to "amazon-bedrock"
+    expect(isEscalationTarget("bedrock", "claude-opus-4-6", resolved.ref)).toBe(true);
+  });
+
+  it("registers escalate tool when current model differs from escalation target", () => {
+    const cfg = {
+      agents: { defaults: { model: { escalation: "bedrock/claude-opus-4-6" } } },
+    } as OpenClawConfig;
+
+    const resolved = resolveEscalationModel(cfg)!;
+    expect(isEscalationTarget("amazon-bedrock", "claude-haiku-4-5", resolved.ref)).toBe(false);
+  });
+});
+
+describe("escalation map consumption (tryHandleEscalation behavior)", () => {
+  it("entry is consumed on read (simulating success path)", async () => {
+    const tool = createEscalateTool({ sessionKey: "session-a" });
+    await tool.execute("call-1", { reason: "complex task" });
+
+    expect(pendingEscalations.has("session-a")).toBe(true);
+
+    // Simulate what tryHandleEscalation does: read + delete
+    const pending = pendingEscalations.get("session-a");
+    pendingEscalations.delete("session-a");
+
+    expect(pending?.reason).toBe("complex task");
+    expect(pendingEscalations.has("session-a")).toBe(false);
+  });
+
+  it("entry is consumed on error path the same way", async () => {
+    const tool = createEscalateTool({ sessionKey: "session-err" });
+    await tool.execute("call-1", { reason: "needs analysis" });
+
+    // Error path also reads + deletes the entry
+    const pending = pendingEscalations.get("session-err");
+    pendingEscalations.delete("session-err");
+
+    expect(pending?.reason).toBe("needs analysis");
+    expect(pendingEscalations.has("session-err")).toBe(false);
+  });
+
+  it("concurrent sessions do not collide", async () => {
+    const toolA = createEscalateTool({ sessionKey: "session-a" });
+    const toolB = createEscalateTool({ sessionKey: "session-b" });
+
+    await toolA.execute("call-1", { reason: "reason A" });
+    await toolB.execute("call-2", { reason: "reason B" });
+
+    expect(pendingEscalations.size).toBe(2);
+
+    // Consuming one does not affect the other
+    pendingEscalations.delete("session-a");
+    expect(pendingEscalations.has("session-b")).toBe(true);
+    expect(pendingEscalations.get("session-b")?.reason).toBe("reason B");
+  });
+});
+
+describe("escalation cleanup (post-loop safety)", () => {
+  it("stale entry is cleaned up by key-based delete", async () => {
+    const tool = createEscalateTool({ sessionKey: "stale-session" });
+    await tool.execute("call-1", { reason: "will not be consumed normally" });
+
+    expect(pendingEscalations.has("stale-session")).toBe(true);
+
+    // Simulate the post-loop defensive cleanup in agent-runner-execution.ts
+    pendingEscalations.delete("stale-session");
+    expect(pendingEscalations.has("stale-session")).toBe(false);
+  });
+
+  it("delete on non-existent key is a no-op", () => {
+    // Ensures the post-loop cleanup is safe even when tryHandleEscalation
+    // already consumed the entry (the normal happy path).
+    expect(pendingEscalations.has("never-set")).toBe(false);
+    pendingEscalations.delete("never-set");
+    expect(pendingEscalations.size).toBe(0);
+  });
+});

--- a/src/agents/tools/escalate-tool.ts
+++ b/src/agents/tools/escalate-tool.ts
@@ -1,0 +1,103 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentConfig } from "../agent-scope.js";
+import { normalizeProviderId } from "../model-selection.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+/**
+ * Session-scoped escalation state.
+ *
+ * When the escalate tool fires it records the session key + reason here.
+ * The agent-runner loop (`tryHandleEscalation` in agent-runner-execution.ts)
+ * checks this map after each run to decide whether to re-run the turn on
+ * the escalation model.
+ *
+ * Note: this is an in-process Map — safe for the single-process gateway,
+ * but would need an external store for multi-worker deployments.
+ */
+export const pendingEscalations = new Map<string, { reason: string }>();
+
+const EscalateSchema = Type.Object({
+  reason: Type.String(),
+});
+
+/**
+ * Create the `escalate` tool that lets a lighter model hand off to
+ * a more capable one mid-turn.
+ *
+ * The tool sets a pending-escalation flag. After the current run
+ * completes normally, the agent-runner loop detects the flag and
+ * re-runs the turn on the escalation model.
+ */
+export function createEscalateTool(params: { sessionKey: string }): AnyAgentTool {
+  return {
+    label: "Escalate",
+    name: "escalate",
+    description:
+      "Escalate this conversation turn to a more capable model. Use this IMMEDIATELY as your first action — before generating any text — when the task requires deep reasoning, complex multi-step analysis, nuanced judgement, creative writing, debugging intricate issues, or when you are uncertain about factual accuracy. Do NOT use this for simple greetings, short answers, or straightforward tasks you can handle confidently.",
+    parameters: EscalateSchema,
+    execute: async (_toolCallId, rawParams) => {
+      const reason = readStringParam(rawParams as Record<string, unknown>, "reason", {
+        required: true,
+      });
+      pendingEscalations.set(params.sessionKey, { reason });
+      return jsonResult({ escalated: true, reason });
+    },
+  };
+}
+
+/**
+ * Parse the escalation model reference from config into provider + model + raw ref.
+ * Checks per-agent config first (when agentId is provided), then falls back to
+ * global defaults. Returns undefined if no escalation model is configured or
+ * the ref is invalid.
+ */
+export function resolveEscalationModel(
+  config?: OpenClawConfig,
+  agentId?: string,
+): { provider: string; model: string; ref: string } | undefined {
+  return (
+    (agentId ? parseEscalationRef(resolveAgentEscalation(config, agentId)) : undefined) ??
+    parseEscalationRef(resolveDefaultEscalation(config))
+  );
+}
+
+function resolveDefaultEscalation(config?: OpenClawConfig): string | undefined {
+  const modelCfg = config?.agents?.defaults?.model;
+  if (!modelCfg || typeof modelCfg === "string") {
+    return undefined;
+  }
+  return modelCfg.escalation;
+}
+
+function resolveAgentEscalation(config?: OpenClawConfig, agentId?: string): string | undefined {
+  if (!config || !agentId) {
+    return undefined;
+  }
+  const agentCfg = resolveAgentConfig(config, agentId);
+  const modelCfg = agentCfg?.model;
+  if (!modelCfg || typeof modelCfg === "string") {
+    return undefined;
+  }
+  return modelCfg.escalation;
+}
+
+function parseEscalationRef(
+  raw?: string,
+): { provider: string; model: string; ref: string } | undefined {
+  const ref = raw?.trim();
+  if (!ref) {
+    return undefined;
+  }
+  const slash = ref.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  const model = ref.slice(slash + 1);
+  if (!model) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(ref.slice(0, slash));
+  return { provider, model, ref: `${provider}/${model}` };
+}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -13,6 +13,7 @@ import {
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { pendingEscalations, resolveEscalationModel } from "../../agents/tools/escalate-tool.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -21,6 +22,7 @@ import {
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   isMarkdownCapableMessageChannel,
@@ -47,6 +49,8 @@ import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 import type { TypingSignaler } from "./typing-mode.js";
+
+const log = createSubsystemLogger("agent-runner");
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -142,6 +146,58 @@ export async function runAgentTurnWithFallback(params: {
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
+  let didEscalate = false;
+  let escalationProviderOverride: string | undefined;
+  let escalationModelOverride: string | undefined;
+
+  /**
+   * Check for a pending self-escalation and, if found, switch the run to the
+   * escalation model. Returns true when escalation was handled (caller should
+   * `continue` the loop).
+   */
+  // Derive escalation key consistently with the escalate tool, which stores
+  // under `sessionKey ?? sessionId` (transcript UUID fallback).
+  const resolveEscalationKey = () =>
+    params.sessionKey ?? params.followupRun.run.sessionKey ?? params.followupRun.run.sessionId;
+
+  const tryHandleEscalation = (path: "success" | "error"): boolean => {
+    if (didEscalate) {
+      return false;
+    }
+    const escalationKey = resolveEscalationKey();
+    const pending = escalationKey ? pendingEscalations.get(escalationKey) : undefined;
+    if (!pending) {
+      return false;
+    }
+    const resolved = resolveEscalationModel(
+      params.followupRun.run.config,
+      params.followupRun.run.agentId,
+    );
+    if (!resolved) {
+      // Config missing/invalid — consume the entry but don't set didEscalate
+      // so we don't block a future retry if config changes mid-session.
+      pendingEscalations.delete(escalationKey);
+      return false;
+    }
+    pendingEscalations.delete(escalationKey);
+    didEscalate = true;
+    const label =
+      path === "error"
+        ? "Self-escalation triggered (from error path)"
+        : "Self-escalation triggered";
+    log.info(`${label}: reason="${pending.reason}" → ${resolved.provider}/${resolved.model}`);
+    // Use local overrides instead of mutating the shared followupRun object,
+    // so outer retry/requeue mechanisms still see the original primary model.
+    escalationProviderOverride = resolved.provider;
+    escalationModelOverride = resolved.model;
+    didNotifyAgentRunStart = false;
+    return true;
+  };
+
+  // Capture once before the loop for post-loop defensive cleanup.
+  // The session key is stable for the lifetime of a turn (set before the loop
+  // and not reassigned), so this matches what tryHandleEscalation uses inside.
+  const escalationCleanupKey = resolveEscalationKey();
 
   while (true) {
     try {
@@ -199,6 +255,10 @@ export async function runAgentTurnWithFallback(params: {
       const onToolResult = params.opts?.onToolResult;
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
+        // When escalation is active, override provider/model without mutating the shared run object.
+        ...(escalationProviderOverride && escalationModelOverride
+          ? { provider: escalationProviderOverride, model: escalationModelOverride }
+          : {}),
         run: (provider, model, runOptions) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
@@ -510,8 +570,28 @@ export async function runAgentTurnWithFallback(params: {
         }
       }
 
+      // Self-escalation: if the model called the escalate tool, re-run on the escalation model.
+      if (tryHandleEscalation("success")) {
+        continue;
+      }
+
       break;
     } catch (err) {
+      // Defensive: check for pending escalation on error path too.
+      {
+        // Log original error before escalation decision so cause appears before consequence.
+        const pendingKey = resolveEscalationKey();
+        const hasPendingEscalation = !!pendingKey && pendingEscalations.has(pendingKey);
+        if (hasPendingEscalation) {
+          log.info(
+            `Primary model error before escalation: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        if (tryHandleEscalation("error")) {
+          continue;
+        }
+      }
+
       const message = err instanceof Error ? err.message : String(err);
       const isContextOverflow = isLikelyContextOverflowError(message);
       const isCompactionFailure = isCompactionFailureError(message);
@@ -622,6 +702,12 @@ export async function runAgentTurnWithFallback(params: {
         },
       };
     }
+  }
+
+  // Clean up any stale escalation entry (defensive — tryHandleEscalation already
+  // deletes on the happy path, but this covers unexpected loop exits).
+  if (escalationCleanupKey) {
+    pendingEscalations.delete(escalationCleanupKey);
   }
 
   // If the run completed but with an embedded context overflow error that

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -494,6 +494,7 @@ export async function runMemoryFlushIfNeeded(params: {
           ...senderContext,
           ...runBaseParams,
           trigger: "memory",
+          disableEscalation: true,
           prompt: resolveMemoryFlushPromptForRun({
             prompt: memoryFlushSettings.prompt,
             cfg: params.cfg,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -210,6 +210,7 @@ export function createFollowupRunner(params: {
               runId,
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
               blockReplyBreak: queued.run.blockReplyBreak,
+              disableEscalation: true,
               bootstrapPromptWarningSignaturesSeen,
               bootstrapPromptWarningSignature:
                 bootstrapPromptWarningSignaturesSeen[

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -498,6 +498,7 @@ function runAgentAttempt(params: {
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
+    disableEscalation: true,
   });
 }
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -16,10 +16,8 @@ export type AgentModelEntryConfig = {
   streaming?: boolean;
 };
 
-export type AgentModelListConfig = {
-  primary?: string;
-  fallbacks?: string[];
-};
+/** The object form of AgentModelConfig (non-string branch of the union). */
+export type AgentModelListConfig = Exclude<AgentModelConfig, string>;
 
 export type AgentContextPruningConfig = {
   mode?: "off" | "cache-ttl";

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -11,6 +11,8 @@ export type AgentModelConfig =
       primary?: string;
       /** Per-agent model fallbacks (provider/model). */
       fallbacks?: string[];
+      /** Escalation target model (provider/model). When set, the primary model can self-escalate to this model via the escalate tool. */
+      escalation?: string;
     };
 
 export type AgentSandboxConfig = {

--- a/src/config/zod-schema.agent-model.ts
+++ b/src/config/zod-schema.agent-model.ts
@@ -6,6 +6,7 @@ export const AgentModelSchema = z.union([
     .object({
       primary: z.string().optional(),
       fallbacks: z.array(z.string()).optional(),
+      escalation: z.string().optional(),
     })
     .strict(),
 ]);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -613,6 +613,7 @@ export async function runCronIsolatedAgentTurn(params: {
             requireExplicitMessageTarget: toolPolicy.requireExplicitMessageTarget,
             disableMessageTool: toolPolicy.disableMessageTool,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            disableEscalation: true,
             abortSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -62,6 +62,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       provider,
       model,
       timeoutMs: 15_000, // 15 second timeout
+      disableEscalation: true,
       runId: `slug-gen-${Date.now()}`,
     });
 


### PR DESCRIPTION
## Summary

Adds a self-escalation tool that lets lighter models (Haiku/Sonnet) hand off complex tasks to a more capable model (e.g. Opus) mid-turn.

- When `agents.defaults.model.escalation` is configured and the current model isn't the escalation target, the agent receives an `escalate` tool
- Calling the tool sets a flag; after the run completes, the agent-runner loop detects it and re-runs the prompt on the escalation model
- `disableEscalation` flag prevents registration on call paths that don't consume the flag (followup-runner, cron, slug-generator)
- One-shot `didEscalate` guard prevents infinite loops
- Local override variables avoid mutating shared run params
- Escalation events logged at info level; error-path escalation logs the original error

### Configuration

```json
{
  "agents": {
    "defaults": {
      "model": {
        "primary": "bedrock/claude-haiku-4-5",
        "escalation": "bedrock/claude-opus-4-6"
      }
    }
  }
}
```

### Files changed

| File | Change |
|------|--------|
| `src/agents/tools/escalate-tool.ts` | New — tool definition, `pendingEscalations` Map, `resolveEscalationModel()` |
| `src/agents/tools/escalate-tool.test.ts` | New — 23 unit tests |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Register escalate tool, system prompt hint |
| `src/agents/pi-embedded-runner/run/params.ts` | Add `disableEscalation` param |
| `src/agents/pi-embedded-runner/run.ts` | Forward `disableEscalation` to attempt |
| `src/auto-reply/reply/agent-runner-execution.ts` | `tryHandleEscalation()`, local overrides, info logging |
| `src/auto-reply/reply/followup-runner.ts` | `disableEscalation: true` |
| `src/cron/isolated-agent/run.ts` | `disableEscalation: true` |
| `src/hooks/llm-slug-generator.ts` | `disableEscalation: true` |
| `src/config/types.agents-shared.ts` | Add `escalation` to `AgentModelConfig` |
| `src/config/types.agent-defaults.ts` | Derive `AgentModelListConfig` from `AgentModelConfig` |
| `src/config/zod-schema.agent-model.ts` | Add `escalation` to schema |
| `docs/concepts/models.md` | User-facing docs |

## Test plan

- [x] `pnpm build` — passes
- [x] `vitest run src/agents/tools/escalate-tool.test.ts` — 23 tests pass
- [x] `pnpm test` — full suite passes
- [x] Production verified on live gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)