### PR TITLE
fix(discord): guard ThreadStarterBody to first turn only

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -377,7 +377,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ReplyToSender: replyContext?.sender,
     ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
     MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
-    ThreadStarterBody: threadStarterBody,
+    ThreadStarterBody: previousTimestamp ? undefined : threadStarterBody,
     ThreadLabel: threadLabel,
     Timestamp: resolveTimestampMs(message.timestamp),
     ...mediaPayload,


### PR DESCRIPTION
## Summary

Fixes #41355. Discord's `ThreadStarterBody` was being re-injected on every turn of a thread conversation, causing echo contamination and inflated token usage.

**Before:** `ThreadStarterBody: threadStarterBody` — set unconditionally on every inbound message in a thread.

**After:** `ThreadStarterBody: previousTimestamp ? undefined : threadStarterBody` — only set on the first turn (when no previous session timestamp exists), matching the existing Slack pattern (fixed in #32133).

## Why

The thread starter context only needs to be injected once (on the first turn) since it's already in the session transcript for subsequent turns. Re-injecting it every turn:
- Wastes tokens on every message
- Can leak `[Thread starter - for context]` markers into outbound messages
- Was already fixed for Slack (#32133) and iMessage (#33295) but missed for Discord

## Test plan

- [x] `pnpm test -- src/discord/monitor/message-handler.process.test.ts` — 20 tests pass
- [ ] Manual: start a Discord thread conversation, verify thread starter context appears on first turn only

🤖 Generated with [Claude Code](https://claude.com/claude-code)