### PR TITLE
fix(ui): do not clear gateway token when editing WebSocket URL

### DIFF
--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -208,7 +208,6 @@ export function renderOverview(props: OverviewProps) {
                 props.onSettingsChange({
                   ...props.settings,
                   gatewayUrl: v,
-                  token: v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : "",
                 });
               }}
               placeholder="ws://100.x.y.z:18789"


### PR DESCRIPTION
## Problem

In the Overview page's Gateway Access section, editing the WebSocket URL input immediately clears the Gateway Token field. This forces users to re-enter the token after any URL edit, and clicking Connect without noticing the cleared token fails the connection.

## Root cause

The URL input's `@input` handler compared the new input value (`v.trim()`) against the current stored URL (`props.settings.gatewayUrl.trim()`) on every keystroke:

```ts
token: v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : ""
```

Since any edit changes `v`, this comparison always evaluates to `false`, clearing the token on every keystroke. The intent was probably to reset the token when switching to a different gateway, but the implementation fires during normal typing.

## Fix

Removed the token-clearing logic from the URL input handler. The URL and token fields are now fully independent: editing one doesn't affect the other. Users switching gateways can update both fields at their own pace.

## Testing

- `pnpm check` clean
- Verified the fix logic: `onSettingsChange` now only updates `gatewayUrl`, leaving `token` untouched

Closes #41545