### PR TITLE
fix(skill-creator): broaden description to trigger on edit/refactor tasks

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+description: Create, update, or refactor AgentSkills. Use when designing, structuring, or packaging, splitting, or merging skills with scripts, references, and assets.
 ---
 
 # Skill Creator


### PR DESCRIPTION
Summary

• Problem: The skill-creator description only mentions 'designing, structuring, or packaging' which reads as blank-slate creation - fails to trigger when agents are editing/refactoring existing skills
• Why it matters: Agents tasked with splitting/merging/updating skills don't match the skill trigger
• What changed: Added 'refactor', 'splitting', 'merging' to description
• What did NOT change: Core skill logic, prompts, or functionality

Change Type

• [x] Bug fix

Scope

• [ ] Gateway / orchestration
• [x] Skills / tool execution
• [ ] Auth / tokens
• [ ] Memory / storage
• [ ] Integrations
• [ ] API / contracts
• [ ] UI / DX
• [ ] CI/CD / infra

Linked Issue/PR

• Closes #36039

User-visible / Behavior Changes

None - skill metadata change affecting LLM trigger matching only

Security Impact

All No

Repro + Verification

N/A - verified by code review

Human Verification

• Verified scenarios: Description now includes edit/refactor/split/merge keywords

Compatibility / Migration

• Backward compatible? Yes
• Config/env changes? None
• Migration needed? No

Risks and Mitigations

None - trivial description change