### PR TITLE
Collect provider routing details in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,6 +76,37 @@ body:
       label: Install method
       description: How OpenClaw was installed or launched.
       placeholder: npm global / pnpm dev / docker / mac app
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: Effective model under test.
+      placeholder: minimax/text-01 / openrouter/anthropic/claude-opus-4.1 / anthropic/claude-sonnet-4.5
+    validations:
+      required: true
+  - type: input
+    id: provider_chain
+    attributes:
+      label: Provider / routing chain
+      description: Effective request path through gateways, proxies, providers, or model routers.
+      placeholder: openclaw -> cloudflare-ai-gateway -> minimax
+    validations:
+      required: true
+  - type: input
+    id: config_location
+    attributes:
+      label: Config file / key location
+      description: Optional. Relevant config source or key path if this bug depends on overrides or custom provider setup. Redact secrets.
+      placeholder: ~/.openclaw/openclaw.json ; models.providers.cloudflare-ai-gateway.baseUrl ; ~/.openclaw/agents/<agentId>/agent/models.json
+  - type: textarea
+    id: provider_setup_details
+    attributes:
+      label: Additional provider/model setup details
+      description: Optional. Include redacted routing details, per-agent overrides, auth-profile interactions, env/config context, or anything else needed to explain the effective provider/model setup. Do not include API keys, tokens, or passwords.
+      placeholder: |
+        Default route is openclaw -> cloudflare-ai-gateway -> minimax.
+        Previous setup was openclaw -> cloudflare-ai-gateway -> openrouter -> minimax.
+        Relevant config lives in ~/.openclaw/openclaw.json under models.providers.minimax and models.providers.cloudflare-ai-gateway.
   - type: textarea
     id: logs
     attributes:


### PR DESCRIPTION
## Summary

- Problem: Bug reports did not ask for the effective model, provider chain, or related config locations.
- Why it matters: Recent duplicate-message investigation depended on the exact routing chain; the report showed duplicates disappeared when the route changed from `openclaw -> cloudflare-ai-gateway -> openrouter -> minimax` to `openclaw -> cloudflare-ai-gateway -> minimax`, even while the patched PR code stayed the same.
- What changed: Added required bug-report fields for `Model` and `Provider / routing chain`, plus optional `Config file / key location` and `Additional provider/model setup details`.
- What did NOT change (scope boundary): Feature request forms, runtime behavior, docs, and any provider code paths were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Bug reporters now provide the effective model and provider/routing chain in the issue form.
- Bug reporters can optionally point to relevant config file/key locations and add redacted provider-setup details.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: n/a
- Model/provider: n/a
- Integration/channel (if any): GitHub issue forms
- Relevant config (redacted): n/a

### Steps

1. Open the bug report issue form.
2. Confirm the form now asks for `Model` and `Provider / routing chain`.
3. Confirm `Config file / key location` and `Additional provider/model setup details` are present as optional diagnostics fields.

### Expected

- The bug form captures enough provider/model routing context to triage reports involving gateways, proxies, or provider overrides.

### Actual

- The YAML parses successfully and includes the new fields in the bug form definition.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed the bug form YAML, confirmed field ordering/content, and parsed the file successfully with Ruby YAML.
- Edge cases checked: Required vs optional diagnostics fields, chained-provider placeholder examples, and redaction guidance for secrets.
- What you did **not** verify: GitHub live rendering of the form in the web UI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the bug report template change.
- Files/config to restore: `.github/ISSUE_TEMPLATE/bug_report.yml`
- Known bad symptoms reviewers should watch for: GitHub issue form fails to render or fields appear in the wrong order.

## Risks and Mitigations

- Risk: Added required fields could slightly increase bug-report friction.
- Mitigation: Kept only model and routing chain required; config location and setup details remain optional.
