### PR TITLE
Backup: add folder-backed encrypted snapshot flow with setup/run/restore

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -1,39 +1,58 @@
 ---
-summary: "CLI reference for `openclaw backup` (create local backup archives)"
+summary: "CLI reference for `openclaw backup` (setup, run, export, list, and restore backups)"
 read_when:
-  - You want a first-class backup archive for local OpenClaw state
-  - You want to preview which paths would be included before reset or uninstall
+  - You want to configure backup into a cloud drive folder
+  - You want to export a local backup archive
+  - You want to list or restore encrypted backup snapshots
 title: "backup"
 ---
 
 # `openclaw backup`
 
-Create a local backup archive for OpenClaw state, config, credentials, sessions, and optionally workspaces.
+Manage OpenClaw backups.
+
+Use `openclaw backup export` for a local plaintext archive, and `openclaw backup run` for the
+configured day to day backup flow.
 
 ```bash
-openclaw backup create
-openclaw backup create --output ~/Backups
-openclaw backup create --dry-run --json
-openclaw backup create --verify
-openclaw backup create --no-include-workspace
-openclaw backup create --only-config
+openclaw backup setup
+openclaw backup run
+openclaw backup status
+openclaw backup export
+openclaw backup export --output ~/Backups
+openclaw backup export --dry-run --json
+openclaw backup export --verify
+openclaw backup export --no-include-workspace
+openclaw backup export --only-config
+openclaw backup list
+openclaw backup restore <snapshot-id>
 openclaw backup verify ./2026-03-09T00-00-00.000Z-openclaw-backup.tar.gz
 ```
 
+Legacy aliases remain available:
+
+- `openclaw backup create` -> `openclaw backup export`
+- `openclaw backup push` -> `openclaw backup run`
+
 ## Notes
 
+- `openclaw backup setup` detects or records the backup target folder.
+- `openclaw backup run` runs the primary backup flow:
+  - if `backup.encryption.key` is configured, it writes an encrypted snapshot into the backup target
+  - otherwise it mirrors workspaces into the backup target
+- `openclaw backup status` shows workspace mirror status plus the latest encrypted snapshot status.
 - The archive includes a `manifest.json` file with the resolved source paths and archive layout.
 - Default output is a timestamped `.tar.gz` archive in the current working directory.
 - If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten.
 - Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
 - `openclaw backup verify <archive>` validates that the archive contains exactly one root manifest, rejects traversal-style archive paths, and checks that every manifest-declared payload exists in the tarball.
-- `openclaw backup create --verify` runs that validation immediately after writing the archive.
-- `openclaw backup create --only-config` backs up just the active JSON config file.
+- `openclaw backup export --verify` runs that validation immediately after writing the archive.
+- `openclaw backup export --only-config` backs up just the active JSON config file.
 
 ## What gets backed up
 
-`openclaw backup create` plans backup sources from your local OpenClaw install:
+`openclaw backup export` plans backup sources from your local OpenClaw install:
 
 - The state directory returned by OpenClaw's local state resolver, usually `~/.openclaw`
 - The active config file path
@@ -48,12 +67,12 @@ The archive payload stores file contents from those source trees, and the embedd
 
 ## Invalid config behavior
 
-`openclaw backup` intentionally bypasses the normal config preflight so it can still help during recovery. Because workspace discovery depends on a valid config, `openclaw backup create` now fails fast when the config file exists but is invalid and workspace backup is still enabled.
+`openclaw backup` intentionally bypasses the normal config preflight so it can still help during recovery. Because workspace discovery depends on a valid config, `openclaw backup export` now fails fast when the config file exists but is invalid and workspace backup is still enabled.
 
 If you still want a partial backup in that situation, rerun:
 
 ```bash
-openclaw backup create --no-include-workspace
+openclaw backup export --no-include-workspace
 ```
 
 That keeps state, config, and credentials in scope while skipping workspace discovery entirely.
@@ -68,7 +87,7 @@ Practical limits come from the local machine and destination filesystem:
 
 - Available space for the temporary archive write plus the final archive
 - Time to walk large workspace trees and compress them into a `.tar.gz`
-- Time to rescan the archive if you use `openclaw backup create --verify` or run `openclaw backup verify`
+- Time to rescan the archive if you use `openclaw backup export --verify` or run `openclaw backup verify`
 - Filesystem behavior at the destination path. OpenClaw prefers a no-overwrite hard-link publish step and falls back to exclusive copy when hard links are unsupported
 
 Large workspaces are usually the main driver of archive size. If you want a smaller or faster backup, use `--no-include-workspace`.

--- a/docs/cli/reset.md
+++ b/docs/cli/reset.md
@@ -11,10 +11,10 @@ title: "reset"
 Reset local config/state (keeps the CLI installed).
 
 ```bash
-openclaw backup create
+openclaw backup export
 openclaw reset
 openclaw reset --dry-run
 openclaw reset --scope config+creds+sessions --yes --non-interactive
 ```
 
-Run `openclaw backup create` first if you want a restorable snapshot before removing local state.
+Run `openclaw backup export` first if you want a restorable snapshot before removing local state.

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -11,10 +11,10 @@ title: "uninstall"
 Uninstall the gateway service + local data (CLI remains).
 
 ```bash
-openclaw backup create
+openclaw backup export
 openclaw uninstall
 openclaw uninstall --all --yes
 openclaw uninstall --dry-run
 ```
 
-Run `openclaw backup create` first if you want a restorable snapshot before removing state or workspaces.
+Run `openclaw backup export` first if you want a restorable snapshot before removing state or workspaces.

--- a/docs/experiments/plans/cloud-backup-cross-device-restore.md
+++ b/docs/experiments/plans/cloud-backup-cross-device-restore.md
@@ -1,0 +1,927 @@
+---
+summary: "Plan: Add reliable personal user backups in two phases: cloud drive workspace backup first, encrypted full snapshots second"
+read_when:
+  - Designing cloud backup for OpenClaw state and workspaces
+  - Planning cross device restore without turning the state dir into a sync folder
+owner: "openclaw"
+status: "draft"
+last_updated: "2026-03-10"
+title: "Cloud Backup and Cross Device Restore Plan"
+---
+
+# Cloud Backup and Cross Device Restore Plan
+
+## Context
+
+OpenClaw is local first today.
+
+Mutable state is spread across a few local locations:
+
+- `~/.openclaw/openclaw.json` for config
+- `~/.openclaw/credentials/` for OAuth tokens, API keys, pairing stores, and channel auth
+- `~/.openclaw/agents/<agentId>/sessions/` for session store files and transcript JSONL files
+- `~/.openclaw/workspace` or a custom workspace path for agent memory and working files
+- device and node pairing state under `~/.openclaw/devices/` and `~/.openclaw/nodes/`
+
+OpenClaw already supports local backup archives through [`/cli/backup`](/cli/backup), and the docs
+already recommend keeping the agent workspace in a private Git repository when possible. See
+[`/concepts/agent-workspace`](/concepts/agent-workspace),
+[`/install/migrating`](/install/migrating), and [`/help/faq`](/help/faq).
+
+At the same time, OpenClaw intentionally warns against placing the state directory in iCloud,
+Dropbox, OneDrive, Google Drive, or other sync folders because sync style replication can leak
+secrets and create file lock or race issues. See [`/gateway/doctor`](/gateway/doctor).
+
+This plan adds cloud backup and restore without changing that trust model.
+
+## Audience and product stance
+
+This is a personal user product first.
+
+`Industrial grade` in this document means:
+
+- backups are reliable and testable
+- restore paths are explicit and safe
+- data handling is conservative
+- failure modes are observable
+
+It does not mean the product should start with enterprise style setup complexity.
+
+The roadmap should therefore prioritize:
+
+- the lowest possible setup cost in `v1`
+- one obvious default path instead of many storage choices
+- a clear separation between lightweight workspace backup and full disaster recovery
+
+## Goals
+
+- Add first class encrypted cloud backups for OpenClaw state.
+- Support full host restore on a replacement machine or server.
+- Support safe cross device continuity for the gateway backed state.
+- Keep the workspace Git recommendation intact.
+- Avoid turning `~/.openclaw` into a multi writer replicated filesystem.
+- Reuse the current local backup manifest and verification model where practical.
+- Define a production ready operating model with clear storage, encryption, retention, and restore
+  requirements.
+
+## Non goals
+
+- Real time bidirectional sync of `~/.openclaw`.
+- Conflict free multi writer session merging between gateways.
+- Restoring device private keys onto a different physical device by default.
+- Replacing private Git backup for workspace only use cases.
+
+## Design principles
+
+- One writer: a single gateway state directory remains the source of truth.
+- Backup, not sync: cloud storage stores immutable encrypted snapshots.
+- Client side encryption: the backup service must not see plaintext tokens or transcripts.
+- Layered restore: restore config, state, and workspace intentionally, not as a blind folder sync.
+- Device trust stays device scoped: gateway state can move; device identities should not silently clone.
+
+## Industrial grade baseline
+
+An industrial grade OpenClaw backup design should target:
+
+- `RPO`: default hourly snapshots, with support for tighter schedules later
+- `RTO`: restore to a working gateway within 30 to 60 minutes for a normal deployment
+- immutable snapshot history for the configured retention window
+- separate backup file access and backup encryption concerns
+- documented restore drills, not just backup creation
+- clear operator visibility for backup freshness, failures, and last verified restore
+
+These are product goals rather than hard runtime guarantees, but the architecture should optimize for
+them from the start.
+
+## Why not sync folders
+
+Sync folders are a poor fit for OpenClaw state:
+
+- credentials, pairing, and transcripts are sensitive
+- session and pairing files are updated frequently and atomically
+- multiple hosts writing to the same synced tree will create race conditions
+- some state is host or device scoped rather than account scoped
+
+The product should keep warning on synced paths and introduce cloud backup as a separate feature,
+not as an exception to the existing warning.
+
+## State classification
+
+OpenClaw should classify persistent state into recovery tiers.
+
+| Tier                          | Examples                                                                 | Cloud backup              | Cross device restore |
+| ----------------------------- | ------------------------------------------------------------------------ | ------------------------- | -------------------- |
+| Workspace memory              | `AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`, `MEMORY.md`, `memory/` | Yes                       | Yes                  |
+| Gateway config                | `openclaw.json`                                                          | Yes                       | Yes                  |
+| Gateway credentials           | OAuth tokens, API keys, pairing allowlists, channel auth                 | Yes                       | Yes, with caution    |
+| Session history               | session store JSON, transcript JSONL files                               | Yes                       | Yes                  |
+| Gateway pairing state         | paired nodes, paired devices, approved scopes                            | Yes                       | Yes                  |
+| Pending ephemeral state       | pending pairing requests, locks, temp files                              | No by default             | No                   |
+| Device local identity         | iOS, Android, macOS device identity private keys                         | Optional same device only | No by default        |
+| Device local auth token cache | device scoped role tokens on the client                                  | Optional same device only | No by default        |
+
+## Product shape
+
+The feature should have two layers.
+
+### Layer 1
+
+Keep the current local archive flow:
+
+- `openclaw backup export`
+- `openclaw backup verify`
+
+This remains the canonical local packaging format and the recovery primitive for manual workflows.
+
+### Layer 2
+
+Add cloud snapshot commands on top of the local archive model:
+
+- `openclaw backup run`
+- `openclaw backup list`
+- `openclaw backup restore`
+
+The cloud feature should write encrypted snapshots plus a small local index into a backup folder,
+not raw folders.
+
+## Product roadmap
+
+OpenClaw should ship backup in two user facing phases.
+
+### V1
+
+`V1` is the default path for personal users.
+
+What it does:
+
+- backs up the agent workspace only
+- copies the workspace into a user selected cloud drive folder
+- optimizes for a setup model users already understand from normal file backup tools
+
+What it protects:
+
+- `AGENTS.md`
+- `SOUL.md`
+- `USER.md`
+- `IDENTITY.md`
+- `MEMORY.md`
+- other workspace files the user wants to keep in Git
+
+What it does not protect:
+
+- `~/.openclaw` gateway state
+- credentials and channel logins
+- session history and transcripts
+- pairing state
+
+Recommended default:
+
+- `workspace` backup into an existing cloud drive folder such as `iCloud Drive`, `Google Drive`,
+  `OneDrive`, or `Dropbox`
+
+Advanced optional path:
+
+- private Git repository for users who explicitly want version control semantics
+
+This is the simplest credible backup path for personal users and matches how they already think
+about file backup.
+
+### V2
+
+`V2` adds full disaster recovery.
+
+What it does:
+
+- creates encrypted full snapshots of gateway state plus workspace
+- writes those snapshots as encrypted backup files into a user selected cloud drive folder
+- supports full host restore on a replacement machine
+
+Recommended default:
+
+- encrypted snapshots in an existing cloud drive folder such as `iCloud Drive`, `Google Drive`,
+  `OneDrive`, or `Dropbox`
+
+This keeps `v1` easy while still giving OpenClaw a clear path to complete disaster recovery later.
+
+## Storage model
+
+### Recommended backend for V2
+
+Use a user selected cloud synced folder for the encrypted backup file first:
+
+- `iCloud Drive`
+- `Google Drive`
+- `OneDrive`
+- `Dropbox`
+
+Reasons:
+
+- users already have these accounts
+- setup is path based instead of credential based
+- users already understand “a backup file in my cloud drive”
+- the product can still keep state safety by writing a single encrypted archive file instead of
+  syncing the live state directory
+
+### Safety rule
+
+The product should make one distinction explicit:
+
+- allowed
+  - writing a single encrypted backup archive into a cloud drive folder
+- not allowed
+  - putting the live `~/.openclaw` directory itself into a cloud synced folder
+
+### What not to use as the primary snapshot store
+
+- GitHub private repositories as the default for ordinary users
+- raw syncing of the live `~/.openclaw` directory into iCloud, Dropbox, Google Drive, OneDrive,
+  and similar sync folders
+- databases or document stores that do not naturally model immutable binary objects
+
+Those options are either too size constrained, too dangerous when used as live sync, or too
+operationally awkward for personal user disaster recovery.
+
+### Backup file layout
+
+Each installation writes encrypted snapshot files into one selected backup folder.
+
+Example:
+
+```text
+<cloud-drive-folder>/
+  OpenClaw Backups/
+    installation.json
+    snapshots/
+      2026-03-10T10-00-00Z-openclaw-backup.envelope.json
+      2026-03-10T10-00-00Z-openclaw-backup.payload.bin
+      2026-03-11T10-00-00Z-openclaw-backup.envelope.json
+      2026-03-11T10-00-00Z-openclaw-backup.payload.bin
+```
+
+`installationId` should still be stable for one gateway lineage and survive host replacement after
+restore.
+
+### Data plane and control plane split
+
+The implementation should keep three concerns separate:
+
+- data plane
+  - encrypted snapshot payloads and envelopes stored as files in the backup folder
+- control plane
+  - local scheduling, retention decisions, status history, and restore orchestration
+- operator plane
+  - human visible status, alerts, and audit logs
+
+This makes it possible to support small local setups and enterprise managed setups with the same
+backup artifact format.
+
+## Encryption model
+
+All cloud backups should be encrypted before being copied into the backup folder.
+
+### Envelope
+
+```json
+{
+  "schemaVersion": 1,
+  "createdAt": "2026-03-09T12:00:00.000Z",
+  "snapshotId": "snap_...",
+  "installationId": "inst_...",
+  "cipher": "aes-256-gcm",
+  "kdf": {
+    "name": "argon2id",
+    "memoryKiB": 262144,
+    "timeCost": 3,
+    "parallelism": 1,
+    "salt": "..."
+  },
+  "wrappedDataKey": "...",
+  "nonce": "...",
+  "archiveSha256": "...",
+  "archiveFormat": "openclaw-backup-tar-gz"
+}
+```
+
+### Key sources
+
+Support these sources in order:
+
+- passphrase entered interactively
+- `SecretRef`
+- environment variable
+- external key service integration in a later phase
+
+The backup file location and the backup encryption key must remain separate concerns.
+
+### Industrial grade key hierarchy
+
+The long term key model should distinguish:
+
+- `DEK`
+  - a per snapshot data encryption key used to encrypt the archive payload
+- `KEK`
+  - a longer lived key used to wrap the DEK
+- operator secret source
+  - passphrase, secret ref, environment, or a later advanced key resolver
+
+For the first production implementation, OpenClaw can derive or resolve a single logical key and
+use it to wrap a fresh per snapshot `DEK`.
+
+### Storage side encryption
+
+### Key rotation
+
+The system should support two distinct rotations:
+
+- backup folder location changes without touching old snapshots
+- backup key rotation by rewrapping future snapshots to a new `KEK`
+
+Re-encrypting all old snapshots should be optional and handled as a maintenance workflow, not as a
+normal backup path.
+
+### Why client side encryption
+
+This keeps the current trust boundary simple:
+
+- OpenClaw operators control backup readability
+- the cloud drive only stores ciphertext files
+- restoring from leaked backup files still requires the backup key
+
+### Threat model boundaries
+
+This design protects against:
+
+- leakage of backup files without the backup key
+- cloud provider compromise that exposes only stored objects
+- accidental deletion or overwrite when immutable storage controls are enabled
+
+This design does not protect against:
+
+- simultaneous compromise of the backup files and the backup key source
+- malicious code already running on the gateway host at backup time
+- operators intentionally restoring sensitive data to an untrusted host
+
+## Backup contents
+
+Cloud snapshots should build from the same logical asset planning as local backup.
+
+Included by default:
+
+- state dir
+- active config
+- credentials dir
+- discovered workspaces
+
+Excluded by default:
+
+- lock files
+- pid files
+- temp directories
+- pending pairing requests older than a short threshold
+- local caches that can be rebuilt
+
+`V2` should not start with user facing content selection. The default snapshot is the whole
+recoverable gateway state plus workspace.
+
+## Restore model
+
+`V2` should support one normal restore path: full host restore.
+
+### Full host restore
+
+Use when replacing the gateway machine.
+
+Restores:
+
+- config
+- credentials
+- pairing state
+- sessions
+- transcripts
+- workspace
+
+Flow:
+
+1. Stop the gateway.
+2. Download snapshot metadata.
+3. Verify integrity.
+4. Decrypt into a staging directory.
+5. Validate manifest paths and schema versions.
+6. Replace the target state directory atomically where possible.
+7. Run `openclaw doctor`.
+8. Restart the gateway.
+
+For industrial deployments, the restore pipeline should also produce a structured restore report
+with:
+
+- snapshot id
+- archive and ciphertext hashes
+- restore start and end timestamps
+- restored targets
+- doctor result
+- operator supplied ticket or change reference if available
+
+## Cross device restore model
+
+The primary cross device story should be gateway continuity, not filesystem cloning across clients.
+
+### Supported
+
+- restore a gateway snapshot onto a new laptop, VM, or server
+- reconnect the same chat channels after restore
+- preserve sessions, transcripts, and pairings held by the gateway
+- continue using a workspace from Git plus state from cloud backup
+
+### Not supported by default
+
+- cloning a mobile or desktop device private identity onto another physical device
+- syncing device local auth caches across phones or laptops
+
+### Reason
+
+Device identity is used as a trust anchor. Copying that identity to another device silently weakens
+the security model and makes device scoped approvals harder to reason about.
+
+Instead, a new device should pair again against the restored gateway. This preserves:
+
+- device provenance
+- per device revocation
+- operator visibility
+
+## CLI proposal
+
+The CLI should also be phased to match the product rollout.
+
+### V1 commands
+
+```bash
+openclaw backup setup
+openclaw backup status
+openclaw backup run
+```
+
+`V1` should stay narrowly focused on helping the user initialize, run, and validate a workspace
+backup into their cloud drive folder. It should not pretend to be full disaster recovery.
+
+### V2 commands
+
+```bash
+openclaw backup run
+openclaw backup list
+openclaw backup restore <snapshot-id>
+```
+
+### Command semantics
+
+#### `openclaw backup run`
+
+Creates a local archive using the existing backup planner, encrypts it, copies it into the
+configured cloud drive folder, and optionally applies retention.
+
+Key flags:
+
+- `--verify`: run local archive verification before encrypt and copy
+- `--output <dir>`: keep the intermediate local archive in a specific directory
+- `--json`
+- `--snapshot-name <name>`: optional human label for operator visibility
+- `--no-retention-prune`: copy only, skip retention cleanup
+
+#### `openclaw backup list`
+
+Lists snapshots visible in the configured backup folder.
+
+Key fields in human and JSON output:
+
+- snapshot id
+- created at
+- snapshot name if present
+- archive size
+- included asset modes
+- openclaw version
+- verified status
+
+#### `openclaw backup restore`
+
+Restores one snapshot into the local installation.
+
+Key flags:
+
+- `--from-file <path>`: restore from a previously copied encrypted bundle
+- `--archive <path>`: restore from a local plaintext backup archive
+- `--staging-dir <path>`
+- `--force-stop`
+- `--skip-doctor`
+- `--restart`
+- `--json`
+
+### Restore safeguards
+
+- refuse to restore while the gateway is running unless `--force-stop` is passed
+- refuse to restore into a cloud synced state dir
+- require explicit confirmation for full host restore in interactive mode
+- always restore into staging first, never stream extract directly into the live state dir
+- run the same archive verification checks used by `backup verify`
+- emit machine readable failure classes and phase names for automation
+
+## Config proposal
+
+`V2` should start with a minimal configuration surface.
+
+```json5
+{
+  backup: {
+    target: "~/Library/Mobile Documents/com~apple~CloudDocs/OpenClaw Backups",
+    encryption: {
+      key: "${OPENCLAW_BACKUP_KEY}",
+    },
+  },
+}
+```
+
+The backup encryption key should follow the same secret handling rules as other credentials and
+should not be duplicated into the workspace.
+
+### Config schema draft
+
+This should be added under the top level `backup` key.
+
+```ts
+type BackupConfig = {
+  target?: string;
+  encryption?: {
+    key?: SecretInput;
+  };
+};
+```
+
+### Deferred advanced config
+
+The following should be deferred until the basic full snapshot flow is stable:
+
+- custom retention tuning
+- transcript exclusion
+- alternate provider specific integrations
+- `KMS` integrations
+
+### Config field semantics
+
+- `backup.target`
+  - required for cloud drive style backup
+  - points to a folder that OpenClaw owns for encrypted backup files
+- `backup.encryption.key`
+  - required for `push` and `restore`
+  - should use existing `SecretInput` support so env and file refs work the same way as other secrets
+
+### Validation rules
+
+- `backup.target` is required for the first release path
+- `backup.encryption.key` is required for any command that would encrypt or decrypt
+- reject `backup.target` when it resolves inside the live state directory
+- reject restore if the resolved local state dir is inside a synced folder even if the backup itself
+  is valid
+
+## Snapshot metadata model
+
+The design should separate three layers of metadata.
+
+### 1. Existing local backup manifest
+
+This remains the manifest embedded inside the plaintext local backup archive produced by the current
+backup system.
+
+It describes:
+
+- included source trees
+- archive layout
+- local backup options
+
+### 2. New cloud snapshot envelope
+
+This is the outer metadata for encrypted backup files.
+
+It describes:
+
+- snapshot id
+- installation id
+- encryption and KDF parameters
+- plaintext archive hash
+- ciphertext hash
+- optional snapshot label
+
+### 3. Backup folder index entry
+
+This is the compact listing record used by `backup list`.
+
+It should be safe to read without downloading the payload and should not include secrets or full
+manifest contents.
+
+Example:
+
+```json
+{
+  "schemaVersion": 1,
+  "snapshotId": "snap_20260309_120000_abc123",
+  "installationId": "inst_main_123",
+  "createdAt": "2026-03-09T12:00:00.000Z",
+  "snapshotName": "pre-migration",
+  "openclawVersion": "2026.3.9",
+  "mode": "full-host",
+  "includeWorkspace": true,
+  "excludeTranscripts": false,
+  "archiveBytes": 182340123,
+  "ciphertextBytes": 182341024,
+  "verified": true
+}
+```
+
+## Installation identity
+
+Cloud backup needs a stable installation identifier that outlives a single host.
+
+### Proposed behavior
+
+- create `installationId` on first successful `backup setup`
+- store it in the state dir under a small dedicated file such as `~/.openclaw/backup/installation.json`
+- restore should preserve this id by default for lineage continuity
+- a user may explicitly rotate it with a later admin command if they want to fork backup history
+
+This id is not a secret. It is a lineage identifier used for listing and retention scope.
+
+## Retention policy
+
+Retention should be deterministic and local decision based.
+
+### Initial algorithm
+
+- keep all snapshots from the last `keepDaily` distinct UTC days
+- keep the most recent snapshot from the last `keepWeekly` distinct ISO weeks beyond the daily set
+- keep the most recent snapshot from the last `keepMonthly` distinct year-month buckets beyond the
+  daily and weekly sets
+- apply `maxSnapshots` as a final hard cap after bucket selection
+
+If retention deletes anything, it should only delete snapshot prefixes that are not selected by the
+current policy and belong to the current installation id.
+
+### Why not rely only on cloud drive version history
+
+Cloud drive version history is too provider specific and too blunt for the first version. OpenClaw
+needs operator visible selection rules and reproducible tests.
+
+## Restore implementation detail
+
+### Restore state machine
+
+The restore pipeline should have explicit phases and checkpoint files in the staging dir:
+
+```text
+resolve-source
+  -> download
+  -> verify-envelope
+  -> decrypt
+  -> verify-archive
+  -> extract
+  -> validate-extract
+  -> prepare-swap
+  -> swap
+  -> doctor
+  -> restart
+```
+
+Each phase should write a tiny status file under the staging dir so interrupted restores are easier
+to inspect.
+
+### Staging layout
+
+```text
+<staging-dir>/
+  envelope.json
+  payload.bin
+  archive.tar.gz
+  extracted/
+  checkpoints/
+  logs/
+```
+
+### Swap rules
+
+- never mutate the live state dir until `validate-extract` passes
+- move the current live dir to a timestamped rollback dir first when possible
+- move the extracted dir into place
+- if swap fails mid-flight, attempt best effort rollback
+- keep at most a small number of rollback dirs and document their location
+
+### Validation before swap
+
+- backup archive verifies successfully
+- extracted config path is present for full host restore
+- required session directories exist when restoring sessions
+- permissions on sensitive files are tightened after extract
+- no extracted path escapes the staging root
+- the snapshot belongs to the expected `installationId` unless the operator explicitly allows lineage
+  fork or adoption
+
+## Same device identity export
+
+The normal roadmap should not attempt device identity export. If this ever exists in a much later
+phase, it should remain outside the default user experience and be treated as an advanced recovery
+tool only.
+
+## Operator visible status
+
+Later status surfaces should expose:
+
+- last successful cloud backup time
+- last failed cloud backup time and phase
+- latest snapshot id
+- whether retention pruning deleted any old snapshots
+- whether the current state dir is ineligible due to synced-folder placement
+- last successful restore drill time
+- active backup profile and storage target
+- whether immutable storage protections are detected or missing
+
+## Exit codes and failure classes
+
+Cloud backup commands should return stable failure classes for automation:
+
+- `2`: config invalid or missing required backup config
+- `3`: secret resolution failed
+- `4`: remote auth or connectivity failed
+- `5`: verification failed
+- `6`: decryption failed
+- `7`: restore swap failed
+- `8`: doctor failed after restore
+
+Exact numeric mapping can still change, but the implementation should keep the failure classes
+separate in code and docs.
+
+## Scheduling and execution model
+
+Industrial grade backup should be host initiated and single writer only.
+
+### Scheduler requirements
+
+- run on the active gateway host only
+- skip overlapping runs if a prior backup is still active
+- write a local execution record for each attempt
+- jitter scheduled execution slightly to avoid fleet thundering herds in managed deployments
+- allow operator forced ad hoc snapshots without disrupting the normal schedule
+
+### Execution phases
+
+Each scheduled run should record:
+
+- plan
+- package
+- verify
+- encrypt
+- copy
+- index-update
+- retention
+- finalize
+
+This creates clean alerting and retry boundaries.
+
+## Internal architecture
+
+### Reuse existing modules
+
+- local backup asset planning from the current backup command
+- current backup manifest verification
+- state path resolution
+- doctor driven migration and repair after restore
+
+### New modules
+
+- `src/commands/backup-push.ts`
+- `src/commands/backup-list.ts`
+- `src/commands/backup-restore.ts`
+- `src/backup/cloud/encryption.ts`
+- `src/backup/cloud/retention.ts`
+- `src/backup/cloud/restore.ts`
+- `src/backup/cloud/scheduler.ts`
+- `src/backup/cloud/status.ts`
+
+### Restore pipeline
+
+```text
+backup file -> verify metadata -> decrypt -> local archive -> verify archive ->
+extract to staging -> validate structure -> swap -> doctor -> restart
+```
+
+## Compatibility and migration
+
+- cloud backup should wrap the existing local archive format rather than replace it
+- older local archives should remain restorable offline
+- restore should tolerate moved absolute source paths because the current backup manifest already
+  records the original path for provenance, not for exact path replay
+- follow up migrations belong in `openclaw doctor`, not inside ad hoc restore scripts
+
+## Security considerations
+
+- never write plaintext transcripts or tokens into the backup folder
+- never store the backup key in the same remote system as an unprotected config file
+- do not auto restore device private identities onto a different device
+- keep synced folder warnings intact
+- keep restore logs careful not to print secrets, raw tokens, or full decrypted manifest payloads
+- require stronger operator acknowledgement when restoring credentials onto a new host
+
+## Compliance and audit posture
+
+Industrial operators often need evidence, not just features.
+
+The design should make it possible to produce:
+
+- backup success and failure history
+- snapshot inventory by installation id
+- restore reports with timestamps and operator identity where available
+- proof that payloads are encrypted before being copied into the backup folder
+- proof that snapshot retention and delete actions were policy driven
+
+The first version does not need a full compliance framework, but the artifact and log model should
+not block later `SOC 2`, internal audit, or regulated environment workflows.
+
+## Failure handling
+
+If restore fails:
+
+- keep the existing live state directory untouched
+- preserve the staging directory for operator inspection when safe
+- emit a precise failure phase such as `copy`, `decrypt`, `verify`, `extract`, `swap`, or `doctor`
+- allow retry from the copied encrypted bundle without forcing another snapshot creation
+
+## Observability and alerting
+
+The implementation should expose enough local status for future UI, CLI, and external monitoring.
+
+Suggested metrics and status fields:
+
+- backup duration by phase
+- archive size and ciphertext size
+- age of last successful snapshot
+- consecutive failure count
+- restore drill freshness
+- retention delete count
+- backup target and installation id
+
+Suggested alert conditions:
+
+- no successful backup within `2 x` the configured schedule interval
+- verification failures
+- repeated backup folder write failures
+- restore drills older than the operator policy threshold
+
+## Testing plan
+
+- unit tests for encryption envelope encode and decode
+- unit tests for backup folder layout and retention selection
+- unit tests for restore refusal on synced state dirs
+- integration tests for `backup run` into a temp backup folder inside a synced-drive-like path
+- integration tests for `backup restore` into a temp home directory
+- regression tests proving that a restored gateway preserves session history and pairing state
+- tests that device local identities are excluded unless explicitly requested
+- tests for scheduler overlap prevention and resumable failure reporting
+- periodic manual or CI driven restore drills using real encrypted snapshots in a disposable target
+
+## Phased rollout
+
+### Phase 1
+
+Ship `v1` workspace backup:
+
+- workspace backup into a cloud drive folder
+- cloud drive folder as the documented default
+- setup and health checks focused on the workspace backup target
+- clear product messaging that this is memory and workspace protection, not full gateway recovery
+
+### Phase 2
+
+Ship `v2` encrypted full snapshots:
+
+- encrypted full snapshots copied into a cloud drive folder
+- manual restore command
+- cloud drive folder as the documented default
+- retention policies
+- scheduled snapshot creation
+- status visibility for last successful backup
+
+### Explicitly deferred
+
+- selective restore modes for normal users
+- device identity export or import across devices
+- multiple first class cloud providers in the initial user experience
+
+## Recommended operator guidance
+
+- use a cloud drive folder for day to day workspace and memory backup
+- use a private Git repository only when version control semantics are explicitly desired
+- use encrypted cloud snapshots only when full disaster recovery is needed
+- keep one local cold backup copy for worst case recovery
+- do not place `~/.openclaw` in a sync folder
+- treat restore drills as part of the operating procedure, not as an emergency only activity
+
+## Open questions
+
+- Should scheduled cloud backups run only on the gateway host or also from the macOS app UI?
+- Do we want to support encrypted deduplicated chunk stores later, or keep full snapshot archives only?
+- Should restore auto restart the gateway, or stop after `openclaw doctor` and require an explicit restart?
+- Which small cache directories are worth excluding from the first version for speed without harming recovery?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   tar: 7.5.11
   tough-cookie: 4.1.3
 
-packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
+packageExtensionsChecksum: 3811f68155837cf0accb2d98d55e636e
 
 importers:
 
@@ -5925,7 +5925,7 @@ packages:
     resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      request: ^2.34
+      request: npm:@cypress/request@3.0.10
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -6796,14 +6796,14 @@ snapshots:
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -6936,56 +6936,56 @@ snapshots:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/credential-provider-node': 3.972.14
+      '@aws-sdk/core': 3.973.18
+      '@aws-sdk/credential-provider-node': 3.972.18
       '@aws-sdk/middleware-bucket-endpoint': 3.972.6
       '@aws-sdk/middleware-expect-continue': 3.972.6
       '@aws-sdk/middleware-flexible-checksums': 3.973.1
-      '@aws-sdk/middleware-host-header': 3.972.6
+      '@aws-sdk/middleware-host-header': 3.972.7
       '@aws-sdk/middleware-location-constraint': 3.972.6
-      '@aws-sdk/middleware-logger': 3.972.6
-      '@aws-sdk/middleware-recursion-detection': 3.972.6
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-sdk-s3': 3.972.15
       '@aws-sdk/middleware-ssec': 3.972.6
-      '@aws-sdk/middleware-user-agent': 3.972.15
-      '@aws-sdk/region-config-resolver': 3.972.6
+      '@aws-sdk/middleware-user-agent': 3.972.19
+      '@aws-sdk/region-config-resolver': 3.972.7
       '@aws-sdk/signature-v4-multi-region': 3.996.3
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-endpoints': 3.996.3
-      '@aws-sdk/util-user-agent-browser': 3.972.6
-      '@aws-sdk/util-user-agent-node': 3.973.0
-      '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.6
-      '@smithy/eventstream-serde-browser': 4.2.10
-      '@smithy/eventstream-serde-config-resolver': 4.3.10
-      '@smithy/eventstream-serde-node': 4.2.10
-      '@smithy/fetch-http-handler': 5.3.11
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-endpoints': 3.996.4
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.4
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.9
+      '@smithy/eventstream-serde-browser': 4.2.11
+      '@smithy/eventstream-serde-config-resolver': 4.3.11
+      '@smithy/eventstream-serde-node': 4.2.11
+      '@smithy/fetch-http-handler': 5.3.13
       '@smithy/hash-blob-browser': 4.2.11
-      '@smithy/hash-node': 4.2.10
+      '@smithy/hash-node': 4.2.11
       '@smithy/hash-stream-node': 4.2.10
-      '@smithy/invalid-dependency': 4.2.10
+      '@smithy/invalid-dependency': 4.2.11
       '@smithy/md5-js': 4.2.10
-      '@smithy/middleware-content-length': 4.2.10
-      '@smithy/middleware-endpoint': 4.4.20
-      '@smithy/middleware-retry': 4.4.37
-      '@smithy/middleware-serde': 4.2.11
-      '@smithy/middleware-stack': 4.2.10
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/smithy-client': 4.12.0
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/middleware-retry': 4.4.40
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
       '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.10
-      '@smithy/util-base64': 4.3.1
-      '@smithy/util-body-length-browser': 4.2.1
-      '@smithy/util-body-length-node': 4.2.2
-      '@smithy/util-defaults-mode-browser': 4.3.36
-      '@smithy/util-defaults-mode-node': 4.2.39
-      '@smithy/util-endpoints': 3.3.1
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-retry': 4.2.10
-      '@smithy/util-stream': 4.5.15
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.39
+      '@smithy/util-defaults-mode-node': 4.2.42
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-stream': 4.5.17
+      '@smithy/util-utf8': 4.2.2
       '@smithy/util-waiter': 4.2.10
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7365,12 +7365,12 @@ snapshots:
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.6':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-arn-parser': 3.972.2
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/protocol-http': 5.3.10
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
-      '@smithy/util-config-provider': 4.2.1
+      '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-eventstream@3.972.7':
@@ -7382,8 +7382,8 @@ snapshots:
 
   '@aws-sdk/middleware-expect-continue@3.972.6':
     dependencies:
-      '@aws-sdk/types': 3.973.4
-      '@smithy/protocol-http': 5.3.10
+      '@aws-sdk/types': 3.973.5
+      '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -7392,16 +7392,16 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/core': 3.973.18
       '@aws-sdk/crc64-nvme': 3.972.3
-      '@aws-sdk/types': 3.973.4
-      '@smithy/is-array-buffer': 4.2.1
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/protocol-http': 5.3.10
+      '@aws-sdk/types': 3.973.5
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-stream': 4.5.15
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-stream': 4.5.17
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.6':
@@ -7420,7 +7420,7 @@ snapshots:
 
   '@aws-sdk/middleware-location-constraint@3.972.6':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -7454,24 +7454,24 @@ snapshots:
 
   '@aws-sdk/middleware-sdk-s3@3.972.15':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.18
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-arn-parser': 3.972.2
-      '@smithy/core': 3.23.6
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/signature-v4': 5.3.10
-      '@smithy/smithy-client': 4.12.0
+      '@smithy/core': 3.23.9
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/signature-v4': 5.3.11
+      '@smithy/smithy-client': 4.12.3
       '@smithy/types': 4.13.0
-      '@smithy/util-config-provider': 4.2.1
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-stream': 4.5.15
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-stream': 4.5.17
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-ssec@3.972.6':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -7681,9 +7681,9 @@ snapshots:
   '@aws-sdk/signature-v4-multi-region@3.996.3':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.15
-      '@aws-sdk/types': 3.973.4
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/signature-v4': 5.3.10
+      '@aws-sdk/types': 3.973.5
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/signature-v4': 5.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -9667,7 +9667,7 @@ snapshots:
 
   '@smithy/chunked-blob-reader-native@4.2.2':
     dependencies:
-      '@smithy/util-base64': 4.3.1
+      '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
   '@smithy/chunked-blob-reader@5.2.1':
@@ -9834,7 +9834,7 @@ snapshots:
   '@smithy/hash-stream-node@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.10':
@@ -9862,7 +9862,7 @@ snapshots:
   '@smithy/md5-js@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.10':
@@ -10267,7 +10267,7 @@ snapshots:
 
   '@smithy/util-waiter@4.2.10':
     dependencies:
-      '@smithy/abort-controller': 4.2.10
+      '@smithy/abort-controller': 4.2.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   tar: 7.5.11
   tough-cookie: 4.1.3
 
-packageExtensionsChecksum: 3811f68155837cf0accb2d98d55e636e
+packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
 importers:
 
@@ -5925,7 +5925,7 @@ packages:
     resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      request: npm:@cypress/request@3.0.10
+      request: ^2.34
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}

--- a/src/backup/snapshot-store/config.test.ts
+++ b/src/backup/snapshot-store/config.test.ts
@@ -38,6 +38,7 @@ describe("resolveSnapshotStoreConfig", () => {
         env: {
           ...process.env,
           HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
         },
       }),
     ).rejects.toThrow("backup.target must not be inside the live state directory.");

--- a/src/backup/snapshot-store/config.test.ts
+++ b/src/backup/snapshot-store/config.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveSnapshotStoreConfig } from "./config.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+  }
+});
+
+describe("resolveSnapshotStoreConfig", () => {
+  it("rejects backup targets that resolve into the live state directory via symlink", async () => {
+    const homeDir = await createTempDir("openclaw-backup-config-home-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const linkedTarget = path.join(homeDir, "BackupsLink");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.symlink(stateDir, linkedTarget);
+
+    await expect(
+      resolveSnapshotStoreConfig({
+        config: {
+          backup: {
+            target: linkedTarget,
+            encryption: { key: "secret" },
+          },
+        },
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      }),
+    ).rejects.toThrow("backup.target must not be inside the live state directory.");
+  });
+
+  it("rejects backup targets that live inside a configured workspace", async () => {
+    const homeDir = await createTempDir("openclaw-backup-config-workspace-");
+    const workspaceDir = path.join(homeDir, "workspace");
+    const targetDir = path.join(workspaceDir, "Backups");
+
+    await fs.mkdir(targetDir, { recursive: true });
+
+    await expect(
+      resolveSnapshotStoreConfig({
+        config: {
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+            },
+          },
+          backup: {
+            target: targetDir,
+            encryption: { key: "secret" },
+          },
+        },
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      }),
+    ).rejects.toThrow("backup.target must not be inside a workspace being backed up.");
+  });
+});

--- a/src/backup/snapshot-store/config.ts
+++ b/src/backup/snapshot-store/config.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs/promises";
 import path from "node:path";
+import { collectWorkspaceDirs, isPathWithin } from "../../commands/cleanup-utils.js";
 import type { BackupConfig, OpenClawConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/config.js";
 import { normalizeSecretInputString } from "../../config/types.secrets.js";
@@ -10,9 +12,23 @@ export type ResolvedSnapshotStoreConfig = {
   encryptionKey: string;
 };
 
-function isPathWithin(child: string, parent: string): boolean {
-  const relative = path.relative(parent, child);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+async function canonicalizePathForContainment(inputPath: string): Promise<string> {
+  const resolved = path.resolve(inputPath);
+  const suffix: string[] = [];
+  let probe = resolved;
+  while (true) {
+    try {
+      const real = await fs.realpath(probe);
+      return suffix.length === 0 ? real : path.join(real, ...suffix.toReversed());
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) {
+        return resolved;
+      }
+      suffix.push(path.basename(probe));
+      probe = parent;
+    }
+  }
 }
 
 function resolveConfiguredBackupSection(cfg: OpenClawConfig): NonNullable<BackupConfig> {
@@ -42,10 +58,16 @@ export async function resolveSnapshotStoreConfig(params: {
     throw new Error("backup.encryption.key is required.");
   }
 
-  const targetDir = resolveUserPath(target);
-  const stateDir = resolveStateDir(params.env);
+  const targetDir = await canonicalizePathForContainment(resolveUserPath(target));
+  const stateDir = await canonicalizePathForContainment(resolveStateDir(params.env));
   if (isPathWithin(targetDir, stateDir)) {
     throw new Error("backup.target must not be inside the live state directory.");
+  }
+  for (const workspaceDir of collectWorkspaceDirs(params.config)) {
+    const canonicalWorkspaceDir = await canonicalizePathForContainment(workspaceDir);
+    if (isPathWithin(targetDir, canonicalWorkspaceDir)) {
+      throw new Error("backup.target must not be inside a workspace being backed up.");
+    }
   }
 
   return {

--- a/src/backup/snapshot-store/config.ts
+++ b/src/backup/snapshot-store/config.ts
@@ -60,12 +60,12 @@ export async function resolveSnapshotStoreConfig(params: {
 
   const targetDir = await canonicalizePathForContainment(resolveUserPath(target));
   const stateDir = await canonicalizePathForContainment(resolveStateDir(params.env));
-  if (isPathWithin(targetDir, stateDir)) {
+  if (targetDir === stateDir || isPathWithin(targetDir, stateDir)) {
     throw new Error("backup.target must not be inside the live state directory.");
   }
   for (const workspaceDir of collectWorkspaceDirs(params.config)) {
     const canonicalWorkspaceDir = await canonicalizePathForContainment(workspaceDir);
-    if (isPathWithin(targetDir, canonicalWorkspaceDir)) {
+    if (targetDir === canonicalWorkspaceDir || isPathWithin(targetDir, canonicalWorkspaceDir)) {
       throw new Error("backup.target must not be inside a workspace being backed up.");
     }
   }

--- a/src/backup/snapshot-store/config.ts
+++ b/src/backup/snapshot-store/config.ts
@@ -1,0 +1,55 @@
+import path from "node:path";
+import type { BackupConfig, OpenClawConfig } from "../../config/config.js";
+import { resolveStateDir } from "../../config/config.js";
+import { normalizeSecretInputString } from "../../config/types.secrets.js";
+import { resolveSecretInputString } from "../../secrets/resolve-secret-input-string.js";
+import { resolveUserPath } from "../../utils.js";
+
+export type ResolvedSnapshotStoreConfig = {
+  targetDir: string;
+  encryptionKey: string;
+};
+
+function isPathWithin(child: string, parent: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function resolveConfiguredBackupSection(cfg: OpenClawConfig): NonNullable<BackupConfig> {
+  const backup = cfg.backup;
+  if (!backup?.target?.trim()) {
+    throw new Error("backup.target is not configured.");
+  }
+  return backup;
+}
+
+export async function resolveSnapshotStoreConfig(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<ResolvedSnapshotStoreConfig> {
+  const backup = resolveConfiguredBackupSection(params.config);
+  const target = backup.target;
+  if (!target) {
+    throw new Error("backup.target is not configured.");
+  }
+  const encryptionKey = await resolveSecretInputString({
+    config: params.config,
+    value: backup.encryption?.key,
+    env: params.env,
+    normalize: (value) => normalizeSecretInputString(value)?.trim() || undefined,
+  });
+  if (!encryptionKey) {
+    throw new Error("backup.encryption.key is required.");
+  }
+
+  const targetDir = resolveUserPath(target);
+  const stateDir = resolveStateDir(params.env);
+  if (isPathWithin(targetDir, stateDir)) {
+    throw new Error("backup.target must not be inside the live state directory.");
+  }
+
+  return {
+    targetDir,
+    encryptionKey,
+  };
+}

--- a/src/backup/snapshot-store/config.ts
+++ b/src/backup/snapshot-store/config.ts
@@ -12,6 +12,11 @@ export type ResolvedSnapshotStoreConfig = {
   encryptionKey: string;
 };
 
+/** Target-only config for read-only operations that do not need decryption. */
+export type ResolvedSnapshotStoreTargetConfig = {
+  targetDir: string;
+};
+
 async function canonicalizePathForContainment(inputPath: string): Promise<string> {
   const resolved = path.resolve(inputPath);
   const suffix: string[] = [];
@@ -39,23 +44,18 @@ function resolveConfiguredBackupSection(cfg: OpenClawConfig): NonNullable<Backup
   return backup;
 }
 
-export async function resolveSnapshotStoreConfig(params: {
+/**
+ * Resolve and validate the backup target directory from config.
+ * Shared by both full config resolution and target-only resolution.
+ */
+async function resolveValidatedTargetDir(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
-}): Promise<ResolvedSnapshotStoreConfig> {
+}): Promise<string> {
   const backup = resolveConfiguredBackupSection(params.config);
   const target = backup.target;
   if (!target) {
     throw new Error("backup.target is not configured.");
-  }
-  const encryptionKey = await resolveSecretInputString({
-    config: params.config,
-    value: backup.encryption?.key,
-    env: params.env,
-    normalize: (value) => normalizeSecretInputString(value)?.trim() || undefined,
-  });
-  if (!encryptionKey) {
-    throw new Error("backup.encryption.key is required.");
   }
 
   const targetDir = await canonicalizePathForContainment(resolveUserPath(target));
@@ -70,8 +70,37 @@ export async function resolveSnapshotStoreConfig(params: {
     }
   }
 
-  return {
-    targetDir,
-    encryptionKey,
-  };
+  return targetDir;
+}
+
+export async function resolveSnapshotStoreConfig(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<ResolvedSnapshotStoreConfig> {
+  const backup = resolveConfiguredBackupSection(params.config);
+  const encryptionKey = await resolveSecretInputString({
+    config: params.config,
+    value: backup.encryption?.key,
+    env: params.env,
+    normalize: (value) => normalizeSecretInputString(value)?.trim() || undefined,
+  });
+  if (!encryptionKey) {
+    throw new Error("backup.encryption.key is required.");
+  }
+
+  const targetDir = await resolveValidatedTargetDir(params);
+  return { targetDir, encryptionKey };
+}
+
+/**
+ * Resolve only the target directory, skipping encryption key validation.
+ * Used by read-only operations (e.g. listing snapshots) that only need
+ * envelope metadata from disk and never perform decryption.
+ */
+export async function resolveSnapshotStoreTargetConfig(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<ResolvedSnapshotStoreTargetConfig> {
+  const targetDir = await resolveValidatedTargetDir(params);
+  return { targetDir };
 }

--- a/src/backup/snapshot-store/encryption.test.ts
+++ b/src/backup/snapshot-store/encryption.test.ts
@@ -27,7 +27,7 @@ describe("snapshot backup encryption", () => {
     const encrypted = await encryptArchiveToPayload({
       archivePath,
       payloadPath,
-      secret: "test-secret",
+      secret: "test-secret", // pragma: allowlist secret
     });
     encrypted.archive.archiveRoot = "fake-root";
     encrypted.archive.createdAt = "2026-03-09T00:00:00.000Z";
@@ -35,7 +35,7 @@ describe("snapshot backup encryption", () => {
     await decryptPayloadToArchive({
       payloadPath,
       archivePath: restoredPath,
-      secret: "test-secret",
+      secret: "test-secret", // pragma: allowlist secret
       envelope: encrypted,
     });
 
@@ -52,7 +52,7 @@ describe("snapshot backup encryption", () => {
     const encrypted = await encryptArchiveToPayload({
       archivePath,
       payloadPath,
-      secret: "test-secret",
+      secret: "test-secret", // pragma: allowlist secret
     });
     encrypted.archive.archiveRoot = "fake-root";
     encrypted.archive.createdAt = "2026-03-09T00:00:00.000Z";
@@ -62,7 +62,7 @@ describe("snapshot backup encryption", () => {
       decryptPayloadToArchive({
         payloadPath,
         archivePath: restoredPath,
-        secret: "test-secret",
+        secret: "test-secret", // pragma: allowlist secret
         envelope: encrypted,
       }),
     ).rejects.toThrow("Decrypted archive checksum mismatch.");

--- a/src/backup/snapshot-store/encryption.test.ts
+++ b/src/backup/snapshot-store/encryption.test.ts
@@ -69,4 +69,30 @@ describe("snapshot backup encryption", () => {
     await expect(fs.access(restoredPath)).rejects.toThrow();
     await expect(fs.access(`${restoredPath}.${process.pid}.tmp`)).rejects.toThrow();
   });
+
+  it("uses envelope key-derivation parameters when deriving the restore key", async () => {
+    const tempDir = await createTempDir("openclaw-snapshot-encryption-kdf-");
+    const archivePath = path.join(tempDir, "archive.tar.gz");
+    const payloadPath = path.join(tempDir, "payload.bin");
+    const restoredPath = path.join(tempDir, "restored.tar.gz");
+    await fs.writeFile(archivePath, "backup archive test\n", "utf8");
+
+    const encrypted = await encryptArchiveToPayload({
+      archivePath,
+      payloadPath,
+      secret: "test-secret", // pragma: allowlist secret
+    });
+    encrypted.archive.archiveRoot = "fake-root";
+    encrypted.archive.createdAt = "2026-03-09T00:00:00.000Z";
+    encrypted.encryption.keyDerivation.cost = encrypted.encryption.keyDerivation.cost + 1;
+
+    await expect(
+      decryptPayloadToArchive({
+        payloadPath,
+        archivePath: restoredPath,
+        secret: "test-secret", // pragma: allowlist secret
+        envelope: encrypted,
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/src/backup/snapshot-store/encryption.test.ts
+++ b/src/backup/snapshot-store/encryption.test.ts
@@ -41,4 +41,32 @@ describe("snapshot backup encryption", () => {
 
     expect(await fs.readFile(restoredPath, "utf8")).toBe("backup archive test\n");
   });
+
+  it("removes temporary plaintext archives when integrity validation fails", async () => {
+    const tempDir = await createTempDir("openclaw-snapshot-encryption-fail-");
+    const archivePath = path.join(tempDir, "archive.tar.gz");
+    const payloadPath = path.join(tempDir, "payload.bin");
+    const restoredPath = path.join(tempDir, "restored.tar.gz");
+    await fs.writeFile(archivePath, "backup archive test\n", "utf8");
+
+    const encrypted = await encryptArchiveToPayload({
+      archivePath,
+      payloadPath,
+      secret: "test-secret",
+    });
+    encrypted.archive.archiveRoot = "fake-root";
+    encrypted.archive.createdAt = "2026-03-09T00:00:00.000Z";
+    encrypted.archive.sha256 = "bad-sha";
+
+    await expect(
+      decryptPayloadToArchive({
+        payloadPath,
+        archivePath: restoredPath,
+        secret: "test-secret",
+        envelope: encrypted,
+      }),
+    ).rejects.toThrow("Decrypted archive checksum mismatch.");
+    await expect(fs.access(restoredPath)).rejects.toThrow();
+    await expect(fs.access(`${restoredPath}.${process.pid}.tmp`)).rejects.toThrow();
+  });
 });

--- a/src/backup/snapshot-store/encryption.test.ts
+++ b/src/backup/snapshot-store/encryption.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { decryptPayloadToArchive, encryptArchiveToPayload } from "./encryption.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("snapshot backup encryption", () => {
+  it("round trips a local archive through encrypt and decrypt", async () => {
+    const tempDir = await createTempDir("openclaw-snapshot-encryption-");
+    const archivePath = path.join(tempDir, "archive.tar.gz");
+    const payloadPath = path.join(tempDir, "payload.bin");
+    const restoredPath = path.join(tempDir, "restored.tar.gz");
+    await fs.writeFile(archivePath, "backup archive test\n", "utf8");
+
+    const encrypted = await encryptArchiveToPayload({
+      archivePath,
+      payloadPath,
+      secret: "test-secret",
+    });
+    encrypted.archive.archiveRoot = "fake-root";
+    encrypted.archive.createdAt = "2026-03-09T00:00:00.000Z";
+
+    await decryptPayloadToArchive({
+      payloadPath,
+      archivePath: restoredPath,
+      secret: "test-secret",
+      envelope: encrypted,
+    });
+
+    expect(await fs.readFile(restoredPath, "utf8")).toBe("backup archive test\n");
+  });
+});

--- a/src/backup/snapshot-store/encryption.ts
+++ b/src/backup/snapshot-store/encryption.ts
@@ -1,0 +1,147 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { BackupSnapshotEnvelope } from "./types.js";
+
+const SCRYPT_COST = 1 << 15;
+const SCRYPT_BLOCK_SIZE = 8;
+const SCRYPT_PARALLELIZATION = 1;
+const SCRYPT_MAX_MEMORY_BYTES = 128 * 1024 * 1024;
+const NONCE_BYTES = 12;
+const KEY_BYTES = 32;
+
+class HashPassthrough extends Transform {
+  private readonly hash = crypto.createHash("sha256");
+  bytes = 0;
+
+  override _transform(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null, data?: Buffer | string) => void,
+  ): void {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.hash.update(buffer);
+    this.bytes += buffer.length;
+    callback(null, chunk);
+  }
+
+  digestHex(): string {
+    return this.hash.digest("hex");
+  }
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer.toString("base64url");
+}
+
+function base64UrlDecode(value: string): Buffer {
+  return Buffer.from(value, "base64url");
+}
+
+async function deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
+  return await new Promise((resolve, reject) => {
+    crypto.scrypt(
+      secret,
+      salt,
+      KEY_BYTES,
+      {
+        N: SCRYPT_COST,
+        r: SCRYPT_BLOCK_SIZE,
+        p: SCRYPT_PARALLELIZATION,
+        maxmem: SCRYPT_MAX_MEMORY_BYTES,
+      },
+      (error, derivedKey) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(Buffer.from(derivedKey));
+      },
+    );
+  });
+}
+
+export async function encryptArchiveToPayload(params: {
+  archivePath: string;
+  payloadPath: string;
+  secret: string;
+}): Promise<Pick<BackupSnapshotEnvelope, "archive" | "ciphertext" | "encryption">> {
+  const salt = crypto.randomBytes(16);
+  const nonce = crypto.randomBytes(NONCE_BYTES);
+  const key = await deriveKey(params.secret, salt);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, nonce);
+  const archiveDigest = new HashPassthrough();
+  const ciphertextDigest = new HashPassthrough();
+
+  await pipeline(
+    fs.createReadStream(params.archivePath),
+    archiveDigest,
+    cipher,
+    ciphertextDigest,
+    fs.createWriteStream(params.payloadPath, { mode: 0o600 }),
+  );
+
+  return {
+    archive: {
+      format: "openclaw-backup-tar-gz",
+      archiveRoot: "",
+      createdAt: "",
+      mode: "full-host",
+      includeWorkspace: true,
+      verified: false,
+      sha256: archiveDigest.digestHex(),
+      bytes: archiveDigest.bytes,
+    },
+    ciphertext: {
+      sha256: ciphertextDigest.digestHex(),
+      bytes: ciphertextDigest.bytes,
+    },
+    encryption: {
+      cipher: "aes-256-gcm",
+      keyDerivation: {
+        name: "scrypt",
+        saltBase64Url: base64UrlEncode(salt),
+        cost: SCRYPT_COST,
+        blockSize: SCRYPT_BLOCK_SIZE,
+        parallelization: SCRYPT_PARALLELIZATION,
+        maxMemoryBytes: SCRYPT_MAX_MEMORY_BYTES,
+      },
+      nonceBase64Url: base64UrlEncode(nonce),
+      authTagBase64Url: base64UrlEncode(cipher.getAuthTag()),
+    },
+  };
+}
+
+export async function decryptPayloadToArchive(params: {
+  payloadPath: string;
+  archivePath: string;
+  secret: string;
+  envelope: Pick<BackupSnapshotEnvelope, "archive" | "ciphertext" | "encryption">;
+}): Promise<void> {
+  const salt = base64UrlDecode(params.envelope.encryption.keyDerivation.saltBase64Url);
+  const nonce = base64UrlDecode(params.envelope.encryption.nonceBase64Url);
+  const authTag = base64UrlDecode(params.envelope.encryption.authTagBase64Url);
+  const key = await deriveKey(params.secret, salt);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, nonce);
+  decipher.setAuthTag(authTag);
+  const ciphertextDigest = new HashPassthrough();
+  const archiveDigest = new HashPassthrough();
+
+  await pipeline(
+    fs.createReadStream(params.payloadPath),
+    ciphertextDigest,
+    decipher,
+    archiveDigest,
+    fs.createWriteStream(params.archivePath, { mode: 0o600 }),
+  );
+
+  const archiveSha = archiveDigest.digestHex();
+  const ciphertextSha = ciphertextDigest.digestHex();
+  if (ciphertextSha !== params.envelope.ciphertext.sha256) {
+    throw new Error("Downloaded payload checksum mismatch.");
+  }
+  if (archiveSha !== params.envelope.archive.sha256) {
+    throw new Error("Decrypted archive checksum mismatch.");
+  }
+}

--- a/src/backup/snapshot-store/encryption.ts
+++ b/src/backup/snapshot-store/encryption.ts
@@ -10,6 +10,12 @@ const SCRYPT_PARALLELIZATION = 1;
 const SCRYPT_MAX_MEMORY_BYTES = 128 * 1024 * 1024;
 const NONCE_BYTES = 12;
 const KEY_BYTES = 32;
+type ScryptOptions = {
+  cost: number;
+  blockSize: number;
+  parallelization: number;
+  maxMemoryBytes: number;
+};
 
 class HashPassthrough extends Transform {
   private readonly hash = crypto.createHash("sha256");
@@ -40,16 +46,29 @@ function base64UrlDecode(value: string): Buffer {
 }
 
 async function deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
+  return await deriveKeyWithOptions(secret, salt, {
+    cost: SCRYPT_COST,
+    blockSize: SCRYPT_BLOCK_SIZE,
+    parallelization: SCRYPT_PARALLELIZATION,
+    maxMemoryBytes: SCRYPT_MAX_MEMORY_BYTES,
+  });
+}
+
+async function deriveKeyWithOptions(
+  secret: string,
+  salt: Buffer,
+  options: ScryptOptions,
+): Promise<Buffer> {
   return await new Promise((resolve, reject) => {
     crypto.scrypt(
       secret,
       salt,
       KEY_BYTES,
       {
-        N: SCRYPT_COST,
-        r: SCRYPT_BLOCK_SIZE,
-        p: SCRYPT_PARALLELIZATION,
-        maxmem: SCRYPT_MAX_MEMORY_BYTES,
+        N: options.cost,
+        r: options.blockSize,
+        p: options.parallelization,
+        maxmem: options.maxMemoryBytes,
       },
       (error, derivedKey) => {
         if (error) {
@@ -122,7 +141,12 @@ export async function decryptPayloadToArchive(params: {
   const salt = base64UrlDecode(params.envelope.encryption.keyDerivation.saltBase64Url);
   const nonce = base64UrlDecode(params.envelope.encryption.nonceBase64Url);
   const authTag = base64UrlDecode(params.envelope.encryption.authTagBase64Url);
-  const key = await deriveKey(params.secret, salt);
+  const key = await deriveKeyWithOptions(params.secret, salt, {
+    cost: params.envelope.encryption.keyDerivation.cost,
+    blockSize: params.envelope.encryption.keyDerivation.blockSize,
+    parallelization: params.envelope.encryption.keyDerivation.parallelization,
+    maxMemoryBytes: params.envelope.encryption.keyDerivation.maxMemoryBytes,
+  });
   const decipher = crypto.createDecipheriv("aes-256-gcm", key, nonce);
   decipher.setAuthTag(authTag);
   const ciphertextDigest = new HashPassthrough();

--- a/src/backup/snapshot-store/encryption.ts
+++ b/src/backup/snapshot-store/encryption.ts
@@ -127,21 +127,28 @@ export async function decryptPayloadToArchive(params: {
   decipher.setAuthTag(authTag);
   const ciphertextDigest = new HashPassthrough();
   const archiveDigest = new HashPassthrough();
+  const tempArchivePath = `${params.archivePath}.${process.pid}.tmp`;
 
-  await pipeline(
-    fs.createReadStream(params.payloadPath),
-    ciphertextDigest,
-    decipher,
-    archiveDigest,
-    fs.createWriteStream(params.archivePath, { mode: 0o600 }),
-  );
+  try {
+    await pipeline(
+      fs.createReadStream(params.payloadPath),
+      ciphertextDigest,
+      decipher,
+      archiveDigest,
+      fs.createWriteStream(tempArchivePath, { flags: "wx", mode: 0o600 }),
+    );
 
-  const archiveSha = archiveDigest.digestHex();
-  const ciphertextSha = ciphertextDigest.digestHex();
-  if (ciphertextSha !== params.envelope.ciphertext.sha256) {
-    throw new Error("Downloaded payload checksum mismatch.");
-  }
-  if (archiveSha !== params.envelope.archive.sha256) {
-    throw new Error("Decrypted archive checksum mismatch.");
+    const archiveSha = archiveDigest.digestHex();
+    const ciphertextSha = ciphertextDigest.digestHex();
+    if (ciphertextSha !== params.envelope.ciphertext.sha256) {
+      throw new Error("Downloaded payload checksum mismatch.");
+    }
+    if (archiveSha !== params.envelope.archive.sha256) {
+      throw new Error("Decrypted archive checksum mismatch.");
+    }
+    await fs.promises.rename(tempArchivePath, params.archivePath);
+  } catch (error) {
+    await fs.promises.rm(tempArchivePath, { force: true }).catch(() => undefined);
+    throw error;
   }
 }

--- a/src/backup/snapshot-store/installation-id.test.ts
+++ b/src/backup/snapshot-store/installation-id.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveInstallationId } from "./installation-id.js";
+
+describe("resolveInstallationId", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map(async (dir) => await fs.rm(dir, { recursive: true, force: true })),
+    );
+    tempDirs.length = 0;
+  });
+
+  it("creates a new installation id when the record is missing", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-installation-id-"));
+    tempDirs.push(stateDir);
+
+    const installationId = await resolveInstallationId({
+      stateDir,
+      createIfMissing: true,
+    });
+
+    expect(installationId).toMatch(/^inst_[0-9a-f]{24}$/);
+  });
+
+  it("rejects malformed installation records instead of rotating ids", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-installation-id-"));
+    tempDirs.push(stateDir);
+    const backupDir = path.join(stateDir, "backup");
+    await fs.mkdir(backupDir, { recursive: true });
+    await fs.writeFile(path.join(backupDir, "installation.json"), "{", "utf8");
+
+    await expect(
+      resolveInstallationId({
+        stateDir,
+        createIfMissing: true,
+      }),
+    ).rejects.toThrow("Invalid backup installation record");
+  });
+});

--- a/src/backup/snapshot-store/installation-id.ts
+++ b/src/backup/snapshot-store/installation-id.ts
@@ -27,9 +27,36 @@ export async function resolveInstallationId(params: {
   createIfMissing?: boolean;
 }): Promise<string | undefined> {
   const filePath = buildInstallationFilePath(params.stateDir);
+  let raw: string | undefined;
   try {
-    const raw = await fs.readFile(filePath, "utf8");
-    const parsed = JSON.parse(raw) as Partial<InstallationRecord>;
+    raw = await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ENOENT"
+    ) {
+      raw = undefined;
+    } else {
+      throw new Error(`Failed to read backup installation record at ${filePath}.`, {
+        cause: error,
+      });
+    }
+  }
+
+  if (raw !== undefined) {
+    let parsed: Partial<InstallationRecord>;
+    try {
+      parsed = JSON.parse(raw) as Partial<InstallationRecord>;
+    } catch (error) {
+      throw new Error(
+        `Invalid backup installation record at ${filePath}. Delete or repair it before continuing.`,
+        {
+          cause: error,
+        },
+      );
+    }
     if (
       parsed.schemaVersion === 1 &&
       typeof parsed.installationId === "string" &&
@@ -37,8 +64,9 @@ export async function resolveInstallationId(params: {
     ) {
       return parsed.installationId;
     }
-  } catch {
-    // Fall through to optional creation.
+    throw new Error(
+      `Invalid backup installation record at ${filePath}. Delete or repair it before continuing.`,
+    );
   }
 
   if (!params.createIfMissing) {

--- a/src/backup/snapshot-store/installation-id.ts
+++ b/src/backup/snapshot-store/installation-id.ts
@@ -79,6 +79,36 @@ export async function resolveInstallationId(params: {
     createdAt: new Date().toISOString(),
   };
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  try {
+    // Use exclusive create (wx) to avoid races: two concurrent processes
+    // that both see ENOENT will only let one writer succeed.
+    await fs.writeFile(filePath, `${JSON.stringify(record, null, 2)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "EEXIST"
+    ) {
+      // Another process won the race — read the file it created.
+      const existing = await fs.readFile(filePath, "utf8");
+      const parsed = JSON.parse(existing) as Partial<InstallationRecord>;
+      if (
+        parsed.schemaVersion === 1 &&
+        typeof parsed.installationId === "string" &&
+        isValidInstallationId(parsed.installationId)
+      ) {
+        return parsed.installationId;
+      }
+      throw new Error(
+        `Invalid backup installation record at ${filePath}. Delete or repair it before continuing.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
   return record.installationId;
 }

--- a/src/backup/snapshot-store/installation-id.ts
+++ b/src/backup/snapshot-store/installation-id.ts
@@ -1,0 +1,50 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type InstallationRecord = {
+  schemaVersion: 1;
+  installationId: string;
+  createdAt: string;
+};
+
+function buildInstallationFilePath(stateDir: string): string {
+  return path.join(stateDir, "backup", "installation.json");
+}
+
+function generateInstallationId(): string {
+  return `inst_${crypto.randomBytes(12).toString("hex")}`;
+}
+
+export async function resolveInstallationId(params: {
+  stateDir: string;
+  createIfMissing?: boolean;
+}): Promise<string | undefined> {
+  const filePath = buildInstallationFilePath(params.stateDir);
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<InstallationRecord>;
+    if (
+      parsed.schemaVersion === 1 &&
+      typeof parsed.installationId === "string" &&
+      parsed.installationId.trim()
+    ) {
+      return parsed.installationId;
+    }
+  } catch {
+    // Fall through to optional creation.
+  }
+
+  if (!params.createIfMissing) {
+    return undefined;
+  }
+
+  const record: InstallationRecord = {
+    schemaVersion: 1,
+    installationId: generateInstallationId(),
+    createdAt: new Date().toISOString(),
+  };
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  return record.installationId;
+}

--- a/src/backup/snapshot-store/installation-id.ts
+++ b/src/backup/snapshot-store/installation-id.ts
@@ -8,12 +8,18 @@ type InstallationRecord = {
   createdAt: string;
 };
 
+const INSTALLATION_ID_PATTERN = /^inst_[0-9a-f]{24}$/;
+
 function buildInstallationFilePath(stateDir: string): string {
   return path.join(stateDir, "backup", "installation.json");
 }
 
 function generateInstallationId(): string {
   return `inst_${crypto.randomBytes(12).toString("hex")}`;
+}
+
+export function isValidInstallationId(value: string): boolean {
+  return INSTALLATION_ID_PATTERN.test(value);
 }
 
 export async function resolveInstallationId(params: {
@@ -27,7 +33,7 @@ export async function resolveInstallationId(params: {
     if (
       parsed.schemaVersion === 1 &&
       typeof parsed.installationId === "string" &&
-      parsed.installationId.trim()
+      isValidInstallationId(parsed.installationId)
     ) {
       return parsed.installationId;
     }

--- a/src/backup/snapshot-store/provider-folder.test.ts
+++ b/src/backup/snapshot-store/provider-folder.test.ts
@@ -138,4 +138,32 @@ describe("folder snapshot store", () => {
       }),
     ).rejects.toThrow("Invalid installationId");
   });
+
+  it("skips malformed envelope files while listing healthy snapshots", async () => {
+    const targetDir = await createTempDir("openclaw-snapshot-store-list-");
+    const snapshotRoot = path.join(targetDir, "snapshots", VALID_INSTALLATION_ID);
+    const validEnvelope = createEnvelope(VALID_SNAPSHOT_ID, VALID_INSTALLATION_ID);
+    await fs.mkdir(snapshotRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(snapshotRoot, `${VALID_SNAPSHOT_ID}.envelope.json`),
+      `${JSON.stringify(validEnvelope, null, 2)}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(snapshotRoot, "snap_2026-03-10T00-00-01-000Z_deadbeef.envelope.json"),
+      "{not-json",
+      "utf8",
+    );
+
+    const store = createFolderSnapshotStore({
+      targetDir,
+      encryptionKey: "secret",
+    });
+
+    await expect(
+      store.listSnapshots({
+        installationId: VALID_INSTALLATION_ID,
+      }),
+    ).resolves.toEqual([validEnvelope]);
+  });
 });

--- a/src/backup/snapshot-store/provider-folder.test.ts
+++ b/src/backup/snapshot-store/provider-folder.test.ts
@@ -94,6 +94,9 @@ describe("folder snapshot store", () => {
   });
 
   it("writes snapshot files with restrictive mode", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
     const targetDir = await createTempDir("openclaw-snapshot-store-mode-");
     const payloadPath = path.join(targetDir, "source.payload");
     await fs.writeFile(payloadPath, "payload-data", "utf8");

--- a/src/backup/snapshot-store/provider-folder.test.ts
+++ b/src/backup/snapshot-store/provider-folder.test.ts
@@ -50,6 +50,9 @@ function createEnvelope(snapshotId: string, installationId: string): BackupSnaps
   };
 }
 
+const VALID_INSTALLATION_ID = "inst_1234567890abcdef12345678";
+const VALID_SNAPSHOT_ID = "snap_2026-03-10T00-00-00-000Z_deadbeef";
+
 afterEach(async () => {
   vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
@@ -70,9 +73,9 @@ describe("folder snapshot store", () => {
     });
 
     await store.uploadSnapshot({
-      installationId: "inst_1",
-      snapshotId: "snap_1",
-      envelope: createEnvelope("snap_1", "inst_1"),
+      installationId: VALID_INSTALLATION_ID,
+      snapshotId: VALID_SNAPSHOT_ID,
+      envelope: createEnvelope(VALID_SNAPSHOT_ID, VALID_INSTALLATION_ID),
       payloadPath,
     });
 
@@ -101,16 +104,38 @@ describe("folder snapshot store", () => {
     });
 
     await store.uploadSnapshot({
-      installationId: "inst_1",
-      snapshotId: "snap_1",
-      envelope: createEnvelope("snap_1", "inst_1"),
+      installationId: VALID_INSTALLATION_ID,
+      snapshotId: VALID_SNAPSHOT_ID,
+      envelope: createEnvelope(VALID_SNAPSHOT_ID, VALID_INSTALLATION_ID),
       payloadPath,
     });
 
-    const snapshotRoot = path.join(targetDir, "snapshots", "inst_1");
-    const envelopeStat = await fs.stat(path.join(snapshotRoot, "snap_1.envelope.json"));
-    const payloadStat = await fs.stat(path.join(snapshotRoot, "snap_1.payload.bin"));
+    const snapshotRoot = path.join(targetDir, "snapshots", VALID_INSTALLATION_ID);
+    const envelopeStat = await fs.stat(
+      path.join(snapshotRoot, `${VALID_SNAPSHOT_ID}.envelope.json`),
+    );
+    const payloadStat = await fs.stat(path.join(snapshotRoot, `${VALID_SNAPSHOT_ID}.payload.bin`));
     expect(envelopeStat.mode & 0o777).toBe(0o600);
     expect(payloadStat.mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects invalid storage identifiers before touching the filesystem", async () => {
+    const targetDir = await createTempDir("openclaw-snapshot-store-invalid-");
+    const payloadPath = path.join(targetDir, "source.payload");
+    await fs.writeFile(payloadPath, "payload-data", "utf8");
+
+    const store = createFolderSnapshotStore({
+      targetDir,
+      encryptionKey: "secret",
+    });
+
+    await expect(
+      store.uploadSnapshot({
+        installationId: "../bad",
+        snapshotId: VALID_SNAPSHOT_ID,
+        envelope: createEnvelope(VALID_SNAPSHOT_ID, VALID_INSTALLATION_ID),
+        payloadPath,
+      }),
+    ).rejects.toThrow("Invalid installationId");
   });
 });

--- a/src/backup/snapshot-store/provider-folder.test.ts
+++ b/src/backup/snapshot-store/provider-folder.test.ts
@@ -63,7 +63,7 @@ describe("folder snapshot store", () => {
     const payloadPath = path.join(targetDir, "source.payload");
     await fs.writeFile(payloadPath, "payload-data", "utf8");
 
-    const writeSpy = vi.spyOn(fs, "writeFile");
+    const renameSpy = vi.spyOn(fs, "rename");
     const store = createFolderSnapshotStore({
       targetDir,
       encryptionKey: "secret",
@@ -76,13 +76,18 @@ describe("folder snapshot store", () => {
       payloadPath,
     });
 
-    const uploadWrites = writeSpy.mock.calls
+    const uploadRenames = renameSpy.mock.calls
       .map((call) => call[0])
       .filter(
-        (filePath): filePath is string => typeof filePath === "string" && filePath.endsWith(".tmp"),
+        (filePath): filePath is string => typeof filePath === "string" && filePath.includes(".tmp"),
       );
-    expect(uploadWrites[0]).toContain(".payload.bin.tmp");
-    expect(uploadWrites[1]).toContain(".envelope.json.tmp");
+    const renameTargets = renameSpy.mock.calls
+      .map((call) => call[1])
+      .filter((filePath): filePath is string => typeof filePath === "string");
+    expect(uploadRenames[0]).toContain(".payload.bin.");
+    expect(uploadRenames[1]).toContain(".envelope.json.");
+    expect(renameTargets[0]).toContain(".payload.bin");
+    expect(renameTargets[1]).toContain(".envelope.json");
   });
 
   it("writes snapshot files with restrictive mode", async () => {
@@ -90,7 +95,6 @@ describe("folder snapshot store", () => {
     const payloadPath = path.join(targetDir, "source.payload");
     await fs.writeFile(payloadPath, "payload-data", "utf8");
 
-    const writeSpy = vi.spyOn(fs, "writeFile");
     const store = createFolderSnapshotStore({
       targetDir,
       encryptionKey: "secret",
@@ -103,13 +107,10 @@ describe("folder snapshot store", () => {
       payloadPath,
     });
 
-    const uploadWrites = writeSpy.mock.calls.filter((call) => {
-      const filePath = call[0];
-      return typeof filePath === "string" && filePath.includes(path.join("snapshots", "inst_1"));
-    });
-    expect(uploadWrites.length).toBeGreaterThanOrEqual(2);
-    for (const call of uploadWrites) {
-      expect(call[2]).toMatchObject({ mode: 0o600 });
-    }
+    const snapshotRoot = path.join(targetDir, "snapshots", "inst_1");
+    const envelopeStat = await fs.stat(path.join(snapshotRoot, "snap_1.envelope.json"));
+    const payloadStat = await fs.stat(path.join(snapshotRoot, "snap_1.payload.bin"));
+    expect(envelopeStat.mode & 0o777).toBe(0o600);
+    expect(payloadStat.mode & 0o777).toBe(0o600);
   });
 });

--- a/src/backup/snapshot-store/provider-folder.test.ts
+++ b/src/backup/snapshot-store/provider-folder.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFolderSnapshotStore } from "./provider-folder.js";
+import type { BackupSnapshotEnvelope } from "./types.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createEnvelope(snapshotId: string, installationId: string): BackupSnapshotEnvelope {
+  return {
+    schemaVersion: 1,
+    snapshotId,
+    installationId,
+    createdAt: "2026-03-09T00:00:00.000Z",
+    openclawVersion: "2026.3.9",
+    archive: {
+      format: "openclaw-backup-tar-gz",
+      archiveRoot: "openclaw-backup",
+      createdAt: "2026-03-09T00:00:00.000Z",
+      mode: "full-host",
+      includeWorkspace: true,
+      verified: true,
+      sha256: "sha256",
+      bytes: 1,
+    },
+    encryption: {
+      cipher: "aes-256-gcm",
+      keyDerivation: {
+        name: "scrypt",
+        saltBase64Url: "salt",
+        cost: 1,
+        blockSize: 8,
+        parallelization: 1,
+        maxMemoryBytes: 1024,
+      },
+      nonceBase64Url: "nonce",
+      authTagBase64Url: "tag",
+    },
+    ciphertext: {
+      sha256: "ciphertext",
+      bytes: 1,
+    },
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("folder snapshot store", () => {
+  it("writes payload before envelope so envelope remains the visibility marker", async () => {
+    const targetDir = await createTempDir("openclaw-snapshot-store-");
+    const payloadPath = path.join(targetDir, "source.payload");
+    await fs.writeFile(payloadPath, "payload-data", "utf8");
+
+    const writeSpy = vi.spyOn(fs, "writeFile");
+    const store = createFolderSnapshotStore({
+      targetDir,
+      encryptionKey: "secret",
+    });
+
+    await store.uploadSnapshot({
+      installationId: "inst_1",
+      snapshotId: "snap_1",
+      envelope: createEnvelope("snap_1", "inst_1"),
+      payloadPath,
+    });
+
+    const uploadWrites = writeSpy.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (filePath): filePath is string => typeof filePath === "string" && filePath.endsWith(".tmp"),
+      );
+    expect(uploadWrites[0]).toContain(".payload.bin.tmp");
+    expect(uploadWrites[1]).toContain(".envelope.json.tmp");
+  });
+
+  it("writes snapshot files with restrictive mode", async () => {
+    const targetDir = await createTempDir("openclaw-snapshot-store-mode-");
+    const payloadPath = path.join(targetDir, "source.payload");
+    await fs.writeFile(payloadPath, "payload-data", "utf8");
+
+    const writeSpy = vi.spyOn(fs, "writeFile");
+    const store = createFolderSnapshotStore({
+      targetDir,
+      encryptionKey: "secret",
+    });
+
+    await store.uploadSnapshot({
+      installationId: "inst_1",
+      snapshotId: "snap_1",
+      envelope: createEnvelope("snap_1", "inst_1"),
+      payloadPath,
+    });
+
+    const uploadWrites = writeSpy.mock.calls.filter((call) => {
+      const filePath = call[0];
+      return typeof filePath === "string" && filePath.includes(path.join("snapshots", "inst_1"));
+    });
+    expect(uploadWrites.length).toBeGreaterThanOrEqual(2);
+    for (const call of uploadWrites) {
+      expect(call[2]).toMatchObject({ mode: 0o600 });
+    }
+  });
+});

--- a/src/backup/snapshot-store/provider-folder.test.ts
+++ b/src/backup/snapshot-store/provider-folder.test.ts
@@ -166,4 +166,48 @@ describe("folder snapshot store", () => {
       }),
     ).resolves.toEqual([validEnvelope]);
   });
+
+  it("skips structurally invalid envelope files while listing healthy snapshots", async () => {
+    const targetDir = await createTempDir("openclaw-snapshot-store-invalid-shape-");
+    const snapshotRoot = path.join(targetDir, "snapshots", VALID_INSTALLATION_ID);
+    const validEnvelope = createEnvelope(VALID_SNAPSHOT_ID, VALID_INSTALLATION_ID);
+    await fs.mkdir(snapshotRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(snapshotRoot, `${VALID_SNAPSHOT_ID}.envelope.json`),
+      `${JSON.stringify(validEnvelope, null, 2)}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(snapshotRoot, "snap_2026-03-10T00-00-02-000Z_deadbeef.envelope.json"),
+      "{}\n",
+      "utf8",
+    );
+
+    const store = createFolderSnapshotStore({
+      targetDir,
+      encryptionKey: "secret",
+    });
+
+    await expect(
+      store.listSnapshots({
+        installationId: VALID_INSTALLATION_ID,
+      }),
+    ).resolves.toEqual([validEnvelope]);
+  });
+
+  it("surfaces snapshot directory read failures other than ENOENT", async () => {
+    const targetDir = await createTempDir("openclaw-snapshot-store-readdir-");
+    const store = createFolderSnapshotStore({
+      targetDir,
+      encryptionKey: "secret",
+    });
+    const denied = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    vi.spyOn(fs, "readdir").mockRejectedValueOnce(denied);
+
+    await expect(
+      store.listSnapshots({
+        installationId: VALID_INSTALLATION_ID,
+      }),
+    ).rejects.toThrow("permission denied");
+  });
 });

--- a/src/backup/snapshot-store/provider-folder.test.ts
+++ b/src/backup/snapshot-store/provider-folder.test.ts
@@ -213,4 +213,39 @@ describe("folder snapshot store", () => {
       }),
     ).rejects.toThrow("permission denied");
   });
+
+  it("surfaces envelope read failures other than ENOENT", async () => {
+    const targetDir = await createTempDir("openclaw-snapshot-store-readfile-");
+    const snapshotRoot = path.join(targetDir, "snapshots", VALID_INSTALLATION_ID);
+    const validEnvelope = createEnvelope(VALID_SNAPSHOT_ID, VALID_INSTALLATION_ID);
+    const validPath = path.join(snapshotRoot, `${VALID_SNAPSHOT_ID}.envelope.json`);
+    const brokenPath = path.join(
+      snapshotRoot,
+      "snap_2026-03-10T00-00-02-000Z_deadbeef.envelope.json",
+    );
+    await fs.mkdir(snapshotRoot, { recursive: true });
+    await fs.writeFile(validPath, `${JSON.stringify(validEnvelope, null, 2)}\n`, "utf8");
+    await fs.writeFile(brokenPath, `${JSON.stringify(validEnvelope, null, 2)}\n`, "utf8");
+
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    readFileSpy.mockImplementation(async (filePath, ...args) => {
+      if (filePath === brokenPath) {
+        throw Object.assign(new Error("i/o error"), { code: "EIO" });
+      }
+      return await vi
+        .importActual<typeof import("node:fs/promises")>("node:fs/promises")
+        .then((actual) => actual.readFile(filePath, ...args));
+    });
+
+    const store = createFolderSnapshotStore({
+      targetDir,
+      encryptionKey: "secret",
+    });
+
+    await expect(
+      store.listSnapshots({
+        installationId: VALID_INSTALLATION_ID,
+      }),
+    ).rejects.toThrow("i/o error");
+  });
 });

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -97,9 +97,16 @@ export function createFolderSnapshotStore(
         return [];
       }
       const envelopes = entries.filter((entry) => entry.endsWith(".envelope.json")).toSorted();
-      return await Promise.all(
-        envelopes.map(async (entry) => await readEnvelopeFile(path.join(root, entry))),
+      const listed = await Promise.all(
+        envelopes.map(async (entry) => {
+          try {
+            return await readEnvelopeFile(path.join(root, entry));
+          } catch {
+            return undefined;
+          }
+        }),
       );
+      return listed.filter((entry): entry is BackupSnapshotEnvelope => entry !== undefined);
     },
 
     async downloadSnapshot(params) {

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -4,17 +4,31 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import type { ResolvedSnapshotStoreConfig } from "./config.js";
+import { isValidInstallationId } from "./installation-id.js";
 import type { BackupSnapshotEnvelope, BackupSnapshotStore } from "./types.js";
 
+const SNAPSHOT_ID_PATTERN = /^snap_[0-9TZ-]+_[0-9a-f]{8}$/;
+
+function assertValidStorageId(kind: "installationId" | "snapshotId", value: string): void {
+  const isValid =
+    kind === "installationId" ? isValidInstallationId(value) : SNAPSHOT_ID_PATTERN.test(value);
+  if (!isValid) {
+    throw new Error(`Invalid ${kind}: ${value}`);
+  }
+}
+
 function installationRoot(targetDir: string, installationId: string): string {
+  assertValidStorageId("installationId", installationId);
   return path.join(targetDir, "snapshots", installationId);
 }
 
 function envelopePath(targetDir: string, installationId: string, snapshotId: string): string {
+  assertValidStorageId("snapshotId", snapshotId);
   return path.join(installationRoot(targetDir, installationId), `${snapshotId}.envelope.json`);
 }
 
 function payloadPath(targetDir: string, installationId: string, snapshotId: string): string {
+  assertValidStorageId("snapshotId", snapshotId);
   return path.join(installationRoot(targetDir, installationId), `${snapshotId}.payload.bin`);
 }
 

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 import type { ResolvedSnapshotStoreConfig } from "./config.js";
 import type { BackupSnapshotEnvelope, BackupSnapshotStore } from "./types.js";
 
@@ -17,9 +20,38 @@ function payloadPath(targetDir: string, installationId: string, snapshotId: stri
 
 async function writeFileAtomic(filePath: string, content: string | Buffer): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  const tempPath = `${filePath}.tmp`;
-  await fs.writeFile(tempPath, content, { mode: 0o600 });
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const handle = await fs.open(tempPath, "wx", 0o600);
+  try {
+    await handle.writeFile(content);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
   await fs.rename(tempPath, filePath);
+}
+
+async function copyFileAtomic(sourcePath: string, destinationPath: string): Promise<void> {
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+  const tempPath = path.join(
+    path.dirname(destinationPath),
+    `.${path.basename(destinationPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    await pipeline(
+      fsSync.createReadStream(sourcePath),
+      fsSync.createWriteStream(tempPath, { flags: "wx", mode: 0o600 }),
+    );
+    await fs.rename(tempPath, destinationPath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 async function readEnvelopeFile(filePath: string): Promise<BackupSnapshotEnvelope> {
@@ -32,9 +64,9 @@ export function createFolderSnapshotStore(
 ): BackupSnapshotStore {
   return {
     async uploadSnapshot(params) {
-      await writeFileAtomic(
+      await copyFileAtomic(
+        params.payloadPath,
         payloadPath(config.targetDir, params.installationId, params.snapshotId),
-        await fs.readFile(params.payloadPath),
       );
       await writeFileAtomic(
         envelopePath(config.targetDir, params.installationId, params.snapshotId),

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import type { ResolvedSnapshotStoreConfig } from "./config.js";
 import { isValidInstallationId } from "./installation-id.js";
-import type { BackupSnapshotEnvelope, BackupSnapshotStore } from "./types.js";
+import {
+  parseBackupSnapshotEnvelope,
+  type BackupSnapshotEnvelope,
+  type BackupSnapshotStore,
+} from "./types.js";
 
 const SNAPSHOT_ID_PATTERN = /^snap_[0-9TZ-]+_[0-9a-f]{8}$/;
 
@@ -70,7 +74,7 @@ async function copyFileAtomic(sourcePath: string, destinationPath: string): Prom
 
 async function readEnvelopeFile(filePath: string): Promise<BackupSnapshotEnvelope> {
   const raw = await fs.readFile(filePath, "utf8");
-  return JSON.parse(raw) as BackupSnapshotEnvelope;
+  return parseBackupSnapshotEnvelope(raw);
 }
 
 export function createFolderSnapshotStore(
@@ -93,8 +97,12 @@ export function createFolderSnapshotStore(
       let entries: string[] = [];
       try {
         entries = await fs.readdir(root);
-      } catch {
-        return [];
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code === "ENOENT") {
+          return [];
+        }
+        throw error;
       }
       const envelopes = entries.filter((entry) => entry.endsWith(".envelope.json")).toSorted();
       const listed = await Promise.all(

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -3,11 +3,12 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
-import type { ResolvedSnapshotStoreConfig } from "./config.js";
+import type { ResolvedSnapshotStoreConfig, ResolvedSnapshotStoreTargetConfig } from "./config.js";
 import { isValidInstallationId } from "./installation-id.js";
 import {
   parseBackupSnapshotEnvelope,
   type BackupSnapshotEnvelope,
+  type BackupSnapshotListStore,
   type BackupSnapshotStore,
 } from "./types.js";
 
@@ -77,6 +78,45 @@ async function readEnvelopeFile(filePath: string): Promise<BackupSnapshotEnvelop
   return parseBackupSnapshotEnvelope(raw);
 }
 
+async function listSnapshotsFromDir(
+  targetDir: string,
+  params: { installationId: string },
+): Promise<BackupSnapshotEnvelope[]> {
+  const root = installationRoot(targetDir, params.installationId);
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(root);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  const envelopes = entries.filter((entry) => entry.endsWith(".envelope.json")).toSorted();
+  const listed = await Promise.all(
+    envelopes.map(async (entry) => {
+      const filePath = path.join(root, entry);
+      let raw: string;
+      try {
+        raw = await fs.readFile(filePath, "utf8");
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code === "ENOENT") {
+          return undefined;
+        }
+        throw error;
+      }
+      try {
+        return parseBackupSnapshotEnvelope(raw);
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+  return listed.filter((entry): entry is BackupSnapshotEnvelope => entry !== undefined);
+}
+
 export function createFolderSnapshotStore(
   config: ResolvedSnapshotStoreConfig,
 ): BackupSnapshotStore {
@@ -93,39 +133,7 @@ export function createFolderSnapshotStore(
     },
 
     async listSnapshots(params) {
-      const root = installationRoot(config.targetDir, params.installationId);
-      let entries: string[] = [];
-      try {
-        entries = await fs.readdir(root);
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException | undefined)?.code;
-        if (code === "ENOENT") {
-          return [];
-        }
-        throw error;
-      }
-      const envelopes = entries.filter((entry) => entry.endsWith(".envelope.json")).toSorted();
-      const listed = await Promise.all(
-        envelopes.map(async (entry) => {
-          const filePath = path.join(root, entry);
-          let raw: string;
-          try {
-            raw = await fs.readFile(filePath, "utf8");
-          } catch (error) {
-            const code = (error as NodeJS.ErrnoException | undefined)?.code;
-            if (code === "ENOENT") {
-              return undefined;
-            }
-            throw error;
-          }
-          try {
-            return parseBackupSnapshotEnvelope(raw);
-          } catch {
-            return undefined;
-          }
-        }),
-      );
-      return listed.filter((entry): entry is BackupSnapshotEnvelope => entry !== undefined);
+      return listSnapshotsFromDir(config.targetDir, params);
     },
 
     async downloadSnapshot(params) {
@@ -144,6 +152,17 @@ export function createFolderSnapshotStore(
       await fs.copyFile(storedEnvelopePath, params.envelopeOutputPath);
       await fs.copyFile(storedPayloadPath, params.payloadOutputPath);
       return envelope;
+    },
+  };
+}
+
+/** Create a list-only store that does not require an encryption key. */
+export function createFolderSnapshotListStore(
+  config: ResolvedSnapshotStoreTargetConfig,
+): BackupSnapshotListStore {
+  return {
+    async listSnapshots(params) {
+      return listSnapshotsFromDir(config.targetDir, params);
     },
   };
 }

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -18,7 +18,7 @@ function payloadPath(targetDir: string, installationId: string, snapshotId: stri
 async function writeFileAtomic(filePath: string, content: string | Buffer): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   const tempPath = `${filePath}.tmp`;
-  await fs.writeFile(tempPath, content);
+  await fs.writeFile(tempPath, content, { mode: 0o600 });
   await fs.rename(tempPath, filePath);
 }
 
@@ -33,12 +33,12 @@ export function createFolderSnapshotStore(
   return {
     async uploadSnapshot(params) {
       await writeFileAtomic(
-        envelopePath(config.targetDir, params.installationId, params.snapshotId),
-        `${JSON.stringify(params.envelope, null, 2)}\n`,
-      );
-      await writeFileAtomic(
         payloadPath(config.targetDir, params.installationId, params.snapshotId),
         await fs.readFile(params.payloadPath),
+      );
+      await writeFileAtomic(
+        envelopePath(config.targetDir, params.installationId, params.snapshotId),
+        `${JSON.stringify(params.envelope, null, 2)}\n`,
       );
     },
 

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -107,8 +107,19 @@ export function createFolderSnapshotStore(
       const envelopes = entries.filter((entry) => entry.endsWith(".envelope.json")).toSorted();
       const listed = await Promise.all(
         envelopes.map(async (entry) => {
+          const filePath = path.join(root, entry);
+          let raw: string;
           try {
-            return await readEnvelopeFile(path.join(root, entry));
+            raw = await fs.readFile(filePath, "utf8");
+          } catch (error) {
+            const code = (error as NodeJS.ErrnoException | undefined)?.code;
+            if (code === "ENOENT") {
+              return undefined;
+            }
+            throw error;
+          }
+          try {
+            return parseBackupSnapshotEnvelope(raw);
           } catch {
             return undefined;
           }

--- a/src/backup/snapshot-store/provider-folder.ts
+++ b/src/backup/snapshot-store/provider-folder.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ResolvedSnapshotStoreConfig } from "./config.js";
+import type { BackupSnapshotEnvelope, BackupSnapshotStore } from "./types.js";
+
+function installationRoot(targetDir: string, installationId: string): string {
+  return path.join(targetDir, "snapshots", installationId);
+}
+
+function envelopePath(targetDir: string, installationId: string, snapshotId: string): string {
+  return path.join(installationRoot(targetDir, installationId), `${snapshotId}.envelope.json`);
+}
+
+function payloadPath(targetDir: string, installationId: string, snapshotId: string): string {
+  return path.join(installationRoot(targetDir, installationId), `${snapshotId}.payload.bin`);
+}
+
+async function writeFileAtomic(filePath: string, content: string | Buffer): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp`;
+  await fs.writeFile(tempPath, content);
+  await fs.rename(tempPath, filePath);
+}
+
+async function readEnvelopeFile(filePath: string): Promise<BackupSnapshotEnvelope> {
+  const raw = await fs.readFile(filePath, "utf8");
+  return JSON.parse(raw) as BackupSnapshotEnvelope;
+}
+
+export function createFolderSnapshotStore(
+  config: ResolvedSnapshotStoreConfig,
+): BackupSnapshotStore {
+  return {
+    async uploadSnapshot(params) {
+      await writeFileAtomic(
+        envelopePath(config.targetDir, params.installationId, params.snapshotId),
+        `${JSON.stringify(params.envelope, null, 2)}\n`,
+      );
+      await writeFileAtomic(
+        payloadPath(config.targetDir, params.installationId, params.snapshotId),
+        await fs.readFile(params.payloadPath),
+      );
+    },
+
+    async listSnapshots(params) {
+      const root = installationRoot(config.targetDir, params.installationId);
+      let entries: string[] = [];
+      try {
+        entries = await fs.readdir(root);
+      } catch {
+        return [];
+      }
+      const envelopes = entries.filter((entry) => entry.endsWith(".envelope.json")).toSorted();
+      return await Promise.all(
+        envelopes.map(async (entry) => await readEnvelopeFile(path.join(root, entry))),
+      );
+    },
+
+    async downloadSnapshot(params) {
+      const storedEnvelopePath = envelopePath(
+        config.targetDir,
+        params.installationId,
+        params.snapshotId,
+      );
+      const storedPayloadPath = payloadPath(
+        config.targetDir,
+        params.installationId,
+        params.snapshotId,
+      );
+      const envelope = await readEnvelopeFile(storedEnvelopePath);
+      await fs.mkdir(path.dirname(params.envelopeOutputPath), { recursive: true });
+      await fs.copyFile(storedEnvelopePath, params.envelopeOutputPath);
+      await fs.copyFile(storedPayloadPath, params.payloadOutputPath);
+      return envelope;
+    },
+  };
+}

--- a/src/backup/snapshot-store/provider.ts
+++ b/src/backup/snapshot-store/provider.ts
@@ -1,0 +1,7 @@
+import type { ResolvedSnapshotStoreConfig } from "./config.js";
+import { createFolderSnapshotStore } from "./provider-folder.js";
+import type { BackupSnapshotStore } from "./types.js";
+
+export function createSnapshotStore(config: ResolvedSnapshotStoreConfig): BackupSnapshotStore {
+  return createFolderSnapshotStore(config);
+}

--- a/src/backup/snapshot-store/provider.ts
+++ b/src/backup/snapshot-store/provider.ts
@@ -1,7 +1,14 @@
-import type { ResolvedSnapshotStoreConfig } from "./config.js";
-import { createFolderSnapshotStore } from "./provider-folder.js";
-import type { BackupSnapshotStore } from "./types.js";
+import type { ResolvedSnapshotStoreConfig, ResolvedSnapshotStoreTargetConfig } from "./config.js";
+import { createFolderSnapshotStore, createFolderSnapshotListStore } from "./provider-folder.js";
+import type { BackupSnapshotListStore, BackupSnapshotStore } from "./types.js";
 
 export function createSnapshotStore(config: ResolvedSnapshotStoreConfig): BackupSnapshotStore {
   return createFolderSnapshotStore(config);
+}
+
+/** Create a store that only supports listing snapshots (no encryption key needed). */
+export function createSnapshotListStore(
+  config: ResolvedSnapshotStoreTargetConfig,
+): BackupSnapshotListStore {
+  return createFolderSnapshotListStore(config);
 }

--- a/src/backup/snapshot-store/targets.test.ts
+++ b/src/backup/snapshot-store/targets.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectCloudDriveTargets } from "./targets.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("detectCloudDriveTargets", () => {
+  it("detects iCloud Drive and CloudStorage folders on macOS", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-snapshot-targets-"));
+    tempDirs.push(home);
+    await fs.mkdir(path.join(home, "Library", "Mobile Documents", "com~apple~CloudDocs"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(home, "Library", "CloudStorage", "Dropbox"), {
+      recursive: true,
+    });
+
+    const detected = await detectCloudDriveTargets({
+      platform: "darwin",
+      homeDir: home,
+    });
+
+    expect(detected.map((entry) => entry.label)).toEqual(
+      expect.arrayContaining(["iCloud Drive", "Dropbox"]),
+    );
+    expect(detected[0]?.targetDir).toContain("OpenClaw Backups");
+  });
+});

--- a/src/backup/snapshot-store/targets.ts
+++ b/src/backup/snapshot-store/targets.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathExists } from "../../utils.js";
+
+export const DEFAULT_BACKUP_TARGET_DIRNAME = "OpenClaw Backups";
+
+export type DetectedCloudDriveTarget = {
+  label: string;
+  rootDir: string;
+  targetDir: string;
+};
+
+function toDetectedTarget(label: string, rootDir: string): DetectedCloudDriveTarget {
+  return {
+    label,
+    rootDir,
+    targetDir: path.join(rootDir, DEFAULT_BACKUP_TARGET_DIRNAME),
+  };
+}
+
+function cloudStoragePriority(name: string): number {
+  const normalized = name.toLowerCase();
+  if (normalized.startsWith("dropbox")) {
+    return 0;
+  }
+  if (normalized.startsWith("googledrive") || normalized.startsWith("google drive")) {
+    return 1;
+  }
+  if (normalized.startsWith("onedrive")) {
+    return 2;
+  }
+  return 100;
+}
+
+export async function detectCloudDriveTargets(params?: {
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+}): Promise<DetectedCloudDriveTarget[]> {
+  const platform = params?.platform ?? process.platform;
+  const homeDir = params?.homeDir ?? os.homedir();
+  const targets: DetectedCloudDriveTarget[] = [];
+
+  if (platform === "darwin") {
+    const iCloudRoot = path.join(homeDir, "Library", "Mobile Documents", "com~apple~CloudDocs");
+    if (await pathExists(iCloudRoot)) {
+      targets.push(toDetectedTarget("iCloud Drive", iCloudRoot));
+    }
+
+    const cloudStorageRoot = path.join(homeDir, "Library", "CloudStorage");
+    try {
+      const entries = await fs.readdir(cloudStorageRoot, { withFileTypes: true });
+      const providers = entries
+        .filter((entry) => entry.isDirectory())
+        .toSorted(
+          (left, right) => cloudStoragePriority(left.name) - cloudStoragePriority(right.name),
+        );
+      for (const entry of providers) {
+        targets.push(
+          toDetectedTarget(
+            entry.name.replaceAll("-", " "),
+            path.join(cloudStorageRoot, entry.name),
+          ),
+        );
+      }
+    } catch {
+      // Best-effort detection only.
+    }
+  } else {
+    const fallbackRoots = [
+      { label: "Dropbox", root: path.join(homeDir, "Dropbox") },
+      { label: "Google Drive", root: path.join(homeDir, "Google Drive") },
+      { label: "Google Drive", root: path.join(homeDir, "GoogleDrive") },
+      { label: "OneDrive", root: path.join(homeDir, "OneDrive") },
+      { label: "iCloud Drive", root: path.join(homeDir, "iCloudDrive") },
+    ];
+    for (const candidate of fallbackRoots) {
+      if (await pathExists(candidate.root)) {
+        targets.push(toDetectedTarget(candidate.label, candidate.root));
+      }
+    }
+  }
+
+  const seen = new Set<string>();
+  return targets.filter((target) => {
+    const key = path.resolve(target.targetDir);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export async function detectPreferredCloudDriveTarget(params?: {
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+}): Promise<DetectedCloudDriveTarget | undefined> {
+  return (await detectCloudDriveTargets(params))[0];
+}

--- a/src/backup/snapshot-store/types.ts
+++ b/src/backup/snapshot-store/types.ts
@@ -1,0 +1,64 @@
+export type BackupArchiveMode = "full-host" | "config-only";
+
+export type BackupSnapshotEnvelope = {
+  schemaVersion: 1;
+  snapshotId: string;
+  installationId: string;
+  createdAt: string;
+  openclawVersion: string;
+  archive: {
+    format: "openclaw-backup-tar-gz";
+    archiveRoot: string;
+    createdAt: string;
+    mode: BackupArchiveMode;
+    includeWorkspace: boolean;
+    verified: boolean;
+    sha256: string;
+    bytes: number;
+  };
+  encryption: {
+    cipher: "aes-256-gcm";
+    keyDerivation: {
+      name: "scrypt";
+      saltBase64Url: string;
+      cost: number;
+      blockSize: number;
+      parallelization: number;
+      maxMemoryBytes: number;
+    };
+    nonceBase64Url: string;
+    authTagBase64Url: string;
+  };
+  ciphertext: {
+    sha256: string;
+    bytes: number;
+  };
+  snapshotName?: string;
+};
+
+export type BackupSnapshotListEntry = Pick<
+  BackupSnapshotEnvelope,
+  "snapshotId" | "installationId" | "createdAt" | "openclawVersion" | "snapshotName"
+> & {
+  mode: BackupArchiveMode;
+  includeWorkspace: boolean;
+  verified: boolean;
+  archiveBytes: number;
+  ciphertextBytes: number;
+};
+
+export type BackupSnapshotStore = {
+  uploadSnapshot(params: {
+    installationId: string;
+    snapshotId: string;
+    envelope: BackupSnapshotEnvelope;
+    payloadPath: string;
+  }): Promise<void>;
+  listSnapshots(params: { installationId: string }): Promise<BackupSnapshotEnvelope[]>;
+  downloadSnapshot(params: {
+    installationId: string;
+    snapshotId: string;
+    envelopeOutputPath: string;
+    payloadOutputPath: string;
+  }): Promise<BackupSnapshotEnvelope>;
+};

--- a/src/backup/snapshot-store/types.ts
+++ b/src/backup/snapshot-store/types.ts
@@ -36,6 +36,140 @@ export type BackupSnapshotEnvelope = {
   snapshotName?: string;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Invalid snapshot envelope: missing ${label}.`);
+  }
+  return value;
+}
+
+function readNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Invalid snapshot envelope: missing ${label}.`);
+  }
+  return value;
+}
+
+function readBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`Invalid snapshot envelope: missing ${label}.`);
+  }
+  return value;
+}
+
+export function parseBackupSnapshotEnvelope(raw: string): BackupSnapshotEnvelope {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Snapshot envelope is not valid JSON: ${String(error)}`, { cause: error });
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("Invalid snapshot envelope: expected an object.");
+  }
+  if (parsed.schemaVersion !== 1) {
+    throw new Error(
+      `Invalid snapshot envelope: unsupported schemaVersion ${String(parsed.schemaVersion)}.`,
+    );
+  }
+  if (!isRecord(parsed.archive)) {
+    throw new Error("Invalid snapshot envelope: missing archive.");
+  }
+  if (!isRecord(parsed.encryption)) {
+    throw new Error("Invalid snapshot envelope: missing encryption.");
+  }
+  if (!isRecord(parsed.ciphertext)) {
+    throw new Error("Invalid snapshot envelope: missing ciphertext.");
+  }
+  if (!isRecord(parsed.encryption.keyDerivation)) {
+    throw new Error("Invalid snapshot envelope: missing encryption.keyDerivation.");
+  }
+
+  const archiveMode = parsed.archive.mode;
+  if (archiveMode !== "full-host" && archiveMode !== "config-only") {
+    throw new Error(`Invalid snapshot envelope: unsupported archive.mode ${String(archiveMode)}.`);
+  }
+
+  return {
+    schemaVersion: 1,
+    snapshotId: readString(parsed.snapshotId, "snapshotId"),
+    installationId: readString(parsed.installationId, "installationId"),
+    createdAt: readString(parsed.createdAt, "createdAt"),
+    openclawVersion: readString(parsed.openclawVersion, "openclawVersion"),
+    archive: {
+      format:
+        readString(parsed.archive.format, "archive.format") === "openclaw-backup-tar-gz"
+          ? "openclaw-backup-tar-gz"
+          : (() => {
+              throw new Error(
+                `Invalid snapshot envelope: unsupported archive.format ${String(parsed.archive.format)}.`,
+              );
+            })(),
+      archiveRoot: readString(parsed.archive.archiveRoot, "archive.archiveRoot"),
+      createdAt: readString(parsed.archive.createdAt, "archive.createdAt"),
+      mode: archiveMode,
+      includeWorkspace: readBoolean(parsed.archive.includeWorkspace, "archive.includeWorkspace"),
+      verified: readBoolean(parsed.archive.verified, "archive.verified"),
+      sha256: readString(parsed.archive.sha256, "archive.sha256"),
+      bytes: readNumber(parsed.archive.bytes, "archive.bytes"),
+    },
+    encryption: {
+      cipher:
+        readString(parsed.encryption.cipher, "encryption.cipher") === "aes-256-gcm"
+          ? "aes-256-gcm"
+          : (() => {
+              throw new Error(
+                `Invalid snapshot envelope: unsupported encryption.cipher ${String(parsed.encryption.cipher)}.`,
+              );
+            })(),
+      keyDerivation: {
+        name:
+          readString(parsed.encryption.keyDerivation.name, "encryption.keyDerivation.name") ===
+          "scrypt"
+            ? "scrypt"
+            : (() => {
+                throw new Error(
+                  `Invalid snapshot envelope: unsupported encryption.keyDerivation.name ${String(parsed.encryption.keyDerivation.name)}.`,
+                );
+              })(),
+        saltBase64Url: readString(
+          parsed.encryption.keyDerivation.saltBase64Url,
+          "encryption.keyDerivation.saltBase64Url",
+        ),
+        cost: readNumber(parsed.encryption.keyDerivation.cost, "encryption.keyDerivation.cost"),
+        blockSize: readNumber(
+          parsed.encryption.keyDerivation.blockSize,
+          "encryption.keyDerivation.blockSize",
+        ),
+        parallelization: readNumber(
+          parsed.encryption.keyDerivation.parallelization,
+          "encryption.keyDerivation.parallelization",
+        ),
+        maxMemoryBytes: readNumber(
+          parsed.encryption.keyDerivation.maxMemoryBytes,
+          "encryption.keyDerivation.maxMemoryBytes",
+        ),
+      },
+      nonceBase64Url: readString(parsed.encryption.nonceBase64Url, "encryption.nonceBase64Url"),
+      authTagBase64Url: readString(
+        parsed.encryption.authTagBase64Url,
+        "encryption.authTagBase64Url",
+      ),
+    },
+    ciphertext: {
+      sha256: readString(parsed.ciphertext.sha256, "ciphertext.sha256"),
+      bytes: readNumber(parsed.ciphertext.bytes, "ciphertext.bytes"),
+    },
+    ...(typeof parsed.snapshotName === "string" && parsed.snapshotName.trim()
+      ? { snapshotName: parsed.snapshotName }
+      : {}),
+  };
+}
+
 export type BackupSnapshotListEntry = Pick<
   BackupSnapshotEnvelope,
   "snapshotId" | "installationId" | "createdAt" | "openclawVersion" | "snapshotName"

--- a/src/backup/snapshot-store/types.ts
+++ b/src/backup/snapshot-store/types.ts
@@ -181,6 +181,11 @@ export type BackupSnapshotListEntry = Pick<
   ciphertextBytes: number;
 };
 
+/** Read-only store interface for listing snapshots without decryption. */
+export type BackupSnapshotListStore = {
+  listSnapshots(params: { installationId: string }): Promise<BackupSnapshotEnvelope[]>;
+};
+
 export type BackupSnapshotStore = {
   uploadSnapshot(params: {
     installationId: string;

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -96,7 +96,7 @@ const coreEntries: CoreCliEntry[] = [
     commands: [
       {
         name: "backup",
-        description: "Create and verify local backup archives for OpenClaw state",
+        description: "Set up, run, inspect, export, and restore backups",
         hasSubcommands: true,
       },
     ],

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -227,12 +227,24 @@ describe("registerBackupCommand", () => {
   });
 
   it("runs backup restore with forwarded options", async () => {
-    await runCli(["backup", "restore", "snap_test", "--force-stop", "--json"]);
+    await runCli([
+      "backup",
+      "restore",
+      "snap_test",
+      "--installation-id",
+      "inst_123",
+      "--mode",
+      "workspace-only",
+      "--force-stop",
+      "--json",
+    ]);
 
     expect(backupRestoreCommand).toHaveBeenCalledWith(
       runtime,
       expect.objectContaining({
         snapshotId: "snap_test",
+        installationId: "inst_123",
+        mode: "workspace-only",
         forceStop: true,
         json: true,
       }),

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -2,7 +2,12 @@ import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const backupCreateCommand = vi.fn();
+const backupListCommand = vi.fn();
+const backupRunCommand = vi.fn();
+const backupStatusCommand = vi.fn();
+const backupRestoreCommand = vi.fn();
 const backupVerifyCommand = vi.fn();
+const workspaceBackupInitCommand = vi.fn();
 
 const runtime = {
   log: vi.fn(),
@@ -12,6 +17,26 @@ const runtime = {
 
 vi.mock("../../commands/backup.js", () => ({
   backupCreateCommand,
+}));
+
+vi.mock("../../commands/backup-list.js", () => ({
+  backupListCommand,
+}));
+
+vi.mock("../../commands/backup-run.js", () => ({
+  backupRunCommand,
+}));
+
+vi.mock("../../commands/backup-status.js", () => ({
+  backupStatusCommand,
+}));
+
+vi.mock("../../commands/workspace-backup.js", () => ({
+  workspaceBackupInitCommand,
+}));
+
+vi.mock("../../commands/backup-restore.js", () => ({
+  backupRestoreCommand,
 }));
 
 vi.mock("../../commands/backup-verify.js", () => ({
@@ -38,11 +63,28 @@ describe("registerBackupCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     backupCreateCommand.mockResolvedValue(undefined);
+    backupListCommand.mockResolvedValue(undefined);
+    backupRunCommand.mockResolvedValue(undefined);
+    backupStatusCommand.mockResolvedValue(undefined);
+    backupRestoreCommand.mockResolvedValue(undefined);
     backupVerifyCommand.mockResolvedValue(undefined);
+    workspaceBackupInitCommand.mockResolvedValue(undefined);
   });
 
-  it("runs backup create with forwarded options", async () => {
-    await runCli(["backup", "create", "--output", "/tmp/backups", "--json", "--dry-run"]);
+  it("runs backup setup with forwarded options", async () => {
+    await runCli(["backup", "setup", "--target", "/tmp/backups", "--json"]);
+
+    expect(workspaceBackupInitCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        target: "/tmp/backups",
+        json: true,
+      }),
+    );
+  });
+
+  it("runs backup export with forwarded options", async () => {
+    await runCli(["backup", "export", "--output", "/tmp/backups", "--json", "--dry-run"]);
 
     expect(backupCreateCommand).toHaveBeenCalledWith(
       runtime,
@@ -57,8 +99,22 @@ describe("registerBackupCommand", () => {
     );
   });
 
+  it("keeps backup create as an alias for backup export", async () => {
+    await runCli(["backup", "create", "--output", "/tmp/backups"]);
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("`backup create` is deprecated; use `backup export`."),
+    );
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        output: "/tmp/backups",
+      }),
+    );
+  });
+
   it("honors --no-include-workspace", async () => {
-    await runCli(["backup", "create", "--no-include-workspace"]);
+    await runCli(["backup", "export", "--no-include-workspace"]);
 
     expect(backupCreateCommand).toHaveBeenCalledWith(
       runtime,
@@ -69,7 +125,7 @@ describe("registerBackupCommand", () => {
   });
 
   it("forwards --verify to backup create", async () => {
-    await runCli(["backup", "create", "--verify"]);
+    await runCli(["backup", "export", "--verify"]);
 
     expect(backupCreateCommand).toHaveBeenCalledWith(
       runtime,
@@ -80,7 +136,7 @@ describe("registerBackupCommand", () => {
   });
 
   it("forwards --only-config to backup create", async () => {
-    await runCli(["backup", "create", "--only-config"]);
+    await runCli(["backup", "export", "--only-config"]);
 
     expect(backupCreateCommand).toHaveBeenCalledWith(
       runtime,
@@ -97,6 +153,87 @@ describe("registerBackupCommand", () => {
       runtime,
       expect.objectContaining({
         archive: "/tmp/openclaw-backup.tar.gz",
+        json: true,
+      }),
+    );
+  });
+
+  it("runs backup run with forwarded options", async () => {
+    await runCli([
+      "backup",
+      "run",
+      "--output",
+      "/tmp/backups",
+      "--verify",
+      "--snapshot-name",
+      "nightly",
+    ]);
+
+    expect(backupRunCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        output: "/tmp/backups",
+        verify: true,
+        snapshotName: "nightly",
+      }),
+    );
+  });
+
+  it("keeps backup push as a legacy alias with snapshot mode", async () => {
+    await runCli([
+      "backup",
+      "push",
+      "--output",
+      "/tmp/backups",
+      "--verify",
+      "--snapshot-name",
+      "nightly",
+    ]);
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("`backup push` is deprecated; use `backup run`."),
+    );
+    expect(backupRunCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        output: "/tmp/backups",
+        verify: true,
+        snapshotName: "nightly",
+        mode: "snapshot",
+      }),
+    );
+  });
+
+  it("runs backup status with forwarded options", async () => {
+    await runCli(["backup", "status", "--json"]);
+
+    expect(backupStatusCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        json: true,
+      }),
+    );
+  });
+
+  it("runs backup list with forwarded options", async () => {
+    await runCli(["backup", "list", "--json"]);
+
+    expect(backupListCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        json: true,
+      }),
+    );
+  });
+
+  it("runs backup restore with forwarded options", async () => {
+    await runCli(["backup", "restore", "snap_test", "--force-stop", "--json"]);
+
+    expect(backupRestoreCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        snapshotId: "snap_test",
+        forceStop: true,
         json: true,
       }),
     );

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -113,6 +113,20 @@ describe("registerBackupCommand", () => {
     );
   });
 
+  it("keeps backup create --json machine-readable by suppressing the deprecation banner", async () => {
+    await runCli(["backup", "create", "--json"]);
+
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("`backup create` is deprecated; use `backup export`."),
+    );
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        json: true,
+      }),
+    );
+  });
+
   it("honors --no-include-workspace", async () => {
     await runCli(["backup", "export", "--no-include-workspace"]);
 
@@ -199,6 +213,21 @@ describe("registerBackupCommand", () => {
         output: "/tmp/backups",
         verify: true,
         snapshotName: "nightly",
+        mode: "snapshot",
+      }),
+    );
+  });
+
+  it("keeps backup push --json machine-readable by suppressing the deprecation banner", async () => {
+    await runCli(["backup", "push", "--json"]);
+
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("`backup push` is deprecated; use `backup run`."),
+    );
+    expect(backupRunCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        json: true,
         mode: "snapshot",
       }),
     );

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -47,7 +47,7 @@ async function runArchiveCommand(
   deprecated?: { oldCommand: string; replacement: string },
 ) {
   await runCommandWithRuntime(defaultRuntime, async () => {
-    if (deprecated) {
+    if (deprecated && !opts.json) {
       logDeprecatedCommand(deprecated.oldCommand, deprecated.replacement);
     }
     await backupCreateCommand(defaultRuntime, {
@@ -77,7 +77,7 @@ async function runSnapshotCommand(
   },
 ) {
   await runCommandWithRuntime(defaultRuntime, async () => {
-    if (params?.deprecated) {
+    if (params?.deprecated && !opts.json) {
       logDeprecatedCommand(params.deprecated.oldCommand, params.deprecated.replacement);
     }
     await backupRunCommand(defaultRuntime, {

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -287,6 +287,8 @@ export function registerBackupCommand(program: Command) {
       "Restore a local archive or encrypted backup snapshot into the current installation",
     )
     .option("--archive <path>", "Restore from a local backup archive instead of backup snapshot")
+    .option("--installation-id <id>", "Override the installation id used to locate snapshots")
+    .option("--mode <mode>", "Restore scope: full-host (default), config-only, or workspace-only")
     .option("--force-stop", "Stop the gateway service before restoring", false)
     .option("--json", "Output JSON", false)
     .action(async (snapshotId, opts) => {
@@ -294,6 +296,8 @@ export function registerBackupCommand(program: Command) {
         await backupRestoreCommand(defaultRuntime, {
           snapshotId: typeof snapshotId === "string" ? snapshotId : undefined,
           archive: opts.archive as string | undefined,
+          installationId: opts.installationId as string | undefined,
+          mode: opts.mode as "full-host" | "config-only" | "workspace-only" | undefined,
           forceStop: Boolean(opts.forceStop),
           json: Boolean(opts.json),
         });

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -1,16 +1,99 @@
 import type { Command } from "commander";
+import { backupListCommand } from "../../commands/backup-list.js";
+import { backupRestoreCommand } from "../../commands/backup-restore.js";
+import { backupRunCommand } from "../../commands/backup-run.js";
+import { backupStatusCommand } from "../../commands/backup-status.js";
 import { backupVerifyCommand } from "../../commands/backup-verify.js";
 import { backupCreateCommand } from "../../commands/backup.js";
+import { workspaceBackupInitCommand } from "../../commands/workspace-backup.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatHelpExamples } from "../help-format.js";
 
+type ArchiveCommandCliOptions = {
+  output?: string;
+  json?: boolean;
+  dryRun?: boolean;
+  verify?: boolean;
+  onlyConfig?: boolean;
+  includeWorkspace?: boolean;
+};
+
+type SnapshotRunCliOptions = {
+  output?: string;
+  json?: boolean;
+  verify?: boolean;
+  snapshotName?: string;
+};
+
+function logDeprecatedCommand(oldCommand: string, replacement: string) {
+  defaultRuntime.log(theme.warn(`\`${oldCommand}\` is deprecated; use \`${replacement}\`.`));
+}
+
+function addArchiveCommandOptions(command: Command): Command {
+  return command
+    .option("--output <path>", "Archive path or destination directory")
+    .option("--json", "Output JSON", false)
+    .option("--dry-run", "Print the backup plan without writing the archive", false)
+    .option("--verify", "Verify the archive after writing it", false)
+    .option("--only-config", "Back up only the active JSON config file", false)
+    .option("--no-include-workspace", "Exclude workspace directories from the backup");
+}
+
+async function runArchiveCommand(
+  opts: ArchiveCommandCliOptions,
+  deprecated?: { oldCommand: string; replacement: string },
+) {
+  await runCommandWithRuntime(defaultRuntime, async () => {
+    if (deprecated) {
+      logDeprecatedCommand(deprecated.oldCommand, deprecated.replacement);
+    }
+    await backupCreateCommand(defaultRuntime, {
+      output: opts.output,
+      json: Boolean(opts.json),
+      dryRun: Boolean(opts.dryRun),
+      verify: Boolean(opts.verify),
+      onlyConfig: Boolean(opts.onlyConfig),
+      includeWorkspace: opts.includeWorkspace as boolean,
+    });
+  });
+}
+
+function addSnapshotRunOptions(command: Command): Command {
+  return command
+    .option("--output <path>", "Keep the intermediate local archive at this path or directory")
+    .option("--json", "Output JSON", false)
+    .option("--verify", "Verify the local archive before copying the encrypted snapshot", false)
+    .option("--snapshot-name <name>", "Optional label for this snapshot");
+}
+
+async function runSnapshotCommand(
+  opts: SnapshotRunCliOptions,
+  params?: {
+    mode?: "snapshot";
+    deprecated?: { oldCommand: string; replacement: string };
+  },
+) {
+  await runCommandWithRuntime(defaultRuntime, async () => {
+    if (params?.deprecated) {
+      logDeprecatedCommand(params.deprecated.oldCommand, params.deprecated.replacement);
+    }
+    await backupRunCommand(defaultRuntime, {
+      output: opts.output,
+      json: Boolean(opts.json),
+      verify: Boolean(opts.verify),
+      snapshotName: opts.snapshotName,
+      mode: params?.mode,
+    });
+  });
+}
+
 export function registerBackupCommand(program: Command) {
   const backup = program
     .command("backup")
-    .description("Create and verify local backup archives for OpenClaw state")
+    .description("Set up, run, inspect, export, and restore backups")
     .addHelpText(
       "after",
       () =>
@@ -18,50 +101,146 @@ export function registerBackupCommand(program: Command) {
     );
 
   backup
-    .command("create")
-    .description("Write a backup archive for config, credentials, sessions, and workspaces")
-    .option("--output <path>", "Archive path or destination directory")
+    .command("setup")
+    .description("Detect a cloud drive folder and save it as the backup target")
+    .option("--target <path>", "Override the detected backup directory")
     .option("--json", "Output JSON", false)
-    .option("--dry-run", "Print the backup plan without writing the archive", false)
-    .option("--verify", "Verify the archive after writing it", false)
-    .option("--only-config", "Back up only the active JSON config file", false)
-    .option("--no-include-workspace", "Exclude workspace directories from the backup")
     .addHelpText(
       "after",
       () =>
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
-          ["openclaw backup create", "Create a timestamped backup in the current directory."],
+          ["openclaw backup setup", "Detect a default cloud drive folder and save it."],
           [
-            "openclaw backup create --output ~/Backups",
-            "Write the archive into an existing backup directory.",
+            "openclaw backup setup --target ~/Dropbox/OpenClaw Backups",
+            "Use a specific cloud drive backup directory.",
           ],
-          [
-            "openclaw backup create --dry-run --json",
-            "Preview the archive plan without writing any files.",
-          ],
-          [
-            "openclaw backup create --verify",
-            "Create the archive and immediately validate its manifest and payload layout.",
-          ],
-          [
-            "openclaw backup create --no-include-workspace",
-            "Back up state/config without agent workspace files.",
-          ],
-          ["openclaw backup create --only-config", "Back up only the active JSON config file."],
         ])}`,
     )
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
-        await backupCreateCommand(defaultRuntime, {
-          output: opts.output as string | undefined,
+        await workspaceBackupInitCommand(defaultRuntime, {
+          target: opts.target as string | undefined,
           json: Boolean(opts.json),
-          dryRun: Boolean(opts.dryRun),
-          verify: Boolean(opts.verify),
-          onlyConfig: Boolean(opts.onlyConfig),
-          includeWorkspace: opts.includeWorkspace as boolean,
         });
       });
     });
+
+  const runCommand = addSnapshotRunOptions(
+    backup.command("run").description("Run the configured backup flow"),
+  );
+  runCommand
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw backup run", "Run the primary backup flow for the current config."],
+          [
+            "openclaw backup run --snapshot-name nightly",
+            "Create a labeled encrypted snapshot when full backup is enabled.",
+          ],
+        ])}`,
+    )
+    .action(async (opts) => {
+      await runSnapshotCommand({
+        output: opts.output as string | undefined,
+        json: Boolean(opts.json),
+        verify: Boolean(opts.verify),
+        snapshotName: opts.snapshotName as string | undefined,
+      });
+    });
+
+  backup
+    .command("status")
+    .description("Show workspace backup status and the latest full backup snapshot")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await backupStatusCommand(defaultRuntime, {
+          json: Boolean(opts.json),
+        });
+      });
+    });
+
+  const archiveExamples = () =>
+    `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+      ["openclaw backup export", "Create a timestamped backup in the current directory."],
+      [
+        "openclaw backup export --output ~/Backups",
+        "Write the archive into an existing backup directory.",
+      ],
+      [
+        "openclaw backup export --dry-run --json",
+        "Preview the archive plan without writing any files.",
+      ],
+      [
+        "openclaw backup export --verify",
+        "Create the archive and immediately validate its manifest and payload layout.",
+      ],
+      [
+        "openclaw backup export --no-include-workspace",
+        "Back up state/config without agent workspace files.",
+      ],
+      ["openclaw backup export --only-config", "Back up only the active JSON config file."],
+    ])}`;
+
+  const exportCommand = addArchiveCommandOptions(
+    backup
+      .command("export")
+      .description("Write a backup archive for config, credentials, sessions, and workspaces"),
+  );
+  exportCommand.addHelpText("after", archiveExamples).action(async (opts) => {
+    await runArchiveCommand({
+      output: opts.output as string | undefined,
+      json: Boolean(opts.json),
+      dryRun: Boolean(opts.dryRun),
+      verify: Boolean(opts.verify),
+      onlyConfig: Boolean(opts.onlyConfig),
+      includeWorkspace: opts.includeWorkspace as boolean,
+    });
+  });
+
+  const createAliasCommand = addArchiveCommandOptions(
+    backup.command("create").description("Deprecated alias for `backup export`"),
+  );
+  createAliasCommand.action(async (opts) => {
+    await runArchiveCommand(
+      {
+        output: opts.output as string | undefined,
+        json: Boolean(opts.json),
+        dryRun: Boolean(opts.dryRun),
+        verify: Boolean(opts.verify),
+        onlyConfig: Boolean(opts.onlyConfig),
+        includeWorkspace: opts.includeWorkspace as boolean,
+      },
+      {
+        oldCommand: "backup create",
+        replacement: "backup export",
+      },
+    );
+  });
+
+  const pushAliasCommand = addSnapshotRunOptions(
+    backup
+      .command("push")
+      .description("Create an encrypted backup snapshot in the configured backup folder"),
+  );
+  pushAliasCommand.action(async (opts) => {
+    await runSnapshotCommand(
+      {
+        output: opts.output as string | undefined,
+        json: Boolean(opts.json),
+        verify: Boolean(opts.verify),
+        snapshotName: opts.snapshotName as string | undefined,
+      },
+      {
+        mode: "snapshot",
+        deprecated: {
+          oldCommand: "backup push",
+          replacement: "backup run",
+        },
+      },
+    );
+  });
 
   backup
     .command("verify <archive>")
@@ -85,6 +264,37 @@ export function registerBackupCommand(program: Command) {
       await runCommandWithRuntime(defaultRuntime, async () => {
         await backupVerifyCommand(defaultRuntime, {
           archive: archive as string,
+          json: Boolean(opts.json),
+        });
+      });
+    });
+
+  backup
+    .command("list")
+    .description("List encrypted backup snapshots for the current installation")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await backupListCommand(defaultRuntime, {
+          json: Boolean(opts.json),
+        });
+      });
+    });
+
+  backup
+    .command("restore [snapshotId]")
+    .description(
+      "Restore a local archive or encrypted backup snapshot into the current installation",
+    )
+    .option("--archive <path>", "Restore from a local backup archive instead of backup snapshot")
+    .option("--force-stop", "Stop the gateway service before restoring", false)
+    .option("--json", "Output JSON", false)
+    .action(async (snapshotId, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await backupRestoreCommand(defaultRuntime, {
+          snapshotId: typeof snapshotId === "string" ? snapshotId : undefined,
+          archive: opts.archive as string | undefined,
+          forceStop: Boolean(opts.forceStop),
           json: Boolean(opts.json),
         });
       });

--- a/src/commands/backup-list.ts
+++ b/src/commands/backup-list.ts
@@ -1,0 +1,55 @@
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  loadResolvedSnapshotBackup,
+  resolveSnapshotStore,
+  resolveCurrentInstallationId,
+  toSnapshotListEntry,
+  type BackupSnapshotDeps,
+} from "./backup-snapshot-shared.js";
+
+export type BackupListOptions = {
+  json?: boolean;
+};
+
+export type BackupListResult = {
+  installationId?: string;
+  snapshots: ReturnType<typeof toSnapshotListEntry>[];
+};
+
+export async function backupListCommand(
+  runtime: RuntimeEnv,
+  opts: BackupListOptions,
+  deps?: BackupSnapshotDeps,
+): Promise<BackupListResult> {
+  const { snapshotStore, stateDir } = await loadResolvedSnapshotBackup({});
+  const installationId = await resolveCurrentInstallationId({
+    stateDir,
+    createIfMissing: false,
+  });
+  if (!installationId) {
+    const empty = { installationId: undefined, snapshots: [] };
+    runtime.log(opts.json ? JSON.stringify(empty, null, 2) : "No backup installation id found.");
+    return empty;
+  }
+
+  const storage = await resolveSnapshotStore({ snapshotStore, deps });
+  const snapshots = (await storage.listSnapshots({ installationId }))
+    .map(toSnapshotListEntry)
+    .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt));
+
+  const result: BackupListResult = { installationId, snapshots };
+  runtime.log(
+    opts.json
+      ? JSON.stringify(result, null, 2)
+      : snapshots.length === 0
+        ? `No backup snapshots found for installation ${installationId}`
+        : [
+            `Backup snapshots for ${installationId}:`,
+            ...snapshots.map(
+              (entry) =>
+                `- ${entry.snapshotId} ${entry.createdAt} ${entry.mode} bytes=${entry.ciphertextBytes}`,
+            ),
+          ].join("\n"),
+  );
+  return result;
+}

--- a/src/commands/backup-list.ts
+++ b/src/commands/backup-list.ts
@@ -1,7 +1,7 @@
 import type { RuntimeEnv } from "../runtime.js";
 import {
-  loadResolvedSnapshotBackup,
-  resolveSnapshotStore,
+  loadResolvedSnapshotBackupTarget,
+  resolveSnapshotListStore,
   resolveCurrentInstallationId,
   toSnapshotListEntry,
   type BackupSnapshotDeps,
@@ -21,7 +21,7 @@ export async function backupListCommand(
   opts: BackupListOptions,
   deps?: BackupSnapshotDeps,
 ): Promise<BackupListResult> {
-  const { snapshotStore, stateDir } = await loadResolvedSnapshotBackup({});
+  const { snapshotStore, stateDir } = await loadResolvedSnapshotBackupTarget({});
   const installationId = await resolveCurrentInstallationId({
     stateDir,
     createIfMissing: false,
@@ -32,7 +32,7 @@ export async function backupListCommand(
     return empty;
   }
 
-  const storage = await resolveSnapshotStore({ snapshotStore, deps });
+  const storage = await resolveSnapshotListStore({ snapshotStore, deps });
   const snapshots = (await storage.listSnapshots({ installationId }))
     .map(toSnapshotListEntry)
     .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt));

--- a/src/commands/backup-push.ts
+++ b/src/commands/backup-push.ts
@@ -45,7 +45,8 @@ export async function backupPushCommand(
   const keepLocalArchive = Boolean(opts.output?.trim());
 
   try {
-    const created = await backupCreateCommand(runtime, {
+    const archiveRuntime: RuntimeEnv = opts.json ? { ...runtime, log: () => {} } : runtime;
+    const created = await backupCreateCommand(archiveRuntime, {
       output: keepLocalArchive ? opts.output : tempDir,
       json: false,
       verify: Boolean(opts.verify),

--- a/src/commands/backup-push.ts
+++ b/src/commands/backup-push.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { encryptArchiveToPayload } from "../backup/snapshot-store/encryption.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  buildEnvelope,
+  createSnapshotId,
+  createTempBackupDir,
+  loadResolvedSnapshotBackup,
+  resolveSnapshotStore,
+  resolveCurrentInstallationId,
+  type BackupSnapshotDeps,
+} from "./backup-snapshot-shared.js";
+import { backupCreateCommand } from "./backup.js";
+
+export type BackupPushOptions = {
+  output?: string;
+  json?: boolean;
+  verify?: boolean;
+  snapshotName?: string;
+};
+
+export type BackupPushResult = {
+  snapshotId: string;
+  installationId: string;
+  createdAt: string;
+  archivePath?: string;
+  verified: boolean;
+};
+
+export async function backupPushCommand(
+  runtime: RuntimeEnv,
+  opts: BackupPushOptions,
+  deps?: BackupSnapshotDeps,
+): Promise<BackupPushResult> {
+  const { snapshotStore, stateDir } = await loadResolvedSnapshotBackup({});
+  const installationId = await resolveCurrentInstallationId({
+    stateDir,
+    createIfMissing: true,
+  });
+  if (!installationId) {
+    throw new Error("Failed to resolve backup installation id.");
+  }
+  const tempDir = await createTempBackupDir();
+  const keepLocalArchive = Boolean(opts.output?.trim());
+
+  try {
+    const created = await backupCreateCommand(runtime, {
+      output: keepLocalArchive ? opts.output : tempDir,
+      json: false,
+      verify: Boolean(opts.verify),
+      onlyConfig: false,
+      includeWorkspace: true,
+    });
+    const snapshotId = createSnapshotId(deps?.nowMs);
+    const payloadPath = path.join(tempDir, `${snapshotId}.payload.bin`);
+    const encrypted = await encryptArchiveToPayload({
+      archivePath: created.archivePath,
+      payloadPath,
+      secret: snapshotStore.encryptionKey,
+    });
+    const envelope = buildEnvelope({
+      snapshotId,
+      installationId,
+      createdAt: new Date(deps?.nowMs ?? Date.now()).toISOString(),
+      archiveRoot: created.archiveRoot,
+      archiveCreatedAt: created.createdAt,
+      includeWorkspace: created.includeWorkspace,
+      verified: created.verified,
+      onlyConfig: created.onlyConfig,
+      snapshotName: opts.snapshotName?.trim() || undefined,
+      encryption: encrypted,
+    });
+    const storage = await resolveSnapshotStore({ snapshotStore, deps });
+    await storage.uploadSnapshot({
+      installationId,
+      snapshotId,
+      envelope,
+      payloadPath,
+    });
+
+    const result: BackupPushResult = {
+      snapshotId,
+      installationId,
+      createdAt: envelope.createdAt,
+      archivePath: keepLocalArchive ? created.archivePath : undefined,
+      verified: created.verified,
+    };
+    runtime.log(
+      opts.json
+        ? JSON.stringify(result, null, 2)
+        : `Wrote encrypted backup snapshot ${snapshotId} for installation ${installationId}`,
+    );
+    return result;
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -260,6 +260,76 @@ describe("backup restore", () => {
     }
   });
 
+  it("prefers current workspace targets over archived absolute paths", async () => {
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const rootDir = path.join(extractDir, "archive-root");
+    const currentWorkspace = path.join(tempHome.home, "current-workspace");
+    const archivedWorkspace = path.join("/tmp", "archived-workspace");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "workspace"), { recursive: true });
+      await fs.mkdir(path.join(rootDir, "assets", "config"), { recursive: true });
+      await fs.writeFile(
+        path.join(rootDir, "assets", "config", "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: archivedWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(tempHome.home, ".openclaw", "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: currentWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      const operations = await buildRestoreOperations({
+        mode: "workspace-only",
+        extractedRoot: rootDir,
+        manifest: {
+          schemaVersion: 1,
+          createdAt: "2026-03-09T00:00:00.000Z",
+          archiveRoot: "archive-root",
+          runtimeVersion: "2026.3.9",
+          platform: process.platform,
+          nodeVersion: process.version,
+          paths: {
+            workspaceDirs: [archivedWorkspace],
+          },
+          assets: [
+            {
+              kind: "config",
+              sourcePath: path.join(tempHome.home, ".openclaw", "openclaw.json"),
+              archivePath: "archive-root/assets/config/openclaw.json",
+            },
+            {
+              kind: "workspace",
+              sourcePath: archivedWorkspace,
+              archivePath: "archive-root/assets/workspace",
+            },
+          ],
+        },
+      });
+
+      expect(operations).toEqual([
+        expect.objectContaining({
+          kind: "workspace",
+          targetPath: currentWorkspace,
+        }),
+      ]);
+    } finally {
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects restoring a workspace directly onto the home directory", async () => {
     const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
     const rootDir = path.join(extractDir, "archive-root");

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -454,6 +454,48 @@ describe("backup restore", () => {
     }
   });
 
+  it("keeps rollback rename moves on the target filesystem", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-exdev-"));
+    const originalRename = fs.rename.bind(fs);
+    try {
+      await fs.writeFile(path.join(stateDir, "state.txt"), "before\n", "utf8");
+
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: false,
+      });
+
+      await fs.writeFile(path.join(stateDir, "state.txt"), "after\n", "utf8");
+
+      const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (sourcePath, destPath) => {
+        const sourcePathString = sourcePath.toString();
+        const destPathString = destPath.toString();
+        const targetParent = path.dirname(stateDir);
+        const relativeDest = path.relative(targetParent, destPathString);
+        if (
+          sourcePathString === stateDir &&
+          (relativeDest.startsWith("..") || path.isAbsolute(relativeDest))
+        ) {
+          const error = new Error("cross-device link not permitted") as NodeJS.ErrnoException;
+          error.code = "EXDEV";
+          throw error;
+        }
+        return await originalRename(sourcePathString, destPathString);
+      });
+
+      await backupRestoreCommand(runtime, {
+        archive: created.archivePath,
+        mode: "full-host",
+      });
+
+      expect(await fs.readFile(path.join(stateDir, "state.txt"), "utf8")).toBe("before\n");
+      renameSpy.mockRestore();
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps --json output clean when force-stopping the gateway", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-force-stop-"));
@@ -522,7 +564,7 @@ describe("backup restore", () => {
           archive: archivePath,
           mode: "full-host",
         }),
-      ).rejects.toThrow(/unsupported tar link entry|tar entry is a link|symbolic link/i);
+      ).rejects.toThrow(/unsupported tar (special )?entry|tar entry is a link|symbolic link/i);
     } finally {
       await fs.rm(archiveDir, { recursive: true, force: true });
       await fs.rm(sourceDir, { recursive: true, force: true });

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -260,6 +260,53 @@ describe("backup restore", () => {
     }
   });
 
+  it("matches workspace assets by source path when candidate dirs include extra workspaces", async () => {
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const workspaceA = path.join(tempHome.home, "workspace-a");
+    const workspaceB = path.join(tempHome.home, "workspace-b");
+    const extraWorkspace = path.join(tempHome.home, "workspace-extra");
+    const rootDir = path.join(extractDir, "archive-root");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-a"), { recursive: true });
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-b"), { recursive: true });
+      const operations = await buildRestoreOperations({
+        mode: "workspace-only",
+        extractedRoot: rootDir,
+        manifest: {
+          schemaVersion: 1,
+          createdAt: "2026-03-09T00:00:00.000Z",
+          archiveRoot: "archive-root",
+          runtimeVersion: "2026.3.9",
+          platform: process.platform,
+          nodeVersion: process.version,
+          paths: {
+            workspaceDirs: [extraWorkspace, workspaceB, workspaceA],
+          },
+          assets: [
+            {
+              kind: "workspace",
+              sourcePath: workspaceA,
+              archivePath: "archive-root/assets/workspace-a",
+            },
+            {
+              kind: "workspace",
+              sourcePath: workspaceB,
+              archivePath: "archive-root/assets/workspace-b",
+            },
+          ],
+        },
+      });
+
+      const workspaceOps = operations.filter((entry) => entry.kind === "workspace");
+      expect(workspaceOps).toEqual([
+        expect.objectContaining({ targetPath: workspaceA }),
+        expect.objectContaining({ targetPath: workspaceB }),
+      ]);
+    } finally {
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
   it("prefers current workspace targets over archived absolute paths", async () => {
     const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
     const rootDir = path.join(extractDir, "archive-root");

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -307,7 +307,78 @@ describe("backup restore", () => {
     }
   });
 
-  it("prefers current workspace targets over archived absolute paths", async () => {
+  it("falls back to current workspace only when source-path matching fails for every candidate", async () => {
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const rootDir = path.join(extractDir, "archive-root");
+    const currentWorkspace = path.join(tempHome.home, "current-workspace");
+    const archivedWorkspace = path.join("/tmp", "archived-workspace");
+    const unmatchedWorkspace = path.join("/tmp", "unmatched-workspace");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "workspace"), { recursive: true });
+      await fs.mkdir(path.join(rootDir, "assets", "config"), { recursive: true });
+      await fs.writeFile(
+        path.join(rootDir, "assets", "config", "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: unmatchedWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(tempHome.home, ".openclaw", "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: currentWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      const operations = await buildRestoreOperations({
+        mode: "workspace-only",
+        extractedRoot: rootDir,
+        manifest: {
+          schemaVersion: 1,
+          createdAt: "2026-03-09T00:00:00.000Z",
+          archiveRoot: "archive-root",
+          runtimeVersion: "2026.3.9",
+          platform: process.platform,
+          nodeVersion: process.version,
+          paths: {
+            workspaceDirs: [unmatchedWorkspace],
+          },
+          assets: [
+            {
+              kind: "config",
+              sourcePath: path.join(tempHome.home, ".openclaw", "openclaw.json"),
+              archivePath: "archive-root/assets/config/openclaw.json",
+            },
+            {
+              kind: "workspace",
+              sourcePath: archivedWorkspace,
+              archivePath: "archive-root/assets/workspace",
+            },
+          ],
+        },
+      });
+
+      expect(operations).toEqual([
+        expect.objectContaining({
+          kind: "workspace",
+          targetPath: currentWorkspace,
+        }),
+      ]);
+    } finally {
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers source-path match from later candidates over early positional fallback", async () => {
     const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
     const rootDir = path.join(extractDir, "archive-root");
     const currentWorkspace = path.join(tempHome.home, "current-workspace");
@@ -369,7 +440,7 @@ describe("backup restore", () => {
       expect(operations).toEqual([
         expect.objectContaining({
           kind: "workspace",
-          targetPath: currentWorkspace,
+          targetPath: archivedWorkspace,
         }),
       ]);
     } finally {

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -9,10 +9,15 @@ import { backupRestoreCommand, buildRestoreOperations } from "./backup-restore.j
 import { normalizeArchiveRoot, parseBackupManifest } from "./backup-verify.js";
 import { backupCreateCommand } from "./backup.js";
 
+const { serviceIsLoaded, serviceStop } = vi.hoisted(() => ({
+  serviceIsLoaded: vi.fn(async () => false),
+  serviceStop: vi.fn(async (_args?: { stdout: NodeJS.WritableStream }) => undefined),
+}));
+
 vi.mock("../daemon/service.js", () => ({
   resolveGatewayService: () => ({
-    isLoaded: vi.fn(async () => false),
-    stop: vi.fn(async () => undefined),
+    isLoaded: serviceIsLoaded,
+    stop: serviceStop,
   }),
 }));
 
@@ -24,6 +29,8 @@ describe("backup restore", () => {
   beforeEach(async () => {
     tempHome = await createTempHomeEnv("openclaw-backup-restore-test-");
     previousCwd = process.cwd();
+    serviceIsLoaded.mockResolvedValue(false);
+    serviceStop.mockResolvedValue(undefined);
     runtime = {
       log: vi.fn() as RuntimeEnv["log"],
       error: vi.fn() as RuntimeEnv["error"],
@@ -246,6 +253,111 @@ describe("backup restore", () => {
       const message = vi.mocked(runtime.log).mock.calls[0]?.[0];
       expect(typeof message).toBe("string");
       expect(() => JSON.parse(String(message))).not.toThrow();
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("restores config-only from the state asset when no standalone config asset exists", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-config-only-"));
+    try {
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          backup: {
+            target: path.join(tempHome.home, "backups"),
+          },
+        }),
+        "utf8",
+      );
+
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: false,
+      });
+
+      await fs.rm(path.join(stateDir, "openclaw.json"), { force: true });
+
+      const restored = await backupRestoreCommand(runtime, {
+        archive: created.archivePath,
+        mode: "config-only",
+      });
+
+      expect(restored.mode).toBe("config-only");
+      expect(await fs.readFile(path.join(stateDir, "openclaw.json"), "utf8")).toContain('"backup"');
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects invalid restore modes instead of defaulting to full-host", async () => {
+    await expect(
+      backupRestoreCommand(runtime, {
+        archive: path.join(tempHome.home, "missing.tar.gz"),
+        mode: "workspace" as "full-host",
+      }),
+    ).rejects.toThrow("Invalid restore mode: workspace");
+  });
+
+  it("restores the original target if copying fails after rollback rename", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-rollback-"));
+    const originalCp = fs.cp.bind(fs);
+    try {
+      await fs.writeFile(path.join(stateDir, "state.txt"), "original\n", "utf8");
+
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: false,
+      });
+
+      const cpSpy = vi.spyOn(fs, "cp").mockImplementation(async (...args) => {
+        const targetPath = args[1];
+        if (targetPath === stateDir) {
+          throw new Error("copy failed");
+        }
+        return await originalCp(...args);
+      });
+
+      await expect(
+        backupRestoreCommand(runtime, {
+          archive: created.archivePath,
+          mode: "full-host",
+        }),
+      ).rejects.toThrow("copy failed");
+      expect(await fs.readFile(path.join(stateDir, "state.txt"), "utf8")).toBe("original\n");
+      cpSpy.mockRestore();
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps --json output clean when force-stopping the gateway", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-force-stop-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: false,
+      });
+
+      serviceIsLoaded.mockResolvedValue(true);
+      serviceStop.mockImplementation(async (args) => {
+        args?.stdout.write("stopping\n");
+      });
+
+      vi.mocked(runtime.log).mockClear();
+      await backupRestoreCommand(runtime, {
+        archive: created.archivePath,
+        mode: "full-host",
+        json: true,
+        forceStop: true,
+      });
+
+      expect(runtime.log).toHaveBeenCalledTimes(1);
+      expect(() => JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0]))).not.toThrow();
     } finally {
       await fs.rm(archiveDir, { recursive: true, force: true });
     }

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -403,6 +403,104 @@ describe("backup restore", () => {
     }
   });
 
+  it("rejects workspace restore targets nested under the oauth directory", async () => {
+    const originalOAuthDir = process.env.OPENCLAW_OAUTH_DIR;
+    const oauthDir = path.join(tempHome.home, "external-oauth");
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const rootDir = path.join(extractDir, "archive-root");
+    const unsafeWorkspace = path.join(oauthDir, "workspace");
+    try {
+      process.env.OPENCLAW_OAUTH_DIR = oauthDir;
+      await fs.mkdir(path.join(rootDir, "assets", "workspace"), { recursive: true });
+
+      await expect(
+        buildRestoreOperations({
+          mode: "workspace-only",
+          extractedRoot: rootDir,
+          manifest: {
+            schemaVersion: 1,
+            createdAt: "2026-03-09T00:00:00.000Z",
+            archiveRoot: "archive-root",
+            runtimeVersion: "2026.3.9",
+            platform: process.platform,
+            nodeVersion: process.version,
+            paths: {
+              workspaceDirs: [unsafeWorkspace],
+            },
+            assets: [
+              {
+                kind: "workspace",
+                sourcePath: unsafeWorkspace,
+                archivePath: "archive-root/assets/workspace",
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow("Refusing to restore workspace to an unsafe path");
+    } finally {
+      if (originalOAuthDir == null) {
+        delete process.env.OPENCLAW_OAUTH_DIR;
+      } else {
+        process.env.OPENCLAW_OAUTH_DIR = originalOAuthDir;
+      }
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails full-host restore when archived workspace assets cannot be mapped", async () => {
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const rootDir = path.join(extractDir, "archive-root");
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archivedWorkspaceA = path.join("/tmp", "archived-workspace-a");
+    const archivedWorkspaceB = path.join("/tmp", "archived-workspace-b");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "state"), { recursive: true });
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-a"), { recursive: true });
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-b"), { recursive: true });
+
+      await expect(
+        buildRestoreOperations({
+          mode: "full-host",
+          extractedRoot: rootDir,
+          manifest: {
+            schemaVersion: 1,
+            createdAt: "2026-03-09T00:00:00.000Z",
+            archiveRoot: "archive-root",
+            runtimeVersion: "2026.3.9",
+            platform: process.platform,
+            nodeVersion: process.version,
+            paths: {
+              workspaceDirs: [
+                archivedWorkspaceA,
+                path.join("/tmp", "missing-workspace"),
+                path.join("/tmp", "missing-workspace-2"),
+              ],
+            },
+            assets: [
+              {
+                kind: "state",
+                sourcePath: stateDir,
+                archivePath: "archive-root/assets/state",
+              },
+              {
+                kind: "workspace",
+                sourcePath: archivedWorkspaceA,
+                archivePath: "archive-root/assets/workspace-a",
+              },
+              {
+                kind: "workspace",
+                sourcePath: archivedWorkspaceB,
+                archivePath: "archive-root/assets/workspace-b",
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow("Workspace restore target mismatch");
+    } finally {
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
   it("emits a single JSON payload when restore runs with --json", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-json-"));

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -143,4 +143,77 @@ describe("backup restore", () => {
       await fs.rm(extractDir, { recursive: true, force: true });
     }
   });
+
+  it("matches workspace assets by source path when manifest workspaceDirs order differs", async () => {
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const workspaceA = path.join(tempHome.home, "workspace-a");
+    const workspaceB = path.join(tempHome.home, "workspace-b");
+    const rootDir = path.join(extractDir, "archive-root");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-a"), { recursive: true });
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-b"), { recursive: true });
+      const operations = await buildRestoreOperations({
+        mode: "workspace-only",
+        extractedRoot: rootDir,
+        manifest: {
+          schemaVersion: 1,
+          createdAt: "2026-03-09T00:00:00.000Z",
+          archiveRoot: "archive-root",
+          runtimeVersion: "2026.3.9",
+          platform: process.platform,
+          nodeVersion: process.version,
+          paths: {
+            workspaceDirs: [workspaceB, workspaceA],
+          },
+          assets: [
+            {
+              kind: "workspace",
+              sourcePath: workspaceA,
+              archivePath: "archive-root/assets/workspace-a",
+            },
+            {
+              kind: "workspace",
+              sourcePath: workspaceB,
+              archivePath: "archive-root/assets/workspace-b",
+            },
+          ],
+        },
+      });
+
+      const workspaceOps = operations.filter((entry) => entry.kind === "workspace");
+      expect(workspaceOps).toEqual([
+        expect.objectContaining({ targetPath: workspaceA }),
+        expect.objectContaining({ targetPath: workspaceB }),
+      ]);
+    } finally {
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a single JSON payload when restore runs with --json", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-json-"));
+    try {
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: false,
+      });
+
+      vi.mocked(runtime.log).mockClear();
+      await backupRestoreCommand(runtime, {
+        archive: created.archivePath,
+        mode: "full-host",
+        json: true,
+      });
+
+      expect(runtime.log).toHaveBeenCalledTimes(1);
+      const message = vi.mocked(runtime.log).mock.calls[0]?.[0];
+      expect(typeof message).toBe("string");
+      expect(() => JSON.parse(String(message))).not.toThrow();
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -29,6 +29,8 @@ describe("backup restore", () => {
   beforeEach(async () => {
     tempHome = await createTempHomeEnv("openclaw-backup-restore-test-");
     previousCwd = process.cwd();
+    serviceIsLoaded.mockClear();
+    serviceStop.mockClear();
     serviceIsLoaded.mockResolvedValue(false);
     serviceStop.mockResolvedValue(undefined);
     runtime = {
@@ -231,6 +233,45 @@ describe("backup restore", () => {
     }
   });
 
+  it("rejects workspace restore targets whose symlinks resolve into the state directory", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const rootDir = path.join(extractDir, "archive-root");
+    const symlinkPath = path.join(tempHome.home, "workspace-link");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-link"), { recursive: true });
+      await fs.symlink(stateDir, symlinkPath);
+
+      await expect(
+        buildRestoreOperations({
+          mode: "workspace-only",
+          extractedRoot: rootDir,
+          manifest: {
+            schemaVersion: 1,
+            createdAt: "2026-03-09T00:00:00.000Z",
+            archiveRoot: "archive-root",
+            runtimeVersion: "2026.3.9",
+            platform: process.platform,
+            nodeVersion: process.version,
+            paths: {
+              workspaceDirs: [symlinkPath],
+            },
+            assets: [
+              {
+                kind: "workspace",
+                sourcePath: symlinkPath,
+                archivePath: "archive-root/assets/workspace-link",
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow("Refusing to restore workspace to an unsafe path");
+    } finally {
+      await fs.rm(symlinkPath, { force: true }).catch(() => undefined);
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
   it("emits a single JSON payload when restore runs with --json", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-json-"));
@@ -292,12 +333,31 @@ describe("backup restore", () => {
   });
 
   it("rejects invalid restore modes instead of defaulting to full-host", async () => {
+    serviceIsLoaded.mockResolvedValue(true);
     await expect(
       backupRestoreCommand(runtime, {
         archive: path.join(tempHome.home, "missing.tar.gz"),
         mode: "workspace" as "full-host",
+        forceStop: true,
       }),
     ).rejects.toThrow("Invalid restore mode: workspace");
+    expect(serviceIsLoaded).not.toHaveBeenCalled();
+    expect(serviceStop).not.toHaveBeenCalled();
+  });
+
+  it("does not stop the gateway when restore archive validation fails", async () => {
+    serviceIsLoaded.mockResolvedValue(true);
+
+    await expect(
+      backupRestoreCommand(runtime, {
+        archive: path.join(tempHome.home, "missing.tar.gz"),
+        mode: "full-host",
+        forceStop: true,
+      }),
+    ).rejects.toThrow();
+
+    expect(serviceIsLoaded).not.toHaveBeenCalled();
+    expect(serviceStop).not.toHaveBeenCalled();
   });
 
   it("restores the original target if copying fails after rollback rename", async () => {

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -190,6 +190,40 @@ describe("backup restore", () => {
     }
   });
 
+  it("rejects restoring a workspace directly onto the home directory", async () => {
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const rootDir = path.join(extractDir, "archive-root");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-home"), { recursive: true });
+      await expect(
+        buildRestoreOperations({
+          mode: "workspace-only",
+          extractedRoot: rootDir,
+          manifest: {
+            schemaVersion: 1,
+            createdAt: "2026-03-09T00:00:00.000Z",
+            archiveRoot: "archive-root",
+            runtimeVersion: "2026.3.9",
+            platform: process.platform,
+            nodeVersion: process.version,
+            paths: {
+              workspaceDirs: [tempHome.home],
+            },
+            assets: [
+              {
+                kind: "workspace",
+                sourcePath: tempHome.home,
+                archivePath: "archive-root/assets/workspace-home",
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow("Refusing to restore workspace to an unsafe path");
+    } finally {
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
   it("emits a single JSON payload when restore runs with --json", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-json-"));
@@ -214,6 +248,51 @@ describe("backup restore", () => {
       expect(() => JSON.parse(String(message))).not.toThrow();
     } finally {
       await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects restore archives that contain symbolic links", async () => {
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-link-archive-"));
+    const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-link-source-"));
+    const linkedDir = path.join(sourceDir, "openclaw-backup");
+    const archivePath = path.join(archiveDir, "malicious-backup.tar.gz");
+    try {
+      await fs.mkdir(path.join(sourceDir, "outside"), { recursive: true });
+      await fs.writeFile(path.join(sourceDir, "outside", "owned.txt"), "owned\n", "utf8");
+      await fs.mkdir(linkedDir, { recursive: true });
+      await fs.writeFile(
+        path.join(linkedDir, "manifest.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          createdAt: "2026-03-09T00:00:00.000Z",
+          archiveRoot: "openclaw-backup",
+          runtimeVersion: "2026.3.9",
+          platform: process.platform,
+          nodeVersion: process.version,
+          assets: [],
+        }),
+        "utf8",
+      );
+      await fs.symlink("../outside", path.join(linkedDir, "payload"));
+
+      await tar.c(
+        {
+          gzip: true,
+          cwd: sourceDir,
+          file: archivePath,
+        },
+        ["openclaw-backup"],
+      );
+
+      await expect(
+        backupRestoreCommand(runtime, {
+          archive: archivePath,
+          mode: "full-host",
+        }),
+      ).rejects.toThrow(/tar entry is a link|symbolic link/i);
+    } finally {
+      await fs.rm(archiveDir, { recursive: true, force: true });
+      await fs.rm(sourceDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { backupRestoreCommand, buildRestoreOperations } from "./backup-restore.js";
+import { normalizeArchiveRoot, parseBackupManifest } from "./backup-verify.js";
+import { backupCreateCommand } from "./backup.js";
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => ({
+    isLoaded: vi.fn(async () => false),
+    stop: vi.fn(async () => undefined),
+  }),
+}));
+
+describe("backup restore", () => {
+  let tempHome: TempHomeEnv;
+  let runtime: RuntimeEnv;
+  let previousCwd: string;
+
+  beforeEach(async () => {
+    tempHome = await createTempHomeEnv("openclaw-backup-restore-test-");
+    previousCwd = process.cwd();
+    runtime = {
+      log: vi.fn() as RuntimeEnv["log"],
+      error: vi.fn() as RuntimeEnv["error"],
+      exit: vi.fn() as RuntimeEnv["exit"],
+    };
+  });
+
+  afterEach(async () => {
+    process.chdir(previousCwd);
+    await tempHome.restore();
+  });
+
+  it("restores a full-host backup archive into the current installation layout", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-ws-"));
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-archive-"));
+    try {
+      await fs.mkdir(externalWorkspace, { recursive: true });
+      await fs.writeFile(path.join(externalWorkspace, "SOUL.md"), "# external\n", "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: externalWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: true,
+      });
+
+      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+
+      const restored = await backupRestoreCommand(runtime, {
+        archive: created.archivePath,
+        mode: "full-host",
+      });
+
+      expect(restored.mode).toBe("full-host");
+      expect(restored.restoredTargets).toEqual(
+        expect.arrayContaining([stateDir, externalWorkspace]),
+      );
+      expect(await fs.readFile(path.join(stateDir, "state.txt"), "utf8")).toBe("state\n");
+      expect(await fs.readFile(path.join(externalWorkspace, "SOUL.md"), "utf8")).toBe(
+        "# external\n",
+      );
+    } finally {
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(archiveDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses manifest workspace paths when restore config falls back to the default workspace", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-ws-"));
+    const archiveDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-archive-"));
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    try {
+      await fs.mkdir(externalWorkspace, { recursive: true });
+      await fs.writeFile(path.join(externalWorkspace, "SOUL.md"), "# external\n", "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: externalWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      const created = await backupCreateCommand(runtime, {
+        output: archiveDir,
+        includeWorkspace: true,
+      });
+      await tar.x({
+        file: created.archivePath,
+        cwd: extractDir,
+        gzip: true,
+      });
+
+      const archiveRoot = normalizeArchiveRoot(
+        path.basename(created.archivePath).replace(/\.tar\.gz$/, ""),
+      );
+      const extractedRoot = path.join(extractDir, archiveRoot);
+      const manifest = parseBackupManifest(
+        await fs.readFile(path.join(extractedRoot, "manifest.json"), "utf8"),
+      );
+
+      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+
+      const operations = await buildRestoreOperations({
+        mode: "full-host",
+        manifest,
+        extractedRoot,
+      });
+
+      expect(operations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ kind: "state", targetPath: stateDir }),
+          expect.objectContaining({ kind: "workspace", targetPath: externalWorkspace }),
+        ]),
+      );
+    } finally {
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(archiveDir, { recursive: true, force: true });
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -199,6 +199,67 @@ describe("backup restore", () => {
     }
   });
 
+  it("matches workspace assets by canonical source path when manifest workspace roots are symlinked", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
+    const workspaceA = path.join(tempHome.home, "workspace-a");
+    const workspaceB = path.join(tempHome.home, "workspace-b");
+    const linkA = path.join(tempHome.home, "workspace-a-link");
+    const linkB = path.join(tempHome.home, "workspace-b-link");
+    const rootDir = path.join(extractDir, "archive-root");
+    try {
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-a"), { recursive: true });
+      await fs.mkdir(path.join(rootDir, "assets", "workspace-b"), { recursive: true });
+      await fs.mkdir(workspaceA, { recursive: true });
+      await fs.mkdir(workspaceB, { recursive: true });
+      await fs.symlink(workspaceA, linkA);
+      await fs.symlink(workspaceB, linkB);
+
+      const operations = await buildRestoreOperations({
+        mode: "workspace-only",
+        extractedRoot: rootDir,
+        manifest: {
+          schemaVersion: 1,
+          createdAt: "2026-03-09T00:00:00.000Z",
+          archiveRoot: "archive-root",
+          runtimeVersion: "2026.3.9",
+          platform: process.platform,
+          nodeVersion: process.version,
+          paths: {
+            workspaceDirs: [linkB, linkA],
+          },
+          assets: [
+            {
+              kind: "workspace",
+              sourcePath: workspaceA,
+              archivePath: "archive-root/assets/workspace-a",
+            },
+            {
+              kind: "workspace",
+              sourcePath: workspaceB,
+              archivePath: "archive-root/assets/workspace-b",
+            },
+          ],
+        },
+      });
+
+      const workspaceOps = operations.filter((entry) => entry.kind === "workspace");
+      expect(workspaceOps).toEqual([
+        expect.objectContaining({ targetPath: linkA }),
+        expect.objectContaining({ targetPath: linkB }),
+      ]);
+    } finally {
+      await fs.rm(linkA, { force: true }).catch(() => undefined);
+      await fs.rm(linkB, { force: true }).catch(() => undefined);
+      await fs.rm(workspaceA, { recursive: true, force: true });
+      await fs.rm(workspaceB, { recursive: true, force: true });
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects restoring a workspace directly onto the home directory", async () => {
     const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-extract-"));
     const rootDir = path.join(extractDir, "archive-root");
@@ -461,7 +522,7 @@ describe("backup restore", () => {
           archive: archivePath,
           mode: "full-host",
         }),
-      ).rejects.toThrow(/tar entry is a link|symbolic link/i);
+      ).rejects.toThrow(/unsupported tar link entry|tar entry is a link|symbolic link/i);
     } finally {
       await fs.rm(archiveDir, { recursive: true, force: true });
       await fs.rm(sourceDir, { recursive: true, force: true });

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -480,12 +480,17 @@ export async function buildRestoreOperations(params: {
           candidateDirs,
           workspaceAssetSourceKeys,
         );
+        // Only fall back to positional matching when there is exactly 1 workspace
+        // (unambiguous). With multiple workspaces, positional mapping can silently
+        // restore to the wrong directory when counts match by coincidence.
         const workspaceTargets =
           workspaceTargetsBySourcePath ??
-          selectWorkspaceTargets({
-            workspaceAssetCount: workspaceAssets.length,
-            workspaceDirs: candidateDirs,
-          });
+          (workspaceAssets.length === 1
+            ? selectWorkspaceTargets({
+                workspaceAssetCount: workspaceAssets.length,
+                workspaceDirs: candidateDirs,
+              })
+            : undefined);
         if (!workspaceTargets) {
           continue;
         }

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -107,10 +107,7 @@ async function mapWorkspaceTargetsBySourcePath(
     workspaceDirs.map(async (entry) => [await canonicalWorkspacePathKey(entry), entry] as const),
   );
   const workspaceMap = new Map(workspaceEntries);
-  if (
-    workspaceMap.size !== workspaceAssetSourceKeys.length ||
-    !workspaceAssetSourceKeys.every((key) => workspaceMap.has(key))
-  ) {
+  if (!workspaceAssetSourceKeys.every((key) => workspaceMap.has(key))) {
     return undefined;
   }
   return workspaceMap;

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -474,27 +474,13 @@ export async function buildRestoreOperations(params: {
       let workspaceTargetError: Error | undefined;
       let restoredWorkspace = false;
       let workspaceCoveredByState = false;
-      for (const candidateDirs of workspaceTargetCandidates) {
-        const workspaceTargetsBySourcePath = await mapWorkspaceTargetsBySourcePath(
-          candidateDirs,
-          workspaceAssetSourceKeys,
-        );
-        // Only fall back to positional matching when there is exactly 1 workspace
-        // (unambiguous). With multiple workspaces, positional mapping can silently
-        // restore to the wrong directory when counts match by coincidence.
-        const workspaceTargets =
-          workspaceTargetsBySourcePath ??
-          (workspaceAssets.length === 1
-            ? selectWorkspaceTargets({
-                workspaceAssetCount: workspaceAssets.length,
-                workspaceDirs: candidateDirs,
-              })
-            : undefined);
+      const tryWorkspaceTargets = async (
+        workspaceTargets: Map<string, string> | string[] | undefined,
+      ): Promise<"missing" | "invalid" | "covered" | "restored"> => {
         if (!workspaceTargets) {
-          continue;
+          return "missing";
         }
         const candidateOperations: RestoreOperation[] = [];
-        let candidateInvalid = false;
         for (const [index, asset] of workspaceAssets.entries()) {
           const assetSourceKey = workspaceAssetSourceKeys[index];
           const targetPath =
@@ -502,8 +488,7 @@ export async function buildRestoreOperations(params: {
               ? workspaceTargets.get(assetSourceKey)
               : workspaceTargets[index];
           if (!targetPath) {
-            candidateInvalid = true;
-            break;
+            return "invalid";
           }
           if (params.mode === "full-host" && stateAsset && isPathWithin(targetPath, stateDir)) {
             continue;
@@ -517,8 +502,7 @@ export async function buildRestoreOperations(params: {
             });
           } catch (error) {
             workspaceTargetError = error instanceof Error ? error : new Error(String(error));
-            candidateInvalid = true;
-            break;
+            return "invalid";
           }
           candidateOperations.push({
             kind: "workspace",
@@ -526,16 +510,45 @@ export async function buildRestoreOperations(params: {
             targetPath,
           });
         }
-        if (candidateInvalid) {
-          continue;
-        }
         if (candidateOperations.length === 0 && params.mode === "full-host" && stateAsset) {
+          return "covered";
+        }
+        operations.push(...candidateOperations);
+        return "restored";
+      };
+
+      // Prefer source-path matching across all candidate sets first.
+      for (const candidateDirs of workspaceTargetCandidates) {
+        const outcome = await tryWorkspaceTargets(
+          await mapWorkspaceTargetsBySourcePath(candidateDirs, workspaceAssetSourceKeys),
+        );
+        if (outcome === "covered") {
           workspaceCoveredByState = true;
           continue;
         }
-        operations.push(...candidateOperations);
-        restoredWorkspace = true;
-        break;
+        if (outcome === "restored") {
+          restoredWorkspace = true;
+          break;
+        }
+      }
+      // Only attempt positional fallback after all source-path matches fail.
+      if (!restoredWorkspace && workspaceAssets.length === 1) {
+        for (const candidateDirs of workspaceTargetCandidates) {
+          const outcome = await tryWorkspaceTargets(
+            selectWorkspaceTargets({
+              workspaceAssetCount: workspaceAssets.length,
+              workspaceDirs: candidateDirs,
+            }),
+          );
+          if (outcome === "covered") {
+            workspaceCoveredByState = true;
+            continue;
+          }
+          if (outcome === "restored") {
+            restoredWorkspace = true;
+            break;
+          }
+        }
       }
       if (!restoredWorkspace) {
         if (workspaceTargetError) {

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -283,36 +283,53 @@ async function copySourceToTarget(sourcePath: string, targetPath: string): Promi
   await fs.copyFile(sourcePath, targetPath);
 }
 
-async function applyRestoreOperations(
-  operations: RestoreOperation[],
-  rollbackRoot: string,
-): Promise<void> {
-  const applied: Array<{ targetPath: string; backupPath?: string }> = [];
+async function moveTargetToRollbackPath(targetPath: string): Promise<{
+  rollbackPath: string;
+  rollbackDir: string;
+}> {
+  const targetParent = path.dirname(targetPath);
+  const rollbackDir = await fs.mkdtemp(path.join(targetParent, ".openclaw-restore-rollback-"));
+  const rollbackPath = path.join(rollbackDir, path.basename(targetPath) || "target");
+  await fs.rename(targetPath, rollbackPath);
+  return {
+    rollbackPath,
+    rollbackDir,
+  };
+}
+
+async function applyRestoreOperations(operations: RestoreOperation[]): Promise<void> {
+  const applied: Array<{ targetPath: string; backupPath?: string; rollbackDir?: string }> = [];
   try {
     for (const operation of operations) {
       let backupPath: string | undefined;
+      let rollbackDir: string | undefined;
       try {
         await fs.access(operation.targetPath);
-        backupPath = path.join(
-          rollbackRoot,
-          `${applied.length}-${path.basename(operation.targetPath) || "target"}`,
-        );
-        await fs.mkdir(path.dirname(backupPath), { recursive: true });
-        await fs.rename(operation.targetPath, backupPath);
+        const moved = await moveTargetToRollbackPath(operation.targetPath);
+        backupPath = moved.rollbackPath;
+        rollbackDir = moved.rollbackDir;
       } catch (error) {
         if (!isNotFoundError(error)) {
           throw error;
         }
         backupPath = undefined;
       }
-      applied.push({ targetPath: operation.targetPath, backupPath });
+      applied.push({ targetPath: operation.targetPath, backupPath, rollbackDir });
       await copySourceToTarget(operation.sourcePath, operation.targetPath);
+    }
+    for (const appliedOp of applied) {
+      if (appliedOp.rollbackDir) {
+        await fs.rm(appliedOp.rollbackDir, { recursive: true, force: true });
+      }
     }
   } catch (error) {
     for (const appliedOp of applied.toReversed()) {
       await fs.rm(appliedOp.targetPath, { recursive: true, force: true }).catch(() => undefined);
       if (appliedOp.backupPath) {
         await fs.rename(appliedOp.backupPath, appliedOp.targetPath).catch(() => undefined);
+      }
+      if (appliedOp.rollbackDir) {
+        await fs.rm(appliedOp.rollbackDir, { recursive: true, force: true }).catch(() => undefined);
       }
     }
     throw error;
@@ -550,8 +567,7 @@ export async function backupRestoreCommand(
       manifest,
       extractedRoot,
     });
-    const rollbackRoot = path.join(workingDir, "rollback");
-    await applyRestoreOperations(operations, rollbackRoot);
+    await applyRestoreOperations(operations);
 
     const result: BackupRestoreResult = {
       mode,

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -88,24 +88,32 @@ async function canonicalWorkspacePathKey(value: string): Promise<string> {
 
 function selectWorkspaceTargets(params: {
   workspaceAssetCount: number;
-  manifestWorkspaceDirs: string[];
-  restoredWorkspaceDirs: string[];
-  currentWorkspaceDirs: string[];
+  workspaceDirs: string[];
 }): string[] | undefined {
-  const candidates = [
-    params.manifestWorkspaceDirs,
-    params.restoredWorkspaceDirs,
-    params.currentWorkspaceDirs,
-  ];
-  for (const dirs of candidates) {
-    if (dirs.length === params.workspaceAssetCount) {
-      return dirs;
-    }
-    if (dirs.length === 1 && params.workspaceAssetCount === 1) {
-      return dirs;
-    }
+  if (params.workspaceDirs.length === params.workspaceAssetCount) {
+    return params.workspaceDirs;
+  }
+  if (params.workspaceDirs.length === 1 && params.workspaceAssetCount === 1) {
+    return params.workspaceDirs;
   }
   return undefined;
+}
+
+async function mapWorkspaceTargetsBySourcePath(
+  workspaceDirs: string[],
+  workspaceAssetSourceKeys: readonly string[],
+): Promise<Map<string, string> | undefined> {
+  const workspaceEntries = await Promise.all(
+    workspaceDirs.map(async (entry) => [await canonicalWorkspacePathKey(entry), entry] as const),
+  );
+  const workspaceMap = new Map(workspaceEntries);
+  if (
+    workspaceMap.size !== workspaceAssetSourceKeys.length ||
+    !workspaceAssetSourceKeys.every((key) => workspaceMap.has(key))
+  ) {
+    return undefined;
+  }
+  return workspaceMap;
 }
 
 async function ensureGatewayStopped(
@@ -408,18 +416,9 @@ export async function buildRestoreOperations(params: {
   const configAsset = assetByKind.get("config")?.[0];
   const credentialsAsset = assetByKind.get("credentials")?.[0];
   const workspaceAssets = assetByKind.get("workspace") ?? [];
-  const manifestWorkspaceEntries = await Promise.all(
-    manifestWorkspaceDirs.map(
-      async (entry) => [await canonicalWorkspacePathKey(entry), entry] as const,
-    ),
-  );
-  const manifestWorkspaceMap = new Map(manifestWorkspaceEntries);
   const workspaceAssetSourceKeys = await Promise.all(
     workspaceAssets.map(async (asset) => await canonicalWorkspacePathKey(asset.sourcePath)),
   );
-  const canMatchWorkspaceTargetsBySourcePath =
-    manifestWorkspaceMap.size === workspaceAssets.length &&
-    workspaceAssetSourceKeys.every((key) => manifestWorkspaceMap.has(key));
 
   if (params.mode === "config-only") {
     const configSourcePath =
@@ -469,58 +468,79 @@ export async function buildRestoreOperations(params: {
 
   if (params.mode === "workspace-only" || params.mode === "full-host") {
     if (workspaceAssets.length > 0) {
-      // The manifest records the exact workspace roots that were archived. Prefer it over
-      // config-derived values because config parsing may fall back to the default workspace.
-      const workspaceTargetsBySourcePath = canMatchWorkspaceTargetsBySourcePath
-        ? new Map<string, string>(
-            await Promise.all(
-              workspaceAssets.map(async (asset): Promise<readonly [string, string]> => {
-                const assetSourceKey = await canonicalWorkspacePathKey(asset.sourcePath);
-                const targetPath = manifestWorkspaceMap.get(assetSourceKey);
-                if (!targetPath) {
-                  throw new Error(
-                    `Workspace restore target mismatch for archived workspace: ${asset.sourcePath}`,
-                  );
-                }
-                return [assetSourceKey, targetPath] as const;
-              }),
-            ),
-          )
-        : undefined;
-      const workspaceTargets = workspaceTargetsBySourcePath
-        ? undefined
-        : selectWorkspaceTargets({
-            workspaceAssetCount: workspaceAssets.length,
-            manifestWorkspaceDirs,
-            restoredWorkspaceDirs,
-            currentWorkspaceDirs,
-          });
-      if (!workspaceTargetsBySourcePath && !workspaceTargets) {
-        throw new Error(
-          `Workspace restore target mismatch: archive has ${workspaceAssets.length} workspace asset(s), but no compatible restore target set was found.`,
+      const workspaceTargetCandidates = [
+        currentWorkspaceDirs,
+        restoredWorkspaceDirs,
+        manifestWorkspaceDirs,
+      ];
+      let workspaceTargetError: Error | undefined;
+      let restoredWorkspace = false;
+      for (const candidateDirs of workspaceTargetCandidates) {
+        const workspaceTargetsBySourcePath = await mapWorkspaceTargetsBySourcePath(
+          candidateDirs,
+          workspaceAssetSourceKeys,
         );
+        const workspaceTargets =
+          workspaceTargetsBySourcePath ??
+          selectWorkspaceTargets({
+            workspaceAssetCount: workspaceAssets.length,
+            workspaceDirs: candidateDirs,
+          });
+        if (!workspaceTargets) {
+          continue;
+        }
+        const candidateOperations: RestoreOperation[] = [];
+        let candidateInvalid = false;
+        for (const [index, asset] of workspaceAssets.entries()) {
+          const assetSourceKey = workspaceAssetSourceKeys[index];
+          const targetPath =
+            workspaceTargets instanceof Map
+              ? workspaceTargets.get(assetSourceKey)
+              : workspaceTargets[index];
+          if (!targetPath) {
+            candidateInvalid = true;
+            break;
+          }
+          if (params.mode === "full-host" && stateAsset && isPathWithin(targetPath, stateDir)) {
+            continue;
+          }
+          try {
+            await assertSafeWorkspaceRestoreTarget({
+              targetPath,
+              stateDir,
+              configPath,
+              oauthDir,
+            });
+          } catch (error) {
+            workspaceTargetError = error instanceof Error ? error : new Error(String(error));
+            candidateInvalid = true;
+            break;
+          }
+          candidateOperations.push({
+            kind: "workspace",
+            sourcePath: getAssetExtractPath(params.extractedRoot, asset),
+            targetPath,
+          });
+        }
+        if (candidateInvalid) {
+          continue;
+        }
+        if (candidateOperations.length === 0 && params.mode === "full-host" && stateAsset) {
+          continue;
+        }
+        operations.push(...candidateOperations);
+        restoredWorkspace = true;
+        break;
       }
-      for (const [index, asset] of workspaceAssets.entries()) {
-        const assetSourceKey = await canonicalWorkspacePathKey(asset.sourcePath);
-        const targetPath =
-          workspaceTargetsBySourcePath?.get(assetSourceKey) ?? workspaceTargets?.[index];
-        if (!targetPath) {
-          continue;
+      if (!restoredWorkspace) {
+        if (workspaceTargetError) {
+          throw workspaceTargetError;
         }
-        await assertSafeWorkspaceRestoreTarget({
-          targetPath,
-          stateDir,
-          configPath,
-          oauthDir,
-        });
-        if (params.mode === "full-host" && stateAsset && isPathWithin(targetPath, stateDir)) {
-          continue;
+        if (!(params.mode === "full-host" && stateAsset)) {
+          throw new Error(
+            `Workspace restore target mismatch: archive has ${workspaceAssets.length} workspace asset(s), but no compatible restore target set was found.`,
+          );
         }
-        operations.push({
-          kind: "workspace",
-          sourcePath: getAssetExtractPath(params.extractedRoot, asset),
-          targetPath,
-        });
       }
     }
   }

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -584,7 +584,6 @@ export async function backupRestoreCommand(
       archive: restoreSource.archivePath,
       json: false,
     });
-    await ensureGatewayStopped(runtime, Boolean(opts.forceStop), Boolean(opts.json));
     workingDir =
       restoreSource.tempDir ?? (await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-")));
     await extractArchive({
@@ -605,6 +604,7 @@ export async function backupRestoreCommand(
       manifest,
       extractedRoot,
     });
+    await ensureGatewayStopped(runtime, Boolean(opts.forceStop), Boolean(opts.json));
     await applyRestoreOperations(operations);
 
     const result: BackupRestoreResult = {

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -377,7 +377,8 @@ async function assertSafeWorkspaceRestoreTarget(params: {
     isUnsafeRestoreTarget(resolved, canonicalHomeDir) ||
     isPathWithin(resolved, stateDir) ||
     resolved === configPath ||
-    resolved === oauthDir
+    resolved === oauthDir ||
+    isPathWithin(resolved, oauthDir)
   ) {
     throw new Error(`Refusing to restore workspace to an unsafe path: ${resolved}`);
   }
@@ -475,6 +476,7 @@ export async function buildRestoreOperations(params: {
       ];
       let workspaceTargetError: Error | undefined;
       let restoredWorkspace = false;
+      let workspaceCoveredByState = false;
       for (const candidateDirs of workspaceTargetCandidates) {
         const workspaceTargetsBySourcePath = await mapWorkspaceTargetsBySourcePath(
           candidateDirs,
@@ -531,6 +533,7 @@ export async function buildRestoreOperations(params: {
           continue;
         }
         if (candidateOperations.length === 0 && params.mode === "full-host" && stateAsset) {
+          workspaceCoveredByState = true;
           continue;
         }
         operations.push(...candidateOperations);
@@ -541,7 +544,7 @@ export async function buildRestoreOperations(params: {
         if (workspaceTargetError) {
           throw workspaceTargetError;
         }
-        if (!(params.mode === "full-host" && stateAsset)) {
+        if (!(params.mode === "full-host" && stateAsset && workspaceCoveredByState)) {
           throw new Error(
             `Workspace restore target mismatch: archive has ${workspaceAssets.length} workspace asset(s), but no compatible restore target set was found.`,
           );

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Writable } from "node:stream";
 import { decryptPayloadToArchive } from "../backup/snapshot-store/encryption.js";
 import {
   isNixMode,
@@ -82,7 +84,11 @@ function selectWorkspaceTargets(params: {
   return undefined;
 }
 
-async function ensureGatewayStopped(runtime: RuntimeEnv, forceStop: boolean): Promise<void> {
+async function ensureGatewayStopped(
+  runtime: RuntimeEnv,
+  forceStop: boolean,
+  quietOutput: boolean,
+): Promise<void> {
   if (isNixMode) {
     return;
   }
@@ -102,7 +108,14 @@ async function ensureGatewayStopped(runtime: RuntimeEnv, forceStop: boolean): Pr
     throw new Error("Gateway service appears to be running. Stop it first or pass --force-stop.");
   }
   try {
-    await service.stop({ env: process.env, stdout: process.stdout });
+    const stdout = quietOutput
+      ? new Writable({
+          write(_chunk, _encoding, callback) {
+            callback();
+          },
+        })
+      : process.stdout;
+    await service.stop({ env: process.env, stdout });
   } catch (error) {
     throw new Error(`Gateway stop failed: ${String(error)}`, {
       cause: error,
@@ -137,30 +150,39 @@ async function prepareRestoreArchive(
   }
 
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-snapshot-restore-"));
-  const envelopePath = path.join(tempDir, `${snapshotId}.envelope.json`);
-  const payloadPath = path.join(tempDir, `${snapshotId}.payload.bin`);
-  const archivePath = path.join(tempDir, `${snapshotId}.tar.gz`);
-  const storage = await resolveSnapshotStore({ snapshotStore, deps });
-  const envelope = await storage.downloadSnapshot({
-    installationId,
-    snapshotId,
-    envelopeOutputPath: envelopePath,
-    payloadOutputPath: payloadPath,
-  });
-  await decryptPayloadToArchive({
-    payloadPath,
-    archivePath,
-    secret: snapshotStore.encryptionKey,
-    envelope,
-  });
-  return { archivePath, tempDir };
+  const filePrefix = randomUUID();
+  const envelopePath = path.join(tempDir, `${filePrefix}.envelope.json`);
+  const payloadPath = path.join(tempDir, `${filePrefix}.payload.bin`);
+  const archivePath = path.join(tempDir, `${filePrefix}.tar.gz`);
+  try {
+    const storage = await resolveSnapshotStore({ snapshotStore, deps });
+    const envelope = await storage.downloadSnapshot({
+      installationId,
+      snapshotId,
+      envelopeOutputPath: envelopePath,
+      payloadOutputPath: payloadPath,
+    });
+    await decryptPayloadToArchive({
+      payloadPath,
+      archivePath,
+      secret: snapshotStore.encryptionKey,
+      envelope,
+    });
+    return { archivePath, tempDir };
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 function normalizeRestoreMode(mode?: string): BackupRestoreMode {
-  if (mode === "config-only" || mode === "workspace-only") {
+  if (!mode?.trim()) {
+    return "full-host";
+  }
+  if (mode === "full-host" || mode === "config-only" || mode === "workspace-only") {
     return mode;
   }
-  return "full-host";
+  throw new Error(`Invalid restore mode: ${mode}`);
 }
 
 function getAssetExtractPath(extractedRoot: string, asset: BackupManifestAsset): string {
@@ -259,8 +281,8 @@ async function applyRestoreOperations(
         }
         backupPath = undefined;
       }
-      await copySourceToTarget(operation.sourcePath, operation.targetPath);
       applied.push({ targetPath: operation.targetPath, backupPath });
+      await copySourceToTarget(operation.sourcePath, operation.targetPath);
     }
   } catch (error) {
     for (const appliedOp of applied.toReversed()) {
@@ -353,13 +375,20 @@ export async function buildRestoreOperations(params: {
     workspaceAssetSourceKeys.every((key) => manifestWorkspaceMap.has(key));
 
   if (params.mode === "config-only") {
-    if (!configAsset) {
+    const configSourcePath =
+      (configAsset && getAssetExtractPath(params.extractedRoot, configAsset)) ??
+      tryResolveExtractedConfigPath({
+        manifest: params.manifest,
+        assetByKind,
+        extractedRoot: params.extractedRoot,
+      });
+    if (!configSourcePath) {
       throw new Error("Backup archive does not contain a config asset.");
     }
     return [
       {
         kind: "config",
-        sourcePath: getAssetExtractPath(params.extractedRoot, configAsset),
+        sourcePath: configSourcePath,
         targetPath: configPath,
       },
     ];
@@ -452,7 +481,7 @@ export async function backupRestoreCommand(
   opts: BackupRestoreOptions,
   deps?: BackupSnapshotDeps,
 ): Promise<BackupRestoreResult> {
-  await ensureGatewayStopped(runtime, Boolean(opts.forceStop));
+  await ensureGatewayStopped(runtime, Boolean(opts.forceStop), Boolean(opts.json));
 
   const mode = normalizeRestoreMode(opts.mode);
   const restoreSource = await prepareRestoreArchive(opts, deps);

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -53,6 +53,11 @@ type RestoreOperation = {
   targetPath: string;
 };
 
+function workspacePathKey(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
 function selectWorkspaceTargets(params: {
   workspaceAssetCount: number;
   manifestWorkspaceDirs: string[];
@@ -279,6 +284,15 @@ export async function buildRestoreOperations(params: {
   const configAsset = assetByKind.get("config")?.[0];
   const credentialsAsset = assetByKind.get("credentials")?.[0];
   const workspaceAssets = assetByKind.get("workspace") ?? [];
+  const manifestWorkspaceMap = new Map(
+    manifestWorkspaceDirs.map((entry) => [workspacePathKey(entry), entry] as const),
+  );
+  const workspaceAssetSourceKeys = workspaceAssets.map((asset) =>
+    workspacePathKey(asset.sourcePath),
+  );
+  const canMatchWorkspaceTargetsBySourcePath =
+    manifestWorkspaceMap.size === workspaceAssets.length &&
+    workspaceAssetSourceKeys.every((key) => manifestWorkspaceMap.has(key));
 
   if (params.mode === "config-only") {
     if (!configAsset) {
@@ -323,19 +337,31 @@ export async function buildRestoreOperations(params: {
     if (workspaceAssets.length > 0) {
       // The manifest records the exact workspace roots that were archived. Prefer it over
       // config-derived values because config parsing may fall back to the default workspace.
-      const workspaceTargets = selectWorkspaceTargets({
-        workspaceAssetCount: workspaceAssets.length,
-        manifestWorkspaceDirs,
-        restoredWorkspaceDirs,
-        currentWorkspaceDirs,
-      });
-      if (!workspaceTargets) {
+      const workspaceTargetsBySourcePath = canMatchWorkspaceTargetsBySourcePath
+        ? new Map(
+            workspaceAssets.map((asset) => [
+              workspacePathKey(asset.sourcePath),
+              manifestWorkspaceMap.get(workspacePathKey(asset.sourcePath)),
+            ]),
+          )
+        : undefined;
+      const workspaceTargets = workspaceTargetsBySourcePath
+        ? undefined
+        : selectWorkspaceTargets({
+            workspaceAssetCount: workspaceAssets.length,
+            manifestWorkspaceDirs,
+            restoredWorkspaceDirs,
+            currentWorkspaceDirs,
+          });
+      if (!workspaceTargetsBySourcePath && !workspaceTargets) {
         throw new Error(
           `Workspace restore target mismatch: archive has ${workspaceAssets.length} workspace asset(s), but no compatible restore target set was found.`,
         );
       }
       for (const [index, asset] of workspaceAssets.entries()) {
-        const targetPath = workspaceTargets[index];
+        const targetPath =
+          workspaceTargetsBySourcePath?.get(workspacePathKey(asset.sourcePath)) ??
+          workspaceTargets?.[index];
         if (!targetPath) {
           continue;
         }
@@ -370,7 +396,8 @@ export async function backupRestoreCommand(
     restoreSource.tempDir ?? (await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-")));
 
   try {
-    const verified = await backupVerifyCommand(runtime, {
+    const verifyRuntime: RuntimeEnv = opts.json ? { ...runtime, log: () => {} } : runtime;
+    const verified = await backupVerifyCommand(verifyRuntime, {
       archive: restoreSource.archivePath,
       json: false,
     });

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -81,6 +81,11 @@ async function canonicalizePathForContainment(inputPath: string): Promise<string
   }
 }
 
+async function canonicalWorkspacePathKey(value: string): Promise<string> {
+  const resolved = await canonicalizePathForContainment(value);
+  return workspacePathKey(resolved);
+}
+
 function selectWorkspaceTargets(params: {
   workspaceAssetCount: number;
   manifestWorkspaceDirs: string[];
@@ -386,11 +391,14 @@ export async function buildRestoreOperations(params: {
   const configAsset = assetByKind.get("config")?.[0];
   const credentialsAsset = assetByKind.get("credentials")?.[0];
   const workspaceAssets = assetByKind.get("workspace") ?? [];
-  const manifestWorkspaceMap = new Map(
-    manifestWorkspaceDirs.map((entry) => [workspacePathKey(entry), entry] as const),
+  const manifestWorkspaceEntries = await Promise.all(
+    manifestWorkspaceDirs.map(
+      async (entry) => [await canonicalWorkspacePathKey(entry), entry] as const,
+    ),
   );
-  const workspaceAssetSourceKeys = workspaceAssets.map((asset) =>
-    workspacePathKey(asset.sourcePath),
+  const manifestWorkspaceMap = new Map(manifestWorkspaceEntries);
+  const workspaceAssetSourceKeys = await Promise.all(
+    workspaceAssets.map(async (asset) => await canonicalWorkspacePathKey(asset.sourcePath)),
   );
   const canMatchWorkspaceTargetsBySourcePath =
     manifestWorkspaceMap.size === workspaceAssets.length &&
@@ -447,11 +455,19 @@ export async function buildRestoreOperations(params: {
       // The manifest records the exact workspace roots that were archived. Prefer it over
       // config-derived values because config parsing may fall back to the default workspace.
       const workspaceTargetsBySourcePath = canMatchWorkspaceTargetsBySourcePath
-        ? new Map(
-            workspaceAssets.map((asset) => [
-              workspacePathKey(asset.sourcePath),
-              manifestWorkspaceMap.get(workspacePathKey(asset.sourcePath)),
-            ]),
+        ? new Map<string, string>(
+            await Promise.all(
+              workspaceAssets.map(async (asset): Promise<readonly [string, string]> => {
+                const assetSourceKey = await canonicalWorkspacePathKey(asset.sourcePath);
+                const targetPath = manifestWorkspaceMap.get(assetSourceKey);
+                if (!targetPath) {
+                  throw new Error(
+                    `Workspace restore target mismatch for archived workspace: ${asset.sourcePath}`,
+                  );
+                }
+                return [assetSourceKey, targetPath] as const;
+              }),
+            ),
           )
         : undefined;
       const workspaceTargets = workspaceTargetsBySourcePath
@@ -468,9 +484,9 @@ export async function buildRestoreOperations(params: {
         );
       }
       for (const [index, asset] of workspaceAssets.entries()) {
+        const assetSourceKey = await canonicalWorkspacePathKey(asset.sourcePath);
         const targetPath =
-          workspaceTargetsBySourcePath?.get(workspacePathKey(asset.sourcePath)) ??
-          workspaceTargets?.[index];
+          workspaceTargetsBySourcePath?.get(assetSourceKey) ?? workspaceTargets?.[index];
         if (!targetPath) {
           continue;
         }

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -1,0 +1,418 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { decryptPayloadToArchive } from "../backup/snapshot-store/encryption.js";
+import {
+  isNixMode,
+  parseConfigJson5,
+  readConfigFileSnapshot,
+  resolveConfigPath,
+  resolveOAuthDir,
+  resolveStateDir,
+} from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveGatewayService } from "../daemon/service.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
+import {
+  loadResolvedSnapshotBackup,
+  resolveSnapshotStore,
+  resolveCurrentInstallationId,
+  type BackupSnapshotDeps,
+} from "./backup-snapshot-shared.js";
+import {
+  backupVerifyCommand,
+  normalizeArchiveRoot,
+  parseBackupManifest,
+  type BackupManifest,
+  type BackupManifestAsset,
+} from "./backup-verify.js";
+import { collectWorkspaceDirs, isPathWithin } from "./cleanup-utils.js";
+
+export type BackupRestoreMode = "full-host" | "config-only" | "workspace-only";
+
+export type BackupRestoreOptions = {
+  snapshotId?: string;
+  archive?: string;
+  installationId?: string;
+  mode?: BackupRestoreMode;
+  json?: boolean;
+  forceStop?: boolean;
+};
+
+export type BackupRestoreResult = {
+  mode: BackupRestoreMode;
+  archivePath: string;
+  restoredTargets: string[];
+};
+
+type RestoreOperation = {
+  kind: BackupManifestAsset["kind"];
+  sourcePath: string;
+  targetPath: string;
+};
+
+function selectWorkspaceTargets(params: {
+  workspaceAssetCount: number;
+  manifestWorkspaceDirs: string[];
+  restoredWorkspaceDirs: string[];
+  currentWorkspaceDirs: string[];
+}): string[] | undefined {
+  const candidates = [
+    params.manifestWorkspaceDirs,
+    params.restoredWorkspaceDirs,
+    params.currentWorkspaceDirs,
+  ];
+  for (const dirs of candidates) {
+    if (dirs.length === params.workspaceAssetCount) {
+      return dirs;
+    }
+    if (dirs.length === 1 && params.workspaceAssetCount === 1) {
+      return dirs;
+    }
+  }
+  return undefined;
+}
+
+async function ensureGatewayStopped(runtime: RuntimeEnv, forceStop: boolean): Promise<void> {
+  if (isNixMode) {
+    return;
+  }
+  const service = resolveGatewayService();
+  let loaded = false;
+  try {
+    loaded = await service.isLoaded({ env: process.env });
+  } catch (error) {
+    throw new Error(`Gateway service check failed: ${String(error)}`, {
+      cause: error,
+    });
+  }
+  if (!loaded) {
+    return;
+  }
+  if (!forceStop) {
+    throw new Error("Gateway service appears to be running. Stop it first or pass --force-stop.");
+  }
+  try {
+    await service.stop({ env: process.env, stdout: process.stdout });
+  } catch (error) {
+    throw new Error(`Gateway stop failed: ${String(error)}`, {
+      cause: error,
+    });
+  }
+}
+
+async function prepareRestoreArchive(
+  opts: BackupRestoreOptions,
+  deps: BackupSnapshotDeps | undefined,
+): Promise<{ archivePath: string; tempDir?: string }> {
+  if (opts.archive?.trim()) {
+    return { archivePath: resolveUserPath(opts.archive) };
+  }
+
+  const snapshotId = opts.snapshotId?.trim();
+  if (!snapshotId) {
+    throw new Error("Pass a local --archive path or a backup snapshot id to restore.");
+  }
+
+  const { snapshotStore, stateDir } = await loadResolvedSnapshotBackup({});
+  const installationId =
+    opts.installationId?.trim() ||
+    (await resolveCurrentInstallationId({
+      stateDir,
+      createIfMissing: false,
+    }));
+  if (!installationId) {
+    throw new Error(
+      "No backup installation id found. Restore from --archive or configure backup first.",
+    );
+  }
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-snapshot-restore-"));
+  const envelopePath = path.join(tempDir, `${snapshotId}.envelope.json`);
+  const payloadPath = path.join(tempDir, `${snapshotId}.payload.bin`);
+  const archivePath = path.join(tempDir, `${snapshotId}.tar.gz`);
+  const storage = await resolveSnapshotStore({ snapshotStore, deps });
+  const envelope = await storage.downloadSnapshot({
+    installationId,
+    snapshotId,
+    envelopeOutputPath: envelopePath,
+    payloadOutputPath: payloadPath,
+  });
+  await decryptPayloadToArchive({
+    payloadPath,
+    archivePath,
+    secret: snapshotStore.encryptionKey,
+    envelope,
+  });
+  return { archivePath, tempDir };
+}
+
+function normalizeRestoreMode(mode?: string): BackupRestoreMode {
+  if (mode === "config-only" || mode === "workspace-only") {
+    return mode;
+  }
+  return "full-host";
+}
+
+function getAssetExtractPath(extractedRoot: string, asset: BackupManifestAsset): string {
+  const parts = asset.archivePath.split("/");
+  const rootName = path.basename(extractedRoot);
+  const relativeParts = parts[0] === rootName ? parts.slice(1) : parts;
+  return path.join(extractedRoot, ...relativeParts);
+}
+
+function tryResolveExtractedConfigPath(params: {
+  manifest: BackupManifest;
+  assetByKind: Map<string, BackupManifestAsset[]>;
+  extractedRoot: string;
+}): string | undefined {
+  const configAsset = params.assetByKind.get("config")?.[0];
+  if (configAsset) {
+    return getAssetExtractPath(params.extractedRoot, configAsset);
+  }
+
+  const stateAsset = params.assetByKind.get("state")?.[0];
+  const oldStateDir = params.manifest.paths?.stateDir;
+  const oldConfigPath = params.manifest.paths?.configPath;
+  if (!stateAsset || !oldStateDir || !oldConfigPath || !isPathWithin(oldConfigPath, oldStateDir)) {
+    return undefined;
+  }
+  const relative = path.relative(oldStateDir, oldConfigPath);
+  return path.join(getAssetExtractPath(params.extractedRoot, stateAsset), relative);
+}
+
+async function loadRestoredConfig(params: {
+  manifest: BackupManifest;
+  assetByKind: Map<string, BackupManifestAsset[]>;
+  extractedRoot: string;
+}): Promise<OpenClawConfig | undefined> {
+  const configPath = tryResolveExtractedConfigPath(params);
+  if (!configPath) {
+    return undefined;
+  }
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    const parsed = parseConfigJson5(raw);
+    return parsed.ok ? (parsed.parsed as OpenClawConfig) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function copySourceToTarget(sourcePath: string, targetPath: string): Promise<void> {
+  const stat = await fs.stat(sourcePath);
+  if (stat.isDirectory()) {
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.cp(sourcePath, targetPath, { recursive: true, force: true });
+    return;
+  }
+
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.copyFile(sourcePath, targetPath);
+}
+
+async function applyRestoreOperations(
+  operations: RestoreOperation[],
+  rollbackRoot: string,
+): Promise<void> {
+  const applied: Array<{ targetPath: string; backupPath?: string }> = [];
+  try {
+    for (const operation of operations) {
+      let backupPath: string | undefined;
+      try {
+        await fs.access(operation.targetPath);
+        backupPath = path.join(
+          rollbackRoot,
+          `${applied.length}-${path.basename(operation.targetPath) || "target"}`,
+        );
+        await fs.mkdir(path.dirname(backupPath), { recursive: true });
+        await fs.rename(operation.targetPath, backupPath);
+      } catch {
+        backupPath = undefined;
+      }
+      await copySourceToTarget(operation.sourcePath, operation.targetPath);
+      applied.push({ targetPath: operation.targetPath, backupPath });
+    }
+  } catch (error) {
+    for (const appliedOp of applied.toReversed()) {
+      await fs.rm(appliedOp.targetPath, { recursive: true, force: true }).catch(() => undefined);
+      if (appliedOp.backupPath) {
+        await fs.rename(appliedOp.backupPath, appliedOp.targetPath).catch(() => undefined);
+      }
+    }
+    throw error;
+  }
+}
+
+export async function buildRestoreOperations(params: {
+  mode: BackupRestoreMode;
+  manifest: BackupManifest;
+  extractedRoot: string;
+}): Promise<RestoreOperation[]> {
+  const assetByKind = new Map<string, BackupManifestAsset[]>();
+  for (const asset of params.manifest.assets) {
+    const entries = assetByKind.get(asset.kind) ?? [];
+    entries.push(asset);
+    assetByKind.set(asset.kind, entries);
+  }
+
+  const stateDir = resolveStateDir();
+  const configPath = resolveConfigPath();
+  const oauthDir = resolveOAuthDir();
+  const currentConfigSnapshot = await readConfigFileSnapshot();
+  const restoredConfig = await loadRestoredConfig({
+    manifest: params.manifest,
+    assetByKind,
+    extractedRoot: params.extractedRoot,
+  });
+  const restoredWorkspaceDirs = restoredConfig ? collectWorkspaceDirs(restoredConfig) : [];
+  const manifestWorkspaceDirs =
+    params.manifest.paths?.workspaceDirs?.map((entry) => resolveUserPath(entry)) ?? [];
+  const currentWorkspaceDirs = collectWorkspaceDirs(
+    currentConfigSnapshot.valid ? currentConfigSnapshot.config : undefined,
+  );
+
+  const operations: RestoreOperation[] = [];
+  const stateAsset = assetByKind.get("state")?.[0];
+  const configAsset = assetByKind.get("config")?.[0];
+  const credentialsAsset = assetByKind.get("credentials")?.[0];
+  const workspaceAssets = assetByKind.get("workspace") ?? [];
+
+  if (params.mode === "config-only") {
+    if (!configAsset) {
+      throw new Error("Backup archive does not contain a config asset.");
+    }
+    return [
+      {
+        kind: "config",
+        sourcePath: getAssetExtractPath(params.extractedRoot, configAsset),
+        targetPath: configPath,
+      },
+    ];
+  }
+
+  if (params.mode === "full-host") {
+    if (stateAsset) {
+      operations.push({
+        kind: "state",
+        sourcePath: getAssetExtractPath(params.extractedRoot, stateAsset),
+        targetPath: stateDir,
+      });
+    }
+
+    if (configAsset && !isPathWithin(configPath, stateDir)) {
+      operations.push({
+        kind: "config",
+        sourcePath: getAssetExtractPath(params.extractedRoot, configAsset),
+        targetPath: configPath,
+      });
+    }
+
+    if (credentialsAsset && !isPathWithin(oauthDir, stateDir)) {
+      operations.push({
+        kind: "credentials",
+        sourcePath: getAssetExtractPath(params.extractedRoot, credentialsAsset),
+        targetPath: oauthDir,
+      });
+    }
+  }
+
+  if (params.mode === "workspace-only" || params.mode === "full-host") {
+    if (workspaceAssets.length > 0) {
+      // The manifest records the exact workspace roots that were archived. Prefer it over
+      // config-derived values because config parsing may fall back to the default workspace.
+      const workspaceTargets = selectWorkspaceTargets({
+        workspaceAssetCount: workspaceAssets.length,
+        manifestWorkspaceDirs,
+        restoredWorkspaceDirs,
+        currentWorkspaceDirs,
+      });
+      if (!workspaceTargets) {
+        throw new Error(
+          `Workspace restore target mismatch: archive has ${workspaceAssets.length} workspace asset(s), but no compatible restore target set was found.`,
+        );
+      }
+      for (const [index, asset] of workspaceAssets.entries()) {
+        const targetPath = workspaceTargets[index];
+        if (!targetPath) {
+          continue;
+        }
+        if (params.mode === "full-host" && stateAsset && isPathWithin(targetPath, stateDir)) {
+          continue;
+        }
+        operations.push({
+          kind: "workspace",
+          sourcePath: getAssetExtractPath(params.extractedRoot, asset),
+          targetPath,
+        });
+      }
+    }
+  }
+
+  if (operations.length === 0) {
+    throw new Error("Backup archive does not contain any assets for the requested restore mode.");
+  }
+  return operations;
+}
+
+export async function backupRestoreCommand(
+  runtime: RuntimeEnv,
+  opts: BackupRestoreOptions,
+  deps?: BackupSnapshotDeps,
+): Promise<BackupRestoreResult> {
+  await ensureGatewayStopped(runtime, Boolean(opts.forceStop));
+
+  const mode = normalizeRestoreMode(opts.mode);
+  const restoreSource = await prepareRestoreArchive(opts, deps);
+  const workingDir =
+    restoreSource.tempDir ?? (await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-")));
+
+  try {
+    const verified = await backupVerifyCommand(runtime, {
+      archive: restoreSource.archivePath,
+      json: false,
+    });
+    await tar.x({
+      file: restoreSource.archivePath,
+      cwd: workingDir,
+      gzip: true,
+    });
+
+    const archiveRoot = normalizeArchiveRoot(verified.archiveRoot);
+    const extractedRoot = path.join(workingDir, archiveRoot);
+    const manifest = parseBackupManifest(
+      await fs.readFile(path.join(extractedRoot, "manifest.json"), "utf8"),
+    );
+    const operations = await buildRestoreOperations({
+      mode,
+      manifest,
+      extractedRoot,
+    });
+    const rollbackRoot = path.join(workingDir, "rollback");
+    await applyRestoreOperations(operations, rollbackRoot);
+
+    const result: BackupRestoreResult = {
+      mode,
+      archivePath: restoreSource.archivePath,
+      restoredTargets: operations.map((operation) => operation.targetPath),
+    };
+    runtime.log(
+      opts.json
+        ? JSON.stringify(result, null, 2)
+        : [
+            `Restored backup archive ${restoreSource.archivePath}`,
+            `Mode: ${mode}`,
+            ...result.restoredTargets.map((target) => `- ${target}`),
+          ].join("\n"),
+    );
+    return result;
+  } finally {
+    if (restoreSource.tempDir) {
+      await fs.rm(restoreSource.tempDir, { recursive: true, force: true }).catch(() => undefined);
+    } else {
+      await fs.rm(workingDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+}

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import * as tar from "tar";
 import { decryptPayloadToArchive } from "../backup/snapshot-store/encryption.js";
 import {
   isNixMode,
@@ -13,8 +12,9 @@ import {
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { extractArchive } from "../infra/archive.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { resolveUserPath } from "../utils.js";
+import { resolveHomeDir, resolveUserPath } from "../utils.js";
 import {
   loadResolvedSnapshotBackup,
   resolveSnapshotStore,
@@ -52,6 +52,8 @@ type RestoreOperation = {
   sourcePath: string;
   targetPath: string;
 };
+
+const RESTORE_EXTRACT_TIMEOUT_MS = 60_000;
 
 function workspacePathKey(value: string): string {
   const resolved = path.resolve(value);
@@ -206,9 +208,26 @@ async function loadRestoredConfig(params: {
   }
 }
 
+async function assertTreeContainsNoSymlinks(rootPath: string): Promise<void> {
+  const entries = await fs.readdir(rootPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(rootPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Refusing to restore directory containing symbolic links: ${entryPath}`);
+    }
+    if (entry.isDirectory()) {
+      await assertTreeContainsNoSymlinks(entryPath);
+    }
+  }
+}
+
 async function copySourceToTarget(sourcePath: string, targetPath: string): Promise<void> {
-  const stat = await fs.stat(sourcePath);
+  const stat = await fs.lstat(sourcePath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Refusing to restore from a symbolic link: ${sourcePath}`);
+  }
   if (stat.isDirectory()) {
+    await assertTreeContainsNoSymlinks(sourcePath);
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
     await fs.cp(sourcePath, targetPath, { recursive: true, force: true });
     return;
@@ -234,7 +253,10 @@ async function applyRestoreOperations(
         );
         await fs.mkdir(path.dirname(backupPath), { recursive: true });
         await fs.rename(operation.targetPath, backupPath);
-      } catch {
+      } catch (error) {
+        if (!isNotFoundError(error)) {
+          throw error;
+        }
         backupPath = undefined;
       }
       await copySourceToTarget(operation.sourcePath, operation.targetPath);
@@ -248,6 +270,42 @@ async function applyRestoreOperations(
       }
     }
     throw error;
+  }
+}
+
+function isUnsafeRestoreTarget(targetPath: string): boolean {
+  const resolved = path.resolve(targetPath);
+  const root = path.parse(resolved).root;
+  if (resolved === root) {
+    return true;
+  }
+  const home = resolveHomeDir();
+  return Boolean(home && resolved === path.resolve(home));
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+function assertSafeWorkspaceRestoreTarget(params: {
+  targetPath: string;
+  stateDir: string;
+  configPath: string;
+  oauthDir: string;
+}): void {
+  const resolved = path.resolve(params.targetPath);
+  if (
+    isUnsafeRestoreTarget(resolved) ||
+    isPathWithin(resolved, params.stateDir) ||
+    resolved === path.resolve(params.configPath) ||
+    resolved === path.resolve(params.oauthDir)
+  ) {
+    throw new Error(`Refusing to restore workspace to an unsafe path: ${resolved}`);
   }
 }
 
@@ -365,6 +423,12 @@ export async function buildRestoreOperations(params: {
         if (!targetPath) {
           continue;
         }
+        assertSafeWorkspaceRestoreTarget({
+          targetPath,
+          stateDir,
+          configPath,
+          oauthDir,
+        });
         if (params.mode === "full-host" && stateAsset && isPathWithin(targetPath, stateDir)) {
           continue;
         }
@@ -401,10 +465,12 @@ export async function backupRestoreCommand(
       archive: restoreSource.archivePath,
       json: false,
     });
-    await tar.x({
-      file: restoreSource.archivePath,
-      cwd: workingDir,
-      gzip: true,
+    await extractArchive({
+      archivePath: restoreSource.archivePath,
+      destDir: workingDir,
+      kind: "tar",
+      tarGzip: true,
+      timeoutMs: RESTORE_EXTRACT_TIMEOUT_MS,
     });
 
     const archiveRoot = normalizeArchiveRoot(verified.archiveRoot);

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -62,6 +62,25 @@ function workspacePathKey(value: string): string {
   return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }
 
+async function canonicalizePathForContainment(inputPath: string): Promise<string> {
+  const resolved = path.resolve(inputPath);
+  const suffix: string[] = [];
+  let probe = resolved;
+  while (true) {
+    try {
+      const real = await fs.realpath(probe);
+      return suffix.length === 0 ? real : path.join(real, ...suffix.toReversed());
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) {
+        return resolved;
+      }
+      suffix.push(path.basename(probe));
+      probe = parent;
+    }
+  }
+}
+
 function selectWorkspaceTargets(params: {
   workspaceAssetCount: number;
   manifestWorkspaceDirs: string[];
@@ -295,14 +314,12 @@ async function applyRestoreOperations(
   }
 }
 
-function isUnsafeRestoreTarget(targetPath: string): boolean {
-  const resolved = path.resolve(targetPath);
-  const root = path.parse(resolved).root;
-  if (resolved === root) {
+function isUnsafeRestoreTarget(targetPath: string, homePath?: string): boolean {
+  const root = path.parse(targetPath).root;
+  if (targetPath === root) {
     return true;
   }
-  const home = resolveHomeDir();
-  return Boolean(home && resolved === path.resolve(home));
+  return Boolean(homePath && targetPath === homePath);
 }
 
 function isNotFoundError(error: unknown): boolean {
@@ -314,18 +331,23 @@ function isNotFoundError(error: unknown): boolean {
   );
 }
 
-function assertSafeWorkspaceRestoreTarget(params: {
+async function assertSafeWorkspaceRestoreTarget(params: {
   targetPath: string;
   stateDir: string;
   configPath: string;
   oauthDir: string;
-}): void {
-  const resolved = path.resolve(params.targetPath);
+}): Promise<void> {
+  const resolved = await canonicalizePathForContainment(params.targetPath);
+  const stateDir = await canonicalizePathForContainment(params.stateDir);
+  const configPath = await canonicalizePathForContainment(params.configPath);
+  const oauthDir = await canonicalizePathForContainment(params.oauthDir);
+  const homeDir = resolveHomeDir();
+  const canonicalHomeDir = homeDir ? await canonicalizePathForContainment(homeDir) : undefined;
   if (
-    isUnsafeRestoreTarget(resolved) ||
-    isPathWithin(resolved, params.stateDir) ||
-    resolved === path.resolve(params.configPath) ||
-    resolved === path.resolve(params.oauthDir)
+    isUnsafeRestoreTarget(resolved, canonicalHomeDir) ||
+    isPathWithin(resolved, stateDir) ||
+    resolved === configPath ||
+    resolved === oauthDir
   ) {
     throw new Error(`Refusing to restore workspace to an unsafe path: ${resolved}`);
   }
@@ -452,7 +474,7 @@ export async function buildRestoreOperations(params: {
         if (!targetPath) {
           continue;
         }
-        assertSafeWorkspaceRestoreTarget({
+        await assertSafeWorkspaceRestoreTarget({
           targetPath,
           stateDir,
           configPath,
@@ -481,12 +503,9 @@ export async function backupRestoreCommand(
   opts: BackupRestoreOptions,
   deps?: BackupSnapshotDeps,
 ): Promise<BackupRestoreResult> {
-  await ensureGatewayStopped(runtime, Boolean(opts.forceStop), Boolean(opts.json));
-
   const mode = normalizeRestoreMode(opts.mode);
   const restoreSource = await prepareRestoreArchive(opts, deps);
-  const workingDir =
-    restoreSource.tempDir ?? (await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-")));
+  let workingDir: string | undefined;
 
   try {
     const verifyRuntime: RuntimeEnv = opts.json ? { ...runtime, log: () => {} } : runtime;
@@ -494,6 +513,9 @@ export async function backupRestoreCommand(
       archive: restoreSource.archivePath,
       json: false,
     });
+    await ensureGatewayStopped(runtime, Boolean(opts.forceStop), Boolean(opts.json));
+    workingDir =
+      restoreSource.tempDir ?? (await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restore-")));
     await extractArchive({
       archivePath: restoreSource.archivePath,
       destDir: workingDir,
@@ -533,7 +555,7 @@ export async function backupRestoreCommand(
   } finally {
     if (restoreSource.tempDir) {
       await fs.rm(restoreSource.tempDir, { recursive: true, force: true }).catch(() => undefined);
-    } else {
+    } else if (workingDir) {
       await fs.rm(workingDir, { recursive: true, force: true }).catch(() => undefined);
     }
   }

--- a/src/commands/backup-run.test.ts
+++ b/src/commands/backup-run.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { backupRunCommand } from "./backup-run.js";
+
+const { readConfigFileSnapshot, backupPushCommand, workspaceBackupRunCommand } = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+  backupPushCommand: vi.fn(),
+  workspaceBackupRunCommand: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  readConfigFileSnapshot,
+}));
+
+vi.mock("./backup-push.js", () => ({
+  backupPushCommand,
+}));
+
+vi.mock("./workspace-backup.js", () => ({
+  workspaceBackupRunCommand,
+}));
+
+describe("backupRunCommand", () => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backupPushCommand.mockResolvedValue({ snapshotId: "snap_1" });
+    workspaceBackupRunCommand.mockResolvedValue({ workspaceCount: 1 });
+  });
+
+  it("uses workspace mirroring when full backup is not configured", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: {
+        backup: {
+          target: "/tmp/backups",
+        },
+      },
+    });
+
+    const result = await backupRunCommand(runtime, {});
+
+    expect(workspaceBackupRunCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({ json: undefined }),
+    );
+    expect(backupPushCommand).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: "workspace",
+      workspace: { workspaceCount: 1 },
+    });
+  });
+
+  it("uses snapshot backup when encryption is configured", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: {
+        backup: {
+          target: "/tmp/backups",
+          encryption: { key: "secret" },
+        },
+      },
+    });
+
+    const result = await backupRunCommand(runtime, {
+      output: "/tmp/archive.tar.gz",
+      verify: true,
+      snapshotName: "nightly",
+    });
+
+    expect(backupPushCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        output: "/tmp/archive.tar.gz",
+        verify: true,
+        snapshotName: "nightly",
+      }),
+      undefined,
+    );
+    expect(result).toEqual({
+      kind: "snapshot",
+      snapshot: { snapshotId: "snap_1" },
+    });
+  });
+
+  it("rejects snapshot-only options when auto mode falls back to workspace mirroring", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: {
+        backup: {
+          target: "/tmp/backups",
+        },
+      },
+    });
+
+    await expect(
+      backupRunCommand(runtime, {
+        snapshotName: "nightly",
+      }),
+    ).rejects.toThrow(
+      "Snapshot-only options are not supported when backup run falls back to workspace mirroring.",
+    );
+  });
+
+  it("allows forcing snapshot mode for the legacy push alias", async () => {
+    const result = await backupRunCommand(runtime, { mode: "snapshot" });
+
+    expect(backupPushCommand).toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: "snapshot",
+      snapshot: { snapshotId: "snap_1" },
+    });
+  });
+});

--- a/src/commands/backup-run.test.ts
+++ b/src/commands/backup-run.test.ts
@@ -55,6 +55,26 @@ describe("backupRunCommand", () => {
     });
   });
 
+  it("keeps workspace fallback when only the encryption key is configured", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: {
+        backup: {
+          encryption: { key: "secret" },
+        },
+      },
+    });
+
+    const result = await backupRunCommand(runtime, {});
+
+    expect(workspaceBackupRunCommand).toHaveBeenCalled();
+    expect(backupPushCommand).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: "workspace",
+      workspace: { workspaceCount: 1 },
+    });
+  });
+
   it("uses snapshot backup when encryption is configured", async () => {
     readConfigFileSnapshot.mockResolvedValue({
       valid: true,

--- a/src/commands/backup-run.ts
+++ b/src/commands/backup-run.ts
@@ -1,0 +1,72 @@
+import { readConfigFileSnapshot } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { backupPushCommand, type BackupPushOptions, type BackupPushResult } from "./backup-push.js";
+import type { BackupSnapshotDeps } from "./backup-snapshot-shared.js";
+import {
+  workspaceBackupRunCommand,
+  type WorkspaceBackupRunOptions,
+  type WorkspaceBackupRunResult,
+} from "./workspace-backup.js";
+
+export type BackupRunMode = "auto" | "snapshot";
+
+export type BackupRunOptions = BackupPushOptions &
+  WorkspaceBackupRunOptions & {
+    mode?: BackupRunMode;
+  };
+
+export type BackupRunResult =
+  | {
+      kind: "snapshot";
+      snapshot: BackupPushResult;
+    }
+  | {
+      kind: "workspace";
+      workspace: WorkspaceBackupRunResult;
+    };
+
+function hasSnapshotBackupConfigured(): Promise<boolean> {
+  return readConfigFileSnapshot().then((snapshot) => {
+    if (!snapshot.valid) {
+      throw new Error("Config is invalid. Backup commands require a valid config file.");
+    }
+    return Boolean(snapshot.config.backup?.encryption?.key);
+  });
+}
+
+export async function backupRunCommand(
+  runtime: RuntimeEnv,
+  opts: BackupRunOptions,
+  deps?: BackupSnapshotDeps,
+): Promise<BackupRunResult> {
+  const mode = opts.mode ?? "auto";
+  const shouldRunSnapshot =
+    mode === "snapshot" || (mode === "auto" && (await hasSnapshotBackupConfigured()));
+
+  if (!shouldRunSnapshot) {
+    if (opts.output || opts.verify || opts.snapshotName) {
+      throw new Error(
+        "Snapshot-only options are not supported when backup run falls back to workspace mirroring.",
+      );
+    }
+    return {
+      kind: "workspace",
+      workspace: await workspaceBackupRunCommand(runtime, {
+        json: opts.json,
+      }),
+    };
+  }
+  return {
+    kind: "snapshot",
+    snapshot: await backupPushCommand(
+      runtime,
+      {
+        output: opts.output,
+        json: opts.json,
+        verify: opts.verify,
+        snapshotName: opts.snapshotName,
+      },
+      deps,
+    ),
+  };
+}

--- a/src/commands/backup-run.ts
+++ b/src/commands/backup-run.ts
@@ -30,7 +30,9 @@ function hasSnapshotBackupConfigured(): Promise<boolean> {
     if (!snapshot.valid) {
       throw new Error("Config is invalid. Backup commands require a valid config file.");
     }
-    return Boolean(snapshot.config.backup?.encryption?.key);
+    return Boolean(
+      snapshot.config.backup?.target?.trim() && snapshot.config.backup?.encryption?.key,
+    );
   });
 }
 

--- a/src/commands/backup-snapshot-shared.ts
+++ b/src/commands/backup-snapshot-shared.ts
@@ -29,9 +29,8 @@ export async function loadResolvedSnapshotBackup(params: { env?: NodeJS.ProcessE
   stateDir: string;
 }> {
   const snapshot = await readConfigFileSnapshot();
-  if (!snapshot.valid) {
-    throw new Error("Config is invalid. Backup snapshot commands require a valid config file.");
-  }
+  // Use best-effort config even when unrelated sections are invalid;
+  // resolveSnapshotStoreConfig will still validate backup-specific fields.
   return {
     snapshotStore: await resolveSnapshotStoreConfig({
       config: snapshot.config,
@@ -53,9 +52,8 @@ export async function loadResolvedSnapshotBackupTarget(params: {
   stateDir: string;
 }> {
   const snapshot = await readConfigFileSnapshot();
-  if (!snapshot.valid) {
-    throw new Error("Config is invalid. Backup snapshot commands require a valid config file.");
-  }
+  // Use best-effort config even when unrelated sections are invalid;
+  // resolveSnapshotStoreTargetConfig will still validate backup-specific fields.
   return {
     snapshotStore: await resolveSnapshotStoreTargetConfig({
       config: snapshot.config,

--- a/src/commands/backup-snapshot-shared.ts
+++ b/src/commands/backup-snapshot-shared.ts
@@ -4,13 +4,16 @@ import os from "node:os";
 import path from "node:path";
 import {
   resolveSnapshotStoreConfig,
+  resolveSnapshotStoreTargetConfig,
   type ResolvedSnapshotStoreConfig,
+  type ResolvedSnapshotStoreTargetConfig,
 } from "../backup/snapshot-store/config.js";
 import { resolveInstallationId } from "../backup/snapshot-store/installation-id.js";
-import { createSnapshotStore } from "../backup/snapshot-store/provider.js";
+import { createSnapshotStore, createSnapshotListStore } from "../backup/snapshot-store/provider.js";
 import type {
   BackupSnapshotEnvelope,
   BackupSnapshotListEntry,
+  BackupSnapshotListStore,
   BackupSnapshotStore,
 } from "../backup/snapshot-store/types.js";
 import { resolveStateDir, readConfigFileSnapshot } from "../config/config.js";
@@ -38,11 +41,42 @@ export async function loadResolvedSnapshotBackup(params: { env?: NodeJS.ProcessE
   };
 }
 
+/**
+ * Resolve only the backup target directory and state dir, without requiring
+ * the encryption key. Used by read-only commands (e.g. backup list) that
+ * only read envelope metadata.
+ */
+export async function loadResolvedSnapshotBackupTarget(params: {
+  env?: NodeJS.ProcessEnv;
+}): Promise<{
+  snapshotStore: ResolvedSnapshotStoreTargetConfig;
+  stateDir: string;
+}> {
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    throw new Error("Config is invalid. Backup snapshot commands require a valid config file.");
+  }
+  return {
+    snapshotStore: await resolveSnapshotStoreTargetConfig({
+      config: snapshot.config,
+      env: params.env ?? process.env,
+    }),
+    stateDir: resolveStateDir(params.env ?? process.env),
+  };
+}
+
 export async function resolveSnapshotStore(params: {
   snapshotStore: ResolvedSnapshotStoreConfig;
   deps?: BackupSnapshotDeps;
 }): Promise<BackupSnapshotStore> {
   return params.deps?.storage ?? createSnapshotStore(params.snapshotStore);
+}
+
+export async function resolveSnapshotListStore(params: {
+  snapshotStore: ResolvedSnapshotStoreTargetConfig;
+  deps?: BackupSnapshotDeps;
+}): Promise<BackupSnapshotListStore> {
+  return params.deps?.storage ?? createSnapshotListStore(params.snapshotStore);
 }
 
 export async function resolveCurrentInstallationId(params: {

--- a/src/commands/backup-snapshot-shared.ts
+++ b/src/commands/backup-snapshot-shared.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolveSnapshotStoreConfig,
+  type ResolvedSnapshotStoreConfig,
+} from "../backup/snapshot-store/config.js";
+import { resolveInstallationId } from "../backup/snapshot-store/installation-id.js";
+import { createSnapshotStore } from "../backup/snapshot-store/provider.js";
+import type {
+  BackupSnapshotEnvelope,
+  BackupSnapshotListEntry,
+  BackupSnapshotStore,
+} from "../backup/snapshot-store/types.js";
+import { resolveStateDir, readConfigFileSnapshot } from "../config/config.js";
+import { resolveRuntimeServiceVersion } from "../version.js";
+
+export type BackupSnapshotDeps = {
+  storage?: BackupSnapshotStore;
+  nowMs?: number;
+};
+
+export async function loadResolvedSnapshotBackup(params: { env?: NodeJS.ProcessEnv }): Promise<{
+  snapshotStore: ResolvedSnapshotStoreConfig;
+  stateDir: string;
+}> {
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    throw new Error("Config is invalid. Backup snapshot commands require a valid config file.");
+  }
+  return {
+    snapshotStore: await resolveSnapshotStoreConfig({
+      config: snapshot.config,
+      env: params.env ?? process.env,
+    }),
+    stateDir: resolveStateDir(params.env ?? process.env),
+  };
+}
+
+export async function resolveSnapshotStore(params: {
+  snapshotStore: ResolvedSnapshotStoreConfig;
+  deps?: BackupSnapshotDeps;
+}): Promise<BackupSnapshotStore> {
+  return params.deps?.storage ?? createSnapshotStore(params.snapshotStore);
+}
+
+export async function resolveCurrentInstallationId(params: {
+  stateDir: string;
+  createIfMissing?: boolean;
+}): Promise<string | undefined> {
+  return await resolveInstallationId({
+    stateDir: params.stateDir,
+    createIfMissing: params.createIfMissing,
+  });
+}
+
+export function createSnapshotId(nowMs = Date.now()): string {
+  const timestamp = new Date(nowMs).toISOString().replace(/[:.]/g, "-");
+  return `snap_${timestamp}_${randomUUID().slice(0, 8)}`;
+}
+
+export async function createTempBackupDir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-snapshot-backup-"));
+}
+
+export function toSnapshotListEntry(envelope: BackupSnapshotEnvelope): BackupSnapshotListEntry {
+  return {
+    snapshotId: envelope.snapshotId,
+    installationId: envelope.installationId,
+    createdAt: envelope.createdAt,
+    openclawVersion: envelope.openclawVersion,
+    snapshotName: envelope.snapshotName,
+    mode: envelope.archive.mode,
+    includeWorkspace: envelope.archive.includeWorkspace,
+    verified: envelope.archive.verified,
+    archiveBytes: envelope.archive.bytes,
+    ciphertextBytes: envelope.ciphertext.bytes,
+  };
+}
+
+export function buildEnvelope(params: {
+  snapshotId: string;
+  installationId: string;
+  createdAt: string;
+  archiveRoot: string;
+  archiveCreatedAt: string;
+  includeWorkspace: boolean;
+  verified: boolean;
+  onlyConfig: boolean;
+  snapshotName?: string;
+  encryption: Pick<BackupSnapshotEnvelope, "archive" | "ciphertext" | "encryption">;
+}): BackupSnapshotEnvelope {
+  return {
+    schemaVersion: 1,
+    snapshotId: params.snapshotId,
+    installationId: params.installationId,
+    createdAt: params.createdAt,
+    openclawVersion: resolveRuntimeServiceVersion(),
+    archive: {
+      ...params.encryption.archive,
+      archiveRoot: params.archiveRoot,
+      createdAt: params.archiveCreatedAt,
+      mode: params.onlyConfig ? "config-only" : "full-host",
+      includeWorkspace: params.includeWorkspace,
+      verified: params.verified,
+    },
+    ciphertext: params.encryption.ciphertext,
+    encryption: params.encryption.encryption,
+    ...(params.snapshotName ? { snapshotName: params.snapshotName } : {}),
+  };
+}

--- a/src/commands/backup-snapshot.test.ts
+++ b/src/commands/backup-snapshot.test.ts
@@ -94,4 +94,13 @@ describe("folder-backed snapshot backup commands", () => {
     expect(await fs.readFile(path.join(stateDir, "state.txt"), "utf8")).toBe("state\n");
     expect(await fs.readFile(path.join(workspaceDir, "SOUL.md"), "utf8")).toBe("# soul\n");
   });
+
+  it("emits a single JSON payload when snapshot push runs with --json", async () => {
+    await backupPushCommand(runtime, { json: true }, { nowMs: Date.UTC(2026, 2, 10) });
+
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(runtime.log).mock.calls[0]?.[0];
+    expect(typeof message).toBe("string");
+    expect(() => JSON.parse(String(message))).not.toThrow();
+  });
 });

--- a/src/commands/backup-snapshot.test.ts
+++ b/src/commands/backup-snapshot.test.ts
@@ -95,6 +95,27 @@ describe("folder-backed snapshot backup commands", () => {
     expect(await fs.readFile(path.join(workspaceDir, "SOUL.md"), "utf8")).toBe("# soul\n");
   });
 
+  it("lists snapshots without encryption key configured", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+
+    // Push a snapshot first (requires key).
+    const pushed = await backupPushCommand(runtime, {}, { nowMs: Date.UTC(2026, 2, 10) });
+    expect(pushed.snapshotId).toContain("snap_");
+
+    // Remove the encryption key from config, keeping only target.
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({ backup: { target: targetDir } }),
+      "utf8",
+    );
+
+    // Listing should succeed even without encryption key.
+    const listed = await backupListCommand(runtime, {});
+    expect(listed.installationId).toBe(pushed.installationId);
+    expect(listed.snapshots).toHaveLength(1);
+    expect(listed.snapshots[0]?.snapshotId).toBe(pushed.snapshotId);
+  });
+
   it("emits a single JSON payload when snapshot push runs with --json", async () => {
     await backupPushCommand(runtime, { json: true }, { nowMs: Date.UTC(2026, 2, 10) });
 

--- a/src/commands/backup-snapshot.test.ts
+++ b/src/commands/backup-snapshot.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { backupListCommand } from "./backup-list.js";
+import { backupPushCommand } from "./backup-push.js";
+import { backupRestoreCommand } from "./backup-restore.js";
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => ({
+    isLoaded: vi.fn(async () => false),
+    stop: vi.fn(async () => undefined),
+  }),
+}));
+
+describe("folder-backed snapshot backup commands", () => {
+  let tempHome: TempHomeEnv;
+  let runtime: RuntimeEnv;
+  let previousCwd: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempHome = await createTempHomeEnv("openclaw-folder-backup-test-");
+    previousCwd = process.cwd();
+    runtime = {
+      log: vi.fn() as RuntimeEnv["log"],
+      error: vi.fn() as RuntimeEnv["error"],
+      exit: vi.fn() as RuntimeEnv["exit"],
+    };
+
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-target-"));
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
+    await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        backup: {
+          target: targetDir,
+          encryption: {
+            key: "test-secret",
+          },
+        },
+      }),
+      "utf8",
+    );
+  });
+
+  afterEach(async () => {
+    process.chdir(previousCwd);
+    await fs.rm(targetDir, { recursive: true, force: true }).catch(() => undefined);
+    await tempHome.restore();
+  });
+
+  it("pushes, lists, and restores an encrypted snapshot from the configured backup folder", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+
+    const pushed = await backupPushCommand(runtime, {}, { nowMs: Date.UTC(2026, 2, 10) });
+    expect(pushed.snapshotId).toContain("snap_");
+    expect(pushed.installationId).toContain("inst_");
+
+    const listed = await backupListCommand(runtime, {});
+    expect(listed.installationId).toBe(pushed.installationId);
+    expect(listed.snapshots).toHaveLength(1);
+    expect(listed.snapshots[0]?.snapshotId).toBe(pushed.snapshotId);
+
+    await fs.rm(stateDir, { recursive: true, force: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        backup: {
+          target: targetDir,
+          encryption: {
+            key: "test-secret",
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const restored = await backupRestoreCommand(runtime, {
+      snapshotId: pushed.snapshotId,
+      installationId: pushed.installationId,
+      mode: "full-host",
+    });
+
+    expect(restored.mode).toBe("full-host");
+    expect(await fs.readFile(path.join(stateDir, "state.txt"), "utf8")).toBe("state\n");
+    expect(await fs.readFile(path.join(workspaceDir, "SOUL.md"), "utf8")).toBe("# soul\n");
+  });
+});

--- a/src/commands/backup-status.test.ts
+++ b/src/commands/backup-status.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { backupStatusCommand } from "./backup-status.js";
+
+const {
+  readConfigFileSnapshot,
+  getWorkspaceBackupStatus,
+  loadResolvedSnapshotBackup,
+  resolveSnapshotStore,
+  resolveCurrentInstallationId,
+} = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+  getWorkspaceBackupStatus: vi.fn(),
+  loadResolvedSnapshotBackup: vi.fn(),
+  resolveSnapshotStore: vi.fn(),
+  resolveCurrentInstallationId: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  readConfigFileSnapshot,
+}));
+
+vi.mock("./workspace-backup.js", () => ({
+  getWorkspaceBackupStatus,
+}));
+
+vi.mock("./backup-snapshot-shared.js", async () => {
+  const actual = await vi.importActual<typeof import("./backup-snapshot-shared.js")>(
+    "./backup-snapshot-shared.js",
+  );
+  return {
+    ...actual,
+    loadResolvedSnapshotBackup,
+    resolveSnapshotStore,
+    resolveCurrentInstallationId,
+  };
+});
+
+describe("backupStatusCommand", () => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getWorkspaceBackupStatus.mockResolvedValue({
+      configured: false,
+      workspaceCount: 0,
+      detected: "iCloud Drive",
+    });
+  });
+
+  it("reports workspace-only backup when full snapshots are not enabled", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: {
+        backup: {
+          target: "/tmp/backups",
+        },
+      },
+    });
+
+    const result = await backupStatusCommand(runtime, {});
+
+    expect(result).toMatchObject({
+      target: "/tmp/backups",
+      snapshot: {
+        enabled: false,
+        snapshotCount: 0,
+      },
+    });
+    expect(loadResolvedSnapshotBackup).not.toHaveBeenCalled();
+  });
+
+  it("includes the latest full snapshot when encryption is configured", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      config: {
+        backup: {
+          target: "/tmp/backups",
+          encryption: {
+            key: "secret",
+          },
+        },
+      },
+    });
+    loadResolvedSnapshotBackup.mockResolvedValue({
+      snapshotStore: {
+        targetDir: "/tmp/backups",
+      },
+      stateDir: "/tmp/state",
+    });
+    resolveCurrentInstallationId.mockResolvedValue("inst_1");
+    resolveSnapshotStore.mockResolvedValue({
+      listSnapshots: vi.fn().mockResolvedValue([
+        {
+          snapshotId: "snap_1",
+          installationId: "inst_1",
+          createdAt: "2026-03-10T00:00:00.000Z",
+          openclawVersion: "2026.3.10",
+          archive: {
+            mode: "full-host",
+            includeWorkspace: true,
+            verified: true,
+            bytes: 128,
+            format: "openclaw-backup-tar-gz",
+            archiveRoot: "root",
+            createdAt: "2026-03-10T00:00:00.000Z",
+            sha256: "abc",
+          },
+          ciphertext: {
+            bytes: 256,
+            sha256: "def",
+          },
+          encryption: {
+            cipher: "aes-256-gcm",
+            keyDerivation: {
+              name: "scrypt",
+              saltBase64Url: "salt",
+              cost: 1,
+              blockSize: 8,
+              parallelization: 1,
+              maxMemoryBytes: 1024,
+            },
+            nonceBase64Url: "nonce",
+            authTagBase64Url: "tag",
+          },
+        },
+      ]),
+    });
+
+    const result = await backupStatusCommand(runtime, {});
+
+    expect(result).toMatchObject({
+      target: "/tmp/backups",
+      snapshot: {
+        enabled: true,
+        installationId: "inst_1",
+        snapshotCount: 1,
+        latestSnapshotId: "snap_1",
+      },
+    });
+  });
+});

--- a/src/commands/backup-status.ts
+++ b/src/commands/backup-status.ts
@@ -1,0 +1,126 @@
+import { readConfigFileSnapshot } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { shortenHomePath } from "../utils.js";
+import {
+  loadResolvedSnapshotBackup,
+  resolveSnapshotStore,
+  resolveCurrentInstallationId,
+  toSnapshotListEntry,
+  type BackupSnapshotDeps,
+} from "./backup-snapshot-shared.js";
+import { getWorkspaceBackupStatus, type WorkspaceBackupStatusResult } from "./workspace-backup.js";
+
+export type BackupStatusOptions = {
+  json?: boolean;
+};
+
+export type BackupStatusResult = {
+  target?: string;
+  workspace: WorkspaceBackupStatusResult;
+  snapshot: {
+    enabled: boolean;
+    installationId?: string;
+    snapshotCount: number;
+    latestSnapshotId?: string;
+    latestSnapshotAt?: string;
+    error?: string;
+  };
+};
+
+async function getSnapshotStatus(
+  deps?: BackupSnapshotDeps,
+): Promise<BackupStatusResult["snapshot"] & { target?: string }> {
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    throw new Error("Config is invalid. Backup commands require a valid config file.");
+  }
+
+  const target = snapshot.config.backup?.target?.trim() || undefined;
+  const enabled = Boolean(target && snapshot.config.backup?.encryption?.key);
+  if (!enabled) {
+    return {
+      enabled: false,
+      snapshotCount: 0,
+      target,
+    };
+  }
+
+  try {
+    const resolved = await loadResolvedSnapshotBackup({});
+    const installationId = await resolveCurrentInstallationId({
+      stateDir: resolved.stateDir,
+      createIfMissing: false,
+    });
+    if (!installationId) {
+      return {
+        enabled: true,
+        snapshotCount: 0,
+        target: resolved.snapshotStore.targetDir,
+      };
+    }
+    const storage = await resolveSnapshotStore({
+      snapshotStore: resolved.snapshotStore,
+      deps,
+    });
+    const entries = (await storage.listSnapshots({ installationId }))
+      .map(toSnapshotListEntry)
+      .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt));
+    return {
+      enabled: true,
+      installationId,
+      snapshotCount: entries.length,
+      latestSnapshotId: entries[0]?.snapshotId,
+      latestSnapshotAt: entries[0]?.createdAt,
+      target: resolved.snapshotStore.targetDir,
+    };
+  } catch (error) {
+    return {
+      enabled: true,
+      snapshotCount: 0,
+      target,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function formatStatusMessage(result: BackupStatusResult): string {
+  const lines = [
+    `Backup target: ${result.target ? shortenHomePath(result.target) : "not configured"}`,
+    `Workspace backup: ${result.workspace.configured ? "configured" : "not configured"}`,
+    `Workspace last updated: ${result.workspace.lastUpdatedAt ?? "never"}`,
+    `Mirrored workspaces: ${result.workspace.workspaceCount}`,
+    `Full backup: ${result.snapshot.enabled ? "enabled" : "not enabled"}`,
+  ];
+
+  if (result.snapshot.installationId) {
+    lines.push(`Installation id: ${result.snapshot.installationId}`);
+  }
+  if (result.snapshot.latestSnapshotId && result.snapshot.latestSnapshotAt) {
+    lines.push(
+      `Latest snapshot: ${result.snapshot.latestSnapshotId} ${result.snapshot.latestSnapshotAt}`,
+    );
+  } else {
+    lines.push("Latest snapshot: none");
+  }
+  lines.push(`Snapshot count: ${result.snapshot.snapshotCount}`);
+  if (result.snapshot.error) {
+    lines.push(`Snapshot status warning: ${result.snapshot.error}`);
+  }
+  return lines.join("\n");
+}
+
+export async function backupStatusCommand(
+  runtime: RuntimeEnv,
+  opts: BackupStatusOptions,
+  deps?: BackupSnapshotDeps,
+): Promise<BackupStatusResult> {
+  const workspace = await getWorkspaceBackupStatus();
+  const snapshot = await getSnapshotStatus(deps);
+  const result: BackupStatusResult = {
+    target: workspace.target ?? snapshot.target,
+    workspace,
+    snapshot,
+  };
+  runtime.log(opts.json ? JSON.stringify(result, null, 2) : formatStatusMessage(result));
+  return result;
+}

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -389,4 +389,49 @@ describe("backupVerifyCommand", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("fails when the archive contains tar link entries", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-link-entry-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    try {
+      const rootName = "2026-03-09T00-00-00.000Z-openclaw-backup";
+      const root = path.join(tempDir, rootName);
+      const outsideDir = path.join(tempDir, "outside");
+      await fs.mkdir(root, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(outsideDir, "owned.txt"), "owned\n", "utf8");
+      await fs.writeFile(
+        path.join(root, "manifest.json"),
+        `${JSON.stringify(
+          {
+            schemaVersion: 1,
+            createdAt: "2026-03-09T00:00:00.000Z",
+            archiveRoot: rootName,
+            runtimeVersion: "test",
+            platform: process.platform,
+            nodeVersion: process.version,
+            assets: [],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      await fs.symlink("../outside", path.join(root, "payload"));
+
+      await tar.c({ file: archivePath, gzip: true, cwd: tempDir }, [rootName]);
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /unsupported tar link entry/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -5,7 +5,7 @@ import * as tar from "tar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 import { buildBackupArchiveRoot } from "./backup-shared.js";
-import { backupVerifyCommand } from "./backup-verify.js";
+import { backupVerifyCommand, findUnsupportedTarSpecialEntry } from "./backup-verify.js";
 import { backupCreateCommand } from "./backup.js";
 
 describe("backupVerifyCommand", () => {
@@ -390,7 +390,7 @@ describe("backupVerifyCommand", () => {
     }
   });
 
-  it("fails when the archive contains tar link entries", async () => {
+  it("fails when the archive contains blocked tar special entries", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-link-entry-"));
     const archivePath = path.join(tempDir, "broken.tar.gz");
     try {
@@ -428,10 +428,24 @@ describe("backupVerifyCommand", () => {
       };
 
       await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
-        /unsupported tar link entry/i,
+        /unsupported tar special entry/i,
       );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("fails when the archive contains fifo tar entries", async () => {
+    expect(
+      findUnsupportedTarSpecialEntry([
+        {
+          path: "2026-03-09T00-00-00.000Z-openclaw-backup/payload/fifo",
+          type: "FIFO",
+        },
+      ]),
+    ).toEqual({
+      path: "2026-03-09T00-00-00.000Z-openclaw-backup/payload/fifo",
+      type: "FIFO",
+    });
   });
 });

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -170,13 +170,15 @@ export function parseBackupManifest(raw: string): BackupManifest {
   };
 }
 
-async function listArchiveEntries(archivePath: string): Promise<string[]> {
-  const entries: string[] = [];
+async function listArchiveEntries(
+  archivePath: string,
+): Promise<Array<{ path: string; type?: string }>> {
+  const entries: Array<{ path: string; type?: string }> = [];
   await tar.t({
     file: archivePath,
     gzip: true,
     onentry: (entry) => {
-      entries.push(entry.path);
+      entries.push({ path: entry.path, type: entry.type });
     },
   });
   return entries;
@@ -285,10 +287,16 @@ export async function backupVerifyCommand(
   if (rawEntries.length === 0) {
     throw new Error("Backup archive is empty.");
   }
+  const unsupportedLinkEntry = rawEntries.find(
+    (entry) => entry.type === "SymbolicLink" || entry.type === "Link",
+  );
+  if (unsupportedLinkEntry) {
+    throw new Error(`Archive contains unsupported tar link entry: ${unsupportedLinkEntry.path}`);
+  }
 
   const entries = rawEntries.map((entry) => ({
-    raw: entry,
-    normalized: normalizeArchivePath(entry, "Archive entry"),
+    raw: entry.path,
+    normalized: normalizeArchivePath(entry.path, "Archive entry"),
   }));
   const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
 

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -5,13 +5,13 @@ import { resolveUserPath } from "../utils.js";
 
 const WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
 
-type BackupManifestAsset = {
+export type BackupManifestAsset = {
   kind: string;
   sourcePath: string;
   archivePath: string;
 };
 
-type BackupManifest = {
+export type BackupManifest = {
   schemaVersion: number;
   createdAt: string;
   archiveRoot: string;
@@ -59,7 +59,7 @@ function stripTrailingSlashes(value: string): string {
   return value.replace(/\/+$/u, "");
 }
 
-function normalizeArchivePath(entryPath: string, label: string): string {
+export function normalizeArchivePath(entryPath: string, label: string): string {
   const trimmed = stripTrailingSlashes(entryPath.trim());
   if (!trimmed) {
     throw new Error(`${label} is empty.`);
@@ -81,7 +81,7 @@ function normalizeArchivePath(entryPath: string, label: string): string {
   return normalized;
 }
 
-function normalizeArchiveRoot(rootName: string): string {
+export function normalizeArchiveRoot(rootName: string): string {
   const normalized = normalizeArchivePath(rootName, "Backup manifest archiveRoot");
   if (normalized.includes("/")) {
     throw new Error(`Backup manifest archiveRoot must be a single path segment: ${rootName}`);
@@ -94,7 +94,7 @@ function isArchivePathWithin(child: string, parent: string): boolean {
   return relative === "" || (!relative.startsWith("../") && relative !== "..");
 }
 
-function parseManifest(raw: string): BackupManifest {
+export function parseBackupManifest(raw: string): BackupManifest {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -306,7 +306,7 @@ export async function backupVerifyCommand(
   }
 
   const manifestRaw = await extractManifest({ archivePath, manifestEntryPath });
-  const manifest = parseManifest(manifestRaw);
+  const manifest = parseBackupManifest(manifestRaw);
   verifyManifestAgainstEntries(manifest, normalizedEntrySet);
 
   const result: BackupVerifyResult = {

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import * as tar from "tar";
+import { isBlockedTarEntryType } from "../infra/archive.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -278,6 +279,12 @@ function findDuplicateNormalizedEntryPath(
   return undefined;
 }
 
+export function findUnsupportedTarSpecialEntry(
+  entries: Array<{ path: string; type?: string }>,
+): { path: string; type?: string } | undefined {
+  return entries.find((entry) => isBlockedTarEntryType(entry.type ?? ""));
+}
+
 export async function backupVerifyCommand(
   runtime: RuntimeEnv,
   opts: BackupVerifyOptions,
@@ -287,11 +294,11 @@ export async function backupVerifyCommand(
   if (rawEntries.length === 0) {
     throw new Error("Backup archive is empty.");
   }
-  const unsupportedLinkEntry = rawEntries.find(
-    (entry) => entry.type === "SymbolicLink" || entry.type === "Link",
-  );
-  if (unsupportedLinkEntry) {
-    throw new Error(`Archive contains unsupported tar link entry: ${unsupportedLinkEntry.path}`);
+  const unsupportedSpecialEntry = findUnsupportedTarSpecialEntry(rawEntries);
+  if (unsupportedSpecialEntry) {
+    throw new Error(
+      `Archive contains unsupported tar special entry (${unsupportedSpecialEntry.type}): ${unsupportedSpecialEntry.path}`,
+    );
   }
 
   const entries = rawEntries.map((entry) => ({

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -1,3 +1,4 @@
+import type { PathLike } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -399,7 +400,10 @@ describe("backup commands", () => {
     const configPath = path.join(tempHome.home, "custom-config.json");
     const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-"));
     const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-outside-"));
-    const originalReaddir = fs.readdir.bind(fs);
+    const originalReaddirWithFileTypes = fs.readdir.bind(fs) as unknown as (
+      target: PathLike,
+      options: { encoding: "buffer"; withFileTypes: true; recursive?: boolean },
+    ) => ReturnType<typeof fs.readdir>;
     const readdirSpy = vi.spyOn(fs, "readdir");
     try {
       process.env.OPENCLAW_CONFIG_PATH = configPath;
@@ -421,7 +425,10 @@ describe("backup commands", () => {
         path.join(externalWorkspace, "shared.txt"),
       );
 
-      readdirSpy.mockImplementation(async (target, options) => {
+      readdirSpy.mockImplementation((async (
+        target: PathLike,
+        options: { encoding: "buffer"; withFileTypes: true; recursive?: boolean },
+      ) => {
         if (target === externalWorkspace && typeof options === "object" && options?.withFileTypes) {
           return [
             {
@@ -430,10 +437,13 @@ describe("backup commands", () => {
               isDirectory: () => false,
               isSymbolicLink: () => false,
             },
-          ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+          ] as unknown;
         }
-        return originalReaddir(target as never, options as never);
-      });
+        return originalReaddirWithFileTypes(
+          target,
+          options as { encoding: "buffer"; withFileTypes: true; recursive?: boolean },
+        );
+      }) as never);
 
       const runtime = {
         log: vi.fn(),

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -335,6 +335,56 @@ describe("backup commands", () => {
     expect(await fs.readFile(existingArchive, "utf8")).toBe("already here");
   });
 
+  it("rejects backup sources that contain symbolic links before writing an archive", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const configPath = path.join(tempHome.home, "custom-config.json");
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-"));
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-outside-"));
+    try {
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: externalWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      await fs.writeFile(path.join(outsideDir, "shared.txt"), "shared\n", "utf8");
+      await fs.symlink(
+        path.join(outsideDir, "shared.txt"),
+        path.join(externalWorkspace, "shared.txt"),
+      );
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(
+        backupCreateCommand(runtime, {
+          output: backupDir,
+          includeWorkspace: true,
+        }),
+      ).rejects.toThrow(/contains symbolic links/i);
+    } finally {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(backupDir, { recursive: true, force: true });
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails fast when config is invalid and workspace backup is enabled", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const configPath = path.join(tempHome.home, "custom-config.json");

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -389,6 +389,73 @@ describe("backup commands", () => {
     }
   });
 
+  it("rejects backup source symlinks even when readdir reports unknown dirent types", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const configPath = path.join(tempHome.home, "custom-config.json");
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-"));
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-outside-"));
+    const originalReaddir = fs.readdir.bind(fs);
+    const readdirSpy = vi.spyOn(fs, "readdir");
+    try {
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: externalWorkspace,
+            },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      await fs.writeFile(path.join(outsideDir, "shared.txt"), "shared\n", "utf8");
+      await fs.symlink(
+        path.join(outsideDir, "shared.txt"),
+        path.join(externalWorkspace, "shared.txt"),
+      );
+
+      readdirSpy.mockImplementation(async (target, options) => {
+        if (target === externalWorkspace && typeof options === "object" && options?.withFileTypes) {
+          return [
+            {
+              name: "shared.txt",
+              isFile: () => false,
+              isDirectory: () => false,
+              isSymbolicLink: () => false,
+            },
+          ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
+        }
+        return originalReaddir(target as never, options as never);
+      });
+
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      await expect(
+        backupCreateCommand(runtime, {
+          output: backupDir,
+          includeWorkspace: true,
+        }),
+      ).rejects.toThrow(/contains symbolic links/i);
+    } finally {
+      readdirSpy.mockRestore();
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(backupDir, { recursive: true, force: true });
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails fast when config is invalid and workspace backup is enabled", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const configPath = path.join(tempHome.home, "custom-config.json");

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -151,8 +151,12 @@ describe("backup commands", () => {
           ]),
         );
 
-        const stateAsset = result.assets.find((asset) => asset.kind === "state");
-        const workspaceAsset = result.assets.find((asset) => asset.kind === "workspace");
+        const stateAsset = result.assets.find(
+          (asset: (typeof result.assets)[number]) => asset.kind === "state",
+        );
+        const workspaceAsset = result.assets.find(
+          (asset: (typeof result.assets)[number]) => asset.kind === "workspace",
+        );
         expect(stateAsset).toBeDefined();
         expect(workspaceAsset).toBeDefined();
 
@@ -427,7 +431,9 @@ describe("backup commands", () => {
       });
 
       expect(result.includeWorkspace).toBe(false);
-      expect(result.assets.some((asset) => asset.kind === "workspace")).toBe(false);
+      expect(
+        result.assets.some((asset: (typeof result.assets)[number]) => asset.kind === "workspace"),
+      ).toBe(false);
     } finally {
       delete process.env.OPENCLAW_CONFIG_PATH;
     }

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,9 +1,4 @@
-import {
-  createBackupArchive,
-  formatBackupCreateSummary,
-  type BackupCreateOptions,
-  type BackupCreateResult,
-} from "../infra/backup-create.js";
+import { createBackupArchive, formatBackupCreateSummary } from "../infra/backup-create.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { backupVerifyCommand } from "./backup-verify.js";
 export type { BackupCreateOptions, BackupCreateResult } from "../infra/backup-create.js";

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,4 +1,5 @@
 import { createBackupArchive, formatBackupCreateSummary } from "../infra/backup-create.js";
+import type { BackupCreateOptions, BackupCreateResult } from "../infra/backup-create.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { backupVerifyCommand } from "./backup-verify.js";
 export type { BackupCreateOptions, BackupCreateResult } from "../infra/backup-create.js";

--- a/src/commands/reset.test.ts
+++ b/src/commands/reset.test.ts
@@ -53,7 +53,7 @@ describe("resetCommand", () => {
       dryRun: true,
     });
 
-    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("openclaw backup export"));
   });
 
   it("does not recommend backup for config-only reset", async () => {
@@ -64,6 +64,6 @@ describe("resetCommand", () => {
       dryRun: true,
     });
 
-    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw backup export"));
   });
 });

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -45,7 +45,7 @@ async function stopGatewayIfRunning(runtime: RuntimeEnv) {
 }
 
 function logBackupRecommendation(runtime: RuntimeEnv) {
-  runtime.log(`Recommended first: ${formatCliCommand("openclaw backup create")}`);
+  runtime.log(`Recommended first: ${formatCliCommand("openclaw backup export")}`);
 }
 
 export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -50,7 +50,7 @@ describe("uninstallCommand", () => {
       dryRun: true,
     });
 
-    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("openclaw backup export"));
   });
 
   it("does not recommend backup for service-only uninstall", async () => {
@@ -61,6 +61,6 @@ describe("uninstallCommand", () => {
       dryRun: true,
     });
 
-    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw backup export"));
   });
 });

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -94,7 +94,7 @@ async function removeMacApp(runtime: RuntimeEnv, dryRun?: boolean) {
 }
 
 function logBackupRecommendation(runtime: RuntimeEnv) {
-  runtime.log(`Recommended first: ${formatCliCommand("openclaw backup create")}`);
+  runtime.log(`Recommended first: ${formatCliCommand("openclaw backup export")}`);
 }
 
 export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptions) {

--- a/src/commands/workspace-backup.test.ts
+++ b/src/commands/workspace-backup.test.ts
@@ -160,4 +160,28 @@ describe("workspace backup commands", () => {
       }),
     ).rejects.toThrow("backup.target must not be inside the live state directory.");
   });
+
+  it("rejects workspace paths nested under backup workspace root", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-target-"));
+    const workspaceDir = path.join(targetDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    await expect(
+      workspaceBackupInitCommand(runtime, {
+        target: targetDir,
+      }),
+    ).rejects.toThrow("workspace path must not be inside backup.target/workspace");
+  });
 });

--- a/src/commands/workspace-backup.test.ts
+++ b/src/commands/workspace-backup.test.ts
@@ -184,4 +184,45 @@ describe("workspace backup commands", () => {
       }),
     ).rejects.toThrow("workspace path must not be inside backup.target/workspace");
   });
+
+  it("keeps existing mirrors when a configured workspace is temporarily missing", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceB = path.join(tempHome.home, "workspace-b");
+    targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-target-"));
+    await fs.mkdir(workspaceB, { recursive: true });
+    await fs.writeFile(path.join(workspaceB, "B.txt"), "b\n", "utf8");
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: {
+          defaults: {
+            workspace: workspaceB,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    await workspaceBackupInitCommand(runtime, { target: targetDir });
+    await workspaceBackupRunCommand(runtime, {});
+
+    const mirrorB = path.join(
+      targetDir,
+      "workspace",
+      "mirrors",
+      encodeAbsolutePathForBackupArchive(workspaceB),
+    );
+    expect(await fs.readFile(path.join(mirrorB, "B.txt"), "utf8")).toBe("b\n");
+
+    await fs.rm(workspaceB, { recursive: true, force: true });
+    const rerun = await workspaceBackupRunCommand(runtime, {});
+
+    expect(rerun.workspaceCount).toBe(0);
+    expect(await fs.readFile(path.join(mirrorB, "B.txt"), "utf8")).toBe("b\n");
+
+    const statusFile = JSON.parse(
+      await fs.readFile(path.join(targetDir, "workspace", "status.json"), "utf8"),
+    ) as { workspaces: Array<{ sourcePath: string }> };
+    expect(statusFile.workspaces).toEqual([{ sourcePath: workspaceB }]);
+  });
 });

--- a/src/commands/workspace-backup.test.ts
+++ b/src/commands/workspace-backup.test.ts
@@ -79,5 +79,59 @@ describe("workspace backup commands", () => {
     expect(status.target).toBe(targetDir);
     expect(status.workspaceCount).toBe(1);
     expect(status.lastUpdatedAt).toBeTruthy();
+
+    const statusFile = JSON.parse(
+      await fs.readFile(path.join(targetDir, "workspace", "status.json"), "utf8"),
+    ) as { schemaVersion: number; workspaces: Array<{ sourcePath: string; backupPath?: string }> };
+    expect(statusFile.schemaVersion).toBe(2);
+    expect(statusFile.workspaces).toEqual([{ sourcePath: workspaceDir }]);
+    expect(statusFile.workspaces[0]?.backupPath).toBeUndefined();
+  });
+
+  it("recomputes stale mirror paths instead of trusting status.json backupPath values", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const protectedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-protected-"));
+    targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-target-"));
+    try {
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
+      await fs.writeFile(path.join(protectedDir, "keep.txt"), "keep\n", "utf8");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      await workspaceBackupInitCommand(runtime, { target: targetDir });
+      await workspaceBackupRunCommand(runtime, {});
+
+      await fs.writeFile(
+        path.join(targetDir, "workspace", "status.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          updatedAt: "2026-03-10T00:00:00.000Z",
+          workspaces: [
+            {
+              sourcePath: path.join(stateDir, "removed-workspace"),
+              backupPath: protectedDir,
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      await workspaceBackupRunCommand(runtime, {});
+
+      expect(await fs.readFile(path.join(protectedDir, "keep.txt"), "utf8")).toBe("keep\n");
+    } finally {
+      await fs.rm(protectedDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/workspace-backup.test.ts
+++ b/src/commands/workspace-backup.test.ts
@@ -134,4 +134,30 @@ describe("workspace backup commands", () => {
       await fs.rm(protectedDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects backup targets that resolve into the live state directory via symlink", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(tempHome.home, "workspace");
+    const linkedTarget = path.join(tempHome.home, "BackupsLink");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.symlink(stateDir, linkedTarget);
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    await expect(
+      workspaceBackupInitCommand(runtime, {
+        target: linkedTarget,
+      }),
+    ).rejects.toThrow("backup.target must not be inside the live state directory.");
+  });
 });

--- a/src/commands/workspace-backup.test.ts
+++ b/src/commands/workspace-backup.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readConfigFileSnapshot } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { encodeAbsolutePathForBackupArchive } from "./backup-shared.js";
+import {
+  getWorkspaceBackupStatus,
+  workspaceBackupInitCommand,
+  workspaceBackupRunCommand,
+} from "./workspace-backup.js";
+
+describe("workspace backup commands", () => {
+  let tempHome: TempHomeEnv;
+  let runtime: RuntimeEnv;
+  let previousCwd: string;
+  let targetDir: string | undefined;
+
+  beforeEach(async () => {
+    tempHome = await createTempHomeEnv("openclaw-workspace-backup-test-");
+    previousCwd = process.cwd();
+    runtime = {
+      log: vi.fn() as RuntimeEnv["log"],
+      error: vi.fn() as RuntimeEnv["error"],
+      exit: vi.fn() as RuntimeEnv["exit"],
+    };
+  });
+
+  afterEach(async () => {
+    process.chdir(previousCwd);
+    if (targetDir) {
+      await fs.rm(targetDir, { recursive: true, force: true }).catch(() => undefined);
+      targetDir = undefined;
+    }
+    await tempHome.restore();
+  });
+
+  it("initializes a target, mirrors the workspace, and reports status", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-target-"));
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const initResult = await workspaceBackupInitCommand(runtime, {
+      target: targetDir,
+    });
+    expect(initResult.target).toBe(targetDir);
+
+    const configSnapshot = await readConfigFileSnapshot();
+    expect(configSnapshot.config.backup?.target).toBe(targetDir);
+
+    const runResult = await workspaceBackupRunCommand(runtime, {});
+    expect(runResult.workspaceCount).toBe(1);
+
+    const mirroredDir = path.join(
+      targetDir,
+      "workspace",
+      "mirrors",
+      encodeAbsolutePathForBackupArchive(workspaceDir),
+    );
+    expect(await fs.readFile(path.join(mirroredDir, "SOUL.md"), "utf8")).toBe("# soul\n");
+
+    const status = await getWorkspaceBackupStatus();
+    expect(status.configured).toBe(true);
+    expect(status.target).toBe(targetDir);
+    expect(status.workspaceCount).toBe(1);
+    expect(status.lastUpdatedAt).toBeTruthy();
+  });
+});

--- a/src/commands/workspace-backup.ts
+++ b/src/commands/workspace-backup.ts
@@ -179,6 +179,9 @@ async function assertWorkspaceBackupSafety(
 ): Promise<void> {
   const canonicalTarget = await canonicalizePathForContainment(target);
   const canonicalStateDir = await canonicalizePathForContainment(stateDir);
+  const canonicalWorkspaceBackupRoot = await canonicalizePathForContainment(
+    workspaceBackupRoot(target),
+  );
   if (isPathWithin(canonicalTarget, canonicalStateDir)) {
     throw new Error("backup.target must not be inside the live state directory.");
   }
@@ -187,6 +190,11 @@ async function assertWorkspaceBackupSafety(
     if (isPathWithin(canonicalTarget, canonicalWorkspaceDir)) {
       throw new Error(
         `backup.target must not live inside a workspace being mirrored: ${shortenHomePath(workspaceDir)}`,
+      );
+    }
+    if (isPathWithin(canonicalWorkspaceDir, canonicalWorkspaceBackupRoot)) {
+      throw new Error(
+        `workspace path must not be inside backup.target/workspace: ${shortenHomePath(workspaceDir)}`,
       );
     }
   }

--- a/src/commands/workspace-backup.ts
+++ b/src/commands/workspace-backup.ts
@@ -297,7 +297,7 @@ export async function workspaceBackupRunCommand(
   );
 
   const mirrored: WorkspaceBackupRunResult["workspaces"] = [];
-  const activeSourcePaths = new Set<string>();
+  const configuredSourcePaths = new Set(workspaceDirs);
   const previousStatus = await readWorkspaceBackupStatus(target);
 
   for (const workspaceDir of workspaceDirs) {
@@ -316,7 +316,6 @@ export async function workspaceBackupRunCommand(
     });
     await fs.mkdir(path.dirname(targetDir), { recursive: true });
     await replaceDirectoryAtomically(stagedDir, targetDir);
-    activeSourcePaths.add(workspaceDir);
     mirrored.push({
       sourcePath: workspaceDir,
       backupPath: targetDir,
@@ -324,7 +323,7 @@ export async function workspaceBackupRunCommand(
   }
 
   for (const previous of previousStatus?.workspaces ?? []) {
-    if (!activeSourcePaths.has(previous.sourcePath)) {
+    if (!configuredSourcePaths.has(previous.sourcePath)) {
       const staleMirrorPath = expectedMirrorPath(mirrorRoot, previous.sourcePath);
       await assertPathContainedWithinRoot(staleMirrorPath, mirrorRoot, "remove stale mirror");
       await fs.rm(staleMirrorPath, { recursive: true, force: true });
@@ -335,9 +334,7 @@ export async function workspaceBackupRunCommand(
   const statusFile: WorkspaceBackupStatusFile = {
     schemaVersion: WORKSPACE_BACKUP_SCHEMA_VERSION,
     updatedAt,
-    workspaces: mirrored.map((workspace) => ({
-      sourcePath: workspace.sourcePath,
-    })),
+    workspaces: [...configuredSourcePaths].map((sourcePath) => ({ sourcePath })),
   };
   await writeJsonAtomic(workspaceStatusPath(target), statusFile);
 

--- a/src/commands/workspace-backup.ts
+++ b/src/commands/workspace-backup.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { detectPreferredCloudDriveTarget } from "../backup/snapshot-store/targets.js";
+import {
+  readConfigFileSnapshot,
+  readConfigFileSnapshotForWrite,
+  resolveStateDir,
+  writeConfigFile,
+} from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { pathExists, resolveUserPath, shortenHomePath } from "../utils.js";
+import { encodeAbsolutePathForBackupArchive } from "./backup-shared.js";
+import { collectWorkspaceDirs, isPathWithin } from "./cleanup-utils.js";
+
+const WORKSPACE_BACKUP_SCHEMA_VERSION = 1;
+
+type WorkspaceBackupStatusFile = {
+  schemaVersion: 1;
+  updatedAt: string;
+  workspaces: Array<{
+    sourcePath: string;
+    backupPath: string;
+  }>;
+};
+
+export type WorkspaceBackupInitOptions = {
+  target?: string;
+  json?: boolean;
+};
+
+export type WorkspaceBackupInitResult = {
+  target: string;
+  detected?: string;
+  updatedConfig: boolean;
+};
+
+export type WorkspaceBackupRunOptions = {
+  json?: boolean;
+};
+
+export type WorkspaceBackupRunResult = {
+  target: string;
+  updatedAt: string;
+  workspaceCount: number;
+  workspaces: Array<{
+    sourcePath: string;
+    backupPath: string;
+  }>;
+};
+
+export type WorkspaceBackupStatusResult = {
+  configured: boolean;
+  target?: string;
+  detected?: string;
+  lastUpdatedAt?: string;
+  workspaceCount: number;
+};
+
+function resolveBackupConfigTarget(cfg: OpenClawConfig | undefined): string | undefined {
+  const configured = cfg?.backup?.target?.trim();
+  return configured ? resolveUserPath(configured) : undefined;
+}
+
+function workspaceBackupRoot(target: string): string {
+  return path.join(target, "workspace");
+}
+
+function workspaceMirrorRoot(target: string): string {
+  return path.join(workspaceBackupRoot(target), "mirrors");
+}
+
+function workspaceStatusPath(target: string): string {
+  return path.join(workspaceBackupRoot(target), "status.json");
+}
+
+async function readWorkspaceBackupStatus(
+  target: string,
+): Promise<WorkspaceBackupStatusFile | undefined> {
+  try {
+    const raw = await fs.readFile(workspaceStatusPath(target), "utf8");
+    return JSON.parse(raw) as WorkspaceBackupStatusFile;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${randomUUID()}.tmp`;
+  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fs.rename(tempPath, filePath);
+}
+
+async function replaceDirectoryAtomically(sourcePath: string, targetPath: string): Promise<void> {
+  const rollbackPath = `${targetPath}.${randomUUID()}.bak`;
+  const targetExists = await pathExists(targetPath);
+  if (targetExists) {
+    await fs.rename(targetPath, rollbackPath);
+  }
+  try {
+    await fs.rename(sourcePath, targetPath);
+    if (targetExists) {
+      await fs.rm(rollbackPath, { recursive: true, force: true });
+    }
+  } catch (error) {
+    if (targetExists) {
+      await fs.rename(rollbackPath, targetPath).catch(() => undefined);
+    }
+    throw error;
+  }
+}
+
+function assertWorkspaceBackupSafety(
+  target: string,
+  stateDir: string,
+  workspaceDirs: readonly string[],
+): void {
+  if (isPathWithin(target, stateDir)) {
+    throw new Error("backup.target must not be inside the live state directory.");
+  }
+  for (const workspaceDir of workspaceDirs) {
+    if (isPathWithin(target, workspaceDir)) {
+      throw new Error(
+        `backup.target must not live inside a workspace being mirrored: ${shortenHomePath(workspaceDir)}`,
+      );
+    }
+  }
+}
+
+async function resolveWorkspaceBackupState(): Promise<{
+  target: string;
+  workspaceDirs: string[];
+  stateDir: string;
+}> {
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    throw new Error("Config is invalid. Workspace backup commands require a valid config file.");
+  }
+  const target = resolveBackupConfigTarget(snapshot.config);
+  if (!target) {
+    throw new Error("backup.target is not configured. Run `openclaw backup setup` first.");
+  }
+  const workspaceDirs = collectWorkspaceDirs(snapshot.config);
+  const stateDir = resolveStateDir();
+  assertWorkspaceBackupSafety(target, stateDir, workspaceDirs);
+  return {
+    target,
+    workspaceDirs,
+    stateDir,
+  };
+}
+
+export async function workspaceBackupInitCommand(
+  runtime: RuntimeEnv,
+  opts: WorkspaceBackupInitOptions,
+): Promise<WorkspaceBackupInitResult> {
+  const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+  if (!snapshot.valid) {
+    throw new Error("Config is invalid. Fix the config before initializing workspace backup.");
+  }
+
+  const configuredTarget = resolveBackupConfigTarget(snapshot.resolved);
+  const explicitTarget = opts.target?.trim() ? resolveUserPath(opts.target) : undefined;
+  const detected =
+    !explicitTarget && !configuredTarget ? await detectPreferredCloudDriveTarget() : undefined;
+  const target = explicitTarget ?? configuredTarget ?? detected?.targetDir;
+  if (!target) {
+    throw new Error(
+      "Could not detect a cloud drive folder automatically. Pass --target to choose a backup directory.",
+    );
+  }
+
+  assertWorkspaceBackupSafety(target, resolveStateDir(), collectWorkspaceDirs(snapshot.config));
+  await fs.mkdir(target, { recursive: true });
+  const nextConfig: OpenClawConfig = {
+    ...snapshot.resolved,
+    backup: {
+      ...snapshot.resolved.backup,
+      target,
+    },
+  };
+  const updatedConfig = configuredTarget !== target;
+  if (updatedConfig) {
+    await writeConfigFile(nextConfig, writeOptions);
+  }
+
+  const result: WorkspaceBackupInitResult = {
+    target,
+    detected: detected?.label,
+    updatedConfig,
+  };
+  runtime.log(
+    opts.json
+      ? JSON.stringify(result, null, 2)
+      : [
+          updatedConfig
+            ? `Configured workspace backup target: ${shortenHomePath(target)}`
+            : `Workspace backup target: ${shortenHomePath(target)}`,
+          ...(detected ? [`Detected cloud drive: ${detected.label}`] : []),
+        ].join("\n"),
+  );
+  return result;
+}
+
+export async function workspaceBackupRunCommand(
+  runtime: RuntimeEnv,
+  opts: WorkspaceBackupRunOptions,
+): Promise<WorkspaceBackupRunResult> {
+  const { target, workspaceDirs, stateDir } = await resolveWorkspaceBackupState();
+  const mirrorRoot = workspaceMirrorRoot(target);
+  const stagingRoot = path.join(workspaceBackupRoot(target), ".staging");
+  await fs.mkdir(mirrorRoot, { recursive: true });
+  await fs.mkdir(stagingRoot, { recursive: true });
+  assertWorkspaceBackupSafety(target, stateDir, workspaceDirs);
+
+  const mirrored: WorkspaceBackupRunResult["workspaces"] = [];
+  const activeSourcePaths = new Set<string>();
+  const previousStatus = await readWorkspaceBackupStatus(target);
+
+  for (const workspaceDir of workspaceDirs) {
+    if (!(await pathExists(workspaceDir))) {
+      continue;
+    }
+    const relativeDir = encodeAbsolutePathForBackupArchive(workspaceDir);
+    const stagedDir = path.join(stagingRoot, `${relativeDir}-${randomUUID()}`);
+    const targetDir = path.join(mirrorRoot, relativeDir);
+    await fs.mkdir(path.dirname(stagedDir), { recursive: true });
+    await fs.cp(workspaceDir, stagedDir, {
+      recursive: true,
+      force: true,
+    });
+    await fs.mkdir(path.dirname(targetDir), { recursive: true });
+    await replaceDirectoryAtomically(stagedDir, targetDir);
+    activeSourcePaths.add(workspaceDir);
+    mirrored.push({
+      sourcePath: workspaceDir,
+      backupPath: targetDir,
+    });
+  }
+
+  for (const previous of previousStatus?.workspaces ?? []) {
+    if (!activeSourcePaths.has(previous.sourcePath)) {
+      await fs.rm(previous.backupPath, { recursive: true, force: true });
+    }
+  }
+
+  const updatedAt = new Date().toISOString();
+  const statusFile: WorkspaceBackupStatusFile = {
+    schemaVersion: WORKSPACE_BACKUP_SCHEMA_VERSION,
+    updatedAt,
+    workspaces: mirrored,
+  };
+  await writeJsonAtomic(workspaceStatusPath(target), statusFile);
+
+  const result: WorkspaceBackupRunResult = {
+    target,
+    updatedAt,
+    workspaceCount: mirrored.length,
+    workspaces: mirrored,
+  };
+  runtime.log(
+    opts.json
+      ? JSON.stringify(result, null, 2)
+      : [
+          `Workspace backup updated: ${shortenHomePath(target)}`,
+          `Mirrored ${mirrored.length} workspace${mirrored.length === 1 ? "" : "s"}.`,
+        ].join("\n"),
+  );
+  return result;
+}
+
+export async function getWorkspaceBackupStatus(): Promise<WorkspaceBackupStatusResult> {
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    throw new Error("Config is invalid. Workspace backup commands require a valid config file.");
+  }
+  const configuredTarget = resolveBackupConfigTarget(snapshot.config);
+  const statusFile = configuredTarget
+    ? await readWorkspaceBackupStatus(configuredTarget)
+    : undefined;
+  const detectedTarget = !configuredTarget ? await detectPreferredCloudDriveTarget() : undefined;
+  return {
+    configured: Boolean(configuredTarget),
+    target: configuredTarget,
+    detected: detectedTarget?.label,
+    lastUpdatedAt: statusFile?.updatedAt,
+    workspaceCount: statusFile?.workspaces.length ?? 0,
+  };
+}

--- a/src/commands/workspace-backup.ts
+++ b/src/commands/workspace-backup.ts
@@ -78,6 +78,37 @@ function expectedMirrorPath(mirrorRoot: string, sourcePath: string): string {
   return path.join(mirrorRoot, encodeAbsolutePathForBackupArchive(sourcePath));
 }
 
+async function canonicalizePathForContainment(inputPath: string): Promise<string> {
+  const resolved = path.resolve(inputPath);
+  const suffix: string[] = [];
+  let probe = resolved;
+  while (true) {
+    try {
+      const real = await fs.realpath(probe);
+      return suffix.length === 0 ? real : path.join(real, ...suffix.toReversed());
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) {
+        return resolved;
+      }
+      suffix.push(path.basename(probe));
+      probe = parent;
+    }
+  }
+}
+
+async function assertPathContainedWithinRoot(
+  childPath: string,
+  rootPath: string,
+  label: string,
+): Promise<void> {
+  const canonicalChild = await canonicalizePathForContainment(childPath);
+  const canonicalRoot = await canonicalizePathForContainment(rootPath);
+  if (!isPathWithin(canonicalChild, canonicalRoot)) {
+    throw new Error(`Refusing to ${label} outside ${shortenHomePath(rootPath)}.`);
+  }
+}
+
 async function readWorkspaceBackupStatus(
   target: string,
 ): Promise<WorkspaceBackupStatusFile | undefined> {
@@ -141,16 +172,19 @@ async function replaceDirectoryAtomically(sourcePath: string, targetPath: string
   }
 }
 
-function assertWorkspaceBackupSafety(
+async function assertWorkspaceBackupSafety(
   target: string,
   stateDir: string,
   workspaceDirs: readonly string[],
-): void {
-  if (isPathWithin(target, stateDir)) {
+): Promise<void> {
+  const canonicalTarget = await canonicalizePathForContainment(target);
+  const canonicalStateDir = await canonicalizePathForContainment(stateDir);
+  if (isPathWithin(canonicalTarget, canonicalStateDir)) {
     throw new Error("backup.target must not be inside the live state directory.");
   }
   for (const workspaceDir of workspaceDirs) {
-    if (isPathWithin(target, workspaceDir)) {
+    const canonicalWorkspaceDir = await canonicalizePathForContainment(workspaceDir);
+    if (isPathWithin(canonicalTarget, canonicalWorkspaceDir)) {
       throw new Error(
         `backup.target must not live inside a workspace being mirrored: ${shortenHomePath(workspaceDir)}`,
       );
@@ -173,7 +207,7 @@ async function resolveWorkspaceBackupState(): Promise<{
   }
   const workspaceDirs = collectWorkspaceDirs(snapshot.config);
   const stateDir = resolveStateDir();
-  assertWorkspaceBackupSafety(target, stateDir, workspaceDirs);
+  await assertWorkspaceBackupSafety(target, stateDir, workspaceDirs);
   return {
     target,
     workspaceDirs,
@@ -201,7 +235,11 @@ export async function workspaceBackupInitCommand(
     );
   }
 
-  assertWorkspaceBackupSafety(target, resolveStateDir(), collectWorkspaceDirs(snapshot.config));
+  await assertWorkspaceBackupSafety(
+    target,
+    resolveStateDir(),
+    collectWorkspaceDirs(snapshot.config),
+  );
   await fs.mkdir(target, { recursive: true });
   const nextConfig: OpenClawConfig = {
     ...snapshot.resolved,
@@ -242,7 +280,13 @@ export async function workspaceBackupRunCommand(
   const stagingRoot = path.join(workspaceBackupRoot(target), ".staging");
   await fs.mkdir(mirrorRoot, { recursive: true });
   await fs.mkdir(stagingRoot, { recursive: true });
-  assertWorkspaceBackupSafety(target, stateDir, workspaceDirs);
+  await assertWorkspaceBackupSafety(target, stateDir, workspaceDirs);
+  await assertPathContainedWithinRoot(mirrorRoot, workspaceBackupRoot(target), "write mirrors");
+  await assertPathContainedWithinRoot(
+    stagingRoot,
+    workspaceBackupRoot(target),
+    "write staging data",
+  );
 
   const mirrored: WorkspaceBackupRunResult["workspaces"] = [];
   const activeSourcePaths = new Set<string>();
@@ -255,6 +299,8 @@ export async function workspaceBackupRunCommand(
     const relativeDir = encodeAbsolutePathForBackupArchive(workspaceDir);
     const stagedDir = path.join(stagingRoot, `${relativeDir}-${randomUUID()}`);
     const targetDir = expectedMirrorPath(mirrorRoot, workspaceDir);
+    await assertPathContainedWithinRoot(stagedDir, stagingRoot, "write staging data");
+    await assertPathContainedWithinRoot(targetDir, mirrorRoot, "write workspace mirror");
     await fs.mkdir(path.dirname(stagedDir), { recursive: true });
     await fs.cp(workspaceDir, stagedDir, {
       recursive: true,
@@ -272,9 +318,7 @@ export async function workspaceBackupRunCommand(
   for (const previous of previousStatus?.workspaces ?? []) {
     if (!activeSourcePaths.has(previous.sourcePath)) {
       const staleMirrorPath = expectedMirrorPath(mirrorRoot, previous.sourcePath);
-      if (!isPathWithin(staleMirrorPath, mirrorRoot)) {
-        continue;
-      }
+      await assertPathContainedWithinRoot(staleMirrorPath, mirrorRoot, "remove stale mirror");
       await fs.rm(staleMirrorPath, { recursive: true, force: true });
     }
   }

--- a/src/commands/workspace-backup.ts
+++ b/src/commands/workspace-backup.ts
@@ -14,14 +14,13 @@ import { pathExists, resolveUserPath, shortenHomePath } from "../utils.js";
 import { encodeAbsolutePathForBackupArchive } from "./backup-shared.js";
 import { collectWorkspaceDirs, isPathWithin } from "./cleanup-utils.js";
 
-const WORKSPACE_BACKUP_SCHEMA_VERSION = 1;
+const WORKSPACE_BACKUP_SCHEMA_VERSION = 2;
 
 type WorkspaceBackupStatusFile = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   updatedAt: string;
   workspaces: Array<{
     sourcePath: string;
-    backupPath: string;
   }>;
 };
 
@@ -75,12 +74,39 @@ function workspaceStatusPath(target: string): string {
   return path.join(workspaceBackupRoot(target), "status.json");
 }
 
+function expectedMirrorPath(mirrorRoot: string, sourcePath: string): string {
+  return path.join(mirrorRoot, encodeAbsolutePathForBackupArchive(sourcePath));
+}
+
 async function readWorkspaceBackupStatus(
   target: string,
 ): Promise<WorkspaceBackupStatusFile | undefined> {
   try {
     const raw = await fs.readFile(workspaceStatusPath(target), "utf8");
-    return JSON.parse(raw) as WorkspaceBackupStatusFile;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return undefined;
+    }
+    const updatedAt =
+      "updatedAt" in parsed && typeof parsed.updatedAt === "string" ? parsed.updatedAt : undefined;
+    const workspaces = Array.isArray((parsed as { workspaces?: unknown }).workspaces)
+      ? (parsed as { workspaces: unknown[] }).workspaces.flatMap((entry) =>
+          typeof entry === "object" &&
+          entry !== null &&
+          "sourcePath" in entry &&
+          typeof entry.sourcePath === "string"
+            ? [{ sourcePath: entry.sourcePath }]
+            : [],
+        )
+      : [];
+    if (!updatedAt) {
+      return undefined;
+    }
+    return {
+      schemaVersion: WORKSPACE_BACKUP_SCHEMA_VERSION,
+      updatedAt,
+      workspaces,
+    };
   } catch {
     return undefined;
   }
@@ -89,7 +115,10 @@ async function readWorkspaceBackupStatus(
 async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   const tempPath = `${filePath}.${randomUUID()}.tmp`;
-  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
   await fs.rename(tempPath, filePath);
 }
 
@@ -225,7 +254,7 @@ export async function workspaceBackupRunCommand(
     }
     const relativeDir = encodeAbsolutePathForBackupArchive(workspaceDir);
     const stagedDir = path.join(stagingRoot, `${relativeDir}-${randomUUID()}`);
-    const targetDir = path.join(mirrorRoot, relativeDir);
+    const targetDir = expectedMirrorPath(mirrorRoot, workspaceDir);
     await fs.mkdir(path.dirname(stagedDir), { recursive: true });
     await fs.cp(workspaceDir, stagedDir, {
       recursive: true,
@@ -242,7 +271,11 @@ export async function workspaceBackupRunCommand(
 
   for (const previous of previousStatus?.workspaces ?? []) {
     if (!activeSourcePaths.has(previous.sourcePath)) {
-      await fs.rm(previous.backupPath, { recursive: true, force: true });
+      const staleMirrorPath = expectedMirrorPath(mirrorRoot, previous.sourcePath);
+      if (!isPathWithin(staleMirrorPath, mirrorRoot)) {
+        continue;
+      }
+      await fs.rm(staleMirrorPath, { recursive: true, force: true });
     }
   }
 
@@ -250,7 +283,9 @@ export async function workspaceBackupRunCommand(
   const statusFile: WorkspaceBackupStatusFile = {
     schemaVersion: WORKSPACE_BACKUP_SCHEMA_VERSION,
     updatedAt,
-    workspaces: mirrored,
+    workspaces: mirrored.map((workspace) => ({
+      sourcePath: workspace.sourcePath,
+    })),
   };
   await writeJsonAtomic(workspaceStatusPath(target), statusFile);
 

--- a/src/config/types.backup.ts
+++ b/src/config/types.backup.ts
@@ -1,0 +1,22 @@
+import type { SecretInput } from "./types.secrets.js";
+
+export type BackupRetentionConfig = {
+  keepDaily?: number;
+  keepWeekly?: number;
+  keepMonthly?: number;
+  maxSnapshots?: number;
+};
+
+export type BackupEncryptionConfig = {
+  key?: SecretInput;
+};
+
+export type BackupConfig = {
+  /**
+   * OpenClaw-owned backup directory inside a user cloud drive folder.
+   * Example: ~/Library/Mobile Documents/com~apple~CloudDocs/OpenClaw Backups
+   */
+  target?: string;
+  retention?: BackupRetentionConfig;
+  encryption?: BackupEncryptionConfig;
+};

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -2,6 +2,7 @@ import type { AcpConfig } from "./types.acp.js";
 import type { AgentBinding, AgentsConfig } from "./types.agents.js";
 import type { ApprovalsConfig } from "./types.approvals.js";
 import type { AuthConfig } from "./types.auth.js";
+import type { BackupConfig } from "./types.backup.js";
 import type { DiagnosticsConfig, LoggingConfig, SessionConfig, WebConfig } from "./types.base.js";
 import type { BrowserConfig } from "./types.browser.js";
 import type { ChannelsConfig } from "./types.channels.js";
@@ -60,6 +61,7 @@ export type OpenClawConfig = {
     lastRunCommand?: string;
     lastRunMode?: "local" | "remote";
   };
+  backup?: BackupConfig;
   diagnostics?: DiagnosticsConfig;
   logging?: LoggingConfig;
   cli?: CliConfig;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -6,6 +6,7 @@ export * from "./types.acp.js";
 export * from "./types.approvals.js";
 export * from "./types.auth.js";
 export * from "./types.base.js";
+export * from "./types.backup.js";
 export * from "./types.browser.js";
 export * from "./types.channels.js";
 export * from "./types.cli.js";

--- a/src/config/zod-schema.backup.ts
+++ b/src/config/zod-schema.backup.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { SecretInputSchema } from "./zod-schema.core.js";
+import { sensitive } from "./zod-schema.sensitive.js";
+
+const BackupRetentionSchema = z
+  .object({
+    keepDaily: z.number().int().nonnegative().optional(),
+    keepWeekly: z.number().int().nonnegative().optional(),
+    keepMonthly: z.number().int().nonnegative().optional(),
+    maxSnapshots: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
+const BackupEncryptionSchema = z
+  .object({
+    key: SecretInputSchema.optional().register(sensitive),
+  })
+  .strict()
+  .optional();
+
+export const BackupSchema = z
+  .object({
+    target: z.string().min(1).optional(),
+    retention: BackupRetentionSchema,
+    encryption: BackupEncryptionSchema,
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -4,6 +4,7 @@ import { parseDurationMs } from "../cli/parse-duration.js";
 import { ToolsSchema } from "./zod-schema.agent-runtime.js";
 import { AgentsSchema, AudioSchema, BindingsSchema, BroadcastSchema } from "./zod-schema.agents.js";
 import { ApprovalsSchema } from "./zod-schema.approvals.js";
+import { BackupSchema } from "./zod-schema.backup.js";
 import {
   HexColorSchema,
   ModelsConfigSchema,
@@ -250,6 +251,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    backup: BackupSchema,
     diagnostics: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -476,7 +476,7 @@ async function extractZip(params: {
 
 export type TarEntryInfo = { path: string; type: string; size: number };
 
-const BLOCKED_TAR_ENTRY_TYPES = new Set([
+export const BLOCKED_TAR_ENTRY_TYPES = new Set([
   "SymbolicLink",
   "Link",
   "BlockDevice",
@@ -484,6 +484,10 @@ const BLOCKED_TAR_ENTRY_TYPES = new Set([
   "FIFO",
   "Socket",
 ]);
+
+export function isBlockedTarEntryType(type: string): boolean {
+  return BLOCKED_TAR_ENTRY_TYPES.has(type);
+}
 
 function readTarEntryInfo(entry: unknown): TarEntryInfo {
   const p =

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -293,6 +293,18 @@ async function assertPathTreeHasNoSymlinks(rootPath: string): Promise<void> {
       }
       if (entry.isDirectory()) {
         pending.push(entryPath);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        // Some filesystems return DT_UNKNOWN for dirent types; re-check via lstat.
+        const entryStat = await fs.lstat(entryPath);
+        if (entryStat.isSymbolicLink()) {
+          throw new Error(`Backup source contains symbolic links: ${entryPath}`);
+        }
+        if (entryStat.isDirectory()) {
+          pending.push(entryPath);
+        }
       }
     }
   }

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -269,6 +269,35 @@ function remapArchiveEntryPath(params: {
   return buildBackupArchivePath(params.archiveRoot, normalizedEntry);
 }
 
+async function assertPathTreeHasNoSymlinks(rootPath: string): Promise<void> {
+  const stat = await fs.lstat(rootPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Backup source contains symbolic links: ${rootPath}`);
+  }
+  if (!stat.isDirectory()) {
+    return;
+  }
+
+  const pending = [rootPath];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) {
+      continue;
+    }
+
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isSymbolicLink()) {
+        throw new Error(`Backup source contains symbolic links: ${entryPath}`);
+      }
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      }
+    }
+  }
+}
+
 export async function createBackupArchive(
   opts: BackupCreateOptions = {},
 ): Promise<BackupCreateResult> {
@@ -304,6 +333,9 @@ export async function createBackupArchive(
 
   if (!opts.dryRun) {
     await assertOutputPathReady(outputPath);
+    for (const asset of plan.included) {
+      await assertPathTreeHasNoSymlinks(asset.sourcePath);
+    }
   }
 
   const createdAt = new Date(nowMs).toISOString();

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,12 +1,16 @@
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 
+// `@vitest/browser-playwright` can resolve its peer `vitest` through a different
+// package instance than `defineConfig()` in monorepo type-aware checks.
+const browserProvider = playwright() as never;
+
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     browser: {
       enabled: true,
-      provider: playwright(),
+      provider: browserProvider,
       instances: [{ browser: "chromium", name: "chromium" }],
       headless: true,
       ui: false,


### PR DESCRIPTION
## Summary

- Problem: personal-user backup needed a simpler default flow than raw local archives, but the CLI and storage model did not support cloud-drive-style workspace mirroring plus encrypted snapshots.
- Why it matters: users need a low-friction backup path for day-to-day workspace protection and a separate full restore path without direct state-dir sync.
- What changed: added `backup setup/run/status/list/restore` around a folder-backed encrypted snapshot store, kept `backup export/verify` for local archives, and documented the new flow.
- What did NOT change (scope boundary): this does not add multi-provider object storage, device-identity export/import, or public-internet deployment changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #32921, #40090, #7598

## User-visible / Behavior Changes

- Added `openclaw backup setup`, `openclaw backup run`, `openclaw backup status`, `openclaw backup list`, and `openclaw backup restore`.
- `openclaw backup export` is now the primary local archive command; `openclaw backup create` remains as a deprecated alias.
- `openclaw backup push` remains as a deprecated alias for snapshot creation via `backup run`.
- `reset` and `uninstall` now recommend `openclaw backup export`.
- Backup config now supports `backup.target` and `backup.encryption.key` for folder-backed encrypted snapshots.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Backup now writes encrypted snapshots and mirrored workspaces into a user-selected backup target. Mitigations: snapshot payloads require `backup.encryption.key`, `backup.target` is rejected inside the live state directory or mirrored workspaces, and restore still enforces service-stop checks before swap.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `backup.target=<temp dir>`, `backup.encryption.key=<redacted>`

### Steps

1. Configure a temp backup target and optional encryption key in `openclaw.json`.
2. Run `openclaw backup run`, `openclaw backup list`, and `openclaw backup restore` in temp-home tests.
3. Run archive export/verify plus `reset`/`uninstall` recommendation flows.
4. Run repo validation commands.

### Expected

- Workspace backup mirrors or encrypted snapshots are created in the configured target.
- Snapshot listing and restore work against the folder-backed store.
- Local archive export/verify continues to work.
- Repo checks pass.

### Actual

- Matched expected behavior in automated verification below.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```bash
pnpm exec vitest run src/commands/backup.test.ts src/commands/backup.atomic.test.ts src/commands/backup-verify.test.ts src/commands/backup-run.test.ts src/commands/backup-status.test.ts src/commands/backup-snapshot.test.ts src/commands/backup-restore.test.ts src/commands/workspace-backup.test.ts src/commands/reset.test.ts src/commands/uninstall.test.ts src/backup/snapshot-store/targets.test.ts src/backup/snapshot-store/encryption.test.ts src/cli/program/register.backup.test.ts src/cli/program/command-registry.test.ts
pnpm exec tsc -p tsconfig.json --noEmit
pnpm build
pnpm check
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the new `backup` CLI flow end-to-end in code and through temp-home tests for workspace mirroring, encrypted snapshot create/list/restore, and local archive export/verify.
- Edge cases checked: invalid config handling for archive export, restore preserving external workspace paths, backup target rejection inside live state/workspaces, deprecated alias coverage.
- What you did **not** verify: manual testing against a real synced provider UI such as iCloud Drive or Dropbox.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:
  - Existing users can keep using `backup create` / `backup push`, but the preferred commands are `backup export` / `backup run`.
  - To enable encrypted snapshots, set `backup.target` and `backup.encryption.key`.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: continue using `openclaw backup export` for local archives only, or revert commit `7f80b73fbe4beffbe968ab79790b001c78a93189`.
- Files/config to restore: `openclaw.json` backup section, snapshot files under the selected backup target, and any prior archive workflow scripts.
- Known bad symptoms reviewers should watch for: `backup run` falling back to workspace mirroring unexpectedly when `backup.encryption.key` is missing; restore failing if the gateway is still running.

## Risks and Mitigations

- Risk: alias compatibility could drift from the primary commands.
  - Mitigation: dedicated CLI tests cover `backup create` and `backup push` forwarding.
- Risk: backup target misconfiguration could point into unsafe paths.
  - Mitigation: config/runtime validation rejects targets inside the live state dir or mirrored workspaces.
- Risk: restore could place workspaces at the wrong path when config parsing falls back to defaults.
  - Mitigation: restore logic prefers manifest workspace paths and has a regression test for external workspaces.