### PR TITLE
fix: preserve Anthropic OAuth beta headers for model-header context1m

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1425,6 +1425,21 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
+  it("preserves OAuth betas when context1m is configured via model headers", () => {
+    const headers = runAnthropicHeaderCase({
+      cfg: {},
+      modelId: "claude-sonnet-4-6",
+      options: {
+        apiKey: "sk-ant-oat01-test-oauth-token", // pragma: allowlist secret
+        headers: { "anthropic-beta": "context-1m-2025-08-07" },
+      },
+    });
+
+    expect(headers?.["anthropic-beta"]).toContain("oauth-2025-04-20");
+    expect(headers?.["anthropic-beta"]).toContain("claude-code-20250219");
+    expect(headers?.["anthropic-beta"]).toContain("context-1m-2025-08-07");
+  });
+
   it("ignores context1m for non-Opus/Sonnet Anthropic models", () => {
     const cfg = buildAnthropicModelConfig("anthropic/claude-haiku-3-5", { context1m: true });
     const headers = runAnthropicHeaderCase({

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -247,6 +247,9 @@ export function createAnthropicBetaHeadersWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const isOauth = isAnthropicOAuthApiKey(options?.apiKey);
+    if (!isOauth && betas.length === 0) {
+      return underlying(model, context, options);
+    }
     const requestedContext1m = betas.includes(ANTHROPIC_CONTEXT_1M_BETA);
     const effectiveBetas =
       isOauth && requestedContext1m

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -358,11 +358,13 @@ export function applyExtraParamsToAgent(
     agent.streamFn = wrappedStreamFn;
   }
 
-  const anthropicBetas = resolveAnthropicBetas(merged, provider, modelId);
-  if (anthropicBetas?.length) {
-    log.debug(
-      `applying Anthropic beta header for ${provider}/${modelId}: ${anthropicBetas.join(",")}`,
-    );
+  const anthropicBetas = resolveAnthropicBetas(merged, provider, modelId) ?? [];
+  if (provider === "anthropic") {
+    if (anthropicBetas.length) {
+      log.debug(
+        `applying Anthropic beta header for ${provider}/${modelId}: ${anthropicBetas.join(",")}`,
+      );
+    }
     agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas);
   }
 


### PR DESCRIPTION
## Summary
Preserve Anthropic OAuth-required beta headers even when `context-1m-2025-08-07` is configured via model/provider headers instead of `params.context1m`.

## Changes
- always wrap Anthropic stream calls so OAuth beta injection still runs without extra params
- keep the wrapper a no-op for non-OAuth calls when no extra Anthropic betas were requested
- add regression coverage for OAuth tokens plus model-header `anthropic-beta: context-1m-2025-08-07`

## Testing
- `pnpm exec vitest run src/agents/pi-embedded-runner-extraparams.test.ts src/gateway/sessions-patch.test.ts`

Fixes openclaw/openclaw#41444