### PR TITLE
fix(agents): flatten assistant content arrays for openai-completions providers

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -20,6 +20,7 @@ import {
 } from "./moonshot-stream-wrappers.js";
 import {
   createCodexDefaultTransportWrapper,
+  createOpenAICompletionsContentFlattenWrapper,
   createOpenAIDefaultTransportWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIServiceTierWrapper,
@@ -446,6 +447,11 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Flatten Anthropic-style content arrays to strings on assistant messages
+  // for openai-completions providers. Without this, multi-turn tool call
+  // sessions loop because providers reject the array content format.
+  agent.streamFn = createOpenAICompletionsContentFlattenWrapper(agent.streamFn);
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [resolvedExtraParams, override],

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.content-flatten.test.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.content-flatten.test.ts
@@ -1,0 +1,106 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import { createOpenAICompletionsContentFlattenWrapper } from "./openai-stream-wrappers.js";
+
+describe("createOpenAICompletionsContentFlattenWrapper", () => {
+  it("flattens assistant content arrays to strings for openai-completions", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const fakeStream = vi.fn(
+      (_model: unknown, _context: unknown, options?: { onPayload?: Function }) => {
+        const payload = {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "hi" }] },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "I'll run the command..." }],
+              tool_calls: [{ id: "call_1", type: "function", function: { name: "exec" } }],
+            },
+            { role: "tool", content: "ok", tool_call_id: "call_1" },
+          ],
+        };
+        options?.onPayload?.(payload, "test-model");
+        capturedPayload = payload;
+        return {};
+      },
+    );
+
+    const wrapped = createOpenAICompletionsContentFlattenWrapper(fakeStream as unknown as StreamFn);
+    void wrapped(
+      { api: "openai-completions" } as Parameters<StreamFn>[0],
+      {} as Parameters<StreamFn>[1],
+      {},
+    );
+
+    const msgs = (capturedPayload as Record<string, unknown>).messages as Array<
+      Record<string, unknown>
+    >;
+    // Assistant content should be flattened to string
+    expect(msgs[1].content).toBe("I'll run the command...");
+    // User content should remain unchanged (only assistant is flattened)
+    expect(Array.isArray(msgs[0].content)).toBe(true);
+  });
+
+  it("sets content to null when no text parts exist", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const fakeStream = vi.fn(
+      (_model: unknown, _context: unknown, options?: { onPayload?: Function }) => {
+        const payload = {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "image", url: "http://example.com/img.png" }],
+              tool_calls: [{ id: "call_1" }],
+            },
+          ],
+        };
+        options?.onPayload?.(payload, "test-model");
+        capturedPayload = payload;
+        return {};
+      },
+    );
+
+    const wrapped = createOpenAICompletionsContentFlattenWrapper(fakeStream as unknown as StreamFn);
+    void wrapped(
+      { api: "openai-completions" } as Parameters<StreamFn>[0],
+      {} as Parameters<StreamFn>[1],
+      {},
+    );
+
+    const msgs = (capturedPayload as Record<string, unknown>).messages as Array<
+      Record<string, unknown>
+    >;
+    expect(msgs[0].content).toBeNull();
+  });
+
+  it("skips non-openai-completions models", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const fakeStream = vi.fn(
+      (_model: unknown, _context: unknown, options?: { onPayload?: Function }) => {
+        const payload = {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "keep me" }],
+            },
+          ],
+        };
+        options?.onPayload?.(payload, "test-model");
+        capturedPayload = payload;
+        return {};
+      },
+    );
+
+    const wrapped = createOpenAICompletionsContentFlattenWrapper(fakeStream as unknown as StreamFn);
+    void wrapped(
+      { api: "anthropic-messages" } as Parameters<StreamFn>[0],
+      {} as Parameters<StreamFn>[1],
+      {},
+    );
+
+    const msgs = (capturedPayload as Record<string, unknown>).messages as Array<
+      Record<string, unknown>
+    >;
+    // Should remain as array since not openai-completions
+    expect(Array.isArray(msgs[0].content)).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -255,3 +255,48 @@ export function createOpenAIDefaultTransportWrapper(baseStreamFn: StreamFn | und
     return underlying(model, context, mergedOptions);
   };
 }
+
+/**
+ * Flatten assistant message content arrays to strings for openai-completions
+ * providers. The internal representation uses Anthropic-style content arrays
+ * (`[{ type: "text", text: "..." }]`) but the OpenAI chat-completions spec
+ * requires `content` to be a string (or null) on assistant messages that
+ * carry `tool_calls`. Without this, providers reject the payload or loop.
+ */
+export function createOpenAICompletionsContentFlattenWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "openai-completions") {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload, payloadModel) => {
+        if (payload && typeof payload === "object") {
+          const messages = (payload as Record<string, unknown>).messages;
+          if (Array.isArray(messages)) {
+            for (const msg of messages as Array<{
+              role?: string;
+              content?: unknown;
+              tool_calls?: unknown;
+            }>) {
+              if (msg.role === "assistant" && Array.isArray(msg.content)) {
+                // Flatten content array to a concatenated string.
+                const parts = msg.content as Array<{ type?: string; text?: string }>;
+                const text = parts
+                  .filter((p) => p.type === "text" && typeof p.text === "string")
+                  .map((p) => p.text)
+                  .join("");
+                msg.content = text || null;
+              }
+            }
+          }
+        }
+        return originalOnPayload?.(payload, payloadModel);
+      },
+    });
+  };
+}


### PR DESCRIPTION
## Problem

When using custom providers with `api: openai-completions`, multi-turn tool call sessions loop indefinitely. The agent executes the tool successfully on the host but keeps retrying the same call. The root cause is visible in intercepted HTTP traffic: the assistant message `content` field is serialized as an array instead of a string.

## Root cause

OpenClaw stores messages internally in Anthropic format where content is an array of typed objects:

```json
{"content": [{"type": "text", "text": "I'll run the command..."}]}
```

When replaying history for OpenAI-compatible endpoints, this array representation leaks through to the API request. The OpenAI chat completions spec requires `content` to be a string (or null) on assistant messages, especially when `tool_calls` is present. Providers either reject the payload or fail to recognize the prior tool call as completed, causing an infinite retry loop.

## Fix

Added a new `onPayload` stream wrapper (`createOpenAICompletionsContentFlattenWrapper`) that intercepts outgoing payloads for `openai-completions` API type. For each assistant message with an array `content`, it:

1. Extracts all `type: "text"` parts
2. Concatenates their `text` values into a single string
3. Sets `content` to the concatenated string, or `null` if no text parts exist

User messages are left unchanged since the OpenAI spec accepts array content for user messages.

The wrapper follows the same pattern as existing `onPayload` wrappers (service tier, context management, etc.) and is applied after the responses context management wrapper in the stream function chain.

## Testing

- Added 3 tests: content flattening, null fallback, and non-openai-completions passthrough
- All 3 tests pass, existing 259 pi-embedded-runner tests still pass
- Lint clean

Closes #41438