### PR TITLE
fix(web): resolve account-level ackReaction and allowFrom in group gating

### DIFF
--- a/src/web/auto-reply/monitor/ack-reaction.test.ts
+++ b/src/web/auto-reply/monitor/ack-reaction.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies before imports.
+vi.mock("../../accounts.js", () => ({
+  resolveWhatsAppAccount: vi.fn(),
+}));
+vi.mock("../../outbound.js", () => ({
+  sendReactionWhatsApp: vi.fn(() => Promise.resolve(true)),
+}));
+vi.mock("../../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+vi.mock("./group-activation.js", () => ({
+  resolveGroupActivationFor: vi.fn(() => "requireMention"),
+}));
+
+import { resolveWhatsAppAccount } from "../../accounts.js";
+import { sendReactionWhatsApp } from "../../outbound.js";
+import type { WebInboundMsg } from "../types.js";
+import { maybeSendAckReaction } from "./ack-reaction.js";
+
+const mockedResolveAccount = vi.mocked(resolveWhatsAppAccount);
+const mockedSendReaction = vi.mocked(sendReactionWhatsApp);
+
+function makeMsg(overrides: Partial<WebInboundMsg> = {}): WebInboundMsg {
+  return {
+    id: "msg-1",
+    from: "+15551234567",
+    to: "+15559876543",
+    body: "hello",
+    chatId: "chat-1",
+    chatType: "direct",
+    ...overrides,
+  } as WebInboundMsg;
+}
+
+function baseCfg() {
+  return {
+    channels: {
+      whatsapp: {
+        allowFrom: ["*"],
+        ackReaction: { emoji: "👍", direct: true, group: "mentions" as const },
+      },
+    },
+  } as ReturnType<typeof import("../../../config/config.js").loadConfig>;
+}
+
+describe("maybeSendAckReaction account-level config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses account-level ackReaction when accountId is provided", () => {
+    const accountEmoji = "🎉";
+    mockedResolveAccount.mockReturnValue({
+      accountId: "acct-2",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: "/tmp/auth",
+      isLegacyAuthDir: false,
+      ackReaction: { emoji: accountEmoji, direct: true, group: "mentions" as const },
+    });
+
+    maybeSendAckReaction({
+      cfg: baseCfg(),
+      msg: makeMsg(),
+      agentId: "main",
+      sessionKey: "sess-1",
+      conversationId: "conv-1",
+      verbose: false,
+      accountId: "acct-2",
+      info: vi.fn(),
+      warn: vi.fn(),
+    });
+
+    expect(mockedResolveAccount).toHaveBeenCalledWith({
+      cfg: expect.anything(),
+      accountId: "acct-2",
+    });
+    // Should send with account-level emoji, not root-level "👍".
+    expect(mockedSendReaction).toHaveBeenCalledWith(
+      "chat-1",
+      "msg-1",
+      accountEmoji,
+      expect.objectContaining({ accountId: "acct-2" }),
+    );
+  });
+
+  it("falls back to root config when accountId is undefined", () => {
+    const rootEmoji = "👍";
+    mockedResolveAccount.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: "/tmp/auth",
+      isLegacyAuthDir: false,
+      ackReaction: { emoji: rootEmoji, direct: true, group: "mentions" as const },
+    });
+
+    maybeSendAckReaction({
+      cfg: baseCfg(),
+      msg: makeMsg(),
+      agentId: "main",
+      sessionKey: "sess-1",
+      conversationId: "conv-1",
+      verbose: false,
+      // accountId omitted — should pass undefined to resolveWhatsAppAccount.
+      info: vi.fn(),
+      warn: vi.fn(),
+    });
+
+    expect(mockedResolveAccount).toHaveBeenCalledWith({
+      cfg: expect.anything(),
+      accountId: undefined,
+    });
+    expect(mockedSendReaction).toHaveBeenCalledWith(
+      "chat-1",
+      "msg-1",
+      rootEmoji,
+      expect.objectContaining({ accountId: undefined }),
+    );
+  });
+
+  it("does not send when account-level ackReaction has empty emoji", () => {
+    mockedResolveAccount.mockReturnValue({
+      accountId: "acct-3",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: "/tmp/auth",
+      isLegacyAuthDir: false,
+      ackReaction: { emoji: "", direct: true, group: "mentions" as const },
+    });
+
+    maybeSendAckReaction({
+      cfg: baseCfg(),
+      msg: makeMsg(),
+      agentId: "main",
+      sessionKey: "sess-1",
+      conversationId: "conv-1",
+      verbose: false,
+      accountId: "acct-3",
+      info: vi.fn(),
+      warn: vi.fn(),
+    });
+
+    expect(mockedSendReaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/auto-reply/monitor/ack-reaction.ts
+++ b/src/web/auto-reply/monitor/ack-reaction.ts
@@ -1,6 +1,7 @@
 import { shouldAckReactionForWhatsApp } from "../../../channels/ack-reactions.js";
 import type { loadConfig } from "../../../config/config.js";
 import { logVerbose } from "../../../globals.js";
+import { resolveWhatsAppAccount } from "../../accounts.js";
 import { sendReactionWhatsApp } from "../../outbound.js";
 import { formatError } from "../../session.js";
 import type { WebInboundMsg } from "../types.js";
@@ -21,7 +22,9 @@ export function maybeSendAckReaction(params: {
     return;
   }
 
-  const ackConfig = params.cfg.channels?.whatsapp?.ackReaction;
+  // Resolve account-level ackReaction (falls back to root config).
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
+  const ackConfig = account.ackReaction;
   const emoji = (ackConfig?.emoji ?? "").trim();
   const directEnabled = ackConfig?.direct ?? true;
   const groupMode = ackConfig?.group ?? "mentions";

--- a/src/web/auto-reply/monitor/group-gating.account.test.ts
+++ b/src/web/auto-reply/monitor/group-gating.account.test.ts
@@ -172,4 +172,24 @@ describe("applyGroupGating account-level allowFrom", () => {
     expect(mentionConfig.allowFrom).toEqual(["+15551111111"]);
     expect(mentionConfig.allowFrom).not.toEqual(["*"]);
   });
+
+  it("does not clobber root allowFrom when account returns undefined", () => {
+    const rootAllowFrom = ["+15550000000"];
+    const mentionConfig = { mentionRegexes: [], allowFrom: rootAllowFrom };
+    mockedBuildMentionConfig.mockReturnValue(mentionConfig);
+    mockedResolveAccount.mockReturnValue({
+      accountId: "no-override-acct",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: "/tmp/auth",
+      isLegacyAuthDir: false,
+      // allowFrom is undefined — should NOT overwrite the root value.
+      allowFrom: undefined,
+    });
+
+    applyGroupGating(baseParams({ accountId: "no-override-acct" }));
+
+    // Root value should be preserved, not replaced with undefined.
+    expect(mentionConfig.allowFrom).toEqual(["+15550000000"]);
+  });
 });

--- a/src/web/auto-reply/monitor/group-gating.account.test.ts
+++ b/src/web/auto-reply/monitor/group-gating.account.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies before imports.
+vi.mock("../../accounts.js", () => ({
+  resolveWhatsAppAccount: vi.fn(),
+}));
+vi.mock("../../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+vi.mock("./group-activation.js", () => ({
+  resolveGroupActivationFor: vi.fn(() => "requireMention"),
+  resolveGroupPolicyFor: vi.fn(() => ({ allowlistEnabled: false, allowed: true })),
+}));
+vi.mock("./group-members.js", () => ({
+  noteGroupMember: vi.fn(),
+}));
+vi.mock("../../../auto-reply/command-detection.js", () => ({
+  hasControlCommand: vi.fn(() => false),
+}));
+vi.mock("../../../auto-reply/group-activation.js", () => ({
+  parseActivationCommand: vi.fn(() => ({ hasCommand: false })),
+}));
+vi.mock("../../../auto-reply/reply/history.js", () => ({
+  recordPendingHistoryEntryIfEnabled: vi.fn(),
+}));
+vi.mock("../../../channels/mention-gating.js", () => ({
+  resolveMentionGating: vi.fn(() => ({
+    shouldSkip: false,
+    effectiveWasMentioned: false,
+  })),
+}));
+vi.mock("../mentions.js", () => ({
+  buildMentionConfig: vi.fn(() => ({
+    mentionRegexes: [],
+    allowFrom: ["*"],
+  })),
+  debugMention: vi.fn(() => ({
+    wasMentioned: false,
+    details: {},
+  })),
+  resolveOwnerList: vi.fn(() => []),
+}));
+vi.mock("./commands.js", () => ({
+  stripMentionsForCommand: vi.fn((body: string) => body),
+}));
+
+import { resolveWhatsAppAccount } from "../../accounts.js";
+import { buildMentionConfig } from "../mentions.js";
+import type { WebInboundMsg } from "../types.js";
+import { applyGroupGating } from "./group-gating.js";
+
+const mockedResolveAccount = vi.mocked(resolveWhatsAppAccount);
+const mockedBuildMentionConfig = vi.mocked(buildMentionConfig);
+
+function makeGroupMsg(overrides: Partial<WebInboundMsg> = {}): WebInboundMsg {
+  return {
+    id: "msg-1",
+    from: "+15551234567",
+    to: "+15559876543",
+    body: "hello group",
+    chatId: "group-chat-1",
+    chatType: "group",
+    conversationId: "testgroup@g.us",
+    senderE164: "+15551234567",
+    senderName: "Alice",
+    ...overrides,
+  } as WebInboundMsg;
+}
+
+function baseCfg() {
+  return {
+    channels: {
+      whatsapp: {
+        allowFrom: ["*"],
+      },
+    },
+  } as ReturnType<typeof import("../../../config/config.js").loadConfig>;
+}
+
+function baseParams(overrides: Record<string, unknown> = {}) {
+  return {
+    cfg: baseCfg(),
+    msg: makeGroupMsg(),
+    conversationId: "testgroup@g.us",
+    groupHistoryKey: "whatsapp:default:group:testgroup@g.us",
+    agentId: "main",
+    sessionKey: "agent:main:whatsapp:group:testgroup@g.us",
+    baseMentionConfig: { mentionRegexes: [], allowFrom: ["*"] },
+    authDir: "/tmp/auth",
+    groupHistories: new Map(),
+    groupHistoryLimit: 50,
+    groupMemberNames: new Map(),
+    logVerbose: vi.fn(),
+    replyLogger: { debug: vi.fn() },
+    ...overrides,
+  };
+}
+
+describe("applyGroupGating account-level allowFrom", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes accountId to resolveWhatsAppAccount and overrides allowFrom", () => {
+    const accountAllowFrom = ["+15559999999"];
+    const mentionConfig = { mentionRegexes: [], allowFrom: ["*"] };
+    mockedBuildMentionConfig.mockReturnValue(mentionConfig);
+    mockedResolveAccount.mockReturnValue({
+      accountId: "acct-2",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: "/tmp/auth",
+      isLegacyAuthDir: false,
+      allowFrom: accountAllowFrom,
+    });
+
+    const result = applyGroupGating(baseParams({ accountId: "acct-2" }));
+
+    expect(mockedResolveAccount).toHaveBeenCalledWith({
+      cfg: expect.anything(),
+      accountId: "acct-2",
+    });
+    // mentionConfig.allowFrom should have been overridden with account-level value.
+    expect(mentionConfig.allowFrom).toEqual(accountAllowFrom);
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("passes undefined accountId when not provided (falls back to default)", () => {
+    const rootAllowFrom = ["*"];
+    const mentionConfig = { mentionRegexes: [], allowFrom: ["*"] };
+    mockedBuildMentionConfig.mockReturnValue(mentionConfig);
+    mockedResolveAccount.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: "/tmp/auth",
+      isLegacyAuthDir: false,
+      allowFrom: rootAllowFrom,
+    });
+
+    const result = applyGroupGating(baseParams());
+
+    expect(mockedResolveAccount).toHaveBeenCalledWith({
+      cfg: expect.anything(),
+      accountId: undefined,
+    });
+    expect(mentionConfig.allowFrom).toEqual(rootAllowFrom);
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("account-level allowFrom overrides root-level for self-chat detection", () => {
+    // Root config has allowFrom: ["*"], but account restricts to specific number.
+    const accountAllowFrom = ["+15551111111"];
+    const mentionConfig = { mentionRegexes: [], allowFrom: ["*"] };
+    mockedBuildMentionConfig.mockReturnValue(mentionConfig);
+    mockedResolveAccount.mockReturnValue({
+      accountId: "restricted-acct",
+      enabled: true,
+      sendReadReceipts: true,
+      authDir: "/tmp/auth",
+      isLegacyAuthDir: false,
+      allowFrom: accountAllowFrom,
+    });
+
+    applyGroupGating(baseParams({ accountId: "restricted-acct" }));
+
+    // The mentionConfig was mutated: root "*" replaced with account-specific value.
+    expect(mentionConfig.allowFrom).toEqual(["+15551111111"]);
+    expect(mentionConfig.allowFrom).not.toEqual(["*"]);
+  });
+});

--- a/src/web/auto-reply/monitor/group-gating.ts
+++ b/src/web/auto-reply/monitor/group-gating.ts
@@ -4,6 +4,7 @@ import { recordPendingHistoryEntryIfEnabled } from "../../../auto-reply/reply/hi
 import { resolveMentionGating } from "../../../channels/mention-gating.js";
 import type { loadConfig } from "../../../config/config.js";
 import { normalizeE164 } from "../../../utils.js";
+import { resolveWhatsAppAccount } from "../../accounts.js";
 import type { MentionConfig } from "../mentions.js";
 import { buildMentionConfig, debugMention, resolveOwnerList } from "../mentions.js";
 import type { WebInboundMsg } from "../types.js";
@@ -94,6 +95,9 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
   );
 
   const mentionConfig = buildMentionConfig(params.cfg, params.agentId);
+  // Override with account-level allowFrom for correct self-chat detection.
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
+  mentionConfig.allowFrom = account.allowFrom;
   const commandBody = stripMentionsForCommand(
     params.msg.body,
     mentionConfig.mentionRegexes,

--- a/src/web/auto-reply/monitor/group-gating.ts
+++ b/src/web/auto-reply/monitor/group-gating.ts
@@ -98,7 +98,9 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
   const mentionConfig = buildMentionConfig(params.cfg, params.agentId);
   // Override with account-level allowFrom for correct self-chat detection.
   const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
-  mentionConfig.allowFrom = account.allowFrom;
+  if (account.allowFrom != null) {
+    mentionConfig.allowFrom = account.allowFrom;
+  }
   const commandBody = stripMentionsForCommand(
     params.msg.body,
     mentionConfig.mentionRegexes,

--- a/src/web/auto-reply/monitor/group-gating.ts
+++ b/src/web/auto-reply/monitor/group-gating.ts
@@ -29,6 +29,7 @@ type ApplyGroupGatingParams = {
   sessionKey: string;
   baseMentionConfig: MentionConfig;
   authDir?: string;
+  accountId?: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
   groupHistoryLimit: number;
   groupMemberNames: Map<string, Map<string, string>>;

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -133,6 +133,7 @@ export function createWebOnMessageHandler(params: {
         sessionKey: route.sessionKey,
         baseMentionConfig: params.baseMentionConfig,
         authDir: params.account.authDir,
+        accountId: route.accountId,
         groupHistories: params.groupHistories,
         groupHistoryLimit: params.groupHistoryLimit,
         groupMemberNames: params.groupMemberNames,


### PR DESCRIPTION
## Summary

- Problem: In multi-account WhatsApp deployments, `maybeSendAckReaction` reads `ackReaction` from root config instead of the account-level override, and `buildMentionConfig` in the group-gating path reads root-level `allowFrom` for self-chat detection instead of the account-resolved value.
- Why it matters: Non-default accounts get the wrong ack reaction emoji/mode and potentially incorrect self-chat detection in group mention gating.
- What changed: Both paths now use `resolveWhatsAppAccount()` to resolve account-level config with root fallback, consistent with all other account-scoped fields.
- What did NOT change (scope boundary): No changes to `resolveWhatsAppAccount` itself, no changes to routing, session handling, or the mention regex logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #41505
- Related #28018

## User-visible / Behavior Changes

- Multi-account WhatsApp deployments now correctly use account-level `ackReaction` config (emoji, direct, group mode) instead of always using root-level config.
- Group mention gating now uses account-resolved `allowFrom` for self-chat detection, preventing incorrect mention behavior for accounts with their own allowFrom lists.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: All
- Runtime/container: Node 22+
- Integration/channel: WhatsApp (web provider)
- Relevant config: Multi-account WhatsApp with per-account ackReaction or allowFrom

### Steps

1. Configure two WhatsApp accounts with different `ackReaction` settings
2. Send a message to the non-default account
3. Observe ack reaction emoji

### Expected

- Account-level ackReaction config used for the account

### Actual

- Root-level ackReaction config used for all accounts

## Evidence

- [x] Failing test/log before + passing after
- Code inspection: `ack-reaction.ts` line 24 read `cfg.channels?.whatsapp?.ackReaction` directly; now uses `resolveWhatsAppAccount()` which resolves `accountCfg?.ackReaction ?? rootCfg?.ackReaction`
- All 86 existing web auto-reply tests pass

## Human Verification (required)

- Verified scenarios: Code path tracing confirms `resolveWhatsAppAccount` correctly resolves account-level with root fallback for both `ackReaction` and `allowFrom`
- Edge cases checked: Single-account deployments (accountId undefined) — `resolveWhatsAppAccount` falls back to root config, no behavior change
- What you did **not** verify: Live multi-account deployment (no multi-account test environment available)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: `src/web/auto-reply/monitor/ack-reaction.ts`, `src/web/auto-reply/monitor/group-gating.ts`
- Known bad symptoms reviewers should watch for: Ack reactions not sending, or unexpected mention behavior in groups

## Risks and Mitigations

- Risk: `resolveWhatsAppAccount()` adds a small overhead per ack-reaction and per group-gating call
  - Mitigation: The function is lightweight (object property lookups with fallback), already called in multiple other per-message paths