### PR TITLE
fix(cron): do not misclassify empty/NO_REPLY as interim acknowledgement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- Cron/subagent followup: do not misclassify empty or `NO_REPLY` cron responses as interim acknowledgements that need a rerun, so deliberately silent cron jobs are no longer retried. (#41383) thanks @jackal092927.
+
 ## 2026.3.7
 
 ### Changes

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -31,8 +31,12 @@ describe("isLikelyInterimCronMessage", () => {
       false,
     );
   });
-  it("treats empty as interim", () => {
-    expect(isLikelyInterimCronMessage("")).toBe(true);
+  it("does not treat empty as interim (empty = NO_REPLY was stripped)", () => {
+    expect(isLikelyInterimCronMessage("")).toBe(false);
+  });
+
+  it("does not treat whitespace-only as interim", () => {
+    expect(isLikelyInterimCronMessage("   ")).toBe(false);
   });
 });
 

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -39,7 +39,10 @@ function normalizeHintText(value: string): string {
 export function isLikelyInterimCronMessage(value: string): boolean {
   const normalized = normalizeHintText(value);
   if (!normalized) {
-    return true;
+    // Empty text after payload filtering means the agent either returned
+    // NO_REPLY (deliberately silent) or produced no deliverable content.
+    // Do not treat this as an interim acknowledgement that needs a rerun.
+    return false;
   }
   const words = normalized.split(" ").filter(Boolean).length;
   return words <= 45 && INTERIM_CRON_HINTS.some((hint) => normalized.includes(hint));


### PR DESCRIPTION
## Problem

Isolated cron jobs that complete with `NO_REPLY` can be incorrectly forced into a rerun. The system injects a follow-up prompt: *"Your previous response was only an acknowledgement and did not complete this cron task."* (fixes #41246)

### Root cause

When the agent returns `NO_REPLY`, the payload filter in `payloads.ts` strips the silent token, leaving an empty payloads array. Then:

1. `pickLastNonEmptyTextFromPayloads([])` returns `undefined`
2. `interimText` becomes `""` (empty string via `?? ""`)
3. `isLikelyInterimCronMessage("")` returns `true` because the empty-string branch was `return true`
4. The cron runner injects a forced rerun prompt

## Solution

Change `isLikelyInterimCronMessage()` to return `false` for empty input. Empty text after payload filtering means the agent deliberately chose silent completion (`NO_REPLY`), not that it sent an interim "on it" acknowledgement.

## Testing

- Updated existing test (`treats empty as interim` → `does not treat empty as interim`)
- Added whitespace-only test case
- 24/24 subagent-followup tests pass
- 3/3 interim-retry integration tests pass
- 16/16 delivery-dispatch tests pass