### PR TITLE
fix(auth): ownerAllowFrom wildcard now grants senderIsOwner

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -346,7 +346,7 @@ export function resolveCommandAuthorization(params: {
   const senderId = matchedSender ?? senderCandidates[0];
 
   const enforceOwner = Boolean(dock?.commands?.enforceOwnerForCommands);
-  const senderIsOwnerByIdentity = Boolean(matchedSender);
+  const senderIsOwnerByIdentity = ownerAllowAll || Boolean(matchedSender);
   const senderIsOwnerByScope =
     isInternalMessageChannel(ctx.Provider) &&
     Array.isArray(ctx.GatewayClientScopes) &&

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -124,6 +124,27 @@ describe("resolveCommandAuthorization", () => {
     expect(otherAuth.isAuthorizedSender).toBe(false);
   });
 
+  it("treats all senders as owner when ownerAllowFrom is wildcard", () => {
+    const cfg = {
+      commands: { ownerAllowFrom: ["*"] },
+      channels: { slack: {} },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "slack",
+      Surface: "slack",
+      From: "slack:U0XXXXXXXXX",
+      SenderId: "U0XXXXXXXXX",
+    } as MsgContext;
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("uses owner allowlist override from context when configured", () => {
     setActivePluginRegistry(
       createTestRegistry([


### PR DESCRIPTION
## Summary

- Problem: Setting `commands.ownerAllowFrom: ["*"]` correctly authorizes commands but does not set `senderIsOwner = true`. Owner-only tools (cron, gateway management) check `senderIsOwner` and remain hidden even when the wildcard is configured.
- Why it matters: Operators who use `ownerAllowFrom: ["*"]` to grant owner access from any source cannot use owner-only tools like cron scheduling.
- What changed: The wildcard `"*"` match in `ownerAllowFrom` now sets `senderIsOwner = true`, making owner-only tools visible and functional.
- What did NOT change: Non-wildcard `ownerAllowFrom` behavior unchanged. Command authorization logic unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25286

## User-visible / Behavior Changes

`ownerAllowFrom: ["*"]` now grants full owner status including visibility of owner-only tools (cron, gateway). Previously these tools were hidden despite the wildcard.

## Security Impact (required)

- New permissions/capabilities? No — wildcard already granted command authorization; this aligns tool visibility with that authorization
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — owner-only tools become visible when wildcard is set (matching the intended behavior of the wildcard)
- Data access scope changed? No
- Risk + mitigation: This is a correctness fix. The wildcard was already documented as granting owner access — tool visibility was inconsistently not reflecting that. No new capabilities beyond what operators already configured.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js
- Model/provider: Any
- Integration/channel: Any
- Relevant config: `commands.ownerAllowFrom: ["*"]`

### Steps

1. Set `commands.ownerAllowFrom: ["*"]` in config
2. Send a message from any source
3. Check available tools

### Expected

- Owner-only tools (cron, gateway) are visible.

### Actual

- Before: Owner-only tools hidden despite wildcard.
- After: Owner-only tools visible and functional.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test in `command-control.test.ts` verifies `senderIsOwner` is `true` when wildcard matches.

## Human Verification (required)

- Verified scenarios: Tested on a fork. Cron and gateway tools visible with wildcard config.
- Edge cases checked: Non-wildcard entries still require exact match for `senderIsOwner`. Empty array still denies.
- What you did **not** verify: Interaction with every possible auth configuration combination.

## Review Conversations

N/A — fresh PR, no review conversations yet.

## Compatibility / Migration

- Backward compatible? Yes — only affects behavior when wildcard is explicitly configured
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the one-line change in `command-auth.ts`.
- Files/config to restore: `src/auto-reply/command-auth.ts`
- Known bad symptoms: Owner-only tools appearing for non-owner sources (would indicate wildcard matching too broadly).

## Risks and Mitigations

None — aligns tool visibility with already-granted authorization.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)