### PR TITLE
UI: align Control UI device auth token signing

### DIFF
--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { storeDeviceAuthToken } from "./device-auth.ts";
+import { clearDeviceAuthToken, storeDeviceAuthToken } from "./device-auth.ts";
 import type { DeviceIdentity } from "./device-identity.ts";
 
 const wsInstances = vi.hoisted((): MockWebSocket[] => []);
@@ -107,6 +107,27 @@ function getLatestWebSocket(): MockWebSocket {
   return ws;
 }
 
+type ConnectFrame = {
+  type?: string;
+  id?: string;
+  method?: string;
+  params?: { auth?: { token?: string } };
+};
+
+async function waitForConnectFrame(ws: MockWebSocket): Promise<ConnectFrame> {
+  let connectFrame: ConnectFrame | undefined;
+  await vi.waitFor(
+    () => {
+      connectFrame = ws.sent
+        .map((frame) => JSON.parse(frame) as ConnectFrame)
+        .find((frame) => frame.type === "req" && frame.method === "connect");
+      expect(connectFrame).toBeDefined();
+    },
+    { interval: 1, timeout: 250 },
+  );
+  return connectFrame!;
+}
+
 describe("GatewayBrowserClient", () => {
   beforeEach(() => {
     wsInstances.length = 0;
@@ -148,7 +169,7 @@ describe("GatewayBrowserClient", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps shared auth token separate from cached device token", async () => {
+  it("prefers cached device token over shared token when pairing is available", async () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",
       token: "shared-auth-token",
@@ -162,19 +183,35 @@ describe("GatewayBrowserClient", () => {
       event: "connect.challenge",
       payload: { nonce: "nonce-1" },
     });
-    await Promise.resolve();
-
-    const connectFrame = JSON.parse(ws.sent.at(-1) ?? "{}") as {
-      id?: string;
-      method?: string;
-      params?: { auth?: { token?: string } };
-    };
+    const connectFrame = await waitForConnectFrame(ws);
     expect(connectFrame.id).toBe("req-1");
     expect(connectFrame.method).toBe("connect");
-    expect(connectFrame.params?.auth?.token).toBe("shared-auth-token");
+    expect(connectFrame.params?.auth?.token).toBe("stored-device-token");
     expect(signDevicePayloadMock).toHaveBeenCalledWith("private-key", expect.any(String));
     const signedPayload = signDevicePayloadMock.mock.calls[0]?.[1];
     expect(signedPayload).toContain("|stored-device-token|nonce-1");
     expect(signedPayload).not.toContain("shared-auth-token");
+  });
+
+  it("uses the shared token for signing when no cached device token exists", async () => {
+    clearDeviceAuthToken({ deviceId: "device-1", role: "operator" });
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+    ws.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "nonce-1" },
+    });
+    const connectFrame = await waitForConnectFrame(ws);
+    expect(connectFrame.params?.auth?.token).toBe("shared-auth-token");
+    const signedPayload = signDevicePayloadMock.mock.calls[0]?.[1];
+    expect(signedPayload).toContain("|shared-auth-token|nonce-1");
   });
 });

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -214,6 +214,9 @@ export class GatewayBrowserClient {
         deviceId: deviceIdentity.deviceId,
         role,
       })?.token;
+      if (deviceToken) {
+        authToken = deviceToken;
+      }
       canFallbackToShared = Boolean(deviceToken && this.opts.token);
     }
     const auth =
@@ -244,7 +247,7 @@ export class GatewayBrowserClient {
         role,
         scopes,
         signedAtMs,
-        token: deviceToken ?? null,
+        token: authToken ?? null,
         nonce,
       });
       const signature = await signDevicePayload(deviceIdentity.privateKey, payload);


### PR DESCRIPTION
## Summary

- Problem: the Control UI could send the shared gateway token in the connect auth params while signing the device-auth payload with the cached device token.
- Why it matters: the gateway expects the signed token and transmitted token to align, otherwise device-auth pairing/reconnect flows can fail or behave inconsistently.
- What changed: when a cached device token exists, the Control UI now uses that token for both the outgoing auth token and the signed payload; tests also cover the cached-token and shared-token paths.
- What did NOT change (scope boundary): server-side auth rules, token issuance, and non-Control-UI gateway clients.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None.

## User-visible / Behavior Changes

- Control UI now signs device-auth connect payloads with the same token it sends to the gateway.
- If a cached device token exists, it is preferred for both auth submission and signing.
- If no cached device token exists, the shared gateway token is still used.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation:
  - This changes which existing token value is used in the Control UI connect handshake so the submitted auth token matches the signed payload. Coverage was added for both cached-token and shared-token paths.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: pnpm workspace / UI package build
- Model/provider: N/A
- Integration/channel (if any): Control UI gateway connect flow
- Relevant config (redacted): N/A

### Steps

1. Seed a cached Control UI device token for the operator role.
2. Start `GatewayBrowserClient` with a shared token and receive a `connect.challenge` nonce.
3. Observe the outgoing `connect` request and the signed device-auth payload.

### Expected

- The outgoing auth token and signed payload use the same token source.
- Cached device token is preferred when available; otherwise the shared token is used.

### Actual

- Verified by node-only UI tests and a UI production build.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:
- `pnpm --dir ui exec vitest run --config vitest.node.config.ts src/ui/gateway.node.test.ts`
- `pnpm --dir ui build`

## Human Verification (required)

- Verified scenarios:
  - Cached device token path sends `stored-device-token` and signs with that same token.
  - No cached device token path sends the shared token and signs with that same token.
- Edge cases checked:
  - Cached-token fallback to shared-token behavior remains covered when no cached token exists.
- What you did **not** verify:
  - A live browser-to-gateway Control UI session against a running gateway.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `03da43601fa122dfbf46fbdab52e2f4420888ff2`.
- Files/config to restore: `ui/src/ui/gateway.ts`, `ui/src/ui/gateway.node.test.ts`
- Known bad symptoms reviewers should watch for: Control UI connect failures or auth mismatch errors when pairing with a cached device token.

## Risks and Mitigations

- Risk: cached-token handshake behavior could diverge from previous reconnect expectations.
  - Mitigation: explicit node-only tests cover both cached-token and shared-token connect flows.
