### PR TITLE
fix: prune image-containing tool results during context pruning

### DIFF
--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -3,8 +3,12 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already processed by model]";
 
 /**
- * Idempotent cleanup for legacy sessions that persisted image blocks in history.
- * Called each run; mutates only user turns that already have an assistant reply.
+ * Idempotent cleanup for sessions that persisted image blocks in history.
+ * Called each run; mutates user and toolResult turns that already have an
+ * assistant reply after them.
+ *
+ * Handles both user-uploaded images and tool result images (e.g. browser
+ * screenshots) to prevent unbounded image accumulation in long sessions.
  */
 export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
   let lastAssistantIndex = -1;
@@ -21,7 +25,11 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
   let didMutate = false;
   for (let i = 0; i < lastAssistantIndex; i++) {
     const message = messages[i];
-    if (!message || message.role !== "user" || !Array.isArray(message.content)) {
+    if (!message || !Array.isArray(message.content)) {
+      continue;
+    }
+    // Prune images from both user messages and tool results
+    if (message.role !== "user" && message.role !== "toolResult") {
       continue;
     }
     for (let j = 0; j < message.content.length; j++) {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -5,9 +5,8 @@ import type { EffectiveContextPruningSettings } from "./settings.js";
 import { makeToolPrunablePredicate } from "./tools.js";
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
-// We currently skip pruning tool results that contain images. Still, we count them (approx.) so
-// we start trimming prunable tool results earlier when image-heavy context is consuming the window.
 const IMAGE_CHAR_ESTIMATE = 8_000;
+const IMAGE_PRUNED_PLACEHOLDER = "[image removed during context pruning]";
 
 function asText(text: string): TextContent {
   return { type: "text", text };
@@ -185,14 +184,39 @@ function findFirstUserIndex(messages: AgentMessage[]): number | null {
   return null;
 }
 
+/**
+ * Strip image blocks from a tool result, replacing them with text placeholders.
+ * Preserves any accompanying text content.
+ */
+function stripImageBlocks(
+  content: ReadonlyArray<TextContent | ImageContent>,
+): (TextContent | ImageContent)[] {
+  const result: (TextContent | ImageContent)[] = [];
+  let lastWasPlaceholder = false;
+  for (const block of content) {
+    if (block.type === "image") {
+      // Deduplicate consecutive placeholders (e.g. multiple images in a row)
+      if (!lastWasPlaceholder) {
+        result.push(asText(IMAGE_PRUNED_PLACEHOLDER));
+        lastWasPlaceholder = true;
+      }
+    } else {
+      result.push(block);
+      lastWasPlaceholder = false;
+    }
+  }
+  return result;
+}
+
 function softTrimToolResultMessage(params: {
   msg: ToolResultMessage;
   settings: EffectiveContextPruningSettings;
 }): ToolResultMessage | null {
   const { msg, settings } = params;
-  // Ignore image tool results for now: these are often directly relevant and hard to partially prune safely.
+
+  // For image-containing tool results: strip image blocks, keep text content.
   if (hasImageBlocks(msg.content)) {
-    return null;
+    return { ...msg, content: stripImageBlocks(msg.content) };
   }
 
   const parts = collectTextSegments(msg.content);
@@ -272,9 +296,6 @@ export function pruneContextMessages(params: {
       continue;
     }
     if (!isToolPrunable(msg.toolName)) {
-      continue;
-    }
-    if (hasImageBlocks(msg.content)) {
       continue;
     }
     prunableToolIndexes.push(i);


### PR DESCRIPTION
## Summary

Closes #41789

Both pruning mechanisms previously ignored tool result images, causing unbounded image accumulation in screenshot-heavy sessions (e.g. browser automation):

- `pruneContextMessages()` in `pruner.ts` explicitly skipped any `toolResult` with image blocks
- `pruneProcessedHistoryImages()` in `history-image-prune.ts` only processed `role === "user"` messages

This meant the context pruner — the last safety net against context overflow — refused to touch the largest consumers of context space.

## Changes

**`src/agents/pi-extensions/context-pruning/pruner.ts`**
- Add `stripImageBlocks()` helper: replaces image blocks with text placeholder `[image removed during context pruning]`, deduplicates consecutive placeholders, preserves accompanying text content
- `softTrimToolResultMessage()`: strip images from image-containing tool results instead of returning `null`
- `pruneContextMessages()`: remove `hasImageBlocks` skip so image tool results participate in both soft-trim and hard-clear phases

**`src/agents/pi-embedded-runner/run/history-image-prune.ts`**
- Extend `pruneProcessedHistoryImages()` to also process `toolResult` messages, not just `user` messages

## Test plan

- [x] Verify existing context pruning tests still pass
- [x] Session with 15+ browser screenshots: confirm images are pruned when soft-trim threshold is reached
- [x] Session with mixed text + image tool results: confirm text content is preserved after image stripping
- [x] Verify `pruneProcessedHistoryImages` now clears toolResult images before `lastAssistantIndex`
- [x] Long session with vision-disabled model: confirm no HTTP 400 loop from accumulated tool result images