### PR TITLE
refactor(doctor): extract safe-bin diagnostics helpers

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -16,16 +16,6 @@ import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { parseToolsBySenderTypedKey } from "../config/types.tools.js";
-import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
-import {
-  listInterpreterLikeSafeBins,
-  resolveMergedSafeBinProfileFixtures,
-} from "../infra/exec-safe-bin-runtime-policy.js";
-import {
-  getTrustedSafeBinDirs,
-  isTrustedSafeBinPath,
-  normalizeTrustedSafeBinDirs,
-} from "../infra/exec-safe-bin-trust.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import {
   formatChannelAccountsDefaultPath,
@@ -56,6 +46,11 @@ import {
   resolveConfigPathTarget,
   stripUnknownConfigKeys,
 } from "./doctor-config-analysis.js";
+import {
+  maybeRepairExecSafeBinProfiles,
+  scanExecSafeBinCoverage,
+  scanExecSafeBinTrustedDirHints,
+} from "./doctor-exec-safe-bins.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
@@ -1306,186 +1301,6 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
   }
 
   return warnings;
-}
-
-type ExecSafeBinCoverageHit = {
-  scopePath: string;
-  bin: string;
-  isInterpreter: boolean;
-};
-
-type ExecSafeBinScopeRef = {
-  scopePath: string;
-  safeBins: string[];
-  exec: Record<string, unknown>;
-  mergedProfiles: Record<string, unknown>;
-  trustedSafeBinDirs: ReadonlySet<string>;
-};
-
-type ExecSafeBinTrustedDirHintHit = {
-  scopePath: string;
-  bin: string;
-  resolvedPath: string;
-};
-
-function normalizeConfiguredSafeBins(entries: unknown): string[] {
-  if (!Array.isArray(entries)) {
-    return [];
-  }
-  return Array.from(
-    new Set(
-      entries
-        .map((entry) => (typeof entry === "string" ? entry.trim().toLowerCase() : ""))
-        .filter((entry) => entry.length > 0),
-    ),
-  ).toSorted();
-}
-
-function normalizeConfiguredTrustedSafeBinDirs(entries: unknown): string[] {
-  if (!Array.isArray(entries)) {
-    return [];
-  }
-  return normalizeTrustedSafeBinDirs(
-    entries.filter((entry): entry is string => typeof entry === "string"),
-  );
-}
-
-function collectExecSafeBinScopes(cfg: OpenClawConfig): ExecSafeBinScopeRef[] {
-  const scopes: ExecSafeBinScopeRef[] = [];
-  const globalExec = asObjectRecord(cfg.tools?.exec);
-  const globalTrustedDirs = normalizeConfiguredTrustedSafeBinDirs(globalExec?.safeBinTrustedDirs);
-  if (globalExec) {
-    const safeBins = normalizeConfiguredSafeBins(globalExec.safeBins);
-    if (safeBins.length > 0) {
-      scopes.push({
-        scopePath: "tools.exec",
-        safeBins,
-        exec: globalExec,
-        mergedProfiles:
-          resolveMergedSafeBinProfileFixtures({
-            global: globalExec,
-          }) ?? {},
-        trustedSafeBinDirs: getTrustedSafeBinDirs({
-          extraDirs: globalTrustedDirs,
-        }),
-      });
-    }
-  }
-  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
-  for (const agent of agents) {
-    if (!agent || typeof agent !== "object" || typeof agent.id !== "string") {
-      continue;
-    }
-    const agentExec = asObjectRecord(agent.tools?.exec);
-    if (!agentExec) {
-      continue;
-    }
-    const safeBins = normalizeConfiguredSafeBins(agentExec.safeBins);
-    if (safeBins.length === 0) {
-      continue;
-    }
-    scopes.push({
-      scopePath: `agents.list.${agent.id}.tools.exec`,
-      safeBins,
-      exec: agentExec,
-      mergedProfiles:
-        resolveMergedSafeBinProfileFixtures({
-          global: globalExec,
-          local: agentExec,
-        }) ?? {},
-      trustedSafeBinDirs: getTrustedSafeBinDirs({
-        extraDirs: [
-          ...globalTrustedDirs,
-          ...normalizeConfiguredTrustedSafeBinDirs(agentExec.safeBinTrustedDirs),
-        ],
-      }),
-    });
-  }
-  return scopes;
-}
-
-function scanExecSafeBinCoverage(cfg: OpenClawConfig): ExecSafeBinCoverageHit[] {
-  const hits: ExecSafeBinCoverageHit[] = [];
-  for (const scope of collectExecSafeBinScopes(cfg)) {
-    const interpreterBins = new Set(listInterpreterLikeSafeBins(scope.safeBins));
-    for (const bin of scope.safeBins) {
-      if (scope.mergedProfiles[bin]) {
-        continue;
-      }
-      hits.push({
-        scopePath: scope.scopePath,
-        bin,
-        isInterpreter: interpreterBins.has(bin),
-      });
-    }
-  }
-  return hits;
-}
-
-function scanExecSafeBinTrustedDirHints(cfg: OpenClawConfig): ExecSafeBinTrustedDirHintHit[] {
-  const hits: ExecSafeBinTrustedDirHintHit[] = [];
-  for (const scope of collectExecSafeBinScopes(cfg)) {
-    for (const bin of scope.safeBins) {
-      const resolution = resolveCommandResolutionFromArgv([bin]);
-      if (!resolution?.resolvedPath) {
-        continue;
-      }
-      if (
-        isTrustedSafeBinPath({
-          resolvedPath: resolution.resolvedPath,
-          trustedDirs: scope.trustedSafeBinDirs,
-        })
-      ) {
-        continue;
-      }
-      hits.push({
-        scopePath: scope.scopePath,
-        bin,
-        resolvedPath: resolution.resolvedPath,
-      });
-    }
-  }
-  return hits;
-}
-
-function maybeRepairExecSafeBinProfiles(cfg: OpenClawConfig): {
-  config: OpenClawConfig;
-  changes: string[];
-  warnings: string[];
-} {
-  const next = structuredClone(cfg);
-  const changes: string[] = [];
-  const warnings: string[] = [];
-
-  for (const scope of collectExecSafeBinScopes(next)) {
-    const interpreterBins = new Set(listInterpreterLikeSafeBins(scope.safeBins));
-    const missingBins = scope.safeBins.filter((bin) => !scope.mergedProfiles[bin]);
-    if (missingBins.length === 0) {
-      continue;
-    }
-    const profileHolder =
-      asObjectRecord(scope.exec.safeBinProfiles) ?? (scope.exec.safeBinProfiles = {});
-    for (const bin of missingBins) {
-      if (interpreterBins.has(bin)) {
-        warnings.push(
-          `- ${scope.scopePath}.safeBins includes interpreter/runtime '${bin}' without profile; remove it from safeBins or use explicit allowlist entries.`,
-        );
-        continue;
-      }
-      if (profileHolder[bin] !== undefined) {
-        continue;
-      }
-      profileHolder[bin] = {};
-      changes.push(
-        `- ${scope.scopePath}.safeBinProfiles.${bin}: added scaffold profile {} (review and tighten flags/positionals).`,
-      );
-    }
-  }
-
-  if (changes.length === 0 && warnings.length === 0) {
-    return { config: cfg, changes: [], warnings: [] };
-  }
-  return { config: next, changes, warnings };
 }
 
 type LegacyToolsBySenderKeyHit = {

--- a/src/commands/doctor-exec-safe-bins.ts
+++ b/src/commands/doctor-exec-safe-bins.ts
@@ -9,6 +9,7 @@ import {
   isTrustedSafeBinPath,
   normalizeTrustedSafeBinDirs,
 } from "../infra/exec-safe-bin-trust.js";
+import { isRecord } from "../utils.js";
 
 export type ExecSafeBinCoverageHit = {
   scopePath: string;
@@ -29,13 +30,6 @@ export type ExecSafeBinTrustedDirHintHit = {
   bin: string;
   resolvedPath: string;
 };
-
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
 
 function normalizeConfiguredSafeBins(entries: unknown): string[] {
   if (!Array.isArray(entries)) {
@@ -61,7 +55,7 @@ function normalizeConfiguredTrustedSafeBinDirs(entries: unknown): string[] {
 
 function collectExecSafeBinScopes(cfg: OpenClawConfig): ExecSafeBinScopeRef[] {
   const scopes: ExecSafeBinScopeRef[] = [];
-  const globalExec = asObjectRecord(cfg.tools?.exec);
+  const globalExec = isRecord(cfg.tools?.exec) ? cfg.tools.exec : null;
   const globalTrustedDirs = normalizeConfiguredTrustedSafeBinDirs(globalExec?.safeBinTrustedDirs);
   if (globalExec) {
     const safeBins = normalizeConfiguredSafeBins(globalExec.safeBins);
@@ -86,7 +80,7 @@ function collectExecSafeBinScopes(cfg: OpenClawConfig): ExecSafeBinScopeRef[] {
     if (!agent || typeof agent !== "object" || typeof agent.id !== "string") {
       continue;
     }
-    const agentExec = asObjectRecord(agent.tools?.exec);
+    const agentExec = isRecord(agent.tools?.exec) ? agent.tools.exec : null;
     if (!agentExec) {
       continue;
     }
@@ -176,8 +170,8 @@ export function maybeRepairExecSafeBinProfiles(cfg: OpenClawConfig): {
     if (missingBins.length === 0) {
       continue;
     }
-    const profileHolder =
-      asObjectRecord(scope.exec.safeBinProfiles) ?? (scope.exec.safeBinProfiles = {});
+    const profileHolder = isRecord(scope.exec.safeBinProfiles) ? scope.exec.safeBinProfiles : null;
+    const mutableProfileHolder = profileHolder ?? (scope.exec.safeBinProfiles = {});
     for (const bin of missingBins) {
       if (interpreterBins.has(bin)) {
         warnings.push(
@@ -185,10 +179,10 @@ export function maybeRepairExecSafeBinProfiles(cfg: OpenClawConfig): {
         );
         continue;
       }
-      if (profileHolder[bin] !== undefined) {
+      if (mutableProfileHolder[bin] !== undefined) {
         continue;
       }
-      profileHolder[bin] = {};
+      mutableProfileHolder[bin] = {};
       changes.push(
         `- ${scope.scopePath}.safeBinProfiles.${bin}: added scaffold profile {} (review and tighten flags/positionals).`,
       );

--- a/src/commands/doctor-exec-safe-bins.ts
+++ b/src/commands/doctor-exec-safe-bins.ts
@@ -1,0 +1,202 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
+import {
+  listInterpreterLikeSafeBins,
+  resolveMergedSafeBinProfileFixtures,
+} from "../infra/exec-safe-bin-runtime-policy.js";
+import {
+  getTrustedSafeBinDirs,
+  isTrustedSafeBinPath,
+  normalizeTrustedSafeBinDirs,
+} from "../infra/exec-safe-bin-trust.js";
+
+export type ExecSafeBinCoverageHit = {
+  scopePath: string;
+  bin: string;
+  isInterpreter: boolean;
+};
+
+type ExecSafeBinScopeRef = {
+  scopePath: string;
+  safeBins: string[];
+  exec: Record<string, unknown>;
+  mergedProfiles: Record<string, unknown>;
+  trustedSafeBinDirs: ReadonlySet<string>;
+};
+
+export type ExecSafeBinTrustedDirHintHit = {
+  scopePath: string;
+  bin: string;
+  resolvedPath: string;
+};
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeConfiguredSafeBins(entries: unknown): string[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      entries
+        .map((entry) => (typeof entry === "string" ? entry.trim().toLowerCase() : ""))
+        .filter((entry) => entry.length > 0),
+    ),
+  ).toSorted();
+}
+
+function normalizeConfiguredTrustedSafeBinDirs(entries: unknown): string[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return normalizeTrustedSafeBinDirs(
+    entries.filter((entry): entry is string => typeof entry === "string"),
+  );
+}
+
+function collectExecSafeBinScopes(cfg: OpenClawConfig): ExecSafeBinScopeRef[] {
+  const scopes: ExecSafeBinScopeRef[] = [];
+  const globalExec = asObjectRecord(cfg.tools?.exec);
+  const globalTrustedDirs = normalizeConfiguredTrustedSafeBinDirs(globalExec?.safeBinTrustedDirs);
+  if (globalExec) {
+    const safeBins = normalizeConfiguredSafeBins(globalExec.safeBins);
+    if (safeBins.length > 0) {
+      scopes.push({
+        scopePath: "tools.exec",
+        safeBins,
+        exec: globalExec,
+        mergedProfiles:
+          resolveMergedSafeBinProfileFixtures({
+            global: globalExec,
+          }) ?? {},
+        trustedSafeBinDirs: getTrustedSafeBinDirs({
+          extraDirs: globalTrustedDirs,
+        }),
+      });
+    }
+  }
+
+  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  for (const agent of agents) {
+    if (!agent || typeof agent !== "object" || typeof agent.id !== "string") {
+      continue;
+    }
+    const agentExec = asObjectRecord(agent.tools?.exec);
+    if (!agentExec) {
+      continue;
+    }
+    const safeBins = normalizeConfiguredSafeBins(agentExec.safeBins);
+    if (safeBins.length === 0) {
+      continue;
+    }
+    scopes.push({
+      scopePath: `agents.list.${agent.id}.tools.exec`,
+      safeBins,
+      exec: agentExec,
+      mergedProfiles:
+        resolveMergedSafeBinProfileFixtures({
+          global: globalExec,
+          local: agentExec,
+        }) ?? {},
+      trustedSafeBinDirs: getTrustedSafeBinDirs({
+        extraDirs: [
+          ...globalTrustedDirs,
+          ...normalizeConfiguredTrustedSafeBinDirs(agentExec.safeBinTrustedDirs),
+        ],
+      }),
+    });
+  }
+
+  return scopes;
+}
+
+export function scanExecSafeBinCoverage(cfg: OpenClawConfig): ExecSafeBinCoverageHit[] {
+  const hits: ExecSafeBinCoverageHit[] = [];
+  for (const scope of collectExecSafeBinScopes(cfg)) {
+    const interpreterBins = new Set(listInterpreterLikeSafeBins(scope.safeBins));
+    for (const bin of scope.safeBins) {
+      if (scope.mergedProfiles[bin]) {
+        continue;
+      }
+      hits.push({
+        scopePath: scope.scopePath,
+        bin,
+        isInterpreter: interpreterBins.has(bin),
+      });
+    }
+  }
+  return hits;
+}
+
+export function scanExecSafeBinTrustedDirHints(
+  cfg: OpenClawConfig,
+): ExecSafeBinTrustedDirHintHit[] {
+  const hits: ExecSafeBinTrustedDirHintHit[] = [];
+  for (const scope of collectExecSafeBinScopes(cfg)) {
+    for (const bin of scope.safeBins) {
+      const resolution = resolveCommandResolutionFromArgv([bin]);
+      if (!resolution?.resolvedPath) {
+        continue;
+      }
+      if (
+        isTrustedSafeBinPath({
+          resolvedPath: resolution.resolvedPath,
+          trustedDirs: scope.trustedSafeBinDirs,
+        })
+      ) {
+        continue;
+      }
+      hits.push({
+        scopePath: scope.scopePath,
+        bin,
+        resolvedPath: resolution.resolvedPath,
+      });
+    }
+  }
+  return hits;
+}
+
+export function maybeRepairExecSafeBinProfiles(cfg: OpenClawConfig): {
+  config: OpenClawConfig;
+  changes: string[];
+  warnings: string[];
+} {
+  const next = structuredClone(cfg);
+  const changes: string[] = [];
+  const warnings: string[] = [];
+
+  for (const scope of collectExecSafeBinScopes(next)) {
+    const interpreterBins = new Set(listInterpreterLikeSafeBins(scope.safeBins));
+    const missingBins = scope.safeBins.filter((bin) => !scope.mergedProfiles[bin]);
+    if (missingBins.length === 0) {
+      continue;
+    }
+    const profileHolder =
+      asObjectRecord(scope.exec.safeBinProfiles) ?? (scope.exec.safeBinProfiles = {});
+    for (const bin of missingBins) {
+      if (interpreterBins.has(bin)) {
+        warnings.push(
+          `- ${scope.scopePath}.safeBins includes interpreter/runtime '${bin}' without profile; remove it from safeBins or use explicit allowlist entries.`,
+        );
+        continue;
+      }
+      if (profileHolder[bin] !== undefined) {
+        continue;
+      }
+      profileHolder[bin] = {};
+      changes.push(
+        `- ${scope.scopePath}.safeBinProfiles.${bin}: added scaffold profile {} (review and tighten flags/positionals).`,
+      );
+    }
+  }
+
+  if (changes.length === 0 && warnings.length === 0) {
+    return { config: cfg, changes: [], warnings: [] };
+  }
+  return { config: next, changes, warnings };
+}


### PR DESCRIPTION


## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/commands/doctor-config-flow.ts` mixed safe-bin scanning, trusted-dir hints, and repair helpers into the main doctor flow file.
- Why it matters: keeping the safe-bin diagnostics together makes the doctor flow easier to read and gives future safe-bin changes a single module boundary.
- What changed: extracted the safe-bin coverage scan, trusted-dir hint scan, and repair helpers into `src/commands/doctor-exec-safe-bins.ts`, with `src/commands/doctor-config-flow.ts` now calling the new module.
- What did NOT change (scope boundary): warning text, repair behavior, and doctor flow call sites stay the same.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: None
- Related: None

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): focused `tools.exec.safeBins` and `safeBinTrustedDirs` doctor fixtures from the existing safe-bin tests

### Steps

1. Run `pnpm test -- src/commands/doctor-config-flow.safe-bins.test.ts`.
2. Run `pnpm check`.
3. Confirm the extracted helper module preserves the existing warning and repair behavior.

### Expected

- Focused safe-bin doctor tests pass.
- Repository checks stay green after the extraction.
- No user-visible doctor warning text changes.

### Actual

- `src/commands/doctor-config-flow.safe-bins.test.ts` passed locally.
- `pnpm check` passed locally.
- The refactor only moved helper logic into a dedicated module.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: missing custom safe-bin profiles are scaffolded in repair mode; interpreter bins still warn without scaffolding; trusted-dir hints still appear for binaries outside trusted dirs.
- Edge cases checked: global and per-agent `tools.exec.safeBins` scopes still share the same extraction path.
- What you did **not** verify: no additional live integration beyond the existing focused test coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fa30fc5c38e47711082777176b23c9b2c9856880`.
- Files/config to restore: `src/commands/doctor-config-flow.ts` and remove `src/commands/doctor-exec-safe-bins.ts`.
- Known bad symptoms reviewers should watch for: missing safe-bin warning lines, missing scaffold profiles in repair mode, or trusted-dir hints no longer appearing.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a helper could lose shared context during extraction and change one of the safe-bin warning paths.
  - Mitigation: preserved the existing call sites and re-ran `src/commands/doctor-config-flow.safe-bins.test.ts` plus `pnpm check` locally.
