### PR TITLE
fix(session): defer systemSent persistence until LLM response succeeds

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -81,7 +81,11 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
-import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
+import {
+  incrementRunCompactionCount,
+  persistRunSessionUsage,
+  persistSystemSentAfterSuccess,
+} from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
@@ -1389,37 +1393,12 @@ export async function runReplyAgent(params: {
       cliSessionBinding,
     });
 
-    // Mark systemSent=true only after a successful LLM response.
-    // This prevents corruption when the first LLM call fails (e.g.
-    // insufficient API credits): without this guard, systemSent=true
-    // would be persisted before the system prompt was actually delivered,
-    // causing all subsequent sessions to skip re-sending it (#41462).
-    // Additionally, skip persistence when the run returned only error
-    // payloads (provider failures surfaced as error payloads still
-    // produce runOutcome.kind !== "final").
-    const hasMetaError = Boolean(runResult.meta?.error);
-    const hasNonErrorPayload = payloadArray.some(
-      (p) => !p.isError && Boolean(p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
-    );
-    // Also count messaging-tool sends (NO_REPLY / tool-only runs still
-    // represent a successful LLM completion and should not re-trigger
-    // first-turn system prompt re-sends).
-    const hasSentViaMessagingTool =
-      (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
-      (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0;
-    if (
-      sessionKey &&
-      storePath &&
-      activeSessionEntry?.systemSent !== true &&
-      !hasMetaError &&
-      (hasNonErrorPayload || hasSentViaMessagingTool)
-    ) {
-      await updateSessionStoreEntry({
-        storePath,
-        sessionKey,
-        update: async () => ({ systemSent: true }),
-      });
-    }
+    await persistSystemSentAfterSuccess({
+      storePath,
+      sessionKey,
+      sessionEntry: activeSessionEntry,
+      runResult,
+    });
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1394,7 +1394,7 @@ export async function runReplyAgent(params: {
     // insufficient API credits): without this guard, systemSent=true
     // would be persisted before the system prompt was actually delivered,
     // causing all subsequent sessions to skip re-sending it (#41462).
-    if (activeIsNewSession && sessionKey && storePath) {
+    if (sessionKey && storePath && activeSessionEntry?.systemSent !== true) {
       await updateSessionStoreEntry({
         storePath,
         sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1401,12 +1401,18 @@ export async function runReplyAgent(params: {
     const hasNonErrorPayload = payloadArray.some(
       (p) => !p.isError && Boolean(p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
     );
+    // Also count messaging-tool sends (NO_REPLY / tool-only runs still
+    // represent a successful LLM completion and should not re-trigger
+    // first-turn system prompt re-sends).
+    const hasSentViaMessagingTool =
+      (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
+      (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0;
     if (
       sessionKey &&
       storePath &&
       activeSessionEntry?.systemSent !== true &&
       !hasMetaError &&
-      hasNonErrorPayload
+      (hasNonErrorPayload || hasSentViaMessagingTool)
     ) {
       await updateSessionStoreEntry({
         storePath,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1394,7 +1394,20 @@ export async function runReplyAgent(params: {
     // insufficient API credits): without this guard, systemSent=true
     // would be persisted before the system prompt was actually delivered,
     // causing all subsequent sessions to skip re-sending it (#41462).
-    if (sessionKey && storePath && activeSessionEntry?.systemSent !== true) {
+    // Additionally, skip persistence when the run returned only error
+    // payloads (provider failures surfaced as error payloads still
+    // produce runOutcome.kind !== "final").
+    const hasMetaError = Boolean(runResult.meta?.error);
+    const hasNonErrorPayload = payloadArray.some(
+      (p) => !p.isError && Boolean(p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
+    );
+    if (
+      sessionKey &&
+      storePath &&
+      activeSessionEntry?.systemSent !== true &&
+      !hasMetaError &&
+      hasNonErrorPayload
+    ) {
       await updateSessionStoreEntry({
         storePath,
         sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1389,6 +1389,19 @@ export async function runReplyAgent(params: {
       cliSessionBinding,
     });
 
+    // Mark systemSent=true only after a successful LLM response.
+    // This prevents corruption when the first LLM call fails (e.g.
+    // insufficient API credits): without this guard, systemSent=true
+    // would be persisted before the system prompt was actually delivered,
+    // causing all subsequent sessions to skip re-sending it (#41462).
+    if (activeIsNewSession && sessionKey && storePath) {
+      await updateSessionStoreEntry({
+        storePath,
+        sessionKey,
+        update: async () => ({ systemSent: true }),
+      });
+    }
+
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -245,7 +245,7 @@ async function persistRunSessionUsageForFollowupTest(
 async function persistSystemSentAfterSuccessForFollowupTest(
   params: Parameters<typeof import("./session-run-accounting.js").persistSystemSentAfterSuccess>[0],
 ): Promise<void> {
-  const { storePath, sessionKey, runResult } = params;
+  const { storePath, sessionKey, sessionEntry, runResult } = params;
   if (!storePath || !sessionKey) {
     return;
   }
@@ -275,9 +275,10 @@ async function persistSystemSentAfterSuccessForFollowupTest(
       updatedAt: Date.now(),
     };
     store[sessionKey] = nextEntry;
-    if (!registeredStore) {
-      await saveSessionStore(storePath, store);
+    if (sessionEntry) {
+      Object.assign(sessionEntry, nextEntry);
     }
+    await saveSessionStore(storePath, store);
   }
 }
 

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1293,6 +1293,41 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     persistSpy.mockRestore();
   });
 
+  it("persists systemSent on successful silent followups", async () => {
+    const scenarios = [{ payloads: [{ text: "NO_REPLY" }] }, { payloads: [] }];
+
+    for (const agentResult of scenarios) {
+      const storePath = path.join(
+        await fs.mkdtemp(path.join(tmpdir(), "openclaw-followup-systemsent-")),
+        "sessions.json",
+      );
+      const sessionKey = "main";
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        systemSent: false,
+      };
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+      await saveSessionStore(storePath, sessionStore);
+
+      await runMessagingCase({
+        agentResult: {
+          ...agentResult,
+          meta: { durationMs: 1, stopReason: "stop" },
+        },
+        runnerOverrides: {
+          sessionEntry,
+          sessionStore,
+          sessionKey,
+          storePath,
+        },
+      });
+
+      const store = loadSessionStore(storePath, { skipCache: true });
+      expect(store[sessionKey]?.systemSent).toBe(true);
+    }
+  });
+
   it("does not send cross-channel payload content to dispatcher when origin routing fails", async () => {
     routeReplyMock.mockResolvedValue({
       ok: false,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -242,6 +242,45 @@ async function persistRunSessionUsageForFollowupTest(
   await saveSessionStore(storePath, store);
 }
 
+async function persistSystemSentAfterSuccessForFollowupTest(
+  params: Parameters<typeof import("./session-run-accounting.js").persistSystemSentAfterSuccess>[0],
+): Promise<void> {
+  const { storePath, sessionKey, runResult } = params;
+  if (!storePath || !sessionKey) {
+    return;
+  }
+  const registeredStore = FOLLOWUP_TEST_SESSION_STORES.get(storePath);
+  const store = registeredStore ?? loadSessionStore(storePath, { skipCache: true });
+  const entry = store[sessionKey];
+  if (!entry || entry.systemSent === true) {
+    return;
+  }
+  const payloadArray = runResult.payloads ?? [];
+  const hasMetaError = Boolean(runResult.meta?.error);
+  const hasNonErrorPayload = payloadArray.some(
+    (p) => !p.isError && Boolean(p.text?.trim() || p.mediaUrl || (p.mediaUrls?.length ?? 0) > 0),
+  );
+  const hasSentViaMessagingTool =
+    runResult.didSendViaMessagingTool === true ||
+    (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
+    (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0;
+  const hasSuccessfulStopReason =
+    Boolean(runResult.meta?.stopReason) &&
+    runResult.meta.stopReason !== "error" &&
+    runResult.meta.stopReason !== "aborted";
+  if (!hasMetaError && (hasNonErrorPayload || hasSentViaMessagingTool || hasSuccessfulStopReason)) {
+    const nextEntry: SessionEntry = {
+      ...entry,
+      systemSent: true,
+      updatedAt: Date.now(),
+    };
+    store[sessionKey] = nextEntry;
+    if (!registeredStore) {
+      await saveSessionStore(storePath, store);
+    }
+  }
+}
+
 async function loadFreshFollowupRunnerModuleForTest() {
   vi.resetModules();
   vi.doUnmock("../../config/config.js");
@@ -273,6 +312,7 @@ async function loadFreshFollowupRunnerModuleForTest() {
   vi.doMock("./session-run-accounting.js", () => ({
     persistRunSessionUsage: persistRunSessionUsageForFollowupTest,
     incrementRunCompactionCount: incrementRunCompactionCountForFollowupTest,
+    persistSystemSentAfterSuccess: persistSystemSentAfterSuccessForFollowupTest,
   }));
   vi.doMock("./agent-runner-memory.js", () => ({
     runMemoryFlushIfNeeded: async (params: { sessionEntry?: SessionEntry }) => params.sessionEntry,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -12,6 +12,7 @@ const compactEmbeddedPiSessionMock = vi.fn();
 const routeReplyMock = vi.fn();
 const isRoutableChannelMock = vi.fn();
 const runPreflightCompactionIfNeededMock = vi.fn();
+const persistSystemSentAfterSuccessMock = vi.fn();
 const resolveCommandSecretRefsViaGatewayMock = vi.fn();
 const resolveQueuedReplyExecutionConfigMock = vi.fn();
 const resolveProviderFollowupFallbackRouteMock = vi.fn();
@@ -252,7 +253,7 @@ async function persistSystemSentAfterSuccessForFollowupTest(
   const registeredStore = FOLLOWUP_TEST_SESSION_STORES.get(storePath);
   const store = registeredStore ?? loadSessionStore(storePath, { skipCache: true });
   const entry = store[sessionKey];
-  if (!entry || entry.systemSent === true) {
+  if (!entry || entry.systemSent === true || sessionEntry?.systemSent === true) {
     return;
   }
   const payloadArray = runResult.payloads ?? [];
@@ -313,7 +314,8 @@ async function loadFreshFollowupRunnerModuleForTest() {
   vi.doMock("./session-run-accounting.js", () => ({
     persistRunSessionUsage: persistRunSessionUsageForFollowupTest,
     incrementRunCompactionCount: incrementRunCompactionCountForFollowupTest,
-    persistSystemSentAfterSuccess: persistSystemSentAfterSuccessForFollowupTest,
+    persistSystemSentAfterSuccess: (...args: unknown[]) =>
+      persistSystemSentAfterSuccessMock(...args),
   }));
   vi.doMock("./agent-runner-memory.js", () => ({
     runMemoryFlushIfNeeded: async (params: { sessionEntry?: SessionEntry }) => params.sessionEntry,
@@ -409,6 +411,7 @@ beforeEach(() => {
   runEmbeddedPiAgentMock.mockReset();
   compactEmbeddedPiSessionMock.mockReset();
   runPreflightCompactionIfNeededMock.mockReset();
+  persistSystemSentAfterSuccessMock.mockReset();
   resolveCommandSecretRefsViaGatewayMock.mockReset();
   resolveQueuedReplyExecutionConfigMock.mockReset();
   resolveProviderFollowupFallbackRouteMock.mockReset();
@@ -423,6 +426,10 @@ beforeEach(() => {
   );
   runPreflightCompactionIfNeededMock.mockImplementation(
     async (params: { sessionEntry?: SessionEntry }) => params.sessionEntry,
+  );
+  persistSystemSentAfterSuccessMock.mockImplementation(
+    async (...args: Parameters<typeof persistSystemSentAfterSuccessForFollowupTest>) =>
+      await persistSystemSentAfterSuccessForFollowupTest(...args),
   );
   resolveCommandSecretRefsViaGatewayMock.mockImplementation(async ({ config }) => ({
     resolvedConfig: config,
@@ -1367,6 +1374,47 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       const store = loadSessionStore(storePath, { skipCache: true });
       expect(store[sessionKey]?.systemSent).toBe(true);
     }
+  });
+
+  it("persists systemSent against the active session entry after preflight refresh", async () => {
+    const storePath = path.join(
+      await fs.mkdtemp(path.join(tmpdir(), "openclaw-followup-systemsent-refresh-")),
+      "sessions.json",
+    );
+    const sessionKey = "main";
+    const staleSessionEntry: SessionEntry = {
+      sessionId: "session-stale",
+      updatedAt: Date.now(),
+      systemSent: true,
+    };
+    const activeSessionEntry: SessionEntry = {
+      sessionId: "session-active",
+      updatedAt: Date.now(),
+      systemSent: false,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: activeSessionEntry };
+    await saveSessionStore(storePath, sessionStore);
+    registerFollowupTestSessionStore(storePath, sessionStore);
+
+    runPreflightCompactionIfNeededMock.mockImplementationOnce(async () => activeSessionEntry);
+
+    await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        meta: { durationMs: 1, stopReason: "stop" },
+      },
+      runnerOverrides: {
+        sessionEntry: staleSessionEntry,
+        sessionStore,
+        sessionKey,
+        storePath,
+      },
+    });
+
+    expect(persistSystemSentAfterSuccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionEntry: activeSessionEntry }),
+    );
+    expect(sessionStore[sessionKey]?.systemSent).toBe(true);
   });
 
   it("does not send cross-channel payload content to dispatcher when origin routing fails", async () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -33,7 +33,11 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { refreshQueuedFollowupSession, type FollowupRun } from "./queue.js";
 import { createReplyOperation } from "./reply-run-registry.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
-import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
+import {
+  incrementRunCompactionCount,
+  persistRunSessionUsage,
+  persistSystemSentAfterSuccess,
+} from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
@@ -404,6 +408,13 @@ export function createFollowupRunner(params: {
           logLabel: "followup",
         });
       }
+
+      await persistSystemSentAfterSuccess({
+        storePath,
+        sessionKey,
+        sessionEntry,
+        runResult,
+      });
 
       const payloadArray = runResult.payloads ?? [];
       if (payloadArray.length === 0) {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -388,7 +388,7 @@ export function createFollowupRunner(params: {
           provider: providerUsed,
           model: modelUsed,
           contextTokensOverride: agentCfgContextTokens,
-          fallbackContextTokens: sessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+          fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
           allowAsyncLoad: false,
         }) ?? DEFAULT_CONTEXT_TOKENS;
 
@@ -412,7 +412,7 @@ export function createFollowupRunner(params: {
       await persistSystemSentAfterSuccess({
         storePath,
         sessionKey,
-        sessionEntry,
+        sessionEntry: activeSessionEntry,
         runResult,
       });
 
@@ -453,7 +453,7 @@ export function createFollowupRunner(params: {
         const previousSessionId = run.sessionId;
         const count = await incrementRunCompactionCount({
           cfg: runtimeConfig,
-          sessionEntry,
+          sessionEntry: activeSessionEntry,
           sessionStore,
           sessionKey,
           storePath,

--- a/src/auto-reply/reply/session-run-accounting.test.ts
+++ b/src/auto-reply/reply/session-run-accounting.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("persistSystemSentAfterSuccess", () => {
+  it("does not fail the reply when systemSent persistence throws", async () => {
+    vi.resetModules();
+    const updateSessionStoreEntryMock = vi.fn(async () => {
+      throw new Error("lock timeout");
+    });
+    const logVerboseMock = vi.fn();
+
+    vi.doMock("../../config/sessions.js", async () => {
+      const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
+        "../../config/sessions.js",
+      );
+      return {
+        ...actual,
+        updateSessionStoreEntry: updateSessionStoreEntryMock,
+      };
+    });
+    vi.doMock("../../globals.js", async () => {
+      const actual = await vi.importActual<typeof import("../../globals.js")>("../../globals.js");
+      return {
+        ...actual,
+        logVerbose: logVerboseMock,
+      };
+    });
+
+    const { persistSystemSentAfterSuccess } = await import("./session-run-accounting.js");
+    const sessionEntry = { sessionId: "s1", updatedAt: Date.now(), systemSent: false };
+
+    await expect(
+      persistSystemSentAfterSuccess({
+        storePath: "/tmp/sessions.json",
+        sessionKey: "main",
+        sessionEntry,
+        runResult: {
+          payloads: [],
+          meta: { stopReason: "stop" },
+        } as never,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(updateSessionStoreEntryMock).toHaveBeenCalledTimes(1);
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      expect.stringContaining("failed to persist systemSent marker"),
+    );
+    expect(sessionEntry.systemSent).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/session-run-accounting.ts
+++ b/src/auto-reply/reply/session-run-accounting.ts
@@ -1,7 +1,8 @@
 import type { EmbeddedPiRunResult } from "../../agents/pi-embedded-runner/types.js";
 import { deriveSessionTotalTokens, type NormalizedUsage } from "../../agents/usage.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { updateSessionStoreEntry, type SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logVerbose } from "../../globals.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 
@@ -85,10 +86,15 @@ export async function persistSystemSentAfterSuccess(
     !hasMetaError &&
     (hasNonErrorPayload || hasSentViaMessagingTool || hasSuccessfulStopReason)
   ) {
-    await updateSessionStoreEntry({
-      storePath,
-      sessionKey,
-      update: async () => ({ systemSent: true }),
-    });
+    try {
+      await updateSessionStoreEntry({
+        storePath,
+        sessionKey,
+        update: async () => ({ systemSent: true }),
+      });
+      sessionEntry.systemSent = true;
+    } catch (err) {
+      logVerbose(`failed to persist systemSent marker: ${String(err)}`);
+    }
   }
 }

--- a/src/auto-reply/reply/session-run-accounting.ts
+++ b/src/auto-reply/reply/session-run-accounting.ts
@@ -1,5 +1,7 @@
+import type { EmbeddedPiRunResult } from "../../agents/pi-embedded-runner/types.js";
 import { deriveSessionTotalTokens, type NormalizedUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { updateSessionStoreEntry, type SessionEntry } from "../../config/sessions.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 
@@ -23,6 +25,13 @@ function resolvePositiveTokenCount(value: number | undefined): number | undefine
     ? Math.floor(value)
     : undefined;
 }
+
+type PersistSystemSentAfterSuccessParams = {
+  storePath?: string;
+  sessionKey?: string;
+  sessionEntry?: SessionEntry;
+  runResult: EmbeddedPiRunResult;
+};
 
 export async function persistRunSessionUsage(params: PersistRunSessionUsageParams): Promise<void> {
   await persistSessionUsageUpdate(params);
@@ -50,4 +59,36 @@ export async function incrementRunCompactionCount(
     newSessionId: params.newSessionId,
     newSessionFile: params.newSessionFile,
   });
+}
+
+export async function persistSystemSentAfterSuccess(
+  params: PersistSystemSentAfterSuccessParams,
+): Promise<void> {
+  const { storePath, sessionKey, sessionEntry, runResult } = params;
+  const payloadArray = runResult.payloads ?? [];
+  const hasMetaError = Boolean(runResult.meta?.error);
+  const hasNonErrorPayload = payloadArray.some(
+    (p) => !p.isError && Boolean(p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0 || p.mediaUrl),
+  );
+  const hasSentViaMessagingTool =
+    runResult.didSendViaMessagingTool === true ||
+    (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
+    (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0;
+  const hasSuccessfulStopReason =
+    Boolean(runResult.meta?.stopReason) &&
+    runResult.meta.stopReason !== "error" &&
+    runResult.meta.stopReason !== "aborted";
+  if (
+    sessionKey &&
+    storePath &&
+    sessionEntry?.systemSent !== true &&
+    !hasMetaError &&
+    (hasNonErrorPayload || hasSentViaMessagingTool || hasSuccessfulStopReason)
+  ) {
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async () => ({ systemSent: true }),
+    });
+  }
 }

--- a/src/auto-reply/reply/session-updates-systemsent.test.ts
+++ b/src/auto-reply/reply/session-updates-systemsent.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+
+/**
+ * Regression test for #41462: ensureSkillSnapshot must NOT persist
+ * systemSent=true to the session store on disk.
+ *
+ * Previously, systemSent was written to disk inside ensureSkillSnapshot
+ * (before the LLM call). If the LLM call failed (e.g. insufficient API
+ * credits), all subsequent sessions would skip re-sending the system
+ * prompt because systemSent=true was already on disk.
+ */
+
+// Disable fast-test bypass so we exercise the real code path
+delete process.env.OPENCLAW_TEST_FAST;
+
+let tmpDir = "";
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemsent-"));
+});
+afterAll(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+describe("ensureSkillSnapshot systemSent persistence (#41462)", () => {
+  it("should return systemSent=true in-memory but NOT write it to disk on first turn", async () => {
+    const storePath = path.join(tmpDir, "sessions-1.json");
+    const sessionKey = "wa:test-user";
+    const initialEntry: SessionEntry = {
+      sessionId: "old-session",
+      updatedAt: Date.now() - 60_000,
+    };
+
+    // Pre-populate store on disk
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: initialEntry }));
+
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: { ...initialEntry },
+    };
+
+    // Dynamic import to avoid module-level side effects
+    const { ensureSkillSnapshot } = await import("./session-updates.js");
+
+    const result = await ensureSkillSnapshot({
+      sessionEntry: sessionStore[sessionKey],
+      sessionStore,
+      sessionKey,
+      storePath,
+      sessionId: "new-session",
+      isFirstTurnInSession: true,
+      workspaceDir: tmpDir,
+      cfg: {} as unknown as import("../../config/config.js").OpenClawConfig,
+    });
+
+    // In-memory: systemSent should be true (so caller sends system prompt)
+    expect(result.systemSent).toBe(true);
+
+    // On disk: systemSent must NOT be true yet — read the file directly
+    const raw = await fs.readFile(storePath, "utf-8");
+    const persisted = JSON.parse(raw) as Record<string, SessionEntry>;
+    const diskEntry = persisted[sessionKey];
+    expect(diskEntry?.systemSent).not.toBe(true);
+  });
+});

--- a/src/auto-reply/reply/session-updates-systemsent.test.ts
+++ b/src/auto-reply/reply/session-updates-systemsent.test.ts
@@ -14,14 +14,20 @@ import type { SessionEntry } from "../../config/sessions.js";
  * prompt because systemSent=true was already on disk.
  */
 
-// Disable fast-test bypass so we exercise the real code path
-delete process.env.OPENCLAW_TEST_FAST;
-
 let tmpDir = "";
+let originalTestFast: string | undefined;
+
 beforeAll(async () => {
+  // Disable fast-test bypass so we exercise the real code path
+  originalTestFast = process.env.OPENCLAW_TEST_FAST;
+  delete process.env.OPENCLAW_TEST_FAST;
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemsent-"));
 });
 afterAll(async () => {
+  // Restore original env value for test isolation
+  if (originalTestFast !== undefined) {
+    process.env.OPENCLAW_TEST_FAST = originalTestFast;
+  }
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }

--- a/src/auto-reply/reply/session-updates-systemsent.test.ts
+++ b/src/auto-reply/reply/session-updates-systemsent.test.ts
@@ -43,7 +43,6 @@ describe("ensureSkillSnapshot systemSent persistence (#41462)", () => {
       [sessionKey]: { ...initialEntry },
     };
 
-    // Dynamic import to avoid module-level side effects
     const { ensureSkillSnapshot } = await import("./session-updates.js");
 
     const result = await ensureSkillSnapshot({
@@ -65,5 +64,76 @@ describe("ensureSkillSnapshot systemSent persistence (#41462)", () => {
     const persisted = JSON.parse(raw) as Record<string, SessionEntry>;
     const diskEntry = persisted[sessionKey];
     expect(diskEntry?.systemSent).not.toBe(true);
+  });
+
+  it("should allow retry with system prompt after simulated LLM failure", async () => {
+    // Scenario: first turn calls ensureSkillSnapshot, then LLM fails.
+    // On the next attempt, the session should still have systemSent=false
+    // on disk, so the system prompt (with tool definitions) is re-sent.
+    const storePath = path.join(tmpDir, "sessions-retry.json");
+    const sessionKey = "wa:retry-user";
+    const initialEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now() - 60_000,
+    };
+
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: initialEntry }));
+
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: { ...initialEntry },
+    };
+
+    const { ensureSkillSnapshot } = await import("./session-updates.js");
+
+    // --- Turn 1: ensureSkillSnapshot succeeds, but LLM will "fail" ---
+    const turn1 = await ensureSkillSnapshot({
+      sessionEntry: sessionStore[sessionKey],
+      sessionStore,
+      sessionKey,
+      storePath,
+      sessionId: "session-1",
+      isFirstTurnInSession: true,
+      workspaceDir: tmpDir,
+      cfg: {} as unknown as import("../../config/config.js").OpenClawConfig,
+    });
+
+    expect(turn1.systemSent).toBe(true);
+
+    // Simulate LLM failure: we do NOT persist systemSent=true
+    // (in real code, agent-runner.ts only persists after success)
+
+    // --- Turn 2: new session attempt loads state from disk ---
+    const rawAfterFailure = await fs.readFile(storePath, "utf-8");
+    const storeAfterFailure = JSON.parse(rawAfterFailure) as Record<string, SessionEntry>;
+    const entryAfterFailure = storeAfterFailure[sessionKey];
+
+    // The key assertion: disk state should NOT have systemSent=true,
+    // so the next turn will treat this as a first turn and re-send
+    // the system prompt with all tool definitions
+    expect(entryAfterFailure?.systemSent).not.toBe(true);
+
+    // Simulate loading the session for retry
+    const sessionStore2: Record<string, SessionEntry> = {
+      [sessionKey]: { ...entryAfterFailure },
+    };
+
+    // isFirstTurnInSession should be true because systemSent is not true
+    const isFirstTurn = !entryAfterFailure?.systemSent;
+    expect(isFirstTurn).toBe(true);
+
+    // --- Turn 2: ensureSkillSnapshot again, should still work ---
+    const turn2 = await ensureSkillSnapshot({
+      sessionEntry: sessionStore2[sessionKey],
+      sessionStore: sessionStore2,
+      sessionKey,
+      storePath,
+      sessionId: "session-1",
+      isFirstTurnInSession: isFirstTurn,
+      workspaceDir: tmpDir,
+      cfg: {} as unknown as import("../../config/config.js").OpenClawConfig,
+    });
+
+    // System prompt will be sent again on retry
+    expect(turn2.systemSent).toBe(true);
   });
 });

--- a/src/auto-reply/reply/session-updates-systemsent.test.ts
+++ b/src/auto-reply/reply/session-updates-systemsent.test.ts
@@ -142,4 +142,37 @@ describe("ensureSkillSnapshot systemSent persistence (#41462)", () => {
     // System prompt will be sent again on retry
     expect(turn2.systemSent).toBe(true);
   });
+
+  it("should persist systemSent=true via updateSessionStoreEntry after successful retry (isNewSession=false)", async () => {
+    // Scenario: first turn fails (systemSent not persisted), second turn
+    // retries with isNewSession=false but systemSent still false on disk.
+    // After success, updateSessionStoreEntry should persist systemSent=true.
+    const storePath = path.join(tmpDir, "sessions-persist.json");
+    const sessionKey = "wa:persist-user";
+    const entryWithoutSystemSent: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      // systemSent is NOT true — simulates state after first-turn LLM failure
+    };
+
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: entryWithoutSystemSent }));
+
+    const { updateSessionStoreEntry } = await import("../../config/sessions/store.js");
+
+    // Simulate the persistence guard from agent-runner.ts:
+    // `if (sessionKey && storePath && activeSessionEntry?.systemSent !== true)`
+    const activeSessionEntry = { ...entryWithoutSystemSent };
+    if (sessionKey && storePath && activeSessionEntry?.systemSent !== true) {
+      await updateSessionStoreEntry({
+        storePath,
+        sessionKey,
+        update: async () => ({ systemSent: true }),
+      });
+    }
+
+    // Verify disk now has systemSent=true
+    const raw = await fs.readFile(storePath, "utf-8");
+    const persisted = JSON.parse(raw) as Record<string, SessionEntry>;
+    expect(persisted[sessionKey]?.systemSent).toBe(true);
+  });
 });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -175,8 +175,12 @@ export async function ensureSkillSnapshot(params: {
       ...current,
       sessionId: sessionId ?? current.sessionId ?? crypto.randomUUID(),
       updatedAt: Date.now(),
-      systemSent: true,
       skillsSnapshot: skillSnapshot,
+      // Note: systemSent is intentionally NOT persisted here.
+      // It must only be persisted after a successful LLM response,
+      // otherwise an API error (e.g. insufficient credits) leaves
+      // systemSent=true on disk while the system prompt was never
+      // actually delivered — corrupting all subsequent sessions.
     };
     await persistSessionEntryUpdate({ sessionStore, sessionKey, storePath, nextEntry });
     systemSent = true;


### PR DESCRIPTION
## Problem

When the first LLM call in a session fails (e.g. insufficient API credits, provider timeout), `systemSent: true` is already persisted to disk by `ensureSkillSnapshot()` in `session-updates.ts`. All subsequent sessions then skip re-sending the system prompt (including tool definitions), causing **"Tool not found" errors for every tool except `read`**.

This is root cause #2 from #41462 — the corrupted session state path. The reporter confirmed that deleting all session files and even rebooting did not help, because `systemSent: true` was written back to disk on every new session attempt before the LLM call.

## Fix

1. **`session-updates.ts`**: Remove `systemSent: true` from the object persisted to disk in `ensureSkillSnapshot()`. The in-memory flag is still returned so the caller knows to include the system prompt in the LLM request.

2. **`agent-runner.ts`**: Persist `systemSent: true` to disk only after a successful LLM response, using `updateSessionStoreEntry()`.

This ensures that a failed first call leaves `systemSent` unset on disk, so the next attempt will re-send the full system prompt with tool definitions.

## Test

Added `session-updates-systemsent.test.ts` that verifies:
- `ensureSkillSnapshot()` returns `systemSent: true` in memory (for the caller)
- The on-disk session store does **not** contain `systemSent: true` after `ensureSkillSnapshot()`

## Files Changed

| File | Change |
|------|--------|
| `src/auto-reply/reply/session-updates.ts` | Remove premature `systemSent: true` from disk write |
| `src/auto-reply/reply/agent-runner.ts` | Persist `systemSent: true` after successful LLM response |
| `src/auto-reply/reply/session-updates-systemsent.test.ts` | Regression test |

Fixes #41462