### PR TITLE
ci: drop gha cache from docker release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -109,8 +109,6 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
-          cache-from: type=gha,scope=docker-release-amd64
-          cache-to: type=gha,mode=max,scope=docker-release-amd64
 
       - name: Build and push amd64 slim image
         id: build-slim
@@ -124,8 +122,6 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
-          cache-from: type=gha,scope=docker-release-amd64
-          cache-to: type=gha,mode=max,scope=docker-release-amd64
 
   # Build arm64 images (default + slim share the build stage cache)
   build-arm64:
@@ -214,8 +210,6 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
-          cache-from: type=gha,scope=docker-release-arm64
-          cache-to: type=gha,mode=max,scope=docker-release-arm64
 
       - name: Build and push arm64 slim image
         id: build-slim
@@ -229,8 +223,6 @@ jobs:
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
           push: true
-          cache-from: type=gha,scope=docker-release-arm64
-          cache-to: type=gha,mode=max,scope=docker-release-arm64
 
   # Create multi-platform manifests
   create-manifest:


### PR DESCRIPTION
## Summary

- Problem: docker-release used Docker Buildx `type=gha` cache alongside Blacksmith Docker builders.
- Why it matters: the extra GitHub Actions cache export/import adds overhead and duplicates Blacksmith's native Docker caching path.
- What changed: removed `cache-from`/`cache-to` `type=gha` settings from both amd64 and arm64 Docker release builds.
- What did NOT change (scope boundary): tags, manifests, build args, Dockerfile, registry push flow.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: GitHub Actions workflow YAML
- Model/provider: N/A
- Integration/channel (if any): Blacksmith runners
- Relevant config (redacted): `.github/workflows/docker-release.yml`

### Steps

1. Parse workflow YAML.
2. Lint workflow with `actionlint`.
3. Inspect diff to confirm only `type=gha` cache settings were removed.

### Expected

- Workflow remains valid.
- Docker release builds rely on Blacksmith builder caching only.

### Actual

- Workflow remained valid.
- Only the four `type=gha` cache lines were removed from each arch pair.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: YAML parse succeeded; `actionlint` passed; diff scope checked.
- Edge cases checked: both amd64 and arm64 jobs still retain identical tags/build args/push config.
- What you did **not** verify: a live `docker-release` workflow run after this change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `.github/workflows/docker-release.yml`
- Known bad symptoms reviewers should watch for: slower or colder Docker release builds than expected.

## Risks and Mitigations

- Risk: Blacksmith cache behavior differs from current assumptions on some refs.
  - Mitigation: scope is limited to workflow cache directives; revert is one-file, low-risk.
