### PR TITLE
Sandbox: avoid config barrel mock crashes in constants

### DIFF
--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { CHANNEL_IDS } from "../../channels/registry.js";
-import { STATE_DIR } from "../../config/config.js";
+import { STATE_DIR } from "../../config/paths.js";
 
 export const DEFAULT_SANDBOX_WORKSPACE_ROOT = path.join(STATE_DIR, "sandboxes");
 


### PR DESCRIPTION
## Summary
Fix a CI regression where sandbox constants import `STATE_DIR` through `config/config.ts`, which many tests partially mock.

## Changes
- import `STATE_DIR` directly from `src/config/paths.ts` in `src/agents/sandbox/constants.ts`
- keep runtime behavior unchanged while avoiding partial `config/config.js` mocks turning `STATE_DIR` into `undefined`

## Validation
- `pnpm exec vitest run src/cli/daemon-cli.coverage.test.ts src/hooks/install.test.ts src/security/fix.test.ts src/cli/program.smoke.test.ts src/slack/monitor/slash.test.ts`
- `pnpm tsgo`
- `pnpm openclaw sandbox --help`
- `pnpm openclaw daemon status --help`

## Notes
This is intended to clear the unrelated CI failures affecting #41337 and other branches based on recent `main`.
