### PR TITLE
fix(telegram): log delivery errors in reply dispatcher

### DIFF
--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -701,6 +701,9 @@ export async function deliverReplies(params: {
         groupId: params.mirrorGroupId,
       });
     } catch (error) {
+      logVerbose(
+        `telegram reply delivery failed chat=${params.chatId} account=${params.accountId}: ${formatErrorMessage(error)}`,
+      );
       emitMessageSentHooks({
         hookRunner,
         enabled: hasMessageSentHooks,

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -13,6 +13,7 @@ import {
   toPluginMessageSentEvent,
 } from "../../hooks/message-hook-mappers.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { logWarn } from "../../logger.js";
 import { buildOutboundMediaLoadOptions } from "../../media/load-options.js";
 import { isGifMedia, kindFromMime } from "../../media/mime.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -701,7 +702,7 @@ export async function deliverReplies(params: {
         groupId: params.mirrorGroupId,
       });
     } catch (error) {
-      logVerbose(
+      logWarn(
         `telegram reply delivery failed chat=${params.chatId} account=${params.accountId}: ${formatErrorMessage(error)}`,
       );
       emitMessageSentHooks({


### PR DESCRIPTION
## Summary

Fixes #41567 - Telegram delivery failures were silently swallowed without any logging, making debugging delivery issues impossible.

## Root Cause

The `catch` block in `src/telegram/bot/delivery.replies.ts` (line 703) only called `emitMessageSentHooks` with `success: false` but did not log the error to any logger.

## Fix

Added `logVerbose()` call to record delivery errors before re-throwing, ensuring failures are visible in gateway logs.

## Test plan

- [x] Format check passes
- [x] TypeScript compilation (existing errors unrelated to this change)
- [ ] Manual test: Trigger a Telegram delivery failure and verify error is logged