### PR TITLE
fix(config): accept agents.list[].params in schema validation

### DIFF
--- a/src/config/zod-schema.agent-params.test.ts
+++ b/src/config/zod-schema.agent-params.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
+
+describe("AgentEntrySchema params field", () => {
+  it("accepts agents.list[].params with cacheRetention", () => {
+    const result = AgentEntrySchema.safeParse({
+      id: "main",
+      params: { cacheRetention: "none" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.params).toEqual({ cacheRetention: "none" });
+    }
+  });
+
+  it("accepts agents.list[].params with arbitrary model overrides", () => {
+    const result = AgentEntrySchema.safeParse({
+      id: "main",
+      params: { temperature: 0.7, maxTokens: 4096 },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.params).toEqual({ temperature: 0.7, maxTokens: 4096 });
+    }
+  });
+
+  it("accepts agents.list[] without params (optional)", () => {
+    const result = AgentEntrySchema.safeParse({
+      id: "main",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.params).toBeUndefined();
+    }
+  });
+});

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -726,6 +726,8 @@ export const AgentEntrySchema = z
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
+    /** Per-agent model params (e.g. cacheRetention, temperature). Merged on top of agents.defaults.models[...].params. */
+    params: z.record(z.string(), z.unknown()).optional(),
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),


### PR DESCRIPTION
## Problem

`openclaw config validate` rejects `agents.list[].params` even though this field is documented and supported by the runtime for per-agent model overrides like `cacheRetention`, `temperature`, etc. (fixes #41160).

The runtime type definition (`types.agents.ts:86`) already declares `params?: Record<string, unknown>`, but the zod validation schema (`AgentEntrySchema`) was missing it.

## Solution

Add `params: z.record(z.string(), z.unknown()).optional()` to `AgentEntrySchema`, matching the existing type definition and the format used in `agents.defaults.models[...].params`.

## Testing

- 3 new tests covering: params with cacheRetention, arbitrary overrides, and omitted params
- All pass