### PR TITLE
fix(fallback): treat http 499 as transient

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -69,6 +69,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
     // Keep the status-only path behavior-preserving and conservative.
+    expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
@@ -87,6 +88,12 @@ describe("failover-error", () => {
         message: OPENAI_RATE_LIMIT_MESSAGE,
       }),
     ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 499,
+        message: ANTHROPIC_OVERLOADED_PAYLOAD,
+      }),
+    ).toBe("overloaded");
     expect(
       resolveFailoverReasonFromError({
         status: 529,

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -443,6 +443,7 @@ describe("isLikelyContextOverflowError", () => {
 
 describe("isTransientHttpError", () => {
   it("returns true for retryable 5xx status codes", () => {
+    expect(isTransientHttpError("499 Client Closed Request")).toBe(true);
     expect(isTransientHttpError("500 Internal Server Error")).toBe(true);
     expect(isTransientHttpError("502 Bad Gateway")).toBe(true);
     expect(isTransientHttpError("503 Service Unavailable")).toBe(true);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -189,7 +189,7 @@ const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
-const TRANSIENT_HTTP_ERROR_CODES = new Set([500, 502, 503, 504, 521, 522, 523, 524, 529]);
+const TRANSIENT_HTTP_ERROR_CODES = new Set([499, 500, 502, 503, 504, 521, 522, 523, 524, 529]);
 const HTTP_ERROR_HINTS = [
   "error",
   "bad request",
@@ -370,6 +370,12 @@ export function classifyFailoverReasonFromHttpStatus(
     return "timeout";
   }
   if (status === 503) {
+    if (message && isOverloadedErrorMessage(message)) {
+      return "overloaded";
+    }
+    return "timeout";
+  }
+  if (status === 499) {
     if (message && isOverloadedErrorMessage(message)) {
       return "overloaded";
     }


### PR DESCRIPTION
## Summary
- add HTTP 499 to the transient HTTP error set used by raw-text failover classification
- treat structured `status: 499` errors as transient so model fallback triggers reliably
- preserve `overloaded` when a 499 payload explicitly matches the existing overload heuristics

Note: current `main` already includes HTTP 504 in `TRANSIENT_HTTP_ERROR_CODES`; this PR closes the remaining 499 gap from #41467.

## Testing
- `corepack pnpm exec vitest run src/agents/failover-error.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `corepack pnpm exec oxlint --type-aware src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts`

## AI disclosure
- This PR was prepared with AI assistance. I reviewed the changes locally and ran the targeted tests and lint command above.

Fixes #41467