### PR TITLE
docs(browser): add Browser Use as a cloud browser provider

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -166,6 +166,41 @@ Notes:
   - On the node: `nodeHost.browserProxy.enabled=false`
   - On the gateway: `gateway.nodes.browser.mode="off"`
 
+## Browser Use (hosted remote CDP)
+
+[Browser Use](https://www.browser-use.com) is a cloud browser platform with
+anti-detect stealth, CAPTCHA solving, persistent profiles, and residential
+proxies.
+
+```json5
+{
+  browser: {
+    enabled: true,
+    defaultProfile: "browseruse",
+    remoteCdpTimeoutMs: 5000,
+    remoteCdpHandshakeTimeoutMs: 15000,
+    profiles: {
+      browseruse: {
+        // All Browser Use session params can be added as query params.
+        // See: https://docs.browser-use.com/cloud/api-v2/browsers/create-browser-session
+        cdpUrl: "wss://your-proxy-host:9223?apiKey=<BROWSER_USE_API_KEY>&timeout=240&profileId=<PROFILE_ID>&proxyCountryCode=us",
+        color: "#ff750e",
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- [Sign up](https://www.browser-use.com) and copy your **API Key** from the
+  dashboard.
+- Replace `<BROWSER_USE_API_KEY>` with your real Browser Use API key.
+- All [Browser Use session parameters](https://docs.browser-use.com/cloud/api-v2/browsers/create-browser-session)
+  (timeout, profileId, proxyCountryCode, screen size, custom proxy, etc.)
+  are passed as query params in the `cdpUrl`.
+- See [browser-use.com](https://www.browser-use.com) for more information.
+
 ## Browserless (hosted remote CDP)
 
 [Browserless](https://browserless.io) is a hosted Chromium service that exposes
@@ -205,7 +240,8 @@ the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
   discover the WebSocket debugger URL, then connects.
 - **WebSocket endpoints** (`ws://` / `wss://`) — OpenClaw connects directly,
   skipping `/json/version`. Use this for services like
-  [Browserbase](https://www.browserbase.com) or any provider that hands you a
+  [Browser Use](https://www.browser-use.com),
+  [Browserbase](https://www.browserbase.com), or any provider that hands you a
   WebSocket URL.
 
 ### Browserbase


### PR DESCRIPTION
## Summary

- **Problem:** Browser Use is a cloud browser platform but has no documentation in the browser tool docs, even though OpenClaw already supports connecting to it via WebSocket CDP URLs.
- **Why it matters:** Users looking to use Browser Use with OpenClaw have no guidance on how to configure it, or what session parameters are available.
- **What changed:** Added a "Browser Use" section to `docs/tools/browser.md` with a config example showing how to set up a profile and pass session parameters (timeout, profileId, proxyCountryCode, etc.) as query params in the `cdpUrl`. Also added Browser Use to the "Direct WebSocket CDP providers" intro.
- **What did NOT change (scope boundary):** No code changes. Existing Browserbase and Browserless docs are untouched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Builds on #31085 (added WebSocket CDP URL support)

## User-visible / Behavior Changes

- New documentation section for Browser Use under "Browser Use (hosted remote CDP)"
- Browser Use added to the "Direct WebSocket CDP providers" provider list

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

- Docs-only change — visual review of the new section in `docs/tools/browser.md`

## Human Verification (required)

- Verified scenarios: New section follows the same structure as the existing Browserbase and Browserless sections
- Edge cases checked: N/A (docs only)
- What I did **not** verify: zh-CN docs (auto-generated by `scripts/docs-i18n`)

## Compatibility / Migration

- Backward compatible? `Yes` — docs only
- Config/env changes? `No`
- Migration needed? `No`

---

🤖 **AI-assisted PR** — Generated with [Claude Code](https://claude.com/claude-code)