### PR TITLE
fix(ui): correct theme type usage and suppress secrets false positives

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -53,7 +53,7 @@ export const en: TranslationMap = {
     sessions: "Active sessions and defaults.",
     usage: "API usage and costs.",
     cron: "Wakeups and recurring runs.",
-    skills: "Skills and API keys.",
+    skills: "Skills and API keys.", // pragma: allowlist secret
     nodes: "Paired devices and commands.",
     chat: "Gateway chat for quick interventions.",
     config: "Edit openclaw.json.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -52,7 +52,7 @@ export const pt_BR: TranslationMap = {
     sessions: "Sessões ativas e padrões.",
     usage: "Uso e custos da API.",
     cron: "Despertares e execuções.",
-    skills: "Habilidades e chaves API.",
+    skills: "Habilidades e chaves API.", // pragma: allowlist secret
     nodes: "Dispositivos e comandos.",
     chat: "Chat do gateway para intervenções rápidas.",
     config: "Editar openclaw.json.",

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -490,7 +490,7 @@ function countHiddenCronSessions(sessionKey: string, sessions: SessionsListResul
 const THEME_ORDER: ThemeMode[] = ["system", "light", "dark"];
 
 export function renderThemeToggle(state: AppViewState) {
-  const index = Math.max(0, THEME_ORDER.indexOf(state.theme));
+  const index = Math.max(0, THEME_ORDER.indexOf(state.themeMode));
   const applyTheme = (next: ThemeMode) => (event: MouseEvent) => {
     const element = event.currentTarget as HTMLElement;
     const context: ThemeTransitionContext = { element };
@@ -506,27 +506,27 @@ export function renderThemeToggle(state: AppViewState) {
       <div class="theme-toggle__track" role="group" aria-label="Theme">
         <span class="theme-toggle__indicator"></span>
         <button
-          class="theme-toggle__button ${state.theme === "system" ? "active" : ""}"
+          class="theme-toggle__button ${state.themeMode === "system" ? "active" : ""}"
           @click=${applyTheme("system")}
-          aria-pressed=${state.theme === "system"}
+          aria-pressed=${state.themeMode === "system"}
           aria-label="System theme"
           title="System"
         >
           ${renderMonitorIcon()}
         </button>
         <button
-          class="theme-toggle__button ${state.theme === "light" ? "active" : ""}"
+          class="theme-toggle__button ${state.themeMode === "light" ? "active" : ""}"
           @click=${applyTheme("light")}
-          aria-pressed=${state.theme === "light"}
+          aria-pressed=${state.themeMode === "light"}
           aria-label="Light theme"
           title="Light"
         >
           ${renderSunIcon()}
         </button>
         <button
-          class="theme-toggle__button ${state.theme === "dark" ? "active" : ""}"
+          class="theme-toggle__button ${state.themeMode === "dark" ? "active" : ""}"
           @click=${applyTheme("dark")}
-          aria-pressed=${state.theme === "dark"}
+          aria-pressed=${state.themeMode === "dark"}
           aria-label="Dark theme"
           title="Dark"
         >


### PR DESCRIPTION
## Summary
Fixes CI failures in the dashboard-v2-ui-utils branch.

## Changes
1. **Theme type fix** (`app-render.helpers.ts`)
   - Changed `state.theme` to `state.themeMode` in `renderThemeToggle`
   - The `AppViewState.theme` field is now `ThemeName` (claw/knot/dash)
   - The `AppViewState.themeMode` field is `ThemeMode` (system/light/dark)
   - The toggle UI compares against ThemeMode values

2. **Secrets false positive fix** (`en.ts`, `pt-BR.ts`)
   - Added `// pragma: allowlist secret` comments
   - The "API keys" / "chaves API" strings are UI labels, not actual secrets

## Test Plan
- [x] TypeScript compilation should pass
- [x] detect-secrets should not flag these lines