### PR TITLE
fix(agents): forward memory flush write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web search: recover OpenRouter Perplexity citation extraction from `message.annotations` when chat-completions responses omit top-level citations. (#40881) Thanks @laurieluo.
 - Security/external content: treat whitespace-delimited `EXTERNAL UNTRUSTED CONTENT` boundary markers like underscore-delimited variants so prompt wrappers cannot bypass marker sanitization. (#35983) Thanks @urianpaul94.
 - Telegram/network env-proxy: apply configured transport policy to proxied HTTPS dispatchers as well as direct `NO_PROXY` bypasses, so resolver-scoped IPv4 fallback and network settings work consistently for env-proxied Telegram traffic. (#40740) Thanks @sircrumpet.
+- Agents/memory flush: forward `memoryFlushWritePath` through `runEmbeddedPiAgent` so memory-triggered flush turns keep the append-only write guard without aborting before tool setup. Follows up on #38574.
 
 ## 2026.3.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web search: recover OpenRouter Perplexity citation extraction from `message.annotations` when chat-completions responses omit top-level citations. (#40881) Thanks @laurieluo.
 - Security/external content: treat whitespace-delimited `EXTERNAL UNTRUSTED CONTENT` boundary markers like underscore-delimited variants so prompt wrappers cannot bypass marker sanitization. (#35983) Thanks @urianpaul94.
 - Telegram/network env-proxy: apply configured transport policy to proxied HTTPS dispatchers as well as direct `NO_PROXY` bypasses, so resolver-scoped IPv4 fallback and network settings work consistently for env-proxied Telegram traffic. (#40740) Thanks @sircrumpet.
-- Agents/memory flush: forward `memoryFlushWritePath` through `runEmbeddedPiAgent` so memory-triggered flush turns keep the append-only write guard without aborting before tool setup. Follows up on #38574.
+- Agents/memory flush: forward `memoryFlushWritePath` through `runEmbeddedPiAgent` so memory-triggered flush turns keep the append-only write guard without aborting before tool setup. Follows up on #38574. (#41761) Thanks @frankekn.
 
 ## 2026.3.8
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -850,6 +850,7 @@ export async function runEmbeddedPiAgent(
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             trigger: params.trigger,
+            memoryFlushWritePath: params.memoryFlushWritePath,
             messageChannel: params.messageChannel,
             messageProvider: params.messageProvider,
             agentAccountId: params.agentAccountId,

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -79,6 +79,36 @@ describe("runEmbeddedPiAgent usage reporting", () => {
     );
   });
 
+  it("forwards memory flush write paths into memory-triggered attempts", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce({
+      aborted: false,
+      promptError: null,
+      timedOut: false,
+      sessionIdUsed: "test-session",
+      assistantTexts: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "flush",
+      timeoutMs: 30000,
+      runId: "run-memory-forwarding",
+      trigger: "memory",
+      memoryFlushWritePath: "memory/2026-03-10.md",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "memory",
+        memoryFlushWritePath: "memory/2026-03-10.md",
+      }),
+    );
+  });
+
   it("reports total usage from the last turn instead of accumulated total", async () => {
     // Simulate a multi-turn run result.
     // Turn 1: Input 100, Output 50. Total 150.


### PR DESCRIPTION
## Summary
- forward `memoryFlushWritePath` through `runEmbeddedPiAgent` into `runEmbeddedAttempt`
- add a regression test that fails if memory-triggered runs drop the append-only path guard
- add a changelog follow-up for the post-merge memory flush fix

## Context
This follows up on #38574. A post-merge review found that memory-triggered flush turns passed `memoryFlushWritePath` into `runEmbeddedPiAgent`, but that parameter was not forwarded into `runEmbeddedAttempt`, causing the new guard in `createOpenClawCodingTools` to throw before tool setup.

## Testing
- `pnpm test src/agents/pi-embedded-runner/usage-reporting.test.ts src/agents/pi-tools.workspace-only-false.test.ts`
- `pnpm exec oxlint src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/usage-reporting.test.ts CHANGELOG.md`
- `pnpm exec oxfmt --check src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/usage-reporting.test.ts CHANGELOG.md`
- `pnpm build`
