### PR TITLE
fix(restart): wait for session event queue before clearing active run

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -110,6 +110,7 @@ import {
   setActiveEmbeddedRun,
 } from "../runs.js";
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
+import { waitForAgentSessionEventQueue } from "../session-event-queue.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
@@ -2002,6 +2003,14 @@ export async function runEmbeddedAttempt(
             `CRITICAL: unsubscribe failed, possible resource leak: runId=${params.runId} ${String(err)}`,
           );
         }
+        await waitForAgentSessionEventQueue({
+          session: activeSession,
+          onTimeout: () => {
+            log.warn(
+              `timed out waiting for agent session event queue drain: runId=${params.runId} sessionId=${params.sessionId}`,
+            );
+          },
+        });
         clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }

--- a/src/agents/pi-embedded-runner/session-event-queue.test.ts
+++ b/src/agents/pi-embedded-runner/session-event-queue.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForAgentSessionEventQueue } from "./session-event-queue.js";
+
+describe("waitForAgentSessionEventQueue", () => {
+  it("waits for the queued session event work to finish", async () => {
+    const resolved: string[] = [];
+    let releaseQueue: (() => void) | undefined;
+    const queue = new Promise<void>((resolve) => {
+      releaseQueue = () => {
+        resolved.push("queue");
+        resolve();
+      };
+    });
+
+    const waitPromise = waitForAgentSessionEventQueue({
+      session: { _agentEventQueue: queue },
+      onTimeout: () => {
+        resolved.push("timeout");
+      },
+    }).then(() => {
+      resolved.push("wait");
+    });
+
+    await Promise.resolve();
+    expect(resolved).toEqual([]);
+
+    releaseQueue?.();
+    await waitPromise;
+
+    expect(resolved).toEqual(["queue", "wait"]);
+  });
+
+  it("returns immediately when no event queue is exposed", async () => {
+    await expect(
+      waitForAgentSessionEventQueue({
+        session: {},
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("times out instead of hanging forever on a stuck queue", async () => {
+    vi.useFakeTimers();
+    try {
+      const events: string[] = [];
+      const waitPromise = waitForAgentSessionEventQueue({
+        session: { _agentEventQueue: new Promise(() => {}) },
+        timeoutMs: 250,
+        onTimeout: () => {
+          events.push("timeout");
+        },
+      }).then(() => {
+        events.push("wait");
+      });
+
+      await vi.advanceTimersByTimeAsync(250);
+      await waitPromise;
+
+      expect(events).toEqual(["timeout", "wait"]);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/session-event-queue.ts
+++ b/src/agents/pi-embedded-runner/session-event-queue.ts
@@ -1,0 +1,40 @@
+const DEFAULT_EVENT_QUEUE_DRAIN_TIMEOUT_MS = 5_000;
+
+// pi-coding-agent does not expose a public "drain pending session persistence" API.
+// Its event queue is the last barrier before transcript/session writes settle.
+type AgentSessionWithEventQueue = {
+  _agentEventQueue?: Promise<unknown>;
+};
+
+export async function waitForAgentSessionEventQueue(params: {
+  session: AgentSessionWithEventQueue | null | undefined;
+  timeoutMs?: number;
+  onTimeout?: () => void;
+}): Promise<void> {
+  const queue = params.session?._agentEventQueue;
+  if (!queue || typeof queue.then !== "function") {
+    return;
+  }
+
+  const timeoutMs =
+    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+      ? Math.max(0, Math.floor(params.timeoutMs))
+      : DEFAULT_EVENT_QUEUE_DRAIN_TIMEOUT_MS;
+
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve(queue).catch(() => undefined),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(() => {
+          params.onTimeout?.();
+          resolve();
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a restart race where embedded runs could be removed from the active-run registry before the pi-coding-agent session event queue had finished draining. That let `update.run` / `gateway restart` emit `SIGUSR1` while transcript/session persistence was still settling.

## Root cause

`runEmbeddedAttempt()` cleared `ACTIVE_EMBEDDED_RUNS` in its cleanup path immediately after unsubscribing. But `AgentSession` persists transcript/session updates through its internal `_agentEventQueue`, and that queue can still be draining after the run itself looks finished.

That meant restart deferral could observe `getActiveEmbeddedRunCount() === 0` too early and restart the gateway before transcript writes had finished.

## Changes

- add `waitForAgentSessionEventQueue()` to wait for the pi-coding-agent session event queue to settle with a bounded timeout
- call that drain helper in `runEmbeddedAttempt()` before `clearActiveEmbeddedRun(...)`
- add unit coverage for the drain helper's normal, missing-queue, and timeout paths

## Testing

- `corepack pnpm exec vitest run src/agents/pi-embedded-runner/session-event-queue.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/runs.test.ts`
- `corepack pnpm exec oxlint --type-aware src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/session-event-queue.ts src/agents/pi-embedded-runner/session-event-queue.test.ts`

AI-assisted. I reviewed the changed code and ran the targeted tests and lint above locally.

Fixes #41538
