### PR TITLE
fix(memory): add voyage-4-large to VOYAGE_MAX_INPUT_TOKENS

### DIFF
--- a/src/memory/embeddings-voyage.ts
+++ b/src/memory/embeddings-voyage.ts
@@ -14,6 +14,7 @@ export type VoyageEmbeddingClient = {
 export const DEFAULT_VOYAGE_EMBEDDING_MODEL = "voyage-4-large";
 const DEFAULT_VOYAGE_BASE_URL = "https://api.voyageai.com/v1";
 const VOYAGE_MAX_INPUT_TOKENS: Record<string, number> = {
+  "voyage-4-large": 32000,
   "voyage-3": 32000,
   "voyage-3-lite": 16000,
   "voyage-code-3": 32000,


### PR DESCRIPTION
## Summary
- The default Voyage embedding model is `voyage-4-large` (32K token context), but it was missing from `VOYAGE_MAX_INPUT_TOKENS`
- When users use the default model, the token limit lookup returns `undefined`, falling through to the generic 8192-token fallback in `resolveEmbeddingMaxInputTokens()`
- This silently truncates embeddings at ~25% of the model's actual capacity, degrading retrieval quality for longer text chunks

## Changes
- Add `"voyage-4-large": 32000` to the `VOYAGE_MAX_INPUT_TOKENS` lookup table in `embeddings-voyage.ts`

## Evidence
- [Voyage API docs](https://docs.voyageai.com/docs/embeddings): voyage-4-large context length = 32,000 tokens
- The fallback chain: `embeddings-voyage.ts` → `embedding-model-limits.ts:resolveEmbeddingMaxInputTokens()` → no match → returns 8192
- Other models (voyage-3, voyage-3-lite, voyage-code-3) are already in the lookup table

## Test plan
- [x] `npx vitest run src/memory/embeddings-voyage.test.ts` — 4 tests passed
- [x] `npx oxlint src/memory/embeddings-voyage.ts` — 0 warnings, 0 errors

lobster-biscuit
