### PR TITLE
Gateway: tighten node pending drain semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - iOS/gateway foreground recovery: reconnect immediately on foreground return after stale background sockets are torn down, so the app no longer stays disconnected until a later wake path happens. (#41384) Thanks @mbelinky.
 - Cron/subagent followup: do not misclassify empty or `NO_REPLY` cron responses as interim acknowledgements that need a rerun, so deliberately silent cron jobs are no longer retried. (#41383) thanks @jackal092927.
 - Auth/cooldowns: reset expired auth-profile cooldown error counters before computing the next backoff so stale on-disk counters do not re-escalate into long cooldown loops after expiry. (#41028) thanks @zerone0x.
+- Gateway/node pending drain followup: keep `hasMore` true when the deferred baseline status item still needs delivery, and avoid allocating empty pending-work state for drain-only nodes with no queued work. (#41429) Thanks @mbelinky.
 
 ## 2026.3.8
 

--- a/src/gateway/node-pending-work.test.ts
+++ b/src/gateway/node-pending-work.test.ts
@@ -3,6 +3,7 @@ import {
   acknowledgeNodePendingWork,
   drainNodePendingWork,
   enqueueNodePendingWork,
+  getNodePendingWorkStateCountForTests,
   resetNodePendingWorkForTests,
 } from "./node-pending-work.js";
 
@@ -42,5 +43,25 @@ describe("node pending work", () => {
 
     const afterAck = drainNodePendingWork("node-2");
     expect(afterAck.items.map((item) => item.id)).toEqual(["baseline-status"]);
+  });
+
+  it("keeps hasMore true when the baseline status item is deferred by maxItems", () => {
+    enqueueNodePendingWork({ nodeId: "node-3", type: "location.request" });
+
+    const drained = drainNodePendingWork("node-3", { maxItems: 1 });
+
+    expect(drained.items.map((item) => item.type)).toEqual(["location.request"]);
+    expect(drained.hasMore).toBe(true);
+  });
+
+  it("does not allocate state for drain-only nodes with no queued work", () => {
+    expect(getNodePendingWorkStateCountForTests()).toBe(0);
+
+    const drained = drainNodePendingWork("node-4");
+    const acked = acknowledgeNodePendingWork({ nodeId: "node-4", itemIds: ["baseline-status"] });
+
+    expect(drained.items.map((item) => item.id)).toEqual(["baseline-status"]);
+    expect(acked).toEqual({ revision: 0, removedItemIds: [] });
+    expect(getNodePendingWorkStateCountForTests()).toBe(0);
   });
 });

--- a/src/gateway/node-pending-work.ts
+++ b/src/gateway/node-pending-work.ts
@@ -45,7 +45,7 @@ const PRIORITY_RANK: Record<NodePendingWorkPriority, number> = {
 
 const stateByNodeId = new Map<string, NodePendingWorkState>();
 
-function getState(nodeId: string): NodePendingWorkState {
+function getOrCreateState(nodeId: string): NodePendingWorkState {
   let state = stateByNodeId.get(nodeId);
   if (!state) {
     state = {
@@ -106,7 +106,7 @@ export function enqueueNodePendingWork(params: {
     throw new Error("nodeId required");
   }
   const nowMs = Date.now();
-  const state = getState(nodeId);
+  const state = getOrCreateState(nodeId);
   pruneExpired(state, nowMs);
   const existing = [...state.itemsById.values()].find((item) => item.type === params.type);
   if (existing) {
@@ -134,21 +134,25 @@ export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): D
     return { revision: 0, items: [], hasMore: false };
   }
   const nowMs = opts.nowMs ?? Date.now();
-  const state = getState(normalizedNodeId);
-  pruneExpired(state, nowMs);
+  const state = stateByNodeId.get(normalizedNodeId);
+  const revision = state?.revision ?? 0;
+  if (state) {
+    pruneExpired(state, nowMs);
+  }
   const maxItems = Math.min(MAX_ITEMS, Math.max(1, Math.trunc(opts.maxItems ?? DEFAULT_MAX_ITEMS)));
-  const explicitItems = sortedItems(state);
+  const explicitItems = state ? sortedItems(state) : [];
   const items = explicitItems.slice(0, maxItems);
   const hasExplicitStatus = explicitItems.some((item) => item.type === "status.request");
   const includeBaseline = opts.includeDefaultStatus !== false && !hasExplicitStatus;
   if (includeBaseline && items.length < maxItems) {
     items.push(makeBaselineStatusItem(nowMs));
   }
+  const explicitReturnedCount = items.filter((item) => item.id !== DEFAULT_STATUS_ITEM_ID).length;
+  const baselineIncluded = items.some((item) => item.id === DEFAULT_STATUS_ITEM_ID);
   return {
-    revision: state.revision,
+    revision,
     items,
-    hasMore:
-      explicitItems.length > items.filter((item) => item.id !== DEFAULT_STATUS_ITEM_ID).length,
+    hasMore: explicitItems.length > explicitReturnedCount || (includeBaseline && !baselineIncluded),
   };
 }
 
@@ -160,7 +164,10 @@ export function acknowledgeNodePendingWork(params: { nodeId: string; itemIds: st
   if (!nodeId) {
     return { revision: 0, removedItemIds: [] };
   }
-  const state = getState(nodeId);
+  const state = stateByNodeId.get(nodeId);
+  if (!state) {
+    return { revision: 0, removedItemIds: [] };
+  }
   const removedItemIds: string[] = [];
   for (const itemId of params.itemIds) {
     const trimmedId = itemId.trim();
@@ -179,4 +186,8 @@ export function acknowledgeNodePendingWork(params: { nodeId: string; itemIds: st
 
 export function resetNodePendingWorkForTests() {
   stateByNodeId.clear();
+}
+
+export function getNodePendingWorkStateCountForTests(): number {
+  return stateByNodeId.size;
 }


### PR DESCRIPTION
## Summary

- Problem: the merged node pending-work foundation can underreport `hasMore` when the synthetic baseline status item is deferred by a full batch, and it also allocates empty queue state for drain-only nodes with no queued work.
- Why it matters: the first issue is a real correctness bug for future queue consumers; the second causes unnecessary map growth on long-running gateways.
- What changed: fix `hasMore` so deferred baseline status work still reports more work pending, avoid allocating state on drain/ack when a node has never queued work, and add regression tests for both cases.
- What did NOT change (scope boundary): no protocol changes, no mobile/background execution changes, and no queue persistence work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #41409

## User-visible / Behavior Changes

- Future `node.pending.drain` consumers now get a correct `hasMore` signal when the baseline status item is deferred by a full batch.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 / pnpm
- Model/provider: n/a
- Integration/channel (if any): gateway node RPC
- Relevant config (redacted): local dev gateway methods only

### Steps

1. Queue one explicit work item and drain with `maxItems: 1`.
2. Observe that the explicit item fills the batch and the baseline status item is deferred.
3. Drain a brand-new node with no queued work and verify no queue state is allocated.

### Expected

- `hasMore` stays `true` until the deferred baseline can be delivered.
- Drain-only nodes do not allocate persistent queue state.

### Actual

- This PR fixes both behaviors and adds tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted gateway tests for the pending-work helpers and surrounding handler coverage.
- Edge cases checked: deferred baseline status, drain-only node state allocation, existing wake-helper/role-policy tests still passing.
- What you did **not** verify: end-to-end mobile consumer behavior.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/gateway/node-pending-work.ts`, `src/gateway/node-pending-work.test.ts`
- Known bad symptoms reviewers should watch for: incorrect `hasMore` on small drains or unexpected node queue state growth.

## Risks and Mitigations

- Risk: low; this is a narrow follow-up in the same queue helper.
  - Mitigation: regression tests cover both corrected cases.
