### PR TITLE
feat(sessions): archive transcripts and create handoff on model change

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -43,7 +43,7 @@ import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
-import { buildHandoffAwareResetPrompt } from "./session-reset-prompt.js";
+import { buildBareSessionResetPrompt, consumeHandoffAsSystemPrompt } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -267,11 +267,18 @@ export async function runPreparedReply(
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
   );
+  // On the first turn of a session, check for a pending model-change handoff and
+  // inject user context as a system prompt section.  This covers normal user messages
+  // after a model change (where isBareSessionReset would be false) so the new model
+  // always receives the handoff notice on its very first reply.
+  const handoffSystemPrompt =
+    isFirstTurnInSession ? consumeHandoffAsSystemPrompt({ storePath, sessionKey }) : null;
   const extraSystemPromptParts = [
     inboundMetaPrompt,
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
+    handoffSystemPrompt,
   ].filter(Boolean);
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   // Use CommandBody/RawBody for bare reset detection (clean message without structural context).
@@ -290,13 +297,7 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset
-    ? buildHandoffAwareResetPrompt({
-        cfg,
-        storePath,
-        sessionKey,
-      })
-    : baseBody;
+  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg) : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession
       ? {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -43,7 +43,7 @@ import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import { buildHandoffAwareResetPrompt } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -290,7 +290,13 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg) : baseBody;
+  const baseBodyFinal = isBareSessionReset
+    ? buildHandoffAwareResetPrompt({
+        cfg,
+        storePath,
+        sessionKey,
+      })
+    : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession
       ? {

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -1,5 +1,10 @@
+import path from "node:path";
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  buildHandoffPromptSection,
+  consumeModelHandoff,
+} from "../../config/sessions/model-handoff.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
   "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
@@ -15,6 +20,39 @@ export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number
     cfg ?? {},
     nowMs ?? Date.now(),
   );
+}
+
+/**
+ * Build a session reset prompt that includes model handoff context if available.
+ * When a model change triggered a session reset, the handoff file contains recent
+ * user messages (only user-authored, no assistant patterns) that help the new model
+ * understand what the user was working on without inheriting behavioral patterns.
+ */
+export function buildHandoffAwareResetPrompt(params: {
+  cfg?: OpenClawConfig;
+  storePath?: string;
+  sessionKey?: string;
+  nowMs?: number;
+}): string {
+  const basePrompt = buildBareSessionResetPrompt(params.cfg, params.nowMs);
+
+  if (!params.storePath || !params.sessionKey) {
+    return basePrompt;
+  }
+
+  try {
+    const sessionsDir = path.dirname(params.storePath);
+    const handoff = consumeModelHandoff(sessionsDir, params.sessionKey);
+    if (!handoff || handoff.recentUserMessages.length === 0) {
+      return basePrompt;
+    }
+
+    const handoffSection = buildHandoffPromptSection(handoff);
+    return `${basePrompt}\n\n${handoffSection}`;
+  } catch {
+    // If handoff resolution fails, fall back to the bare prompt.
+    return basePrompt;
+  }
 }
 
 /** @deprecated Use buildBareSessionResetPrompt(cfg) instead */

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -23,35 +23,31 @@ export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number
 }
 
 /**
- * Build a session reset prompt that includes model handoff context if available.
- * When a model change triggered a session reset, the handoff file contains recent
- * user messages (only user-authored, no assistant patterns) that help the new model
- * understand what the user was working on without inheriting behavioral patterns.
+ * Consume a pending model-change handoff and return its content as a system
+ * prompt section, or null if no handoff exists for this session.
+ *
+ * Called on the first turn of every new session so the new model always
+ * receives handoff context — even when the user sends a normal message rather
+ * than /new or /reset.  The handoff file is deleted after the first read
+ * so subsequent turns are not affected.
  */
-export function buildHandoffAwareResetPrompt(params: {
-  cfg?: OpenClawConfig;
+export function consumeHandoffAsSystemPrompt(params: {
   storePath?: string;
   sessionKey?: string;
-  nowMs?: number;
-}): string {
-  const basePrompt = buildBareSessionResetPrompt(params.cfg, params.nowMs);
-
+}): string | null {
   if (!params.storePath || !params.sessionKey) {
-    return basePrompt;
+    return null;
   }
 
   try {
     const sessionsDir = path.dirname(params.storePath);
     const handoff = consumeModelHandoff(sessionsDir, params.sessionKey);
     if (!handoff || handoff.recentUserMessages.length === 0) {
-      return basePrompt;
+      return null;
     }
-
-    const handoffSection = buildHandoffPromptSection(handoff);
-    return `${basePrompt}\n\n${handoffSection}`;
+    return buildHandoffPromptSection(handoff);
   } catch {
-    // If handoff resolution fails, fall back to the bare prompt.
-    return basePrompt;
+    return null;
   }
 }
 

--- a/src/config/sessions/model-handoff.test.ts
+++ b/src/config/sessions/model-handoff.test.ts
@@ -135,13 +135,15 @@ describe("extractUserMessagesFromTranscript", () => {
 
 describe("resolveHandoffPath", () => {
   test("creates a safe filename from session key", () => {
-    const result = resolveHandoffPath("/tmp/sessions", "telegram:381198032");
-    expect(result).toBe("/tmp/sessions/handoff-telegram_381198032.json");
+    const sessionsDir = path.join(os.tmpdir(), "sessions");
+    const result = resolveHandoffPath(sessionsDir, "telegram:381198032");
+    expect(result).toBe(path.join(sessionsDir, "handoff-telegram_381198032.json"));
   });
 
   test("handles complex session keys", () => {
-    const result = resolveHandoffPath("/tmp/sessions", "agent:main:group:-1003833119217");
-    expect(result).toBe("/tmp/sessions/handoff-agent_main_group_-1003833119217.json");
+    const sessionsDir = path.join(os.tmpdir(), "sessions");
+    const result = resolveHandoffPath(sessionsDir, "agent:main:group:-1003833119217");
+    expect(result).toBe(path.join(sessionsDir, "handoff-agent_main_group_-1003833119217.json"));
   });
 });
 

--- a/src/config/sessions/model-handoff.test.ts
+++ b/src/config/sessions/model-handoff.test.ts
@@ -1,0 +1,303 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  buildHandoffPromptSection,
+  cleanupHandoffFiles,
+  consumeModelHandoff,
+  createModelHandoff,
+  extractUserMessagesFromTranscript,
+  readModelHandoff,
+  resolveHandoffPath,
+  type SessionHandoff,
+} from "./model-handoff.js";
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-handoff-test-"));
+});
+
+afterAll(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function writeTranscript(sessionId: string, lines: unknown[]): string {
+  const filePath = path.join(tmpDir, `${sessionId}.jsonl`);
+  fs.writeFileSync(filePath, lines.map((line) => JSON.stringify(line)).join("\n"), "utf-8");
+  return filePath;
+}
+
+describe("extractUserMessagesFromTranscript", () => {
+  test("extracts user messages and ignores assistant messages", () => {
+    const filePath = writeTranscript("extract-basic", [
+      { type: "session", version: 1, id: "extract-basic" },
+      { message: { role: "user", content: "Hello" } },
+      { message: { role: "assistant", content: "Hi there, how can I help?" } },
+      { message: { role: "user", content: "Run the news pipeline" } },
+      { message: { role: "assistant", content: "Sure, running now..." } },
+    ]);
+
+    const messages = extractUserMessagesFromTranscript(filePath);
+    expect(messages).toEqual(["Hello", "Run the news pipeline"]);
+  });
+
+  test("handles array content format", () => {
+    const filePath = writeTranscript("extract-array", [
+      { message: { role: "user", content: [{ type: "text", text: "Array message" }] } },
+    ]);
+
+    const messages = extractUserMessagesFromTranscript(filePath);
+    expect(messages).toEqual(["Array message"]);
+  });
+
+  test("handles input_text content format", () => {
+    const filePath = writeTranscript("extract-input-text", [
+      { message: { role: "user", content: [{ type: "input_text", text: "Input text" }] } },
+    ]);
+
+    const messages = extractUserMessagesFromTranscript(filePath);
+    expect(messages).toEqual(["Input text"]);
+  });
+
+  test("skips inter-session forwarded messages", () => {
+    const filePath = writeTranscript("extract-skip-inter", [
+      {
+        message: {
+          role: "user",
+          content: "Forwarded",
+          provenance: { kind: "inter_session" },
+        },
+      },
+      { message: { role: "user", content: "Real message" } },
+    ]);
+
+    const messages = extractUserMessagesFromTranscript(filePath);
+    expect(messages).toEqual(["Real message"]);
+  });
+
+  test("returns only the last N messages", () => {
+    const lines = [];
+    for (let i = 0; i < 10; i++) {
+      lines.push({ message: { role: "user", content: `Message ${i}` } });
+    }
+    const filePath = writeTranscript("extract-limit", lines);
+
+    const messages = extractUserMessagesFromTranscript(filePath, 3);
+    expect(messages).toEqual(["Message 7", "Message 8", "Message 9"]);
+  });
+
+  test("truncates long messages", () => {
+    const longText = "a".repeat(300);
+    const filePath = writeTranscript("extract-truncate", [
+      { message: { role: "user", content: longText } },
+    ]);
+
+    const messages = extractUserMessagesFromTranscript(filePath, 5, 50);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].length).toBe(50);
+    expect(messages[0].endsWith("...")).toBe(true);
+  });
+
+  test("skips empty and whitespace-only messages", () => {
+    const filePath = writeTranscript("extract-empty", [
+      { message: { role: "user", content: "" } },
+      { message: { role: "user", content: "  " } },
+      { message: { role: "user", content: "Valid" } },
+    ]);
+
+    const messages = extractUserMessagesFromTranscript(filePath);
+    expect(messages).toEqual(["Valid"]);
+  });
+
+  test("returns empty array for missing file", () => {
+    const messages = extractUserMessagesFromTranscript("/nonexistent/file.jsonl");
+    expect(messages).toEqual([]);
+  });
+
+  test("handles malformed JSON lines gracefully", () => {
+    const filePath = path.join(tmpDir, "extract-malformed.jsonl");
+    fs.writeFileSync(
+      filePath,
+      ["not valid json", JSON.stringify({ message: { role: "user", content: "Valid" } })].join(
+        "\n",
+      ),
+      "utf-8",
+    );
+
+    const messages = extractUserMessagesFromTranscript(filePath);
+    expect(messages).toEqual(["Valid"]);
+  });
+});
+
+describe("resolveHandoffPath", () => {
+  test("creates a safe filename from session key", () => {
+    const result = resolveHandoffPath("/tmp/sessions", "telegram:381198032");
+    expect(result).toBe("/tmp/sessions/handoff-telegram_381198032.json");
+  });
+
+  test("handles complex session keys", () => {
+    const result = resolveHandoffPath("/tmp/sessions", "agent:main:group:-1003833119217");
+    expect(result).toBe("/tmp/sessions/handoff-agent_main_group_-1003833119217.json");
+  });
+});
+
+describe("createModelHandoff", () => {
+  test("creates handoff file from transcript", () => {
+    const transcriptPath = writeTranscript("handoff-create", [
+      { type: "session", version: 1, id: "handoff-create" },
+      { message: { role: "user", content: "Run the news pipeline" } },
+      { message: { role: "assistant", content: "I'll describe the steps..." } },
+      { message: { role: "user", content: "No, actually execute it" } },
+    ]);
+
+    const handoff = createModelHandoff({
+      sessionsDir: tmpDir,
+      sessionKey: "test:user1",
+      transcriptPath,
+      previousModel: "minimax/MiniMax-Text-01",
+      previousProvider: "minimax",
+      newModel: "moonshot/kimi-k2.5",
+    });
+
+    expect(handoff).not.toBeNull();
+    expect(handoff!.recentUserMessages).toEqual(["Run the news pipeline", "No, actually execute it"]);
+    expect(handoff!.previousModel).toBe("minimax/MiniMax-Text-01");
+    expect(handoff!.newModel).toBe("moonshot/kimi-k2.5");
+
+    // Verify the file was written
+    const handoffPath = resolveHandoffPath(tmpDir, "test:user1");
+    expect(fs.existsSync(handoffPath)).toBe(true);
+  });
+
+  test("returns null when no user messages exist", () => {
+    const transcriptPath = writeTranscript("handoff-empty", [
+      { type: "session", version: 1, id: "handoff-empty" },
+      { message: { role: "assistant", content: "Only assistant messages" } },
+    ]);
+
+    const handoff = createModelHandoff({
+      sessionsDir: tmpDir,
+      sessionKey: "test:empty",
+      transcriptPath,
+    });
+
+    expect(handoff).toBeNull();
+  });
+});
+
+describe("readModelHandoff", () => {
+  test("reads existing handoff file", () => {
+    const handoffData: SessionHandoff = {
+      switchedAt: new Date().toISOString(),
+      previousModel: "minimax/MiniMax-Text-01",
+      newModel: "moonshot/kimi-k2.5",
+      sessionKey: "test:read",
+      recentUserMessages: ["Hello", "Run pipeline"],
+    };
+    const handoffPath = resolveHandoffPath(tmpDir, "test:read");
+    fs.writeFileSync(handoffPath, JSON.stringify(handoffData), "utf-8");
+
+    const result = readModelHandoff(tmpDir, "test:read");
+    expect(result).not.toBeNull();
+    expect(result!.recentUserMessages).toEqual(["Hello", "Run pipeline"]);
+  });
+
+  test("returns null for missing handoff", () => {
+    const result = readModelHandoff(tmpDir, "test:nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("discards stale handoff files", () => {
+    const staleHandoff: SessionHandoff = {
+      switchedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString(),
+      sessionKey: "test:stale",
+      recentUserMessages: ["Old message"],
+    };
+    const handoffPath = resolveHandoffPath(tmpDir, "test:stale");
+    fs.writeFileSync(handoffPath, JSON.stringify(staleHandoff), "utf-8");
+
+    const result = readModelHandoff(tmpDir, "test:stale");
+    expect(result).toBeNull();
+    // Verify the stale file was cleaned up
+    expect(fs.existsSync(handoffPath)).toBe(false);
+  });
+});
+
+describe("consumeModelHandoff", () => {
+  test("reads and deletes handoff file", () => {
+    const handoffData: SessionHandoff = {
+      switchedAt: new Date().toISOString(),
+      sessionKey: "test:consume",
+      recentUserMessages: ["Hello"],
+    };
+    const handoffPath = resolveHandoffPath(tmpDir, "test:consume");
+    fs.writeFileSync(handoffPath, JSON.stringify(handoffData), "utf-8");
+
+    const result = consumeModelHandoff(tmpDir, "test:consume");
+    expect(result).not.toBeNull();
+    expect(result!.recentUserMessages).toEqual(["Hello"]);
+
+    // File should be deleted after consume
+    expect(fs.existsSync(handoffPath)).toBe(false);
+  });
+
+  test("returns null when no handoff exists", () => {
+    const result = consumeModelHandoff(tmpDir, "test:no-consume");
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildHandoffPromptSection", () => {
+  test("builds prompt with user messages and model info", () => {
+    const handoff: SessionHandoff = {
+      switchedAt: new Date().toISOString(),
+      previousModel: "minimax/MiniMax-Text-01",
+      newModel: "moonshot/kimi-k2.5",
+      sessionKey: "test:prompt",
+      recentUserMessages: ["Run the news pipeline", "I need the video today"],
+    };
+
+    const prompt = buildHandoffPromptSection(handoff);
+
+    expect(prompt).toContain("[Model Handoff Notice]");
+    expect(prompt).toContain("minimax/MiniMax-Text-01");
+    expect(prompt).toContain("Run the news pipeline");
+    expect(prompt).toContain("I need the video today");
+    expect(prompt).toContain("do not imitate");
+  });
+});
+
+describe("cleanupHandoffFiles", () => {
+  test("removes old handoff files beyond limit", () => {
+    const cleanupDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-handoff-cleanup-"));
+
+    // Create 7 handoff files
+    for (let i = 0; i < 7; i++) {
+      const name = `handoff-session_${i}.json`;
+      const filePath = path.join(cleanupDir, name);
+      fs.writeFileSync(filePath, JSON.stringify({ switchedAt: new Date().toISOString() }));
+      // Stagger mtime so ordering is deterministic
+      const mtime = new Date(Date.now() - i * 1000);
+      fs.utimesSync(filePath, mtime, mtime);
+    }
+
+    const removed = cleanupHandoffFiles(cleanupDir);
+
+    // Should keep 5 (MAX_HANDOFF_FILES) and remove 2
+    expect(removed).toBe(2);
+
+    const remaining = fs.readdirSync(cleanupDir).filter((n) => n.startsWith("handoff-"));
+    expect(remaining).toHaveLength(5);
+
+    fs.rmSync(cleanupDir, { recursive: true, force: true });
+  });
+
+  test("handles non-existent directory gracefully", () => {
+    const removed = cleanupHandoffFiles("/nonexistent/directory");
+    expect(removed).toBe(0);
+  });
+});

--- a/src/config/sessions/model-handoff.ts
+++ b/src/config/sessions/model-handoff.ts
@@ -1,0 +1,305 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("sessions/model-handoff");
+
+/**
+ * Maximum number of recent user messages to include in a handoff.
+ * Only user-authored messages are extracted — assistant responses are excluded
+ * to prevent behavioral pattern contamination from the previous model.
+ */
+const MAX_HANDOFF_USER_MESSAGES = 5;
+
+/** Maximum character length per extracted user message. */
+const MAX_MESSAGE_CHARS = 200;
+
+/** Maximum age of handoff files before auto-cleanup (30 days). */
+const HANDOFF_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Maximum number of archived handoff files to retain per session directory. */
+const HANDOFF_MAX_FILES = 5;
+
+export type SessionHandoff = {
+  /** ISO timestamp when the model switch occurred. */
+  switchedAt: string;
+  /** Previous model identifier (e.g. "minimax/MiniMax-Text-01"). */
+  previousModel?: string;
+  /** Previous provider identifier. */
+  previousProvider?: string;
+  /** New model identifier that is taking over. */
+  newModel?: string;
+  /** Session key this handoff applies to. */
+  sessionKey: string;
+  /** Recent user messages extracted from the old transcript (most recent last). */
+  recentUserMessages: string[];
+  /** Path to the archived transcript file. */
+  archivePath?: string;
+};
+
+type TranscriptLine = {
+  type?: string;
+  message?: {
+    role?: string;
+    content?: string | Array<{ type?: string; text?: string }>;
+    provenance?: { kind?: string };
+  };
+};
+
+/**
+ * Extract recent user messages from a session transcript file.
+ * Only reads user-role messages, ignoring assistant responses and tool calls
+ * to avoid carrying over model-specific behavioral patterns.
+ */
+export function extractUserMessagesFromTranscript(
+  transcriptPath: string,
+  maxMessages = MAX_HANDOFF_USER_MESSAGES,
+  maxChars = MAX_MESSAGE_CHARS,
+): string[] {
+  if (!fs.existsSync(transcriptPath)) {
+    return [];
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(transcriptPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lines = content.split(/\r?\n/).filter((l) => l.trim());
+  const userMessages: string[] = [];
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as TranscriptLine;
+      const msg = parsed?.message;
+      if (!msg || msg.role !== "user") {
+        continue;
+      }
+      // Skip inter-session forwarded messages
+      if (
+        msg.provenance &&
+        typeof msg.provenance === "object" &&
+        (msg.provenance as { kind?: string }).kind === "inter_session"
+      ) {
+        continue;
+      }
+      const text = extractTextContent(msg.content);
+      if (text) {
+        const trimmed = text.length > maxChars ? `${text.slice(0, maxChars - 3)}...` : text;
+        userMessages.push(trimmed);
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  // Return only the most recent N messages
+  return userMessages.slice(-maxMessages);
+}
+
+function extractTextContent(
+  content: string | Array<{ type?: string; text?: string }> | undefined,
+): string | null {
+  if (typeof content === "string") {
+    const trimmed = content.trim();
+    return trimmed || null;
+  }
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (
+        part &&
+        typeof part.text === "string" &&
+        (part.type === "text" || part.type === "input_text")
+      ) {
+        const trimmed = part.text.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the handoff file path for a given session directory and session key.
+ * Handoff files are stored as `handoff-<sanitized-key>.json` in the sessions directory.
+ */
+export function resolveHandoffPath(sessionsDir: string, sessionKey: string): string {
+  const safeKey = sessionKey.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100);
+  return path.join(sessionsDir, `handoff-${safeKey}.json`);
+}
+
+/**
+ * Create a model handoff file from a session transcript.
+ * Extracts user messages and writes a structured handoff JSON.
+ */
+export function createModelHandoff(params: {
+  sessionsDir: string;
+  sessionKey: string;
+  transcriptPath: string;
+  previousModel?: string;
+  previousProvider?: string;
+  newModel?: string;
+  archivePath?: string;
+}): SessionHandoff | null {
+  const userMessages = extractUserMessagesFromTranscript(params.transcriptPath);
+  if (userMessages.length === 0) {
+    return null;
+  }
+
+  const handoff: SessionHandoff = {
+    switchedAt: new Date().toISOString(),
+    previousModel: params.previousModel,
+    previousProvider: params.previousProvider,
+    newModel: params.newModel,
+    sessionKey: params.sessionKey,
+    recentUserMessages: userMessages,
+    archivePath: params.archivePath,
+  };
+
+  const handoffPath = resolveHandoffPath(params.sessionsDir, params.sessionKey);
+  try {
+    fs.writeFileSync(handoffPath, JSON.stringify(handoff, null, 2), "utf-8");
+  } catch (err) {
+    log.warn(`failed to write handoff file: ${String(err)}`);
+    return null;
+  }
+
+  return handoff;
+}
+
+/**
+ * Read a model handoff file for a given session key, if one exists.
+ * Returns null if no handoff file is found or if it's too old.
+ */
+export function readModelHandoff(
+  sessionsDir: string,
+  sessionKey: string,
+): SessionHandoff | null {
+  const handoffPath = resolveHandoffPath(sessionsDir, sessionKey);
+  if (!fs.existsSync(handoffPath)) {
+    return null;
+  }
+
+  try {
+    const raw = fs.readFileSync(handoffPath, "utf-8");
+    const handoff = JSON.parse(raw) as SessionHandoff;
+
+    // Validate basic structure
+    if (!handoff.switchedAt || !Array.isArray(handoff.recentUserMessages)) {
+      return null;
+    }
+
+    // Check age — discard stale handoffs
+    const switchedAtMs = Date.parse(handoff.switchedAt);
+    if (Number.isNaN(switchedAtMs) || Date.now() - switchedAtMs > HANDOFF_MAX_AGE_MS) {
+      // Clean up stale handoff file
+      try {
+        fs.unlinkSync(handoffPath);
+      } catch {
+        // best-effort cleanup
+      }
+      return null;
+    }
+
+    return handoff;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Consume (read + delete) a handoff file. Called after the handoff context
+ * has been injected into the new session's first prompt.
+ */
+export function consumeModelHandoff(
+  sessionsDir: string,
+  sessionKey: string,
+): SessionHandoff | null {
+  const handoff = readModelHandoff(sessionsDir, sessionKey);
+  if (!handoff) {
+    return null;
+  }
+
+  const handoffPath = resolveHandoffPath(sessionsDir, sessionKey);
+  try {
+    fs.unlinkSync(handoffPath);
+  } catch {
+    // best-effort cleanup
+  }
+
+  return handoff;
+}
+
+/**
+ * Build a prompt section from a handoff, suitable for injection into
+ * the user's first message in the new session.
+ */
+export function buildHandoffPromptSection(handoff: SessionHandoff): string {
+  const lines: string[] = [];
+  lines.push("[Model Handoff Notice]");
+  lines.push(
+    `You are taking over from a previous model (${handoff.previousModel ?? "unknown"}).`,
+  );
+  lines.push("The previous conversation has been archived. The user's recent messages were:");
+  lines.push("");
+
+  for (const msg of handoff.recentUserMessages) {
+    lines.push(`- "${msg}"`);
+  }
+
+  lines.push("");
+  lines.push(
+    "If the user refers to earlier work, pick up from where they left off based on their messages above.",
+  );
+  lines.push(
+    "Execute tasks using your own approach — do not imitate any patterns from the previous model.",
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Clean up old handoff files from a sessions directory.
+ * Removes files older than HANDOFF_MAX_AGE_MS and keeps at most HANDOFF_MAX_FILES.
+ */
+export function cleanupHandoffFiles(sessionsDir: string): number {
+  let removed = 0;
+  try {
+    const entries = fs.readdirSync(sessionsDir);
+    const handoffFiles = entries
+      .filter((name) => name.startsWith("handoff-") && name.endsWith(".json"))
+      .map((name) => {
+        const fullPath = path.join(sessionsDir, name);
+        try {
+          const stat = fs.statSync(fullPath);
+          return { name, fullPath, mtimeMs: stat.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+    const now = Date.now();
+    for (let i = 0; i < handoffFiles.length; i++) {
+      const file = handoffFiles[i];
+      const isOld = now - file.mtimeMs > HANDOFF_MAX_AGE_MS;
+      const isBeyondLimit = i >= HANDOFF_MAX_FILES;
+      if (isOld || isBeyondLimit) {
+        try {
+          fs.unlinkSync(file.fullPath);
+          removed++;
+        } catch {
+          // best-effort
+        }
+      }
+    }
+  } catch {
+    // directory may not exist yet
+  }
+  return removed;
+}

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -745,8 +745,8 @@ export async function clearSessionModelFields(storePath: string): Promise<number
         continue;
       }
       if (entry.model || entry.modelProvider) {
-        entry.model = undefined;
-        entry.modelProvider = undefined;
+        delete entry.model;
+        delete entry.modelProvider;
         cleared++;
       }
     }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -726,6 +726,37 @@ async function withSessionStoreLock<T>(
   return await promise;
 }
 
+/**
+ * Clear persisted model/provider fields from all session entries that do not
+ * have an explicit user-set model override.  This forces sessions to re-resolve
+ * the default model from the current config on their next turn, which is the
+ * desired behavior when the operator changes the default model via config.
+ */
+export async function clearSessionModelFields(storePath: string): Promise<number> {
+  return await withSessionStoreLock(storePath, async () => {
+    const store = loadSessionStore(storePath, { skipCache: true });
+    let cleared = 0;
+    for (const [, entry] of Object.entries(store)) {
+      if (!entry) {
+        continue;
+      }
+      // Preserve explicit user-set overrides (/model command).
+      if (entry.modelOverride || entry.providerOverride) {
+        continue;
+      }
+      if (entry.model || entry.modelProvider) {
+        entry.model = undefined;
+        entry.modelProvider = undefined;
+        cleared++;
+      }
+    }
+    if (cleared > 0) {
+      await saveSessionStoreUnlocked(storePath, store, { skipMaintenance: true });
+    }
+    return cleared;
+  });
+}
+
 export async function updateSessionStoreEntry(params: {
   storePath: string;
   sessionKey: string;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -802,10 +802,13 @@ export async function archiveAndHandoffOnModelChange(params: {
         : path.join(sessionsDir, `${entry.sessionId}.jsonl`);
 
       if (!fs.existsSync(transcriptPath)) {
-        // No transcript to archive — just clear model fields
-        if (entry.model || entry.modelProvider) {
+        // No transcript to archive — just clear stale model fields so the
+        // session picks up the new default model on its next turn.
+        if (entry.model || entry.modelProvider || entry.contextTokens) {
           delete entry.model;
           delete entry.modelProvider;
+          delete entry.contextTokens;
+          archived++; // count as "touched" so the store is saved below
         }
         continue;
       }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { acquireSessionWriteLock } from "../../agents/session-write-lock.js";
@@ -8,6 +9,10 @@ import {
 } from "../../gateway/session-utils.fs.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  cleanupHandoffFiles,
+  createModelHandoff,
+} from "./model-handoff.js";
 import {
   deliveryContextFromSession,
   mergeDeliveryContext,
@@ -754,6 +759,105 @@ export async function clearSessionModelFields(storePath: string): Promise<number
       await saveSessionStoreUnlocked(storePath, store, { skipMaintenance: true });
     }
     return cleared;
+  });
+}
+
+/**
+ * Archive session transcripts and create handoff files when the default model changes.
+ * For each session without an explicit user-set model override:
+ * 1. Extract recent user messages from the old transcript (ignoring assistant responses).
+ * 2. Write a structured handoff file with user context only.
+ * 3. Archive the old transcript so it's no longer loaded as conversation history.
+ * 4. Assign a new sessionId so the new model starts with a clean session.
+ *
+ * This prevents behavioral pattern pollution (e.g. a broken model's tool-avoidance habits)
+ * from contaminating the new model, while preserving the user's recent intent/context.
+ */
+export async function archiveAndHandoffOnModelChange(params: {
+  storePath: string;
+  previousModel?: string;
+  previousProvider?: string;
+  newModel?: string;
+}): Promise<{ archived: number; handoffs: number }> {
+  const { storePath } = params;
+  return await withSessionStoreLock(storePath, async () => {
+    const store = loadSessionStore(storePath, { skipCache: true });
+    const sessionsDir = path.dirname(storePath);
+    let archived = 0;
+    let handoffs = 0;
+
+    for (const [sessionKey, entry] of Object.entries(store)) {
+      if (!entry) {
+        continue;
+      }
+      // Preserve sessions with explicit user-set model overrides (/model command).
+      if (entry.modelOverride || entry.providerOverride) {
+        continue;
+      }
+
+      // Resolve the transcript file path
+      const sessionFile = entry.sessionFile?.trim();
+      const transcriptPath = sessionFile
+        ? path.resolve(sessionsDir, sessionFile)
+        : path.join(sessionsDir, `${entry.sessionId}.jsonl`);
+
+      if (!fs.existsSync(transcriptPath)) {
+        // No transcript to archive — just clear model fields
+        if (entry.model || entry.modelProvider) {
+          delete entry.model;
+          delete entry.modelProvider;
+        }
+        continue;
+      }
+
+      // Step 1: Create handoff (extract user messages before archiving)
+      const handoff = createModelHandoff({
+        sessionsDir,
+        sessionKey,
+        transcriptPath,
+        previousModel: params.previousModel ?? entry.model,
+        previousProvider: params.previousProvider ?? entry.modelProvider,
+        newModel: params.newModel,
+      });
+
+      // Step 2: Archive the old transcript
+      const archivedPaths = archiveSessionTranscripts({
+        sessionId: entry.sessionId,
+        storePath,
+        sessionFile: entry.sessionFile,
+        reason: "reset",
+      });
+
+      if (archivedPaths.length > 0) {
+        archived++;
+
+        // Update the handoff with the archive path
+        if (handoff && archivedPaths[0]) {
+          handoff.archivePath = archivedPaths[0];
+        }
+        if (handoff) {
+          handoffs++;
+        }
+      }
+
+      // Step 3: Assign a new session ID so the new model starts clean
+      entry.sessionId = crypto.randomUUID();
+      delete entry.sessionFile;
+      delete entry.model;
+      delete entry.modelProvider;
+      delete entry.contextTokens;
+      entry.systemSent = false;
+      entry.updatedAt = Date.now();
+    }
+
+    if (archived > 0 || handoffs > 0) {
+      await saveSessionStoreUnlocked(storePath, store, { skipMaintenance: true });
+    }
+
+    // Clean up old handoff files
+    cleanupHandoffFiles(sessionsDir);
+
+    return { archived, handoffs };
   });
 }
 

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -14,6 +14,7 @@ export type GatewayReloadPlan = {
   restartCron: boolean;
   restartHeartbeat: boolean;
   restartHealthMonitor: boolean;
+  resetSessionModels: boolean;
   restartChannels: Set<ChannelKind>;
   noopPaths: string[];
 };
@@ -31,6 +32,7 @@ type ReloadAction =
   | "restart-cron"
   | "restart-heartbeat"
   | "restart-health-monitor"
+  | "reset-session-models"
   | `restart-channel:${ChannelId}`;
 
 const BASE_RELOAD_RULES: ReloadRule[] = [
@@ -53,17 +55,17 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   {
     prefix: "agents.defaults.models",
     kind: "hot",
-    actions: ["restart-heartbeat"],
+    actions: ["restart-heartbeat", "reset-session-models"],
   },
   {
     prefix: "agents.defaults.model",
     kind: "hot",
-    actions: ["restart-heartbeat"],
+    actions: ["restart-heartbeat", "reset-session-models"],
   },
   {
     prefix: "models",
     kind: "hot",
-    actions: ["restart-heartbeat"],
+    actions: ["restart-heartbeat", "reset-session-models"],
   },
   { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
@@ -151,6 +153,7 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     restartCron: false,
     restartHeartbeat: false,
     restartHealthMonitor: false,
+    resetSessionModels: false,
     restartChannels: new Set(),
     noopPaths: [],
   };
@@ -179,6 +182,9 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
         break;
       case "restart-health-monitor":
         plan.restartHealthMonitor = true;
+        break;
+      case "reset-session-models":
+        plan.resetSessionModels = true;
         break;
       default:
         break;

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,9 +1,12 @@
+import { listAgentIds } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { isRestartEnabled } from "../config/commands.js";
 import type { loadConfig } from "../config/config.js";
+import { clearSessionModelFields } from "../config/sessions/store.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -109,6 +112,25 @@ export function createGatewayReloadHandlers(params: {
         onSkipped: () =>
           params.logHooks.info("skipping gmail watcher restart (OPENCLAW_SKIP_GMAIL_WATCHER=1)"),
       });
+    }
+
+    if (plan.resetSessionModels) {
+      const agentIds = listAgentIds(nextConfig);
+      let totalCleared = 0;
+      for (const agentId of agentIds) {
+        try {
+          const storePath = resolveStorePath(nextConfig.session?.store, { agentId });
+          const cleared = await clearSessionModelFields(storePath);
+          totalCleared += cleared;
+        } catch {
+          // Session store may not exist yet for some agents; skip silently.
+        }
+      }
+      if (totalCleared > 0) {
+        params.logReload.info(
+          `cleared persisted model from ${totalCleared} session(s) to pick up new default model`,
+        );
+      }
     }
 
     if (plan.restartChannels.size > 0) {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -5,8 +5,8 @@ import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { isRestartEnabled } from "../config/commands.js";
 import type { loadConfig } from "../config/config.js";
-import { clearSessionModelFields } from "../config/sessions/store.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import { clearSessionModelFields } from "../config/sessions/store.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -122,8 +122,13 @@ export function createGatewayReloadHandlers(params: {
           const storePath = resolveStorePath(nextConfig.session?.store, { agentId });
           const cleared = await clearSessionModelFields(storePath);
           totalCleared += cleared;
-        } catch {
-          // Session store may not exist yet for some agents; skip silently.
+        } catch (err) {
+          // Session store may not exist yet for some agents — ignore ENOENT.
+          if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+            params.logReload.warn(
+              `failed to clear session models for agent ${agentId}: ${String(err)}`,
+            );
+          }
         }
       }
       if (totalCleared > 0) {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -135,8 +135,12 @@ export function createGatewayReloadHandlers(params: {
               const storePath = resolveStorePath(nextConfig.session?.store, { agentId });
               const cleared = await clearSessionModelFields(storePath);
               totalCleared += cleared;
-            } catch {
-              // best-effort
+            } catch (fallbackErr) {
+              if ((fallbackErr as NodeJS.ErrnoException).code !== "ENOENT") {
+                params.logReload.warn(
+                  `fallback clearSessionModelFields also failed for agent ${agentId}: ${String(fallbackErr)}`,
+                );
+              }
             }
             params.logReload.warn(
               `failed to archive/handoff sessions for agent ${agentId}: ${String(err)}`,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -6,7 +6,7 @@ import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../conf
 import { isRestartEnabled } from "../config/commands.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { clearSessionModelFields } from "../config/sessions/store.js";
+import { archiveAndHandoffOnModelChange, clearSessionModelFields } from "../config/sessions/store.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -116,24 +116,42 @@ export function createGatewayReloadHandlers(params: {
 
     if (plan.resetSessionModels) {
       const agentIds = listAgentIds(nextConfig);
+      let totalArchived = 0;
+      let totalHandoffs = 0;
       let totalCleared = 0;
       for (const agentId of agentIds) {
         try {
           const storePath = resolveStorePath(nextConfig.session?.store, { agentId });
-          const cleared = await clearSessionModelFields(storePath);
-          totalCleared += cleared;
+          const result = await archiveAndHandoffOnModelChange({
+            storePath,
+            newModel: nextConfig.agents?.defaults?.model,
+          });
+          totalArchived += result.archived;
+          totalHandoffs += result.handoffs;
         } catch (err) {
-          // Session store may not exist yet for some agents — ignore ENOENT.
           if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+            // Fall back to clearing model fields only if handoff fails.
+            try {
+              const storePath = resolveStorePath(nextConfig.session?.store, { agentId });
+              const cleared = await clearSessionModelFields(storePath);
+              totalCleared += cleared;
+            } catch {
+              // best-effort
+            }
             params.logReload.warn(
-              `failed to clear session models for agent ${agentId}: ${String(err)}`,
+              `failed to archive/handoff sessions for agent ${agentId}: ${String(err)}`,
             );
           }
         }
       }
+      if (totalArchived > 0 || totalHandoffs > 0) {
+        params.logReload.info(
+          `model change: archived ${totalArchived} session(s), created ${totalHandoffs} handoff(s) for new default model`,
+        );
+      }
       if (totalCleared > 0) {
         params.logReload.info(
-          `cleared persisted model from ${totalCleared} session(s) to pick up new default model`,
+          `cleared persisted model from ${totalCleared} session(s) (fallback)`,
         );
       }
     }

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -1,5 +1,6 @@
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { ACP_SESSION_IDENTITY_RENDERER_VERSION } from "../acp/runtime/session-identifiers.js";
+import { listAgentIds } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
@@ -12,6 +13,8 @@ import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { clearSessionModelFields } from "../config/sessions/store.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import {
   clearInternalHooks,
@@ -59,6 +62,37 @@ export async function startGatewaySidecars(params: {
     }
   } catch (err) {
     params.log.warn(`session lock cleanup failed on startup: ${String(err)}`);
+  }
+
+  // Clear persisted model fields from all sessions on startup.
+  // This ensures sessions use the current default model config after a gateway restart,
+  // fixing the case where config changes trigger a full restart (not hot reload) and
+  // the hot-reload path's resetSessionModels action is skipped.
+  // See: PR #41649 code review feedback.
+  try {
+    const agentIds = listAgentIds(params.cfg);
+    let totalCleared = 0;
+    for (const agentId of agentIds) {
+      try {
+        const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
+        const cleared = await clearSessionModelFields(storePath);
+        totalCleared += cleared;
+      } catch (err) {
+        // Session store may not exist yet for some agents — ignore ENOENT.
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          params.log.warn(
+            `failed to clear session models for agent ${agentId} on startup: ${String(err)}`,
+          );
+        }
+      }
+    }
+    if (totalCleared > 0) {
+      params.log.warn(
+        `cleared persisted model from ${totalCleared} session(s) on startup to use current default model`,
+      );
+    }
+  } catch (err) {
+    params.log.warn(`session model cleanup failed on startup: ${String(err)}`);
   }
 
   // Start OpenClaw browser control server (unless disabled via config).


### PR DESCRIPTION
## Summary

- When the default model changes via config reload, old session transcripts can pollute the new model's behavior through in-context learning (e.g. a broken model's tool-avoidance habits carry over to the replacement model)
- Instead of only clearing model metadata fields (`clearSessionModelFields`), this PR archives old transcripts and creates a structured **handoff file** containing only the user's recent messages
- On the new session's first turn, the handoff context is injected into the reset prompt so the new model knows what the user was working on — without inheriting any behavioral patterns from the old model

## Problem

When switching models (e.g. from MiniMax-Text-01 to Kimi K2.5), the old model's conversation history remains in the `.jsonl` transcript. The new model loads this history and copies the old model's patterns via in-context learning. For example, if the old model fabricated tool outputs instead of calling tools, the new model would do the same — even though it is fully capable of tool calling.

Previously, `clearSessionModelFields()` only cleared the `model`/`modelProvider` metadata but left the transcript intact.

## Solution: Context-Preserving Model Handoff

```
Config detects model change
  -> extractUserMessagesFromTranscript()  // only user messages, no assistant patterns
  -> createModelHandoff()                 // write handoff-<key>.json
  -> archiveSessionTranscripts()          // old .jsonl -> .jsonl.reset.<timestamp>
  -> assign new sessionId                 // new model starts with clean session

Next user message (isNewSession = true)
  -> consumeModelHandoff()               // read + delete handoff file
  -> buildHandoffPromptSection()          // inject user context into reset prompt
```

Key design principle: **trust user messages, do not trust old model responses.** User messages carry intent; assistant responses carry behavioral patterns. Only the former should cross model boundaries.

## Changes

- **`src/config/sessions/model-handoff.ts`** (new): Core handoff logic — extract user messages, create/read/consume handoff files, build prompt section, cleanup old handoffs
- **`src/config/sessions/model-handoff.test.ts`** (new): Tests for all handoff functions
- **`src/config/sessions/store.ts`**: New `archiveAndHandoffOnModelChange()` function that combines archiving + handoff creation + session ID rotation
- **`src/gateway/server-reload-handlers.ts`**: `resetSessionModels` block now calls `archiveAndHandoffOnModelChange()` with fallback to `clearSessionModelFields()`
- **`src/auto-reply/reply/session-reset-prompt.ts`**: New `buildHandoffAwareResetPrompt()` that injects handoff context on first turn
- **`src/auto-reply/reply/get-reply-run.ts`**: Use `buildHandoffAwareResetPrompt` instead of `buildBareSessionResetPrompt` for bare session resets

## Handoff file format

```json
{
  "switchedAt": "2026-03-10T14:30:00Z",
  "previousModel": "minimax/MiniMax-Text-01",
  "newModel": "moonshot/kimi-k2.5",
  "sessionKey": "telegram:381198032",
  "recentUserMessages": [
    "Run the news pipeline",
    "I still have not received the video"
  ],
  "archivePath": "abc123.jsonl.reset.2026-03-10T14-30-00.000Z"
}
```

## What the new model sees on first turn

```
[Model Handoff Notice]
You are taking over from a previous model (minimax/MiniMax-Text-01).
The previous conversation has been archived. The user's recent messages were:

- "Run the news pipeline"
- "I still have not received the video"

If the user refers to earlier work, pick up from where they left off based on their messages above.
Execute tasks using your own approach — do not imitate any patterns from the previous model.
```

## Cleanup

- Handoff files older than 30 days are auto-deleted
- At most 5 handoff files retained per session directory
- Archived transcripts use existing `cleanupArchivedSessionTranscripts()` lifecycle

## Test plan

- [ ] Unit tests pass: `pnpm test -- --run src/config/sessions/model-handoff.test.ts`
- [ ] Verify `extractUserMessagesFromTranscript` only extracts user messages
- [ ] Verify `consumeModelHandoff` reads and deletes handoff file (one-shot)
- [ ] Verify `archiveAndHandoffOnModelChange` skips sessions with explicit model overrides
- [ ] Verify fallback to `clearSessionModelFields` when handoff fails
- [ ] Manual: change default model in config, verify old transcript archived, handoff file created, new session starts clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)