### PR TITLE
fix (discord): resolve bare numeric allowlist entries as guilds before channel lookup

### DIFF
--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -301,40 +301,51 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res[0]?.channelId).toBeUndefined();
   });
 
-  it("bare numeric guild id is misrouted as channel id (regression)", async () => {
-    // Demonstrates why provider.ts must prefix guild-only entries with "guild:"
+  it("resolves bare numeric guild id as a guild before channel lookup", async () => {
     // In reality, Discord returns 404 when a guild ID is sent to /channels/<guildId>,
-    // which causes fetchDiscord to throw and the entire resolver to crash.
+    // so bare numeric server IDs must resolve against the guild list first.
     const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
       const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "999", name: "My Server" }]);
       }
-      // Guild ID hitting /channels/ returns 404 — just like real Discord
       if (url.includes("/channels/")) {
-        return new Response(JSON.stringify({ message: "Unknown Channel" }), { status: 404 });
+        throw new Error("guild id was incorrectly routed to /channels/");
       }
       return new Response("not found", { status: 404 });
     });
 
-    // Without the guild: prefix, a bare numeric string hits /channels/999 → 404 → unresolved
     const res = await resolveDiscordChannelAllowlist({
       token: "test",
       entries: ["999"],
       fetcher,
     });
-    expect(res[0]?.resolved).toBe(false);
-    expect(res[0]?.channelId).toBe("999");
-    expect(res[0]?.guildId).toBeUndefined();
 
-    // With the guild: prefix, it correctly resolves as a guild (never hits /channels/)
-    const res2 = await resolveDiscordChannelAllowlist({
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("999");
+    expect(res[0]?.channelId).toBeUndefined();
+  });
+
+  it("falls back to channel lookup for bare numeric ids that are not guild ids", async () => {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111", name: "Guild One" }]);
+      }
+      if (url.endsWith("/channels/999")) {
+        return jsonResponse({ id: "999", name: "general", guild_id: "111", type: 0 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await resolveDiscordChannelAllowlist({
       token: "test",
-      entries: ["guild:999"],
+      entries: ["999"],
       fetcher,
     });
-    expect(res2[0]?.resolved).toBe(true);
-    expect(res2[0]?.guildId).toBe("999");
-    expect(res2[0]?.channelId).toBeUndefined();
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("111");
+    expect(res[0]?.channelId).toBe("999");
   });
 });

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -40,6 +40,7 @@ function parseDiscordChannelInput(raw: string): {
   channelId?: string;
   guildId?: string;
   guildOnly?: boolean;
+  bareNumericId?: string;
 } {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -49,13 +50,17 @@ function parseDiscordChannelInput(raw: string): {
   if (mention) {
     return { channelId: mention[1] };
   }
-  const channelPrefix = trimmed.match(/^(?:channel:|discord:)?(\d+)$/i);
+  const channelPrefix = trimmed.match(/^(?:channel:|discord:)(\d+)$/i);
   if (channelPrefix) {
     return { channelId: channelPrefix[1] };
   }
-  const guildPrefix = trimmed.match(/^(?:guild:|server:)?(\d+)$/i);
-  if (guildPrefix && !trimmed.includes("/") && !trimmed.includes("#")) {
+  const guildPrefix = trimmed.match(/^(?:guild:|server:)(\d+)$/i);
+  if (guildPrefix) {
     return { guildId: guildPrefix[1], guildOnly: true };
+  }
+  const bareNumeric = trimmed.match(/^(\d+)$/);
+  if (bareNumeric) {
+    return { bareNumericId: bareNumeric[1] };
   }
   const split = trimmed.includes("/") ? trimmed.split("/") : trimmed.split("#");
   if (split.length >= 2) {
@@ -202,8 +207,22 @@ export async function resolveDiscordChannelAllowlist(params: {
       continue;
     }
 
-    if (parsed.channelId) {
-      const channelId = parsed.channelId;
+    if (parsed.bareNumericId) {
+      const guild = guilds.find((entry) => entry.id === parsed.bareNumericId);
+      if (guild) {
+        results.push({
+          input,
+          resolved: true,
+          guildId: guild.id,
+          guildName: guild.name,
+        });
+        continue;
+      }
+    }
+
+    const lookupChannelId = parsed.channelId ?? parsed.bareNumericId;
+    if (lookupChannelId) {
+      const channelId = lookupChannelId;
       const result = await fetchChannel(token, fetcher, channelId);
       if (result.status === "found") {
         const channel = result.channel;


### PR DESCRIPTION
## Summary

- Problem: Discord allowlist resolution treated any bare numeric entry like `999` as a channel ID in `src/discord/resolve-channels.ts`, so raw guild IDs were misrouted to channel lookup.
- Why it matters: server-wide Discord allowlist entries using numeric guild IDs failed unless users knew to write `guild:<id>`, which broke a valid and likely configuration path.
- What changed: bare numeric IDs now resolve as `guild` first if they match a known guild, then fall back to channel lookup if no guild matches; explicit `channel:`/`discord:` and `guild:`/`server:` prefixes keep their existing meaning. Regression coverage was updated in `src/discord/resolve-channels.test.ts`.
- What did NOT change (scope boundary): no changes to Discord API calls, config schema, onboarding flow, or non-Discord allowlist behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Discord allowlist entries that are bare numeric IDs now resolve as guild IDs when they match a known guild, instead of being forced through channel lookup first.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun 1.3.10 for static bundle verification
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord guild allowlist containing a bare numeric entry such as `999`

### Steps

1. Configure a Discord allowlist entry with a bare numeric guild ID like `999`.
2. Run Discord allowlist resolution against a bot that belongs to guild `999`.
3. Observe how the resolver classifies that entry.

### Expected

- The entry resolves as guild `999` without requiring a `guild:` prefix.

### Actual

- Before the fix, the entry was treated as channel ID `999`, causing unresolved results when `/channels/999` returned 404.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Note: full Vitest execution was not available in the workspace because dependencies were missing and `pnpm install` was blocked. I did verify both edited files bundle cleanly with Bun:
- `src/discord/resolve-channels.ts`
- `src/discord/resolve-channels.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the resolver code path, confirmed the previous bare-numeric parsing behavior, patched the decision order, and verified the edited files build successfully with Bun bundling.
- Edge cases checked: explicit `channel:`/`discord:` channel IDs still remain channel-only; explicit `guild:`/`server:` IDs still remain guild-only; bare numeric IDs still fall back to channel lookup when they do not match a guild.
- What you did **not** verify: full unit test execution, live Discord API behavior, and end-to-end onboarding/config flows.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the resolver change in `src/discord/resolve-channels.ts`
- Files/config to restore: `src/discord/resolve-channels.ts`, `src/discord/resolve-channels.test.ts`
- Known bad symptoms reviewers should watch for: bare numeric channel IDs no longer resolving as channels when they are not guild IDs

## Risks and Mitigations

- Risk: a bare numeric value that could plausibly refer to either a guild and a channel will now prefer guild resolution.
  - Mitigation: explicit `channel:` and `guild:` prefixes remain available, and the resolver still falls back to channel lookup when no guild matches.