### PR TITLE
fix(cron): reload external store edits before reusing cache

### DIFF
--- a/src/cron/service.external-store-reload.test.ts
+++ b/src/cron/service.external-store-reload.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
+
+const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-external-reload-",
+});
+
+async function bumpStoreMtime(storePath: string, iso: string) {
+  const ts = new Date(iso);
+  await fs.utimes(storePath, ts, ts);
+}
+
+describe("CronService external store reload", () => {
+  it("reloads a manually cleared running marker before cron.run", async () => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    try {
+      await cron.start();
+      const job = await cron.add({
+        name: "manual recovery",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "run now" },
+        delivery: { mode: "none" },
+      });
+
+      const internal = cron as unknown as {
+        state: {
+          store: {
+            jobs: Array<{
+              id: string;
+              state: { runningAtMs?: number };
+            }>;
+          } | null;
+        };
+      };
+      const inMemoryJob = internal.state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(inMemoryJob).toBeDefined();
+      inMemoryJob!.state.runningAtMs = Date.now();
+
+      await writeCronStoreSnapshot({
+        storePath: store.storePath,
+        jobs: [{ ...job, state: { ...job.state, runningAtMs: undefined } }],
+      });
+      await bumpStoreMtime(store.storePath, "2030-01-01T00:00:00.000Z");
+
+      await expect(cron.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("reloads externally deleted jobs for list and run", async () => {
+    const store = await makeStorePath();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const, summary: "done" })),
+    });
+
+    try {
+      await cron.start();
+      const job = await cron.add({
+        name: "manual delete",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "run now" },
+        delivery: { mode: "none" },
+      });
+
+      await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+      await fs.writeFile(
+        store.storePath,
+        JSON.stringify({ version: 1, jobs: [] }, null, 2),
+        "utf-8",
+      );
+      await bumpStoreMtime(store.storePath, "2030-01-01T00:05:00.000Z");
+
+      await expect(cron.list({ includeDisabled: true })).resolves.toEqual([]);
+      await expect(cron.run(job.id, "force")).rejects.toThrow(`unknown cron job id: ${job.id}`);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -23,10 +23,15 @@ export async function ensureLoaded(
     skipRecompute?: boolean;
   },
 ) {
-  // Fast path: store is already in memory. Other callers (add, list, run, …)
-  // trust the in-memory copy to avoid a stat syscall on every operation.
+  // Fast path: keep the in-memory store unless the backing file changed.
+  // This lets live cron instances recover from manual jobs.json edits without
+  // requiring a gateway restart, while still avoiding a full file read when the
+  // store has not changed.
   if (state.store && !opts?.forceReload) {
-    return;
+    const fileMtimeMs = await getFileMtimeMs(state.deps.storePath);
+    if (fileMtimeMs === state.storeFileMtimeMs) {
+      return;
+    }
   }
   // Force reload always re-reads the file to avoid missing cross-service
   // edits on filesystems with coarse mtime resolution.

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -8,6 +8,9 @@ import type { CronServiceState } from "./state.js";
 async function getFileMtimeMs(path: string): Promise<number | null> {
   try {
     const stats = await fs.promises.stat(path);
+    if (!stats.isFile()) {
+      return null;
+    }
     return stats.mtimeMs;
   } catch {
     return null;
@@ -29,7 +32,7 @@ export async function ensureLoaded(
   // store has not changed.
   if (state.store && !opts?.forceReload) {
     const fileMtimeMs = await getFileMtimeMs(state.deps.storePath);
-    if (fileMtimeMs === state.storeFileMtimeMs) {
+    if (fileMtimeMs === null || fileMtimeMs === state.storeFileMtimeMs) {
       return;
     }
   }


### PR DESCRIPTION
$## What\nCron currently trusts the in-memory job store on normal operations, so live gateways can miss external edits to `~/.openclaw/cron/jobs.json` until restart.\n\nThis patch makes `ensureLoaded()` stat the backing store and reload when the file mtime changes before reusing the cached store. That lets a running gateway see manual recovery edits like clearing `runningAtMs` or removing wedged jobs.\n\n## Why\nIn production we hit a cron job stuck in `already-running` even after clearing `runningAtMs` in `jobs.json`. The live process was still consulting stale in-memory state.\n\n## Tests\nAdded `src/cron/service.external-store-reload.test.ts` covering:\n- external clearing of a stale `runningAtMs` marker before `cron.run`\n- external deletion of a job reflected by `cron.list` and `cron.run`\n\nRan:\n```bash\npnpm exec vitest run --config vitest.unit.config.ts \\\n  src/cron/service.external-store-reload.test.ts \\\n  src/cron/service.read-ops-nonblocking.test.ts \\\n  src/cron/service.restart-catchup.test.ts\n```\n\nAll passed (13 tests).\n\n## Notes\nThis fixes the stale cached store path. It does not address the separate issue where a manual `cron.run` can return `enqueued: true` but later fail before a run-history entry is recorded.