### PR TITLE
hooks: avoid LLM-blocking slug path on /new,/reset and use canonical daily memory file

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -65,23 +65,15 @@ async function runNewWithPreviousSessionEntry(params: {
   previousSessionEntry: { sessionId: string; sessionFile?: string };
   cfg?: OpenClawConfig;
   action?: "new" | "reset";
-  sessionKey?: string;
-  workspaceDirOverride?: string;
 }): Promise<{ files: string[]; memoryContent: string }> {
-  const event = createHookEvent(
-    "command",
-    params.action ?? "new",
-    params.sessionKey ?? "agent:main:main",
-    {
-      cfg:
-        params.cfg ??
-        ({
-          agents: { defaults: { workspace: params.tempDir } },
-        } satisfies OpenClawConfig),
-      previousSessionEntry: params.previousSessionEntry,
-      ...(params.workspaceDirOverride ? { workspaceDir: params.workspaceDirOverride } : {}),
-    },
-  );
+  const event = createHookEvent("command", params.action ?? "new", "agent:main:main", {
+    cfg:
+      params.cfg ??
+      ({
+        agents: { defaults: { workspace: params.tempDir } },
+      } satisfies OpenClawConfig),
+    previousSessionEntry: params.previousSessionEntry,
+  });
 
   await handler(event);
 
@@ -250,42 +242,58 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Captured before reset");
   });
 
-  it("prefers workspaceDir from hook context when sessionKey points at main", async () => {
-    const mainWorkspace = await createCaseWorkspace("workspace-main");
-    const naviWorkspace = await createCaseWorkspace("workspace-navi");
-    const naviSessionsDir = path.join(naviWorkspace, "sessions");
-    await fs.mkdir(naviSessionsDir, { recursive: true });
+  it("appends multiple sessions into the same daily memory file", async () => {
+    vi.useFakeTimers();
+    try {
+      const tempDir = await createCaseWorkspace("workspace");
+      const sessionsDir = path.join(tempDir, "sessions");
+      await fs.mkdir(sessionsDir, { recursive: true });
 
-    const sessionFile = await writeWorkspaceFile({
-      dir: naviSessionsDir,
-      name: "navi-session.jsonl",
-      content: createMockSessionContent([
-        { role: "user", content: "Remember this under Navi" },
-        { role: "assistant", content: "Stored in the bound workspace" },
-      ]),
-    });
+      vi.setSystemTime(new Date("2026-03-10T00:00:00Z"));
+      const sessionFile1 = await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "s1.jsonl",
+        content: createMockSessionContent([
+          { role: "user", content: "First" },
+          { role: "assistant", content: "One" },
+        ]),
+      });
+      await runNewWithPreviousSessionEntry({
+        tempDir,
+        previousSessionEntry: { sessionId: "s1", sessionFile: sessionFile1 },
+      });
 
-    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
-      tempDir: naviWorkspace,
-      cfg: {
-        agents: {
-          defaults: { workspace: mainWorkspace },
-          list: [{ id: "navi", workspace: naviWorkspace }],
-        },
-      } satisfies OpenClawConfig,
-      sessionKey: "agent:main:main",
-      workspaceDirOverride: naviWorkspace,
-      previousSessionEntry: {
-        sessionId: "navi-session",
-        sessionFile,
-      },
-    });
+      vi.setSystemTime(new Date("2026-03-10T00:01:00Z"));
+      const sessionFile2 = await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "s2.jsonl",
+        content: createMockSessionContent([
+          { role: "user", content: "Second" },
+          { role: "assistant", content: "Two" },
+        ]),
+      });
+      await runNewWithPreviousSessionEntry({
+        tempDir,
+        previousSessionEntry: { sessionId: "s2", sessionFile: sessionFile2 },
+      });
 
-    expect(files.length).toBe(1);
-    expect(memoryContent).toContain("user: Remember this under Navi");
-    expect(memoryContent).toContain("assistant: Stored in the bound workspace");
-    expect(memoryContent).toContain("- **Session Key**: agent:navi:main");
-    await expect(fs.access(path.join(mainWorkspace, "memory"))).rejects.toThrow();
+      const memoryDir = path.join(tempDir, "memory");
+      const files = await fs.readdir(memoryDir);
+      expect(files).toEqual(["2026-03-10.md"]);
+      const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+
+      expect(memoryContent).toContain("# 2026-03-10");
+      expect(memoryContent).toContain("user: First");
+      expect(memoryContent).toContain("assistant: One");
+      expect(memoryContent).toContain("user: Second");
+      expect(memoryContent).toContain("assistant: Two");
+      expect(memoryContent).toContain("### Conversation Summary");
+
+      const sessionHeadings = (memoryContent.match(/## Session:/g) ?? []).length;
+      expect(sessionHeadings).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("filters out non-message entries (tool calls, system)", async () => {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
-import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
+import { appendFileWithinRoot } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
   parseAgentSessionKey,
@@ -319,11 +319,12 @@ const saveSessionToMemory: HookHandler = async (event) => {
       const allowLlmSlug = !isTestEnv && hookConfig?.llmSlug === true;
 
       if (sessionContent && cfg && allowLlmSlug) {
+        const envTimeoutMs = Number(process.env.OPENCLAW_SESSION_MEMORY_SLUG_TIMEOUT_MS);
+        const configTimeoutMs = (hookConfig as Record<string, unknown> | undefined)
+          ?.slugTimeoutMs as number;
         const configuredTimeoutMs =
-          Number(process.env.OPENCLAW_SESSION_MEMORY_SLUG_TIMEOUT_MS) ||
-          (typeof (hookConfig as Record<string, unknown> | undefined)?.slugTimeoutMs === "number"
-            ? ((hookConfig as Record<string, unknown>).slugTimeoutMs as number)
-            : undefined) ||
+          (Number.isFinite(envTimeoutMs) ? envTimeoutMs : undefined) ||
+          (Number.isFinite(configTimeoutMs) ? configTimeoutMs : undefined) ||
           5000;
         log.debug("Calling generateSlugViaLLM...", { timeoutMs: configuredTimeoutMs });
         const llmSlug = await generateSlugViaLLM({
@@ -369,35 +370,30 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Include conversation content if available
     if (sessionContent) {
-      entryParts.push("## Conversation Summary", "", sessionContent, "");
+      entryParts.push("### Conversation Summary", "", sessionContent, "");
     }
 
     const entry = entryParts.join("\n");
 
-    let existing = "";
-    try {
-      existing = await fs.readFile(memoryFilePath, "utf-8");
-    } catch {
-      // New daily file.
-    }
-
     const dailyHeader = `# ${dateStr}`;
-    const normalizedExisting = existing.trim();
-    const base = normalizedExisting
-      ? normalizedExisting.startsWith("# ")
-        ? normalizedExisting
-        : `${dailyHeader}\n\n${normalizedExisting}`
-      : dailyHeader;
-    const combined = `${base}\n\n${entry}`;
 
-    // Write under memory root with alias-safe file validation.
-    await writeFileWithinRoot({
+    // Append under memory root with alias-safe file validation.
+    // Use O_APPEND semantics to avoid lost updates when multiple sessions close concurrently.
+    const openResult = await appendFileWithinRoot({
       rootDir: memoryDir,
       relativePath: filename,
-      data: `${combined.trimEnd()}\n`,
+      data: "",
       encoding: "utf-8",
     });
-    log.debug("Memory file written successfully");
+    const needsHeader = openResult.createdForWrite || openResult.openedStat.size === 0;
+
+    await appendFileWithinRoot({
+      rootDir: memoryDir,
+      relativePath: filename,
+      data: needsHeader ? `${dailyHeader}\n\n${entry}\n` : `\n\n${entry}\n`,
+      encoding: "utf-8",
+    });
+    log.debug("Memory file appended successfully");
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
     const relPath = memoryFilePath.replace(os.homedir(), "~");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -26,6 +26,25 @@ import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 
+function generateLocalSlug(sessionContent: string | null): string {
+  if (!sessionContent) {
+    return "session";
+  }
+  const candidate = sessionContent
+    .toLowerCase()
+    .replace(/\b(user|assistant):/g, " ")
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter((token) => token.length >= 3)
+    .slice(0, 2)
+    .join("-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return candidate || "session";
+}
+
 const log = createSubsystemLogger("hooks/session-memory");
 
 function resolveDisplaySessionKey(params: {
@@ -288,31 +307,43 @@ const saveSessionToMemory: HookHandler = async (event) => {
         messageCount,
       });
 
-      // Avoid calling the model provider in unit tests; keep hooks fast and deterministic.
+      // /new and /reset must not depend on LLM. Use local slug by default.
+      slug = generateLocalSlug(sessionContent);
+
+      // Optional enhancement: enable LLM slug explicitly via hook config.
       const isTestEnv =
         process.env.OPENCLAW_TEST_FAST === "1" ||
         process.env.VITEST === "true" ||
         process.env.VITEST === "1" ||
         process.env.NODE_ENV === "test";
-      const allowLlmSlug = !isTestEnv && hookConfig?.llmSlug !== false;
+      const allowLlmSlug = !isTestEnv && hookConfig?.llmSlug === true;
 
       if (sessionContent && cfg && allowLlmSlug) {
-        log.debug("Calling generateSlugViaLLM...");
-        // Use LLM to generate a descriptive slug
-        slug = await generateSlugViaLLM({ sessionContent, cfg });
+        const configuredTimeoutMs =
+          Number(process.env.OPENCLAW_SESSION_MEMORY_SLUG_TIMEOUT_MS) ||
+          (typeof (hookConfig as Record<string, unknown> | undefined)?.slugTimeoutMs === "number"
+            ? ((hookConfig as Record<string, unknown>).slugTimeoutMs as number)
+            : undefined) ||
+          5000;
+        log.debug("Calling generateSlugViaLLM...", { timeoutMs: configuredTimeoutMs });
+        const llmSlug = await generateSlugViaLLM({
+          sessionContent,
+          cfg,
+          timeoutMs: configuredTimeoutMs,
+        });
+        if (llmSlug) {
+          slug = llmSlug;
+        }
         log.debug("Generated slug", { slug });
       }
     }
 
-    // If no slug, use timestamp
     if (!slug) {
-      const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
-      slug = timeSlug.slice(0, 4); // HHMM
-      log.debug("Using fallback timestamp slug", { slug });
+      slug = "session";
     }
 
-    // Create filename with date and slug
-    const filename = `${dateStr}-${slug}.md`;
+    // Canonical daily filename; avoids reader/writer mismatch (YYYY-MM-DD.md).
+    const filename = `${dateStr}.md`;
     const memoryFilePath = path.join(memoryDir, filename);
     log.debug("Memory file path resolved", {
       filename,
@@ -328,7 +359,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Build Markdown entry
     const entryParts = [
-      `# Session: ${dateStr} ${timeStr} UTC`,
+      `## Session: ${dateStr} ${timeStr} UTC (${slug})`,
       "",
       `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,
@@ -343,11 +374,27 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     const entry = entryParts.join("\n");
 
+    let existing = "";
+    try {
+      existing = await fs.readFile(memoryFilePath, "utf-8");
+    } catch {
+      // New daily file.
+    }
+
+    const dailyHeader = `# ${dateStr}`;
+    const normalizedExisting = existing.trim();
+    const base = normalizedExisting
+      ? normalizedExisting.startsWith("# ")
+        ? normalizedExisting
+        : `${dailyHeader}\n\n${normalizedExisting}`
+      : dailyHeader;
+    const combined = `${base}\n\n${entry}`;
+
     // Write under memory root with alias-safe file validation.
     await writeFileWithinRoot({
       rootDir: memoryDir,
       relativePath: filename,
-      data: entry,
+      data: `${combined.trimEnd()}\n`,
       encoding: "utf-8",
     });
     log.debug("Memory file written successfully");

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -25,6 +25,7 @@ const log = createSubsystemLogger("llm-slug-generator");
 export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
+  timeoutMs?: number;
 }): Promise<string | null> {
   let tempSessionFile: string | null = null;
 
@@ -61,7 +62,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       provider,
       model,
-      timeoutMs: 15_000, // 15 second timeout
+      timeoutMs: Math.max(500, params.timeoutMs ?? 5_000),
       runId: `slug-gen-${Date.now()}`,
     });
 

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -46,7 +46,7 @@ async function expectWriteOpenRaceIsBlocked(params: {
 async function expectSymlinkWriteRaceRejectsOutside(params: {
   slotPath: string;
   outsideDir: string;
-  runWrite: (relativePath: string) => Promise<void>;
+  runWrite: (relativePath: string) => Promise<unknown>;
 }): Promise<void> {
   const relativePath = path.join("slot", "target.txt");
   await expectWriteOpenRaceIsBlocked({

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -507,7 +507,7 @@ export async function appendFileWithinRoot(params: {
   encoding?: BufferEncoding;
   mkdir?: boolean;
   prependNewlineIfNeeded?: boolean;
-}): Promise<void> {
+}): Promise<SafeWritableOpenResult> {
   const target = await openWritableFileWithinRoot({
     rootDir: params.rootDir,
     relativePath: params.relativePath,
@@ -533,12 +533,13 @@ export async function appendFileWithinRoot(params: {
 
     if (typeof params.data === "string") {
       await target.handle.appendFile(`${prefix}${params.data}`, params.encoding ?? "utf8");
-      return;
+      return target;
     }
 
     const payload =
       prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
     await target.handle.appendFile(payload);
+    return target;
   } finally {
     await target.handle.close().catch(() => {});
   }

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -5,9 +5,9 @@ import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 import { logWarn } from "../logger.js";
 import { sameFileIdentity } from "./file-identity.js";
-import { runPinnedWriteHelper } from "./fs-pinned-write-helper.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { assertNoPathAliasEscape } from "./path-alias-guards.js";
 import {
@@ -57,10 +57,11 @@ const OPEN_WRITE_CREATE_FLAGS =
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+
 const OPEN_APPEND_EXISTING_FLAGS =
-  fsConstants.O_RDWR | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+  fsConstants.O_WRONLY | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 const OPEN_APPEND_CREATE_FLAGS =
-  fsConstants.O_RDWR |
+  fsConstants.O_WRONLY |
   fsConstants.O_APPEND |
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
@@ -332,13 +333,13 @@ async function writeTempFileForAtomicReplace(params: {
 async function verifyAtomicWriteResult(params: {
   rootDir: string;
   targetPath: string;
-  expectedIdentity: { dev: number | bigint; ino: number | bigint };
+  expectedStat: Stats;
 }): Promise<void> {
   const rootReal = await fs.realpath(params.rootDir);
   const rootWithSep = ensureTrailingSep(rootReal);
   const opened = await openVerifiedLocalFile(params.targetPath, { rejectHardlinks: true });
   try {
-    if (!sameFileIdentity(opened.stat, params.expectedIdentity)) {
+    if (!sameFileIdentity(opened.stat, params.expectedStat)) {
       throw new SafeOpenError("path-mismatch", "path changed during write");
     }
     if (!isPathInside(rootWithSep, opened.realPath)) {
@@ -383,7 +384,6 @@ export async function openWritableFileWithinRoot(params: {
   mkdir?: boolean;
   mode?: number;
   truncateExisting?: boolean;
-  append?: boolean;
 }): Promise<SafeWritableOpenResult> {
   const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot(params);
   try {
@@ -419,16 +419,14 @@ export async function openWritableFileWithinRoot(params: {
 
   let handle: FileHandle;
   let createdForWrite = false;
-  const existingFlags = params.append ? OPEN_APPEND_EXISTING_FLAGS : OPEN_WRITE_EXISTING_FLAGS;
-  const createFlags = params.append ? OPEN_APPEND_CREATE_FLAGS : OPEN_WRITE_CREATE_FLAGS;
   try {
     try {
-      handle = await fs.open(ioPath, existingFlags, fileMode);
+      handle = await fs.open(ioPath, OPEN_WRITE_EXISTING_FLAGS, fileMode);
     } catch (err) {
       if (!isNotFoundPathError(err)) {
         throw err;
       }
-      handle = await fs.open(ioPath, createFlags, fileMode);
+      handle = await fs.open(ioPath, OPEN_WRITE_CREATE_FLAGS, fileMode);
       createdForWrite = true;
     }
   } catch (err) {
@@ -480,7 +478,7 @@ export async function openWritableFileWithinRoot(params: {
 
     // Truncate only after boundary and identity checks complete. This avoids
     // irreversible side effects if a symlink target changes before validation.
-    if (params.append !== true && params.truncateExisting !== false && !createdForWrite) {
+    if (params.truncateExisting !== false && !createdForWrite) {
       await handle.truncate(0);
     }
     return {
@@ -500,240 +498,7 @@ export async function openWritableFileWithinRoot(params: {
   }
 }
 
-export async function appendFileWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-  data: string | Buffer;
-  encoding?: BufferEncoding;
-  mkdir?: boolean;
-  prependNewlineIfNeeded?: boolean;
-}): Promise<void> {
-  const target = await openWritableFileWithinRoot({
-    rootDir: params.rootDir,
-    relativePath: params.relativePath,
-    mkdir: params.mkdir,
-    truncateExisting: false,
-    append: true,
-  });
-  try {
-    let prefix = "";
-    if (
-      params.prependNewlineIfNeeded === true &&
-      !target.createdForWrite &&
-      target.openedStat.size > 0 &&
-      ((typeof params.data === "string" && !params.data.startsWith("\n")) ||
-        (Buffer.isBuffer(params.data) && params.data.length > 0 && params.data[0] !== 0x0a))
-    ) {
-      const lastByte = Buffer.alloc(1);
-      const { bytesRead } = await target.handle.read(lastByte, 0, 1, target.openedStat.size - 1);
-      if (bytesRead === 1 && lastByte[0] !== 0x0a) {
-        prefix = "\n";
-      }
-    }
-
-    if (typeof params.data === "string") {
-      await target.handle.appendFile(`${prefix}${params.data}`, params.encoding ?? "utf8");
-      return;
-    }
-
-    const payload =
-      prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
-    await target.handle.appendFile(payload);
-  } finally {
-    await target.handle.close().catch(() => {});
-  }
-}
-
 export async function writeFileWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-  data: string | Buffer;
-  encoding?: BufferEncoding;
-  mkdir?: boolean;
-}): Promise<void> {
-  if (process.platform === "win32") {
-    await writeFileWithinRootLegacy(params);
-    return;
-  }
-
-  const pinned = await resolvePinnedWriteTargetWithinRoot({
-    rootDir: params.rootDir,
-    relativePath: params.relativePath,
-  });
-
-  const identity = await runPinnedWriteHelper({
-    rootPath: pinned.rootReal,
-    relativeParentPath: pinned.relativeParentPath,
-    basename: pinned.basename,
-    mkdir: params.mkdir !== false,
-    mode: pinned.mode,
-    input: {
-      kind: "buffer",
-      data: params.data,
-      encoding: params.encoding,
-    },
-  }).catch((error) => {
-    throw normalizePinnedWriteError(error);
-  });
-
-  try {
-    await verifyAtomicWriteResult({
-      rootDir: params.rootDir,
-      targetPath: pinned.targetPath,
-      expectedIdentity: identity,
-    });
-  } catch (err) {
-    emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);
-    throw err;
-  }
-}
-
-export async function copyFileWithinRoot(params: {
-  sourcePath: string;
-  rootDir: string;
-  relativePath: string;
-  maxBytes?: number;
-  mkdir?: boolean;
-  rejectSourceHardlinks?: boolean;
-}): Promise<void> {
-  const source = await openVerifiedLocalFile(params.sourcePath, {
-    rejectHardlinks: params.rejectSourceHardlinks,
-  });
-  if (params.maxBytes !== undefined && source.stat.size > params.maxBytes) {
-    await source.handle.close().catch(() => {});
-    throw new SafeOpenError(
-      "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${source.stat.size})`,
-    );
-  }
-
-  try {
-    if (process.platform === "win32") {
-      await copyFileWithinRootLegacy(params, source);
-      return;
-    }
-
-    const pinned = await resolvePinnedWriteTargetWithinRoot({
-      rootDir: params.rootDir,
-      relativePath: params.relativePath,
-    });
-    const sourceStream = source.handle.createReadStream();
-    const identity = await runPinnedWriteHelper({
-      rootPath: pinned.rootReal,
-      relativeParentPath: pinned.relativeParentPath,
-      basename: pinned.basename,
-      mkdir: params.mkdir !== false,
-      mode: pinned.mode,
-      input: {
-        kind: "stream",
-        stream: sourceStream,
-      },
-    }).catch((error) => {
-      throw normalizePinnedWriteError(error);
-    });
-    try {
-      await verifyAtomicWriteResult({
-        rootDir: params.rootDir,
-        targetPath: pinned.targetPath,
-        expectedIdentity: identity,
-      });
-    } catch (err) {
-      emitWriteBoundaryWarning(`post-copy verification failed: ${String(err)}`);
-      throw err;
-    }
-  } finally {
-    await source.handle.close().catch(() => {});
-  }
-}
-
-export async function writeFileFromPathWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-  sourcePath: string;
-  mkdir?: boolean;
-}): Promise<void> {
-  await copyFileWithinRoot({
-    sourcePath: params.sourcePath,
-    rootDir: params.rootDir,
-    relativePath: params.relativePath,
-    mkdir: params.mkdir,
-    rejectSourceHardlinks: true,
-  });
-}
-
-async function resolvePinnedWriteTargetWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-}): Promise<{
-  rootReal: string;
-  targetPath: string;
-  relativeParentPath: string;
-  basename: string;
-  mode: number;
-}> {
-  const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot(params);
-  try {
-    await assertNoPathAliasEscape({
-      absolutePath: resolved,
-      rootPath: rootReal,
-      boundaryLabel: "root",
-    });
-  } catch (err) {
-    throw new SafeOpenError("invalid-path", "path alias escape blocked", { cause: err });
-  }
-
-  const relativeResolved = path.relative(rootReal, resolved);
-  if (relativeResolved.startsWith("..") || path.isAbsolute(relativeResolved)) {
-    throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-  }
-  const relativePosix = relativeResolved
-    ? relativeResolved.split(path.sep).join(path.posix.sep)
-    : "";
-  const basename = path.posix.basename(relativePosix);
-  if (!basename || basename === "." || basename === "/") {
-    throw new SafeOpenError("invalid-path", "invalid target path");
-  }
-  let mode = 0o600;
-  try {
-    const opened = await openFileWithinRoot({
-      rootDir: params.rootDir,
-      relativePath: params.relativePath,
-      rejectHardlinks: true,
-    });
-    try {
-      mode = opened.stat.mode & 0o777;
-      if (!isPathInside(rootWithSep, opened.realPath)) {
-        throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-      }
-    } finally {
-      await opened.handle.close().catch(() => {});
-    }
-  } catch (err) {
-    if (!(err instanceof SafeOpenError) || err.code !== "not-found") {
-      throw err;
-    }
-  }
-
-  return {
-    rootReal,
-    targetPath: resolved,
-    relativeParentPath:
-      path.posix.dirname(relativePosix) === "." ? "" : path.posix.dirname(relativePosix),
-    basename,
-    mode: mode || 0o600,
-  };
-}
-
-function normalizePinnedWriteError(error: unknown): Error {
-  if (error instanceof SafeOpenError) {
-    return error;
-  }
-  return new SafeOpenError("invalid-path", "path is not a regular file under root", {
-    cause: error instanceof Error ? error : undefined,
-  });
-}
-
-async function writeFileWithinRootLegacy(params: {
   rootDir: string;
   relativePath: string;
   data: string | Buffer;
@@ -764,7 +529,7 @@ async function writeFileWithinRootLegacy(params: {
       await verifyAtomicWriteResult({
         rootDir: params.rootDir,
         targetPath: destinationPath,
-        expectedIdentity: writtenStat,
+        expectedStat: writtenStat,
       });
     } catch (err) {
       emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);
@@ -777,17 +542,155 @@ async function writeFileWithinRootLegacy(params: {
   }
 }
 
-async function copyFileWithinRootLegacy(
-  params: {
-    sourcePath: string;
-    rootDir: string;
-    relativePath: string;
-    maxBytes?: number;
-    mkdir?: boolean;
-    rejectSourceHardlinks?: boolean;
-  },
-  source: SafeOpenResult,
-): Promise<void> {
+export async function appendFileWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  data: string | Buffer;
+  encoding?: BufferEncoding;
+  mkdir?: boolean;
+  mode?: number;
+}): Promise<{
+  createdForWrite: boolean;
+  openedRealPath: string;
+  openedStat: import("node:fs").Stats;
+}> {
+  const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot({
+    rootDir: params.rootDir,
+    relativePath: params.relativePath,
+  });
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: resolved,
+      rootPath: rootReal,
+      boundaryLabel: "root",
+    });
+  } catch (err) {
+    throw new SafeOpenError("invalid-path", "path alias escape blocked", { cause: err });
+  }
+
+  if (params.mkdir !== false) {
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+  }
+
+  let ioPath = resolved;
+  try {
+    const resolvedRealPath = await fs.realpath(resolved);
+    if (!isPathInside(rootWithSep, resolvedRealPath)) {
+      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+    }
+    ioPath = resolvedRealPath;
+  } catch (err) {
+    if (err instanceof SafeOpenError) {
+      throw err;
+    }
+    if (!isNotFoundPathError(err)) {
+      throw err;
+    }
+  }
+
+  const fileMode = params.mode ?? 0o600;
+
+  let handle: FileHandle;
+  let createdForWrite = false;
+  try {
+    try {
+      handle = await fs.open(ioPath, OPEN_APPEND_EXISTING_FLAGS, fileMode);
+    } catch (err) {
+      if (!isNotFoundPathError(err)) {
+        throw err;
+      }
+      handle = await fs.open(ioPath, OPEN_APPEND_CREATE_FLAGS, fileMode);
+      createdForWrite = true;
+    }
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new SafeOpenError("not-found", "file not found");
+    }
+    if (isSymlinkOpenError(err)) {
+      throw new SafeOpenError("invalid-path", "symlink open blocked", { cause: err });
+    }
+    throw err;
+  }
+
+  let openedRealPath: string | null = null;
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new SafeOpenError("invalid-path", "path is not a regular file under root");
+    }
+    if (stat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
+
+    try {
+      const lstat = await fs.lstat(ioPath);
+      if (lstat.isSymbolicLink() || !lstat.isFile()) {
+        throw new SafeOpenError("invalid-path", "path is not a regular file under root");
+      }
+      if (!sameFileIdentity(stat, lstat)) {
+        throw new SafeOpenError("path-mismatch", "path changed during append");
+      }
+    } catch (err) {
+      if (!isNotFoundPathError(err)) {
+        throw err;
+      }
+    }
+
+    const realPath = await resolveOpenedFileRealPathForHandle(handle, ioPath);
+    openedRealPath = realPath;
+    const realStat = await fs.stat(realPath);
+    if (!sameFileIdentity(stat, realStat)) {
+      throw new SafeOpenError("path-mismatch", "path mismatch");
+    }
+    if (realStat.nlink > 1) {
+      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+    }
+    if (!isPathInside(rootWithSep, realPath)) {
+      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+    }
+
+    if (typeof params.data === "string") {
+      await handle.writeFile(
+        params.data,
+        params.encoding ? { encoding: params.encoding } : undefined,
+      );
+    } else {
+      await handle.writeFile(params.data);
+    }
+
+    return { createdForWrite, openedRealPath: realPath, openedStat: stat };
+  } catch (err) {
+    const cleanupCreatedPath = createdForWrite && err instanceof SafeOpenError;
+    const cleanupPath = openedRealPath ?? ioPath;
+    await handle.close().catch(() => {});
+    if (cleanupCreatedPath) {
+      await fs.rm(cleanupPath, { force: true }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+export async function copyFileWithinRoot(params: {
+  sourcePath: string;
+  rootDir: string;
+  relativePath: string;
+  maxBytes?: number;
+  mkdir?: boolean;
+  rejectSourceHardlinks?: boolean;
+}): Promise<void> {
+  const source = await openVerifiedLocalFile(params.sourcePath, {
+    rejectHardlinks: params.rejectSourceHardlinks,
+  });
+  if (params.maxBytes !== undefined && source.stat.size > params.maxBytes) {
+    await source.handle.close().catch(() => {});
+    throw new SafeOpenError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${source.stat.size})`,
+    );
+  }
+
   let target: SafeWritableOpenResult | null = null;
   let sourceClosedByStream = false;
   let targetClosedByUs = false;
@@ -816,9 +719,7 @@ async function copyFileWithinRootLegacy(
     targetStream.once("close", () => {
       tempClosedByStream = true;
     });
-    await import("node:stream/promises").then(({ pipeline }) =>
-      pipeline(sourceStream, targetStream),
-    );
+    await pipeline(sourceStream, targetStream);
     const writtenStat = await fs.stat(tempPath);
     if (!tempClosedByStream) {
       await tempHandle.close().catch(() => {});
@@ -831,7 +732,7 @@ async function copyFileWithinRootLegacy(
       await verifyAtomicWriteResult({
         rootDir: params.rootDir,
         targetPath: destinationPath,
-        expectedIdentity: writtenStat,
+        expectedStat: writtenStat,
       });
     } catch (err) {
       emitWriteBoundaryWarning(`post-copy verification failed: ${String(err)}`);
@@ -856,4 +757,19 @@ async function copyFileWithinRootLegacy(
       await target.handle.close().catch(() => {});
     }
   }
+}
+
+export async function writeFileFromPathWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  sourcePath: string;
+  mkdir?: boolean;
+}): Promise<void> {
+  await copyFileWithinRoot({
+    sourcePath: params.sourcePath,
+    rootDir: params.rootDir,
+    relativePath: params.relativePath,
+    mkdir: params.mkdir,
+    rejectSourceHardlinks: true,
+  });
 }

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -5,9 +5,9 @@ import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { pipeline } from "node:stream/promises";
 import { logWarn } from "../logger.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { runPinnedWriteHelper } from "./fs-pinned-write-helper.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { assertNoPathAliasEscape } from "./path-alias-guards.js";
 import {
@@ -57,11 +57,10 @@ const OPEN_WRITE_CREATE_FLAGS =
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
-
 const OPEN_APPEND_EXISTING_FLAGS =
-  fsConstants.O_WRONLY | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+  fsConstants.O_RDWR | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 const OPEN_APPEND_CREATE_FLAGS =
-  fsConstants.O_WRONLY |
+  fsConstants.O_RDWR |
   fsConstants.O_APPEND |
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
@@ -333,13 +332,13 @@ async function writeTempFileForAtomicReplace(params: {
 async function verifyAtomicWriteResult(params: {
   rootDir: string;
   targetPath: string;
-  expectedStat: Stats;
+  expectedIdentity: { dev: number | bigint; ino: number | bigint };
 }): Promise<void> {
   const rootReal = await fs.realpath(params.rootDir);
   const rootWithSep = ensureTrailingSep(rootReal);
   const opened = await openVerifiedLocalFile(params.targetPath, { rejectHardlinks: true });
   try {
-    if (!sameFileIdentity(opened.stat, params.expectedStat)) {
+    if (!sameFileIdentity(opened.stat, params.expectedIdentity)) {
       throw new SafeOpenError("path-mismatch", "path changed during write");
     }
     if (!isPathInside(rootWithSep, opened.realPath)) {
@@ -384,6 +383,7 @@ export async function openWritableFileWithinRoot(params: {
   mkdir?: boolean;
   mode?: number;
   truncateExisting?: boolean;
+  append?: boolean;
 }): Promise<SafeWritableOpenResult> {
   const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot(params);
   try {
@@ -419,14 +419,16 @@ export async function openWritableFileWithinRoot(params: {
 
   let handle: FileHandle;
   let createdForWrite = false;
+  const existingFlags = params.append ? OPEN_APPEND_EXISTING_FLAGS : OPEN_WRITE_EXISTING_FLAGS;
+  const createFlags = params.append ? OPEN_APPEND_CREATE_FLAGS : OPEN_WRITE_CREATE_FLAGS;
   try {
     try {
-      handle = await fs.open(ioPath, OPEN_WRITE_EXISTING_FLAGS, fileMode);
+      handle = await fs.open(ioPath, existingFlags, fileMode);
     } catch (err) {
       if (!isNotFoundPathError(err)) {
         throw err;
       }
-      handle = await fs.open(ioPath, OPEN_WRITE_CREATE_FLAGS, fileMode);
+      handle = await fs.open(ioPath, createFlags, fileMode);
       createdForWrite = true;
     }
   } catch (err) {
@@ -478,7 +480,7 @@ export async function openWritableFileWithinRoot(params: {
 
     // Truncate only after boundary and identity checks complete. This avoids
     // irreversible side effects if a symlink target changes before validation.
-    if (params.truncateExisting !== false && !createdForWrite) {
+    if (params.append !== true && params.truncateExisting !== false && !createdForWrite) {
       await handle.truncate(0);
     }
     return {
@@ -498,7 +500,240 @@ export async function openWritableFileWithinRoot(params: {
   }
 }
 
+export async function appendFileWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  data: string | Buffer;
+  encoding?: BufferEncoding;
+  mkdir?: boolean;
+  prependNewlineIfNeeded?: boolean;
+}): Promise<void> {
+  const target = await openWritableFileWithinRoot({
+    rootDir: params.rootDir,
+    relativePath: params.relativePath,
+    mkdir: params.mkdir,
+    truncateExisting: false,
+    append: true,
+  });
+  try {
+    let prefix = "";
+    if (
+      params.prependNewlineIfNeeded === true &&
+      !target.createdForWrite &&
+      target.openedStat.size > 0 &&
+      ((typeof params.data === "string" && !params.data.startsWith("\n")) ||
+        (Buffer.isBuffer(params.data) && params.data.length > 0 && params.data[0] !== 0x0a))
+    ) {
+      const lastByte = Buffer.alloc(1);
+      const { bytesRead } = await target.handle.read(lastByte, 0, 1, target.openedStat.size - 1);
+      if (bytesRead === 1 && lastByte[0] !== 0x0a) {
+        prefix = "\n";
+      }
+    }
+
+    if (typeof params.data === "string") {
+      await target.handle.appendFile(`${prefix}${params.data}`, params.encoding ?? "utf8");
+      return;
+    }
+
+    const payload =
+      prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
+    await target.handle.appendFile(payload);
+  } finally {
+    await target.handle.close().catch(() => {});
+  }
+}
+
 export async function writeFileWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  data: string | Buffer;
+  encoding?: BufferEncoding;
+  mkdir?: boolean;
+}): Promise<void> {
+  if (process.platform === "win32") {
+    await writeFileWithinRootLegacy(params);
+    return;
+  }
+
+  const pinned = await resolvePinnedWriteTargetWithinRoot({
+    rootDir: params.rootDir,
+    relativePath: params.relativePath,
+  });
+
+  const identity = await runPinnedWriteHelper({
+    rootPath: pinned.rootReal,
+    relativeParentPath: pinned.relativeParentPath,
+    basename: pinned.basename,
+    mkdir: params.mkdir !== false,
+    mode: pinned.mode,
+    input: {
+      kind: "buffer",
+      data: params.data,
+      encoding: params.encoding,
+    },
+  }).catch((error) => {
+    throw normalizePinnedWriteError(error);
+  });
+
+  try {
+    await verifyAtomicWriteResult({
+      rootDir: params.rootDir,
+      targetPath: pinned.targetPath,
+      expectedIdentity: identity,
+    });
+  } catch (err) {
+    emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);
+    throw err;
+  }
+}
+
+export async function copyFileWithinRoot(params: {
+  sourcePath: string;
+  rootDir: string;
+  relativePath: string;
+  maxBytes?: number;
+  mkdir?: boolean;
+  rejectSourceHardlinks?: boolean;
+}): Promise<void> {
+  const source = await openVerifiedLocalFile(params.sourcePath, {
+    rejectHardlinks: params.rejectSourceHardlinks,
+  });
+  if (params.maxBytes !== undefined && source.stat.size > params.maxBytes) {
+    await source.handle.close().catch(() => {});
+    throw new SafeOpenError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${source.stat.size})`,
+    );
+  }
+
+  try {
+    if (process.platform === "win32") {
+      await copyFileWithinRootLegacy(params, source);
+      return;
+    }
+
+    const pinned = await resolvePinnedWriteTargetWithinRoot({
+      rootDir: params.rootDir,
+      relativePath: params.relativePath,
+    });
+    const sourceStream = source.handle.createReadStream();
+    const identity = await runPinnedWriteHelper({
+      rootPath: pinned.rootReal,
+      relativeParentPath: pinned.relativeParentPath,
+      basename: pinned.basename,
+      mkdir: params.mkdir !== false,
+      mode: pinned.mode,
+      input: {
+        kind: "stream",
+        stream: sourceStream,
+      },
+    }).catch((error) => {
+      throw normalizePinnedWriteError(error);
+    });
+    try {
+      await verifyAtomicWriteResult({
+        rootDir: params.rootDir,
+        targetPath: pinned.targetPath,
+        expectedIdentity: identity,
+      });
+    } catch (err) {
+      emitWriteBoundaryWarning(`post-copy verification failed: ${String(err)}`);
+      throw err;
+    }
+  } finally {
+    await source.handle.close().catch(() => {});
+  }
+}
+
+export async function writeFileFromPathWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+  sourcePath: string;
+  mkdir?: boolean;
+}): Promise<void> {
+  await copyFileWithinRoot({
+    sourcePath: params.sourcePath,
+    rootDir: params.rootDir,
+    relativePath: params.relativePath,
+    mkdir: params.mkdir,
+    rejectSourceHardlinks: true,
+  });
+}
+
+async function resolvePinnedWriteTargetWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+}): Promise<{
+  rootReal: string;
+  targetPath: string;
+  relativeParentPath: string;
+  basename: string;
+  mode: number;
+}> {
+  const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot(params);
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: resolved,
+      rootPath: rootReal,
+      boundaryLabel: "root",
+    });
+  } catch (err) {
+    throw new SafeOpenError("invalid-path", "path alias escape blocked", { cause: err });
+  }
+
+  const relativeResolved = path.relative(rootReal, resolved);
+  if (relativeResolved.startsWith("..") || path.isAbsolute(relativeResolved)) {
+    throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+  }
+  const relativePosix = relativeResolved
+    ? relativeResolved.split(path.sep).join(path.posix.sep)
+    : "";
+  const basename = path.posix.basename(relativePosix);
+  if (!basename || basename === "." || basename === "/") {
+    throw new SafeOpenError("invalid-path", "invalid target path");
+  }
+  let mode = 0o600;
+  try {
+    const opened = await openFileWithinRoot({
+      rootDir: params.rootDir,
+      relativePath: params.relativePath,
+      rejectHardlinks: true,
+    });
+    try {
+      mode = opened.stat.mode & 0o777;
+      if (!isPathInside(rootWithSep, opened.realPath)) {
+        throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+      }
+    } finally {
+      await opened.handle.close().catch(() => {});
+    }
+  } catch (err) {
+    if (!(err instanceof SafeOpenError) || err.code !== "not-found") {
+      throw err;
+    }
+  }
+
+  return {
+    rootReal,
+    targetPath: resolved,
+    relativeParentPath:
+      path.posix.dirname(relativePosix) === "." ? "" : path.posix.dirname(relativePosix),
+    basename,
+    mode: mode || 0o600,
+  };
+}
+
+function normalizePinnedWriteError(error: unknown): Error {
+  if (error instanceof SafeOpenError) {
+    return error;
+  }
+  return new SafeOpenError("invalid-path", "path is not a regular file under root", {
+    cause: error instanceof Error ? error : undefined,
+  });
+}
+
+async function writeFileWithinRootLegacy(params: {
   rootDir: string;
   relativePath: string;
   data: string | Buffer;
@@ -529,7 +764,7 @@ export async function writeFileWithinRoot(params: {
       await verifyAtomicWriteResult({
         rootDir: params.rootDir,
         targetPath: destinationPath,
-        expectedStat: writtenStat,
+        expectedIdentity: writtenStat,
       });
     } catch (err) {
       emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);
@@ -542,155 +777,17 @@ export async function writeFileWithinRoot(params: {
   }
 }
 
-export async function appendFileWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-  data: string | Buffer;
-  encoding?: BufferEncoding;
-  mkdir?: boolean;
-  mode?: number;
-}): Promise<{
-  createdForWrite: boolean;
-  openedRealPath: string;
-  openedStat: import("node:fs").Stats;
-}> {
-  const { rootReal, rootWithSep, resolved } = await resolvePathWithinRoot({
-    rootDir: params.rootDir,
-    relativePath: params.relativePath,
-  });
-  try {
-    await assertNoPathAliasEscape({
-      absolutePath: resolved,
-      rootPath: rootReal,
-      boundaryLabel: "root",
-    });
-  } catch (err) {
-    throw new SafeOpenError("invalid-path", "path alias escape blocked", { cause: err });
-  }
-
-  if (params.mkdir !== false) {
-    await fs.mkdir(path.dirname(resolved), { recursive: true });
-  }
-
-  let ioPath = resolved;
-  try {
-    const resolvedRealPath = await fs.realpath(resolved);
-    if (!isPathInside(rootWithSep, resolvedRealPath)) {
-      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-    }
-    ioPath = resolvedRealPath;
-  } catch (err) {
-    if (err instanceof SafeOpenError) {
-      throw err;
-    }
-    if (!isNotFoundPathError(err)) {
-      throw err;
-    }
-  }
-
-  const fileMode = params.mode ?? 0o600;
-
-  let handle: FileHandle;
-  let createdForWrite = false;
-  try {
-    try {
-      handle = await fs.open(ioPath, OPEN_APPEND_EXISTING_FLAGS, fileMode);
-    } catch (err) {
-      if (!isNotFoundPathError(err)) {
-        throw err;
-      }
-      handle = await fs.open(ioPath, OPEN_APPEND_CREATE_FLAGS, fileMode);
-      createdForWrite = true;
-    }
-  } catch (err) {
-    if (isNotFoundPathError(err)) {
-      throw new SafeOpenError("not-found", "file not found");
-    }
-    if (isSymlinkOpenError(err)) {
-      throw new SafeOpenError("invalid-path", "symlink open blocked", { cause: err });
-    }
-    throw err;
-  }
-
-  let openedRealPath: string | null = null;
-  try {
-    const stat = await handle.stat();
-    if (!stat.isFile()) {
-      throw new SafeOpenError("invalid-path", "path is not a regular file under root");
-    }
-    if (stat.nlink > 1) {
-      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-    }
-
-    try {
-      const lstat = await fs.lstat(ioPath);
-      if (lstat.isSymbolicLink() || !lstat.isFile()) {
-        throw new SafeOpenError("invalid-path", "path is not a regular file under root");
-      }
-      if (!sameFileIdentity(stat, lstat)) {
-        throw new SafeOpenError("path-mismatch", "path changed during append");
-      }
-    } catch (err) {
-      if (!isNotFoundPathError(err)) {
-        throw err;
-      }
-    }
-
-    const realPath = await resolveOpenedFileRealPathForHandle(handle, ioPath);
-    openedRealPath = realPath;
-    const realStat = await fs.stat(realPath);
-    if (!sameFileIdentity(stat, realStat)) {
-      throw new SafeOpenError("path-mismatch", "path mismatch");
-    }
-    if (realStat.nlink > 1) {
-      throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-    }
-    if (!isPathInside(rootWithSep, realPath)) {
-      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-    }
-
-    if (typeof params.data === "string") {
-      await handle.writeFile(
-        params.data,
-        params.encoding ? { encoding: params.encoding } : undefined,
-      );
-    } else {
-      await handle.writeFile(params.data);
-    }
-
-    return { createdForWrite, openedRealPath: realPath, openedStat: stat };
-  } catch (err) {
-    const cleanupCreatedPath = createdForWrite && err instanceof SafeOpenError;
-    const cleanupPath = openedRealPath ?? ioPath;
-    await handle.close().catch(() => {});
-    if (cleanupCreatedPath) {
-      await fs.rm(cleanupPath, { force: true }).catch(() => {});
-    }
-    throw err;
-  } finally {
-    await handle.close().catch(() => {});
-  }
-}
-
-export async function copyFileWithinRoot(params: {
-  sourcePath: string;
-  rootDir: string;
-  relativePath: string;
-  maxBytes?: number;
-  mkdir?: boolean;
-  rejectSourceHardlinks?: boolean;
-}): Promise<void> {
-  const source = await openVerifiedLocalFile(params.sourcePath, {
-    rejectHardlinks: params.rejectSourceHardlinks,
-  });
-  if (params.maxBytes !== undefined && source.stat.size > params.maxBytes) {
-    await source.handle.close().catch(() => {});
-    throw new SafeOpenError(
-      "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${source.stat.size})`,
-    );
-  }
-
+async function copyFileWithinRootLegacy(
+  params: {
+    sourcePath: string;
+    rootDir: string;
+    relativePath: string;
+    maxBytes?: number;
+    mkdir?: boolean;
+    rejectSourceHardlinks?: boolean;
+  },
+  source: SafeOpenResult,
+): Promise<void> {
   let target: SafeWritableOpenResult | null = null;
   let sourceClosedByStream = false;
   let targetClosedByUs = false;
@@ -719,7 +816,9 @@ export async function copyFileWithinRoot(params: {
     targetStream.once("close", () => {
       tempClosedByStream = true;
     });
-    await pipeline(sourceStream, targetStream);
+    await import("node:stream/promises").then(({ pipeline }) =>
+      pipeline(sourceStream, targetStream),
+    );
     const writtenStat = await fs.stat(tempPath);
     if (!tempClosedByStream) {
       await tempHandle.close().catch(() => {});
@@ -732,7 +831,7 @@ export async function copyFileWithinRoot(params: {
       await verifyAtomicWriteResult({
         rootDir: params.rootDir,
         targetPath: destinationPath,
-        expectedStat: writtenStat,
+        expectedIdentity: writtenStat,
       });
     } catch (err) {
       emitWriteBoundaryWarning(`post-copy verification failed: ${String(err)}`);
@@ -757,19 +856,4 @@ export async function copyFileWithinRoot(params: {
       await target.handle.close().catch(() => {});
     }
   }
-}
-
-export async function writeFileFromPathWithinRoot(params: {
-  rootDir: string;
-  relativePath: string;
-  sourcePath: string;
-  mkdir?: boolean;
-}): Promise<void> {
-  await copyFileWithinRoot({
-    sourcePath: params.sourcePath,
-    rootDir: params.rootDir,
-    relativePath: params.relativePath,
-    mkdir: params.mkdir,
-    rejectSourceHardlinks: true,
-  });
 }


### PR DESCRIPTION
## Summary
- switch session-memory output to canonical `memory/YYYY-MM-DD.md` to avoid date-only reader mismatch
- append session entries into the daily file instead of creating per-run timestamped filenames
- make `/new` and `/reset` non-blocking by using a local slug first; only use LLM slug when explicitly enabled
- make LLM slug timeout configurable via `OPENCLAW_SESSION_MEMORY_SLUG_TIMEOUT_MS` (or hook config `slugTimeoutMs`) and default to 5s

## Why
- fixes ENOENT scenarios where readers expect `memory/YYYY-MM-DD.md` while writers produced `memory/YYYY-MM-DD-HHmm.md`
- prevents reset/new instability when embedded slug generation times out

## Validation
- `pnpm vitest run src/hooks/bundled/session-memory/handler.test.ts src/agents/session-slug.test.ts`