### PR TITLE
Gateway: add session activity status RPC

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -130,6 +130,7 @@ export async function runAgentTurnWithFallback(params: {
       sessionKey: params.sessionKey,
       verboseLevel: params.resolvedVerboseLevel,
       isHeartbeat: params.isHeartbeat,
+      activitySource: params.isHeartbeat ? "heartbeat" : "chat",
       isControlUiVisible: shouldSurfaceToControlUi,
     });
   }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -142,6 +142,7 @@ export function createFollowupRunner(params: {
         registerAgentRunContext(runId, {
           sessionKey: queued.run.sessionKey,
           verboseLevel: queued.run.verboseLevel,
+          activitySource: "chat",
           isControlUiVisible: shouldSurfaceToControlUi,
         });
       }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -537,6 +537,7 @@ export async function runCronIsolatedAgentTurn(params: {
     registerAgentRunContext(cronSession.sessionEntry.sessionId, {
       sessionKey: agentSessionKey,
       verboseLevel: resolvedVerboseLevel,
+      activitySource: "cron",
     });
     const messageChannel = resolvedDelivery.channel;
     // Per-job payload.fallbacks takes priority over agent-level fallbacks.

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -65,6 +65,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "skills.status",
     "voicewake.get",
     "sessions.list",
+    "session.activity",
     "sessions.get",
     "sessions.preview",
     "sessions.resolve",

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -65,7 +65,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "skills.status",
     "voicewake.get",
     "sessions.list",
-    "session.activity",
+    "sessions.activity",
     "sessions.get",
     "sessions.preview",
     "sessions.resolve",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -1,6 +1,7 @@
 import AjvPkg, { type ErrorObject } from "ajv";
 import type { SessionsPatchResult } from "../session-utils.types.js";
 import {
+  type SessionActivityParams,
   type AgentEvent,
   AgentEventSchema,
   type AgentIdentityParams,
@@ -255,6 +256,9 @@ export const validateEventFrame = ajv.compile<EventFrame>(EventFrameSchema);
 export const validateSendParams = ajv.compile(SendParamsSchema);
 export const validatePollParams = ajv.compile<PollParams>(PollParamsSchema);
 export const validateAgentParams = ajv.compile(AgentParamsSchema);
+export const validateSessionActivityParams = ajv.compile<SessionActivityParams>(
+  ProtocolSchemas.SessionActivityParams,
+);
 export const validateAgentIdentityParams =
   ajv.compile<AgentIdentityParams>(AgentIdentityParamsSchema);
 export const validateAgentWaitParams = ajv.compile<AgentWaitParams>(AgentWaitParamsSchema);
@@ -621,6 +625,7 @@ export type {
   NodeInvokeParams,
   NodeInvokeResultParams,
   NodeEventParams,
+  SessionActivityParams,
   SessionsListParams,
   SessionsPreviewParams,
   SessionsResolveParams,

--- a/src/gateway/protocol/schema/activity.ts
+++ b/src/gateway/protocol/schema/activity.ts
@@ -1,0 +1,10 @@
+import { Type } from "@sinclair/typebox";
+import { NonEmptyString } from "./primitives.js";
+
+export const SessionActivityParamsSchema = Type.Object(
+  {
+    key: Type.Optional(NonEmptyString),
+    keys: Type.Optional(Type.Array(NonEmptyString, { minItems: 1 })),
+  },
+  { additionalProperties: false },
+);

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -1,4 +1,5 @@
 import type { TSchema } from "@sinclair/typebox";
+import { SessionActivityParamsSchema } from "./activity.js";
 import {
   AgentEventSchema,
   AgentIdentityParamsSchema,
@@ -167,6 +168,7 @@ export const ProtocolSchemas = {
   Snapshot: SnapshotSchema,
   ErrorShape: ErrorShapeSchema,
   AgentEvent: AgentEventSchema,
+  SessionActivityParams: SessionActivityParamsSchema,
   SendParams: SendParamsSchema,
   PollParams: PollParamsSchema,
   AgentParams: AgentParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -15,6 +15,7 @@ export type PresenceEntry = SchemaType<"PresenceEntry">;
 export type ErrorShape = SchemaType<"ErrorShape">;
 export type StateVersion = SchemaType<"StateVersion">;
 export type AgentEvent = SchemaType<"AgentEvent">;
+export type SessionActivityParams = SchemaType<"SessionActivityParams">;
 export type AgentIdentityParams = SchemaType<"AgentIdentityParams">;
 export type AgentIdentityResult = SchemaType<"AgentIdentityResult">;
 export type PollParams = SchemaType<"PollParams">;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -54,7 +54,7 @@ const BASE_METHODS = [
   "secrets.reload",
   "secrets.resolve",
   "sessions.list",
-  "session.activity",
+  "sessions.activity",
   "sessions.preview",
   "sessions.patch",
   "sessions.reset",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -54,6 +54,7 @@ const BASE_METHODS = [
   "secrets.reload",
   "secrets.resolve",
   "sessions.list",
+  "session.activity",
   "sessions.preview",
   "sessions.patch",
   "sessions.reset",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -4,6 +4,7 @@ import { consumeControlPlaneWriteBudget } from "./control-plane-rate-limit.js";
 import { ADMIN_SCOPE, authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import { isRoleAuthorizedForMethod, parseGatewayRole } from "./role-policy.js";
+import { activityHandlers } from "./server-methods/activity.js";
 import { agentHandlers } from "./server-methods/agent.js";
 import { agentsHandlers } from "./server-methods/agents.js";
 import { browserHandlers } from "./server-methods/browser.js";
@@ -66,6 +67,7 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
 
 export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...connectHandlers,
+  ...activityHandlers,
   ...logsHandlers,
   ...voicewakeHandlers,
   ...healthHandlers,

--- a/src/gateway/server-methods/activity.ts
+++ b/src/gateway/server-methods/activity.ts
@@ -20,13 +20,17 @@ function normalizeRequestedKeys(params: SessionActivityParams): string[] {
   return [...keys];
 }
 
+function toCanonicalSessionKey(cfg: ReturnType<typeof loadConfig>, key: string): string {
+  return resolveGatewaySessionStoreTarget({ cfg, key }).canonicalKey;
+}
+
 export const activityHandlers: GatewayRequestHandlers = {
-  "session.activity": ({ respond, params, context }) => {
+  "sessions.activity": ({ respond, params, context }) => {
     if (
       !assertValidParams<SessionActivityParams>(
         params,
         validateSessionActivityParams,
-        "session.activity",
+        "sessions.activity",
         respond,
       )
     ) {
@@ -35,16 +39,14 @@ export const activityHandlers: GatewayRequestHandlers = {
 
     const cfg = loadConfig();
     const requestedKeys = normalizeRequestedKeys(params);
-    const canonicalRequestedKeys = requestedKeys.map(
-      (key) => resolveGatewaySessionStoreTarget({ cfg, key }).canonicalKey,
-    );
+    const canonicalRequestedKeys = requestedKeys.map((key) => toCanonicalSessionKey(cfg, key));
     const heartbeatByKey = new Map(
       listHeartbeatWakeSnapshotEntries()
         .filter(
           (entry): entry is typeof entry & { sessionKey: string } =>
             typeof entry.sessionKey === "string" && entry.sessionKey.trim().length > 0,
         )
-        .map((entry) => [entry.sessionKey, entry] as const),
+        .map((entry) => [toCanonicalSessionKey(cfg, entry.sessionKey), entry] as const),
     );
 
     const keys =

--- a/src/gateway/server-methods/activity.ts
+++ b/src/gateway/server-methods/activity.ts
@@ -1,0 +1,81 @@
+import { loadConfig } from "../../config/config.js";
+import { listHeartbeatWakeSnapshotEntries } from "../../infra/heartbeat-wake.js";
+import { validateSessionActivityParams, type SessionActivityParams } from "../protocol/index.js";
+import { resolveGatewaySessionStoreTarget } from "../session-utils.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+function normalizeRequestedKeys(params: SessionActivityParams): string[] {
+  const keys = new Set<string>();
+  if (typeof params.key === "string" && params.key.trim()) {
+    keys.add(params.key.trim());
+  }
+  if (Array.isArray(params.keys)) {
+    for (const key of params.keys) {
+      if (typeof key === "string" && key.trim()) {
+        keys.add(key.trim());
+      }
+    }
+  }
+  return [...keys];
+}
+
+export const activityHandlers: GatewayRequestHandlers = {
+  "session.activity": ({ respond, params, context }) => {
+    if (
+      !assertValidParams<SessionActivityParams>(
+        params,
+        validateSessionActivityParams,
+        "session.activity",
+        respond,
+      )
+    ) {
+      return;
+    }
+
+    const cfg = loadConfig();
+    const requestedKeys = normalizeRequestedKeys(params);
+    const canonicalRequestedKeys = requestedKeys.map(
+      (key) => resolveGatewaySessionStoreTarget({ cfg, key }).canonicalKey,
+    );
+    const heartbeatByKey = new Map(
+      listHeartbeatWakeSnapshotEntries()
+        .filter(
+          (entry): entry is typeof entry & { sessionKey: string } =>
+            typeof entry.sessionKey === "string" && entry.sessionKey.trim().length > 0,
+        )
+        .map((entry) => [entry.sessionKey, entry] as const),
+    );
+
+    const keys =
+      canonicalRequestedKeys.length > 0
+        ? canonicalRequestedKeys
+        : Array.from(
+            new Set([...context.sessionActivity.listActiveSessionKeys(), ...heartbeatByKey.keys()]),
+          ).toSorted();
+
+    const sessions = keys.map((key) => {
+      const running = context.sessionActivity.getRunning(key);
+      if (running) {
+        return running;
+      }
+      const heartbeat = heartbeatByKey.get(key);
+      if (heartbeat) {
+        return {
+          key,
+          phase: heartbeat.phase,
+          source: "heartbeat" as const,
+          startedAt: heartbeat.startedAt,
+          lastActivityAt: heartbeat.startedAt ?? heartbeat.requestedAt,
+        };
+      }
+      return {
+        key,
+        phase: "idle" as const,
+        source: null,
+      };
+    });
+
+    respond(true, { ts: Date.now(), sessions }, undefined);
+  },
+};

--- a/src/gateway/server-methods/activity.ts
+++ b/src/gateway/server-methods/activity.ts
@@ -24,7 +24,7 @@ function normalizeRequestedKeys(params: SessionActivityParams): string[] {
 }
 
 function toCanonicalSessionKey(cfg: ReturnType<typeof loadConfig>, key: string): string {
-  return resolveGatewaySessionStoreTarget({ cfg, key }).canonicalKey;
+  return resolveGatewaySessionStoreTarget({ cfg, key, scanLegacyKeys: false }).canonicalKey;
 }
 
 function heartbeatSnapshotSortKey(entry: HeartbeatWakeSnapshotEntry): number {

--- a/src/gateway/server-methods/activity.ts
+++ b/src/gateway/server-methods/activity.ts
@@ -1,5 +1,8 @@
 import { loadConfig } from "../../config/config.js";
-import { listHeartbeatWakeSnapshotEntries } from "../../infra/heartbeat-wake.js";
+import {
+  listHeartbeatWakeSnapshotEntries,
+  type HeartbeatWakeSnapshotEntry,
+} from "../../infra/heartbeat-wake.js";
 import { validateSessionActivityParams, type SessionActivityParams } from "../protocol/index.js";
 import { resolveGatewaySessionStoreTarget } from "../session-utils.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -24,6 +27,23 @@ function toCanonicalSessionKey(cfg: ReturnType<typeof loadConfig>, key: string):
   return resolveGatewaySessionStoreTarget({ cfg, key }).canonicalKey;
 }
 
+function heartbeatSnapshotSortKey(entry: HeartbeatWakeSnapshotEntry): number {
+  return entry.startedAt ?? entry.requestedAt;
+}
+
+function selectHeartbeatSnapshotEntry(
+  current: HeartbeatWakeSnapshotEntry | undefined,
+  next: HeartbeatWakeSnapshotEntry,
+): HeartbeatWakeSnapshotEntry {
+  if (!current) {
+    return next;
+  }
+  if (current.phase !== next.phase) {
+    return current.phase === "running" ? current : next;
+  }
+  return heartbeatSnapshotSortKey(next) >= heartbeatSnapshotSortKey(current) ? next : current;
+}
+
 export const activityHandlers: GatewayRequestHandlers = {
   "sessions.activity": ({ respond, params, context }) => {
     if (
@@ -40,14 +60,17 @@ export const activityHandlers: GatewayRequestHandlers = {
     const cfg = loadConfig();
     const requestedKeys = normalizeRequestedKeys(params);
     const canonicalRequestedKeys = requestedKeys.map((key) => toCanonicalSessionKey(cfg, key));
-    const heartbeatByKey = new Map(
-      listHeartbeatWakeSnapshotEntries()
-        .filter(
-          (entry): entry is typeof entry & { sessionKey: string } =>
-            typeof entry.sessionKey === "string" && entry.sessionKey.trim().length > 0,
-        )
-        .map((entry) => [toCanonicalSessionKey(cfg, entry.sessionKey), entry] as const),
-    );
+    const heartbeatByKey = new Map<string, HeartbeatWakeSnapshotEntry>();
+    for (const entry of listHeartbeatWakeSnapshotEntries()) {
+      if (typeof entry.sessionKey !== "string" || entry.sessionKey.trim().length === 0) {
+        continue;
+      }
+      const canonicalKey = toCanonicalSessionKey(cfg, entry.sessionKey);
+      heartbeatByKey.set(
+        canonicalKey,
+        selectHeartbeatSnapshotEntry(heartbeatByKey.get(canonicalKey), entry),
+      );
+    }
 
     const keys =
       canonicalRequestedKeys.length > 0

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -535,7 +535,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           bestEffortDeliver = true;
         }
       }
-      registerAgentRunContext(idem, { sessionKey: canonicalSessionKey });
+      registerAgentRunContext(idem, { sessionKey: canonicalSessionKey, activitySource: "chat" });
     }
 
     const runId = idem;

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -11,6 +11,7 @@ import type { ConnectParams, ErrorShape, RequestFrame } from "../protocol/index.
 import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "../server-broadcast.js";
 import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 import type { DedupeEntry } from "../server-shared.js";
+import type { SessionActivityRegistry } from "../session-activity.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -63,6 +64,7 @@ export type GatewayRequestContext = {
     clientRunId: string,
     sessionKey?: string,
   ) => { sessionKey: string; clientRunId: string } | undefined;
+  sessionActivity: SessionActivityRegistry;
   registerToolEventRecipient: (runId: string, connId: string) => void;
   dedupe: Map<string, DedupeEntry>;
   wizardSessions: Map<string, WizardSession>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,7 +21,7 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
-import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
+import { clearAgentRunContext, getAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
   isPackageProvenControlUiRootSync,
@@ -109,6 +109,7 @@ import {
 } from "./server/health-state.js";
 import { createReadinessChecker } from "./server/readiness.js";
 import { loadGatewayTlsRuntime } from "./server/tls.js";
+import { createSessionActivityRegistry, type SessionActivitySource } from "./session-activity.js";
 import {
   ensureGatewayStartupAuth,
   mergeGatewayAuthConfig,
@@ -129,6 +130,17 @@ function resolveMediaCleanupTtlMs(ttlHoursRaw: number): number {
     throw new Error(`Invalid media.ttlHours: ${String(ttlHoursRaw)}`);
   }
   return ttlMs;
+}
+
+function resolveRuntimeSessionActivitySource(runId: string): SessionActivitySource {
+  const context = getAgentRunContext(runId);
+  if (context?.activitySource === "heartbeat" || context?.isHeartbeat === true) {
+    return "heartbeat";
+  }
+  if (context?.activitySource === "cron") {
+    return "cron";
+  }
+  return "chat";
 }
 
 const log = createSubsystemLogger("gateway");
@@ -643,6 +655,7 @@ export async function startGatewayServer(
     broadcast("voicewake.changed", { triggers }, { dropIfSlow: true });
   };
   const hasMobileNodeConnected = () => hasConnectedMobileNode(nodeRegistry);
+  const sessionActivity = createSessionActivityRegistry();
   applyGatewayLaneConcurrency(cfgAtStart);
 
   let cronState = buildGatewayCronService({
@@ -724,20 +737,43 @@ export async function startGatewayServer(
     }));
   }
 
+  const agentEventHandler = createAgentEventHandler({
+    broadcast,
+    broadcastToConnIds,
+    nodeSendToSession,
+    agentRunSeq,
+    chatRunState,
+    resolveSessionKeyForRun,
+    clearAgentRunContext,
+    toolEventRecipients,
+  });
   const agentUnsub = minimalTestGateway
     ? null
-    : onAgentEvent(
-        createAgentEventHandler({
-          broadcast,
-          broadcastToConnIds,
-          nodeSendToSession,
-          agentRunSeq,
-          chatRunState,
-          resolveSessionKeyForRun,
-          clearAgentRunContext,
-          toolEventRecipients,
-        }),
-      );
+    : onAgentEvent((evt) => {
+        if (evt.stream === "lifecycle") {
+          const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+          const contextSessionKey = getAgentRunContext(evt.runId)?.sessionKey;
+          const sessionKey =
+            typeof evt.sessionKey === "string" && evt.sessionKey.trim()
+              ? evt.sessionKey.trim()
+              : typeof contextSessionKey === "string" && contextSessionKey.trim()
+                ? contextSessionKey.trim()
+                : undefined;
+          if (phase === "start" && sessionKey) {
+            sessionActivity.markRunStarted({
+              sessionKey,
+              runId: evt.runId,
+              source: resolveRuntimeSessionActivitySource(evt.runId),
+              startedAt: typeof evt.data.startedAt === "number" ? evt.data.startedAt : evt.ts,
+            });
+          } else if (phase === "end" || phase === "error") {
+            sessionActivity.markRunFinished(evt.runId);
+          }
+        } else {
+          sessionActivity.touchRun(evt.runId, evt.ts);
+        }
+        agentEventHandler(evt);
+      });
 
   const heartbeatUnsub = minimalTestGateway
     ? null
@@ -850,6 +886,7 @@ export async function startGatewayServer(
     chatDeltaSentAt: chatRunState.deltaSentAt,
     addChatRun,
     removeChatRun,
+    sessionActivity,
     registerToolEventRecipient: toolEventRecipients.add,
     dedupe,
     wizardSessions,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -110,6 +110,7 @@ import {
 import { createReadinessChecker } from "./server/readiness.js";
 import { loadGatewayTlsRuntime } from "./server/tls.js";
 import { createSessionActivityRegistry, type SessionActivitySource } from "./session-activity.js";
+import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
 import {
   ensureGatewayStartupAuth,
   mergeGatewayAuthConfig,
@@ -140,7 +141,14 @@ function resolveRuntimeSessionActivitySource(runId: string): SessionActivitySour
   if (context?.activitySource === "cron") {
     return "cron";
   }
+  // Current run entrypoints register agent run context before lifecycle events
+  // fire. If context is missing here, treat it as a plain chat run and require
+  // future non-chat callers to set `activitySource` explicitly.
   return "chat";
+}
+
+function toCanonicalSessionKey(cfg: OpenClawConfig, key: string): string {
+  return resolveGatewaySessionStoreTarget({ cfg, key }).canonicalKey;
 }
 
 const log = createSubsystemLogger("gateway");
@@ -761,7 +769,7 @@ export async function startGatewayServer(
                 : undefined;
           if (phase === "start" && sessionKey) {
             sessionActivity.markRunStarted({
-              sessionKey,
+              sessionKey: toCanonicalSessionKey(cfgAtStart, sessionKey),
               runId: evt.runId,
               source: resolveRuntimeSessionActivitySource(evt.runId),
               startedAt: typeof evt.data.startedAt === "number" ? evt.data.startedAt : evt.ts,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -148,7 +148,7 @@ function resolveRuntimeSessionActivitySource(runId: string): SessionActivitySour
 }
 
 function toCanonicalSessionKey(cfg: OpenClawConfig, key: string): string {
-  return resolveGatewaySessionStoreTarget({ cfg, key }).canonicalKey;
+  return resolveGatewaySessionStoreTarget({ cfg, key, scanLegacyKeys: false }).canonicalKey;
 }
 
 const log = createSubsystemLogger("gateway");

--- a/src/gateway/session-activity.test.ts
+++ b/src/gateway/session-activity.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createSessionActivityRegistry } from "./session-activity.js";
+
+describe("session activity registry", () => {
+  it("tracks a run from start to finish", () => {
+    const registry = createSessionActivityRegistry();
+
+    registry.markRunStarted({
+      sessionKey: "agent:main:main",
+      runId: "run-1",
+      source: "chat",
+      startedAt: 100,
+    });
+
+    expect(registry.getRunning("agent:main:main")).toEqual({
+      key: "agent:main:main",
+      phase: "running",
+      source: "chat",
+      runId: "run-1",
+      startedAt: 100,
+      lastActivityAt: 100,
+    });
+
+    registry.markRunFinished("run-1");
+
+    expect(registry.getRunning("agent:main:main")).toBeNull();
+  });
+
+  it("prefers the most recently active run for a session", () => {
+    const registry = createSessionActivityRegistry();
+
+    registry.markRunStarted({
+      sessionKey: "agent:main:main",
+      runId: "run-1",
+      source: "chat",
+      startedAt: 100,
+    });
+    registry.markRunStarted({
+      sessionKey: "agent:main:main",
+      runId: "run-2",
+      source: "heartbeat",
+      startedAt: 200,
+    });
+
+    expect(registry.getRunning("agent:main:main")?.runId).toBe("run-2");
+    expect(registry.getRunning("agent:main:main")?.source).toBe("heartbeat");
+
+    registry.touchRun("run-1", 300);
+
+    expect(registry.getRunning("agent:main:main")?.runId).toBe("run-1");
+    expect(registry.getRunning("agent:main:main")?.lastActivityAt).toBe(300);
+  });
+
+  it("moves a reused run id to the new session", () => {
+    const registry = createSessionActivityRegistry();
+
+    registry.markRunStarted({
+      sessionKey: "agent:main:main",
+      runId: "run-1",
+      source: "chat",
+      startedAt: 100,
+    });
+    registry.markRunStarted({
+      sessionKey: "agent:ops:main",
+      runId: "run-1",
+      source: "cron",
+      startedAt: 150,
+    });
+
+    expect(registry.getRunning("agent:main:main")).toBeNull();
+    expect(registry.getRunning("agent:ops:main")).toEqual({
+      key: "agent:ops:main",
+      phase: "running",
+      source: "cron",
+      runId: "run-1",
+      startedAt: 100,
+      lastActivityAt: 150,
+    });
+  });
+});

--- a/src/gateway/session-activity.test.ts
+++ b/src/gateway/session-activity.test.ts
@@ -77,4 +77,23 @@ describe("session activity registry", () => {
       lastActivityAt: 150,
     });
   });
+
+  it("normalizes run ids for touch and finish lookups", () => {
+    const registry = createSessionActivityRegistry();
+
+    registry.markRunStarted({
+      sessionKey: "agent:main:main",
+      runId: " run-1 ",
+      source: "chat",
+      startedAt: 100,
+    });
+
+    registry.touchRun(" run-1 ", 300);
+
+    expect(registry.getRunning("agent:main:main")?.lastActivityAt).toBe(300);
+
+    registry.markRunFinished(" run-1 ");
+
+    expect(registry.getRunning("agent:main:main")).toBeNull();
+  });
 });

--- a/src/gateway/session-activity.ts
+++ b/src/gateway/session-activity.ts
@@ -43,6 +43,10 @@ function compareRuns(a: ActiveSessionRun, b: ActiveSessionRun) {
   return a.runId.localeCompare(b.runId);
 }
 
+function normalizeRunId(runId: string): string {
+  return runId.trim();
+}
+
 export function createSessionActivityRegistry(): SessionActivityRegistry {
   const runsById = new Map<string, ActiveSessionRun>();
   const runIdsBySession = new Map<string, Set<string>>();
@@ -61,7 +65,7 @@ export function createSessionActivityRegistry(): SessionActivityRegistry {
   return {
     markRunStarted: ({ sessionKey, runId, source, startedAt }) => {
       const normalizedSessionKey = sessionKey.trim();
-      const normalizedRunId = runId.trim();
+      const normalizedRunId = normalizeRunId(runId);
       if (!normalizedSessionKey || !normalizedRunId) {
         return;
       }
@@ -85,19 +89,27 @@ export function createSessionActivityRegistry(): SessionActivityRegistry {
       sessionRuns.add(normalizedRunId);
     },
     touchRun: (runId, at) => {
-      const existing = runsById.get(runId);
+      const normalizedRunId = normalizeRunId(runId);
+      if (!normalizedRunId) {
+        return;
+      }
+      const existing = runsById.get(normalizedRunId);
       if (!existing) {
         return;
       }
       existing.lastActivityAt = Number.isFinite(at) ? Math.max(0, at ?? 0) : Date.now();
     },
     markRunFinished: (runId) => {
-      const existing = runsById.get(runId);
+      const normalizedRunId = normalizeRunId(runId);
+      if (!normalizedRunId) {
+        return;
+      }
+      const existing = runsById.get(normalizedRunId);
       if (!existing) {
         return;
       }
-      runsById.delete(runId);
-      removeRunIdFromSession(existing.sessionKey, runId);
+      runsById.delete(normalizedRunId);
+      removeRunIdFromSession(existing.sessionKey, normalizedRunId);
     },
     getRunning: (sessionKey) => {
       const sessionRuns = runIdsBySession.get(sessionKey);

--- a/src/gateway/session-activity.ts
+++ b/src/gateway/session-activity.ts
@@ -1,0 +1,129 @@
+export type SessionActivityPhase = "idle" | "queued" | "running";
+
+export type SessionActivitySource = "chat" | "heartbeat" | "cron";
+
+export type SessionActivityEntry = {
+  key: string;
+  phase: SessionActivityPhase;
+  source: SessionActivitySource | null;
+  runId?: string;
+  startedAt?: number;
+  lastActivityAt?: number;
+};
+
+type ActiveSessionRun = {
+  sessionKey: string;
+  runId: string;
+  source: SessionActivitySource;
+  startedAt: number;
+  lastActivityAt: number;
+};
+
+export type SessionActivityRegistry = {
+  markRunStarted: (entry: {
+    sessionKey: string;
+    runId: string;
+    source: SessionActivitySource;
+    startedAt?: number;
+  }) => void;
+  touchRun: (runId: string, at?: number) => void;
+  markRunFinished: (runId: string) => void;
+  getRunning: (sessionKey: string) => SessionActivityEntry | null;
+  listActiveSessionKeys: () => string[];
+  clear: () => void;
+};
+
+function compareRuns(a: ActiveSessionRun, b: ActiveSessionRun) {
+  if (a.lastActivityAt !== b.lastActivityAt) {
+    return b.lastActivityAt - a.lastActivityAt;
+  }
+  if (a.startedAt !== b.startedAt) {
+    return b.startedAt - a.startedAt;
+  }
+  return a.runId.localeCompare(b.runId);
+}
+
+export function createSessionActivityRegistry(): SessionActivityRegistry {
+  const runsById = new Map<string, ActiveSessionRun>();
+  const runIdsBySession = new Map<string, Set<string>>();
+
+  const removeRunIdFromSession = (sessionKey: string, runId: string) => {
+    const sessionRuns = runIdsBySession.get(sessionKey);
+    if (!sessionRuns) {
+      return;
+    }
+    sessionRuns.delete(runId);
+    if (sessionRuns.size === 0) {
+      runIdsBySession.delete(sessionKey);
+    }
+  };
+
+  return {
+    markRunStarted: ({ sessionKey, runId, source, startedAt }) => {
+      const normalizedSessionKey = sessionKey.trim();
+      const normalizedRunId = runId.trim();
+      if (!normalizedSessionKey || !normalizedRunId) {
+        return;
+      }
+      const now = Number.isFinite(startedAt) ? Math.max(0, startedAt ?? 0) : Date.now();
+      const existing = runsById.get(normalizedRunId);
+      if (existing && existing.sessionKey !== normalizedSessionKey) {
+        removeRunIdFromSession(existing.sessionKey, normalizedRunId);
+      }
+      runsById.set(normalizedRunId, {
+        sessionKey: normalizedSessionKey,
+        runId: normalizedRunId,
+        source,
+        startedAt: existing?.startedAt ?? now,
+        lastActivityAt: now,
+      });
+      let sessionRuns = runIdsBySession.get(normalizedSessionKey);
+      if (!sessionRuns) {
+        sessionRuns = new Set<string>();
+        runIdsBySession.set(normalizedSessionKey, sessionRuns);
+      }
+      sessionRuns.add(normalizedRunId);
+    },
+    touchRun: (runId, at) => {
+      const existing = runsById.get(runId);
+      if (!existing) {
+        return;
+      }
+      existing.lastActivityAt = Number.isFinite(at) ? Math.max(0, at ?? 0) : Date.now();
+    },
+    markRunFinished: (runId) => {
+      const existing = runsById.get(runId);
+      if (!existing) {
+        return;
+      }
+      runsById.delete(runId);
+      removeRunIdFromSession(existing.sessionKey, runId);
+    },
+    getRunning: (sessionKey) => {
+      const sessionRuns = runIdsBySession.get(sessionKey);
+      if (!sessionRuns || sessionRuns.size === 0) {
+        return null;
+      }
+      const best = [...sessionRuns]
+        .map((runId) => runsById.get(runId))
+        .filter((entry): entry is ActiveSessionRun => Boolean(entry))
+        .toSorted(compareRuns)[0];
+      if (!best) {
+        return null;
+      }
+      return {
+        key: sessionKey,
+        phase: "running",
+        source: best.source,
+        runId: best.runId,
+        startedAt: best.startedAt,
+        lastActivityAt: best.lastActivityAt,
+      };
+    },
+    listActiveSessionKeys: () => [...runIdsBySession.keys()].toSorted(),
+    clear: () => {
+      runsById.clear();
+      runIdsBySession.clear();
+    },
+  };
+}

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -2,6 +2,8 @@ import type { VerboseLevel } from "../auto-reply/thinking.js";
 
 export type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error" | (string & {});
 
+export type AgentRunActivitySource = "chat" | "heartbeat" | "cron" | (string & {});
+
 export type AgentEventPayload = {
   runId: string;
   seq: number;
@@ -15,6 +17,7 @@ export type AgentRunContext = {
   sessionKey?: string;
   verboseLevel?: VerboseLevel;
   isHeartbeat?: boolean;
+  activitySource?: AgentRunActivitySource;
   /** Whether control UI clients should receive chat/agent updates for this run. */
   isControlUiVisible?: boolean;
 };
@@ -44,6 +47,9 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
   if (context.isHeartbeat !== undefined && existing.isHeartbeat !== context.isHeartbeat) {
     existing.isHeartbeat = context.isHeartbeat;
+  }
+  if (context.activitySource && existing.activitySource !== context.activitySource) {
+    existing.activitySource = context.activitySource;
   }
 }
 

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -24,6 +24,15 @@ type PendingWakeReason = {
   sessionKey?: string;
 };
 
+export type HeartbeatWakeSnapshotEntry = {
+  phase: "queued" | "running";
+  reason: string;
+  requestedAt: number;
+  startedAt?: number;
+  agentId?: string;
+  sessionKey?: string;
+};
+
 let handler: HeartbeatWakeHandler | null = null;
 let handlerGeneration = 0;
 const pendingWakes = new Map<string, PendingWakeReason>();
@@ -32,6 +41,7 @@ let running = false;
 let timer: NodeJS.Timeout | null = null;
 let timerDueAt: number | null = null;
 let timerKind: WakeTimerKind | null = null;
+let activeWake: (PendingWakeReason & { startedAt: number }) | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
@@ -147,6 +157,10 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
     running = true;
     try {
       for (const pendingWake of pendingBatch) {
+        activeWake = {
+          ...pendingWake,
+          startedAt: Date.now(),
+        };
         const wakeOpts = {
           reason: pendingWake.reason ?? undefined,
           ...(pendingWake.agentId ? { agentId: pendingWake.agentId } : {}),
@@ -162,6 +176,7 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
           });
           schedule(DEFAULT_RETRY_MS, "retry");
         }
+        activeWake = null;
       }
     } catch {
       // Error is already logged by the heartbeat runner; schedule a retry.
@@ -174,6 +189,7 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
       }
       schedule(DEFAULT_RETRY_MS, "retry");
     } finally {
+      activeWake = null;
       running = false;
       if (pendingWakes.size > 0 || scheduled) {
         schedule(delay, "normal");
@@ -247,6 +263,30 @@ export function hasPendingHeartbeatWake() {
   return pendingWakes.size > 0 || Boolean(timer) || scheduled;
 }
 
+export function listHeartbeatWakeSnapshotEntries(): HeartbeatWakeSnapshotEntry[] {
+  const queued = Array.from(pendingWakes.values()).map((entry) => ({
+    phase: "queued" as const,
+    reason: entry.reason,
+    requestedAt: entry.requestedAt,
+    agentId: entry.agentId,
+    sessionKey: entry.sessionKey,
+  }));
+  if (!activeWake) {
+    return queued;
+  }
+  return [
+    {
+      phase: "running",
+      reason: activeWake.reason,
+      requestedAt: activeWake.requestedAt,
+      startedAt: activeWake.startedAt,
+      agentId: activeWake.agentId,
+      sessionKey: activeWake.sessionKey,
+    },
+    ...queued,
+  ];
+}
+
 export function resetHeartbeatWakeStateForTests() {
   if (timer) {
     clearTimeout(timer);
@@ -257,6 +297,7 @@ export function resetHeartbeatWakeStateForTests() {
   pendingWakes.clear();
   scheduled = false;
   running = false;
+  activeWake = null;
   handlerGeneration += 1;
   handler = null;
 }

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -225,6 +225,9 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     // `scheduled === true` can cause spurious immediate re-runs.
     running = false;
     scheduled = false;
+    activeWake = null;
+  } else {
+    activeWake = null;
   }
   if (handler && pendingWakes.size > 0) {
     schedule(DEFAULT_COALESCE_MS, "normal");


### PR DESCRIPTION
## Summary
- add a lightweight `session.activity` gateway RPC that reports per-session `idle`, `queued`, and `running` state with source and timing metadata
- track live session activity from agent lifecycle events and heartbeat wake state so clients can detect background work without depending on flaky event delivery
- keep this as a minimal gateway-side slice for #39127 instead of reviving the broader #39438 design

## Testing
- `pnpm vitest run src/gateway/session-activity.test.ts`
