### PR TITLE
fix(subagents): align /agents with spawn allowlists

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -207,6 +207,42 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     });
   });
 
+  it("sessions_spawn ignores tools.agentToAgent.enabled when subagent allowlist permits the target", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: {
+              allowAgents: ["*"],
+            },
+          },
+          {
+            id: "ssh-agent",
+          },
+        ],
+      },
+      tools: {
+        agentToAgent: {
+          enabled: false,
+        },
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5300);
+
+    const result = await executeSpawn("call-agent-to-agent-disabled", "ssh-agent");
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(getChildSessionKey()?.startsWith("agent:ssh-agent:subagent:")).toBe(true);
+  });
+
   it("forbids sandboxed cross-agent spawns that would unsandbox the child", async () => {
     setResearchUnsandboxedConfig({ includeSandboxedDefault: true });
 

--- a/src/agents/subagent-allowlist.ts
+++ b/src/agents/subagent-allowlist.ts
@@ -1,0 +1,73 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { listAgentEntries, resolveAgentConfig } from "./agent-scope.js";
+
+export type AllowedSubagentTarget = {
+  id: string;
+  name?: string;
+  configured: boolean;
+};
+
+export type ResolvedSubagentAllowlist = {
+  requester: string;
+  allowAny: boolean;
+  crossAgentIds: string[];
+  agents: AllowedSubagentTarget[];
+};
+
+export function resolveAllowedSubagentTargets(params: {
+  cfg: OpenClawConfig;
+  requesterAgentId?: string | null;
+}): ResolvedSubagentAllowlist {
+  const requesterAgentId = normalizeAgentId(params.requesterAgentId ?? DEFAULT_AGENT_ID);
+  const allowAgents =
+    resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+  const allowAny = allowAgents.some((value) => value.trim() === "*");
+  const crossAgentIds = Array.from(
+    new Set(
+      allowAgents
+        .filter((value) => value.trim() && value.trim() !== "*")
+        .map((value) => normalizeAgentId(value)),
+    ),
+  );
+
+  const configuredIds = new Set<string>();
+  const configuredNameMap = new Map<string, string>();
+  for (const entry of listAgentEntries(params.cfg)) {
+    const id = normalizeAgentId(entry.id);
+    configuredIds.add(id);
+    const name = entry?.name?.trim() ?? "";
+    if (name && !configuredNameMap.has(id)) {
+      configuredNameMap.set(id, name);
+    }
+  }
+
+  const allowed = new Set<string>([requesterAgentId]);
+  if (allowAny) {
+    for (const id of configuredIds) {
+      allowed.add(id);
+    }
+  } else {
+    for (const id of crossAgentIds) {
+      allowed.add(id);
+    }
+  }
+
+  const orderedIds = [
+    requesterAgentId,
+    ...Array.from(allowed)
+      .filter((id) => id !== requesterAgentId)
+      .toSorted((a, b) => a.localeCompare(b)),
+  ];
+
+  return {
+    requester: requesterAgentId,
+    allowAny,
+    crossAgentIds,
+    agents: orderedIds.map((id) => ({
+      id,
+      name: configuredNameMap.get(id),
+      configured: configuredIds.has(id),
+    })),
+  };
+}

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -21,6 +21,7 @@ import {
   normalizeSpawnedRunMetadata,
   resolveSpawnedWorkspaceInheritance,
 } from "./spawned-context.js";
+import { resolveAllowedSubagentTargets } from "./subagent-allowlist.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
 import {
   decodeStrictBase64,
@@ -335,16 +336,13 @@ export async function spawnSubagentDirect(
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
-    const allowAny = allowAgents.some((value) => value.trim() === "*");
-    const normalizedTargetId = targetAgentId.toLowerCase();
-    const allowSet = new Set(
-      allowAgents
-        .filter((value) => value.trim() && value.trim() !== "*")
-        .map((value) => normalizeAgentId(value).toLowerCase()),
-    );
-    if (!allowAny && !allowSet.has(normalizedTargetId)) {
-      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+    const allowedTargets = resolveAllowedSubagentTargets({
+      cfg,
+      requesterAgentId,
+    });
+    if (!allowedTargets.allowAny && !allowedTargets.crossAgentIds.includes(targetAgentId)) {
+      const allowedText =
+        allowedTargets.crossAgentIds.length > 0 ? allowedTargets.crossAgentIds.join(", ") : "none";
       return {
         status: "forbidden",
         error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -5,18 +5,12 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
-import { resolveAgentConfig } from "../agent-scope.js";
+import { resolveAllowedSubagentTargets } from "../subagent-allowlist.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
 
 const AgentsListToolSchema = Type.Object({});
-
-type AgentListEntry = {
-  id: string;
-  name?: string;
-  configured: boolean;
-};
 
 export function createAgentsListTool(opts?: {
   agentSessionKey?: string;
@@ -45,54 +39,7 @@ export function createAgentsListTool(opts?: {
           parseAgentSessionKey(requesterInternalKey)?.agentId ??
           DEFAULT_AGENT_ID,
       );
-
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
-      const allowAny = allowAgents.some((value) => value.trim() === "*");
-      const allowSet = new Set(
-        allowAgents
-          .filter((value) => value.trim() && value.trim() !== "*")
-          .map((value) => normalizeAgentId(value)),
-      );
-
-      const configuredAgents = Array.isArray(cfg.agents?.list) ? cfg.agents?.list : [];
-      const configuredIds = configuredAgents.map((entry) => normalizeAgentId(entry.id));
-      const configuredNameMap = new Map<string, string>();
-      for (const entry of configuredAgents) {
-        const name = entry?.name?.trim() ?? "";
-        if (!name) {
-          continue;
-        }
-        configuredNameMap.set(normalizeAgentId(entry.id), name);
-      }
-
-      const allowed = new Set<string>();
-      allowed.add(requesterAgentId);
-      if (allowAny) {
-        for (const id of configuredIds) {
-          allowed.add(id);
-        }
-      } else {
-        for (const id of allowSet) {
-          allowed.add(id);
-        }
-      }
-
-      const all = Array.from(allowed);
-      const rest = all
-        .filter((id) => id !== requesterAgentId)
-        .toSorted((a, b) => a.localeCompare(b));
-      const ordered = [requesterAgentId, ...rest];
-      const agents: AgentListEntry[] = ordered.map((id) => ({
-        id,
-        name: configuredNameMap.get(id),
-        configured: configuredIds.includes(id),
-      }));
-
-      return jsonResult({
-        requester: requesterAgentId,
-        allowAny,
-        agents,
-      });
+      return jsonResult(resolveAllowedSubagentTargets({ cfg, requesterAgentId }));
     },
   };
 }

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -377,7 +377,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "agents",
       nativeName: "agents",
-      description: "List thread-bound agents for this session.",
+      description: "List available spawn targets and active bindings for this session.",
       textAlias: "/agents",
       category: "management",
     }),

--- a/src/auto-reply/reply/commands-subagents-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-focus.test.ts
@@ -360,6 +360,58 @@ describe("/focus, /unfocus, /agents", () => {
     expect(text).not.toContain("default:tg-1");
   });
 
+  it("/agents lists the requester agent when no bindings exist", async () => {
+    const result = await handleSubagentsCommand(createDiscordCommandParams("/agents"), true);
+    const text = result?.reply?.text ?? "";
+
+    expect(text).toContain("agents:");
+    expect(text).toContain("- main");
+    expect(text).not.toContain("(none)");
+    expect(text).not.toContain("active conversation bindings:");
+  });
+
+  it("/agents includes allowlisted custom subagents even when tools.agentToAgent is disabled", async () => {
+    const cfg = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: {
+              allowAgents: ["*"],
+            },
+          },
+          {
+            id: "ssh-agent",
+            name: "SSH Agent",
+          },
+        ],
+      },
+      tools: {
+        agentToAgent: {
+          enabled: false,
+        },
+      },
+    } satisfies OpenClawConfig;
+    const params = buildCommandTestParams("/agents", cfg, {
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "channel:parent-1",
+      AccountId: "default",
+      MessageThreadId: "thread-1",
+    });
+    params.command.senderId = "user-1";
+
+    const result = await handleSubagentsCommand(params, true);
+    const text = result?.reply?.text ?? "";
+
+    expect(text).toContain("agents:");
+    expect(text).toContain("- main");
+    expect(text).toContain("- ssh-agent (SSH Agent)");
+    expect(text).not.toContain("(none)");
+  });
+
   it("/agents keeps finished session-mode runs visible while binding remains", async () => {
     addSubagentRunForTests({
       runId: "run-session-1",

--- a/src/auto-reply/reply/commands-subagents/action-agents.ts
+++ b/src/auto-reply/reply/commands-subagents/action-agents.ts
@@ -1,4 +1,6 @@
+import { resolveAllowedSubagentTargets } from "../../../agents/subagent-allowlist.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
+import { DEFAULT_AGENT_ID, parseAgentSessionKey } from "../../../routing/session-key.js";
 import type { CommandHandlerResult } from "../commands-types.js";
 import { formatRunLabel, sortSubagentRuns } from "../subagents-utils.js";
 import {
@@ -19,6 +21,15 @@ function formatConversationBindingText(params: {
     return `conversation:${params.conversationId}`;
   }
   return `binding:${params.conversationId}`;
+}
+
+function formatAllowedAgentLine(agent: { id: string; name?: string; configured: boolean }): string {
+  const nameText =
+    agent.name && agent.name.trim().toLowerCase() !== agent.id.toLowerCase()
+      ? ` (${agent.name})`
+      : "";
+  const configuredText = agent.configured ? "" : " [allowlisted only]";
+  return `- ${agent.id}${nameText}${configuredText}`;
 }
 
 export function handleSubagentsAgentsAction(ctx: SubagentsCommandContext): CommandHandlerResult {
@@ -53,9 +64,21 @@ export function handleSubagentsAgentsAction(ctx: SubagentsCommandContext): Comma
   });
 
   const lines = ["agents:", "-----"];
-  if (visibleRuns.length === 0) {
+  const requesterAgentId = parseAgentSessionKey(requesterKey)?.agentId ?? DEFAULT_AGENT_ID;
+  const allowedTargets = resolveAllowedSubagentTargets({
+    cfg: params.cfg,
+    requesterAgentId,
+  }).agents;
+  if (allowedTargets.length === 0) {
     lines.push("(none)");
   } else {
+    for (const agent of allowedTargets) {
+      lines.push(formatAllowedAgentLine(agent));
+    }
+  }
+
+  if (visibleRuns.length > 0) {
+    lines.push("", "active conversation bindings:", "-----");
     let index = 1;
     for (const entry of visibleRuns) {
       const binding = resolveSessionBindings(entry.childSessionKey)[0];


### PR DESCRIPTION
## Summary
- share subagent allowlist resolution across `agents_list`, `sessions_spawn`, and `/agents`
- make `/agents` list available spawn targets before active conversation bindings
- add regressions covering the reported `tools.agentToAgent.enabled = false` setup for both `/agents` and `sessions_spawn`

Fixes #41463

## Testing
- `corepack pnpm exec vitest run src/agents/openclaw-tools.agents.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/auto-reply/reply/commands-subagents-focus.test.ts`
- `corepack pnpm exec oxlint --type-aware src/agents/subagent-allowlist.ts src/agents/tools/agents-list-tool.ts src/agents/subagent-spawn.ts src/auto-reply/reply/commands-subagents/action-agents.ts src/auto-reply/reply/commands-subagents-focus.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/auto-reply/commands-registry.data.ts`

## AI Usage
- AI assisted with drafting the patch and tests; I reviewed the diff and validated the targeted test and lint commands above.