### PR TITLE
fix(cron): start isolated job timeout after queue wait

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -273,6 +273,7 @@ export async function runEmbeddedPiAgent(
 
   return enqueueSession(() =>
     enqueueGlobal(async () => {
+      params.onExecutionStart?.();
       const started = Date.now();
       const workspaceResolution = resolveRunWorkspaceDir({
         workspaceDir: params.workspaceDir,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -97,6 +97,7 @@ export type RunEmbeddedPiAgentParams = {
   timeoutMs: number;
   runId: string;
   abortSignal?: AbortSignal;
+  onExecutionStart?: () => void;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -203,6 +203,7 @@ export async function runCronIsolatedAgentTurn(params: {
   job: CronJob;
   message: string;
   abortSignal?: AbortSignal;
+  onExecutionStart?: () => void;
   signal?: AbortSignal;
   sessionKey: string;
   agentId?: string;
@@ -572,6 +573,7 @@ export async function runCronIsolatedAgentTurn(params: {
             const cliSessionId = cronSession.isNewSession
               ? undefined
               : getCliSessionId(cronSession.sessionEntry, providerOverride);
+            params.onExecutionStart?.();
             const result = await runCliAgent({
               sessionId: cronSession.sessionEntry.sessionId,
               sessionKey: agentSessionKey,
@@ -625,6 +627,7 @@ export async function runCronIsolatedAgentTurn(params: {
             disableMessageTool: toolPolicy.disableMessageTool,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             abortSignal,
+            onExecutionStart: params.onExecutionStart,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
           });

--- a/src/cron/service.issue-regressions.test-helpers.ts
+++ b/src/cron/service.issue-regressions.test-helpers.ts
@@ -84,8 +84,9 @@ export function createDefaultIsolatedRunner(): CronServiceOptions["runIsolatedAg
 
 export function createAbortAwareIsolatedRunner(summary = "late") {
   let observedAbortSignal: AbortSignal | undefined;
-  const runIsolatedAgentJob = vi.fn(async ({ abortSignal }) => {
+  const runIsolatedAgentJob = vi.fn(async ({ abortSignal, onExecutionStart }) => {
     observedAbortSignal = abortSignal;
+    onExecutionStart?.();
     await new Promise<void>((resolve) => {
       if (!abortSignal) {
         return;

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -25,10 +25,12 @@ import {
 import { computeJobNextRunAtMs } from "./service/jobs.js";
 import { enqueueRun, run } from "./service/ops.js";
 import { createCronServiceState, type CronEvent } from "./service/state.js";
+import * as timeoutPolicy from "./service/timeout-policy.js";
 import {
   DEFAULT_JOB_TIMEOUT_MS,
   applyJobResult,
   executeJobCore,
+  executeJobCoreWithTimeout,
   onTimer,
   runMissedJobs,
 } from "./service/timer.js";
@@ -1302,6 +1304,54 @@ describe("Cron issue regressions", () => {
     expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
     expect(runHeartbeatOnce).toHaveBeenCalled();
     expect(requestHeartbeatNow).not.toHaveBeenCalled();
+  });
+
+  it("keeps outer timeout enforcement for main-session wake-now jobs", async () => {
+    vi.useRealTimers();
+    const timeoutSpy = vi.spyOn(timeoutPolicy, "resolveCronJobTimeoutMs").mockReturnValue(20);
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const runHeartbeatOnce = vi.fn(
+      async (): Promise<HeartbeatRunResult> => ({
+        status: "skipped",
+        reason: "requests-in-flight",
+      }),
+    );
+    const mainJob: CronJob = {
+      id: "main-wrapper-timeout",
+      name: "main wrapper timeout",
+      enabled: true,
+      createdAtMs: Date.now(),
+      updatedAtMs: Date.now(),
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
+    };
+    const state = createCronServiceState({
+      cronEnabled: false,
+      storePath: "/tmp/openclaw-cron-main-timeout/jobs.json",
+      log: noopLogger,
+      nowMs: () => Date.now(),
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runHeartbeatOnce,
+      wakeNowHeartbeatBusyMaxWaitMs: DEFAULT_JOB_TIMEOUT_MS * 2,
+      wakeNowHeartbeatBusyRetryDelayMs: 60_000,
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    try {
+      await expect(executeJobCoreWithTimeout(state, mainJob)).rejects.toThrow(
+        "cron: job execution timed out",
+      );
+      expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+      expect(runHeartbeatOnce).toHaveBeenCalled();
+      expect(requestHeartbeatNow).not.toHaveBeenCalled();
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it("retries cron schedule computation from the next second when the first attempt returns undefined (#17821)", () => {

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1126,6 +1126,59 @@ describe("Cron issue regressions", () => {
     expect(job?.state.lastError).toContain("timed out");
   });
 
+  it("starts isolated timeout only after execution begins on the cron lane", async () => {
+    vi.useRealTimers();
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "timeout-after-lane-start",
+      name: "timeout after lane start",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: 0.02 },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let abortedBeforeStart = false;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(
+        async ({
+          abortSignal,
+          onExecutionStart,
+        }: {
+          abortSignal?: AbortSignal;
+          onExecutionStart?: () => void;
+        }) => {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          abortedBeforeStart = abortSignal?.aborted === true;
+          onExecutionStart?.();
+          await new Promise<void>((resolve) => {
+            if (abortSignal?.aborted) {
+              resolve();
+              return;
+            }
+            abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          return { status: "ok" as const, summary: "late" };
+        },
+      ),
+    });
+
+    await onTimer(state);
+
+    expect(abortedBeforeStart).toBe(false);
+    const job = state.store?.jobs.find((entry) => entry.id === "timeout-after-lane-start");
+    expect(job?.state.lastStatus).toBe("error");
+    expect(job?.state.lastError).toContain("timed out");
+  });
+
   it("suppresses isolated follow-up side effects after timeout", async () => {
     vi.useRealTimers();
     const store = makeStorePath();
@@ -1152,6 +1205,7 @@ describe("Cron issue regressions", () => {
       requestHeartbeatNow: vi.fn(),
       runIsolatedAgentJob: vi.fn(async (params) => {
         const abortSignal = params.abortSignal;
+        params.onExecutionStart?.();
         await new Promise<void>((resolve, reject) => {
           const onAbort = () => {
             abortSignal?.removeEventListener("abort", onAbort);
@@ -1178,6 +1232,42 @@ describe("Cron issue regressions", () => {
     expect(jobAfterTimeout?.state.lastStatus).toBe("error");
     expect(jobAfterTimeout?.state.lastError).toContain("timed out");
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("fails fast after isolated timeout even if the runner never settles", async () => {
+    vi.useRealTimers();
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "timeout-hung-runner",
+      name: "timeout hung runner",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(
+        async ({ onExecutionStart }: { onExecutionStart?: () => void }) => {
+          onExecutionStart?.();
+          await new Promise<never>(() => {});
+        },
+      ),
+    });
+
+    await onTimer(state);
+
+    const job = state.store?.jobs.find((entry) => entry.id === "timeout-hung-runner");
+    expect(job?.state.lastStatus).toBe("error");
+    expect(job?.state.lastError).toContain("timed out");
   });
 
   it("applies timeoutSeconds to manual cron.run isolated executions", async () => {
@@ -1681,30 +1771,39 @@ describe("Cron issue regressions", () => {
       nowMs: () => now,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeatNow: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
-        started = true;
-        await new Promise<void>((resolve) => {
-          if (!abortSignal) {
-            resolve();
-            return;
-          }
-          if (abortSignal.aborted) {
-            abortWallMs = Date.now();
-            resolve();
-            return;
-          }
-          abortSignal.addEventListener(
-            "abort",
-            () => {
+      runIsolatedAgentJob: vi.fn(
+        async ({
+          abortSignal,
+          onExecutionStart,
+        }: {
+          abortSignal?: AbortSignal;
+          onExecutionStart?: () => void;
+        }) => {
+          onExecutionStart?.();
+          started = true;
+          await new Promise<void>((resolve) => {
+            if (!abortSignal) {
+              resolve();
+              return;
+            }
+            if (abortSignal.aborted) {
               abortWallMs = Date.now();
               resolve();
-            },
-            { once: true },
-          );
-        });
-        now += 5;
-        return { status: "ok" as const, summary: "done" };
-      }),
+              return;
+            }
+            abortSignal.addEventListener(
+              "abort",
+              () => {
+                abortWallMs = Date.now();
+                resolve();
+              },
+              { once: true },
+            );
+          });
+          now += 5;
+          return { status: "ok" as const, summary: "done" };
+        },
+      ),
     });
 
     await onTimer(state);

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1258,7 +1258,7 @@ describe("Cron issue regressions", () => {
       runIsolatedAgentJob: vi.fn(
         async ({ onExecutionStart }: { onExecutionStart?: () => void }) => {
           onExecutionStart?.();
-          await new Promise<never>(() => {});
+          return await new Promise<never>(() => {});
         },
       ),
     });

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -84,6 +84,7 @@ export type CronServiceDeps = {
     job: CronJob;
     message: string;
     abortSignal?: AbortSignal;
+    onExecutionStart?: () => void;
   }) => Promise<
     {
       summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -632,7 +632,10 @@ export async function onTimer(state: CronServiceState) {
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
 
       try {
-        const result = await executeJobCore(state, job);
+        const result =
+          job.sessionTarget === "isolated" && job.payload.kind === "agentTurn"
+            ? await executeJobCore(state, job)
+            : await executeJobCoreWithTimeout(state, job);
         return { jobId: id, ...result, startedAt, endedAt: state.deps.nowMs() };
       } catch (err) {
         const errorText = isAbortError(err) ? timeoutErrorMessage() : String(err);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -28,6 +28,7 @@ import { DEFAULT_JOB_TIMEOUT_MS, resolveCronJobTimeoutMs } from "./timeout-polic
 export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;
+const MAX_SET_TIMEOUT_MS = 2_147_483_647;
 
 /**
  * Minimum gap between consecutive fires of the same cron job.  This is a
@@ -65,8 +66,11 @@ type StartupCatchupPlan = {
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
+  opts?: { timeoutMsOverride?: number },
 ): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
-  const jobTimeoutMs = resolveCronJobTimeoutMs(job);
+  const jobTimeoutMs = normalizeCronTimerDelayMs(
+    opts?.timeoutMsOverride ?? resolveCronJobTimeoutMs(job),
+  );
   if (typeof jobTimeoutMs !== "number") {
     return await executeJobCore(state, job);
   }
@@ -88,6 +92,30 @@ export async function executeJobCoreWithTimeout(
       clearTimeout(timeoutId);
     }
   }
+}
+
+function normalizeCronTimerDelayMs(timeoutMs: number | undefined): number | undefined {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return undefined;
+  }
+  if (timeoutMs <= 0) {
+    return undefined;
+  }
+  return Math.min(MAX_SET_TIMEOUT_MS, Math.max(1, Math.floor(timeoutMs)));
+}
+
+function resolveDueJobHardTimeoutMs(job: CronJob): number | undefined {
+  const executionTimeoutMs = normalizeCronTimerDelayMs(resolveCronJobTimeoutMs(job));
+  if (typeof executionTimeoutMs !== "number") {
+    return undefined;
+  }
+  if (job.sessionTarget !== "isolated" || job.payload.kind !== "agentTurn") {
+    return executionTimeoutMs;
+  }
+  // Queue wait on the shared cron lane should not consume the isolated run's
+  // execution budget, but timer-driven jobs still need a separate hard guard so
+  // a wedged downstream lane cannot block the scheduler indefinitely.
+  return normalizeCronTimerDelayMs(executionTimeoutMs + DEFAULT_JOB_TIMEOUT_MS);
 }
 
 function resolveRunConcurrency(state: CronServiceState): number {
@@ -632,10 +660,9 @@ export async function onTimer(state: CronServiceState) {
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
 
       try {
-        const result =
-          job.sessionTarget === "isolated" && job.payload.kind === "agentTurn"
-            ? await executeJobCore(state, job)
-            : await executeJobCoreWithTimeout(state, job);
+        const result = await executeJobCoreWithTimeout(state, job, {
+          timeoutMsOverride: resolveDueJobHardTimeoutMs(job),
+        });
         return { jobId: id, ...result, startedAt, endedAt: state.deps.nowMs() };
       } catch (err) {
         const errorText = isAbortError(err) ? timeoutErrorMessage() : String(err);
@@ -1133,27 +1160,48 @@ export async function executeJobCore(
     return resolveAbortError();
   }
 
-  const isolatedTimeoutMs = resolveCronJobTimeoutMs(job);
+  const isolatedTimeoutMs = normalizeCronTimerDelayMs(resolveCronJobTimeoutMs(job));
   const isolatedAbortController = new AbortController();
   let isolatedTimeoutId: NodeJS.Timeout | undefined;
+  let isolatedTimeoutReject: ((reason?: unknown) => void) | undefined;
+  let isolatedTimeoutStarted = false;
   const combinedAbortSignal = abortSignal
     ? AbortSignal.any([abortSignal, isolatedAbortController.signal])
     : isolatedAbortController.signal;
+  const isolatedTimeoutPromise =
+    typeof isolatedTimeoutMs === "number"
+      ? new Promise<never>((_, reject) => {
+          isolatedTimeoutReject = reject;
+        })
+      : undefined;
+  const startIsolatedTimeout = () => {
+    if (isolatedTimeoutStarted || typeof isolatedTimeoutMs !== "number") {
+      return;
+    }
+    isolatedTimeoutStarted = true;
+    isolatedTimeoutId = setTimeout(() => {
+      isolatedAbortController.abort(timeoutErrorMessage());
+      isolatedTimeoutReject?.(new Error(timeoutErrorMessage()));
+    }, isolatedTimeoutMs);
+  };
 
   try {
-    if (typeof isolatedTimeoutMs === "number") {
-      isolatedTimeoutId = setTimeout(() => {
-        isolatedAbortController.abort(timeoutErrorMessage());
-      }, isolatedTimeoutMs);
-    }
-
-    const res = await state.deps.runIsolatedAgentJob({
+    const runPromise = state.deps.runIsolatedAgentJob({
       job,
       message: job.payload.message,
       abortSignal: combinedAbortSignal,
+      onExecutionStart: startIsolatedTimeout,
     });
+    const res = isolatedTimeoutPromise
+      ? await Promise.race([runPromise, isolatedTimeoutPromise])
+      : await runPromise;
 
-    if (combinedAbortSignal.aborted) {
+    const isolatedTimedOut =
+      isolatedAbortController.signal.aborted &&
+      isolatedAbortController.signal.reason === timeoutErrorMessage();
+    const upstreamTimedOut =
+      abortSignal?.aborted === true && abortSignal.reason === timeoutErrorMessage();
+    if (isolatedTimedOut || upstreamTimedOut) {
       return { status: "error", error: timeoutErrorMessage() };
     }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -632,7 +632,7 @@ export async function onTimer(state: CronServiceState) {
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
 
       try {
-        const result = await executeJobCoreWithTimeout(state, job);
+        const result = await executeJobCore(state, job);
         return { jobId: id, ...result, startedAt, endedAt: state.deps.nowMs() };
       } catch (err) {
         const errorText = isAbortError(err) ? timeoutErrorMessage() : String(err);
@@ -1130,28 +1130,57 @@ export async function executeJobCore(
     return resolveAbortError();
   }
 
-  const res = await state.deps.runIsolatedAgentJob({
-    job,
-    message: job.payload.message,
-    abortSignal,
-  });
+  const isolatedTimeoutMs = resolveCronJobTimeoutMs(job);
+  const isolatedAbortController = new AbortController();
+  let isolatedTimeoutId: NodeJS.Timeout | undefined;
+  const combinedAbortSignal = abortSignal
+    ? AbortSignal.any([abortSignal, isolatedAbortController.signal])
+    : isolatedAbortController.signal;
 
-  if (abortSignal?.aborted) {
-    return { status: "error", error: timeoutErrorMessage() };
+  try {
+    if (typeof isolatedTimeoutMs === "number") {
+      isolatedTimeoutId = setTimeout(() => {
+        isolatedAbortController.abort(timeoutErrorMessage());
+      }, isolatedTimeoutMs);
+    }
+
+    const res = await state.deps.runIsolatedAgentJob({
+      job,
+      message: job.payload.message,
+      abortSignal: combinedAbortSignal,
+    });
+
+    if (combinedAbortSignal.aborted) {
+      return { status: "error", error: timeoutErrorMessage() };
+    }
+
+    return {
+      status: res.status,
+      error: res.error,
+      summary: res.summary,
+      delivered: res.delivered,
+      deliveryAttempted: res.deliveryAttempted,
+      sessionId: res.sessionId,
+      sessionKey: res.sessionKey,
+      model: res.model,
+      provider: res.provider,
+      usage: res.usage,
+    };
+  } catch (err) {
+    const isolatedTimedOut =
+      isolatedAbortController.signal.aborted &&
+      isolatedAbortController.signal.reason === timeoutErrorMessage();
+    const upstreamTimedOut =
+      abortSignal?.aborted === true && abortSignal.reason === timeoutErrorMessage();
+    if (isolatedTimedOut || upstreamTimedOut) {
+      return { status: "error", error: timeoutErrorMessage() };
+    }
+    throw err;
+  } finally {
+    if (isolatedTimeoutId) {
+      clearTimeout(isolatedTimeoutId);
+    }
   }
-
-  return {
-    status: res.status,
-    error: res.error,
-    summary: res.summary,
-    delivered: res.delivered,
-    deliveryAttempted: res.deliveryAttempted,
-    sessionId: res.sessionId,
-    sessionKey: res.sessionKey,
-    model: res.model,
-    provider: res.provider,
-    usage: res.usage,
-  };
 }
 
 /**

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -282,7 +282,7 @@ export function buildGatewayCronService(params: {
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },
-    runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
+    runIsolatedAgentJob: async ({ job, message, abortSignal, onExecutionStart }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       return await runCronIsolatedAgentTurn({
         cfg: runtimeConfig,
@@ -290,6 +290,7 @@ export function buildGatewayCronService(params: {
         job,
         message,
         abortSignal,
+        onExecutionStart,
         agentId,
         sessionKey: `cron:${job.id}`,
         lane: "cron",


### PR DESCRIPTION
## Summary
Fix isolated cron job timeout semantics so queue wait on the shared `cron` lane does not consume the entire execution timeout budget.

Closes #41783.

## Root cause
Before this change, `executeJobCoreWithTimeout()` started the cron job timeout timer before the isolated agent job actually got CPU on the downstream cron lane. Under contention, a job could sit queued for minutes and then immediately fail with `cron: job execution timed out` once execution finally began.

## What changed
- removed the outer timeout wrapper for due-job execution in `onTimer`
- moved isolated-agent timeout enforcement into the isolated branch of `executeJobCore()`
- start the timeout right before `runIsolatedAgentJob(...)`
- preserve upstream abort behavior by combining signals with `AbortSignal.any(...)`
- normalize timeout-triggered aborts back to `cron: job execution timed out`

## Validation
Ran targeted tests locally:
- `pnpm vitest run src/cron/service.issue-regressions.test.ts -t "suppresses isolated follow-up side effects after timeout"`
- `pnpm vitest run src/cron/service.issue-regressions.test.ts src/cron/service/timeout-policy.test.ts`

Both passed.
