### PR TITLE
fix(restart): drain active work before restarting

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -48,6 +48,7 @@ const GatewayToolSchema = Type.Object({
   // restart
   delayMs: Type.Optional(Type.Number()),
   reason: Type.Optional(Type.String()),
+  force: Type.Optional(Type.Boolean()),
   // config.get, config.schema.lookup, config.apply, update.run
   gatewayUrl: Type.Optional(Type.String()),
   gatewayToken: Type.Optional(Type.String()),
@@ -99,6 +100,7 @@ export function createGatewayTool(opts?: {
             : undefined;
         const note =
           typeof params.note === "string" && params.note.trim() ? params.note.trim() : undefined;
+        const force = params.force === true;
         // Extract channel + threadId for routing after restart
         // Supports both :thread: (most channels) and :topic: (Telegram)
         const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
@@ -122,11 +124,12 @@ export function createGatewayTool(opts?: {
           // ignore: sentinel is best-effort
         }
         log.info(
-          `gateway tool: restart requested (delayMs=${delayMs ?? "default"}, reason=${reason ?? "none"})`,
+          `gateway tool: restart requested (delayMs=${delayMs ?? "default"}, reason=${reason ?? "none"}, force=${force})`,
         );
         const scheduled = scheduleGatewaySigusr1Restart({
           delayMs,
           reason,
+          force,
         });
         return jsonResult(scheduled);
       }

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -232,20 +232,42 @@ describe("infra runtime", () => {
       }
     });
 
-    it("emits SIGUSR1 after deferral timeout even if still pending", async () => {
+    it("waits indefinitely by default when pending work exists (no forced timeout)", async () => {
       const emitSpy = vi.spyOn(process, "emit");
       const handler = () => {};
       process.on("SIGUSR1", handler);
       try {
-        setPreRestartDeferralCheck(() => 5); // always pending
+        let pending = 5;
+        setPreRestartDeferralCheck(() => pending);
         scheduleGatewaySigusr1Restart({ delayMs: 0 });
 
         // Fire initial timeout
         await vi.advanceTimersByTimeAsync(0);
         expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
 
-        // Advance past the 90s max deferral wait
-        await vi.advanceTimersByTimeAsync(90_000);
+        // Advance well past the old 90s limit — should still NOT restart
+        await vi.advanceTimersByTimeAsync(300_000);
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+        // Drain pending work — now it restarts
+        pending = 0;
+        await vi.advanceTimersByTimeAsync(500);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("emits SIGUSR1 immediately when force is true even if pending", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        setPreRestartDeferralCheck(() => 5); // always pending
+        scheduleGatewaySigusr1Restart({ delayMs: 0, force: true });
+
+        // Fire initial timeout — force skips deferral entirely
+        await vi.advanceTimersByTimeAsync(0);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -19,8 +19,9 @@ export type RestartAttempt = {
 const SPAWN_TIMEOUT_MS = 2000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
-// Cover slow in-flight embedded compaction work before forcing restart.
-const DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000;
+// 0 = wait indefinitely for drain (no forced restart while work is active).
+const DEFAULT_DEFERRAL_MAX_WAIT_MS = 0;
+const DEFERRAL_WARN_INTERVAL_MS = 30_000;
 const RESTART_COOLDOWN_MS = 30_000;
 
 const restartLog = createSubsystemLogger("restart");
@@ -198,11 +199,17 @@ export function deferGatewayRestartUntilIdle(opts: {
   hooks?: RestartDeferralHooks;
   pollMs?: number;
   maxWaitMs?: number;
+  force?: boolean;
 }): void {
+  if (opts.force) {
+    emitGatewayRestart();
+    return;
+  }
+
   const pollMsRaw = opts.pollMs ?? DEFAULT_DEFERRAL_POLL_MS;
   const pollMs = Math.max(10, Math.floor(pollMsRaw));
   const maxWaitMsRaw = opts.maxWaitMs ?? DEFAULT_DEFERRAL_MAX_WAIT_MS;
-  const maxWaitMs = Math.max(pollMs, Math.floor(maxWaitMsRaw));
+  const maxWaitMs = maxWaitMsRaw > 0 ? Math.max(pollMs, Math.floor(maxWaitMsRaw)) : 0;
 
   let pending: number;
   try {
@@ -220,6 +227,7 @@ export function deferGatewayRestartUntilIdle(opts: {
 
   opts.hooks?.onDeferring?.(pending);
   const startedAt = Date.now();
+  let lastWarnAt = startedAt;
   const poll = setInterval(() => {
     let current: number;
     try {
@@ -236,11 +244,17 @@ export function deferGatewayRestartUntilIdle(opts: {
       emitGatewayRestart();
       return;
     }
-    const elapsedMs = Date.now() - startedAt;
-    if (elapsedMs >= maxWaitMs) {
+    const now = Date.now();
+    const elapsedMs = now - startedAt;
+    if (maxWaitMs > 0 && elapsedMs >= maxWaitMs) {
       clearInterval(poll);
       opts.hooks?.onTimeout?.(current, elapsedMs);
       emitGatewayRestart();
+      return;
+    }
+    if (now - lastWarnAt >= DEFERRAL_WARN_INTERVAL_MS) {
+      lastWarnAt = now;
+      restartLog.warn(`restart deferred: ${current} items still active (${elapsedMs}ms elapsed)`);
     }
   }, pollMs);
 }
@@ -407,6 +421,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   delayMs?: number;
   reason?: string;
   audit?: RestartAuditInfo;
+  force?: boolean;
 }): ScheduledRestart {
   const delayMsRaw =
     typeof opts?.delayMs === "number" && Number.isFinite(opts.delayMs)
@@ -470,6 +485,10 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       pendingRestartTimer = null;
       pendingRestartDueAt = 0;
       pendingRestartReason = undefined;
+      if (opts?.force) {
+        emitGatewayRestart();
+        return;
+      }
       const pendingCheck = preRestartCheck;
       if (!pendingCheck) {
         emitGatewayRestart();


### PR DESCRIPTION
### Problem

`deferGatewayRestartUntilIdle` uses a hard 90s timeout (`DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000`). After 90s it force-restarts the gateway regardless of in-flight work. Opus agent turns routinely take 30s-5min, so config patches, updates, and manual restarts can silently kill active responses.

### Changes

- Default `maxWaitMs` changed to `0` (wait indefinitely for drain). The gateway now polls until all pending work (LLM streams, outbound queue, embedded runs) reaches zero before restarting.
- Periodic warning log every 30s while waiting: `restart deferred: N items still active (Xms elapsed)`.
- Finite `maxWaitMs` still supported -- if configured, the old timeout-then-restart behavior is preserved.
- `force` parameter added to `scheduleGatewaySigusr1Restart` and `deferGatewayRestartUntilIdle` for break-glass scenarios. `gateway restart` tool accepts `force: true` to skip the drain gate entirely.

### Files

- `src/infra/restart.ts` - default to unlimited drain wait, add periodic warn logs, add `force` bypass
- `src/agents/tools/gateway-tool.ts` - expose `force` param on restart action schema
- `src/infra/infra-runtime.test.ts` - updated: verify indefinite wait by default, verify force bypass