### PR TITLE
fix(net): honor HTTP(S)_PROXY in embedded runner dispatcher

### DIFF
--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -7,8 +7,25 @@ export const PROXY_ENV_KEYS = [
   "all_proxy",
 ] as const;
 
+export const HTTP_PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "https_proxy",
+] as const;
+
 export function hasProxyEnvConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
   for (const key of PROXY_ENV_KEYS) {
+    const value = env[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasHttpProxyEnvConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  for (const key of HTTP_PROXY_ENV_KEYS) {
     const value = env[key];
     if (typeof value === "string" && value.trim().length > 0) {
       return true;

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -66,6 +66,13 @@ import {
 describe("ensureGlobalUndiciStreamTimeouts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("all_proxy", "");
     resetGlobalUndiciStreamTimeoutsForTests();
     setCurrentDispatcher(new Agent());
     getDefaultAutoSelectFamily.mockReturnValue(undefined);
@@ -104,6 +111,30 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     });
   });
 
+  it("upgrades default Agent dispatcher to EnvHttpProxyAgent when HTTP(S) proxy env is configured", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+  });
+
+  it("does not upgrade default Agent dispatcher when only ALL_PROXY is configured", () => {
+    vi.stubEnv("ALL_PROXY", "socks5://proxy.test:1080");
+
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+  });
+
   it("does not override unsupported custom proxy dispatcher types", () => {
     setCurrentDispatcher(new ProxyAgent("http://proxy.test:8080"));
 
@@ -134,5 +165,22 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
       autoSelectFamily: false,
       autoSelectFamilyAttemptTimeout: 300,
     });
+  });
+
+  it("re-applies after another subsystem replaces the env proxy dispatcher", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+
+    ensureGlobalUndiciStreamTimeouts();
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+
+    setCurrentDispatcher(new EnvHttpProxyAgent({ connect: { autoSelectFamily: false } }));
+
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
   });
 });

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,11 +1,13 @@
 import * as net from "node:net";
 import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { hasHttpProxyEnvConfigured } from "./proxy-env.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
 const AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
 
 let lastAppliedDispatcherKey: string | null = null;
+let lastAppliedDispatcher: unknown = null;
 
 type DispatcherKind = "agent" | "env-proxy" | "unsupported";
 
@@ -78,29 +80,34 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
     return;
   }
 
+  const nextKind: DispatcherKind =
+    kind === "agent" && hasHttpProxyEnvConfigured() ? "env-proxy" : kind;
+
   const autoSelectFamily = resolveAutoSelectFamily();
-  const nextKey = resolveDispatcherKey({ kind, timeoutMs, autoSelectFamily });
-  if (lastAppliedDispatcherKey === nextKey) {
+  const nextKey = resolveDispatcherKey({ kind: nextKind, timeoutMs, autoSelectFamily });
+  if (lastAppliedDispatcherKey === nextKey && lastAppliedDispatcher === dispatcher) {
     return;
   }
 
   const connect = resolveConnectOptions(autoSelectFamily);
   try {
-    if (kind === "env-proxy") {
+    if (nextKind === "env-proxy") {
       const proxyOptions = {
         bodyTimeout: timeoutMs,
         headersTimeout: timeoutMs,
         ...(connect ? { connect } : {}),
       } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
-      setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
+      const nextDispatcher = new EnvHttpProxyAgent(proxyOptions);
+      setGlobalDispatcher(nextDispatcher);
+      lastAppliedDispatcher = nextDispatcher;
     } else {
-      setGlobalDispatcher(
-        new Agent({
-          bodyTimeout: timeoutMs,
-          headersTimeout: timeoutMs,
-          ...(connect ? { connect } : {}),
-        }),
-      );
+      const nextDispatcher = new Agent({
+        bodyTimeout: timeoutMs,
+        headersTimeout: timeoutMs,
+        ...(connect ? { connect } : {}),
+      });
+      setGlobalDispatcher(nextDispatcher);
+      lastAppliedDispatcher = nextDispatcher;
     }
     lastAppliedDispatcherKey = nextKey;
   } catch {
@@ -110,4 +117,5 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 
 export function resetGlobalUndiciStreamTimeoutsForTests(): void {
   lastAppliedDispatcherKey = null;
+  lastAppliedDispatcher = null;
 }


### PR DESCRIPTION
## Summary

- Problem: `ensureGlobalUndiciStreamTimeouts()` kept a plain undici `Agent` even when `HTTP_PROXY` / `HTTPS_PROXY` were configured.
- Why it matters: embedded runner requests such as `openai-codex/gpt-5.4` could still try direct connections and time out behind HTTP proxies.
- What changed: when `HTTP_PROXY` / `HTTPS_PROXY` are present, the dispatcher now upgrades `Agent -> EnvHttpProxyAgent`, and it re-applies the extended timeouts if another subsystem replaces that global dispatcher. Tests cover the upgrade path, the re-apply path, and the `ALL_PROXY`-only non-upgrade path.
- What did NOT change (scope boundary): this PR does not add `ALL_PROXY` support and does not change Telegram-specific proxy selection logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #41046

## User-visible / Behavior Changes

- Before: embedded runner requests could still time out with `LLM request timed out` even when `HTTP_PROXY` / `HTTPS_PROXY` were set.
- After: embedded runner requests use `EnvHttpProxyAgent` when `HTTP_PROXY` / `HTTPS_PROXY` are set.
- After: if another subsystem replaces the global env-proxy dispatcher, embedded runner setup restores the extended stream timeouts on the next run.
- Out of scope: `ALL_PROXY`-only setups are unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 14.x
- Runtime/container: Node.js v24.14.0
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): Gateway-backed agent CLI
- Relevant config (redacted):
  ```json
  {
    "agents": {
      "defaults": {
        "model": {
          "primary": "openai-codex/gpt-5.4"
        }
      }
    }
  }
  ```

### Steps

1. Set `agents.defaults.model.primary` to `openai-codex/gpt-5.4`.
2. Run OpenClaw with working `HTTP_PROXY` / `HTTPS_PROXY` values.
3. Run:
   ```bash
   openclaw agent --session-id proxy-check-gpt54-gateway --message "Reply with only OK." --json --timeout 120
   ```

### Expected

- Embedded runner traffic uses the configured HTTP proxy.
- The `openai-codex/gpt-5.4` turn completes successfully.

### Actual

- Before fix: `embedded run agent end: ... error=LLM request timed out.`
- After fix: the gateway-backed agent turn completes with `status: ok` and reply `OK`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Log Before Fix

```text
warn agent/embedded {"subsystem":"agent/embedded"} embedded run agent end: runId=... isError=true error=LLM request timed out.
```

### Log / Command After Fix

```bash
$ openclaw agent --session-id proxy-check-gpt54-gateway --message "Reply with only OK." --json --timeout 120
{
  "status": "ok",
  "result": {
    "payloads": [
      {
        "text": "OK"
      }
    ]
  }
}
```

### Unit Tests

```bash
$ pnpm exec vitest run src/infra/net/undici-global-dispatcher.test.ts
✓ src/infra/net/undici-global-dispatcher.test.ts (8 tests)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `HTTP_PROXY` / `HTTPS_PROXY` configured on macOS
  - gateway-backed `openai-codex/gpt-5.4` turn succeeds
  - unit tests for dispatcher upgrade behavior pass
- Edge cases checked:
  - existing `EnvHttpProxyAgent` remains on env-proxy path
  - an externally replaced `EnvHttpProxyAgent` is re-applied with extended timeouts
  - `ALL_PROXY`-only setup does not upgrade in this PR
  - custom `ProxyAgent` remains untouched
- What you did **not** verify:
  - `ALL_PROXY` support
  - Windows
  - Docker / containerized installs
  - non-OpenAI embedded providers

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore:
  - `src/infra/net/proxy-env.ts`
  - `src/infra/net/undici-global-dispatcher.ts`
  - `src/infra/net/undici-global-dispatcher.test.ts`
- Known bad symptoms reviewers should watch for:
  - `HTTP_PROXY` / `HTTPS_PROXY` configured but embedded runner traffic still behaves like direct-connect
  - unexpected dispatcher changes when a custom proxy dispatcher is already installed

## Risks and Mitigations

- Risk: readers may assume this also fixes `ALL_PROXY`-only environments.
  - Mitigation: scope is explicitly limited in code, tests, and this PR description to `HTTP_PROXY` / `HTTPS_PROXY`.
- Risk: changing the default dispatcher path could affect embedded runner networking behavior.
  - Mitigation: the change only applies when a plain `Agent` is active and `HTTP_PROXY` / `HTTPS_PROXY` are already configured; custom proxy dispatchers remain untouched, and tests cover re-application after an external dispatcher swap.
