### PR TITLE
Discord extension: route outbound sends to thread targets

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -4,6 +4,33 @@ import { discordPlugin } from "./channel.js";
 import { setDiscordRuntime } from "./runtime.js";
 
 describe("discordPlugin outbound", () => {
+  it("routes text sends to thread targets when threadId is provided", async () => {
+    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m-thread" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendMessageDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    await discordPlugin.outbound!.sendText!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:parent-1",
+      text: "hello",
+      threadId: "thread-1",
+      accountId: "work",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:thread-1",
+      "hello",
+      expect.objectContaining({
+        accountId: "work",
+      }),
+    );
+  });
+
   it("forwards mediaLocalRoots to sendMessageDiscord", async () => {
     const sendMessageDiscord = vi.fn(async () => ({ messageId: "m1" }));
     setDiscordRuntime({
@@ -32,5 +59,66 @@ describe("discordPlugin outbound", () => {
       }),
     );
     expect(result).toMatchObject({ channel: "discord", messageId: "m1" });
+  });
+
+  it("routes media sends to thread targets when threadId is provided", async () => {
+    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m-media" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendMessageDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    await discordPlugin.outbound!.sendMedia!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:parent-1",
+      text: "hi",
+      mediaUrl: "/tmp/image.png",
+      threadId: "thread-1",
+      accountId: "work",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:thread-1",
+      "hi",
+      expect.objectContaining({
+        mediaUrl: "/tmp/image.png",
+        accountId: "work",
+      }),
+    );
+  });
+
+  it("routes poll sends to thread targets when threadId is provided", async () => {
+    const sendPollDiscord = vi.fn(async () => ({
+      ok: true,
+      channel: "discord",
+      pollId: "poll-1",
+    }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendMessageDiscord: vi.fn(),
+          sendPollDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    await discordPlugin.outbound!.sendPoll!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:parent-1",
+      poll: { question: "Best snack?", options: ["banana", "apple"] },
+      threadId: "thread-1",
+      accountId: "work",
+    });
+
+    expect(sendPollDiscord).toHaveBeenCalledWith(
+      "channel:thread-1",
+      { question: "Best snack?", options: ["banana", "apple"] },
+      expect.objectContaining({
+        accountId: "work",
+      }),
+    );
   });
 });

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -37,6 +37,17 @@ import { getDiscordRuntime } from "./runtime.js";
 
 const meta = getChatChannelMeta("discord");
 
+function resolveDiscordThreadTarget(params: {
+  to: string;
+  threadId?: string | number | null;
+}): string {
+  if (params.threadId == null) {
+    return params.to;
+  }
+  const threadId = String(params.threadId).trim();
+  return threadId ? `channel:${threadId}` : params.to;
+}
+
 const discordMessageActions: ChannelMessageActionAdapter = {
   listActions: (ctx) =>
     getDiscordRuntime().channel.discord.messageActions?.listActions?.(ctx) ?? [],
@@ -306,9 +317,10 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-    sendText: async ({ cfg, to, text, accountId, deps, replyToId, silent }) => {
+    sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = resolveDiscordThreadTarget({ to, threadId });
+      const result = await send(target, text, {
         verbose: false,
         cfg,
         replyTo: replyToId ?? undefined,
@@ -326,10 +338,12 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       accountId,
       deps,
       replyToId,
+      threadId,
       silent,
     }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = resolveDiscordThreadTarget({ to, threadId });
+      const result = await send(target, text, {
         verbose: false,
         cfg,
         mediaUrl,
@@ -340,12 +354,16 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       });
       return { channel: "discord", ...result };
     },
-    sendPoll: async ({ cfg, to, poll, accountId, silent }) =>
-      await getDiscordRuntime().channel.discord.sendPollDiscord(to, poll, {
-        cfg,
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-      }),
+    sendPoll: async ({ cfg, to, poll, accountId, threadId, silent }) =>
+      await getDiscordRuntime().channel.discord.sendPollDiscord(
+        resolveDiscordThreadTarget({ to, threadId }),
+        poll,
+        {
+          cfg,
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+        },
+      ),
   },
   status: {
     defaultRuntime: {


### PR DESCRIPTION
Fixes #33554.

## Summary

When the Discord extension sends outbound text, media, or polls with a `threadId`, it currently ignores that thread target and posts to the parent `to` target instead.

This PR makes the Discord extension route outbound sends to `channel:<threadId>` when a thread target is present, matching the behavior that already exists in the core Discord outbound adapter.

This appears to be part of a broader extension-adapter passthrough pattern across multiple channels, but in this case the data is specifically dropped in `extensions/discord/src/channel.ts`, so this PR fixes the Discord extension only.

## Root Cause

The shared outbound contract already carries `threadId`, but `extensions/discord/src/channel.ts` dropped it in all three outbound methods:

- `sendText`
- `sendMedia`
- `sendPoll`

That means the data was present upstream and disappeared inside the extension adapter itself.

## Fix

- add a small Discord thread-target resolver in `extensions/discord/src/channel.ts`
- use that resolver in extension `sendText`, `sendMedia`, and `sendPoll`
- add regression tests in `extensions/discord/src/channel.test.ts` for thread-target routing across all three send paths

## Tests

```bash
pnpm exec vitest run extensions/discord/src/channel.test.ts
pnpm exec oxfmt --check extensions/discord/src/channel.ts extensions/discord/src/channel.test.ts
```

## Related Issues

This looks like one instance of a broader extension-adapter passthrough pattern, but this PR intentionally stays scoped to Discord:

- #33561
- #33572
- #33548
- #33542
- #33537
- #33533
- #33504
- #33580
