### PR TITLE
fix(imessage): strip [[reply_to:*]] directive tags from outbound text

### DIFF
--- a/src/imessage/monitor/sanitize-outbound.test.ts
+++ b/src/imessage/monitor/sanitize-outbound.test.ts
@@ -53,6 +53,19 @@ describe("sanitizeOutboundText", () => {
     expect(sanitizeOutboundText(text)).toBe("Hello\n\nWorld");
   });
 
+  it("strips [[reply_to:<id>]] tags", () => {
+    expect(sanitizeOutboundText("[[reply_to:1578]] Hey Matt.")).toBe("Hey Matt.");
+  });
+
+  it("strips [[reply_to_current]] tags", () => {
+    expect(sanitizeOutboundText("[[reply_to_current]] Hello there.")).toBe("Hello there.");
+  });
+
+  it("strips reply tags with whitespace inside brackets", () => {
+    expect(sanitizeOutboundText("[[ reply_to : 42 ]] Hi.")).toBe("Hi.");
+    expect(sanitizeOutboundText("[[ reply_to_current ]] Hi.")).toBe("Hi.");
+  });
+
   it("handles combined internal markers in one message", () => {
     const text = "<thinking>step 1</thinking>NO_REPLY +#+#+#+# assistant to=final\n\nActual reply";
     const result = sanitizeOutboundText(text);

--- a/src/imessage/monitor/sanitize-outbound.ts
+++ b/src/imessage/monitor/sanitize-outbound.ts
@@ -7,6 +7,7 @@ import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-v
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/g;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/gi;
 const ROLE_TURN_MARKER_RE = /\b(?:user|system|assistant)\s*:\s*$/gm;
+const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]*)\s*\]\]\s*/gi;
 
 /**
  * Strip all assistant-internal scaffolding from outbound text before delivery.
@@ -20,6 +21,7 @@ export function sanitizeOutboundText(text: string): string {
 
   let cleaned = stripAssistantInternalScaffolding(text);
 
+  cleaned = cleaned.replace(REPLY_TAG_RE, "");
   cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
   cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");
   cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, "");


### PR DESCRIPTION
## Problem

`sanitizeOutboundText()` in the iMessage delivery path strips thinking tags, memory tags, role markers, and internal separators, but does not strip `[[reply_to:<id>]]` or `[[reply_to_current]]` directive tags. This causes raw metadata to leak into user-visible iMessage replies:

```
[[reply_to:1578]] Hey Matt.
```

## Root cause

The iMessage channel has its own `sanitizeOutboundText()` function that predates the centralized `parseInlineDirectives()` utility. Other channels call `parseInlineDirectives(text, { stripReplyTags: true })` which handles this correctly, but the iMessage path never picked up reply tag stripping.

## Fix

Added a `REPLY_TAG_RE` pattern to `sanitize-outbound.ts` that matches both `[[reply_to_current]]` and `[[reply_to:<id>]]` (with flexible whitespace), and strips them before delivery. This aligns with the existing directive tag regex in `src/utils/directive-tags.ts`.

## Testing

- Added 3 test cases covering `[[reply_to:<id>]]`, `[[reply_to_current]]`, and whitespace variants
- All 14 tests pass in `sanitize-outbound.test.ts`
- `pnpm check` clean

Closes #41576