### PR TITLE
refactor(doctor): extract open policy allowFrom repair helpers

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -57,6 +57,7 @@ import {
   stripUnknownConfigKeys,
 } from "./doctor-config-analysis.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
+import { maybeRepairOpenPolicyAllowFrom } from "./doctor-open-policy-allowfrom.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
 
@@ -886,137 +887,6 @@ function scanMutableAllowlistEntries(cfg: OpenClawConfig): MutableAllowlistHit[]
   }
 
   return hits;
-}
-
-/**
- * Scan all channel configs for dmPolicy="open" without allowFrom including "*".
- * This configuration is rejected by the schema validator but can easily occur when
- * users (or integrations) set dmPolicy to "open" without realising that an explicit
- * allowFrom wildcard is also required.
- */
-function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
-  config: OpenClawConfig;
-  changes: string[];
-} {
-  const channels = cfg.channels;
-  if (!channels || typeof channels !== "object") {
-    return { config: cfg, changes: [] };
-  }
-
-  const next = structuredClone(cfg);
-  const changes: string[] = [];
-
-  type OpenPolicyAllowFromMode = "topOnly" | "topOrNested" | "nestedOnly";
-
-  const resolveAllowFromMode = (channelName: string): OpenPolicyAllowFromMode => {
-    if (channelName === "googlechat") {
-      return "nestedOnly";
-    }
-    if (channelName === "discord" || channelName === "slack") {
-      return "topOrNested";
-    }
-    return "topOnly";
-  };
-
-  const hasWildcard = (list?: Array<string | number>) =>
-    list?.some((v) => String(v).trim() === "*") ?? false;
-
-  const ensureWildcard = (
-    account: Record<string, unknown>,
-    prefix: string,
-    mode: OpenPolicyAllowFromMode,
-  ) => {
-    const dmEntry = account.dm;
-    const dm =
-      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
-        ? (dmEntry as Record<string, unknown>)
-        : undefined;
-    const dmPolicy =
-      (account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined) ?? undefined;
-
-    if (dmPolicy !== "open") {
-      return;
-    }
-
-    const topAllowFrom = account.allowFrom as Array<string | number> | undefined;
-    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
-
-    if (mode === "nestedOnly") {
-      if (hasWildcard(nestedAllowFrom)) {
-        return;
-      }
-      if (Array.isArray(nestedAllowFrom)) {
-        nestedAllowFrom.push("*");
-        changes.push(`- ${prefix}.dm.allowFrom: added "*" (required by dmPolicy="open")`);
-        return;
-      }
-      const nextDm = dm ?? {};
-      nextDm.allowFrom = ["*"];
-      account.dm = nextDm;
-      changes.push(`- ${prefix}.dm.allowFrom: set to ["*"] (required by dmPolicy="open")`);
-      return;
-    }
-
-    if (mode === "topOrNested") {
-      if (hasWildcard(topAllowFrom) || hasWildcard(nestedAllowFrom)) {
-        return;
-      }
-
-      if (Array.isArray(topAllowFrom)) {
-        topAllowFrom.push("*");
-        changes.push(`- ${prefix}.allowFrom: added "*" (required by dmPolicy="open")`);
-      } else if (Array.isArray(nestedAllowFrom)) {
-        nestedAllowFrom.push("*");
-        changes.push(`- ${prefix}.dm.allowFrom: added "*" (required by dmPolicy="open")`);
-      } else {
-        account.allowFrom = ["*"];
-        changes.push(`- ${prefix}.allowFrom: set to ["*"] (required by dmPolicy="open")`);
-      }
-      return;
-    }
-
-    if (hasWildcard(topAllowFrom)) {
-      return;
-    }
-    if (Array.isArray(topAllowFrom)) {
-      topAllowFrom.push("*");
-      changes.push(`- ${prefix}.allowFrom: added "*" (required by dmPolicy="open")`);
-    } else {
-      account.allowFrom = ["*"];
-      changes.push(`- ${prefix}.allowFrom: set to ["*"] (required by dmPolicy="open")`);
-    }
-  };
-
-  const nextChannels = next.channels as Record<string, Record<string, unknown>>;
-  for (const [channelName, channelConfig] of Object.entries(nextChannels)) {
-    if (!channelConfig || typeof channelConfig !== "object") {
-      continue;
-    }
-
-    const allowFromMode = resolveAllowFromMode(channelName);
-
-    // Check the top-level channel config
-    ensureWildcard(channelConfig, `channels.${channelName}`, allowFromMode);
-
-    // Check per-account configs (e.g. channels.discord.accounts.mybot)
-    const accounts = channelConfig.accounts as Record<string, Record<string, unknown>> | undefined;
-    if (accounts && typeof accounts === "object") {
-      for (const [accountName, accountConfig] of Object.entries(accounts)) {
-        if (accountConfig && typeof accountConfig === "object") {
-          ensureWildcard(
-            accountConfig,
-            `channels.${channelName}.accounts.${accountName}`,
-            allowFromMode,
-          );
-        }
-      }
-    }
-  }
-
-  if (changes.length === 0) {
-    return { config: cfg, changes: [] };
-  }
-  return { config: next, changes };
 }
 
 function hasAllowFromEntries(list?: Array<string | number>) {

--- a/src/commands/doctor-open-policy-allowfrom.test.ts
+++ b/src/commands/doctor-open-policy-allowfrom.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { maybeRepairOpenPolicyAllowFrom } from "./doctor-open-policy-allowfrom.js";
+
+describe("doctor open policy allowFrom", () => {
+  it("sets top-level allowFrom for top-only channels", () => {
+    const result = maybeRepairOpenPolicyAllowFrom({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(result.changes).toEqual([
+      '- channels.telegram.allowFrom: set to ["*"] (required by dmPolicy="open")',
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+  });
+
+  it("prefers existing nested dm.allowFrom for top-or-nested channels", () => {
+    const result = maybeRepairOpenPolicyAllowFrom({
+      channels: {
+        discord: {
+          dmPolicy: "open",
+          dm: {
+            allowFrom: ["123"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(result.changes).toEqual([
+      '- channels.discord.dm.allowFrom: added "*" (required by dmPolicy="open")',
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        discord: {
+          dmPolicy: "open",
+          dm: {
+            allowFrom: ["123", "*"],
+          },
+        },
+      },
+    });
+  });
+
+  it("repairs googlechat nested allowFrom even when a stale top-level wildcard exists", () => {
+    const result = maybeRepairOpenPolicyAllowFrom({
+      channels: {
+        googlechat: {
+          allowFrom: ["*"],
+          dm: {
+            policy: "open",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(result.changes).toEqual([
+      '- channels.googlechat.dm.allowFrom: set to ["*"] (required by dmPolicy="open")',
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        googlechat: {
+          allowFrom: ["*"],
+          dm: {
+            policy: "open",
+            allowFrom: ["*"],
+          },
+        },
+      },
+    });
+  });
+
+  it("repairs per-account open dmPolicy without touching accounts that already include a wildcard", () => {
+    const original = {
+      channels: {
+        slack: {
+          accounts: {
+            work: {
+              dmPolicy: "open",
+              allowFrom: ["U123"],
+            },
+            ready: {
+              dmPolicy: "open",
+              allowFrom: ["*"],
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = maybeRepairOpenPolicyAllowFrom(original);
+
+    expect(result.changes).toEqual([
+      '- channels.slack.accounts.work.allowFrom: added "*" (required by dmPolicy="open")',
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        slack: {
+          accounts: {
+            work: {
+              dmPolicy: "open",
+              allowFrom: ["U123", "*"],
+            },
+            ready: {
+              dmPolicy: "open",
+              allowFrom: ["*"],
+            },
+          },
+        },
+      },
+    });
+    expect(original.channels?.slack?.accounts?.work?.allowFrom).toEqual(["U123"]);
+  });
+
+  it("returns the original config when no repair is needed", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = maybeRepairOpenPolicyAllowFrom(cfg);
+
+    expect(result).toEqual({ config: cfg, changes: [] });
+  });
+});

--- a/src/commands/doctor-open-policy-allowfrom.ts
+++ b/src/commands/doctor-open-policy-allowfrom.ts
@@ -1,0 +1,128 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { isRecord } from "../utils.js";
+
+type OpenPolicyAllowFromMode = "topOnly" | "topOrNested" | "nestedOnly";
+
+function resolveAllowFromMode(channelName: string): OpenPolicyAllowFromMode {
+  if (channelName === "googlechat") {
+    return "nestedOnly";
+  }
+  if (channelName === "discord" || channelName === "slack") {
+    return "topOrNested";
+  }
+  return "topOnly";
+}
+
+function hasWildcard(list?: Array<string | number>) {
+  return list?.some((value) => String(value).trim() === "*") ?? false;
+}
+
+function ensureWildcard(
+  account: Record<string, unknown>,
+  prefix: string,
+  mode: OpenPolicyAllowFromMode,
+  changes: string[],
+) {
+  const dm = isRecord(account.dm) ? account.dm : undefined;
+  const dmPolicy =
+    (account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined) ?? undefined;
+
+  if (dmPolicy !== "open") {
+    return;
+  }
+
+  const topAllowFrom = account.allowFrom as Array<string | number> | undefined;
+  const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+
+  if (mode === "nestedOnly") {
+    if (hasWildcard(nestedAllowFrom)) {
+      return;
+    }
+    if (Array.isArray(nestedAllowFrom)) {
+      nestedAllowFrom.push("*");
+      changes.push(`- ${prefix}.dm.allowFrom: added "*" (required by dmPolicy="open")`);
+      return;
+    }
+    const nextDm = dm ?? {};
+    nextDm.allowFrom = ["*"];
+    account.dm = nextDm;
+    changes.push(`- ${prefix}.dm.allowFrom: set to ["*"] (required by dmPolicy="open")`);
+    return;
+  }
+
+  if (mode === "topOrNested") {
+    if (hasWildcard(topAllowFrom) || hasWildcard(nestedAllowFrom)) {
+      return;
+    }
+
+    if (Array.isArray(topAllowFrom)) {
+      topAllowFrom.push("*");
+      changes.push(`- ${prefix}.allowFrom: added "*" (required by dmPolicy="open")`);
+    } else if (Array.isArray(nestedAllowFrom)) {
+      nestedAllowFrom.push("*");
+      changes.push(`- ${prefix}.dm.allowFrom: added "*" (required by dmPolicy="open")`);
+    } else {
+      account.allowFrom = ["*"];
+      changes.push(`- ${prefix}.allowFrom: set to ["*"] (required by dmPolicy="open")`);
+    }
+    return;
+  }
+
+  if (hasWildcard(topAllowFrom)) {
+    return;
+  }
+  if (Array.isArray(topAllowFrom)) {
+    topAllowFrom.push("*");
+    changes.push(`- ${prefix}.allowFrom: added "*" (required by dmPolicy="open")`);
+  } else {
+    account.allowFrom = ["*"];
+    changes.push(`- ${prefix}.allowFrom: set to ["*"] (required by dmPolicy="open")`);
+  }
+}
+
+export function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  if (!isRecord(cfg.channels)) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next = structuredClone(cfg);
+  const nextChannels = isRecord(next.channels) ? next.channels : null;
+  if (!nextChannels) {
+    return { config: cfg, changes: [] };
+  }
+
+  const changes: string[] = [];
+
+  for (const [channelName, rawChannelConfig] of Object.entries(nextChannels)) {
+    if (!isRecord(rawChannelConfig)) {
+      continue;
+    }
+
+    const allowFromMode = resolveAllowFromMode(channelName);
+    ensureWildcard(rawChannelConfig, `channels.${channelName}`, allowFromMode, changes);
+
+    const accounts = isRecord(rawChannelConfig.accounts) ? rawChannelConfig.accounts : null;
+    if (!accounts) {
+      continue;
+    }
+    for (const [accountName, rawAccountConfig] of Object.entries(accounts)) {
+      if (!isRecord(rawAccountConfig)) {
+        continue;
+      }
+      ensureWildcard(
+        rawAccountConfig,
+        `channels.${channelName}.accounts.${accountName}`,
+        allowFromMode,
+        changes,
+      );
+    }
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return { config: next, changes };
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/commands/doctor-config-flow.ts` still inlined the `dmPolicy="open"` allowFrom wildcard repair logic for top-level and per-account channel configs.
- Why it matters: That keeps the doctor flow file monolithic and makes channel-specific open-policy repair behavior harder to review and test in isolation.
- What changed: Extracted open-policy allowFrom repair helpers into `src/commands/doctor-open-policy-allowfrom.ts` and added focused tests for top-only, top-or-nested, nested-only, per-account, and no-op cases.
- What did NOT change (scope boundary): Doctor warning text, repair messages, and call-site behavior were kept the same.

AI-assisted with Codex. Focused local tests passed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.14.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): doctor config flow / open-policy allowFrom repair
- Relevant config (redacted): synthetic invalid doctor config fixtures in unit tests

### Steps

1. Run `pnpm test -- src/commands/doctor-open-policy-allowfrom.test.ts src/commands/doctor-config-flow.test.ts`.
2. Run `pnpm check`.
3. Compare the extracted helper behavior with the existing doctor warning and repair call sites.

### Expected

- Open-policy allowFrom repair remains behaviorally unchanged across supported channels.
- Focused tests and repo checks pass.

### Actual

- `pnpm test -- src/commands/doctor-open-policy-allowfrom.test.ts src/commands/doctor-config-flow.test.ts` passed.
- `pnpm check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: top-only channels, Discord/Slack top-or-nested behavior, Google Chat nested-only behavior, per-account repairs, and no-op cases when a wildcard already exists.
- Edge cases checked: nested `dm.allowFrom`, stale top-level Google Chat wildcard, existing allowFrom arrays, and preserving untouched configs.
- What you did **not** verify: manual end-to-end doctor runs against live channel configs beyond the targeted automated coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ddf76c5b4e2d343bf54300d199e6f5c23d8c67f1`.
- Files/config to restore: `src/commands/doctor-config-flow.ts` and the extracted helper module.
- Known bad symptoms reviewers should watch for: missing open-policy allowFrom repairs, changed repair message paths, or Google Chat repairs writing to the wrong scope.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the extracted helper could drift from the original per-channel mode rules.
  - Mitigation: focused helper tests plus the existing `doctor-config-flow` repair tests still pass.
