### PR TITLE
fix(utils): preserve code block indentation in directive whitespace normalization

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
@@ -55,5 +56,28 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toEqual(input);
+  });
+});
+
+describe("parseInlineDirectives preserves code block indentation", () => {
+  test("preserves indentation inside fenced code blocks", () => {
+    const input =
+      '[[reply_to_current]] Here is code:\n```json\n{\n  "a": {\n    "b": 1\n  }\n}\n```';
+    const result = parseInlineDirectives(input, { stripReplyTags: true });
+    expect(result.text).toContain('  "a"');
+    expect(result.text).toContain('    "b"');
+    expect(result.replyToCurrent).toBe(true);
+  });
+
+  test("preserves indentation with tilde fences", () => {
+    const input = "~~~python\ndef foo():\n    return 42\n~~~";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain("    return 42");
+  });
+
+  test("normalizes whitespace outside code blocks", () => {
+    const input = "  hello   world  \n  text  ";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("hello world\ntext");
   });
 });

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -18,10 +18,19 @@ const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
 function normalizeDirectiveWhitespace(text: string): string {
-  return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+  // Split on fenced code blocks to preserve their internal whitespace.
+  // Regex captures the full fenced block (``` or ~~~ with optional info string).
+  const parts = text.split(/(```[\s\S]*?```|~~~[\s\S]*?~~~)/g);
+  const normalized = parts
+    .map((part, i) => {
+      // Odd indices are the captured code-block groups; leave them untouched.
+      if (i % 2 === 1) {
+        return part;
+      }
+      return part.replace(/[ \t]+/g, " ").replace(/[ \t]*\n[ \t]*/g, "\n");
+    })
+    .join("");
+  return normalized.trim();
 }
 
 type StripInlineDirectiveTagsResult = {


### PR DESCRIPTION
## Problem

Code blocks in chat replies lose their leading indentation before delivery to channels. JSON, Python, YAML and other indentation-sensitive content becomes unreadable. The issue is 100% reproducible: the original assistant output in session history has correct indentation, but the delivered message does not.

## Root cause

`normalizeDirectiveWhitespace()` in `src/utils/directive-tags.ts` applies two regex replacements to the entire message body:

```ts
text.replace(/[ \t]+/g, " ").replace(/[ \t]*\n[ \t]*/g, "\n")
```

The first collapses all horizontal whitespace runs to a single space. The second strips all leading whitespace after newlines. Both destroy indentation inside fenced code blocks.

This function is called by `parseInlineDirectives()` which runs on every outbound message, even when no directive tags are present.

## Fix

The function now splits the text on fenced code blocks (both backtick and tilde fences) before normalizing. Only the prose segments between code blocks get whitespace normalization. Code block content passes through untouched.

```ts
const parts = text.split(/(backtick-fence|tilde-fence)/g);
parts.map((part, i) => i % 2 === 1 ? part : normalize(part));
```

## Testing

- Added 3 tests: backtick fences, tilde fences, and prose-only normalization
- All 9 directive-tags tests pass
- `pnpm check` clean

Closes #41699