### PR TITLE
fix: harden iMessage echo filtering and heartbeat payload selection

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -242,9 +242,13 @@ async function runImagePrompt(params: {
       }
 
       const context = buildImageContext(params.prompt, params.images);
+      const isOpenAICodex =
+        model.provider === "openai-codex" ||
+        (model.provider === "openai" && /codex/i.test(model.id));
       const message = await complete(model, context, {
         apiKey,
         maxTokens: resolveImageToolMaxTokens(model.maxTokens),
+        ...(isOpenAICodex ? { systemPrompt: params.prompt } : {}),
       });
       const text = coerceImageAssistantText({
         message,

--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -1,5 +1,17 @@
 import type { ReplyPayload } from "./types.js";
 
+function isUserVisibleHeartbeatPayload(payload: ReplyPayload | undefined): boolean {
+  if (!payload) {
+    return false;
+  }
+  if (payload.isReasoning) {
+    return false;
+  }
+  return Boolean(
+    payload.text || payload.mediaUrl || (payload.mediaUrls && payload.mediaUrls.length > 0),
+  );
+}
+
 export function resolveHeartbeatReplyPayload(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload | undefined {
@@ -7,14 +19,11 @@ export function resolveHeartbeatReplyPayload(
     return undefined;
   }
   if (!Array.isArray(replyResult)) {
-    return replyResult;
+    return isUserVisibleHeartbeatPayload(replyResult) ? replyResult : undefined;
   }
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
     const payload = replyResult[idx];
-    if (!payload) {
-      continue;
-    }
-    if (payload.text || payload.mediaUrl || (payload.mediaUrls && payload.mediaUrls.length > 0)) {
+    if (isUserVisibleHeartbeatPayload(payload)) {
       return payload;
     }
   }

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -217,7 +217,12 @@ export function resolveIMessageInboundDecision(params: {
 
   // Echo detection: check if the received message matches a recently sent message.
   // Scope by conversation so same text in different chats is not conflated.
-  const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
+  const inboundMessageId =
+    typeof params.message.guid === "string" && params.message.guid.trim()
+      ? params.message.guid.trim()
+      : params.message.id != null
+        ? String(params.message.id)
+        : undefined;
   if (params.echoCache && (messageText || inboundMessageId)) {
     const echoScope = buildIMessageEchoScope({
       accountId: params.accountId,

--- a/src/imessage/monitor/types.ts
+++ b/src/imessage/monitor/types.ts
@@ -9,6 +9,7 @@ export type IMessageAttachment = {
 
 export type IMessagePayload = {
   id?: number | null;
+  guid?: string | null;
   chat_id?: number | null;
   sender?: string | null;
   is_from_me?: boolean | null;


### PR DESCRIPTION
## Summary\n- prefer iMessage message GUIDs for echo suppression instead of transient row ids\n- ignore heartbeat reasoning-only payloads when selecting the user-visible reply payload\n- pass prompt as systemPrompt for OpenAI Codex image-tool calls to avoid `Instructions are required` failures\n\n## Why\n- fixes #41330 by making echo-loop suppression use a stable message identity where available\n- reduces #41329 corruption risk by ensuring heartbeat delivery ignores reasoning-only payloads\n- addresses #41322 regression for Codex-backed image analysis\n\n## Validation\n- pnpm vitest run src/imessage/monitor/loop-rate-limiter.test.ts src/agents/session-transcript-repair.test.ts src/agents/tools/image-tool.test.ts\n