### PR TITLE
fix(i18n): add locale prefix to internal links during translation

### DIFF
--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -174,7 +174,7 @@ Gateway 网关启动后，打开浏览器控制界面。
   <Card title="多智能体路由" href="/zh-CN/concepts/multi-agent" icon="route">
     工作区隔离和按智能体的会话管理。
   </Card>
-  <Card title="安全" href="/gateway/security" icon="shield">
+  <Card title="安全" href="/zh-CN/gateway/security" icon="shield">
     令牌、白名单和安全控制。
   </Card>
   <Card title="故障排除" href="/zh-CN/gateway/troubleshooting" icon="wrench">

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -37,13 +37,13 @@ x-i18n:
 </p>
 
 <Columns>
-  <Card title="入门指南" href="/start/getting-started" icon="rocket">
+  <Card title="入门指南" href="/zh-CN/start/getting-started" icon="rocket">
     安装 OpenClaw 并在几分钟内启动 Gateway 网关。
   </Card>
-  <Card title="运行向导" href="/start/wizard" icon="sparkles">
+  <Card title="运行向导" href="/zh-CN/start/wizard" icon="sparkles">
     通过 `openclaw onboard` 和配对流程进行引导式设置。
   </Card>
-  <Card title="打开控制界面" href="/web/control-ui" icon="layout-dashboard">
+  <Card title="打开控制界面" href="/zh-CN/web/control-ui" icon="layout-dashboard">
     启动浏览器仪表板，管理聊天、配置和会话。
   </Card>
 </Columns>
@@ -145,22 +145,22 @@ Gateway 网关启动后，打开浏览器控制界面。
 ## 从这里开始
 
 <Columns>
-  <Card title="文档中心" href="/start/hubs" icon="book-open">
+  <Card title="文档中心" href="/zh-CN/start/hubs" icon="book-open">
     所有文档和指南，按用例分类。
   </Card>
-  <Card title="配置" href="/gateway/configuration" icon="settings">
+  <Card title="配置" href="/zh-CN/gateway/configuration" icon="settings">
     核心 Gateway 网关设置、令牌和提供商配置。
   </Card>
-  <Card title="远程访问" href="/gateway/remote" icon="globe">
+  <Card title="远程访问" href="/zh-CN/gateway/remote" icon="globe">
     SSH 和 tailnet 访问模式。
   </Card>
-  <Card title="渠道" href="/channels/telegram" icon="message-square">
+  <Card title="渠道" href="/zh-CN/channels/telegram" icon="message-square">
     WhatsApp、Telegram、Discord 等渠道的具体设置。
   </Card>
-  <Card title="节点" href="/nodes" icon="smartphone">
+  <Card title="节点" href="/zh-CN/nodes" icon="smartphone">
     iOS 和 Android 节点的配对与 Canvas 功能。
   </Card>
-  <Card title="帮助" href="/help" icon="life-buoy">
+  <Card title="帮助" href="/zh-CN/help" icon="life-buoy">
     常见修复方法和故障排除入口。
   </Card>
 </Columns>
@@ -168,19 +168,19 @@ Gateway 网关启动后，打开浏览器控制界面。
 ## 了解更多
 
 <Columns>
-  <Card title="完整功能列表" href="/concepts/features" icon="list">
+  <Card title="完整功能列表" href="/zh-CN/concepts/features" icon="list">
     全部渠道、路由和媒体功能。
   </Card>
-  <Card title="多智能体路由" href="/concepts/multi-agent" icon="route">
+  <Card title="多智能体路由" href="/zh-CN/concepts/multi-agent" icon="route">
     工作区隔离和按智能体的会话管理。
   </Card>
   <Card title="安全" href="/gateway/security" icon="shield">
     令牌、白名单和安全控制。
   </Card>
-  <Card title="故障排除" href="/gateway/troubleshooting" icon="wrench">
+  <Card title="故障排除" href="/zh-CN/gateway/troubleshooting" icon="wrench">
     Gateway 网关诊断和常见错误。
   </Card>
-  <Card title="关于与致谢" href="/reference/credits" icon="info">
+  <Card title="关于与致谢" href="/zh-CN/reference/credits" icon="info">
     项目起源、贡献者和许可证。
   </Card>
 </Columns>

--- a/scripts/docs-i18n/masking.go
+++ b/scripts/docs-i18n/masking.go
@@ -7,16 +7,18 @@ import (
 )
 
 var (
-	inlineCodeRe  = regexp.MustCompile("`[^`]+`")
-	angleLinkRe   = regexp.MustCompile(`<https?://[^>]+>`)
-	linkURLRe     = regexp.MustCompile(`\[[^\]]*\]\(([^)]+)\)`)
-	placeholderRe = regexp.MustCompile(`__OC_I18N_\d+__`)
+	inlineCodeRe     = regexp.MustCompile("`[^`]+`")
+	angleLinkRe      = regexp.MustCompile(`<https?://[^>]+>`)
+	linkURLRe        = regexp.MustCompile(`\[[^\]]*\]\(([^)]+)\)`)
+	jsxAttributeRe   = regexp.MustCompile(`\s(href|src|action)=["'](/[^"']+)["']`)
+	placeholderRe    = regexp.MustCompile(`__OC_I18N_\d+__`)
 )
 
 func maskMarkdown(text string, nextPlaceholder func() string, placeholders *[]string, mapping map[string]string) string {
 	masked := maskMatches(text, inlineCodeRe, nextPlaceholder, placeholders, mapping)
 	masked = maskMatches(masked, angleLinkRe, nextPlaceholder, placeholders, mapping)
 	masked = maskLinkURLs(masked, nextPlaceholder, placeholders, mapping)
+	masked = maskJSXAttributes(masked, nextPlaceholder, placeholders, mapping)
 	return masked
 }
 
@@ -81,6 +83,37 @@ func unmaskMarkdown(text string, placeholders []string, mapping map[string]strin
 		out = strings.ReplaceAll(out, placeholder, original)
 	}
 	return out
+}
+
+func maskJSXAttributes(text string, nextPlaceholder func() string, placeholders *[]string, mapping map[string]string) string {
+	matches := jsxAttributeRe.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return text
+	}
+	var out strings.Builder
+	pos := 0
+	for _, match := range matches {
+		if len(match) < 4 {
+			continue
+		}
+		start, end := match[0], match[1]
+		fullMatch := text[start:end]
+		attrStart, attrEnd := match[2], match[3]
+		attrValue := text[start+attrStart : start+attrEnd]
+		if start < pos {
+			continue
+		}
+		out.WriteString(text[pos:start])
+		placeholder := nextPlaceholder()
+		mapping[placeholder] = attrValue
+		*placeholders = append(*placeholders, placeholder)
+		out.WriteString(fullMatch[:attrStart])
+		out.WriteString(placeholder)
+		out.WriteString(fullMatch[attrEnd-start:])
+		pos = end
+	}
+	out.WriteString(text[pos:])
+	return out.String()
 }
 
 func validatePlaceholders(text string, placeholders []string) error {

--- a/scripts/docs-i18n/masking.go
+++ b/scripts/docs-i18n/masking.go
@@ -70,10 +70,14 @@ func maskLinkURLs(text string, nextPlaceholder func() string, placeholders *[]st
 	return out.String()
 }
 
-func unmaskMarkdown(text string, placeholders []string, mapping map[string]string) string {
+func unmaskMarkdown(text string, placeholders []string, mapping map[string]string, tgtLang string) string {
 	out := text
 	for _, placeholder := range placeholders {
 		original := mapping[placeholder]
+		// Add locale prefix for non-English targets if it's an internal link
+		if tgtLang != "" && tgtLang != "en" && strings.HasPrefix(original, "/") && !strings.HasPrefix(original, "/"+tgtLang+"/") && !strings.HasPrefix(original, "/"+tgtLang) {
+			original = "/" + tgtLang + original
+		}
 		out = strings.ReplaceAll(out, placeholder, original)
 	}
 	return out

--- a/scripts/docs-i18n/translator.go
+++ b/scripts/docs-i18n/translator.go
@@ -19,7 +19,8 @@ const (
 var errEmptyTranslation = errors.New("empty translation")
 
 type PiTranslator struct {
-	client *pi.OneShotClient
+	client  *pi.OneShotClient
+	tgtLang string
 }
 
 func NewPiTranslator(srcLang, tgtLang string, glossary []GlossaryEntry, thinking string) (*PiTranslator, error) {
@@ -37,7 +38,7 @@ func NewPiTranslator(srcLang, tgtLang string, glossary []GlossaryEntry, thinking
 	if err != nil {
 		return nil, err
 	}
-	return &PiTranslator{client: client}, nil
+	return &PiTranslator{client: client, tgtLang: tgtLang}, nil
 }
 
 func (t *PiTranslator) Translate(ctx context.Context, text, srcLang, tgtLang string) (string, error) {
@@ -102,7 +103,7 @@ func (t *PiTranslator) translateMasked(ctx context.Context, core string) (string
 	if err := validatePlaceholders(translated, placeholders); err != nil {
 		return "", err
 	}
-	return unmaskMarkdown(translated, placeholders, mapping), nil
+	return unmaskMarkdown(translated, placeholders, mapping, t.tgtLang), nil
 }
 
 func (t *PiTranslator) translateRaw(ctx context.Context, core string) (string, error) {


### PR DESCRIPTION
## Summary

When translating docs to non-English locales (e.g., zh-CN), internal links should include the locale prefix (e.g., /start/getting-started becomes /zh-CN/start/getting-started) so users stay within the localized docs.

## Problem

Chinese users clicking on homepage cards were redirected to English documentation instead of Chinese translations because internal links in zh-CN docs didn't have the /zh-CN/ prefix.

## Solution

Modify the docs-i18n translation tool to automatically prepend the target locale to internal links during the unmask phase.

Changes:
- Added  field to  struct
- Modified  to add locale prefix to internal links (links starting with  that don't already have a locale prefix)

## Files Changed

-  - Added locale prefix logic in unmaskMarkdown
-  - Pass tgtLang to translator

## Impact

This fix ensures that all generated locale docs will have correct internal links without needing manual edits. The fix only applies to non-English targets.

## Related

- Related to Issue #41731
- Complements PR #33681 (manual zh-CN link fixes)