### PR TITLE
fix: always apply Anthropic beta headers wrapper for OAuth token support

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1348,7 +1348,7 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
-  it("does not add Anthropic 1M beta header when context1m is not enabled", () => {
+  it("injects pi-ai default betas even when context1m is not enabled", () => {
     const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", {
       temperature: 0.2,
     });
@@ -1358,7 +1358,29 @@ describe("applyExtraParamsToAgent", () => {
       options: { headers: { "X-Custom": "1" } },
     });
 
-    expect(headers).toEqual({ "X-Custom": "1" });
+    expect(headers).toEqual({
+      "X-Custom": "1",
+      "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
+    });
+  });
+
+  it("injects OAuth betas for sk-ant-oat tokens even without context1m", () => {
+    const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", {
+      temperature: 0.2,
+    });
+    const headers = runAnthropicHeaderCase({
+      cfg,
+      modelId: "claude-opus-4-6",
+      options: {
+        apiKey: "sk-ant-oat01-test-oauth-token", // pragma: allowlist secret
+        headers: { "X-Custom": "1" },
+      },
+    });
+
+    const betaHeader = headers?.["anthropic-beta"] as string;
+    expect(betaHeader).toContain("oauth-2025-04-20");
+    expect(betaHeader).toContain("claude-code-20250219");
+    expect(betaHeader).not.toContain("context-1m-2025-08-07");
   });
 
   it("skips context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
@@ -1425,14 +1447,17 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
-  it("ignores context1m for non-Opus/Sonnet Anthropic models", () => {
+  it("ignores context1m for non-Opus/Sonnet Anthropic models but still injects default betas", () => {
     const cfg = buildAnthropicModelConfig("anthropic/claude-haiku-3-5", { context1m: true });
     const headers = runAnthropicHeaderCase({
       cfg,
       modelId: "claude-haiku-3-5",
       options: { headers: { "X-Custom": "1" } },
     });
-    expect(headers).toEqual({ "X-Custom": "1" });
+    expect(headers).toEqual({
+      "X-Custom": "1",
+      "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
+    });
   });
 
   it("forces store=true for direct OpenAI Responses payloads", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -359,11 +359,12 @@ export function applyExtraParamsToAgent(
   }
 
   const anthropicBetas = resolveAnthropicBetas(merged, provider, modelId);
-  if (anthropicBetas?.length) {
-    log.debug(
-      `applying Anthropic beta header for ${provider}/${modelId}: ${anthropicBetas.join(",")}`,
-    );
-    agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas);
+  if (provider === "anthropic") {
+    const betas = anthropicBetas ?? [];
+    if (betas.length) {
+      log.debug(`applying Anthropic beta header for ${provider}/${modelId}: ${betas.join(",")}`);
+    }
+    agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, betas);
   }
 
   if (shouldApplySiliconFlowThinkingOffCompat({ provider, modelId, thinkingLevel })) {


### PR DESCRIPTION
## Summary

- Always apply `createAnthropicBetaHeadersWrapper` for Anthropic providers, not just when `resolveAnthropicBetas()` returns non-empty
- This ensures the `oauth-2025-04-20` beta is injected for OAuth tokens (`sk-ant-oat-*`) even when `context1m` is configured via model-level `headers` instead of agent extra params

## Problem

When `context-1m-2025-08-07` is set in `models.providers.anthropic.models[].headers` (model-level) rather than in `agents.defaults.models[].params.context1m` (extra params), `resolveAnthropicBetas()` returns `undefined`, so `createAnthropicBetaHeadersWrapper` is never applied. The pi-ai SDK detects the `sk-ant-oat` prefix and uses `Authorization: Bearer`, but without the required `oauth-2025-04-20` beta header, Anthropic rejects with:

```
HTTP 401 authentication_error: OAuth authentication is currently not supported.
```

The fix from #19789 correctly handles this *inside* the wrapper, but the wrapper was gated behind a non-empty betas check that prevented it from running.

## Changes

**`extra-params.ts`**: Always apply the beta headers wrapper for `provider === "anthropic"`, passing an empty array when no explicit betas are configured. The wrapper's internal OAuth detection then runs unconditionally.

**`pi-embedded-runner-extraparams.test.ts`**: Updated existing test and added new test for OAuth tokens without `context1m` configured.

## Test plan

- [x] All 67 existing tests pass
- [x] New test: OAuth betas injected for `sk-ant-oat` tokens even without `context1m`
- [x] Verified fix resolves the issue on a live deployment

Fixes #41444
Related: #19769, #19789

🤖 Generated with [Claude Code](https://claude.com/claude-code)