### PR TITLE
docs: fix stale documentation for recent features

### DIFF
--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -25,7 +25,7 @@ Example hook config (enable Gmail preset mapping):
 {
   hooks: {
     enabled: true,
-    token: "OPENCLAW_HOOK_TOKEN",
+    token: "${OPENCLAW_HOOKS_TOKEN}",
     path: "/hooks",
     presets: ["gmail"],
   },
@@ -39,7 +39,7 @@ that sets `deliver` + optional `channel`/`to`:
 {
   hooks: {
     enabled: true,
-    token: "OPENCLAW_HOOK_TOKEN",
+    token: "${OPENCLAW_HOOKS_TOKEN}",
     presets: ["gmail"],
     mappings: [
       {
@@ -186,7 +186,7 @@ gog gmail watch serve \
   --path /gmail-pubsub \
   --token <shared> \
   --hook-url http://127.0.0.1:18789/hooks/gmail \
-  --hook-token OPENCLAW_HOOK_TOKEN \
+  --hook-token "$OPENCLAW_HOOKS_TOKEN" \
   --include-body \
   --max-bytes 20000
 ```

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -266,6 +266,10 @@ Learn more about session keys at [/concepts/session](/concepts/session).
 - `--require-existing`: fail if the session key/label does not exist.
 - `--reset-session`: reset the session key before first use.
 - `--no-prefix-cwd`: do not prefix prompts with the working directory.
+- `--provenance <mode>`: ACP ingress provenance mode. Controls whether session metadata is attached to prompts forwarded through the bridge. Values:
+  - `off` (default): no provenance metadata is added.
+  - `meta`: attaches structured provenance metadata (origin session ID, source channel, source tool) to each forwarded user message. Useful for downstream audit or routing logic.
+  - `meta+receipt`: like `meta`, plus injects a visible `[Source Receipt]` block into the prompt text with bridge name, origin host, working directory, session ID, and session key.
 - `--verbose, -v`: verbose logging to stderr.
 
 Security note:

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -64,6 +64,7 @@ OpenClaw also injects context markers into spawned child processes:
 - `OPENCLAW_SHELL=acp`: set for ACP runtime backend process spawns (for example `acpx`).
 - `OPENCLAW_SHELL=acp-client`: set for `openclaw acp client` when it spawns the ACP bridge process.
 - `OPENCLAW_SHELL=tui-local`: set for local TUI `!` shell commands.
+- `OPENCLAW_CLI=1`: set for child processes spawned by the CLI entry point, marking that the process is running inside an OpenClaw CLI context.
 
 These are runtime markers (not required user config). They can be used in shell/profile logic
 to apply context-specific rules.

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -48,7 +48,12 @@ Where does the **Gateway** run?
 - **This Mac (Local only):** onboarding can configure auth and write credentials
   locally.
 - **Remote (over SSH/Tailnet):** onboarding does **not** configure local auth;
-  credentials must exist on the gateway host.
+  credentials must exist on the gateway host. When remote mode is selected,
+  a **remote gateway token** field appears so you can enter the token for
+  connecting to your remote Gateway. Existing non-plaintext token values in
+  `gateway.remote.token` are preserved until you explicitly replace them.
+  If the loaded token shape cannot be used directly from the macOS app,
+  a warning is shown.
 - **Configure later:** skip setup and leave the app unconfigured.
 
 <Tip>

--- a/docs/zh-CN/automation/gmail-pubsub.md
+++ b/docs/zh-CN/automation/gmail-pubsub.md
@@ -32,7 +32,7 @@ x-i18n:
 {
   hooks: {
     enabled: true,
-    token: "OPENCLAW_HOOK_TOKEN",
+    token: "${OPENCLAW_HOOKS_TOKEN}",
     path: "/hooks",
     presets: ["gmail"],
   },
@@ -45,7 +45,7 @@ x-i18n:
 {
   hooks: {
     enabled: true,
-    token: "OPENCLAW_HOOK_TOKEN",
+    token: "${OPENCLAW_HOOKS_TOKEN}",
     presets: ["gmail"],
     mappings: [
       {
@@ -180,7 +180,7 @@ gog gmail watch serve \
   --path /gmail-pubsub \
   --token <shared> \
   --hook-url http://127.0.0.1:18789/hooks/gmail \
-  --hook-token OPENCLAW_HOOK_TOKEN \
+  --hook-token "$OPENCLAW_HOOKS_TOKEN" \
   --include-body \
   --max-bytes 20000
 ```


### PR DESCRIPTION
## Summary

- **`docs/help/environment.md`**: add `OPENCLAW_CLI=1` runtime marker — landed in #41411 without a docs update
- **`docs/cli/acp.md`**: document `--provenance` flag (`off`, `meta`, `meta+receipt` modes) — landed in #40473 without updating the Options section
- **`docs/start/onboarding.md`**: document the remote gateway token field added for macOS remote mode onboarding (commit 6b338dd28)
- **`docs/automation/gmail-pubsub.md`**: standardize hook token references to `${OPENCLAW_HOOKS_TOKEN}` env var substitution pattern, matching `webhook.md` (was using literal `"OPENCLAW_HOOK_TOKEN"`)

## Context

Audited the last 100 commits against existing docs and identified these 4 gaps where features landed without corresponding documentation updates. Cross-checked against open issues/PRs — no duplicates (the separate `docs/zh-CN/tools/diffs.md` gap is already covered by #36545).

## Test plan

- [x] Verify `pnpm check` passes (formatting)
- [x] Verify docs render correctly on Mintlify preview
- [x] Spot-check each changed file against source code for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)