### PR TITLE
fix(telegram): clear stale retain before transient final fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 - Security/plugin runtime: stop unauthenticated plugin HTTP routes from inheriting synthetic admin gateway scopes when they call `runtime.subagent.*`, so admin-only methods like `sessions.delete` stay blocked without gateway auth.
 - Security/session_status: enforce sandbox session-tree visibility and shared agent-to-agent access guards before reading or mutating target session state, so sandboxed subagents can no longer inspect parent session metadata or write parent model overrides via `session_status`.
 - Security/nodes: treat the `nodes` agent tool as owner-only fallback policy so non-owner senders cannot reach paired-node approval or invoke paths through the shared tool set.
+- Telegram/final preview cleanup follow-up: clear stale cleanup-retain state only for transient preview finals so archived-preview retains no longer leave a stale partial bubble beside a later fallback-sent final. (#41763) Thanks @obviyus.
 
 ## 2026.3.8
 

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1031,6 +1031,81 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("clears the active preview when a later final falls back after archived retain", async () => {
+    let answerMessageId: number | undefined;
+    let answerDraftParams:
+      | {
+          onSupersededPreview?: (preview: { messageId: number; textSnapshot: string }) => void;
+        }
+      | undefined;
+    const answerDraftStream = {
+      update: vi.fn().mockImplementation((text: string) => {
+        if (text.includes("Message B")) {
+          answerMessageId = 1002;
+        }
+      }),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockImplementation(() => answerMessageId),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn().mockImplementation(() => {
+        answerMessageId = undefined;
+      }),
+    };
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce((params) => {
+        answerDraftParams = params as typeof answerDraftParams;
+        return answerDraftStream;
+      })
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        answerDraftParams?.onSupersededPreview?.({
+          messageId: 1001,
+          textSnapshot: "Message A partial",
+        });
+
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    const preConnectErr = new Error("connect ECONNREFUSED 149.154.167.220:443");
+    (preConnectErr as NodeJS.ErrnoException).code = "ECONNREFUSED";
+    editMessageTelegram
+      .mockRejectedValueOnce(new Error("400: Bad Request: message to edit not found"))
+      .mockRejectedValueOnce(preConnectErr);
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      1002,
+      "Message B final",
+      expect.any(Object),
+    );
+    const finalTextSentViaDeliverReplies = deliverReplies.mock.calls.some((call: unknown[]) =>
+      (call[0] as { replies?: Array<{ text?: string }> })?.replies?.some(
+        (r: { text?: string }) => r.text === "Message B final",
+      ),
+    );
+    expect(finalTextSentViaDeliverReplies).toBe(true);
+    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
   it.each(["partial", "block"] as const)(
     "keeps finalized text preview when the next assistant message is media-only (%s mode)",
     async (streamMode) => {

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -464,6 +464,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       !hasMedia && text.length > 0 && text.length <= params.draftMaxChars && !payload.isError;
 
     if (infoKind === "final") {
+      // Transient previews must decide cleanup retention per final attempt.
+      // Completed previews intentionally stay retained so later extra payloads
+      // do not clear the already-finalized message.
+      if (params.activePreviewLifecycleByLane[laneName] === "transient") {
+        params.retainPreviewOnCleanupByLane[laneName] = false;
+      }
       if (laneName === "answer") {
         const archivedResult = await consumeArchivedAnswerPreviewForFinal({
           lane,


### PR DESCRIPTION
## Summary

- Problem: `retainPreviewOnCleanupByLane` could stay `true` after an archived-preview retain and leak into a later transient final on the same lane.
- Why it matters: when that later final fell back to `sendPayload`, cleanup skipped `stream.clear()` and left a stale partial preview next to the fallback-sent final message.
- What changed: clear the retain flag only when a lane is still in the transient preview lifecycle, then let the current final attempt set it back if it really retains the preview.
- What did NOT change (scope boundary): no new fallback behavior, no new preview-state model, no changes outside Telegram final-preview cleanup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #41662

## User-visible / Behavior Changes

- Telegram multi-message draft streams no longer leave a stale partial preview visible when an earlier archived preview was retained but a later transient final falls back to a normal send.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: n/a
- Integration/channel (if any): Telegram
- Relevant config (redacted): streamMode `partial`

### Steps

1. Stream message A so its preview is archived.
2. Retain that archived preview path via `message to edit not found`, then send message B as the active preview.
3. Make B's final edit fail pre-connect so it falls back to `sendPayload`.

### Expected

- Cleanup clears B's stale active preview before exit.

### Actual

- Before this fix, the stale retain flag skipped cleanup and left the partial preview visible beside the fallback-sent final.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest coverage for `src/telegram/lane-delivery.test.ts`, `src/telegram/bot-message-dispatch.test.ts`, and `src/telegram/network-errors.test.ts`; `pnpm tsgo`.
- Edge cases checked: existing regression that finalized previews stay visible when extra final payloads are sent still passes; new regression covers archived retain followed by transient fallback-send cleanup.
- What you did **not** verify: live Telegram delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `87bf43145`.
- Files/config to restore: `src/telegram/lane-delivery-text-deliverer.ts`, `src/telegram/bot-message-dispatch.test.ts`
- Known bad symptoms reviewers should watch for: stale Telegram preview bubbles surviving after a fallback-sent final, or finalized previews being cleared by later extra final payloads.

## Risks and Mitigations

- Risk: the retain reset could clear protection for already-finalized previews.
  - Mitigation: reset is gated to `activePreviewLifecycleByLane === "transient"`, and the existing finalized-preview regression still passes.
