### PR TITLE
fix(skills): add OS filters for mac only skills

### DIFF
--- a/skills/1password/SKILL.md
+++ b/skills/1password/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "1password-cli",
               "bins": ["op"],
               "label": "Install 1Password CLI (brew)",

--- a/skills/camsnap/SKILL.md
+++ b/skills/camsnap/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/camsnap",
               "bins": ["camsnap"],
               "label": "Install camsnap (brew)",

--- a/skills/gemini/SKILL.md
+++ b/skills/gemini/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "gemini-cli",
               "bins": ["gemini"],
               "label": "Install Gemini CLI (brew)",

--- a/skills/gifgrep/SKILL.md
+++ b/skills/gifgrep/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/gifgrep",
               "bins": ["gifgrep"],
               "label": "Install gifgrep (brew)",

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -12,6 +12,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "gh",
               "bins": ["gh"],
               "label": "Install GitHub CLI (brew)",

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/gogcli",
               "bins": ["gog"],
               "label": "Install gog (brew)",

--- a/skills/goplaces/SKILL.md
+++ b/skills/goplaces/SKILL.md
@@ -14,6 +14,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/goplaces",
               "bins": ["goplaces"],
               "label": "Install goplaces (brew)",

--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "himalaya",
               "bins": ["himalaya"],
               "label": "Install Himalaya (brew)",

--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -14,6 +14,7 @@ metadata:
             {
               "id": "uv-brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "uv",
               "bins": ["uv"],
               "label": "Install uv (brew)",

--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin"],
               "formula": "yakitrak/yakitrak/obsidian-cli",
               "bins": ["obsidian-cli"],
               "label": "Install obsidian-cli (brew)",

--- a/skills/openai-image-gen/SKILL.md
+++ b/skills/openai-image-gen/SKILL.md
@@ -14,6 +14,7 @@ metadata:
             {
               "id": "python-brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "python",
               "bins": ["python3"],
               "label": "Install Python (brew)",

--- a/skills/openai-whisper/SKILL.md
+++ b/skills/openai-whisper/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "openai-whisper",
               "bins": ["whisper"],
               "label": "Install OpenAI Whisper (brew)",

--- a/skills/openhue/SKILL.md
+++ b/skills/openhue/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "openhue/cli/openhue-cli",
               "bins": ["openhue"],
               "label": "Install OpenHue CLI (brew)",

--- a/skills/ordercli/SKILL.md
+++ b/skills/ordercli/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/ordercli",
               "bins": ["ordercli"],
               "label": "Install ordercli (brew)",

--- a/skills/sag/SKILL.md
+++ b/skills/sag/SKILL.md
@@ -14,6 +14,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/sag",
               "bins": ["sag"],
               "label": "Install sag (brew)",

--- a/skills/songsee/SKILL.md
+++ b/skills/songsee/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/songsee",
               "bins": ["songsee"],
               "label": "Install songsee (brew)",

--- a/skills/spotify-player/SKILL.md
+++ b/skills/spotify-player/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "spogo",
               "tap": "steipete/tap",
               "bins": ["spogo"],
@@ -21,6 +22,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "spotify_player",
               "bins": ["spotify_player"],
               "label": "Install spotify_player (brew)",

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/summarize",
               "bins": ["summarize"],
               "label": "Install summarize (brew)",

--- a/skills/video-frames/SKILL.md
+++ b/skills/video-frames/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "ffmpeg",
               "bins": ["ffmpeg"],
               "label": "Install ffmpeg (brew)",

--- a/skills/wacli/SKILL.md
+++ b/skills/wacli/SKILL.md
@@ -13,6 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "steipete/tap/wacli",
               "bins": ["wacli"],
               "label": "Install wacli (brew)",

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -12,13 +12,14 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
+              "os": ["darwin", "linux"],
               "formula": "xdevplatform/tap/xurl",
               "bins": ["xurl"],
               "label": "Install xurl (brew)",
             },
             {
-              "id": "npm",
-              "kind": "npm",
+              "id": "node",
+              "kind": "node",
               "package": "@xdevplatform/xurl",
               "bins": ["xurl"],
               "label": "Install xurl (npm)",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Windows (Git Bash) onboarding lists brew-only skills, even though they’re not installable.
- Why it matters: It confuses Windows users and makes the skills list noisy during onboarding.
- What changed: Added OS metadata for brew-only skills so they’re filtered out on Windows.
- What did NOT change (scope boundary): Skill logic/behavior and install scripts remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra


## User-visible / Behavior Changes

Windows onboarding will no longer surface brew-only skills as install options; they are filtered by OS.


## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Windows 10/11
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run openclaw onboard --install-daemon on Windows (Git Bash).
2. Open skills configuration step.
3.

### Expected

- Brew-only skills do not appear as installable options.

### Actual

- Before: Brew-only skills appeared in the install list.
- After: Brew-only skills are filtered by OS.
 
## Evidence

Attach at least one:

- [x] Failing test/log before + passing after

Before:

 All the skills that that needs brew to install

After: 
In git bash windows terminal: 
◆  Install missing skill dependencies
│  ◻ Skip for now
│  ◻ 📰 blogwatcher
│  ◻ 🫐 blucli
│  ◻ 🧩 clawhub
│  ◻ 🎛️ eightctl
│  ◻ 🧲 gifgrep
│  ◻ 📦 mcporter
│  ◻ 📄 nano-pdf
│  ◻ 🧿 oracle
│  ◻ 🛵 ordercli
│  ◻ 🔊 sonoscli
│  ◻ 📱 wacli (Send WhatsApp messages to other people or search/sync WhatsApp history via the wacli CLI …)
└
![Snipaste_2026-03-09_15-18-13](https://github.com/user-attachments/assets/8a68f2fe-6a19-4c0d-af4a-a92b3b464002)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Verified scenarios: Windows onboarding no longer lists brew-only skills as installable.
- Edge cases checked: N/A
- What you did **not** verify: macOS/Linux onboarding behavior, since I do not have a latest MacOS device. My old one's MacOS is too old for installation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.


## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: skill SKILL.md metadata blocks.
- Known bad symptoms reviewers should watch for: brew-only skills reappearing on Windows.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-filtering if a brew-only skill is actually supported on Windows via alternative installs (not likely according to my study).
- Mitigation: Only add OS metadata where brew is the sole install method.
