### PR TITLE
fix(models): report correct 1M context window for gpt-5.4 in catalog

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -149,6 +149,7 @@ describe("loadModelCatalog", () => {
         provider: "openai",
         id: "gpt-5.4",
         name: "gpt-5.4",
+        contextWindow: 1_050_000,
       }),
     );
     expect(result).toContainEqual(
@@ -156,6 +157,7 @@ describe("loadModelCatalog", () => {
         provider: "openai",
         id: "gpt-5.4-pro",
         name: "gpt-5.4-pro",
+        contextWindow: 1_050_000,
       }),
     );
     expect(result).toContainEqual(
@@ -163,6 +165,7 @@ describe("loadModelCatalog", () => {
         provider: "openai-codex",
         id: "gpt-5.4",
         name: "gpt-5.4",
+        contextWindow: 1_050_000,
       }),
     );
   });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -45,6 +45,7 @@ type SyntheticCatalogFallback = {
   provider: string;
   id: string;
   templateIds: readonly string[];
+  contextWindow?: number;
 };
 
 const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
@@ -52,16 +53,19 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_MODEL_ID,
     templateIds: ["gpt-5.2"],
+    contextWindow: 1_050_000,
   },
   {
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_PRO_MODEL_ID,
     templateIds: ["gpt-5.2-pro", "gpt-5.2"],
+    contextWindow: 1_050_000,
   },
   {
     provider: CODEX_PROVIDER,
     id: OPENAI_CODEX_GPT54_MODEL_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
+    contextWindow: 1_050_000,
   },
   {
     provider: CODEX_PROVIDER,
@@ -92,6 +96,7 @@ function applySyntheticCatalogFallbacks(models: ModelCatalogEntry[]): void {
       ...template,
       id: fallback.id,
       name: fallback.id,
+      ...(fallback.contextWindow != null ? { contextWindow: fallback.contextWindow } : {}),
     });
   }
 }


### PR DESCRIPTION
## Problem

`openclaw models list` shows gpt-5.4 (both openai and openai-codex) with a context window of 266-272k instead of the correct 1M tokens (fixes #41318).

The synthetic catalog fallback copies all properties from the template model (gpt-5.3-codex / gpt-5.2), including the old context window, without applying the gpt-5.4 override.

## Solution

- Add an optional `contextWindow` field to `SyntheticCatalogFallback`
- Set `contextWindow: 1_050_000` for all three gpt-5.4 fallback entries (openai, openai-pro, openai-codex)
- Apply the override in `applySyntheticCatalogFallbacks()` when present

## Testing

- Updated existing catalog test to assert correct contextWindow on all three gpt-5.4 synthetic entries
- 7/7 tests pass