### PR TITLE
fix(models): override template contextWindow for gpt-5.4 synthetic catalog entries

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -149,6 +149,7 @@ describe("loadModelCatalog", () => {
         provider: "openai",
         id: "gpt-5.4",
         name: "gpt-5.4",
+        contextWindow: 1_050_000,
       }),
     );
     expect(result).toContainEqual(
@@ -156,6 +157,7 @@ describe("loadModelCatalog", () => {
         provider: "openai",
         id: "gpt-5.4-pro",
         name: "gpt-5.4-pro",
+        contextWindow: 1_050_000,
       }),
     );
     expect(result).toContainEqual(
@@ -163,8 +165,30 @@ describe("loadModelCatalog", () => {
         provider: "openai-codex",
         id: "gpt-5.4",
         name: "gpt-5.4",
+        contextWindow: 1_050_000,
       }),
     );
+  });
+
+  it("overrides template contextWindow for gpt-5.4 synthetic entries", async () => {
+    mockPiDiscoveryModels([
+      {
+        id: "gpt-5.3-codex",
+        provider: "openai-codex",
+        name: "GPT-5.3 Codex",
+        reasoning: true,
+        contextWindow: 266_000,
+        input: ["text", "image"],
+      },
+    ]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    const codexGpt54 = result.find(
+      (entry) => entry.provider === "openai-codex" && entry.id === "gpt-5.4",
+    );
+
+    expect(codexGpt54).toBeDefined();
+    expect(codexGpt54?.contextWindow).toBe(1_050_000);
   });
 
   it("merges configured models for opted-in non-pi-native providers", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -45,6 +45,7 @@ type SyntheticCatalogFallback = {
   provider: string;
   id: string;
   templateIds: readonly string[];
+  contextWindow?: number;
 };
 
 const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
@@ -52,16 +53,19 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_MODEL_ID,
     templateIds: ["gpt-5.2"],
+    contextWindow: 1_050_000,
   },
   {
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_PRO_MODEL_ID,
     templateIds: ["gpt-5.2-pro", "gpt-5.2"],
+    contextWindow: 1_050_000,
   },
   {
     provider: CODEX_PROVIDER,
     id: OPENAI_CODEX_GPT54_MODEL_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
+    contextWindow: 1_050_000,
   },
   {
     provider: CODEX_PROVIDER,
@@ -92,6 +96,7 @@ function applySyntheticCatalogFallbacks(models: ModelCatalogEntry[]): void {
       ...template,
       id: fallback.id,
       name: fallback.id,
+      ...(fallback.contextWindow != null ? { contextWindow: fallback.contextWindow } : {}),
     });
   }
 }


### PR DESCRIPTION
The `openclaw models list` command shows 266k context window for `openai-codex/gpt-5.4` instead of the correct 1,050k (1M+).

This happens because the synthetic catalog fallback system clones the template model entry (gpt-5.3-codex with 266k context) without overriding the context window. The forward-compat runner code in `model-forward-compat.ts` already applies the correct 1,050k value at runtime, so actual agent behavior is fine, but the display is wrong.

**Changes:**

- Added an optional `contextWindow` field to `SyntheticCatalogFallback`
- Set `contextWindow: 1_050_000` on the openai/gpt-5.4, openai/gpt-5.4-pro, and openai-codex/gpt-5.4 fallback entries
- Updated `applySyntheticCatalogFallbacks` to apply the override when present
- Added a regression test that verifies a 266k template produces a 1,050k synthetic entry
- Updated existing test assertions to check contextWindow values

**Testing:**

All 15 tests pass across model-catalog.test.ts and list-command.forward-compat.test.ts.

Closes #41318