### PR TITLE
Doctor: honor repair gating for legacy cron fixes

### DIFF
--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -155,4 +155,115 @@ describe("maybeRepairLegacyCronStore", () => {
       "Doctor warnings",
     );
   });
+
+  it("does not auto-repair in non-interactive mode without explicit repair approval", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              jobId: "legacy-job",
+              name: "Legacy job",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "cron", cron: "0 7 * * *", tz: "UTC" },
+              payload: {
+                kind: "systemEvent",
+                text: "Morning brief",
+              },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    const prompter = makePrompter(false);
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+          webhook: "https://example.invalid/cron-finished",
+        },
+      },
+      options: { nonInteractive: true },
+      prompter,
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(prompter.confirm).toHaveBeenCalledWith({
+      message: "Repair legacy cron jobs now?",
+      initialValue: true,
+    });
+    expect(persisted.jobs[0]?.jobId).toBe("legacy-job");
+    expect(persisted.jobs[0]?.notify).toBe(true);
+    expect(noteSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Cron store normalized"),
+      "Doctor changes",
+    );
+  });
+
+  it("migrates notify fallback none delivery jobs to cron.webhook", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "notify-none",
+              name: "Notify none",
+              notify: true,
+              createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+              schedule: { kind: "every", everyMs: 60_000 },
+              payload: {
+                kind: "systemEvent",
+                text: "Status",
+              },
+              delivery: { mode: "none", to: "123456789" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await maybeRepairLegacyCronStore({
+      cfg: {
+        cron: {
+          store: storePath,
+          webhook: "https://example.invalid/cron-finished",
+        },
+      },
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(persisted.jobs[0]?.notify).toBeUndefined();
+    expect(persisted.jobs[0]?.delivery).toMatchObject({
+      mode: "webhook",
+      to: "https://example.invalid/cron-finished",
+    });
+  });
 });

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -96,7 +96,7 @@ function migrateLegacyNotifyFallback(params: {
       raw.delivery = {
         ...delivery,
         mode: "webhook",
-        to: to ?? params.legacyWebhook,
+        to: mode === "none" ? params.legacyWebhook : (to ?? params.legacyWebhook),
       };
       delete raw.notify;
       changed = true;
@@ -152,13 +152,10 @@ export async function maybeRepairLegacyCronStore(params: {
     "Cron",
   );
 
-  const shouldRepair =
-    params.options.nonInteractive === true
-      ? true
-      : await params.prompter.confirm({
-          message: "Repair legacy cron jobs now?",
-          initialValue: true,
-        });
+  const shouldRepair = await params.prompter.confirm({
+    message: "Repair legacy cron jobs now?",
+    initialValue: true,
+  });
   if (!shouldRepair) {
     return;
   }


### PR DESCRIPTION
## Summary

- Problem: `maybeRepairLegacyCronStore` bypassed the doctor prompter contract and auto-repaired in non-interactive runs even without `--fix`, and its `notify: true` migration could convert `delivery.mode: "none"` jobs into explicit webhook delivery with a non-URL `delivery.to`.
- Why it matters: health-check style `openclaw doctor` runs could mutate `jobs.json` unexpectedly, and some repaired cron jobs could lose webhook notifications after `doctor --fix`.
- What changed: cron doctor repair prompting now always goes through `prompter.confirm()`, and legacy `notify: true` migrations prefer `cron.webhook` when upgrading `delivery.mode: "none"` jobs to explicit webhook delivery.
- What did NOT change (scope boundary): runtime cron delivery behavior and broader cron migration rules outside these two doctor repair cases.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #40998

## User-visible / Behavior Changes

- `openclaw doctor --non-interactive` no longer rewrites legacy cron storage unless repair is explicitly requested (`--fix`/`--repair`/`--yes`).
- `openclaw doctor --fix` now migrates `notify: true` jobs with `delivery.mode: "none"` to `cron.webhook` instead of preserving a non-webhook `delivery.to` value.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): cron doctor migration
- Relevant config (redacted): legacy cron store with `notify: true`

### Steps

1. Run `openclaw doctor --non-interactive` against a legacy cron store without `--fix`.
2. Run `openclaw doctor --fix` against a legacy cron store containing `notify: true` plus `delivery.mode: "none"` and a non-URL `delivery.to`.
3. Inspect the persisted cron store.

### Expected

- Step 1 should report the legacy store but not rewrite it.
- Step 2 should convert the job to explicit webhook delivery using `cron.webhook`.

### Actual

- This patch makes both behaviors match the expected contract.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/commands/doctor-cron.test.ts`
- Edge cases checked:
  - non-interactive runs without repair approval leave the legacy store untouched
  - `delivery.mode: "none"` migrations use `cron.webhook` instead of preserving a non-URL recipient
- What you did **not** verify:
  - I did not run the full repo suite.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  Revert this PR.
- Files/config to restore:
  - `src/commands/doctor-cron.ts`
- Known bad symptoms reviewers should watch for:
  - non-interactive doctor runs still mutating cron store without repair flags
  - repaired `notify: true` jobs ending up with invalid webhook targets

## Risks and Mitigations

- Risk:
  - Doctor could stop repairing a case that relied on the old shortcut.
  - Mitigation:
    - The change restores the existing doctor prompter contract used by the other repair paths.
- Risk:
  - The `delivery.mode: "none"` migration rule could be too narrow.
  - Mitigation:
    - It only applies to the explicit `mode === "none"` case where runtime behavior previously depended on `cron.webhook`.
