### PR TITLE
fix(matrix): bootstrap missing SDK before startup

### DIFF
--- a/extensions/matrix/src/matrix/client/config.install-sdk.test.ts
+++ b/extensions/matrix/src/matrix/client/config.install-sdk.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  credentialsMatchConfig: vi.fn(),
+  ensureMatrixSdkInstalled: vi.fn(),
+  ensureMatrixSdkLoggingConfigured: vi.fn(),
+  getChildLogger: vi.fn(),
+  getUserId: vi.fn(),
+  loadMatrixCredentials: vi.fn(),
+  loadMatrixSdk: vi.fn(),
+  saveMatrixCredentials: vi.fn(),
+  touchMatrixCredentials: vi.fn(),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  getMatrixRuntime: () => ({
+    config: {
+      loadConfig: vi.fn(),
+    },
+    logging: {
+      getChildLogger: mocks.getChildLogger,
+    },
+  }),
+}));
+
+vi.mock("../deps.js", () => ({
+  ensureMatrixSdkInstalled: mocks.ensureMatrixSdkInstalled,
+}));
+
+vi.mock("./logging.js", () => ({
+  ensureMatrixSdkLoggingConfigured: mocks.ensureMatrixSdkLoggingConfigured,
+}));
+
+vi.mock("../sdk-runtime.js", () => ({
+  loadMatrixSdk: mocks.loadMatrixSdk,
+}));
+
+vi.mock("../credentials.js", () => ({
+  credentialsMatchConfig: mocks.credentialsMatchConfig,
+  loadMatrixCredentials: mocks.loadMatrixCredentials,
+  saveMatrixCredentials: mocks.saveMatrixCredentials,
+  touchMatrixCredentials: mocks.touchMatrixCredentials,
+}));
+
+const { resolveMatrixAuth } = await import("./config.js");
+
+describe("resolveMatrixAuth", () => {
+  beforeEach(() => {
+    mocks.credentialsMatchConfig.mockReset();
+    mocks.ensureMatrixSdkInstalled.mockReset();
+    mocks.ensureMatrixSdkLoggingConfigured.mockReset();
+    mocks.getChildLogger.mockReset();
+    mocks.getUserId.mockReset();
+    mocks.loadMatrixCredentials.mockReset();
+    mocks.loadMatrixSdk.mockReset();
+    mocks.saveMatrixCredentials.mockReset();
+    mocks.touchMatrixCredentials.mockReset();
+
+    mocks.credentialsMatchConfig.mockReturnValue(false);
+    mocks.getChildLogger.mockReturnValue({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    });
+    mocks.loadMatrixCredentials.mockReturnValue(null);
+  });
+
+  it("installs the matrix SDK before whoami when access token auth omits userId", async () => {
+    const order: string[] = [];
+    const env: NodeJS.ProcessEnv = {};
+
+    class FakeMatrixClient {
+      constructor(_homeserver: string, _accessToken: string) {}
+
+      async getUserId() {
+        return await mocks.getUserId();
+      }
+    }
+
+    mocks.ensureMatrixSdkInstalled.mockImplementation(async () => {
+      order.push("ensure");
+    });
+    mocks.loadMatrixSdk.mockImplementation(() => {
+      order.push("load");
+      return {
+        MatrixClient: FakeMatrixClient,
+      };
+    });
+    mocks.getUserId.mockResolvedValue("@lobster:example.com");
+
+    const auth = await resolveMatrixAuth({
+      cfg: {
+        channels: {
+          matrix: {
+            homeserver: "https://matrix.example.com",
+            accessToken: "tok",
+          },
+        },
+      },
+      env,
+    });
+
+    expect(order).toEqual(["ensure", "load"]);
+    expect(mocks.ensureMatrixSdkInstalled).toHaveBeenCalledWith({
+      log: expect.any(Function),
+    });
+    expect(mocks.ensureMatrixSdkLoggingConfigured).toHaveBeenCalledTimes(1);
+    expect(mocks.saveMatrixCredentials).toHaveBeenCalledWith(
+      {
+        homeserver: "https://matrix.example.com",
+        userId: "@lobster:example.com",
+        accessToken: "tok",
+      },
+      env,
+      undefined,
+    );
+    expect(auth).toMatchObject({
+      homeserver: "https://matrix.example.com",
+      userId: "@lobster:example.com",
+      accessToken: "tok",
+    });
+  });
+});

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -6,6 +6,7 @@ import {
   normalizeSecretInputString,
 } from "../../secret-input.js";
 import type { CoreConfig } from "../../types.js";
+import { ensureMatrixSdkInstalled } from "../deps.js";
 import { loadMatrixSdk } from "../sdk-runtime.js";
 import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import type { MatrixAuth, MatrixResolvedConfig } from "./types.js";
@@ -134,6 +135,10 @@ export async function resolveMatrixAuth(params?: {
   if (resolved.accessToken) {
     let userId = resolved.userId;
     if (!userId) {
+      const logger = getMatrixRuntime().logging.getChildLogger({ plugin: "matrix" });
+      await ensureMatrixSdkInstalled({
+        log: (message) => logger.info(message),
+      });
       // Fetch userId from access token via whoami
       ensureMatrixSdkLoggingConfigured();
       const { MatrixClient } = loadMatrixSdk();

--- a/extensions/matrix/src/matrix/client/create-client.install-sdk.test.ts
+++ b/extensions/matrix/src/matrix/client/create-client.install-sdk.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureMatrixSdkInstalled: vi.fn(),
+  getChildLogger: vi.fn(),
+  loadMatrixSdk: vi.fn(),
+  mkdirSync: vi.fn(),
+  maybeMigrateLegacyStorage: vi.fn(),
+  resolveMatrixStoragePaths: vi.fn(),
+  writeStorageMeta: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  default: {
+    mkdirSync: mocks.mkdirSync,
+  },
+}));
+
+vi.mock("../../runtime.js", () => ({
+  getMatrixRuntime: () => ({
+    logging: {
+      getChildLogger: mocks.getChildLogger,
+    },
+  }),
+}));
+
+vi.mock("../deps.js", () => ({
+  ensureMatrixSdkInstalled: mocks.ensureMatrixSdkInstalled,
+}));
+
+vi.mock("../sdk-runtime.js", () => ({
+  loadMatrixSdk: mocks.loadMatrixSdk,
+}));
+
+vi.mock("./storage.js", () => ({
+  maybeMigrateLegacyStorage: mocks.maybeMigrateLegacyStorage,
+  resolveMatrixStoragePaths: mocks.resolveMatrixStoragePaths,
+  writeStorageMeta: mocks.writeStorageMeta,
+}));
+
+const { createMatrixClient } = await import("./create-client.js");
+
+describe("createMatrixClient", () => {
+  beforeEach(() => {
+    mocks.ensureMatrixSdkInstalled.mockReset();
+    mocks.getChildLogger.mockReset();
+    mocks.loadMatrixSdk.mockReset();
+    mocks.mkdirSync.mockReset();
+    mocks.maybeMigrateLegacyStorage.mockReset();
+    mocks.resolveMatrixStoragePaths.mockReset();
+    mocks.writeStorageMeta.mockReset();
+
+    mocks.getChildLogger.mockReturnValue({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    });
+    mocks.resolveMatrixStoragePaths.mockReturnValue({
+      rootDir: "/tmp/matrix-root",
+      storagePath: "/tmp/matrix-store.json",
+      cryptoPath: "/tmp/matrix-crypto",
+    });
+  });
+
+  it("ensures the matrix SDK is installed before loading it", async () => {
+    const order: string[] = [];
+
+    class FakeMatrixClient {
+      crypto = undefined;
+      constructor(
+        _homeserver: string,
+        _accessToken: string,
+        _storage?: unknown,
+        _cryptoStorage?: unknown,
+      ) {}
+    }
+
+    class FakeStorageProvider {
+      constructor(_storagePath: string) {}
+    }
+
+    class FakeCryptoStorageProvider {
+      constructor(_cryptoPath: string, _storeType: unknown) {}
+    }
+
+    class FakeConsoleLogger {
+      trace() {}
+      debug() {}
+      info() {}
+      warn() {}
+      error() {}
+    }
+
+    mocks.ensureMatrixSdkInstalled.mockImplementation(async () => {
+      order.push("ensure");
+    });
+    mocks.loadMatrixSdk.mockImplementation(() => {
+      order.push("load");
+      return {
+        MatrixClient: FakeMatrixClient,
+        SimpleFsStorageProvider: FakeStorageProvider,
+        RustSdkCryptoStorageProvider: FakeCryptoStorageProvider,
+        ConsoleLogger: FakeConsoleLogger,
+        LogService: {
+          setLogger: vi.fn(),
+          warn: vi.fn(),
+        },
+      };
+    });
+
+    await createMatrixClient({
+      homeserver: "https://matrix.example.com",
+      userId: "@lobster:example.com",
+      accessToken: "tok",
+    });
+
+    expect(order[0]).toBe("ensure");
+    expect(order.slice(1)).toEqual(["load", "load"]);
+    expect(mocks.ensureMatrixSdkInstalled).toHaveBeenCalledWith({
+      log: expect.any(Function),
+    });
+  });
+});

--- a/extensions/matrix/src/matrix/client/create-client.ts
+++ b/extensions/matrix/src/matrix/client/create-client.ts
@@ -4,6 +4,8 @@ import type {
   ICryptoStorageProvider,
   MatrixClient,
 } from "@vector-im/matrix-bot-sdk";
+import { getMatrixRuntime } from "../../runtime.js";
+import { ensureMatrixSdkInstalled } from "../deps.js";
 import { loadMatrixSdk } from "../sdk-runtime.js";
 import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import {
@@ -44,6 +46,10 @@ export async function createMatrixClient(params: {
   localTimeoutMs?: number;
   accountId?: string | null;
 }): Promise<MatrixClient> {
+  const logger = getMatrixRuntime().logging.getChildLogger({ plugin: "matrix" });
+  await ensureMatrixSdkInstalled({
+    log: (message) => logger.info(message),
+  });
   const { MatrixClient, SimpleFsStorageProvider, RustSdkCryptoStorageProvider, LogService } =
     loadMatrixSdk();
   ensureMatrixSdkLoggingConfigured();

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
-import { ensureMatrixCryptoRuntime } from "./deps.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureMatrixCryptoRuntime, ensureMatrixSdkInstalled } from "./deps.js";
 
 const logStub = vi.fn();
+
+beforeEach(() => {
+  logStub.mockReset();
+});
 
 describe("ensureMatrixCryptoRuntime", () => {
   it("returns immediately when matrix SDK loads", async () => {
@@ -70,5 +74,76 @@ describe("ensureMatrixCryptoRuntime", () => {
 
     expect(runCommand).not.toHaveBeenCalled();
     expect(requireFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ensureMatrixSdkInstalled", () => {
+  it("returns immediately when the matrix SDK is already available", async () => {
+    const runCommand = vi.fn();
+
+    await ensureMatrixSdkInstalled({
+      log: logStub,
+      isAvailable: () => true,
+      runCommand,
+      resolvePluginRoot: () => "/tmp/matrix",
+    });
+
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(logStub).not.toHaveBeenCalled();
+  });
+
+  it("installs the matrix SDK when missing and rechecks availability", async () => {
+    let available = false;
+    const runCommand = vi.fn(async () => {
+      available = true;
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await ensureMatrixSdkInstalled({
+      log: logStub,
+      isAvailable: () => available,
+      runCommand,
+      resolvePluginRoot: () => "/tmp/matrix",
+    });
+
+    expect(runCommand).toHaveBeenCalledWith({
+      argv: ["npm", "install", "--omit=dev", "--silent"],
+      cwd: "/tmp/matrix",
+      timeoutMs: 300_000,
+      env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    });
+    expect(logStub).toHaveBeenCalledWith("matrix: installing dependencies via npm (/tmp/matrix)…");
+  });
+
+  it("coalesces concurrent install attempts into a single command", async () => {
+    let available = false;
+    let resolveInstall: (() => void) | undefined;
+    const runCommand = vi.fn(
+      async () =>
+        await new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
+          resolveInstall = () => {
+            available = true;
+            resolve({ code: 0, stdout: "", stderr: "" });
+          };
+        }),
+    );
+
+    const first = ensureMatrixSdkInstalled({
+      log: logStub,
+      isAvailable: () => available,
+      runCommand,
+      resolvePluginRoot: () => "/tmp/matrix",
+    });
+    const second = ensureMatrixSdkInstalled({
+      log: logStub,
+      isAvailable: () => available,
+      runCommand,
+      resolvePluginRoot: () => "/tmp/matrix",
+    });
+
+    resolveInstall?.();
+    await Promise.all([first, second]);
+
+    expect(runCommand).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -2,10 +2,11 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { runPluginCommandWithTimeout, type RuntimeEnv } from "openclaw/plugin-sdk/matrix";
+import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/matrix";
 
 const MATRIX_SDK_PACKAGE = "@vector-im/matrix-bot-sdk";
 const MATRIX_CRYPTO_DOWNLOAD_HELPER = "@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js";
+let matrixSdkInstallPromise: Promise<void> | null = null;
 
 function formatCommandError(result: { stderr: string; stdout: string }): string {
   const stderr = result.stderr.trim();
@@ -88,39 +89,52 @@ export async function ensureMatrixCryptoRuntime(
 }
 
 export async function ensureMatrixSdkInstalled(params: {
-  runtime: RuntimeEnv;
+  log?: (message: string) => void;
   confirm?: (message: string) => Promise<boolean>;
+  isAvailable?: () => boolean;
+  resolvePluginRoot?: () => string;
+  runCommand?: typeof runPluginCommandWithTimeout;
 }): Promise<void> {
-  if (isMatrixSdkAvailable()) {
+  const isAvailable = params.isAvailable ?? isMatrixSdkAvailable;
+  if (isAvailable()) {
     return;
   }
-  const confirm = params.confirm;
-  if (confirm) {
-    const ok = await confirm("Matrix requires @vector-im/matrix-bot-sdk. Install now?");
-    if (!ok) {
-      throw new Error("Matrix requires @vector-im/matrix-bot-sdk (install dependencies first).");
-    }
-  }
+  if (!matrixSdkInstallPromise) {
+    matrixSdkInstallPromise = (async () => {
+      const confirm = params.confirm;
+      if (confirm) {
+        const ok = await confirm("Matrix requires @vector-im/matrix-bot-sdk. Install now?");
+        if (!ok) {
+          throw new Error(
+            "Matrix requires @vector-im/matrix-bot-sdk (install dependencies first).",
+          );
+        }
+      }
 
-  const root = resolvePluginRoot();
-  const command = fs.existsSync(path.join(root, "pnpm-lock.yaml"))
-    ? ["pnpm", "install"]
-    : ["npm", "install", "--omit=dev", "--silent"];
-  params.runtime.log?.(`matrix: installing dependencies via ${command[0]} (${root})…`);
-  const result = await runPluginCommandWithTimeout({
-    argv: command,
-    cwd: root,
-    timeoutMs: 300_000,
-    env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
-  });
-  if (result.code !== 0) {
-    throw new Error(
-      result.stderr.trim() || result.stdout.trim() || "Matrix dependency install failed.",
-    );
+      const root = (params.resolvePluginRoot ?? resolvePluginRoot)();
+      const command = fs.existsSync(path.join(root, "pnpm-lock.yaml"))
+        ? ["pnpm", "install"]
+        : ["npm", "install", "--omit=dev", "--silent"];
+      params.log?.(`matrix: installing dependencies via ${command[0]} (${root})…`);
+      const result = await (params.runCommand ?? runPluginCommandWithTimeout)({
+        argv: command,
+        cwd: root,
+        timeoutMs: 300_000,
+        env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+      });
+      if (result.code !== 0) {
+        throw new Error(
+          result.stderr.trim() || result.stdout.trim() || "Matrix dependency install failed.",
+        );
+      }
+      if (!isAvailable()) {
+        throw new Error(
+          "Matrix dependency install completed but @vector-im/matrix-bot-sdk is still missing.",
+        );
+      }
+    })().finally(() => {
+      matrixSdkInstallPromise = null;
+    });
   }
-  if (!isMatrixSdkAvailable()) {
-    throw new Error(
-      "Matrix dependency install completed but @vector-im/matrix-bot-sdk is still missing.",
-    );
-  }
+  await matrixSdkInstallPromise;
 }

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -200,7 +200,7 @@ export const matrixOnboardingAdapter: ChannelOnboardingAdapter = {
   configure: async ({ cfg, runtime, prompter, forceAllowFrom }) => {
     let next = cfg as CoreConfig;
     await ensureMatrixSdkInstalled({
-      runtime,
+      log: runtime.log,
       confirm: async (message) =>
         await prompter.confirm({
           message,


### PR DESCRIPTION
## Summary
- auto-install `@vector-im/matrix-bot-sdk` before Matrix startup paths call `loadMatrixSdk()`
- coalesce concurrent SDK install attempts so crash-looping startup paths do not spawn duplicate installs
- add regression tests for both `createMatrixClient()` and the access-token `resolveMatrixAuth()` whoami path

## Testing
- `corepack pnpm exec vitest run extensions/matrix/src/matrix/deps.test.ts extensions/matrix/src/matrix/client/create-client.install-sdk.test.ts extensions/matrix/src/matrix/client/config.install-sdk.test.ts extensions/matrix/src/matrix/client.test.ts`

## AI disclosure
- This PR was prepared with AI assistance. I reviewed the changes locally and ran the targeted Matrix test suite above.

Fixes #41431