### PR TITLE
fix(heartbeat): clamp setTimeout delay to avoid 32-bit overflow

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -249,9 +249,10 @@ describe("startHeartbeatRunner", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
 
-    const warnSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
-
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
 
     // 30 days in ms (2,592,000,000) exceeds 2^31-1 (2,147,483,647)
     const runner = startHeartbeatRunner({
@@ -261,13 +262,14 @@ describe("startHeartbeatRunner", () => {
       runOnce: runSpy,
     });
 
-    // Should not have emitted a TimeoutOverflowWarning
-    const overflowWarnings = warnSpy.mock.calls.filter(
-      (call) => typeof call[0] === "string" && call[0].includes("does not fit into a 32-bit"),
-    );
-    expect(overflowWarnings).toHaveLength(0);
+    // The delay passed to setTimeout must be clamped to MAX_SAFE_TIMEOUT_MS
+    const schedulingCalls = setTimeoutSpy.mock.calls.filter((call) => typeof call[1] === "number");
+    expect(schedulingCalls.every((call) => (call[1] as number) <= MAX_SAFE_TIMEOUT_MS)).toBe(true);
 
-    warnSpy.mockRestore();
+    // The heartbeat should NOT have run yet (it is not due for 30 days)
+    expect(runSpy).not.toHaveBeenCalled();
+
+    setTimeoutSpy.mockRestore();
     runner.stop();
   });
 

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -245,6 +245,32 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("clamps setTimeout delay to avoid 32-bit overflow with large intervals", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const warnSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    // 30 days in ms (2,592,000,000) exceeds 2^31-1 (2,147,483,647)
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "30d" } } },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    // Should not have emitted a TimeoutOverflowWarning
+    const overflowWarnings = warnSpy.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("does not fit into a 32-bit"),
+    );
+    expect(overflowWarnings).toHaveLength(0);
+
+    warnSpy.mockRestore();
+    runner.stop();
+  });
+
   it("does not fan out to unrelated agents for session-scoped exec wakes", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -98,6 +98,8 @@ export type HeartbeatSummary = {
 };
 
 const DEFAULT_HEARTBEAT_TARGET = "none";
+/** Maximum safe value for Node.js setTimeout (2^31 − 1 ms ≈ 24.8 days). */
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
 export { isCronSystemEvent };
 
 type HeartbeatAgentState = {
@@ -1054,8 +1056,7 @@ export function startHeartbeatRunner(opts: {
     }
     // Node.js setTimeout uses a 32-bit signed integer; values above 2^31-1
     // overflow to 1ms, causing a tight loop and massive log spam.
-    const MAX_TIMEOUT_MS = 2_147_483_647;
-    const delay = Math.min(Math.max(0, nextDue - now), MAX_TIMEOUT_MS);
+    const delay = Math.min(Math.max(0, nextDue - now), MAX_SAFE_TIMEOUT_MS);
     state.timer = setTimeout(() => {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1052,7 +1052,10 @@ export function startHeartbeatRunner(opts: {
     if (!Number.isFinite(nextDue)) {
       return;
     }
-    const delay = Math.max(0, nextDue - now);
+    // Node.js setTimeout uses a 32-bit signed integer; values above 2^31-1
+    // overflow to 1ms, causing a tight loop and massive log spam.
+    const MAX_TIMEOUT_MS = 2_147_483_647;
+    const delay = Math.min(Math.max(0, nextDue - now), MAX_TIMEOUT_MS);
     state.timer = setTimeout(() => {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });


### PR DESCRIPTION
## Summary
- Clamp `setTimeout` delay to `2^31 - 1` (2,147,483,647ms) to prevent Node.js 32-bit signed integer overflow
- When heartbeat interval exceeds ~24.8 days, Node.js silently sets timeout to 1ms, causing a tight loop and 500MB+ log spam
- The timer fires early, checks if the heartbeat is actually due, and reschedules — no behavioral change for valid intervals

Fixes #41240

## Test plan
- [x] Added test verifying no `TimeoutOverflowWarning` is emitted with a 30-day interval
- [x] All 9 existing heartbeat scheduler tests pass
- [ ] Verify on a real gateway with `heartbeat.every: "30d"` — no log spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)