### PR TITLE
fix(cli): bootstrap unloaded launchd restart

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -176,4 +176,33 @@ describe("runServiceRestart token drift", () => {
     expect(payload.result).toBe("restarted");
     expect(payload.message).toContain("unmanaged process");
   });
+
+  it("rechecks service status after a not-loaded restart handler bootstraps the service", async () => {
+    const postRestartCheck = vi.fn(async () => {});
+    service.isLoaded.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+      onNotLoaded: async () => ({
+        result: "restarted",
+        message: "Gateway LaunchAgent was not loaded; bootstrapped from the existing plist.",
+      }),
+      postRestartCheck,
+    });
+
+    expect(postRestartCheck).toHaveBeenCalledTimes(1);
+    expect(service.restart).not.toHaveBeenCalled();
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as {
+      result?: string;
+      message?: string;
+      service?: { loaded?: boolean };
+    };
+    expect(payload.result).toBe("restarted");
+    expect(payload.message).toContain("bootstrapped");
+    expect(payload.service?.loaded).toBe(true);
+  });
 });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -409,7 +409,7 @@ export async function runServiceRestart(params: {
       await params.postRestartCheck({ json, stdout, warnings, fail });
     }
     let restarted = loaded;
-    if (loaded) {
+    if (loaded || handledNotLoaded?.result === "restarted") {
       try {
         restarted = await params.service.isLoaded({ env: process.env });
       } catch {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -152,6 +152,12 @@ describe("runDaemonRestart health checks", () => {
       healthy: true,
       portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
     });
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
     probeGateway.mockResolvedValue({
       ok: true,
       configSnapshot: { commands: { restart: true } },
@@ -278,6 +284,33 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps an installed macOS LaunchAgent when restart finds it unloaded", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    findGatewayPidsOnPortSync.mockReturnValue([]);
+    runServiceRestart.mockImplementation(
+      async (params: RestartParams & { onNotLoaded?: () => Promise<unknown> }) => {
+        await params.onNotLoaded?.();
+        await params.postRestartCheck?.({
+          json: Boolean(params.opts?.json),
+          stdout: process.stdout,
+          warnings: [],
+          fail: (message: string) => {
+            throw new Error(message);
+          },
+        });
+        return true;
+      },
+    );
+
+    await runDaemonRestart({ json: true });
+
+    expect(service.readCommand).toHaveBeenCalled();
+    expect(service.restart).toHaveBeenCalledTimes(1);
+    expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
+    expect(waitForGatewayHealthyListener).not.toHaveBeenCalled();
+    expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
   });
 
   it("fails unmanaged restart when multiple gateway listeners are present", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -180,6 +180,27 @@ async function restartGatewayWithoutServiceManager(port: number) {
   };
 }
 
+async function restartInstalledLaunchAgentWhenUnloaded(
+  service: {
+    readCommand: (env: NodeJS.ProcessEnv) => Promise<unknown>;
+    restart: (args: { env: NodeJS.ProcessEnv; stdout: NodeJS.WritableStream }) => Promise<void>;
+  },
+  stdout: NodeJS.WritableStream,
+): Promise<{ result: "restarted"; message: string } | null> {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const installed = await service.readCommand(process.env).catch(() => null);
+  if (!installed) {
+    return null;
+  }
+  await service.restart({ env: process.env, stdout });
+  return {
+    result: "restarted",
+    message: "Gateway LaunchAgent was not loaded; bootstrapped from the existing plist.",
+  };
+}
+
 export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
   return await runServiceUninstall({
     serviceNoun: "Gateway",
@@ -233,12 +254,14 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     renderStartHints: renderGatewayServiceStartHints,
     opts,
     checkTokenDrift: true,
-    onNotLoaded: async () => {
+    onNotLoaded: async (ctx) => {
+      const stdout = ctx?.stdout ?? process.stdout;
       const handled = await restartGatewayWithoutServiceManager(restartPort);
       if (handled) {
         restartedWithoutServiceManager = true;
+        return handled;
       }
-      return handled;
+      return await restartInstalledLaunchAgentWhenUnloaded(service, stdout);
     },
     postRestartCheck: async ({ warnings, fail, stdout }) => {
       if (restartedWithoutServiceManager) {


### PR DESCRIPTION
## Summary
- let `openclaw gateway restart` re-bootstrap an installed macOS LaunchAgent when the plist exists but launchd reports the service as unloaded
- keep the existing unmanaged-process restart path first, then fall back to launchd bootstrap only for installed LaunchAgents
- re-check service loaded status after a not-loaded restart handler reports success so JSON/status output reflects the real post-restart state

Fixes #41353

## Testing
- `corepack pnpm exec vitest run src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle.test.ts src/daemon/launchd.test.ts`
- `corepack pnpm exec oxlint --type-aware src/cli/daemon-cli/lifecycle-core.ts src/cli/daemon-cli/lifecycle.ts src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle.test.ts`

## AI Usage
- AI assisted with drafting the patch and tests; I reviewed the diff and validated the targeted test and lint commands above.