### PR TITLE
fix(gateway): rewrite favicon hrefs with basePath in Control UI

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -233,10 +233,22 @@ function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) 
   res.end(body);
 }
 
-function serveResolvedIndexHtml(res: ServerResponse, body: string) {
+/** Prepend basePath to favicon/apple-touch-icon href values in link tags.
+ *  Handles both absolute (`/favicon.svg`) and Vite-built relative (`./favicon.svg`) paths. */
+function injectFaviconBasePath(html: string, basePath: string | null): string {
+  if (!basePath) {
+    return html;
+  }
+  return html.replace(
+    /\bhref="\.?\/((?:favicon|apple-touch-icon)[^"]*)"/g,
+    `href="${basePath}/$1"`,
+  );
+}
+
+function serveResolvedIndexHtml(res: ServerResponse, body: string, basePath?: string | null) {
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache");
-  res.end(body);
+  res.end(injectFaviconBasePath(body, basePath ?? null));
 }
 
 function isExpectedSafePathError(error: unknown): boolean {
@@ -441,7 +453,7 @@ export function handleControlUiHttpRequest(
         return true;
       }
       if (path.basename(safeFile.path) === "index.html") {
-        serveResolvedIndexHtml(res, fs.readFileSync(safeFile.fd, "utf8"));
+        serveResolvedIndexHtml(res, fs.readFileSync(safeFile.fd, "utf8"), basePath);
         return true;
       }
       serveResolvedFile(res, safeFile.path, fs.readFileSync(safeFile.fd));
@@ -469,7 +481,7 @@ export function handleControlUiHttpRequest(
       if (respondHeadForFile(req, res, safeIndex.path)) {
         return true;
       }
-      serveResolvedIndexHtml(res, fs.readFileSync(safeIndex.fd, "utf8"));
+      serveResolvedIndexHtml(res, fs.readFileSync(safeIndex.fd, "utf8"), basePath);
       return true;
     } finally {
       fs.closeSync(safeIndex.fd);

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -241,7 +241,7 @@ function injectFaviconBasePath(html: string, basePath: string | null): string {
   }
   return html.replace(
     /\bhref="\.?\/((?:favicon|apple-touch-icon)[^"]*)"/g,
-    `href="${basePath}/$1"`,
+    (_, p1) => `href="${basePath}/${p1}"`,
   );
 }
 

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -151,6 +151,58 @@ describe("GatewayClient", () => {
       expect(res.statusCode).toBe(200);
     });
   });
+
+  it("rewrites favicon hrefs when basePath is set", async () => {
+    const indexHtml = [
+      "<html><head>",
+      '<link rel="icon" href="./favicon.svg" />',
+      '<link rel="icon" href="/favicon.svg" />',
+      '<link rel="icon" href="./favicon-32.png" />',
+      '<link rel="apple-touch-icon" href="./apple-touch-icon.png" />',
+      '<link rel="stylesheet" href="./assets/index.css" />',
+      "</head></html>",
+    ].join("\n");
+
+    await withControlUiRoot({ indexHtml }, async (tmp) => {
+      const { res } = makeControlUiResponse();
+      handleControlUiHttpRequest({ url: "/webchat/", method: "GET" } as IncomingMessage, res, {
+        root: { kind: "resolved", path: tmp },
+        basePath: "/webchat",
+      });
+      const body = (res.end as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+
+      expect(body).toContain('href="/webchat/favicon.svg"');
+      expect(body).toContain('href="/webchat/favicon-32.png"');
+      expect(body).toContain('href="/webchat/apple-touch-icon.png"');
+      // Non-favicon hrefs must remain unchanged
+      expect(body).toContain('href="./assets/index.css"');
+      // No leftover original relative favicon paths
+      expect(body).not.toContain('href="./favicon.svg"');
+      expect(body).not.toContain('href="/favicon.svg"');
+    });
+  });
+
+  it("leaves favicon hrefs unchanged when basePath is not set", async () => {
+    const indexHtml = [
+      "<html><head>",
+      '<link rel="icon" href="./favicon.svg" />',
+      '<link rel="icon" href="/favicon.svg" />',
+      '<link rel="apple-touch-icon" href="./apple-touch-icon.png" />',
+      "</head></html>",
+    ].join("\n");
+
+    await withControlUiRoot({ indexHtml }, async (tmp) => {
+      const { res } = makeControlUiResponse();
+      handleControlUiHttpRequest({ url: "/", method: "GET" } as IncomingMessage, res, {
+        root: { kind: "resolved", path: tmp },
+      });
+      const body = (res.end as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+
+      expect(body).toContain('href="./favicon.svg"');
+      expect(body).toContain('href="/favicon.svg"');
+      expect(body).toContain('href="./apple-touch-icon.png"');
+    });
+  });
 });
 
 type TestSocket = {


### PR DESCRIPTION
## Summary

- Fixes #41205 — favicon/apple-touch-icon links in Control UI return 404 when served under a `basePath` (e.g. `/webchat`)
- Adds `injectFaviconBasePath()` helper in `src/gateway/control-ui.ts` that rewrites favicon/apple-touch-icon `href` values at serve time
- Handles both absolute (`/favicon.svg`) and Vite-built relative (`./favicon.svg`) paths
- Passes `basePath` through both `serveResolvedIndexHtml` call sites

## Why only favicons?

Vite's `base: "./"` config rewrites JS/CSS imports to relative paths, which the browser resolves correctly relative to the page URL. The gateway's basePath-stripping logic then serves the correct files from disk. However, hardcoded `<link>` tags in `index.html` for favicons are NOT rewritten by Vite — they remain as `/favicon.svg`, which the browser resolves against the root, skipping the basePath entirely.

## Test plan

- [x] Added 2 unit tests in `gateway-misc.test.ts` (all 23 tests pass)
- [x] Verified `./favicon.svg`, `/favicon.svg`, `./favicon-32.png`, `./apple-touch-icon.png` are all rewritten when basePath is set
- [x] Verified non-favicon hrefs (e.g. `./assets/index.css`) are NOT rewritten
- [x] Verified no-op when basePath is null

### Manual verification

1. Set `basePath` in `~/.openclaw/openclaw.json`:
   ```json
   {"gateway":{"mode":"local","auth":{"token":"dev-test-token"},"controlUi":{"basePath":"/webchat"}}}
   ```
2. Build and run:
   ```bash
   pnpm build
   OPENCLAW_SKIP_CHANNELS=1 node scripts/run-node.mjs gateway
   ```
3. Open `http://localhost:18789/webchat/` in Chrome
4. Verify favicon appears in browser tab
5. Check Network tab: `GET /webchat/favicon.svg` returns 200
6. Check page source: `href="/webchat/favicon.svg"` (not `href="./favicon.svg"`)

### Verification evidence

**curl output confirming rewritten hrefs:**
```
$ curl -s http://localhost:18789/webchat/ | grep favicon
href="/webchat/favicon.svg"
href="/webchat/favicon-32.png"
href="/webchat/apple-touch-icon.png"
```

**Network request: `GET /webchat/favicon.svg` → 200**

### Screenshot

![favicon-fix-verification](https://github.com/user-attachments/assets/e804ea92-5aa6-441c-a54d-81f8aef3e309)
