### PR TITLE
fix(daemon): terminate gateway process on Windows stop

### DIFF
--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -1,0 +1,116 @@
+import { PassThrough } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stopScheduledTask } from "./schtasks.js";
+
+const schtasksCalls: string[][] = [];
+
+vi.mock("./schtasks-exec.js", () => ({
+  execSchtasks: async (argv: string[]) => {
+    schtasksCalls.push(argv);
+    return { code: 0, stdout: "", stderr: "" };
+  },
+}));
+
+const killedPids: { pid: number; graceMs?: number }[] = [];
+
+vi.mock("../process/kill-tree.js", () => ({
+  killProcessTree: (pid: number, opts?: { graceMs?: number }) => {
+    killedPids.push({ pid, graceMs: opts?.graceMs });
+  },
+}));
+
+let portUsageMock: {
+  port: number;
+  status: string;
+  listeners: { pid?: number; command?: string }[];
+  hints: string[];
+} = { port: 18789, status: "free", listeners: [], hints: [] };
+
+vi.mock("../infra/ports-inspect.js", () => ({
+  inspectPortUsage: async (_port: number) => portUsageMock,
+}));
+
+beforeEach(() => {
+  schtasksCalls.length = 0;
+  killedPids.length = 0;
+  portUsageMock = { port: 18789, status: "free", listeners: [], hints: [] };
+});
+
+describe("stopScheduledTask", () => {
+  it("terminates gateway process listening on the configured port after schtasks /End", async () => {
+    portUsageMock = {
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 12345, command: "node.exe" }],
+      hints: [],
+    };
+
+    const stdout = new PassThrough();
+    await stopScheduledTask({
+      stdout,
+      env: { USERPROFILE: "C:\\Users\\test", OPENCLAW_PROFILE: "default" },
+    });
+
+    // Should call schtasks /Query (availability check) then /End
+    expect(schtasksCalls[0]).toEqual(["/Query"]);
+    expect(schtasksCalls[1]).toEqual(["/End", "/TN", "OpenClaw Gateway"]);
+
+    // Should kill the gateway process found on the port
+    expect(killedPids).toEqual([{ pid: 12345, graceMs: 2000 }]);
+  });
+
+  it("uses OPENCLAW_GATEWAY_PORT from env when set", async () => {
+    portUsageMock = {
+      port: 9999,
+      status: "busy",
+      listeners: [{ pid: 54321, command: "node.exe" }],
+      hints: [],
+    };
+
+    const stdout = new PassThrough();
+    await stopScheduledTask({
+      stdout,
+      env: {
+        USERPROFILE: "C:\\Users\\test",
+        OPENCLAW_PROFILE: "default",
+        OPENCLAW_GATEWAY_PORT: "9999",
+      },
+    });
+
+    expect(killedPids).toEqual([{ pid: 54321, graceMs: 2000 }]);
+  });
+
+  it("does not kill any process when port is free", async () => {
+    portUsageMock = {
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    };
+
+    const stdout = new PassThrough();
+    await stopScheduledTask({
+      stdout,
+      env: { USERPROFILE: "C:\\Users\\test", OPENCLAW_PROFILE: "default" },
+    });
+
+    expect(killedPids).toEqual([]);
+  });
+
+  it("does not kill listeners without a valid pid", async () => {
+    portUsageMock = {
+      port: 18789,
+      status: "busy",
+      listeners: [{ command: "node.exe" }],
+      hints: [],
+    };
+
+    const stdout = new PassThrough();
+    await stopScheduledTask({
+      stdout,
+      env: { USERPROFILE: "C:\\Users\\test", OPENCLAW_PROFILE: "default" },
+    });
+
+    expect(killedPids).toEqual([]);
+  });
+});

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,5 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DEFAULT_GATEWAY_PORT } from "../config/paths.js";
+import { inspectPortUsage } from "../infra/ports-inspect.js";
+import { killProcessTree } from "../process/kill-tree.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
@@ -306,12 +309,48 @@ function isTaskNotRunning(res: { stdout: string; stderr: string; code: number })
 
 export async function stopScheduledTask({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
-  const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
+  const resolvedEnv = env ?? (process.env as GatewayServiceEnv);
+  const taskName = resolveTaskName(resolvedEnv);
   const res = await execSchtasks(["/End", "/TN", taskName]);
   if (res.code !== 0 && !isTaskNotRunning(res)) {
     throw new Error(`schtasks end failed: ${res.stderr || res.stdout}`.trim());
   }
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
+
+  // schtasks /End only disables the scheduled task but does not terminate the
+  // running gateway process. Find and kill any gateway process still listening
+  // on the configured port so the behavior matches macOS (launchctl bootout)
+  // and Linux (systemctl stop), both of which terminate the process.
+  await terminateGatewayProcessOnPort(resolvedEnv);
+}
+
+function resolveGatewayPortFromEnv(env: GatewayServiceEnv): number {
+  const raw = env.OPENCLAW_GATEWAY_PORT?.trim();
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_GATEWAY_PORT;
+}
+
+async function terminateGatewayProcessOnPort(env: GatewayServiceEnv): Promise<void> {
+  const port = resolveGatewayPortFromEnv(env);
+  let portUsage;
+  try {
+    portUsage = await inspectPortUsage(port);
+  } catch {
+    return;
+  }
+  if (portUsage.status !== "busy") {
+    return;
+  }
+  for (const listener of portUsage.listeners) {
+    if (Number.isFinite(listener.pid) && (listener.pid as number) > 0) {
+      killProcessTree(listener.pid as number, { graceMs: 2000 });
+    }
+  }
 }
 
 export async function restartScheduledTask({


### PR DESCRIPTION
## Summary

- Problem: `openclaw gateway stop` on Windows only calls `schtasks /End` which disables the scheduled task but does NOT terminate the running node.exe gateway process. The port remains occupied.
- Why it matters: macOS (`launchctl bootout`) and Linux (`systemctl stop`) both terminate the gateway process on stop. Windows is inconsistent, leaving the gateway running after "stop".
- What changed: After calling `schtasks /End`, `stopScheduledTask()` now uses `inspectPortUsage()` to find any process still listening on the gateway port and calls `killProcessTree()` to terminate it.
- What did NOT change (scope boundary): No changes to the install, uninstall, restart, or runtime query flows. The schtasks /End call is still made first for backwards compatibility.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41591

## User-visible / Behavior Changes

`openclaw gateway stop` on Windows now terminates the running gateway process (matching macOS and Linux behavior). Previously the process kept running after the command completed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (uses existing `killProcessTree` and `inspectPortUsage`)
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows (any version with schtasks)
- Runtime/container: Node 22+

### Steps

1. Install the gateway daemon on Windows: `openclaw gateway install`
2. Verify gateway is running on the configured port
3. Run `openclaw gateway stop`

### Expected

- The gateway process is terminated and the port is freed

### Actual (before fix)

- The scheduled task is disabled but the node.exe process continues running

## Evidence

- [x] Failing test/log before + passing after
- New test file `src/daemon/schtasks.stop.test.ts` with 4 test cases covering: process termination after stop, custom port via env, no-op when port is free, and skipping listeners without valid PIDs

## Human Verification (required)

- Verified scenarios: All schtasks tests pass (29 tests across 3 files), `pnpm check` passes
- Edge cases checked: port free (no-op), listener without PID (skipped), custom port via OPENCLAW_GATEWAY_PORT
- What you did **not** verify: Actual Windows execution (developed on macOS; logic is tested via mocks)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/daemon/schtasks.ts`
- Known bad symptoms reviewers should watch for: Gateway process not stopping on Windows, or being killed on the wrong port

## Risks and Mitigations

- Risk: If a non-gateway process is listening on the configured port, it could be terminated.
  - Mitigation: This mirrors the exact same risk surface as the existing `terminateStaleGatewayPids()` pattern used elsewhere in the codebase. The port is resolved from `OPENCLAW_GATEWAY_PORT` or the well-known default (18789).