### PR TITLE
fix(agent): route explicit channel targets per recipient

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -33,6 +33,7 @@ function mockConfig(storePath: string, overrides?: Partial<OpenClawConfig>) {
         timeoutSeconds: 600,
         ...overrides?.agents?.defaults,
       },
+      list: overrides?.agents?.list,
     },
     session: {
       store: storePath,
@@ -137,5 +138,33 @@ describe("agentCliCommand", () => {
       expect(agentCommand).toHaveBeenCalledTimes(1);
       expect(runtime.log).toHaveBeenCalledWith("local");
     });
+  });
+
+  it("routes explicit channel targets to a per-recipient session key", async () => {
+    await withTempStore(
+      async () => {
+        mockGatewaySuccessReply();
+
+        await agentCliCommand(
+          {
+            message: "hi",
+            agent: "chatwoot_agent",
+            channel: "whatsapp",
+            to: "cw_111",
+          },
+          runtime,
+        );
+
+        const request = vi.mocked(callGateway).mock.calls[0]?.[0] as {
+          params?: { sessionKey?: string };
+        };
+        expect(request.params?.sessionKey).toBe("agent:chatwoot_agent:whatsapp:direct:cw_111");
+      },
+      {
+        agents: {
+          list: [{ id: "chatwoot_agent" }],
+        },
+      },
+    );
   });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -109,15 +109,16 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
     timeoutSeconds === 0
       ? NO_GATEWAY_TIMEOUT_MS // no timeout (timer-safe max)
       : Math.max(10_000, (timeoutSeconds + 30) * 1000);
+  const channel = normalizeMessageChannel(opts.channel);
 
   const sessionKey = resolveSessionKeyForRequest({
     cfg,
     agentId,
     to: opts.to,
     sessionId: opts.sessionId,
+    channel,
   }).sessionKey;
 
-  const channel = normalizeMessageChannel(opts.channel);
   const idempotencyKey = opts.runId?.trim() || randomIdempotencyKey();
 
   const response = await withProgress(

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -607,6 +607,8 @@ async function prepareAgentCommandExecution(
     sessionId: opts.sessionId,
     sessionKey: opts.sessionKey,
     agentId: agentIdOverride,
+    channel: opts.channel,
+    accountId: opts.accountId,
   });
 
   const {

--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -27,6 +27,7 @@ const { resolveSessionKeyForRequest } = await import("./session.js");
 describe("resolveSessionKeyForRequest", () => {
   const MAIN_STORE_PATH = "/tmp/main-store.json";
   const MYBOT_STORE_PATH = "/tmp/mybot-store.json";
+  const CHATWOOT_STORE_PATH = "/tmp/chatwoot-store.json";
   type SessionStoreEntry = { sessionId: string; updatedAt: number };
   type SessionStoreMap = Record<string, SessionStoreEntry>;
 
@@ -36,6 +37,21 @@ describe("resolveSessionKeyForRequest", () => {
       (_store: string | undefined, opts?: { agentId?: string }) => {
         if (opts?.agentId === "mybot") {
           return MYBOT_STORE_PATH;
+        }
+        return MAIN_STORE_PATH;
+      },
+    );
+  };
+
+  const setupAgentStorePaths = () => {
+    mocks.listAgentIds.mockReturnValue(["main", "mybot", "chatwoot_agent"]);
+    mocks.resolveStorePath.mockImplementation(
+      (_store: string | undefined, opts?: { agentId?: string }) => {
+        if (opts?.agentId === "mybot") {
+          return MYBOT_STORE_PATH;
+        }
+        if (opts?.agentId === "chatwoot_agent") {
+          return CHATWOOT_STORE_PATH;
         }
         return MAIN_STORE_PATH;
       },
@@ -158,6 +174,21 @@ describe("resolveSessionKeyForRequest", () => {
     // so the cross-store search finds it in the mybot store
     expect(result.sessionKey).toBe("agent:mybot:main");
     expect(result.storePath).toBe(MYBOT_STORE_PATH);
+  });
+
+  it("derives an isolated per-target session key when channel + to are provided", async () => {
+    setupAgentStorePaths();
+    mocks.loadSessionStore.mockReturnValue({});
+
+    const result = resolveSessionKeyForRequest({
+      cfg: baseCfg,
+      agentId: "chatwoot_agent",
+      channel: "whatsapp",
+      to: "cw_111",
+    });
+
+    expect(result.sessionKey).toBe("agent:chatwoot_agent:whatsapp:direct:cw_111");
+    expect(result.storePath).toBe(CHATWOOT_STORE_PATH);
   });
 
   it("skips already-searched primary store when iterating agents", async () => {

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -21,7 +21,17 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../../config/sessions.js";
-import { normalizeMainKey } from "../../routing/session-key.js";
+import {
+  buildAgentPeerSessionKey,
+  normalizeAgentId,
+  normalizeMainKey,
+  toAgentRequestSessionKey,
+  toAgentStoreSessionKey,
+} from "../../routing/session-key.js";
+import {
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 
 export type SessionResolution = {
   sessionId: string;
@@ -40,31 +50,80 @@ type SessionKeyResolution = {
   storePath: string;
 };
 
+function resolveDerivedSessionKey(opts: {
+  cfg: OpenClawConfig;
+  to?: string;
+  channel?: string;
+  accountId?: string | null;
+  agentId?: string;
+  mainKey: string;
+  scope: NonNullable<OpenClawConfig["session"]>["scope"] | "per-sender";
+}): string | undefined {
+  const rawTo = opts.to?.trim();
+  if (!rawTo) {
+    return undefined;
+  }
+
+  const agentId = normalizeAgentId(opts.agentId);
+  const normalizedChannel = normalizeMessageChannel(opts.channel);
+  if (normalizedChannel && isDeliverableMessageChannel(normalizedChannel)) {
+    const dmScope = opts.cfg.session?.dmScope;
+    return buildAgentPeerSessionKey({
+      agentId,
+      mainKey: opts.mainKey,
+      channel: normalizedChannel,
+      accountId: opts.accountId,
+      peerKind: "direct",
+      peerId: rawTo,
+      dmScope: dmScope && dmScope !== "main" ? dmScope : "per-channel-peer",
+    });
+  }
+
+  const ctx: MsgContext = { From: rawTo };
+  const genericSessionKey = resolveSessionKey(opts.scope, ctx, opts.mainKey);
+  const requestKey = toAgentRequestSessionKey(genericSessionKey) ?? genericSessionKey;
+  return toAgentStoreSessionKey({
+    agentId,
+    requestKey,
+    mainKey: opts.mainKey,
+  });
+}
+
 export function resolveSessionKeyForRequest(opts: {
   cfg: OpenClawConfig;
   to?: string;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
+  channel?: string;
+  accountId?: string | null;
 }): SessionKeyResolution {
   const sessionCfg = opts.cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
   const mainKey = normalizeMainKey(sessionCfg?.mainKey);
-  const explicitSessionKey =
-    opts.sessionKey?.trim() ||
-    resolveExplicitAgentSessionKey({
-      cfg: opts.cfg,
-      agentId: opts.agentId,
-    });
+  const explicitSessionKey = opts.sessionKey?.trim();
+  const fallbackAgentSessionKey = resolveExplicitAgentSessionKey({
+    cfg: opts.cfg,
+    agentId: opts.agentId,
+  });
   const storeAgentId = resolveAgentIdFromSessionKey(explicitSessionKey);
   const storePath = resolveStorePath(sessionCfg?.store, {
-    agentId: storeAgentId,
+    agentId: opts.agentId?.trim() ? normalizeAgentId(opts.agentId) : storeAgentId,
   });
   const sessionStore = loadSessionStore(storePath);
 
-  const ctx: MsgContext | undefined = opts.to?.trim() ? { From: opts.to } : undefined;
   let sessionKey: string | undefined =
-    explicitSessionKey ?? (ctx ? resolveSessionKey(scope, ctx, mainKey) : undefined);
+    explicitSessionKey ??
+    resolveDerivedSessionKey({
+      cfg: opts.cfg,
+      to: opts.to,
+      channel: opts.channel,
+      accountId: opts.accountId,
+      agentId: opts.agentId,
+      mainKey,
+      scope,
+    }) ??
+    fallbackAgentSessionKey;
 
   // If a session id was provided, prefer to re-use its entry (by id) even when no key was derived.
   if (
@@ -114,6 +173,8 @@ export function resolveSession(opts: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
+  channel?: string;
+  accountId?: string | null;
 }): SessionResolution {
   const sessionCfg = opts.cfg.session;
   const { sessionKey, sessionStore, storePath } = resolveSessionKeyForRequest({
@@ -122,6 +183,8 @@ export function resolveSession(opts: {
     sessionId: opts.sessionId,
     sessionKey: opts.sessionKey,
     agentId: opts.agentId,
+    channel: opts.channel,
+    accountId: opts.accountId,
   });
   const now = Date.now();
 


### PR DESCRIPTION
## Summary
- stop treating `--agent` as an implicit hard-pin to that agent's main session when `openclaw agent` also gets an explicit `--to` target
- derive per-recipient session keys for explicit channel targets so `--agent ... --channel ... --to ...` no longer collapses every run into `agent:<id>:main`
- thread the normalized channel through both embedded and gateway agent entrypoints, with regression coverage at the resolver and CLI->gateway layers

## Testing
- corepack pnpm exec vitest run src/commands/agent/session.test.ts src/commands/agent-via-gateway.test.ts
- corepack pnpm exec oxlint --type-aware src/commands/agent/session.ts src/commands/agent.ts src/commands/agent-via-gateway.ts src/commands/agent/session.test.ts src/commands/agent-via-gateway.test.ts

## Notes
- AI-assisted with Codex; targeted tests passed and I understand the change

Fixes #41483