### PR TITLE
fix(memory): update rebrand leftover in batch-voyage metadata

### DIFF
--- a/src/memory/batch-voyage.ts
+++ b/src/memory/batch-voyage.ts
@@ -89,7 +89,7 @@ async function submitVoyageBatch(params: {
         input_type: "document",
       },
       metadata: {
-        source: "clawdbot-memory",
+        source: "openclaw-memory",
         agent: params.agentId,
       },
     },


### PR DESCRIPTION
## Summary
- `batch-voyage.ts` still uses `"clawdbot-memory"` as the metadata source field in Voyage batch API requests
- `batch-openai.ts` was already updated to `"openclaw-memory"` during the project rename, but the Voyage path was missed
- This is the only remaining `"clawdbot-memory"` reference in `src/`

## Changes
- `src/memory/batch-voyage.ts`: `"clawdbot-memory"` → `"openclaw-memory"`

## Test plan
- [x] `npx vitest run src/memory/batch-voyage.test.ts` — 2 tests passed
- [x] `npx oxlint src/memory/batch-voyage.ts` — 0 warnings, 0 errors
- [x] Verified via `grep -rn "clawdbot-memory" src/` — 0 remaining hits

lobster-biscuit
