### PR TITLE
refactor(doctor): extract allowlist store recovery helpers

### DIFF
--- a/src/commands/doctor-allowlist-store-recovery.test.ts
+++ b/src/commands/doctor-allowlist-store-recovery.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { maybeRepairAllowlistPolicyAllowFrom } from "./doctor-allowlist-store-recovery.js";
+
+describe("doctor allowlist store recovery", () => {
+  it("restores top-level allowFrom from pairing store for top-only channels", async () => {
+    const result = await withTempHome(async (home) => {
+      const credentialsDir = path.join(home, ".openclaw", "credentials");
+      await fs.mkdir(credentialsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(credentialsDir, "telegram-default-allowFrom.json"),
+        JSON.stringify({ version: 1, allowFrom: ["12345"] }, null, 2),
+        "utf-8",
+      );
+
+      return await maybeRepairAllowlistPolicyAllowFrom({
+        channels: {
+          telegram: {
+            dmPolicy: "allowlist",
+          },
+        },
+      } as unknown as OpenClawConfig);
+    });
+
+    expect(result.changes).toEqual([
+      '- channels.telegram.allowFrom: restored 1 sender entry from pairing store (dmPolicy="allowlist").',
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        telegram: {
+          dmPolicy: "allowlist",
+          allowFrom: ["12345"],
+        },
+      },
+    });
+  });
+
+  it("restores nested dm.allowFrom for nested-only channels", async () => {
+    const result = await withTempHome(async (home) => {
+      const credentialsDir = path.join(home, ".openclaw", "credentials");
+      await fs.mkdir(credentialsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(credentialsDir, "googlechat-default-allowFrom.json"),
+        JSON.stringify({ version: 1, allowFrom: ["users/123"] }, null, 2),
+        "utf-8",
+      );
+
+      return await maybeRepairAllowlistPolicyAllowFrom({
+        channels: {
+          googlechat: {
+            dm: {
+              policy: "allowlist",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig);
+    });
+
+    expect(result.changes).toEqual([
+      '- channels.googlechat.dm.allowFrom: restored 1 sender entry from pairing store (dmPolicy="allowlist").',
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        googlechat: {
+          dm: {
+            policy: "allowlist",
+            allowFrom: ["users/123"],
+          },
+        },
+      },
+    });
+  });
+
+  it("restores nested dm.allowFrom for top-or-nested account scopes when dm already exists", async () => {
+    const result = await withTempHome(async (home) => {
+      const credentialsDir = path.join(home, ".openclaw", "credentials");
+      await fs.mkdir(credentialsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(credentialsDir, "discord-work-allowFrom.json"),
+        JSON.stringify({ version: 1, allowFrom: ["111", "111", " 222 "] }, null, 2),
+        "utf-8",
+      );
+
+      return await maybeRepairAllowlistPolicyAllowFrom({
+        channels: {
+          discord: {
+            accounts: {
+              work: {
+                dm: {
+                  policy: "allowlist",
+                  allowFrom: [],
+                },
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig);
+    });
+
+    expect(result.changes).toEqual([
+      '- channels.discord.accounts.work.dm.allowFrom: restored 2 sender entries from pairing store (dmPolicy="allowlist").',
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        discord: {
+          accounts: {
+            work: {
+              dm: {
+                policy: "allowlist",
+                allowFrom: ["111", "222"],
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("returns the original config when allowFrom is already populated", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          dmPolicy: "allowlist",
+          allowFrom: ["12345"],
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await withTempHome(async () => await maybeRepairAllowlistPolicyAllowFrom(cfg));
+
+    expect(result).toEqual({ config: cfg, changes: [] });
+  });
+});

--- a/src/commands/doctor-allowlist-store-recovery.ts
+++ b/src/commands/doctor-allowlist-store-recovery.ts
@@ -1,0 +1,155 @@
+import { normalizeChatChannelId } from "../channels/registry.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+import { isRecord } from "../utils.js";
+
+type AllowFromMode = "topOnly" | "topOrNested" | "nestedOnly";
+
+function hasAllowFromEntries(list?: Array<string | number>) {
+  return (
+    Array.isArray(list) && list.map((value) => String(value).trim()).filter(Boolean).length > 0
+  );
+}
+
+function resolveAllowFromMode(channelName: string): AllowFromMode {
+  if (channelName === "googlechat") {
+    return "nestedOnly";
+  }
+  if (channelName === "discord" || channelName === "slack") {
+    return "topOrNested";
+  }
+  return "topOnly";
+}
+
+export async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise<{
+  config: OpenClawConfig;
+  changes: string[];
+}> {
+  if (!isRecord(cfg.channels)) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next = structuredClone(cfg);
+  const nextChannels = isRecord(next.channels) ? next.channels : null;
+  if (!nextChannels) {
+    return { config: cfg, changes: [] };
+  }
+
+  const changes: string[] = [];
+
+  const applyRecoveredAllowFrom = (params: {
+    account: Record<string, unknown>;
+    allowFrom: string[];
+    mode: AllowFromMode;
+    prefix: string;
+  }) => {
+    const count = params.allowFrom.length;
+    const noun = count === 1 ? "entry" : "entries";
+
+    if (params.mode === "nestedOnly") {
+      const dm = isRecord(params.account.dm) ? params.account.dm : {};
+      dm.allowFrom = params.allowFrom;
+      params.account.dm = dm;
+      changes.push(
+        `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+      );
+      return;
+    }
+
+    if (params.mode === "topOrNested") {
+      const dm = isRecord(params.account.dm) ? params.account.dm : undefined;
+      const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+      if (dm && !Array.isArray(params.account.allowFrom) && Array.isArray(nestedAllowFrom)) {
+        dm.allowFrom = params.allowFrom;
+        changes.push(
+          `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+        );
+        return;
+      }
+    }
+
+    params.account.allowFrom = params.allowFrom;
+    changes.push(
+      `- ${params.prefix}.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
+    );
+  };
+
+  const recoverAllowFromForAccount = async (params: {
+    channelName: string;
+    account: Record<string, unknown>;
+    accountId?: string;
+    prefix: string;
+  }) => {
+    const dm = isRecord(params.account.dm) ? params.account.dm : undefined;
+    const dmPolicy =
+      (params.account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined);
+    if (dmPolicy !== "allowlist") {
+      return;
+    }
+
+    const topAllowFrom = params.account.allowFrom as Array<string | number> | undefined;
+    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+    if (hasAllowFromEntries(topAllowFrom) || hasAllowFromEntries(nestedAllowFrom)) {
+      return;
+    }
+
+    const normalizedChannelId = (normalizeChatChannelId(params.channelName) ?? params.channelName)
+      .trim()
+      .toLowerCase();
+    if (!normalizedChannelId) {
+      return;
+    }
+    const normalizedAccountId = normalizeAccountId(params.accountId) || DEFAULT_ACCOUNT_ID;
+    const fromStore = await readChannelAllowFromStore(
+      normalizedChannelId,
+      process.env,
+      normalizedAccountId,
+    ).catch(() => []);
+    const recovered = Array.from(new Set(fromStore.map((entry) => String(entry).trim()))).filter(
+      Boolean,
+    );
+    if (recovered.length === 0) {
+      return;
+    }
+
+    applyRecoveredAllowFrom({
+      account: params.account,
+      allowFrom: recovered,
+      mode: resolveAllowFromMode(params.channelName),
+      prefix: params.prefix,
+    });
+  };
+
+  for (const [channelName, rawChannelConfig] of Object.entries(nextChannels)) {
+    if (!isRecord(rawChannelConfig)) {
+      continue;
+    }
+    await recoverAllowFromForAccount({
+      channelName,
+      account: rawChannelConfig,
+      prefix: `channels.${channelName}`,
+    });
+
+    const accounts = isRecord(rawChannelConfig.accounts) ? rawChannelConfig.accounts : null;
+    if (!accounts) {
+      continue;
+    }
+    for (const [accountId, rawAccountConfig] of Object.entries(accounts)) {
+      if (!isRecord(rawAccountConfig)) {
+        continue;
+      }
+      await recoverAllowFromForAccount({
+        channelName,
+        account: rawAccountConfig,
+        accountId,
+        prefix: `channels.${channelName}.accounts.${accountId}`,
+      });
+    }
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return { config: next, changes };
+}

--- a/src/commands/doctor-allowlist-store-recovery.ts
+++ b/src/commands/doctor-allowlist-store-recovery.ts
@@ -3,14 +3,9 @@ import type { OpenClawConfig } from "../config/config.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { isRecord } from "../utils.js";
+import { hasAllowFromEntries } from "./doctor-allowlist-utils.js";
 
 type AllowFromMode = "topOnly" | "topOrNested" | "nestedOnly";
-
-function hasAllowFromEntries(list?: Array<string | number>) {
-  return (
-    Array.isArray(list) && list.map((value) => String(value).trim()).filter(Boolean).length > 0
-  );
-}
 
 function resolveAllowFromMode(channelName: string): AllowFromMode {
   if (channelName === "googlechat") {

--- a/src/commands/doctor-allowlist-utils.ts
+++ b/src/commands/doctor-allowlist-utils.ts
@@ -1,0 +1,5 @@
+export function hasAllowFromEntries(list?: Array<string | number>) {
+  return (
+    Array.isArray(list) && list.map((value) => String(value).trim()).filter(Boolean).length > 0
+  );
+}

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -49,6 +49,7 @@ import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/acco
 import { note } from "../terminal/note.js";
 import { resolveHomeDir } from "../utils.js";
 import { maybeRepairAllowlistPolicyAllowFrom } from "./doctor-allowlist-store-recovery.js";
+import { hasAllowFromEntries } from "./doctor-allowlist-utils.js";
 import {
   formatConfigPath,
   noteIncludeConfinementWarning,
@@ -1017,12 +1018,6 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
     return { config: cfg, changes: [] };
   }
   return { config: next, changes };
-}
-
-function hasAllowFromEntries(list?: Array<string | number>) {
-  return (
-    Array.isArray(list) && list.map((value) => String(value).trim()).filter(Boolean).length > 0
-  );
 }
 
 /**

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -26,7 +26,6 @@ import {
   isTrustedSafeBinPath,
   normalizeTrustedSafeBinDirs,
 } from "../infra/exec-safe-bin-trust.js";
-import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import {
   formatChannelAccountsDefaultPath,
   formatSetExplicitDefaultInstruction,
@@ -49,6 +48,7 @@ import { inspectTelegramAccount } from "../telegram/account-inspect.js";
 import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/accounts.js";
 import { note } from "../terminal/note.js";
 import { resolveHomeDir } from "../utils.js";
+import { maybeRepairAllowlistPolicyAllowFrom } from "./doctor-allowlist-store-recovery.js";
 import {
   formatConfigPath,
   noteIncludeConfinementWarning,
@@ -1020,160 +1020,9 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
 }
 
 function hasAllowFromEntries(list?: Array<string | number>) {
-  return Array.isArray(list) && list.map((v) => String(v).trim()).filter(Boolean).length > 0;
-}
-
-async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise<{
-  config: OpenClawConfig;
-  changes: string[];
-}> {
-  const channels = cfg.channels;
-  if (!channels || typeof channels !== "object") {
-    return { config: cfg, changes: [] };
-  }
-
-  type AllowFromMode = "topOnly" | "topOrNested" | "nestedOnly";
-
-  const resolveAllowFromMode = (channelName: string): AllowFromMode => {
-    if (channelName === "googlechat") {
-      return "nestedOnly";
-    }
-    if (channelName === "discord" || channelName === "slack") {
-      return "topOrNested";
-    }
-    return "topOnly";
-  };
-
-  const next = structuredClone(cfg);
-  const changes: string[] = [];
-
-  const applyRecoveredAllowFrom = (params: {
-    account: Record<string, unknown>;
-    allowFrom: string[];
-    mode: AllowFromMode;
-    prefix: string;
-  }) => {
-    const count = params.allowFrom.length;
-    const noun = count === 1 ? "entry" : "entries";
-
-    if (params.mode === "nestedOnly") {
-      const dmEntry = params.account.dm;
-      const dm =
-        dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
-          ? (dmEntry as Record<string, unknown>)
-          : {};
-      dm.allowFrom = params.allowFrom;
-      params.account.dm = dm;
-      changes.push(
-        `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
-      );
-      return;
-    }
-
-    if (params.mode === "topOrNested") {
-      const dmEntry = params.account.dm;
-      const dm =
-        dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
-          ? (dmEntry as Record<string, unknown>)
-          : undefined;
-      const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
-      if (dm && !Array.isArray(params.account.allowFrom) && Array.isArray(nestedAllowFrom)) {
-        dm.allowFrom = params.allowFrom;
-        changes.push(
-          `- ${params.prefix}.dm.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
-        );
-        return;
-      }
-    }
-
-    params.account.allowFrom = params.allowFrom;
-    changes.push(
-      `- ${params.prefix}.allowFrom: restored ${count} sender ${noun} from pairing store (dmPolicy="allowlist").`,
-    );
-  };
-
-  const recoverAllowFromForAccount = async (params: {
-    channelName: string;
-    account: Record<string, unknown>;
-    accountId?: string;
-    prefix: string;
-  }) => {
-    const dmEntry = params.account.dm;
-    const dm =
-      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
-        ? (dmEntry as Record<string, unknown>)
-        : undefined;
-    const dmPolicy =
-      (params.account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined);
-    if (dmPolicy !== "allowlist") {
-      return;
-    }
-
-    const topAllowFrom = params.account.allowFrom as Array<string | number> | undefined;
-    const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
-    if (hasAllowFromEntries(topAllowFrom) || hasAllowFromEntries(nestedAllowFrom)) {
-      return;
-    }
-
-    const normalizedChannelId = (normalizeChatChannelId(params.channelName) ?? params.channelName)
-      .trim()
-      .toLowerCase();
-    if (!normalizedChannelId) {
-      return;
-    }
-    const normalizedAccountId = normalizeAccountId(params.accountId) || DEFAULT_ACCOUNT_ID;
-    const fromStore = await readChannelAllowFromStore(
-      normalizedChannelId,
-      process.env,
-      normalizedAccountId,
-    ).catch(() => []);
-    const recovered = Array.from(new Set(fromStore.map((entry) => String(entry).trim()))).filter(
-      Boolean,
-    );
-    if (recovered.length === 0) {
-      return;
-    }
-
-    applyRecoveredAllowFrom({
-      account: params.account,
-      allowFrom: recovered,
-      mode: resolveAllowFromMode(params.channelName),
-      prefix: params.prefix,
-    });
-  };
-
-  const nextChannels = next.channels as Record<string, Record<string, unknown>>;
-  for (const [channelName, channelConfig] of Object.entries(nextChannels)) {
-    if (!channelConfig || typeof channelConfig !== "object") {
-      continue;
-    }
-    await recoverAllowFromForAccount({
-      channelName,
-      account: channelConfig,
-      prefix: `channels.${channelName}`,
-    });
-
-    const accounts = channelConfig.accounts as Record<string, Record<string, unknown>> | undefined;
-    if (!accounts || typeof accounts !== "object") {
-      continue;
-    }
-    for (const [accountId, accountConfig] of Object.entries(accounts)) {
-      if (!accountConfig || typeof accountConfig !== "object") {
-        continue;
-      }
-      await recoverAllowFromForAccount({
-        channelName,
-        account: accountConfig,
-        accountId,
-        prefix: `channels.${channelName}.accounts.${accountId}`,
-      });
-    }
-  }
-
-  if (changes.length === 0) {
-    return { config: cfg, changes: [] };
-  }
-  return { config: next, changes };
+  return (
+    Array.isArray(list) && list.map((value) => String(value).trim()).filter(Boolean).length > 0
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/commands/doctor-config-flow.ts` still embedded the pairing-store allowFrom recovery logic for `dmPolicy="allowlist"` configs.
- Why it matters: That keeps the doctor flow file monolithic and makes channel-specific recovery semantics harder to review and test in isolation.
- What changed: Extracted allowlist store recovery into `src/commands/doctor-allowlist-store-recovery.ts` and added focused tests for top-level, nested, account-scoped, and no-op recovery cases.
- What did NOT change (scope boundary): Repair messages, doctor flow call sites, and pairing-store recovery behavior were kept the same.

AI-assisted with Codex. Focused local tests passed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.14.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): doctor config flow / allowlist store recovery
- Relevant config (redacted): synthetic invalid doctor config fixtures and pairing-store fixtures in unit tests

### Steps

1. Run `pnpm test -- src/commands/doctor-allowlist-store-recovery.test.ts src/commands/doctor-config-flow.test.ts`.
2. Run `pnpm check`.
3. Compare the extracted helper behavior with the existing doctor repair call site.

### Expected

- Pairing-store allowFrom recovery remains behaviorally unchanged across supported channels.
- Focused tests and repo checks pass.

### Actual

- `pnpm test -- src/commands/doctor-allowlist-store-recovery.test.ts src/commands/doctor-config-flow.test.ts` passed.
- `pnpm check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: top-level recovery, Google Chat nested `dm.allowFrom` recovery, Discord account-scoped nested recovery, and no-op behavior when `allowFrom` already exists.
- Edge cases checked: default-account store lookup, deduping recovered entries, and nested-vs-top-level target selection.
- What you did **not** verify: manual end-to-end doctor runs against live channel configs beyond the targeted automated coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fdc7301a5b96b68a5d835a65a8afaa6a9d157db4`.
- Files/config to restore: `src/commands/doctor-config-flow.ts` and the extracted helper module.
- Known bad symptoms reviewers should watch for: missing allowFrom recovery, recovery targeting the wrong scope, or duplicate restored entries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the extracted helper could drift from the original per-channel recovery target rules.
  - Mitigation: focused helper tests plus the existing `doctor-config-flow` repair test still pass.
