### PR TITLE
fix(models-config): normalize Google provider baseUrl to include /v1beta

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11488,6 +11488,22 @@
         "line_number": 20
       }
     ],
+    "src/agents/models-config.providers.google-base-url.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.google-base-url.test.ts",
+        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.google-base-url.test.ts",
+        "hashed_secret": "ec14684b9b882e2aa9abdc4960c720050287e8eb",
+        "is_verified": false,
+        "line_number": 107
+      }
+    ],
     "src/agents/models-config.providers.nvidia.test.ts": [
       {
         "type": "Secret Keyword",

--- a/src/agents/models-config.providers.google-base-url.test.ts
+++ b/src/agents/models-config.providers.google-base-url.test.ts
@@ -25,6 +25,11 @@ describe("normalizeGoogleBaseUrl", () => {
       "https://generativelanguage.googleapis.com///",
       "https://generativelanguage.googleapis.com/v1beta",
     ],
+    // query string preserved correctly via pathname mutation
+    [
+      "https://generativelanguage.googleapis.com?key=abc",
+      "https://generativelanguage.googleapis.com/v1beta?key=abc",
+    ],
   ])("appends /v1beta to bare googleapis.com host: %s", (input, expected) => {
     expect(normalizeGoogleBaseUrl(input)).toBe(expected);
   });

--- a/src/agents/models-config.providers.google-base-url.test.ts
+++ b/src/agents/models-config.providers.google-base-url.test.ts
@@ -40,10 +40,14 @@ describe("normalizeGoogleBaseUrl", () => {
   });
 
   it.each([
-    // custom proxy without googleapis domain – leave as-is
+    // custom proxy without googleapis domain – leave completely as-is,
+    // including any trailing slashes
     "https://my-proxy.example.com/gemini",
+    "https://my-proxy.example.com/gemini/",
     "https://openai.example.com/v1",
     "http://localhost:4000",
+    // look-alike domain must not be treated as canonical googleapis
+    "https://generativelanguage.googleapis.com.evil.com",
   ])("does not modify non-googleapis base URLs: %s", (url) => {
     expect(normalizeGoogleBaseUrl(url)).toBe(url);
   });

--- a/src/agents/models-config.providers.google-base-url.test.ts
+++ b/src/agents/models-config.providers.google-base-url.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeGoogleBaseUrl,
+  normalizeProviders,
+  type ProviderConfig,
+} from "./models-config.providers.js";
+
+describe("normalizeGoogleBaseUrl", () => {
+  it.each([
+    // bare host – the regression case from #41276
+    [
+      "https://generativelanguage.googleapis.com",
+      "https://generativelanguage.googleapis.com/v1beta",
+    ],
+    // trailing slash stripped then /v1beta appended
+    [
+      "https://generativelanguage.googleapis.com/",
+      "https://generativelanguage.googleapis.com/v1beta",
+    ],
+    // multiple trailing slashes
+    [
+      "https://generativelanguage.googleapis.com///",
+      "https://generativelanguage.googleapis.com/v1beta",
+    ],
+  ])("appends /v1beta to bare googleapis.com host: %s", (input, expected) => {
+    expect(normalizeGoogleBaseUrl(input)).toBe(expected);
+  });
+
+  it.each([
+    // already versioned – must not double-append
+    "https://generativelanguage.googleapis.com/v1beta",
+    "https://generativelanguage.googleapis.com/v1beta/",
+    "https://generativelanguage.googleapis.com/v1alpha",
+    "https://generativelanguage.googleapis.com/v2beta",
+  ])("leaves already-versioned googleapis.com URL unchanged: %s", (url) => {
+    expect(normalizeGoogleBaseUrl(url)).toBe(url.replace(/\/+$/, ""));
+  });
+
+  it.each([
+    // custom proxy without googleapis domain – leave as-is
+    "https://my-proxy.example.com/gemini",
+    "https://openai.example.com/v1",
+    "http://localhost:4000",
+  ])("does not modify non-googleapis base URLs: %s", (url) => {
+    expect(normalizeGoogleBaseUrl(url)).toBe(url);
+  });
+});
+
+describe("google provider baseUrl normalization via normalizeProviders", () => {
+  function buildModel(id: string): NonNullable<ProviderConfig["models"]>[number] {
+    return {
+      id,
+      name: id,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1048576,
+      maxTokens: 65536,
+    };
+  }
+
+  it("appends /v1beta when google provider baseUrl omits version path (#41276)", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = {
+      google: {
+        baseUrl: "https://generativelanguage.googleapis.com",
+        api: "google-generative-ai",
+        apiKey: "GEMINI_KEY",
+        models: [buildModel("gemini-3.1-flash-lite-preview")],
+      } satisfies ProviderConfig,
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    expect(normalized?.google?.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
+  });
+
+  it("preserves existing /v1beta in google provider baseUrl", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = {
+      google: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        api: "google-generative-ai",
+        apiKey: "GEMINI_KEY",
+        models: [buildModel("gemini-3.1-flash-lite-preview")],
+      } satisfies ProviderConfig,
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    expect(normalized?.google?.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
+  });
+
+  it("does not modify baseUrl for non-google providers", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        api: "openai-responses",
+        apiKey: "OPENAI_KEY",
+        models: [buildModel("gpt-5")],
+      } satisfies ProviderConfig,
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    expect(normalized?.openai?.baseUrl).toBe("https://api.openai.com/v1");
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -311,7 +311,8 @@ export function normalizeGoogleBaseUrl(baseUrl: string): string {
     return baseUrl;
   }
   if (!/\/v\d/.test(parsed.pathname)) {
-    return `${trimmed}/v1beta`;
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") + "/v1beta";
+    return parsed.toString();
   }
   return trimmed;
 }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -297,7 +297,20 @@ function normalizeProviderModels(
  */
 export function normalizeGoogleBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.replace(/\/+$/, "");
-  if (trimmed.includes("generativelanguage.googleapis.com") && !/\/v\d/.test(trimmed)) {
+  // Use a reliable hostname check to avoid false-positives on look-alike domains
+  // (e.g. generativelanguage.googleapis.com.evil.com) or query strings that
+  // happen to contain the googleapis domain as a substring.
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return baseUrl;
+  }
+  if (parsed.hostname !== "generativelanguage.googleapis.com") {
+    // Non-googleapis URLs (custom proxies) are left completely unchanged.
+    return baseUrl;
+  }
+  if (!/\/v\d/.test(parsed.pathname)) {
     return `${trimmed}/v1beta`;
   }
   return trimmed;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -285,8 +285,33 @@ function normalizeProviderModels(
   return mutated ? { ...provider, models } : provider;
 }
 
+/**
+ * Appends /v1beta to Google Generative Language API base URLs that omit the
+ * API version path.  Users sometimes configure the bare host
+ * (https://generativelanguage.googleapis.com) while the embedded/probe path
+ * treats any explicit model.baseUrl as a fully-versioned URL and does not
+ * re-append the version – resulting in 404s (#41276).
+ *
+ * Only the canonical Google AI Studio domain is touched; custom proxies are
+ * left unchanged so they can supply their own version path.
+ */
+export function normalizeGoogleBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  if (trimmed.includes("generativelanguage.googleapis.com") && !/\/v\d/.test(trimmed)) {
+    return `${trimmed}/v1beta`;
+  }
+  return trimmed;
+}
+
 function normalizeGoogleProvider(provider: ProviderConfig): ProviderConfig {
-  return normalizeProviderModels(provider, normalizeGoogleModelId);
+  let normalized = normalizeProviderModels(provider, normalizeGoogleModelId);
+  if (typeof normalized.baseUrl === "string") {
+    const normalizedBaseUrl = normalizeGoogleBaseUrl(normalized.baseUrl);
+    if (normalizedBaseUrl !== normalized.baseUrl) {
+      normalized = { ...normalized, baseUrl: normalizedBaseUrl };
+    }
+  }
+  return normalized;
 }
 
 function normalizeAntigravityProvider(provider: ProviderConfig): ProviderConfig {


### PR DESCRIPTION
## Summary

- When `models.providers.google.baseUrl` is set to the bare host (`https://generativelanguage.googleapis.com`) without a version path, the provider override replaces the built-in model baseUrl (which includes `/v1beta`), causing 404s in the embedded/probe path.
- Added `normalizeGoogleBaseUrl()` that appends `/v1beta` to canonical `generativelanguage.googleapis.com` URLs that have no version segment (`/v\d`). Custom proxy URLs are left unchanged.
- Extended `normalizeGoogleProvider()` to call this normalization alongside the existing model-ID normalization.

Fixes #41276.

## Test plan

- [ ] New unit tests in `models-config.providers.google-base-url.test.ts` cover: bare host → `/v1beta` appended, trailing slashes stripped, already-versioned URLs preserved, non-googleapis URLs untouched.
- [ ] Existing Google provider tests (`models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts`, `models-config.providers.google-antigravity.test.ts`) still pass.
- [ ] `pnpm check` (lint + typecheck + format) passes.