### PR TITLE
fix(memory): add depth limit to chokidar watchers to prevent FD exhaustion

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -20,12 +20,13 @@ describe("ensureSkillsWatcher", () => {
 
     expect(watchMock).toHaveBeenCalledTimes(1);
     const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown }]>
+      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown; depth?: number }]>
     )[0];
     const targets = firstCall?.[0] ?? [];
     const opts = firstCall?.[1] ?? {};
 
     expect(opts.ignored).toBe(mod.DEFAULT_SKILLS_WATCH_IGNORED);
+    expect(opts.depth).toBe(2);
     const posix = (p: string) => p.replaceAll("\\", "/");
     expect(targets).toEqual(
       expect.arrayContaining([

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -175,6 +175,7 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     // Avoid FD exhaustion on macOS when a workspace contains huge trees.
     // This watcher only needs to react to SKILL.md changes.
     ignored: DEFAULT_SKILLS_WATCH_IGNORED,
+    depth: 2,
   });
 
   const state: SkillsWatchState = { watcher, pathsKey, debounceMs };

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -395,6 +395,7 @@ export abstract class MemoryManagerSyncOps {
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),
+      depth: 2,
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -96,6 +96,7 @@ describe("memory watcher config", () => {
       ]),
     );
     expect(options.ignoreInitial).toBe(true);
+    expect(options.depth).toBe(2);
     expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
 
     const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;


### PR DESCRIPTION
## Problem

The memory and skills chokidar watchers had no depth limit, so a workspace with many files under `memory/` or skills paths would open thousands of FSEventWrap handles (9,000+ observed) and exhaust file descriptors. This caused `spawn EBADF` errors when the exec tool tried to create child processes, effectively breaking shell command execution.

## Root cause

`chokidar.watch()` in both `src/memory/manager-sync-ops.ts` (ensureWatcher) and `src/agents/skills/refresh.ts` (ensureSkillsWatcher) had no `depth` option. The skills watcher already had ignore patterns for node_modules/dist/.git etc (added in #1056), but neither had a depth cap. When watched directories contained accumulated session data or large file trees, chokidar recursed without limit and opened one FSEvent per file.

## Fix

Added `depth: 2` to both chokidar.watch calls. This covers the typical shallow layouts that both watchers need:
- Memory: `memory/YYYY-MM-DD.md`, `memory/subdir/file.md`
- Skills: `skills/name/SKILL.md`

Deeper nesting isn't expected for either use case, so depth 2 caps FD usage while preserving all watch functionality.

## Testing

- Updated existing tests in `manager.watcher-config.test.ts` and `refresh.test.ts` to assert `depth: 2`
- Both test files pass (2/2)
- `pnpm check` clean

Closes #41606