### PR TITLE
fix(nextcloud-talk): add fetch timeout to send and reaction POST calls

### DIFF
--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -105,17 +105,24 @@ export async function sendMessageNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${roomToken}/message`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
-    },
-    body: bodyStr,
-    signal: AbortSignal.timeout(30_000),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body: bodyStr,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Nextcloud Talk send failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");
@@ -197,17 +204,24 @@ export async function sendReactionNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${normalizedToken}/reaction/${messageId}`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
-    },
-    body,
-    signal: AbortSignal.timeout(30_000),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Nextcloud Talk reaction failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -114,6 +114,7 @@ export async function sendMessageNextcloudTalk(
       "X-Nextcloud-Talk-Bot-Signature": signature,
     },
     body: bodyStr,
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!response.ok) {
@@ -205,6 +206,7 @@ export async function sendReactionNextcloudTalk(
       "X-Nextcloud-Talk-Bot-Signature": signature,
     },
     body,
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

- `sendMessageNextcloudTalk()` and `sendReactionNextcloudTalk()` in `extensions/nextcloud-talk/src/send.ts` both call `fetch()` without a timeout
- A stalled Nextcloud server can hang the bot process indefinitely
- Adds `AbortSignal.timeout(30_000)` to both POST calls (30s for writes vs 10s for reads), consistent with the pattern from #5926 and #6914

## Test plan

- [ ] Verify CI passes
- [ ] Confirm no existing tests break
- [ ] Manual: stalled Nextcloud server now times out after 30s instead of hanging forever

lobster-biscuit