### PR TITLE
fix(outbound): tolerate legacy plugin target normalizers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12608,14 +12608,14 @@
         "filename": "src/infra/outbound/message-action-runner.test.ts",
         "hashed_secret": "804ec071803318791b835cffd6e509c8d32239db",
         "is_verified": false,
-        "line_number": 180
+        "line_number": 187
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/outbound/message-action-runner.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 529
+        "line_number": 536
       }
     ],
     "src/infra/outbound/outbound.test.ts": [
@@ -13013,5 +13013,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T03:11:06Z"
+  "generated_at": "2026-03-10T06:47:43Z"
 }

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -15,6 +15,11 @@ import { loadWebMedia } from "../../web/media.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
 import { runMessageAction } from "./message-action-runner.js";
 
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(async () => null),
+  getOAuthProviders: () => [],
+}));
+
 vi.mock("../../web/media.js", async () => {
   const actual = await vi.importActual<typeof import("../../web/media.js")>("../../web/media.js");
   return {
@@ -882,6 +887,73 @@ describe("runMessageAction media caption behavior", () => {
       expect.objectContaining({
         text: "caption-only text",
         mediaUrl: "https://example.com/cat.png",
+      }),
+    );
+  });
+});
+
+describe("runMessageAction legacy target normalization compatibility", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+    vi.clearAllMocks();
+  });
+
+  it("sends through plugins that still return { ok, to } from normalizeTarget", async () => {
+    const sendText = vi.fn().mockResolvedValue({
+      channel: "qqbot",
+      messageId: "qq-msg-1",
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "qqbot",
+          source: "test",
+          plugin: {
+            ...createOutboundTestPlugin({
+              id: "qqbot",
+              outbound: {
+                deliveryMode: "direct",
+                sendText,
+                sendMedia: vi.fn().mockResolvedValue({
+                  channel: "qqbot",
+                  messageId: "qq-media-1",
+                }),
+              },
+            }),
+            messaging: {
+              normalizeTarget: (raw: string) => ({ ok: true, to: `qqbot:${raw}` }),
+              targetResolver: {
+                looksLikeId: (raw: string) => /^(c2c|group|channel):/i.test(raw),
+              },
+            },
+          } as ChannelPlugin,
+        },
+      ]),
+    );
+
+    const result = await runMessageAction({
+      cfg: {
+        channels: {
+          qqbot: {
+            enabled: true,
+          },
+        },
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "qqbot",
+        target: "c2c:0123456789ABCDEF0123456789ABCDEF",
+        message: "hi",
+      },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "qqbot:c2c:0123456789ABCDEF0123456789ABCDEF",
+        text: "hi",
       }),
     );
   });

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -15,6 +15,8 @@ import { loadWebMedia } from "../../web/media.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
 import { runMessageAction } from "./message-action-runner.js";
 
+// Current local dependency resolution can miss the oauth subpath export; this
+// keeps the runner tests focused on outbound behavior.
 vi.mock("@mariozechner/pi-ai/oauth", () => ({
   getOAuthApiKey: vi.fn(async () => null),
   getOAuthProviders: () => [],
@@ -903,6 +905,10 @@ describe("runMessageAction legacy target normalization compatibility", () => {
       channel: "qqbot",
       messageId: "qq-msg-1",
     });
+    const legacyNormalizeTarget = ((raw: string) => ({
+      ok: true,
+      to: `qqbot:${raw}`,
+    })) as unknown as NonNullable<ChannelPlugin["messaging"]>["normalizeTarget"];
 
     setActivePluginRegistry(
       createTestRegistry([
@@ -922,12 +928,12 @@ describe("runMessageAction legacy target normalization compatibility", () => {
               },
             }),
             messaging: {
-              normalizeTarget: (raw: string) => ({ ok: true, to: `qqbot:${raw}` }),
+              normalizeTarget: legacyNormalizeTarget,
               targetResolver: {
                 looksLikeId: (raw: string) => /^(c2c|group|channel):/i.test(raw),
               },
             },
-          } as ChannelPlugin,
+          },
         },
       ]),
     );

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -14,6 +14,11 @@ type TargetNormalizerCacheEntry = {
 
 const targetNormalizerCacheByChannelId = new Map<string, TargetNormalizerCacheEntry>();
 
+type LegacyTargetNormalizerResult = {
+  ok?: boolean;
+  to?: unknown;
+};
+
 function resolveTargetNormalizer(channelId: ChannelId): TargetNormalizer {
   const version = getActivePluginRegistryVersion();
   const cached = targetNormalizerCacheByChannelId.get(channelId);
@@ -39,8 +44,25 @@ export function normalizeTargetForProvider(provider: string, raw?: string): stri
   }
   const providerId = normalizeChannelId(provider);
   const normalizer = providerId ? resolveTargetNormalizer(providerId) : undefined;
-  const normalized = normalizer?.(raw) ?? fallback;
+  const candidate = normalizer?.(raw);
+  const normalized =
+    typeof candidate === "string"
+      ? candidate
+      : isLegacyTargetNormalizerResult(candidate)
+        ? readLegacyTarget(candidate)
+        : fallback;
   return normalized || undefined;
+}
+
+function isLegacyTargetNormalizerResult(value: unknown): value is LegacyTargetNormalizerResult {
+  return typeof value === "object" && value !== null && ("ok" in value || "to" in value);
+}
+
+function readLegacyTarget(value: LegacyTargetNormalizerResult): string | undefined {
+  if (typeof value.to === "string" && value.to.trim()) {
+    return value.to.trim();
+  }
+  return undefined;
 }
 
 export function buildTargetResolverSignature(channel: ChannelId): string {

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -48,7 +48,10 @@ export function normalizeTargetForProvider(provider: string, raw?: string): stri
   const normalized =
     typeof candidate === "string"
       ? candidate
-      : isLegacyTargetNormalizerResult(candidate)
+      : // Some older/out-of-tree plugins returned `{ ok, to }` instead of a plain
+        // string. Keep the runtime path tolerant so generic message sends keep
+        // working even when plugin typings lag behind core.
+        isLegacyTargetNormalizerResult(candidate)
         ? readLegacyTarget(candidate)
         : fallback;
   return normalized || undefined;

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -75,4 +75,33 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listGroups).not.toHaveBeenCalled();
     expect(mocks.listGroupsLive).not.toHaveBeenCalled();
   });
+
+  it("accepts legacy object-shaped plugin target normalization results", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      messaging: {
+        normalizeTarget: (raw: string) => ({ ok: true, to: `qqbot:${raw}` }),
+        targetResolver: {
+          looksLikeId: (raw: string) => /^(c2c|group|channel):/i.test(raw),
+        },
+      },
+      directory: {
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+    });
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "qqbot",
+      input: "c2c:0123456789ABCDEF0123456789ABCDEF",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.target.source).toBe("normalized");
+      expect(result.target.to).toBe("qqbot:c2c:0123456789ABCDEF0123456789ABCDEF");
+    }
+    expect(mocks.listGroups).not.toHaveBeenCalled();
+    expect(mocks.listGroupsLive).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: `openclaw message send` could fail with `ToolInputError: to required` when a channel plugin returned a legacy object-shaped `{ ok, to }` value from `messaging.normalizeTarget`.
- Why it matters: the generic outbound send path treated that object as the normalized target, so `params.to` stopped being a string before send execution.
- What changed: core target normalization now extracts string targets from legacy object results, and regression tests cover both target resolution and full `runMessageAction("send")` dispatch.
- What did NOT change (scope boundary): this does not change plugin SDK contracts or qqbot-specific target parsing rules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`openclaw message send --channel qqbot --target c2c:<id> ...` no longer fails early when the installed plugin still returns legacy object-shaped target normalization results.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: Node 22 via pnpm / Vitest
- Model/provider: N/A
- Integration/channel (if any): qqbot-style plugin target normalization
- Relevant config (redacted): test plugin registry; local qqbot install used only for manual investigation

### Steps

1. Register a channel plugin whose `messaging.normalizeTarget` returns `{ ok: true, to: "qqbot:c2c:..." }`.
2. Run `runMessageAction({ action: "send", params: { channel: "qqbot", target: "c2c:...", message: "hi" } })`.
3. Observe the target forwarded into outbound send.

### Expected

- The normalized target stays a string and outbound send executes.

### Actual

- Before this patch, the legacy object could flow through as `params.to`, which then failed string validation with `to required`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run --config vitest.unit.config.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/message-action-runner.test.ts`; `pnpm exec oxfmt --check src/infra/outbound/target-normalization.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/message-action-runner.test.ts`; `pnpm exec oxlint src/infra/outbound/target-normalization.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/message-action-runner.test.ts`
- Edge cases checked: direct-id resolution still skips directory lookup; full send path forwards a string `to` even with legacy object normalization.
- What you did **not** verify: source-CLI end-to-end send on this checkout is currently blocked before message handling by an unrelated `@mariozechner/pi-ai/oauth` export mismatch in local dependencies.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore strict string-only plugin normalization.
- Files/config to restore: `src/infra/outbound/target-normalization.ts`
- Known bad symptoms reviewers should watch for: plugins returning malformed objects without a `to` string should still fall back to existing unknown-target handling.

## Risks and Mitigations

- Risk: accepting legacy object-shaped normalizer results could hide malformed plugin behavior.
- Mitigation: the compatibility layer only extracts a trimmed string `to`; invalid objects continue through the existing fallback/validation path.
