### PR TITLE
fix(googlechat,talk-voice): add fetch timeout to external HTTP calls

### DIFF
--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -79,7 +79,9 @@ async function fetchChatCerts(): Promise<Record<string, string>> {
   if (cachedCerts && now - cachedCerts.fetchedAt < 10 * 60 * 1000) {
     return cachedCerts.certs;
   }
-  const res = await fetch(CHAT_CERTS_URL);
+  const res = await fetch(CHAT_CERTS_URL, {
+    signal: AbortSignal.timeout(10_000),
+  });
   if (!res.ok) {
     throw new Error(`Failed to fetch Chat certs (${res.status})`);
   }

--- a/extensions/talk-voice/index.ts
+++ b/extensions/talk-voice/index.ts
@@ -120,7 +120,13 @@ export default function register(api: OpenClawPluginApi) {
 
       if (action === "list") {
         const limit = Number.parseInt(tokens[1] ?? "12", 10);
-        const voices = await listVoices(apiKey);
+        let voices: ElevenLabsVoice[];
+        try {
+          voices = await listVoices(apiKey);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return { text: `Failed to fetch ElevenLabs voices: ${msg}` };
+        }
         return { text: formatVoiceList(voices, Number.isFinite(limit) ? limit : 12) };
       }
 
@@ -129,7 +135,13 @@ export default function register(api: OpenClawPluginApi) {
         if (!query) {
           return { text: `Usage: ${commandLabel} set <voiceId|name>` };
         }
-        const voices = await listVoices(apiKey);
+        let voices: ElevenLabsVoice[];
+        try {
+          voices = await listVoices(apiKey);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return { text: `Failed to fetch ElevenLabs voices: ${msg}` };
+        }
         const chosen = findVoice(voices, query);
         if (!chosen) {
           const hint = isLikelyVoiceId(query) ? query : `"${query}"`;

--- a/extensions/talk-voice/index.ts
+++ b/extensions/talk-voice/index.ts
@@ -28,6 +28,7 @@ async function listVoices(apiKey: string): Promise<ElevenLabsVoice[]> {
     headers: {
       "xi-api-key": apiKey,
     },
+    signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) {
     throw new Error(`ElevenLabs voices API error (${res.status})`);


### PR DESCRIPTION
## Summary

- `fetchChatCerts()` in `extensions/googlechat/src/auth.ts` and `listVoices()` in `extensions/talk-voice/index.ts` both call `fetch()` without a timeout
- A stalled remote endpoint (Google JWKS, ElevenLabs API) can hang the process indefinitely
- Adds `AbortSignal.timeout(10_000)` to both calls, consistent with the pattern from #5926 and #6914

## Test plan

- [ ] Verify CI passes
- [ ] Confirm no existing tests break
- [ ] Manual: stalled endpoint now times out after 10s instead of hanging forever

lobster-biscuit