### PR TITLE
fix(telegram): route inbound media downloads through telegram fetch wrapper

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -363,7 +363,13 @@ export const registerTelegramHandlers = ({
       for (const { ctx } of entry.messages) {
         let media;
         try {
-          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+          media = await resolveMedia(
+            ctx,
+            mediaMaxBytes,
+            opts.token,
+            opts.proxyFetch,
+            telegramCfg.network,
+          );
         } catch (mediaErr) {
           if (!isRecoverableMediaGroupError(mediaErr)) {
             throw mediaErr;
@@ -468,6 +474,7 @@ export const registerTelegramHandlers = ({
         mediaMaxBytes,
         opts.token,
         opts.proxyFetch,
+        telegramCfg.network,
       );
       if (!media) {
         return [];
@@ -978,7 +985,13 @@ export const registerTelegramHandlers = ({
 
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
-      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+      media = await resolveMedia(
+        ctx,
+        mediaMaxBytes,
+        opts.token,
+        opts.proxyFetch,
+        telegramCfg.network,
+      );
     } catch (mediaErr) {
       if (isMediaSizeLimitError(mediaErr)) {
         if (sendOversizeWarning) {

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -5,6 +5,7 @@ import type { TelegramContext } from "./types.js";
 
 const saveMediaBuffer = vi.fn();
 const fetchRemoteMedia = vi.fn();
+const resolveTelegramFetch = vi.fn();
 
 vi.mock("../../media/store.js", () => ({
   saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
@@ -12,6 +13,10 @@ vi.mock("../../media/store.js", () => ({
 
 vi.mock("../../media/fetch.js", () => ({
   fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
+}));
+
+vi.mock("../fetch.js", () => ({
+  resolveTelegramFetch: (...args: unknown[]) => resolveTelegramFetch(...args),
 }));
 
 vi.mock("../../globals.js", () => ({
@@ -164,6 +169,10 @@ describe("resolveMedia getFile retry", () => {
     vi.useFakeTimers();
     fetchRemoteMedia.mockClear();
     saveMediaBuffer.mockClear();
+    resolveTelegramFetch.mockReset();
+    resolveTelegramFetch.mockImplementation(
+      (fetchImpl?: typeof fetch) => fetchImpl ?? globalThis.fetch,
+    );
   });
 
   afterEach(() => {
@@ -200,6 +209,32 @@ describe("resolveMedia getFile retry", () => {
     ).rejects.toThrow("download failed");
 
     expect(getFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves Telegram media downloads through the Telegram fetch wrapper", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    const rawFetch = vi.fn();
+    const wrappedFetch = vi.fn();
+    const network = { autoSelectFamily: false, dnsResultOrder: "ipv4first" } as const;
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      fileName: "file_0.oga",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
+    resolveTelegramFetch.mockReturnValueOnce(wrappedFetch);
+
+    await resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN, rawFetch, network);
+
+    expect(resolveTelegramFetch).toHaveBeenCalledWith(rawFetch, { network });
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchImpl: wrappedFetch,
+      }),
+    );
   });
 
   it("does not retry 'file is too big' error (400 Bad Request) and returns null", async () => {

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -335,6 +335,10 @@ describe("resolveMedia original filename preservation", () => {
     vi.useFakeTimers();
     fetchRemoteMedia.mockClear();
     saveMediaBuffer.mockClear();
+    resolveTelegramFetch.mockReset();
+    resolveTelegramFetch.mockImplementation(
+      (fetchImpl?: typeof fetch) => fetchImpl ?? globalThis.fetch,
+    );
   });
 
   afterEach(() => {

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -1,9 +1,11 @@
 import { GrammyError } from "grammy";
+import type { TelegramNetworkConfig } from "../../config/types.telegram.js";
 import { logVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { retryAsync } from "../../infra/retry.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
+import { resolveTelegramFetch } from "../fetch.js";
 import { cacheSticker, getCachedSticker } from "../sticker-cache.js";
 import { resolveTelegramMediaPlaceholder } from "./helpers.js";
 import type { StickerMetadata, TelegramContext } from "./types.js";
@@ -92,8 +94,11 @@ async function resolveTelegramFileWithRetry(
   }
 }
 
-function resolveRequiredFetchImpl(proxyFetch?: typeof fetch): typeof fetch {
-  const fetchImpl = proxyFetch ?? globalThis.fetch;
+function resolveRequiredFetchImpl(
+  proxyFetch?: typeof fetch,
+  network?: TelegramNetworkConfig,
+): typeof fetch {
+  const fetchImpl = resolveTelegramFetch(proxyFetch, { network });
   if (!fetchImpl) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
@@ -135,6 +140,7 @@ async function resolveStickerMedia(params: {
   maxBytes: number;
   token: string;
   proxyFetch?: typeof fetch;
+  network?: TelegramNetworkConfig;
 }): Promise<
   | {
       path: string;
@@ -145,7 +151,7 @@ async function resolveStickerMedia(params: {
   | null
   | undefined
 > {
-  const { msg, ctx, maxBytes, token, proxyFetch } = params;
+  const { msg, ctx, maxBytes, token, proxyFetch, network } = params;
   if (!msg.sticker) {
     return undefined;
   }
@@ -165,15 +171,10 @@ async function resolveStickerMedia(params: {
       logVerbose("telegram: getFile returned no file_path for sticker");
       return null;
     }
-    const fetchImpl = proxyFetch ?? globalThis.fetch;
-    if (!fetchImpl) {
-      logVerbose("telegram: fetch not available for sticker download");
-      return null;
-    }
     const saved = await downloadAndSaveTelegramFile({
       filePath: file.file_path,
       token,
-      fetchImpl,
+      fetchImpl: resolveRequiredFetchImpl(proxyFetch, network),
       maxBytes,
     });
 
@@ -230,6 +231,7 @@ export async function resolveMedia(
   maxBytes: number,
   token: string,
   proxyFetch?: typeof fetch,
+  network?: TelegramNetworkConfig,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -243,6 +245,7 @@ export async function resolveMedia(
     maxBytes,
     token,
     proxyFetch,
+    network,
   });
   if (stickerResolved !== undefined) {
     return stickerResolved;
@@ -263,7 +266,7 @@ export async function resolveMedia(
   const saved = await downloadAndSaveTelegramFile({
     filePath: file.file_path,
     token,
-    fetchImpl: resolveRequiredFetchImpl(proxyFetch),
+    fetchImpl: resolveRequiredFetchImpl(proxyFetch, network),
     maxBytes,
     telegramFileName: resolveTelegramFileName(msg),
   });

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -98,11 +98,7 @@ function resolveRequiredFetchImpl(
   proxyFetch?: typeof fetch,
   network?: TelegramNetworkConfig,
 ): typeof fetch {
-  const fetchImpl = resolveTelegramFetch(proxyFetch, { network });
-  if (!fetchImpl) {
-    throw new Error("fetch is not available; set channels.telegram.proxy in config");
-  }
-  return fetchImpl;
+  return resolveTelegramFetch(proxyFetch, { network }) as typeof fetch;
 }
 
 /** Default idle timeout for Telegram media downloads (30 seconds). */


### PR DESCRIPTION
## Summary

- Problem: inbound Telegram media downloads used raw `proxyFetch ?? globalThis.fetch` inside `resolveMedia`, so `api.telegram.org/file/...` downloads could bypass the Telegram-specific fetch wrapper and its IPv4 fallback/retry behavior.
- Why it matters: users hit `⚠️ Failed to download media. Please try again.` with logs like `MediaFetchError ... TypeError: fetch failed`, especially on IPv6-broken hosts.
- What changed: route inbound Telegram media downloads (including stickers, reply media, and media groups) through `resolveTelegramFetch(...)`, and thread `telegramCfg.network` into `resolveMedia(...)` so the channel's network settings are preserved.
- What did NOT change (scope boundary): no new user-facing copy, no outbound Telegram send changes, and no broad retry-policy rewrite beyond reusing the existing Telegram fetch wrapper.
- AI-assisted: prepared with Codex; diff and tests were reviewed before opening.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #32326

## User-visible / Behavior Changes

- Telegram inbound media downloads now reuse the channel's existing Telegram fetch wrapper, so transient `fetch failed` transport errors can use the same IPv4-safe fallback path already used elsewhere in Telegram networking.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram account with Node 22 defaults and channel network config available

### Steps

1. Inspect the inbound Telegram media path (`resolveMedia`) and compare it with the Telegram fetch wrapper used by other Telegram network operations.
2. Reproduce/report the failure mode via logs showing `MediaFetchError ... TypeError: fetch failed` for `api.telegram.org/file/...` downloads.
3. Run the targeted Telegram tests after threading the fetch wrapper through inbound media download resolution.

### Expected

- Inbound Telegram media downloads use the Telegram fetch wrapper and preserve `channels.telegram.network` settings.
- Existing Telegram fetch fallback behavior remains covered by tests.

### Actual

- Before this patch, inbound Telegram media downloads used raw fetch and bypassed the Telegram fetch wrapper.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the local gateway logs for `MediaFetchError ... TypeError: fetch failed`; confirmed the inbound media path bypassed `resolveTelegramFetch`; ran `pnpm vitest run src/telegram/fetch.test.ts src/telegram/bot/delivery.resolve-media-retry.test.ts`; ran `pnpm exec oxlint --type-aware src/telegram/bot/delivery.resolve-media.ts src/telegram/bot-handlers.ts src/telegram/bot/delivery.resolve-media-retry.test.ts`.
- Edge cases checked: sticker downloads still use the same helper path; reply media and media groups now pass through the same network config; fetch-wrapper usage is covered by a new unit test.
- What you did **not** verify: live end-to-end Telegram uploads against a real bot/token in this PR branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fix(telegram): route inbound media downloads through telegram fetch wrapper`
- Files/config to restore: `src/telegram/bot/delivery.resolve-media.ts`, `src/telegram/bot-handlers.ts`, `src/telegram/bot/delivery.resolve-media-retry.test.ts`
- Known bad symptoms reviewers should watch for: inbound Telegram attachments failing before `fetchRemoteMedia`, or unexpected changes to Telegram network config application.

## Risks and Mitigations

- Risk: inbound media downloads now call the Telegram fetch wrapper, which applies Telegram network config decisions in this path too.
  - Mitigation: the wrapper is already the established Telegram transport path, and the PR threads the existing `telegramCfg.network` through explicitly instead of inventing a new config source.
- Risk: signature expansion for `resolveMedia(...)` could miss a call site.
  - Mitigation: all production Telegram call sites were updated and the focused tests passed.
