### PR TITLE
fix(cron): do not misclassify empty/NO_REPLY as interim acknowledgement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - ACP/setSessionMode: propagate gateway `sessions.patch` failures back to ACP clients so rejected mode changes no longer return silent success. (#41185) thanks @pejmanjohn.
 - Agents/embedded logs: add structured, sanitized lifecycle and failover observation events so overload and provider failures are easier to tail and filter. (#41336) thanks @altaywtf.
 - iOS/gateway foreground recovery: reconnect immediately on foreground return after stale background sockets are torn down, so the app no longer stays disconnected until a later wake path happens. (#41384) Thanks @mbelinky.
+- Cron/subagent followup: do not misclassify empty or `NO_REPLY` cron responses as interim acknowledgements that need a rerun, so deliberately silent cron jobs are no longer retried. (#41383) thanks @jackal092927.
 
 ## 2026.3.8
 

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -47,8 +47,12 @@ describe("isLikelyInterimCronMessage", () => {
       false,
     );
   });
-  it("treats empty as interim", () => {
-    expect(isLikelyInterimCronMessage("")).toBe(true);
+  it("does not treat empty as interim (empty = NO_REPLY was stripped)", () => {
+    expect(isLikelyInterimCronMessage("")).toBe(false);
+  });
+
+  it("does not treat whitespace-only as interim", () => {
+    expect(isLikelyInterimCronMessage("   ")).toBe(false);
   });
 });
 

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -42,7 +42,10 @@ function normalizeHintText(value: string): string {
 export function isLikelyInterimCronMessage(value: string): boolean {
   const normalized = normalizeHintText(value);
   if (!normalized) {
-    return true;
+    // Empty text after payload filtering means the agent either returned
+    // NO_REPLY (deliberately silent) or produced no deliverable content.
+    // Do not treat this as an interim acknowledgement that needs a rerun.
+    return false;
   }
   const words = normalized.split(" ").filter(Boolean).length;
   return words <= 45 && INTERIM_CRON_HINTS.some((hint) => normalized.includes(hint));


### PR DESCRIPTION
Rebased and CHANGELOG-updated version of #41383 by @jackal092927.

Fixes #41246.

Co-authored-by: xaeon2026 <xaeon2026@gmail.com>