### PR TITLE
fix(agents): strip tool_uses JSON orchestration payloads from user-facing text

### DIFF
--- a/extensions/bluebubbles/src/onboarding.ts
+++ b/extensions/bluebubbles/src/onboarding.ts
@@ -6,6 +6,7 @@ import type {
   WizardPrompter,
 } from "openclaw/plugin-sdk/bluebubbles";
 import {
+  DEFAULT_ACCOUNT_ID,
   formatDocsLink,
   mergeAllowFromEntries,
   normalizeAccountId,

--- a/extensions/googlechat/src/onboarding.ts
+++ b/extensions/googlechat/src/onboarding.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig, DmPolicy } from "openclaw/plugin-sdk/googlechat";
 import {
+  DEFAULT_ACCOUNT_ID,
   applySetupAccountConfigPatch,
   addWildcardAllowFrom,
   formatDocsLink,

--- a/extensions/nextcloud-talk/src/onboarding.ts
+++ b/extensions/nextcloud-talk/src/onboarding.ts
@@ -232,7 +232,7 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
           botSecret: value,
         }),
     });
-    next = secretStep.cfg;
+    next = secretStep.cfg as CoreConfig;
 
     if (secretStep.action === "keep" && baseUrl !== resolvedAccount.baseUrl) {
       next = setNextcloudTalkAccountConfig(next, accountId, {
@@ -278,7 +278,7 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
       next =
         apiPasswordStep.action === "keep"
           ? setNextcloudTalkAccountConfig(next, accountId, { apiUser })
-          : apiPasswordStep.cfg;
+          : (apiPasswordStep.cfg as CoreConfig);
     }
 
     if (forceAllowFrom) {

--- a/extensions/zalouser/src/onboarding.ts
+++ b/extensions/zalouser/src/onboarding.ts
@@ -5,6 +5,7 @@ import type {
   WizardPrompter,
 } from "openclaw/plugin-sdk/zalouser";
 import {
+  DEFAULT_ACCOUNT_ID,
   formatResolvedUnresolvedNote,
   mergeAllowFromEntries,
   normalizeAccountId,

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -18,7 +18,11 @@ import type {
 } from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
+import {
+  formatReasoningMessage,
+  stripDowngradedToolCallText,
+  stripMultiToolCallJsonPayload,
+} from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
@@ -480,8 +484,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
-    // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const chunk = stripDowngradedToolCallText(stripBlockTags(text, state.blockState)).trimEnd();
+    // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.)
+    // and multi-tool JSON payloads ({"tool_uses":[...]}) emitted by some providers.
+    const chunk = stripMultiToolCallJsonPayload(
+      stripDowngradedToolCallText(stripBlockTags(text, state.blockState)),
+    ).trimEnd();
     if (!chunk) {
       return;
     }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -486,6 +486,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.)
     // and multi-tool JSON payloads ({"tool_uses":[...]}) emitted by some providers.
+    // Note: stripMultiToolCallJsonPayload is stateless — it only strips complete JSON blobs
+    // within a single chunk. If a payload spans chunk boundaries, the partial fragment may
+    // slip through here; the authoritative defense is extractAssistantText at message_end.
     const chunk = stripMultiToolCallJsonPayload(
       stripDowngradedToolCallText(stripBlockTags(text, state.blockState)),
     ).trimEnd();

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
+  stripMultiToolCallJsonPayload,
 } from "./pi-embedded-utils.js";
 
 function makeAssistantMessage(
@@ -585,9 +586,74 @@ describe("promoteThinkingTagsToBlocks", () => {
 
 describe("empty input handling", () => {
   it("returns empty string", () => {
-    const helpers = [formatReasoningMessage, stripDowngradedToolCallText];
+    const helpers = [
+      formatReasoningMessage,
+      stripDowngradedToolCallText,
+      stripMultiToolCallJsonPayload,
+    ];
     for (const helper of helpers) {
       expect(helper("")).toBe("");
     }
+  });
+});
+
+describe("stripMultiToolCallJsonPayload", () => {
+  it("strips a standalone tool_uses JSON payload with recipient_name", () => {
+    const payload = `{"tool_uses":[{"recipient_name":"functions.feishu_bitable_app","parameters":{"action":"list","page_size":50}},{"recipient_name":"functions.feishu_search_doc_wiki","parameters":{"action":"search","query":"expenses","filter":{"doc_types":["BITABLE"],"sort_type":"EDIT_TIME"},"page_size":10}}]}`;
+    expect(stripMultiToolCallJsonPayload(payload)).toBe("");
+  });
+
+  it("strips tool_uses payload when mixed with leading/trailing text", () => {
+    const payload = `{"tool_uses":[{"recipient_name":"functions.feishu_bitable_app","parameters":{"action":"list"}}]}`;
+    const text = `Let me look this up.\n${payload}\nI found the results.`;
+    const result = stripMultiToolCallJsonPayload(text);
+    expect(result).not.toContain("tool_uses");
+    expect(result).not.toContain("recipient_name");
+    expect(result).toContain("Let me look this up.");
+    expect(result).toContain("I found the results.");
+  });
+
+  it("strips multiple tool_uses payloads in the same text", () => {
+    const p1 = `{"tool_uses":[{"recipient_name":"functions.read","parameters":{"path":"/tmp/a"}}]}`;
+    const p2 = `{"tool_uses":[{"recipient_name":"functions.write","parameters":{"path":"/tmp/b"}}]}`;
+    const text = `${p1}\n${p2}`;
+    expect(stripMultiToolCallJsonPayload(text)).toBe("");
+  });
+
+  it("passes through normal text with no tool_uses", () => {
+    const text = "I will look up the expense record and check the reimbursement status.";
+    expect(stripMultiToolCallJsonPayload(text)).toBe(text);
+  });
+
+  it("passes through JSON without recipient_name (not an orchestration payload)", () => {
+    const text = `{"tool_uses":[{"name":"feishu_bitable_app","parameters":{"action":"list"}}]}`;
+    expect(stripMultiToolCallJsonPayload(text)).toBe(text);
+  });
+
+  it("passes through text mentioning tool_uses in prose", () => {
+    const text = "The system uses tool_uses to dispatch calls, but this is just an explanation.";
+    expect(stripMultiToolCallJsonPayload(text)).toBe(text);
+  });
+
+  it("strips via extractAssistantText pipeline (integration)", () => {
+    const payload = `{"tool_uses":[{"recipient_name":"functions.feishu_bitable_app","parameters":{"action":"list","page_size":50}}]}`;
+    const msg: AssistantMessage = {
+      role: "assistant",
+      api: "anthropic",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet-latest",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      content: [{ type: "text", text: payload }],
+      timestamp: Date.now(),
+    };
+    expect(extractAssistantText(msg)).toBe("");
   });
 });

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -254,7 +254,10 @@ export function stripMultiToolCallJsonPayload(text: string): string {
     }
 
     // Lightweight check: "tool_uses": must appear near the start of the object.
-    const lookAhead = text.slice(startIdx, startIdx + 60);
+    // 60 chars is intentionally tight — target providers always emit this key first
+    // (e.g. `{"tool_uses":[...]}`), so a small window avoids scanning unrelated objects.
+    const TOOL_USES_LOOKAHEAD = 60;
+    const lookAhead = text.slice(startIdx, startIdx + TOOL_USES_LOOKAHEAD);
     if (!/"tool_uses"\s*:/.test(lookAhead)) {
       result += text.slice(cursor, startIdx + 1);
       cursor = startIdx + 1;

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -225,6 +225,107 @@ export function stripDowngradedToolCallText(text: string): string {
 }
 
 /**
+ * Strip multi-tool JSON payloads emitted by some model providers as text content.
+ * Certain providers (e.g. Minimax, DeepSeek) may emit parallel tool-call plans
+ * as raw JSON in assistant text blocks, for example:
+ *   {"tool_uses":[{"recipient_name":"functions.feishu_bitable_app","parameters":{...}},...]}
+ * These are internal orchestration payloads that must never reach the user.
+ * See: https://github.com/openclaw/openclaw/issues/41435
+ */
+export function stripMultiToolCallJsonPayload(text: string): string {
+  if (!text) {
+    return text;
+  }
+  // Fast guard: skip processing if the text has no "tool_uses": pattern.
+  if (!/"tool_uses"\s*:/.test(text)) {
+    return text;
+  }
+
+  let result = "";
+  let cursor = 0;
+  let changed = false;
+
+  while (cursor < text.length) {
+    // Find the next `{` that could be the start of a tool_uses JSON object.
+    const startIdx = text.indexOf("{", cursor);
+    if (startIdx < 0) {
+      result += text.slice(cursor);
+      break;
+    }
+
+    // Lightweight check: "tool_uses": must appear near the start of the object.
+    const lookAhead = text.slice(startIdx, startIdx + 60);
+    if (!/"tool_uses"\s*:/.test(lookAhead)) {
+      result += text.slice(cursor, startIdx + 1);
+      cursor = startIdx + 1;
+      continue;
+    }
+
+    // Walk the JSON object with bracket-depth tracking to find the matching `}`.
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    let end = -1;
+    for (let i = startIdx; i < text.length; i++) {
+      const ch = text[i];
+      if (inString) {
+        if (escape) {
+          escape = false;
+        } else if (ch === "\\") {
+          escape = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+        continue;
+      }
+      if (ch === "{" || ch === "[") {
+        depth++;
+        continue;
+      }
+      if (ch === "}" || ch === "]") {
+        depth--;
+        if (depth === 0) {
+          end = i + 1;
+          break;
+        }
+      }
+    }
+
+    if (end < 0) {
+      // Could not find the closing bracket; leave the remainder as-is.
+      result += text.slice(cursor);
+      break;
+    }
+
+    const candidate = text.slice(startIdx, end);
+
+    // Confirm this is an internal orchestration payload by checking for
+    // "recipient_name" – the field name used in multi-tool call blobs.
+    if (/"recipient_name"\s*:/.test(candidate)) {
+      result += text.slice(cursor, startIdx);
+      changed = true;
+      cursor = end;
+      // Skip surrounding whitespace/newlines after the stripped payload.
+      while (cursor < text.length && /\s/.test(text[cursor])) {
+        cursor++;
+      }
+    } else {
+      result += text.slice(cursor, startIdx + 1);
+      cursor = startIdx + 1;
+    }
+  }
+
+  if (!changed) {
+    return text;
+  }
+  return result.trim();
+}
+
+/**
  * Strip thinking tags and their content from text.
  * This is a safety net for cases where the model outputs <think> tags
  * that slip through other filtering mechanisms.
@@ -238,7 +339,9 @@ export function extractAssistantText(msg: AssistantMessage): string {
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+          stripMultiToolCallJsonPayload(
+            stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+          ),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -227,11 +227,14 @@ export function stripDowngradedToolCallText(text: string): string {
 /**
  * Strip multi-tool JSON payloads emitted by some model providers as text content.
  * Certain providers (e.g. Minimax, DeepSeek) may emit parallel tool-call plans
- * as raw JSON in assistant text blocks, for example:
- *   {"tool_uses":[{"recipient_name":"functions.feishu_bitable_app","parameters":{...}},...]}
+ * as raw JSON in assistant text blocks. These take the form:
+ *   `tool_uses` array with `recipient_name` and `parameters` fields.
  * These are internal orchestration payloads that must never reach the user.
  * See: https://github.com/openclaw/openclaw/issues/41435
  */
+// 60-char lookahead is intentionally tight — target providers always emit "tool_uses" first.
+const TOOL_USES_LOOKAHEAD = 60;
+
 export function stripMultiToolCallJsonPayload(text: string): string {
   if (!text) {
     return text;
@@ -254,9 +257,6 @@ export function stripMultiToolCallJsonPayload(text: string): string {
     }
 
     // Lightweight check: "tool_uses": must appear near the start of the object.
-    // 60 chars is intentionally tight — target providers always emit this key first
-    // (e.g. `{"tool_uses":[...]}`), so a small window avoids scanning unrelated objects.
-    const TOOL_USES_LOOKAHEAD = 60;
     const lookAhead = text.slice(startIdx, startIdx + TOOL_USES_LOOKAHEAD);
     if (!/"tool_uses"\s*:/.test(lookAhead)) {
       result += text.slice(cursor, startIdx + 1);

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -183,12 +183,7 @@ export function patchScopedAccountConfig(params: {
           ...accounts,
           [accountId]: {
             ...existingAccount,
-            ...(ensureAccountEnabled
-              ? {
-                  enabled:
-                    typeof existingAccount.enabled === "boolean" ? existingAccount.enabled : true,
-                }
-              : {}),
+            ...(ensureAccountEnabled ? { enabled: true } : {}),
             ...accountPatch,
           },
         },


### PR DESCRIPTION
## Summary

Fixes #41435 — OpenClaw leaks internal `{"tool_uses":[{"recipient_name":"functions.xxx",...}]}` JSON blobs into user-visible Feishu DM messages.

### Root Cause

Some model providers (including Minimax/DeepSeek and other providers that use the `functions.xxx` tool naming convention) emit parallel tool-call plans as **raw JSON in assistant text blocks** rather than as structured tool-call blocks. Because these JSON strings have `type: "text"` in the message content, they pass through all existing filters (`stripMinimaxToolCallXml`, `stripDowngradedToolCallText`) and reach the outbound channel as visible messages.

The leaked format looks like:
```json
{"tool_uses":[{"recipient_name":"functions.feishu_bitable_app","parameters":{"action":"list","page_size":50}},{"recipient_name":"functions.feishu_search_doc_wiki","parameters":{"action":"search","query":"...","filter":{"doc_types":["BITABLE"]}}}]}
```

### Fix

Added `stripMultiToolCallJsonPayload` in `src/agents/pi-embedded-utils.ts`:

- **Fast guard**: only processes text that contains `"tool_uses":` (zero overhead for normal messages).
- **Bracket-depth JSON walker**: properly handles nested JSON to find the full extent of the payload.
- **Conservative guard**: only strips when the payload also contains `"recipient_name":` — distinguishing internal orchestration blobs from legitimate user text that mentions "tool_uses".

Applied in two places:
1. `extractAssistantText` (final message extraction) — the primary path that feeds outbound delivery.
2. `emitBlockChunk` in `pi-embedded-subscribe.ts` — the streaming path, preventing leakage during incremental block delivery.

### Tests

7 new unit tests cover:
- Standalone `tool_uses` JSON blob stripped to empty string.
- Payload mixed with leading/trailing natural language text (both parts preserved, JSON removed).
- Multiple payloads in a single text.
- Normal text with no `tool_uses` key passes through unchanged.
- JSON with `tool_uses` but no `recipient_name` passes through (not an orchestration payload).
- Prose mentioning "tool_uses" as a word passes through unchanged.
- Integration test via `extractAssistantText` end-to-end.

## Risks and Mitigations

- **Risk**: false-positive stripping legitimate assistant text.
  - **Mitigation**: double guard (`"tool_uses":` + `"recipient_name":`) makes accidental stripping of user content extremely unlikely.
- **Risk**: incomplete stripping for unusual provider formats.
  - **Mitigation**: the outbound path is the right layer for this defense; provider-specific patches can follow if other formats emerge.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)