### PR TITLE
refactor(doctor): extract empty allowlist policy warnings

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -56,6 +56,7 @@ import {
   resolveConfigPathTarget,
   stripUnknownConfigKeys,
 } from "./doctor-config-analysis.js";
+import { detectEmptyAllowlistPolicy } from "./doctor-empty-allowlist-warnings.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
@@ -1174,138 +1175,6 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
     return { config: cfg, changes: [] };
   }
   return { config: next, changes };
-}
-
-/**
- * Scan all channel configs for dmPolicy="allowlist" without any allowFrom entries.
- * This configuration blocks all DMs because no sender can match the empty
- * allowlist. Common after upgrades that remove external allowlist
- * file support.
- */
-function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
-  const channels = cfg.channels;
-  if (!channels || typeof channels !== "object") {
-    return [];
-  }
-
-  const warnings: string[] = [];
-
-  const usesSenderBasedGroupAllowlist = (channelName?: string): boolean => {
-    if (!channelName) {
-      return true;
-    }
-    // These channels enforce group access via channel/space config, not sender-based
-    // groupAllowFrom lists.
-    return !(channelName === "discord" || channelName === "slack" || channelName === "googlechat");
-  };
-
-  const allowsGroupAllowFromFallback = (channelName?: string): boolean => {
-    if (!channelName) {
-      return true;
-    }
-    // Keep doctor warnings aligned with runtime access semantics.
-    return !(
-      channelName === "googlechat" ||
-      channelName === "imessage" ||
-      channelName === "matrix" ||
-      channelName === "msteams" ||
-      channelName === "irc"
-    );
-  };
-
-  const checkAccount = (
-    account: Record<string, unknown>,
-    prefix: string,
-    parent?: Record<string, unknown>,
-    channelName?: string,
-  ) => {
-    const dmEntry = account.dm;
-    const dm =
-      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
-        ? (dmEntry as Record<string, unknown>)
-        : undefined;
-    const parentDmEntry = parent?.dm;
-    const parentDm =
-      parentDmEntry && typeof parentDmEntry === "object" && !Array.isArray(parentDmEntry)
-        ? (parentDmEntry as Record<string, unknown>)
-        : undefined;
-    const dmPolicy =
-      (account.dmPolicy as string | undefined) ??
-      (dm?.policy as string | undefined) ??
-      (parent?.dmPolicy as string | undefined) ??
-      (parentDm?.policy as string | undefined) ??
-      undefined;
-
-    const topAllowFrom =
-      (account.allowFrom as Array<string | number> | undefined) ??
-      (parent?.allowFrom as Array<string | number> | undefined);
-    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
-    const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
-    const effectiveAllowFrom = topAllowFrom ?? nestedAllowFrom ?? parentNestedAllowFrom;
-
-    if (dmPolicy === "allowlist" && !hasAllowFromEntries(effectiveAllowFrom)) {
-      warnings.push(
-        `- ${prefix}.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to ${prefix}.allowFrom, or run "${formatCliCommand("openclaw doctor --fix")}" to auto-migrate from pairing store when entries exist.`,
-      );
-    }
-
-    const groupPolicy =
-      (account.groupPolicy as string | undefined) ??
-      (parent?.groupPolicy as string | undefined) ??
-      undefined;
-
-    if (groupPolicy === "allowlist" && usesSenderBasedGroupAllowlist(channelName)) {
-      const rawGroupAllowFrom =
-        (account.groupAllowFrom as Array<string | number> | undefined) ??
-        (parent?.groupAllowFrom as Array<string | number> | undefined);
-      // Match runtime semantics: resolveGroupAllowFromSources treats
-      // empty arrays as unset and falls back to allowFrom.
-      const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom) ? rawGroupAllowFrom : undefined;
-      const fallbackToAllowFrom = allowsGroupAllowFromFallback(channelName);
-      const effectiveGroupAllowFrom =
-        groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
-
-      if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {
-        if (fallbackToAllowFrom) {
-          warnings.push(
-            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,
-          );
-        } else {
-          warnings.push(
-            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom is empty — this channel does not fall back to allowFrom, so all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom, or set groupPolicy to "open".`,
-          );
-        }
-      }
-    }
-  };
-
-  for (const [channelName, channelConfig] of Object.entries(
-    channels as Record<string, Record<string, unknown>>,
-  )) {
-    if (!channelConfig || typeof channelConfig !== "object") {
-      continue;
-    }
-    checkAccount(channelConfig, `channels.${channelName}`, undefined, channelName);
-
-    const accounts = channelConfig.accounts;
-    if (accounts && typeof accounts === "object") {
-      for (const [accountId, account] of Object.entries(
-        accounts as Record<string, Record<string, unknown>>,
-      )) {
-        if (!account || typeof account !== "object") {
-          continue;
-        }
-        checkAccount(
-          account,
-          `channels.${channelName}.accounts.${accountId}`,
-          channelConfig,
-          channelName,
-        );
-      }
-    }
-  }
-
-  return warnings;
 }
 
 type ExecSafeBinCoverageHit = {

--- a/src/commands/doctor-empty-allowlist-warnings.test.ts
+++ b/src/commands/doctor-empty-allowlist-warnings.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { detectEmptyAllowlistPolicy } from "./doctor-empty-allowlist-warnings.js";
+
+describe("doctor empty allowlist warnings", () => {
+  it("warns when dmPolicy allowlist has no sender entries", () => {
+    const warnings = detectEmptyAllowlistPolicy({
+      channels: {
+        telegram: {
+          dmPolicy: "allowlist",
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(warnings).toEqual([
+      '- channels.telegram.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to channels.telegram.allowFrom, or run "openclaw doctor --fix" to auto-migrate from pairing store when entries exist.',
+    ]);
+  });
+
+  it("falls back from empty groupAllowFrom to allowFrom when the channel supports it", () => {
+    const warnings = detectEmptyAllowlistPolicy({
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          allowFrom: ["12345"],
+          groupAllowFrom: [],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("does not warn for googlechat sender-based group allowlists", () => {
+    const warnings = detectEmptyAllowlistPolicy({
+      channels: {
+        googlechat: {
+          groupPolicy: "allowlist",
+          accounts: {
+            work: {
+              groupPolicy: "allowlist",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns when group allowlist does not fall back to allowFrom", () => {
+    const warnings = detectEmptyAllowlistPolicy({
+      channels: {
+        imessage: {
+          groupPolicy: "allowlist",
+          allowFrom: ["+15551234567"],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(warnings).toEqual([
+      '- channels.imessage.groupPolicy is "allowlist" but groupAllowFrom is empty — this channel does not fall back to allowFrom, so all group messages will be silently dropped. Add sender IDs to channels.imessage.groupAllowFrom, or set groupPolicy to "open".',
+    ]);
+  });
+
+  it("inherits parent allowFrom and groupPolicy for account-scoped warnings", () => {
+    const warnings = detectEmptyAllowlistPolicy({
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          accounts: {
+            work: {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(warnings).toEqual([
+      '- channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.telegram.groupAllowFrom or channels.telegram.allowFrom, or set groupPolicy to "open".',
+      '- channels.telegram.accounts.work.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.telegram.accounts.work.groupAllowFrom or channels.telegram.accounts.work.allowFrom, or set groupPolicy to "open".',
+    ]);
+  });
+});

--- a/src/commands/doctor-empty-allowlist-warnings.ts
+++ b/src/commands/doctor-empty-allowlist-warnings.ts
@@ -1,0 +1,123 @@
+import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { isRecord } from "../utils.js";
+
+function hasAllowFromEntries(list?: Array<string | number>) {
+  return (
+    Array.isArray(list) && list.map((value) => String(value).trim()).filter(Boolean).length > 0
+  );
+}
+
+export function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
+  if (!isRecord(cfg.channels)) {
+    return [];
+  }
+
+  const warnings: string[] = [];
+
+  const usesSenderBasedGroupAllowlist = (channelName?: string): boolean => {
+    if (!channelName) {
+      return true;
+    }
+    // These channels enforce group access via channel/space config, not sender-based
+    // groupAllowFrom lists.
+    return !(channelName === "discord" || channelName === "slack" || channelName === "googlechat");
+  };
+
+  const allowsGroupAllowFromFallback = (channelName?: string): boolean => {
+    if (!channelName) {
+      return true;
+    }
+    // Keep doctor warnings aligned with runtime access semantics.
+    return !(
+      channelName === "googlechat" ||
+      channelName === "imessage" ||
+      channelName === "matrix" ||
+      channelName === "msteams" ||
+      channelName === "irc"
+    );
+  };
+
+  const checkAccount = (
+    account: Record<string, unknown>,
+    prefix: string,
+    parent?: Record<string, unknown>,
+    channelName?: string,
+  ) => {
+    const dm = isRecord(account.dm) ? account.dm : undefined;
+    const parentDm = isRecord(parent?.dm) ? parent.dm : undefined;
+    const dmPolicy =
+      (account.dmPolicy as string | undefined) ??
+      (dm?.policy as string | undefined) ??
+      (parent?.dmPolicy as string | undefined) ??
+      (parentDm?.policy as string | undefined) ??
+      undefined;
+
+    const topAllowFrom =
+      (account.allowFrom as Array<string | number> | undefined) ??
+      (parent?.allowFrom as Array<string | number> | undefined);
+    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+    const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
+    const effectiveAllowFrom = topAllowFrom ?? nestedAllowFrom ?? parentNestedAllowFrom;
+
+    if (dmPolicy === "allowlist" && !hasAllowFromEntries(effectiveAllowFrom)) {
+      warnings.push(
+        `- ${prefix}.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to ${prefix}.allowFrom, or run "${formatCliCommand("openclaw doctor --fix")}" to auto-migrate from pairing store when entries exist.`,
+      );
+    }
+
+    const groupPolicy =
+      (account.groupPolicy as string | undefined) ??
+      (parent?.groupPolicy as string | undefined) ??
+      undefined;
+
+    if (groupPolicy === "allowlist" && usesSenderBasedGroupAllowlist(channelName)) {
+      const rawGroupAllowFrom =
+        (account.groupAllowFrom as Array<string | number> | undefined) ??
+        (parent?.groupAllowFrom as Array<string | number> | undefined);
+      // Match runtime semantics: resolveGroupAllowFromSources treats
+      // empty arrays as unset and falls back to allowFrom.
+      const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom) ? rawGroupAllowFrom : undefined;
+      const fallbackToAllowFrom = allowsGroupAllowFromFallback(channelName);
+      const effectiveGroupAllowFrom =
+        groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
+
+      if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {
+        if (fallbackToAllowFrom) {
+          warnings.push(
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,
+          );
+        } else {
+          warnings.push(
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom is empty — this channel does not fall back to allowFrom, so all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom, or set groupPolicy to "open".`,
+          );
+        }
+      }
+    }
+  };
+
+  for (const [channelName, rawChannelConfig] of Object.entries(cfg.channels)) {
+    if (!isRecord(rawChannelConfig)) {
+      continue;
+    }
+    checkAccount(rawChannelConfig, `channels.${channelName}`, undefined, channelName);
+
+    const accounts = isRecord(rawChannelConfig.accounts) ? rawChannelConfig.accounts : null;
+    if (!accounts) {
+      continue;
+    }
+    for (const [accountId, rawAccount] of Object.entries(accounts)) {
+      if (!isRecord(rawAccount)) {
+        continue;
+      }
+      checkAccount(
+        rawAccount,
+        `channels.${channelName}.accounts.${accountId}`,
+        rawChannelConfig,
+        channelName,
+      );
+    }
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/commands/doctor-config-flow.ts` still embedded empty allowlist warning detection for DM and group policies.
- Why it matters: That keeps the doctor flow file monolithic and makes fallback semantics and channel-specific warning behavior harder to review and test in isolation.
- What changed: Extracted empty allowlist warning detection into `src/commands/doctor-empty-allowlist-warnings.ts` and added focused tests for DM warnings, group fallback, no-fallback channels, Google Chat exceptions, and parent-scope inheritance.
- What did NOT change (scope boundary): Warning text, warning call sites, and doctor flow behavior were kept the same.

AI-assisted with Codex. Focused local tests passed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.14.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): doctor config flow / allowlist warnings
- Relevant config (redacted): synthetic invalid doctor config fixtures in unit tests

### Steps

1. Run `pnpm test -- src/commands/doctor-empty-allowlist-warnings.test.ts src/commands/doctor-config-flow.test.ts`.
2. Run `pnpm check`.
3. Compare the extracted helper behavior with the existing doctor warning call sites.

### Expected

- Empty allowlist warnings remain behaviorally unchanged across supported channels.
- Focused tests and repo checks pass.

### Actual

- `pnpm test -- src/commands/doctor-empty-allowlist-warnings.test.ts src/commands/doctor-config-flow.test.ts` passed.
- `pnpm check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: empty DM allowlists, group allowlists that fall back to `allowFrom`, channels that do not fall back, Google Chat sender-based exception handling, and inherited parent scope warnings.
- Edge cases checked: empty arrays treated as unset, parent `groupPolicy` propagation, and account-scoped warning paths.
- What you did **not** verify: manual end-to-end doctor runs against live channel configs beyond the targeted automated coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b7bab4ef0a496afcc8be563dbce637331c885e9f`.
- Files/config to restore: `src/commands/doctor-config-flow.ts` and the extracted helper module.
- Known bad symptoms reviewers should watch for: missing allowlist warnings, changed warning paths, or channels using the wrong fallback semantics.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the extracted helper could drift from the original channel-specific fallback rules.
  - Mitigation: focused helper tests plus the existing `doctor-config-flow` warning tests still pass.
