### PR TITLE
fix(daemon): terminate gateway process on Windows after schtasks /End

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -152,6 +152,46 @@ describe("runServiceRestart token drift", () => {
     expect(service.stop).not.toHaveBeenCalled();
   });
 
+  it("calls postStop after service.stop succeeds", async () => {
+    service.stop.mockClear();
+    service.isLoaded.mockResolvedValue(true);
+    service.stop.mockResolvedValue(undefined);
+    const postStop = vi.fn(async () => {});
+
+    await runServiceStop({
+      serviceNoun: "Gateway",
+      service,
+      opts: { json: true },
+      postStop,
+    });
+
+    expect(service.stop).toHaveBeenCalledTimes(1);
+    expect(postStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fail stop when postStop throws", async () => {
+    service.stop.mockClear();
+    service.isLoaded.mockResolvedValue(true);
+    service.stop.mockResolvedValue(undefined);
+    const postStop = vi.fn(async () => {
+      throw new Error("cleanup failed");
+    });
+
+    await runServiceStop({
+      serviceNoun: "Gateway",
+      service,
+      opts: { json: true },
+      postStop,
+    });
+
+    expect(service.stop).toHaveBeenCalledTimes(1);
+    expect(postStop).toHaveBeenCalledTimes(1);
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as { ok?: boolean; result?: string };
+    expect(payload.ok).toBe(true);
+    expect(payload.result).toBe("stopped");
+  });
+
   it("runs restart health checks after an unmanaged restart signal", async () => {
     const postRestartCheck = vi.fn(async () => {});
     service.isLoaded.mockResolvedValue(false);

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -248,6 +248,7 @@ export async function runServiceStop(params: {
   service: GatewayService;
   opts?: DaemonLifecycleOptions;
   onNotLoaded?: (ctx: NotLoadedActionContext) => Promise<NotLoadedActionResult | null>;
+  postStop?: () => Promise<void>;
 }) {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createActionIO({ action: "stop", json });
@@ -296,6 +297,14 @@ export async function runServiceStop(params: {
   } catch (err) {
     fail(`${params.serviceNoun} stop failed: ${String(err)}`);
     return;
+  }
+
+  if (params.postStop) {
+    try {
+      await params.postStop();
+    } catch {
+      // Best-effort cleanup; do not fail the stop operation.
+    }
   }
 
   let stopped = false;

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -209,6 +209,19 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
     service,
     opts,
     onNotLoaded: async () => stopGatewayWithoutServiceManager(gatewayPort),
+    postStop: async () => {
+      // On Windows, schtasks /End kills the task-runner shell but the
+      // spawned node.exe gateway process may survive.  Send SIGTERM to
+      // any remaining gateway processes listening on the port.
+      const remainingPids = resolveVerifiedGatewayListenerPids(gatewayPort);
+      for (const pid of remainingPids) {
+        try {
+          signalGatewayPid(pid, "SIGTERM");
+        } catch {
+          // Best-effort: process may have exited between the check and the kill.
+        }
+      }
+    },
   });
 }
 


### PR DESCRIPTION
## Problem

On Windows, `openclaw gateway stop` only runs `schtasks /End` which ends the scheduled task trigger (the cmd.exe wrapper) but does not terminate the spawned node.exe gateway process. The gateway keeps running, the WebSocket port stays open, and connected clients remain connected. Running `gateway status` still shows "Listening".

## Root cause

The Windows service backend (`stopScheduledTask`) calls `schtasks /End /TN <taskName>`, which tells the Task Scheduler to end the task. However, the task's action typically runs a .cmd script that spawns node.exe. When `schtasks /End` kills the cmd.exe shell, the child node.exe process gets orphaned and keeps running.

The macOS equivalent (`launchctl bootout`) terminates the entire process tree, which is why this only affects Windows.

## Fix

Added a `postStop` callback parameter to `runServiceStop` (lifecycle-core.ts) and wired it up in `runDaemonStop` (lifecycle.ts). After the service manager's stop completes, the callback finds any remaining gateway PIDs listening on the port via `resolveVerifiedGatewayListenerPids` and sends SIGTERM to each one. This reuses the same verified PID resolution and safe signal logic already used by `stopGatewayWithoutServiceManager`.

The cleanup is best-effort: if a process already exited between detection and signaling, the error is silently caught.

## Testing

- Added 2 tests: postStop called after service.stop, postStop errors don't fail the stop
- All 14 lifecycle tests pass
- `pnpm check` clean

Closes #41591