### PR TITLE
refactor(doctor): extract default account warning helpers

### DIFF
--- a/src/commands/doctor-config-default-account-warnings.ts
+++ b/src/commands/doctor-config-default-account-warnings.ts
@@ -1,0 +1,163 @@
+import { normalizeChatChannelId } from "../channels/registry.js";
+import { listRouteBindings } from "../config/bindings.js";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  formatChannelAccountsDefaultPath,
+  formatSetExplicitDefaultInstruction,
+  formatSetExplicitDefaultToConfiguredInstruction,
+} from "../routing/default-account-warnings.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  normalizeOptionalAccountId,
+} from "../routing/session-key.js";
+
+type ChannelMissingDefaultAccountContext = {
+  channelKey: string;
+  channel: Record<string, unknown>;
+  normalizedAccountIds: string[];
+};
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeBindingChannelKey(raw?: string | null): string {
+  const normalized = normalizeChatChannelId(raw);
+  if (normalized) {
+    return normalized;
+  }
+  return (raw ?? "").trim().toLowerCase();
+}
+
+function collectChannelsMissingDefaultAccount(
+  cfg: OpenClawConfig,
+): ChannelMissingDefaultAccountContext[] {
+  const channels = asObjectRecord(cfg.channels);
+  if (!channels) {
+    return [];
+  }
+
+  const contexts: ChannelMissingDefaultAccountContext[] = [];
+  for (const [channelKey, rawChannel] of Object.entries(channels)) {
+    const channel = asObjectRecord(rawChannel);
+    if (!channel) {
+      continue;
+    }
+    const accounts = asObjectRecord(channel.accounts);
+    if (!accounts) {
+      continue;
+    }
+
+    const normalizedAccountIds = Array.from(
+      new Set(
+        Object.keys(accounts)
+          .map((accountId) => normalizeAccountId(accountId))
+          .filter(Boolean),
+      ),
+    ).toSorted((a, b) => a.localeCompare(b));
+    if (normalizedAccountIds.length === 0 || normalizedAccountIds.includes(DEFAULT_ACCOUNT_ID)) {
+      continue;
+    }
+    contexts.push({ channelKey, channel, normalizedAccountIds });
+  }
+  return contexts;
+}
+
+export function collectMissingDefaultAccountBindingWarnings(cfg: OpenClawConfig): string[] {
+  const bindings = listRouteBindings(cfg);
+  const warnings: string[] = [];
+
+  for (const { channelKey, normalizedAccountIds } of collectChannelsMissingDefaultAccount(cfg)) {
+    const accountIdSet = new Set(normalizedAccountIds);
+    const channelPattern = normalizeBindingChannelKey(channelKey);
+
+    let hasWildcardBinding = false;
+    const coveredAccountIds = new Set<string>();
+    for (const binding of bindings) {
+      const bindingRecord = asObjectRecord(binding);
+      if (!bindingRecord) {
+        continue;
+      }
+      const match = asObjectRecord(bindingRecord.match);
+      if (!match) {
+        continue;
+      }
+
+      const matchChannel =
+        typeof match.channel === "string" ? normalizeBindingChannelKey(match.channel) : "";
+      if (!matchChannel || matchChannel !== channelPattern) {
+        continue;
+      }
+
+      const rawAccountId = typeof match.accountId === "string" ? match.accountId.trim() : "";
+      if (!rawAccountId) {
+        continue;
+      }
+      if (rawAccountId === "*") {
+        hasWildcardBinding = true;
+        continue;
+      }
+      const normalizedBindingAccountId = normalizeAccountId(rawAccountId);
+      if (accountIdSet.has(normalizedBindingAccountId)) {
+        coveredAccountIds.add(normalizedBindingAccountId);
+      }
+    }
+
+    if (hasWildcardBinding) {
+      continue;
+    }
+
+    const uncoveredAccountIds = normalizedAccountIds.filter(
+      (accountId) => !coveredAccountIds.has(accountId),
+    );
+    if (uncoveredAccountIds.length === 0) {
+      continue;
+    }
+    if (coveredAccountIds.size > 0) {
+      warnings.push(
+        `- channels.${channelKey}: accounts.default is missing and account bindings only cover a subset of configured accounts. Uncovered accounts: ${uncoveredAccountIds.join(", ")}. Add bindings[].match.accountId for uncovered accounts (or "*"), or add ${formatChannelAccountsDefaultPath(channelKey)}.`,
+      );
+      continue;
+    }
+
+    warnings.push(
+      `- channels.${channelKey}: accounts.default is missing and no valid account-scoped binding exists for configured accounts (${normalizedAccountIds.join(", ")}). Channel-only bindings (no accountId) match only default. Add bindings[].match.accountId for one of these accounts (or "*"), or add ${formatChannelAccountsDefaultPath(channelKey)}.`,
+    );
+  }
+
+  return warnings;
+}
+
+export function collectMissingExplicitDefaultAccountWarnings(cfg: OpenClawConfig): string[] {
+  const warnings: string[] = [];
+  for (const { channelKey, channel, normalizedAccountIds } of collectChannelsMissingDefaultAccount(
+    cfg,
+  )) {
+    if (normalizedAccountIds.length < 2) {
+      continue;
+    }
+
+    const preferredDefault = normalizeOptionalAccountId(
+      typeof channel.defaultAccount === "string" ? channel.defaultAccount : undefined,
+    );
+    if (preferredDefault) {
+      if (normalizedAccountIds.includes(preferredDefault)) {
+        continue;
+      }
+      warnings.push(
+        `- channels.${channelKey}: defaultAccount is set to "${preferredDefault}" but does not match configured accounts (${normalizedAccountIds.join(", ")}). ${formatSetExplicitDefaultToConfiguredInstruction({ channelKey })} to avoid fallback routing.`,
+      );
+      continue;
+    }
+
+    warnings.push(
+      `- channels.${channelKey}: multiple accounts are configured but no explicit default is set. ${formatSetExplicitDefaultInstruction(channelKey)} to avoid fallback routing.`,
+    );
+  }
+
+  return warnings;
+}

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectMissingDefaultAccountBindingWarnings } from "./doctor-config-flow.js";
+import { collectMissingDefaultAccountBindingWarnings } from "./doctor-config-default-account-warnings.js";
 
 describe("collectMissingDefaultAccountBindingWarnings", () => {
   it("warns when named accounts exist without default and no valid binding exists", () => {

--- a/src/commands/doctor-config-flow.missing-explicit-default-account.test.ts
+++ b/src/commands/doctor-config-flow.missing-explicit-default-account.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectMissingExplicitDefaultAccountWarnings } from "./doctor-config-flow.js";
+import { collectMissingExplicitDefaultAccountWarnings } from "./doctor-config-default-account-warnings.js";
 
 describe("collectMissingExplicitDefaultAccountWarnings", () => {
   it("warns when multiple named accounts are configured without default selection", () => {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { normalizeChatChannelId } from "../channels/registry.js";
 import {
   isNumericTelegramUserId,
   normalizeTelegramAllowFromEntry,
@@ -9,7 +8,6 @@ import { fetchTelegramChatId } from "../channels/telegram/api.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
 import { getChannelsCommandSecretTargetIds } from "../cli/command-secret-targets.js";
-import { listRouteBindings } from "../config/bindings.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, migrateLegacyConfig, readConfigFileSnapshot } from "../config/config.js";
 import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
@@ -27,16 +25,7 @@ import {
   normalizeTrustedSafeBinDirs,
 } from "../infra/exec-safe-bin-trust.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
-import {
-  formatChannelAccountsDefaultPath,
-  formatSetExplicitDefaultInstruction,
-  formatSetExplicitDefaultToConfiguredInstruction,
-} from "../routing/default-account-warnings.js";
-import {
-  DEFAULT_ACCOUNT_ID,
-  normalizeAccountId,
-  normalizeOptionalAccountId,
-} from "../routing/session-key.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import {
   isDiscordMutableAllowEntry,
   isGoogleChatMutableAllowEntry,
@@ -56,6 +45,10 @@ import {
   resolveConfigPathTarget,
   stripUnknownConfigKeys,
 } from "./doctor-config-analysis.js";
+import {
+  collectMissingDefaultAccountBindingWarnings,
+  collectMissingExplicitDefaultAccountWarnings,
+} from "./doctor-config-default-account-warnings.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
@@ -73,149 +66,6 @@ function asObjectRecord(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
-}
-
-function normalizeBindingChannelKey(raw?: string | null): string {
-  const normalized = normalizeChatChannelId(raw);
-  if (normalized) {
-    return normalized;
-  }
-  return (raw ?? "").trim().toLowerCase();
-}
-
-type ChannelMissingDefaultAccountContext = {
-  channelKey: string;
-  channel: Record<string, unknown>;
-  normalizedAccountIds: string[];
-};
-
-function collectChannelsMissingDefaultAccount(
-  cfg: OpenClawConfig,
-): ChannelMissingDefaultAccountContext[] {
-  const channels = asObjectRecord(cfg.channels);
-  if (!channels) {
-    return [];
-  }
-
-  const contexts: ChannelMissingDefaultAccountContext[] = [];
-  for (const [channelKey, rawChannel] of Object.entries(channels)) {
-    const channel = asObjectRecord(rawChannel);
-    if (!channel) {
-      continue;
-    }
-    const accounts = asObjectRecord(channel.accounts);
-    if (!accounts) {
-      continue;
-    }
-
-    const normalizedAccountIds = Array.from(
-      new Set(
-        Object.keys(accounts)
-          .map((accountId) => normalizeAccountId(accountId))
-          .filter(Boolean),
-      ),
-    ).toSorted((a, b) => a.localeCompare(b));
-    if (normalizedAccountIds.length === 0 || normalizedAccountIds.includes(DEFAULT_ACCOUNT_ID)) {
-      continue;
-    }
-    contexts.push({ channelKey, channel, normalizedAccountIds });
-  }
-  return contexts;
-}
-
-export function collectMissingDefaultAccountBindingWarnings(cfg: OpenClawConfig): string[] {
-  const bindings = listRouteBindings(cfg);
-  const warnings: string[] = [];
-
-  for (const { channelKey, normalizedAccountIds } of collectChannelsMissingDefaultAccount(cfg)) {
-    const accountIdSet = new Set(normalizedAccountIds);
-    const channelPattern = normalizeBindingChannelKey(channelKey);
-
-    let hasWildcardBinding = false;
-    const coveredAccountIds = new Set<string>();
-    for (const binding of bindings) {
-      const bindingRecord = asObjectRecord(binding);
-      if (!bindingRecord) {
-        continue;
-      }
-      const match = asObjectRecord(bindingRecord.match);
-      if (!match) {
-        continue;
-      }
-
-      const matchChannel =
-        typeof match.channel === "string" ? normalizeBindingChannelKey(match.channel) : "";
-      if (!matchChannel || matchChannel !== channelPattern) {
-        continue;
-      }
-
-      const rawAccountId = typeof match.accountId === "string" ? match.accountId.trim() : "";
-      if (!rawAccountId) {
-        continue;
-      }
-      if (rawAccountId === "*") {
-        hasWildcardBinding = true;
-        continue;
-      }
-      const normalizedBindingAccountId = normalizeAccountId(rawAccountId);
-      if (accountIdSet.has(normalizedBindingAccountId)) {
-        coveredAccountIds.add(normalizedBindingAccountId);
-      }
-    }
-
-    if (hasWildcardBinding) {
-      continue;
-    }
-
-    const uncoveredAccountIds = normalizedAccountIds.filter(
-      (accountId) => !coveredAccountIds.has(accountId),
-    );
-    if (uncoveredAccountIds.length === 0) {
-      continue;
-    }
-    if (coveredAccountIds.size > 0) {
-      warnings.push(
-        `- channels.${channelKey}: accounts.default is missing and account bindings only cover a subset of configured accounts. Uncovered accounts: ${uncoveredAccountIds.join(", ")}. Add bindings[].match.accountId for uncovered accounts (or "*"), or add ${formatChannelAccountsDefaultPath(channelKey)}.`,
-      );
-      continue;
-    }
-
-    warnings.push(
-      `- channels.${channelKey}: accounts.default is missing and no valid account-scoped binding exists for configured accounts (${normalizedAccountIds.join(", ")}). Channel-only bindings (no accountId) match only default. Add bindings[].match.accountId for one of these accounts (or "*"), or add ${formatChannelAccountsDefaultPath(channelKey)}.`,
-    );
-  }
-
-  return warnings;
-}
-
-export function collectMissingExplicitDefaultAccountWarnings(cfg: OpenClawConfig): string[] {
-  const warnings: string[] = [];
-  for (const { channelKey, channel, normalizedAccountIds } of collectChannelsMissingDefaultAccount(
-    cfg,
-  )) {
-    if (normalizedAccountIds.length < 2) {
-      continue;
-    }
-
-    const preferredDefault = normalizeOptionalAccountId(
-      typeof channel.defaultAccount === "string" ? channel.defaultAccount : undefined,
-    );
-    if (preferredDefault) {
-      if (normalizedAccountIds.includes(preferredDefault)) {
-        continue;
-      }
-      warnings.push(
-        `- channels.${channelKey}: defaultAccount is set to "${preferredDefault}" but does not match configured accounts (${normalizedAccountIds.join(", ")}). ${formatSetExplicitDefaultToConfiguredInstruction({ channelKey })} to avoid fallback routing.`,
-      );
-      continue;
-    }
-
-    warnings.push(
-      `- channels.${channelKey}: multiple accounts are configured but no explicit default is set. ${formatSetExplicitDefaultInstruction(channelKey)} to avoid fallback routing.`,
-    );
-  }
-
-  return warnings;
 }
 
 function collectTelegramAccountScopes(

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { normalizeChatChannelId } from "../channels/registry.js";
 import {
   isNumericTelegramUserId,
   normalizeTelegramAllowFromEntry,


### PR DESCRIPTION


## Summary

- Problem: `src/commands/doctor-config-flow.ts` mixed default-account warning analysis with unrelated doctor repair flows.
- Why it matters: the file is already large, and keeping this warning logic inline makes it harder to review and test in isolation.
- What changed: extracted the default-account warning helpers into `src/commands/doctor-config-default-account-warnings.ts`, updated `doctor-config-flow.ts` to call the new module, and pointed the focused tests at the extracted helpers.
- What did NOT change (scope boundary): warning text, repair behavior, and other doctor diagnostics remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #30967

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): doctor config diagnostics
- Relevant config (redacted): multi-account channel configs with and without default-account bindings

### Steps

1. Run `pnpm test -- src/commands/doctor-config-flow.missing-default-account-bindings.test.ts src/commands/doctor-config-flow.missing-explicit-default-account.test.ts src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts`.
2. Run `pnpm exec oxfmt --check src/commands/doctor-config-default-account-warnings.ts src/commands/doctor-config-flow.ts src/commands/doctor-config-flow.missing-default-account-bindings.test.ts src/commands/doctor-config-flow.missing-explicit-default-account.test.ts`.
3. Confirm the extracted module preserves the same doctor warning behavior and the focused tests still pass.

### Expected

- The default-account warning logic is isolated in a dedicated module.
- Existing doctor warning behavior remains unchanged.
- Focused tests and formatting checks pass.

### Actual

- Extracted the helpers into `src/commands/doctor-config-default-account-warnings.ts`.
- Focused doctor tests passed locally.
- Formatting check passed locally.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: missing default-account binding warnings, missing explicit default-account warnings, and integration coverage for doctor warning emission.
- Edge cases checked: wildcard bindings, single-account configs, valid explicit defaults, and invalid `defaultAccount` values.
- What you did **not** verify: full `pnpm check`, unrelated doctor repair flows, or end-to-end channel onboarding.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `d66f126591ac6321a1841c2f44b20299f6aba853`
- Files/config to restore: `src/commands/doctor-config-flow.ts`
- Known bad symptoms reviewers should watch for: missing or changed doctor warnings around `accounts.default`, `defaultAccount`, or account-scoped bindings

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: extracting helper logic could accidentally change warning text or account-coverage behavior.
  - Mitigation: kept the logic intact and validated the existing focused unit/integration tests after extraction.
