### PR TITLE
fix(cli): guard zsh completion compdef call to avoid command not found

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -401,7 +401,9 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
-compdef _${rootCmd}_root_completion ${rootCmd}
+if (( $+functions[compdef] )); then
+  compdef _${rootCmd}_root_completion ${rootCmd}
+fi
 `;
   return script;
 }


### PR DESCRIPTION
## Problem

Running `source <(openclaw completion --shell zsh)` in `.zshrc` causes `command not found: compdef` when `compinit` hasn't been called yet. This happens because the generated zsh completion script calls `compdef` unconditionally, but `compdef` is only available after the zsh completion system is initialized.

## Root cause

The `generateZshCompletion()` function emits a bare `compdef _openclaw_root_completion openclaw` at the end of the script. In zsh, `compdef` is defined by `compinit`, so if the user sources the completion early in their `.zshrc` (before `compinit` runs), they get an error on every shell startup.

## Fix

Wrapped the `compdef` call in a `$+functions[compdef]` guard:

```zsh
if (( $+functions[compdef] )); then
  compdef _openclaw_root_completion openclaw
fi
```

This is the standard pattern used by kubectl, gh, docker, and other CLI tools. The completion functions are still defined and available; the `compdef` registration just waits until the completion system is ready.

## Testing

- All 735 CLI tests pass
- Verified the generated script includes the guard

Closes #14289