### PR TITLE
fix: 2026.3.8 regressions - config crash and cron deadlock

### DIFF
--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,10 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  // FIX #41247: Filter out empty strings to prevent RangeError
+  const values = [...params.sensitiveValues]
+    .filter((v) => v && v.length > 0)
+    .toSorted((a, b) => b.length - a.length);
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -292,7 +292,10 @@ export function buildGatewayCronService(params: {
         abortSignal,
         agentId,
         sessionKey: `cron:${job.id}`,
-        lane: "cron",
+        // FIX #41266: Use subagent lane to avoid deadlock with cron lane
+        // The outer enqueueRun already holds CommandLane.Cron; using "cron"
+        // here would cause deadlock since cron lane has concurrency=1.
+        lane: "subagent",
       });
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {


### PR DESCRIPTION
# Fix: 2026.3.8 Regressions — Config Crash & Cron Deadlock

## What This Fixes

Hey team! This PR squashes two nasty bugs that slipped into the 2026.3.8 release. Both are causing real pain for users, so let's get them fixed fast.

---

## 🐛 Bug 1: Config Page Crashes with Empty API Keys

**Issues:** [#41247](https://github.com/openclaw/openclaw/issues/41247), [#40818](https://github.com/openclaw/openclaw/issues/40818)

**The Problem:**  
Imagine you have an empty API key in your config (like `"apiKey": ""`). When OpenClaw tries to hide (redact) sensitive info before showing the config, it does a "find and replace" — but replacing NOTHING with `__REDACTED__` causes JavaScript to freak out and throw `RangeError: Invalid string length`. The whole Agents page goes white. Not fun.

**The Fix:**  
Simple check: skip empty strings when hiding sensitive data. If it's empty, we don't need to redact it anyway!

```typescript
// Before: Crash on empty string
const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);

// After: Skip empty strings
const values = [...params.sensitiveValues]
  .filter((v) => v && v.length > 0)
  .toSorted((a, b) => b.length - a.length);
```

---

## 🐛 Bug 2: Manual Cron Jobs Never Run (They Just... Wait Forever)

**Issues:** [#41266](https://github.com/openclaw/openclaw/issues/41266), [#41128](https://github.com/openclaw/openclaw/issues/41128), [#41129](https://github.com/openclaw/openclaw/issues/41129)

**The Problem:**  
You tell OpenClaw "run this job NOW" and it says "Got it, enqueued!" but then... crickets. It never runs. Just sits there until it times out.

Here's what's happening:
1. The outer queue manager grabs the **Cron lane** (only allows 1 job at a time)
2. It tries to run the actual work... which ALSO tries to grab the **Cron lane**
3. But the outer manager is already holding it!
4. **Deadlock.** The inner work waits forever. You wait forever. Everyone's sad.

**The Fix:**  
Make the actual work use a **different lane** (the "subagent" lane). Now the queue manager can hand off the work cleanly, and the work runs without fighting for the same lock.

```typescript
// Before: Deadlock city
lane: "cron",

// After: Smooth handoff
lane: "subagent",
```

---

## Files Changed

| File | What Changed |
|------|--------------|
| `src/config/redact-snapshot.raw.ts` | Filter empty strings before redaction |
| `src/gateway/server-cron.ts` | Use subagent lane for isolated cron jobs |

## Testing
- ✅ Config.get works with empty sensitive values
- ✅ Manual cron runs execute immediately  
- ✅ Scheduled cron runs still work fine
- ✅ All existing tests pass

## Risk Assessment
- **Risk:** Low — 8 lines changed, surgical fixes
- **Breaking Changes:** None
- **Backport to 3.8:** Recommended

---

*Fixes 5 bugs with 8 lines. Sometimes less is more.* 🎯
