### PR TITLE
refactor(doctor): extract discord numeric id repair helpers

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -56,6 +56,10 @@ import {
   resolveConfigPathTarget,
   stripUnknownConfigKeys,
 } from "./doctor-config-analysis.js";
+import {
+  maybeRepairDiscordNumericIds,
+  scanDiscordNumericIdEntries,
+} from "./doctor-discord-numeric-ids.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
@@ -450,164 +454,6 @@ async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promi
 
   for (const scope of collectTelegramAccountScopes(next)) {
     await repairAccount(scope.prefix, scope.account);
-  }
-
-  if (changes.length === 0) {
-    return { config: cfg, changes: [] };
-  }
-  return { config: next, changes };
-}
-
-type DiscordNumericIdHit = { path: string; entry: number };
-
-type DiscordIdListRef = {
-  pathLabel: string;
-  holder: Record<string, unknown>;
-  key: string;
-};
-
-function collectDiscordAccountScopes(
-  cfg: OpenClawConfig,
-): Array<{ prefix: string; account: Record<string, unknown> }> {
-  const scopes: Array<{ prefix: string; account: Record<string, unknown> }> = [];
-  const discord = asObjectRecord(cfg.channels?.discord);
-  if (!discord) {
-    return scopes;
-  }
-
-  scopes.push({ prefix: "channels.discord", account: discord });
-  const accounts = asObjectRecord(discord.accounts);
-  if (!accounts) {
-    return scopes;
-  }
-  for (const key of Object.keys(accounts)) {
-    const account = asObjectRecord(accounts[key]);
-    if (!account) {
-      continue;
-    }
-    scopes.push({ prefix: `channels.discord.accounts.${key}`, account });
-  }
-
-  return scopes;
-}
-
-function collectDiscordIdLists(
-  prefix: string,
-  account: Record<string, unknown>,
-): DiscordIdListRef[] {
-  const refs: DiscordIdListRef[] = [
-    { pathLabel: `${prefix}.allowFrom`, holder: account, key: "allowFrom" },
-  ];
-  const dm = asObjectRecord(account.dm);
-  if (dm) {
-    refs.push({ pathLabel: `${prefix}.dm.allowFrom`, holder: dm, key: "allowFrom" });
-    refs.push({ pathLabel: `${prefix}.dm.groupChannels`, holder: dm, key: "groupChannels" });
-  }
-  const execApprovals = asObjectRecord(account.execApprovals);
-  if (execApprovals) {
-    refs.push({
-      pathLabel: `${prefix}.execApprovals.approvers`,
-      holder: execApprovals,
-      key: "approvers",
-    });
-  }
-  const guilds = asObjectRecord(account.guilds);
-  if (!guilds) {
-    return refs;
-  }
-
-  for (const guildId of Object.keys(guilds)) {
-    const guild = asObjectRecord(guilds[guildId]);
-    if (!guild) {
-      continue;
-    }
-    refs.push({ pathLabel: `${prefix}.guilds.${guildId}.users`, holder: guild, key: "users" });
-    refs.push({ pathLabel: `${prefix}.guilds.${guildId}.roles`, holder: guild, key: "roles" });
-    const channels = asObjectRecord(guild.channels);
-    if (!channels) {
-      continue;
-    }
-    for (const channelId of Object.keys(channels)) {
-      const channel = asObjectRecord(channels[channelId]);
-      if (!channel) {
-        continue;
-      }
-      refs.push({
-        pathLabel: `${prefix}.guilds.${guildId}.channels.${channelId}.users`,
-        holder: channel,
-        key: "users",
-      });
-      refs.push({
-        pathLabel: `${prefix}.guilds.${guildId}.channels.${channelId}.roles`,
-        holder: channel,
-        key: "roles",
-      });
-    }
-  }
-  return refs;
-}
-
-function scanDiscordNumericIdEntries(cfg: OpenClawConfig): DiscordNumericIdHit[] {
-  const hits: DiscordNumericIdHit[] = [];
-  const scanList = (pathLabel: string, list: unknown) => {
-    if (!Array.isArray(list)) {
-      return;
-    }
-    for (const [index, entry] of list.entries()) {
-      if (typeof entry !== "number") {
-        continue;
-      }
-      hits.push({ path: `${pathLabel}[${index}]`, entry });
-    }
-  };
-
-  for (const scope of collectDiscordAccountScopes(cfg)) {
-    for (const ref of collectDiscordIdLists(scope.prefix, scope.account)) {
-      scanList(ref.pathLabel, ref.holder[ref.key]);
-    }
-  }
-
-  return hits;
-}
-
-function maybeRepairDiscordNumericIds(cfg: OpenClawConfig): {
-  config: OpenClawConfig;
-  changes: string[];
-} {
-  const hits = scanDiscordNumericIdEntries(cfg);
-  if (hits.length === 0) {
-    return { config: cfg, changes: [] };
-  }
-
-  const next = structuredClone(cfg);
-  const changes: string[] = [];
-
-  const repairList = (pathLabel: string, holder: Record<string, unknown>, key: string) => {
-    const raw = holder[key];
-    if (!Array.isArray(raw)) {
-      return;
-    }
-    let converted = 0;
-    const updated = raw.map((entry) => {
-      if (typeof entry === "number") {
-        converted += 1;
-        return String(entry);
-      }
-      return entry;
-    });
-    if (converted === 0) {
-      return;
-    }
-    holder[key] = updated;
-    changes.push(
-      `- ${pathLabel}: converted ${converted} numeric ${converted === 1 ? "entry" : "entries"} to strings`,
-    );
-  };
-
-  for (const scope of collectDiscordAccountScopes(next)) {
-    for (const ref of collectDiscordIdLists(scope.prefix, scope.account)) {
-      repairList(ref.pathLabel, ref.holder, ref.key);
-    }
   }
 
   if (changes.length === 0) {

--- a/src/commands/doctor-discord-numeric-ids.test.ts
+++ b/src/commands/doctor-discord-numeric-ids.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  maybeRepairDiscordNumericIds,
+  scanDiscordNumericIdEntries,
+} from "./doctor-discord-numeric-ids.js";
+
+describe("doctor discord numeric ids", () => {
+  it("scans numeric entries across top-level and account-scoped discord lists", () => {
+    const hits = scanDiscordNumericIdEntries({
+      channels: {
+        discord: {
+          allowFrom: ["already-string", 123],
+          dm: { allowFrom: [456], groupChannels: ["789", 999] },
+          execApprovals: { approvers: [321] },
+          guilds: {
+            "100": {
+              users: [111],
+              roles: ["222", 333],
+              channels: {
+                general: { users: [444], roles: ["555"] },
+              },
+            },
+          },
+          accounts: {
+            work: {
+              allowFrom: [666],
+              dm: { allowFrom: ["777"], groupChannels: [888] },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(hits).toEqual([
+      { path: "channels.discord.allowFrom[1]", entry: 123 },
+      { path: "channels.discord.dm.allowFrom[0]", entry: 456 },
+      { path: "channels.discord.dm.groupChannels[1]", entry: 999 },
+      { path: "channels.discord.execApprovals.approvers[0]", entry: 321 },
+      { path: "channels.discord.guilds.100.users[0]", entry: 111 },
+      { path: "channels.discord.guilds.100.roles[1]", entry: 333 },
+      { path: "channels.discord.guilds.100.channels.general.users[0]", entry: 444 },
+      { path: "channels.discord.accounts.work.allowFrom[0]", entry: 666 },
+      { path: "channels.discord.accounts.work.dm.groupChannels[0]", entry: 888 },
+    ]);
+  });
+
+  it("converts numeric ids to strings while preserving untouched entries", () => {
+    const original = {
+      channels: {
+        discord: {
+          allowFrom: [123, "already-string"],
+          dm: { allowFrom: [456], groupChannels: ["789", 999] },
+          execApprovals: { approvers: [321] },
+          guilds: {
+            "100": {
+              users: [111],
+              roles: ["222", 333],
+              channels: {
+                general: { users: [444], roles: ["555"] },
+              },
+            },
+          },
+          accounts: {
+            work: {
+              allowFrom: [666],
+              dm: { allowFrom: ["777"], groupChannels: [888] },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = maybeRepairDiscordNumericIds(original);
+
+    expect(result.changes).toEqual([
+      "- channels.discord.allowFrom: converted 1 numeric entry to strings",
+      "- channels.discord.dm.allowFrom: converted 1 numeric entry to strings",
+      "- channels.discord.dm.groupChannels: converted 1 numeric entry to strings",
+      "- channels.discord.execApprovals.approvers: converted 1 numeric entry to strings",
+      "- channels.discord.guilds.100.users: converted 1 numeric entry to strings",
+      "- channels.discord.guilds.100.roles: converted 1 numeric entry to strings",
+      "- channels.discord.guilds.100.channels.general.users: converted 1 numeric entry to strings",
+      "- channels.discord.accounts.work.allowFrom: converted 1 numeric entry to strings",
+      "- channels.discord.accounts.work.dm.groupChannels: converted 1 numeric entry to strings",
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        discord: {
+          allowFrom: ["123", "already-string"],
+          dm: { allowFrom: ["456"], groupChannels: ["789", "999"] },
+          execApprovals: { approvers: ["321"] },
+          guilds: {
+            "100": {
+              users: ["111"],
+              roles: ["222", "333"],
+              channels: {
+                general: { users: ["444"], roles: ["555"] },
+              },
+            },
+          },
+          accounts: {
+            work: {
+              allowFrom: ["666"],
+              dm: { allowFrom: ["777"], groupChannels: ["888"] },
+            },
+          },
+        },
+      },
+    });
+    expect(original.channels?.discord?.allowFrom).toEqual([123, "already-string"]);
+  });
+
+  it("returns the original config unchanged when no numeric ids are present", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          allowFrom: ["123"],
+          dm: { allowFrom: ["456"], groupChannels: ["789"] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = maybeRepairDiscordNumericIds(cfg);
+
+    expect(result).toEqual({ config: cfg, changes: [] });
+  });
+});

--- a/src/commands/doctor-discord-numeric-ids.ts
+++ b/src/commands/doctor-discord-numeric-ids.ts
@@ -1,0 +1,157 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { isRecord } from "../utils.js";
+
+type DiscordNumericIdHit = { path: string; entry: number };
+
+type DiscordIdListRef = {
+  pathLabel: string;
+  holder: Record<string, unknown>;
+  key: string;
+};
+
+function collectDiscordAccountScopes(
+  cfg: OpenClawConfig,
+): Array<{ prefix: string; account: Record<string, unknown> }> {
+  const scopes: Array<{ prefix: string; account: Record<string, unknown> }> = [];
+  const discord = isRecord(cfg.channels?.discord) ? cfg.channels.discord : null;
+  if (!discord) {
+    return scopes;
+  }
+
+  scopes.push({ prefix: "channels.discord", account: discord });
+  const accounts = isRecord(discord.accounts) ? discord.accounts : null;
+  if (!accounts) {
+    return scopes;
+  }
+  for (const [key, rawAccount] of Object.entries(accounts)) {
+    if (!isRecord(rawAccount)) {
+      continue;
+    }
+    scopes.push({ prefix: `channels.discord.accounts.${key}`, account: rawAccount });
+  }
+
+  return scopes;
+}
+
+function collectDiscordIdLists(
+  prefix: string,
+  account: Record<string, unknown>,
+): DiscordIdListRef[] {
+  const refs: DiscordIdListRef[] = [
+    { pathLabel: `${prefix}.allowFrom`, holder: account, key: "allowFrom" },
+  ];
+  const dm = isRecord(account.dm) ? account.dm : null;
+  if (dm) {
+    refs.push({ pathLabel: `${prefix}.dm.allowFrom`, holder: dm, key: "allowFrom" });
+    refs.push({ pathLabel: `${prefix}.dm.groupChannels`, holder: dm, key: "groupChannels" });
+  }
+  const execApprovals = isRecord(account.execApprovals) ? account.execApprovals : null;
+  if (execApprovals) {
+    refs.push({
+      pathLabel: `${prefix}.execApprovals.approvers`,
+      holder: execApprovals,
+      key: "approvers",
+    });
+  }
+  const guilds = isRecord(account.guilds) ? account.guilds : null;
+  if (!guilds) {
+    return refs;
+  }
+
+  for (const [guildId, rawGuild] of Object.entries(guilds)) {
+    if (!isRecord(rawGuild)) {
+      continue;
+    }
+    refs.push({ pathLabel: `${prefix}.guilds.${guildId}.users`, holder: rawGuild, key: "users" });
+    refs.push({ pathLabel: `${prefix}.guilds.${guildId}.roles`, holder: rawGuild, key: "roles" });
+    const channels = isRecord(rawGuild.channels) ? rawGuild.channels : null;
+    if (!channels) {
+      continue;
+    }
+    for (const [channelId, rawChannel] of Object.entries(channels)) {
+      if (!isRecord(rawChannel)) {
+        continue;
+      }
+      refs.push({
+        pathLabel: `${prefix}.guilds.${guildId}.channels.${channelId}.users`,
+        holder: rawChannel,
+        key: "users",
+      });
+      refs.push({
+        pathLabel: `${prefix}.guilds.${guildId}.channels.${channelId}.roles`,
+        holder: rawChannel,
+        key: "roles",
+      });
+    }
+  }
+  return refs;
+}
+
+export function scanDiscordNumericIdEntries(cfg: OpenClawConfig): DiscordNumericIdHit[] {
+  const hits: DiscordNumericIdHit[] = [];
+  const scanList = (pathLabel: string, list: unknown) => {
+    if (!Array.isArray(list)) {
+      return;
+    }
+    for (const [index, entry] of list.entries()) {
+      if (typeof entry !== "number") {
+        continue;
+      }
+      hits.push({ path: `${pathLabel}[${index}]`, entry });
+    }
+  };
+
+  for (const scope of collectDiscordAccountScopes(cfg)) {
+    for (const ref of collectDiscordIdLists(scope.prefix, scope.account)) {
+      scanList(ref.pathLabel, ref.holder[ref.key]);
+    }
+  }
+
+  return hits;
+}
+
+export function maybeRepairDiscordNumericIds(cfg: OpenClawConfig): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  const hits = scanDiscordNumericIdEntries(cfg);
+  if (hits.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next = structuredClone(cfg);
+  const changes: string[] = [];
+
+  const repairList = (pathLabel: string, holder: Record<string, unknown>, key: string) => {
+    const raw = holder[key];
+    if (!Array.isArray(raw)) {
+      return;
+    }
+    let converted = 0;
+    const updated = raw.map((entry) => {
+      if (typeof entry === "number") {
+        converted += 1;
+        return String(entry);
+      }
+      return entry;
+    });
+    if (converted === 0) {
+      return;
+    }
+    holder[key] = updated;
+    changes.push(
+      `- ${pathLabel}: converted ${converted} numeric ${converted === 1 ? "entry" : "entries"} to strings`,
+    );
+  };
+
+  for (const scope of collectDiscordAccountScopes(next)) {
+    for (const ref of collectDiscordIdLists(scope.prefix, scope.account)) {
+      repairList(ref.pathLabel, ref.holder, ref.key);
+    }
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return { config: next, changes };
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/commands/doctor-config-flow.ts` still embedded Discord numeric ID scope collection, scanning, and repair logic.
- Why it matters: That keeps the doctor flow file monolithic and makes Discord-specific config diagnostics harder to review and test in isolation.
- What changed: Extracted Discord numeric ID helpers into `src/commands/doctor-discord-numeric-ids.ts` and added focused tests for scan paths plus repair behavior.
- What did NOT change (scope boundary): Doctor warning text, repair output, and config-migration flow behavior were kept the same.

AI-assisted with Codex. Focused local tests passed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.14.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): doctor config flow / Discord config validation
- Relevant config (redacted): synthetic invalid Discord config fixtures in unit tests

### Steps

1. Run `pnpm test -- src/commands/doctor-discord-numeric-ids.test.ts src/commands/doctor-config-flow.test.ts`.
2. Run `pnpm check`.
3. Compare the extracted helper behavior with the existing doctor warning and repair call sites.

### Expected

- Discord numeric ID detection and repair remain behaviorally unchanged.
- Focused tests and repo checks pass.

### Actual

- `pnpm test -- src/commands/doctor-discord-numeric-ids.test.ts src/commands/doctor-config-flow.test.ts` passed.
- `pnpm check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: top-level Discord lists, account-scoped lists, nested guild/channel lists, and numeric-to-string repair output.
- Edge cases checked: mixed string/number lists, untouched string entries, and the no-op path when no numeric IDs are present.
- What you did **not** verify: manual end-to-end doctor runs against live Discord configs beyond the targeted automated coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c2057cba323d91259045d4b74d444674bd2cb468`.
- Files/config to restore: `src/commands/doctor-config-flow.ts` and the extracted helper module.
- Known bad symptoms reviewers should watch for: missing Discord numeric-ID warnings, changed path labels in warning samples, or incomplete numeric-to-string repairs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the extracted helper could miss one of the nested Discord ID list paths during scan or repair.
  - Mitigation: focused helper tests plus the existing `doctor-config-flow` repair test still pass.
