### PR TITLE
fix(feishu): share webhook server across accounts on same host:port

### DIFF
--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -13,6 +13,21 @@ export const httpServers = new Map<string, http.Server>();
 export const botOpenIds = new Map<string, string>();
 export const botNames = new Map<string, string>();
 
+/** Shared webhook server pool — keyed by "host:port". */
+export type WebhookRoute = {
+  accountId: string;
+  appId: string;
+  token: string;
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void;
+};
+export type WebhookServerEntry = {
+  server: http.Server;
+  routes: Map<string, WebhookRoute>; // accountId → route
+  /** Resolves once server.listen() succeeds; rejects on bind failure. */
+  ready: Promise<void>;
+};
+export const webhookServerPool = new Map<string, WebhookServerEntry>();
+
 export const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 export const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 
@@ -135,21 +150,44 @@ export function recordWebhookStatus(
 export function stopFeishuMonitorState(accountId?: string): void {
   if (accountId) {
     wsClients.delete(accountId);
-    const server = httpServers.get(accountId);
-    if (server) {
-      server.close();
-      httpServers.delete(accountId);
+    // Remove from shared pool; close the server only when no routes remain.
+    for (const [key, entry] of webhookServerPool) {
+      if (entry.routes.has(accountId)) {
+        entry.routes.delete(accountId);
+        if (entry.routes.size === 0) {
+          entry.server.close();
+          webhookServerPool.delete(key);
+        }
+        break;
+      }
     }
+    // For non-pooled servers (shouldn't happen, defensive).
+    const server = httpServers.get(accountId);
+    if (server && !isPooledServer(server)) {
+      server.close();
+    }
+    httpServers.delete(accountId);
     botOpenIds.delete(accountId);
     botNames.delete(accountId);
     return;
   }
 
   wsClients.clear();
+  for (const entry of webhookServerPool.values()) {
+    entry.server.close();
+  }
+  webhookServerPool.clear();
   for (const server of httpServers.values()) {
-    server.close();
+    if (!isPooledServer(server)) server.close();
   }
   httpServers.clear();
   botOpenIds.clear();
   botNames.clear();
+}
+
+function isPooledServer(server: http.Server): boolean {
+  for (const entry of webhookServerPool.values()) {
+    if (entry.server === server) return true;
+  }
+  return false;
 }

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import crypto from "node:crypto";
+import { Readable } from "stream";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import {
   applyBasicWebhookRequestGuards,
@@ -16,7 +17,9 @@ import {
   feishuWebhookRateLimiter,
   httpServers,
   recordWebhookStatus,
+  webhookServerPool,
   wsClients,
+  type WebhookServerEntry,
 } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -130,17 +133,191 @@ export async function monitorWebhook({
   const port = account.config.webhookPort ?? 3000;
   const path = account.config.webhookPath ?? "/feishu/events";
   const host = account.config.webhookHost ?? "127.0.0.1";
+  const serverKey = `${host}:${port}`;
 
+  // ---------------------------------------------------------------------------
+  // Helper: join an existing pooled server that is ready (or becoming ready).
+  // ---------------------------------------------------------------------------
+  const joinExistingServer = (existing: WebhookServerEntry): Promise<void> => {
+    existing.routes.set(accountId, {
+      accountId,
+      appId: account.appId?.trim() ?? "",
+      token: account.verificationToken?.trim() ?? "",
+      handler: createGuardedHandler({ account, accountId, path, runtime, error, eventDispatcher }),
+    });
+    httpServers.set(accountId, existing.server);
+    log(
+      `feishu[${accountId}]: joined shared Webhook server on ${serverKey} ` +
+        `(${existing.routes.size} accounts)`,
+    );
+
+    return new Promise<void>((resolve) => {
+      const handleAbort = () => {
+        log(`feishu[${accountId}]: abort, leaving shared server on ${serverKey}`);
+        existing.routes.delete(accountId);
+        httpServers.delete(accountId);
+        botOpenIds.delete(accountId);
+        botNames.delete(accountId);
+        if (existing.routes.size === 0) {
+          existing.server.close();
+          webhookServerPool.delete(serverKey);
+        }
+        resolve();
+      };
+      if (abortSignal?.aborted) {
+        handleAbort();
+        return;
+      }
+      abortSignal?.addEventListener("abort", handleAbort, { once: true });
+    });
+  };
+
+  // ---------------------------------------------------------------------------
+  // Try to re-use an existing server on the same host:port.
+  // The pool entry is published *before* listen() completes (reservation) so
+  // concurrent starters coalesce on the same entry.  Joiners await
+  // `entry.ready` and fall through to create a new server if listen fails.
+  // ---------------------------------------------------------------------------
+  const existing = webhookServerPool.get(serverKey);
+  if (existing) {
+    try {
+      await existing.ready;
+    } catch {
+      // Creator's listen failed; the pool entry has been cleaned up.
+      // Fall through to create a fresh server below.
+      log(`feishu[${accountId}]: shared server on ${serverKey} failed to start, creating new`);
+    }
+    // Re-check: the pool entry may have been removed by the creator's error handler.
+    const current = webhookServerPool.get(serverKey);
+    if (current === existing) {
+      return joinExistingServer(existing);
+    }
+    // else: fall through to create a new server.
+  }
+
+  // ---------------------------------------------------------------------------
+  // First account on this host:port — create a new pooled server.
+  // Publish the pool entry immediately (reservation) so concurrent starters
+  // see it and await `ready` instead of creating duplicate servers.
+  // ---------------------------------------------------------------------------
   log(`feishu[${accountId}]: starting Webhook server on ${host}:${port}, path ${path}...`);
-
   const server = http.createServer();
 
-  server.on("request", (req, res) => {
-    res.on("finish", () => {
-      recordWebhookStatus(runtime, accountId, path, res.statusCode);
+  let resolveReady!: () => void;
+  let rejectReady!: (err: unknown) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  // Mark the rejection as observed so that Node does not treat it as an
+  // unhandled rejection when no joiner is awaiting the promise (e.g. single-
+  // account EADDRINUSE or early abort).  Joiners still receive the rejection
+  // via their own `await existing.ready` inside a try/catch.
+  ready.catch(() => {});
+
+  const entry: WebhookServerEntry = {
+    server,
+    ready,
+    routes: new Map([
+      [
+        accountId,
+        {
+          accountId,
+          appId: account.appId?.trim() ?? "",
+          token: account.verificationToken?.trim() ?? "",
+          handler: createGuardedHandler({
+            account,
+            accountId,
+            path,
+            runtime,
+            error,
+            eventDispatcher,
+          }),
+        },
+      ],
+    ]),
+  };
+  // Publish reservation before listen so concurrent starters coalesce.
+  webhookServerPool.set(serverKey, entry);
+  httpServers.set(accountId, server);
+
+  server.on("request", createPoolDispatcher(entry));
+
+  return new Promise((resolve, reject) => {
+    // Remove only this account's route; close the server only when no routes remain.
+    // This mirrors the joiner's abort handler so creator and joiner behave identically.
+    const removeOwnRoute = () => {
+      entry.routes.delete(accountId);
+      httpServers.delete(accountId);
+      botOpenIds.delete(accountId);
+      botNames.delete(accountId);
+      if (entry.routes.size === 0) {
+        server.close();
+        webhookServerPool.delete(serverKey);
+      }
+    };
+
+    const handleAbort = () => {
+      log(`feishu[${accountId}]: abort signal received, leaving Webhook server on ${serverKey}`);
+      // Settle `ready` so concurrent joiners awaiting it do not hang forever.
+      rejectReady(new Error("aborted"));
+      removeOwnRoute();
+      resolve();
+    };
+
+    if (abortSignal?.aborted) {
+      rejectReady(new Error("aborted"));
+      removeOwnRoute();
+      resolve();
+      return;
+    }
+
+    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+    server.listen(port, host, () => {
+      resolveReady();
+      log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
     });
 
-    const rateLimitKey = `${accountId}:${path}:${req.socket.remoteAddress ?? "unknown"}`;
+    server.on("error", (err) => {
+      error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      // Signal pending joiners that this server will not start.
+      rejectReady(err);
+      // Clean pool state so the next restart does not join a dead server.
+      server.close();
+      webhookServerPool.delete(serverKey);
+      for (const aid of entry.routes.keys()) {
+        httpServers.delete(aid);
+        botOpenIds.delete(aid);
+        botNames.delete(aid);
+      }
+      abortSignal?.removeEventListener("abort", handleAbort);
+      reject(err);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — kept private to this module.
+// ---------------------------------------------------------------------------
+
+/** Wrap an account's webhook logic with rate-limit, body-guard, signature
+ *  validation, challenge handling, and event dispatch.
+ *  Signature stays `(req, res) => void` so it slots into the route map. */
+function createGuardedHandler(opts: {
+  account: ResolvedFeishuAccount;
+  accountId: string;
+  path: string;
+  runtime?: RuntimeEnv;
+  error: (...args: unknown[]) => void;
+  eventDispatcher: Lark.EventDispatcher;
+}): (req: http.IncomingMessage, res: http.ServerResponse) => void {
+  return (req, res) => {
+    res.on("finish", () => {
+      recordWebhookStatus(opts.runtime, opts.accountId, opts.path, res.statusCode);
+    });
+
+    const rateLimitKey = `${opts.accountId}:${opts.path}:${req.socket.remoteAddress ?? "unknown"}`;
     if (
       !applyBasicWebhookRequestGuards({
         req,
@@ -188,7 +365,7 @@ export async function monitorWebhook({
           !isFeishuWebhookSignatureValid({
             headers: req.headers,
             payload: bodyResult.value,
-            encryptKey: account.encryptKey,
+            encryptKey: opts.account.encryptKey,
           })
         ) {
           respondText(res, 401, "Invalid signature");
@@ -196,7 +373,7 @@ export async function monitorWebhook({
         }
 
         const { isChallenge, challenge } = Lark.generateChallenge(bodyResult.value, {
-          encryptKey: account.encryptKey ?? "",
+          encryptKey: opts.account.encryptKey ?? "",
         });
         if (isChallenge) {
           res.statusCode = 200;
@@ -205,7 +382,7 @@ export async function monitorWebhook({
           return;
         }
 
-        const value = await eventDispatcher.invoke(
+        const value = await opts.eventDispatcher.invoke(
           buildFeishuWebhookEnvelope(req, bodyResult.value),
           { needCheck: false },
         );
@@ -216,7 +393,7 @@ export async function monitorWebhook({
         }
       } catch (err) {
         if (!guard.isTripped()) {
-          error(`feishu[${accountId}]: webhook handler error: ${String(err)}`);
+          opts.error(`feishu[${opts.accountId}]: webhook handler error: ${String(err)}`);
           if (!res.headersSent) {
             respondText(res, 500, "Internal Server Error");
           }
@@ -225,40 +402,150 @@ export async function monitorWebhook({
         guard.dispose();
       }
     })();
-  });
+  };
+}
 
-  httpServers.set(accountId, server);
-
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      server.close();
-      httpServers.delete(accountId);
-      botOpenIds.delete(accountId);
-      botNames.delete(accountId);
-    };
-
-    const handleAbort = () => {
-      log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
-      cleanup();
-      resolve();
-    };
-
-    if (abortSignal?.aborted) {
-      cleanup();
-      resolve();
+/** Create the single `request` listener for a pooled server.
+ *
+ *  - 1 route  → fast-path: delegate directly (zero body parsing overhead).
+ *  - N routes → read body once, extract `header.token` / `header.app_id` for
+ *               routing, then replay the body as a new Readable stream. */
+function createPoolDispatcher(entry: WebhookServerEntry) {
+  return (req: http.IncomingMessage, res: http.ServerResponse) => {
+    // Fast path: single account — no routing needed.
+    if (entry.routes.size === 1) {
+      const route = entry.routes.values().next().value;
+      if (route) route.handler(req, res);
       return;
     }
 
-    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+    // Apply lightweight request guards *before* buffering the body so that
+    // invalid-method / non-JSON requests are rejected without consuming socket
+    // and memory resources.  Rate limiting is intentionally omitted here — each
+    // routed account's createGuardedHandler applies its own per-account limit.
+    // A pool-wide per-IP limit would cap aggregate traffic from one IP across
+    // all accounts at a single-account threshold, rejecting legitimate events.
+    if (
+      !applyBasicWebhookRequestGuards({
+        req,
+        res,
+        requireJsonContentType: true,
+      })
+    ) {
+      return;
+    }
 
-    server.listen(port, host, () => {
-      log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
-    });
+    // Multi-account: buffer body to extract the routing token.
+    // Enforce the same body size limit and timeout used by the per-account guard
+    // so an oversized or slow payload is rejected before we finish buffering.
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let aborted = false;
 
-    server.on("error", (err) => {
-      error(`feishu[${accountId}]: Webhook server error: ${err}`);
-      abortSignal?.removeEventListener("abort", handleAbort);
-      reject(err);
+    const bodyTimeout = setTimeout(() => {
+      if (aborted) return;
+      aborted = true;
+      res.statusCode = 408;
+      res.end("Request Timeout");
+      req.destroy();
+    }, FEISHU_WEBHOOK_BODY_TIMEOUT_MS);
+
+    const finishBuffering = () => {
+      clearTimeout(bodyTimeout);
+    };
+
+    req.on("data", (c: Buffer) => {
+      if (aborted) return;
+      totalBytes += c.length;
+      if (totalBytes > FEISHU_WEBHOOK_MAX_BODY_BYTES) {
+        aborted = true;
+        finishBuffering();
+        res.statusCode = 413;
+        res.end("Payload Too Large");
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
     });
+    req.on("end", () => {
+      finishBuffering();
+      if (aborted) return;
+      const raw = Buffer.concat(chunks);
+      const route = resolveRoute(entry, raw);
+      if (!route) {
+        res.statusCode = 404;
+        res.end("Not Found");
+        return;
+      }
+      route.handler(replayRequest(req, raw), res);
+    });
+    req.on("error", () => {
+      finishBuffering();
+      if (!res.headersSent) {
+        res.statusCode = 400;
+        res.end("Bad Request");
+      }
+    });
+  };
+}
+
+/** Pick the matching route using a three-tier strategy:
+ *  1. token + appId  (strongest — disambiguates shared/inherited tokens)
+ *  2. token-only     (sufficient when tokens are unique per account)
+ *  3. appId-only     (fallback when verificationToken is absent)
+ *  4. url_verification → any account can respond. */
+function resolveRoute(entry: WebhookServerEntry, body: Buffer) {
+  let token: string | undefined;
+  let appId: string | undefined;
+  let type: string | undefined;
+  try {
+    const json = JSON.parse(body.toString("utf-8"));
+    token = json.header?.token ?? json.token;
+    appId = json.header?.app_id ?? json.event?.app_id;
+    type = json.type;
+  } catch {
+    return undefined;
+  }
+
+  // Tier 1: both token and appId match — handles shared/inherited tokens.
+  if (token && appId) {
+    for (const route of entry.routes.values()) {
+      if (route.token && route.token === token && route.appId && route.appId === appId) {
+        return route;
+      }
+    }
+  }
+  // Tier 2: token-only (unique token per account).
+  if (token) {
+    for (const route of entry.routes.values()) {
+      if (route.token && route.token === token) return route;
+    }
+  }
+  // Tier 3: appId-only (verificationToken absent).
+  if (appId) {
+    for (const route of entry.routes.values()) {
+      if (route.appId && route.appId === appId) return route;
+    }
+  }
+  // url_verification: any account can respond.
+  if (type === "url_verification") return entry.routes.values().next().value;
+  return undefined;
+}
+
+/** Create a Readable that replays `rawBody` while preserving original request
+ *  properties so downstream handlers can consume it normally. */
+function replayRequest(original: http.IncomingMessage, rawBody: Buffer): http.IncomingMessage {
+  const stream = new Readable({ read() {} });
+  stream.push(rawBody);
+  stream.push(null);
+  Object.assign(stream, {
+    method: original.method,
+    url: original.url,
+    headers: original.headers,
+    rawHeaders: original.rawHeaders,
+    httpVersion: original.httpVersion,
+    socket: original.socket,
+    connection: original.connection,
   });
+  return stream as unknown as http.IncomingMessage;
 }


### PR DESCRIPTION
When multiple Feishu accounts use webhook mode on the same host:port, each previously created its own http.Server, causing EADDRINUSE on the second listen().

Add a server pool keyed by host:port in monitor.state.ts.  Accounts joining an existing pool entry register a route (token + handler); the pool dispatcher routes by verification token or app_id.

Single-account fast-path: when only one route is registered the dispatcher delegates directly with zero body-parsing overhead.

Cleanup in stopFeishuMonitorState correctly removes routes and only closes the server when the last account leaves.

Files changed: monitor.transport.ts, monitor.state.ts

## Summary

- **Problem:** `monitorWebhook()` in `monitor.transport.ts` calls `http.createServer()` per account. When ≥2 accounts share the same `host:port` (or rely on the default port 3000), the second `server.listen()` fails with `EADDRINUSE`.
- **Why it matters:** Multi-account Feishu/Lark webhook deployments on a single OpenClaw instance are impossible without manual per-account port assignment plus an external reverse proxy — unnecessarily complex for a common use case.
- **What changed:** Introduced a `webhookServerPool` (`Map<string, WebhookServerEntry>`) in `monitor.state.ts` keyed by `host:port`. `monitorWebhook()` checks the pool before creating a new server; subsequent accounts join the existing entry. A pool dispatcher routes incoming requests by `header.token` or `header.app_id`. Body size is capped at `FEISHU_WEBHOOK_MAX_BODY_BYTES` (1 MB) before buffering. Existing rate-limit and body-guard logic is extracted into `createGuardedHandler()` (no behavioral change). `stopFeishuMonitorState()` is updated with pool-aware cleanup.
- **What did NOT change (scope boundary):** WebSocket mode, `monitor.ts`, `monitor.account.ts`, `monitor.startup.ts`, event dispatching internals, config schema, and all other files remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None — single-account setups hit the fast path and behave identically. Multi-account setups that previously crashed with `EADDRINUSE` now work without config changes.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — verification tokens are read from existing config, used only for in-process routing comparison, never logged or transmitted.
- New/changed network calls? `No` — the same `http.createServer()` and `server.listen()` calls are used; the change is that they are shared instead of duplicated.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (tested on Ubuntu 22.04)
- Runtime/container: Node.js 20+
- Model/provider: N/A
- Integration/channel: Feishu / Lark International (webhook mode)
- Relevant config (redacted):
  ```yaml
  channels:
    feishu:
      accounts:
        bot-a:
          appId: "cli_aaa..."
          verificationToken: "tok_aaa..."
          connectionMode: webhook
        bot-b:
          appId: "cli_bbb..."
          verificationToken: "tok_bbb..."
          connectionMode: webhook
      webhookPort: 3000
  ```

### Steps

1. Configure 2+ Feishu accounts in webhook mode sharing the same port (or relying on default 3000).
2. Start the OpenClaw gateway.
3. Observe the second account starts successfully and joins the shared server.
4. Send a webhook event with `header.token` matching bot-b's verification token.
5. Verify bot-b's event dispatcher receives the event.

### Expected

- All accounts share a single HTTP server on port 3000.
- Each account's events are routed by verification token.
- Stopping a single account removes its route; server stays alive for remaining accounts.
- Stopping all accounts (or the last one) closes the server.

### Actual

- Before fix: second account crashes with `Error: listen EADDRINUSE: address already in use 0.0.0.0:3000`.
- After fix: all accounts share the server and route correctly.

## Evidence

- Code review of `monitor.transport.ts` and `monitor.state.ts` diffs.
- `oxfmt --check` passes (formatting compliant).

## Human Verification (required)

- Verified scenarios: multi-account webhook startup (no EADDRINUSE), single-account fast-path (zero overhead), account removal with pool cleanup.
- Edge cases checked: oversized body (413 Payload Too Large), malformed JSON body (404 Not Found), `url_verification` challenge forwarded to first handler, abort signal on creator vs joiner account, `appId` fallback routing when `verificationToken` is absent.
- What you did **not** verify: full integration test with Lark SDK's `adaptDefault()` consuming the replayed `Readable` stream end-to-end (would require a live Feishu app).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: assign unique `webhookPort` per account in config to bypass the shared server path entirely.
- Files/config to restore: revert `monitor.transport.ts` and `monitor.state.ts` to upstream/main.
- Known bad symptoms reviewers should watch for: webhook events delivered to wrong account (token mismatch), 404 responses for valid webhooks (routing failure), memory growth from unbounded body buffering (mitigated by 1 MB cap).

## Risks and Mitigations

- Risk: Replayed `Readable` stream may behave differently from the original `IncomingMessage` for edge-case middleware in the Lark SDK.
  - Mitigation: `replayRequest` copies `method`, `url`, `headers`, `rawHeaders`, `httpVersion`, `socket`, and `connection` from the original request. The single-account fast path avoids replay entirely.
- Risk: Multi-account body buffering adds latency vs. direct streaming.
  - Mitigation: Feishu webhook payloads are typically <10 KB. The 1 MB cap (`FEISHU_WEBHOOK_MAX_BODY_BYTES`) prevents memory abuse. Single-account setups are unaffected (fast path).