### PR TITLE
fix(web-search): align Brave llm-context snippet type with API schema

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -272,8 +272,7 @@ type BraveSearchResponse = {
   };
 };
 
-type BraveLlmContextSnippet = { text: string };
-type BraveLlmContextResult = { url: string; title: string; snippets: BraveLlmContextSnippet[] };
+type BraveLlmContextResult = { url: string; title: string; snippets: string[] };
 type BraveLlmContextResponse = {
   grounding: { generic?: BraveLlmContextResult[] };
   sources?: { url?: string; hostname?: string; date?: string }[];
@@ -1481,7 +1480,7 @@ async function runBraveLlmContextSearch(params: {
       const mapped = genericResults.map((entry) => ({
         url: entry.url ?? "",
         title: entry.title ?? "",
-        snippets: (entry.snippets ?? []).map((s) => s.text ?? "").filter(Boolean),
+        snippets: (entry.snippets ?? []).filter(Boolean),
         siteName: resolveSiteName(entry.url) || undefined,
       }));
 

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -694,7 +694,7 @@ describe("web_search external content wrapping", () => {
     const mockFetch = installBraveLlmContextFetch({
       title: "Context title",
       url: "https://example.com/ctx",
-      snippets: [{ text: "Context chunk one" }, { text: "Context chunk two" }],
+      snippets: ["Context chunk one", "Context chunk two"],
     });
 
     const tool = createWebSearchTool({


### PR DESCRIPTION
## Summary

Fixes #41370. The Brave LLM Context API (`/res/v1/llm/context`) returns snippets as **plain strings** in an array, but the code was typed as `{ text: string }[]` and mapped via `s.text`, causing all snippets to resolve to `undefined` → empty after filtering.

**Before:**
```typescript
type BraveLlmContextSnippet = { text: string };
// ...
snippets: (entry.snippets ?? []).map((s) => s.text ?? "").filter(Boolean),
// → s.text is undefined for plain strings → all snippets empty
```

**After:**
```typescript
type BraveLlmContextResult = { url: string; title: string; snippets: string[] };
// ...
snippets: (entry.snippets ?? []).filter(Boolean),
```

## Why

The Brave LLM Context API response schema uses `grounding.generic[].snippets: string[]` (plain string arrays), not objects with a `text` field. The type mismatch meant all pre-extracted page content chunks were silently dropped, making the `llm-context` mode return empty snippets for every result.

## Test plan

- [x] `pnpm test -- src/agents/tools/web-tools.enabled-defaults.test.ts` — 43 tests pass
- [x] `pnpm tsgo` — clean typecheck
- [x] Test mock updated to match real API response format (plain strings)
- [ ] Manual: configure `tools.web.search.brave.mode: "llm-context"` and verify snippets are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)