### PR TITLE
fix(webchat): filter delivery-mirror messages from chat.history

### DIFF
--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { stripEnvelopeFromMessage } from "./chat-sanitize.js";
+import { filterDeliveryMirrorMessages, stripEnvelopeFromMessage } from "./chat-sanitize.js";
 
 describe("stripEnvelopeFromMessage", () => {
   test("removes message_id hint lines from user messages", () => {
@@ -89,5 +89,40 @@ describe("stripEnvelopeFromMessage", () => {
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("hello");
+  });
+});
+
+describe("filterDeliveryMirrorMessages", () => {
+  test("removes delivery-mirror messages", () => {
+    const messages = [
+      { role: "user", content: "hello", model: "user" },
+      { role: "assistant", content: "hi", model: "gpt-4o", provider: "openai" },
+      { role: "assistant", content: "hi", model: "delivery-mirror", provider: "openclaw" },
+    ];
+    const result = filterDeliveryMirrorMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([
+      { role: "user", content: "hello", model: "user" },
+      { role: "assistant", content: "hi", model: "gpt-4o", provider: "openai" },
+    ]);
+  });
+
+  test("preserves all messages when no delivery-mirror present", () => {
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi", model: "gpt-4o" },
+    ];
+    const result = filterDeliveryMirrorMessages(messages);
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles empty array", () => {
+    expect(filterDeliveryMirrorMessages([])).toEqual([]);
+  });
+
+  test("handles non-object entries gracefully", () => {
+    const messages = [null, undefined, "string", { role: "assistant", model: "delivery-mirror" }];
+    const result = filterDeliveryMirrorMessages(messages);
+    expect(result).toEqual([null, undefined, "string"]);
   });
 });

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -108,6 +108,17 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   return changed ? next : message;
 }
 
+/** Filter out delivery-mirror messages that duplicate assistant replies in chat history. */
+export function filterDeliveryMirrorMessages(messages: unknown[]): unknown[] {
+  return messages.filter((msg) => {
+    if (!msg || typeof msg !== "object") {
+      return true;
+    }
+    const entry = msg as Record<string, unknown>;
+    return entry.model !== "delivery-mirror";
+  });
+}
+
 export function stripEnvelopeFromMessages(messages: unknown[]): unknown[] {
   if (messages.length === 0) {
     return messages;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -32,7 +32,11 @@ import {
   resolveChatRunExpiresAtMs,
 } from "../chat-abort.js";
 import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
-import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
+import {
+  filterDeliveryMirrorMessages,
+  stripEnvelopeFromMessage,
+  stripEnvelopeFromMessages,
+} from "../chat-sanitize.js";
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
@@ -765,7 +769,8 @@ export const chatHandlers: GatewayRequestHandlers = {
     const max = Math.min(hardMax, requested);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
     const sanitized = stripEnvelopeFromMessages(sliced);
-    const normalized = sanitizeChatHistoryMessages(sanitized);
+    const filtered = filterDeliveryMirrorMessages(sanitized);
+    const normalized = sanitizeChatHistoryMessages(filtered);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
     const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
     const replaced = replaceOversizedChatHistoryMessages({


### PR DESCRIPTION
## Summary

Fixes #38061 — Webchat shows duplicate assistant messages because `chat.history` returns `delivery-mirror` transcript entries as normal assistant messages.

## Problem

When an assistant reply is delivered to a channel (e.g. Telegram), `appendAssistantMessageToSessionTranscript()` writes a duplicate entry with `provider: 'openclaw', model: 'delivery-mirror'` to the session transcript. The `chat.history` handler returns these alongside the real assistant messages, causing the webchat Control UI to render the same content twice.

## Fix

- Added `filterDeliveryMirrorMessages()` in `chat-sanitize.ts` that filters out messages where `model === 'delivery-mirror'`
- Applied the filter in the `chat.history` handler after `stripEnvelopeFromMessages()` and before `sanitizeChatHistoryMessages()`
- Added 4 unit tests covering normal filtering, no-op, empty array, and edge cases

## Related Issues

- #39289 (Duplicate messages in Webchat)
- #32579 (broadcast scoping — not addressed in this PR, separate concern)
- #39469 (double-records in session JSONL)

## Testing

- All 13 existing `chat-sanitize` tests pass
- All 23 `server-chat.agent-events` tests pass
- New tests added for `filterDeliveryMirrorMessages`