### PR TITLE
fix(acp): scope cancellation and event routing by runId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Docs: https://docs.openclaw.ai
 - Skills/download installs: pin the validated per-skill tools root before writing downloaded archives, so rebinding the lexical tools path cannot redirect download writes outside the intended tools directory. Thanks @tdjackey.
 - Control UI/Debug: replace the Manual RPC free-text method field with a sorted dropdown sourced from gateway-advertised methods, and stack the form vertically for narrower layouts. (#14967) thanks @rixau.
 - Auth/profile resolution: log debug details when auto-discovered auth profiles fail during provider API-key resolution, so `--debug` output surfaces the real refresh/keychain/credential-store failure instead of only the generic missing-key message. (#41271) thanks @he-yufeng.
+- ACP/cancel scoping: scope `chat.abort` and shared-session ACP event routing by `runId` so one session cannot cancel or consume another session's run when they share the same gateway session key. (#41331) Thanks @pejmanjohn.
 
 ## 2026.3.7
 

--- a/src/acp/translator.cancel-scoping.test.ts
+++ b/src/acp/translator.cancel-scoping.test.ts
@@ -1,0 +1,235 @@
+import type { CancelNotification, PromptRequest, PromptResponse } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import type { EventFrame } from "../gateway/protocol/index.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+type Harness = {
+  agent: AcpGatewayAgent;
+  requestSpy: ReturnType<typeof vi.fn>;
+  sessionUpdateSpy: ReturnType<typeof vi.fn>;
+  sessionStore: ReturnType<typeof createInMemorySessionStore>;
+  sentRunIds: string[];
+};
+
+function createPromptRequest(sessionId: string): PromptRequest {
+  return {
+    sessionId,
+    prompt: [{ type: "text", text: "hello" }],
+    _meta: {},
+  } as unknown as PromptRequest;
+}
+
+function createChatEvent(payload: Record<string, unknown>): EventFrame {
+  return {
+    type: "event",
+    event: "chat",
+    payload,
+  } as EventFrame;
+}
+
+function createToolEvent(payload: Record<string, unknown>): EventFrame {
+  return {
+    type: "event",
+    event: "agent",
+    payload,
+  } as EventFrame;
+}
+
+function createHarness(sessions: Array<{ sessionId: string; sessionKey: string }>): Harness {
+  const sentRunIds: string[] = [];
+  const requestSpy = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === "chat.send") {
+      const runId = params?.idempotencyKey;
+      if (typeof runId === "string") {
+        sentRunIds.push(runId);
+      }
+      return new Promise<never>(() => {});
+    }
+    return {};
+  });
+  const connection = createAcpConnection();
+  const sessionStore = createInMemorySessionStore();
+  for (const session of sessions) {
+    sessionStore.createSession({
+      sessionId: session.sessionId,
+      sessionKey: session.sessionKey,
+      cwd: "/tmp",
+    });
+  }
+
+  const agent = new AcpGatewayAgent(
+    connection,
+    createAcpGateway(requestSpy as unknown as GatewayClient["request"]),
+    { sessionStore },
+  );
+
+  return {
+    agent,
+    requestSpy,
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    sessionUpdateSpy: connection.sessionUpdate as unknown as ReturnType<typeof vi.fn>,
+    sessionStore,
+    sentRunIds,
+  };
+}
+
+async function startPendingPrompt(
+  harness: Harness,
+  sessionId: string,
+): Promise<{ promptPromise: Promise<PromptResponse>; runId: string }> {
+  const before = harness.sentRunIds.length;
+  const promptPromise = harness.agent.prompt(createPromptRequest(sessionId));
+  await vi.waitFor(() => {
+    expect(harness.sentRunIds.length).toBe(before + 1);
+  });
+  return {
+    promptPromise,
+    runId: harness.sentRunIds[before],
+  };
+}
+
+describe("acp translator cancel and run scoping", () => {
+  it("cancel passes active runId to chat.abort", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const pending = await startPendingPrompt(harness, "session-1");
+
+    await harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
+
+    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
+      sessionKey,
+      runId: pending.runId,
+    });
+    await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+  });
+
+  it("cancel omits runId when there is no active run", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+
+    await harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
+
+    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
+      sessionKey,
+    });
+  });
+
+  it("drops chat events when runId does not match the active prompt", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const pending = await startPendingPrompt(harness, "session-1");
+
+    await harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: "run-other",
+        sessionKey,
+        seq: 1,
+        state: "final",
+      }),
+    );
+    expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(pending.runId);
+
+    await harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: pending.runId,
+        sessionKey,
+        seq: 2,
+        state: "final",
+      }),
+    );
+    await expect(pending.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("drops tool events when runId does not match the active prompt", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const pending = await startPendingPrompt(harness, "session-1");
+    harness.sessionUpdateSpy.mockClear();
+
+    await harness.agent.handleGatewayEvent(
+      createToolEvent({
+        runId: "run-other",
+        sessionKey,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "read_file",
+          toolCallId: "tool-1",
+          args: { path: "README.md" },
+        },
+      }),
+    );
+
+    expect(harness.sessionUpdateSpy).not.toHaveBeenCalled();
+
+    await harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: pending.runId,
+        sessionKey,
+        seq: 1,
+        state: "final",
+      }),
+    );
+    await expect(pending.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("routes events to the pending prompt that matches runId when session keys are shared", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([
+      { sessionId: "session-1", sessionKey },
+      { sessionId: "session-2", sessionKey },
+    ]);
+    const pending1 = await startPendingPrompt(harness, "session-1");
+    const pending2 = await startPendingPrompt(harness, "session-2");
+    harness.sessionUpdateSpy.mockClear();
+
+    await harness.agent.handleGatewayEvent(
+      createToolEvent({
+        runId: pending2.runId,
+        sessionKey,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "read_file",
+          toolCallId: "tool-2",
+          args: { path: "notes.txt" },
+        },
+      }),
+    );
+    expect(harness.sessionUpdateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-2",
+        update: expect.objectContaining({
+          sessionUpdate: "tool_call",
+          toolCallId: "tool-2",
+          status: "in_progress",
+        }),
+      }),
+    );
+    expect(harness.sessionUpdateSpy).toHaveBeenCalledTimes(1);
+
+    await harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: pending2.runId,
+        sessionKey,
+        seq: 1,
+        state: "final",
+      }),
+    );
+    await expect(pending2.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(pending1.runId);
+
+    await harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: pending1.runId,
+        sessionKey,
+        seq: 2,
+        state: "final",
+      }),
+    );
+    await expect(pending1.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+});

--- a/src/acp/translator.cancel-scoping.test.ts
+++ b/src/acp/translator.cancel-scoping.test.ts
@@ -112,9 +112,33 @@ describe("acp translator cancel and run scoping", () => {
 
     await harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
 
-    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
-      sessionKey,
-    });
+    const abortCalls = harness.requestSpy.mock.calls.filter(([method]) => method === "chat.abort");
+    expect(abortCalls).toHaveLength(0);
+  });
+
+  it("cancel from a session without active run does not abort another session sharing the same key", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([
+      { sessionId: "session-1", sessionKey },
+      { sessionId: "session-2", sessionKey },
+    ]);
+    const pending2 = await startPendingPrompt(harness, "session-2");
+
+    await harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
+
+    const abortCalls = harness.requestSpy.mock.calls.filter(([method]) => method === "chat.abort");
+    expect(abortCalls).toHaveLength(0);
+    expect(harness.sessionStore.getSession("session-2")?.activeRunId).toBe(pending2.runId);
+
+    await harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: pending2.runId,
+        sessionKey,
+        seq: 1,
+        state: "final",
+      }),
+    );
+    await expect(pending2.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
   });
 
   it("drops chat events when runId does not match the active prompt", async () => {

--- a/src/acp/translator.cancel-scoping.test.ts
+++ b/src/acp/translator.cancel-scoping.test.ts
@@ -106,7 +106,22 @@ describe("acp translator cancel and run scoping", () => {
     await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
   });
 
-  it("cancel omits runId when there is no active run", async () => {
+  it("cancel uses pending runId when there is no active run", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const pending = await startPendingPrompt(harness, "session-1");
+    harness.sessionStore.clearActiveRun("session-1");
+
+    await harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
+
+    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
+      sessionKey,
+      runId: pending.runId,
+    });
+    await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+  });
+
+  it("cancel skips chat.abort when there is no active run and no pending prompt", async () => {
     const sessionKey = "agent:main:shared";
     const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
 

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -633,9 +633,15 @@ export class AcpGatewayAgent implements Agent {
     if (!session) {
       return;
     }
+    // Capture runId before cancelActiveRun clears session.activeRunId.
+    const activeRunId = session.activeRunId;
+
     this.sessionStore.cancelActiveRun(params.sessionId);
     try {
-      await this.gateway.request("chat.abort", { sessionKey: session.sessionKey });
+      await this.gateway.request("chat.abort", {
+        sessionKey: session.sessionKey,
+        ...(activeRunId ? { runId: activeRunId } : {}),
+      });
     } catch (err) {
       this.log(`cancel error: ${String(err)}`);
     }
@@ -672,6 +678,7 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
     const stream = payload.stream as string | undefined;
+    const runId = payload.runId as string | undefined;
     const data = payload.data as Record<string, unknown> | undefined;
     const sessionKey = payload.sessionKey as string | undefined;
     if (!stream || !data || !sessionKey) {
@@ -688,7 +695,7 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
 
-    const pending = this.findPendingBySessionKey(sessionKey);
+    const pending = this.findPendingBySessionKey(sessionKey, runId);
     if (!pending) {
       return;
     }
@@ -774,11 +781,8 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
 
-    const pending = this.findPendingBySessionKey(sessionKey);
+    const pending = this.findPendingBySessionKey(sessionKey, runId);
     if (!pending) {
-      return;
-    }
-    if (runId && pending.idempotencyKey !== runId) {
       return;
     }
 
@@ -853,11 +857,15 @@ export class AcpGatewayAgent implements Agent {
     pending.resolve({ stopReason });
   }
 
-  private findPendingBySessionKey(sessionKey: string): PendingPrompt | undefined {
+  private findPendingBySessionKey(sessionKey: string, runId?: string): PendingPrompt | undefined {
     for (const pending of this.pendingPrompts.values()) {
-      if (pending.sessionKey === sessionKey) {
-        return pending;
+      if (pending.sessionKey !== sessionKey) {
+        continue;
       }
+      if (runId && pending.idempotencyKey !== runId) {
+        continue;
+      }
+      return pending;
     }
     return undefined;
   }

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -637,25 +637,21 @@ export class AcpGatewayAgent implements Agent {
     const activeRunId = session.activeRunId;
 
     this.sessionStore.cancelActiveRun(params.sessionId);
-    if (!activeRunId) {
-      const pending = this.pendingPrompts.get(params.sessionId);
-      if (pending) {
-        this.pendingPrompts.delete(params.sessionId);
-        pending.resolve({ stopReason: "cancelled" });
-      }
+    const pending = this.pendingPrompts.get(params.sessionId);
+    const scopedRunId = activeRunId ?? pending?.idempotencyKey;
+    if (!scopedRunId) {
       return;
     }
 
     try {
       await this.gateway.request("chat.abort", {
         sessionKey: session.sessionKey,
-        runId: activeRunId,
+        runId: scopedRunId,
       });
     } catch (err) {
       this.log(`cancel error: ${String(err)}`);
     }
 
-    const pending = this.pendingPrompts.get(params.sessionId);
     if (pending) {
       this.pendingPrompts.delete(params.sessionId);
       pending.resolve({ stopReason: "cancelled" });

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -637,10 +637,19 @@ export class AcpGatewayAgent implements Agent {
     const activeRunId = session.activeRunId;
 
     this.sessionStore.cancelActiveRun(params.sessionId);
+    if (!activeRunId) {
+      const pending = this.pendingPrompts.get(params.sessionId);
+      if (pending) {
+        this.pendingPrompts.delete(params.sessionId);
+        pending.resolve({ stopReason: "cancelled" });
+      }
+      return;
+    }
+
     try {
       await this.gateway.request("chat.abort", {
         sessionKey: session.sessionKey,
-        ...(activeRunId ? { runId: activeRunId } : {}),
+        runId: activeRunId,
       });
     } catch (err) {
       this.log(`cancel error: ${String(err)}`);


### PR DESCRIPTION
## Summary

- **Problem:** When multiple ACP sessions share a gateway session key, cancellation and event routing can cross-wire between sessions
- **Root causes (3 related issues):**
  1. `cancel` could call `chat.abort` without a scoped `runId`, aborting all runs on the session key instead of just the target run
  2. `findPendingBySessionKey` returned the first matching pending prompt by session key, so shared-key sessions could route events to the wrong prompt
  3. `handleAgentEvent` (tool events) did not pass `runId` into pending-prompt lookup, allowing tool updates to route to the wrong session
- **What changed:**
  - `cancel` now derives a scoped `runId` from `session.activeRunId` first, then falls back to the pending prompt `idempotencyKey`, and always passes that `runId` to `chat.abort`
  - `cancel` skips `chat.abort` only when there is truly nothing to cancel (no active run and no pending prompt)
  - `findPendingBySessionKey` accepts optional `runId` and matches on both `sessionKey` and `idempotencyKey` when provided
  - `handleAgentEvent` extracts `runId` from the event payload and passes it through to the lookup, matching the pattern used by `handleChatEvent`
- **What did NOT change:** Single-session behavior is unchanged. When `runId` is absent from events, routing still falls back to session-key-only matching (existing behavior).

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Related: [ACP protocol gap analysis](https://super-agentic.ai/resources/super-posts/openclaw-acp-what-coding-agent-users-need-to-know-about-protocol-gaps)

## User-visible / Behavior Changes

- Cancel now aborts only the target run, not all runs on the session key
- Tool and chat events route to the correct ACP session when multiple sessions share a gateway key
- No change in single-session setups

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — `chat.abort` already accepts optional `runId`; we now pass it consistently
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4 (arm64)
- Runtime: Node v24.13.0

### Steps

1. Open two ACP sessions that resolve to the same gateway session key
2. Start a prompt in both sessions
3. Cancel one session or emit tool/chat events for one run
4. Observe whether the other session is also aborted or receives the wrong updates

### Expected (after fix)

- Only the cancelled session aborts; the other continues normally
- Tool/chat events route only to the session whose runId matches

### Actual (before fix)

- Unscoped `chat.abort` could abort all runs on the shared session key
- Shared-session event lookup could resolve the wrong pending prompt and silently misroute updates

## Evidence

- [x] Failing test/log before + passing after
- New test file: `src/acp/translator.cancel-scoping.test.ts` (7 tests):
  1. Cancel passes active `runId` to `chat.abort`
  2. Cancel uses pending prompt `runId` when the active run was cleared
  3. Cancel skips `chat.abort` when there is no active run and no pending prompt
  4. Cancel from an idle shared-key session does not abort a sibling session's active run
  5. Chat events with mismatched `runId` are dropped
  6. Tool events with mismatched `runId` are dropped
  7. Events route to the correct pending prompt when session keys are shared
- Maintainer verification on the rebased branch:
  - `pnpm lint`
  - `pnpm build`
  - `pnpm test`

## Human Verification

- Verified: `ChatAbortParamsSchema` already accepts optional `runId`, and the gateway `chat.abort` handler scopes aborts by `runId` when present
- Verified: Gateway chat and agent event payloads carry `runId`
- Verified: local maintainer gate passed after rebasing onto current `main`
- Not verified: end-to-end with a live multi-session ACP client

## AI-Assisted 🤖

- Initial implementation by Codex CLI, independently verified before coding
- Reviewed and refined through a second Codex pass after follow-up feedback on the cancel path
- Final maintainer review re-verified the bug claim in code and ran the full local gate before landing

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — `runId` is optional in `chat.abort`, and event lookup still falls back to session-key-only matching when `runId` is absent.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- Revert the landed commit(s)

## Risks and Mitigations

- **Risk:** If an event lacks `runId`, routing still falls back to session-key-only matching (`first match wins`)
  - **Mitigation:** Gateway chat and agent events both include `runId`; the fallback preserves existing single-session behavior.
- **Risk:** Cancel could miss a remote abort if `activeRunId` was cleared before cancel
  - **Mitigation:** The pending prompt `idempotencyKey` is used as a fallback scoped `runId`.
