### PR TITLE
fix(daemon): harden macOS LaunchAgent restart

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -336,6 +336,18 @@ describe("launchd install", () => {
         OPENCLAW_SERVICE_KIND: "node",
       }),
     ).toBe(false);
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        XPC_SERVICE_NAME: "ai.openclaw.gateway",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        XPC_SERVICE_NAME: "com.other.service",
+      }),
+    ).toBe(false);
   });
 
   it("restarts a loaded LaunchAgent with kickstart only", async () => {
@@ -416,11 +428,10 @@ describe("launchd install", () => {
         stdio: "ignore",
       }),
     );
-    expect(
-      Array.from(state.files.values()).some((content) =>
-        content.includes("launchctl kickstart -k"),
-      ),
-    ).toBe(true);
+    const [scriptPath, scriptContent] = Array.from(state.files.entries())[0] ?? [];
+    expect(scriptPath).toMatch(/openclaw-launchd-restart-[0-9a-f-]+\.sh$/);
+    expect(scriptContent).toContain("launchctl kickstart -k");
+    expect(scriptContent).toContain("grep -qiE 'no such process|could not find service|not found'");
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,6 +11,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  shouldUseDetachedLaunchAgentRestart,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -18,6 +19,8 @@ const state = vi.hoisted(() => ({
   listOutput: "",
   printOutput: "",
   bootstrapError: "",
+  kickstartResponses: [] as Array<{ stdout: string; stderr: string; code: number }>,
+  spawnCalls: [] as Array<{ file: string; args: string[]; options: Record<string, unknown> }>,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -49,7 +52,19 @@ vi.mock("./exec-file.js", () => ({
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
     }
+    if (call[0] === "kickstart" && state.kickstartResponses.length > 0) {
+      return state.kickstartResponses.shift()!;
+    }
     return { stdout: "", stderr: "", code: 0 };
+  }),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn((file: string, args: string[], options: Record<string, unknown>) => {
+    state.spawnCalls.push({ file, args, options });
+    return {
+      unref: vi.fn(),
+    };
   }),
 }));
 
@@ -109,6 +124,8 @@ beforeEach(() => {
   state.listOutput = "";
   state.printOutput = "";
   state.bootstrapError = "";
+  state.kickstartResponses.length = 0;
+  state.spawnCalls.length = 0;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -304,8 +321,55 @@ describe("launchd install", () => {
     expect(state.fileModes.get(plistPath)).toBe(0o644);
   });
 
-  it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {
+  it("detects gateway service env as detached-restart context", () => {
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "node",
+      }),
+    ).toBe(false);
+  });
+
+  it("restarts a loaded LaunchAgent with kickstart only", async () => {
     const env = createDefaultLaunchdEnv();
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const serviceId = `${domain}/${label}`;
+    const kickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
+    );
+
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout")).toBe(false);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(false);
+    expect(state.launchctlCalls.some((c) => c[0] === "enable")).toBe(false);
+  });
+
+  it("bootstraps when kickstart reports the LaunchAgent is not loaded", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.kickstartResponses.push(
+      {
+        stdout: "",
+        stderr:
+          'Bad request. Could not find service "ai.openclaw.gateway" in domain for user gui: 501',
+        code: 1,
+      },
+      { stdout: "", stderr: "", code: 0 },
+    );
+
     await restartLaunchAgent({
       env,
       stdout: new PassThrough(),
@@ -315,62 +379,48 @@ describe("launchd install", () => {
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
     const serviceId = `${domain}/${label}`;
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === serviceId,
-    );
     const enableIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "enable" && c[1] === serviceId,
     );
     const bootstrapIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
     );
-    const kickstartIndex = state.launchctlCalls.findIndex(
+    const kickstartCalls = state.launchctlCalls.filter(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
-    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
     expect(enableIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(enableIndex);
-    expect(enableIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
+    expect(kickstartCalls).toHaveLength(2);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout")).toBe(false);
   });
 
-  it("waits for previous launchd pid to exit before bootstrapping", async () => {
-    const env = createDefaultLaunchdEnv();
-    state.printOutput = ["state = running", "pid = 4242"].join("\n");
-    const killSpy = vi.spyOn(process, "kill");
-    killSpy
-      .mockImplementationOnce(() => true)
-      .mockImplementationOnce(() => {
-        const err = new Error("no such process") as NodeJS.ErrnoException;
-        err.code = "ESRCH";
-        throw err;
-      });
+  it("uses a detached helper when restart is invoked from the managed gateway process tree", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
+    };
 
-    vi.useFakeTimers();
-    try {
-      const restartPromise = restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      });
-      await vi.advanceTimersByTimeAsync(250);
-      await restartPromise;
-      expect(killSpy).toHaveBeenCalledWith(4242, 0);
-      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-      const label = "ai.openclaw.gateway";
-      const bootoutIndex = state.launchctlCalls.findIndex(
-        (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
-      );
-      const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
-      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-      expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    } finally {
-      vi.useRealTimers();
-      killSpy.mockRestore();
-    }
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    expect(state.launchctlCalls).toEqual([]);
+    expect(state.spawnCalls).toHaveLength(1);
+    expect(state.spawnCalls[0]?.file).toBe("/bin/sh");
+    expect(state.spawnCalls[0]?.options).toEqual(
+      expect.objectContaining({
+        detached: true,
+        stdio: "ignore",
+      }),
+    );
+    expect(
+      Array.from(state.files.values()).some((content) =>
+        content.includes("launchctl kickstart -k"),
+      ),
+    ).toBe(true);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -393,17 +394,26 @@ async function prepareDetachedLaunchAgentRestartScript(
   plistPath: string,
 ): Promise<string | null> {
   try {
-    const scriptPath = path.join(os.tmpdir(), `openclaw-launchd-restart-${Date.now()}.sh`);
+    const scriptId = randomUUID();
+    const scriptPath = path.join(os.tmpdir(), `openclaw-launchd-restart-${scriptId}.sh`);
+    const kickstartErrPath = path.join(os.tmpdir(), `openclaw-launchd-kickstart-${scriptId}.log`);
     const escapedServiceId = shellEscape(serviceId);
     const escapedDomain = shellEscape(domain);
     const escapedPlistPath = shellEscape(plistPath);
+    const escapedKickstartErrPath = shellEscape(kickstartErrPath);
     const scriptContent = `#!/bin/sh
 sleep 1
-if ! launchctl kickstart -k '${escapedServiceId}' 2>/dev/null; then
+if launchctl kickstart -k '${escapedServiceId}' >'${escapedKickstartErrPath}' 2>&1; then
+  rm -f '${escapedKickstartErrPath}'
+  rm -f "$0"
+  exit 0
+fi
+if grep -qiE 'no such process|could not find service|not found' '${escapedKickstartErrPath}' 2>/dev/null; then
   launchctl enable '${escapedServiceId}' 2>/dev/null
   launchctl bootstrap '${escapedDomain}' '${escapedPlistPath}' 2>/dev/null
   launchctl kickstart -k '${escapedServiceId}' 2>/dev/null || true
 fi
+rm -f '${escapedKickstartErrPath}'
 rm -f "$0"
 `;
     await fs.writeFile(scriptPath, scriptContent, {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,6 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import {
@@ -27,6 +29,7 @@ import type {
 
 const LAUNCH_AGENT_DIR_MODE = 0o755;
 const LAUNCH_AGENT_PLIST_MODE = 0o644;
+const DETACHED_RESTART_SCRIPT_MODE = 0o700;
 
 function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefined> }): string {
   const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();
@@ -106,6 +109,10 @@ async function execLaunchctl(
   const file = isWindows ? (process.env.ComSpec ?? "cmd.exe") : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
   return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
+}
+
+function shellEscape(value: string): string {
+  return value.replace(/'/g, "'\\''");
 }
 
 function resolveGuiDomain(): string {
@@ -352,32 +359,69 @@ function isUnsupportedGuiDomain(detail: string): boolean {
   );
 }
 
-const RESTART_PID_WAIT_TIMEOUT_MS = 10_000;
-const RESTART_PID_WAIT_INTERVAL_MS = 200;
-
-async function sleepMs(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+function formatLaunchAgentBootstrapError(detail: string, domain: string): Error {
+  if (isUnsupportedGuiDomain(detail)) {
+    return new Error(
+      [
+        `launchctl bootstrap failed: ${detail}`,
+        `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
+        "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
+        "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway restart`.",
+        "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
+      ].join("\n"),
+    );
+  }
+  return new Error(`launchctl bootstrap failed: ${detail}`);
 }
 
-async function waitForPidExit(pid: number): Promise<void> {
-  if (!Number.isFinite(pid) || pid <= 1) {
-    return;
+export function shouldUseDetachedLaunchAgentRestart(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): boolean {
+  const marker = env.OPENCLAW_SERVICE_MARKER?.trim();
+  const serviceKind = env.OPENCLAW_SERVICE_KIND?.trim();
+  if (marker === "openclaw" && serviceKind === "gateway") {
+    return true;
   }
-  const deadline = Date.now() + RESTART_PID_WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ESRCH" || code === "EPERM") {
-        return;
-      }
-      return;
-    }
-    await sleepMs(RESTART_PID_WAIT_INTERVAL_MS);
+
+  const label = resolveLaunchAgentLabel({ env });
+  return env.XPC_SERVICE_NAME?.trim() === label;
+}
+
+async function prepareDetachedLaunchAgentRestartScript(
+  serviceId: string,
+  domain: string,
+  plistPath: string,
+): Promise<string | null> {
+  try {
+    const scriptPath = path.join(os.tmpdir(), `openclaw-launchd-restart-${Date.now()}.sh`);
+    const escapedServiceId = shellEscape(serviceId);
+    const escapedDomain = shellEscape(domain);
+    const escapedPlistPath = shellEscape(plistPath);
+    const scriptContent = `#!/bin/sh
+sleep 1
+if ! launchctl kickstart -k '${escapedServiceId}' 2>/dev/null; then
+  launchctl enable '${escapedServiceId}' 2>/dev/null
+  launchctl bootstrap '${escapedDomain}' '${escapedPlistPath}' 2>/dev/null
+  launchctl kickstart -k '${escapedServiceId}' 2>/dev/null || true
+fi
+rm -f "$0"
+`;
+    await fs.writeFile(scriptPath, scriptContent, {
+      encoding: "utf8",
+      mode: DETACHED_RESTART_SCRIPT_MODE,
+    });
+    return scriptPath;
+  } catch {
+    return null;
   }
+}
+
+async function runDetachedLaunchAgentRestart(scriptPath: string): Promise<void> {
+  const child = spawn("/bin/sh", [scriptPath], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
 }
 
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
@@ -476,47 +520,52 @@ export async function restartLaunchAgent({
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const serviceId = `${domain}/${label}`;
 
-  const runtime = await execLaunchctl(["print", `${domain}/${label}`]);
-  const previousPid =
-    runtime.code === 0
-      ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
-      : undefined;
-
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
-    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
+  if (shouldUseDetachedLaunchAgentRestart(serviceEnv)) {
+    const scriptPath = await prepareDetachedLaunchAgentRestartScript(serviceId, domain, plistPath);
+    if (scriptPath) {
+      await runDetachedLaunchAgentRestart(scriptPath);
+      try {
+        stdout.write(`${formatLine("Scheduled LaunchAgent restart", serviceId)}\n`);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+          throw err;
+        }
+      }
+      return;
+    }
   }
-  if (typeof previousPid === "number") {
-    await waitForPidExit(previousPid);
+
+  const start = await execLaunchctl(["kickstart", "-k", serviceId]);
+  if (start.code === 0) {
+    try {
+      stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+        throw err;
+      }
+    }
+    return;
+  }
+  if (!isLaunchctlNotLoaded(start)) {
+    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
 
-  // launchd can persist "disabled" state after bootout; clear it before bootstrap
-  // (matches the same guard in installLaunchAgent).
-  await execLaunchctl(["enable", `${domain}/${label}`]);
+  // launchd can persist "disabled" state while the plist still exists; clear it before bootstrap.
+  await execLaunchctl(["enable", serviceId]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();
-    if (isUnsupportedGuiDomain(detail)) {
-      throw new Error(
-        [
-          `launchctl bootstrap failed: ${detail}`,
-          `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
-          "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
-          "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway restart`.",
-          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
-        ].join("\n"),
-      );
-    }
-    throw new Error(`launchctl bootstrap failed: ${detail}`);
+    throw formatLaunchAgentBootstrapError(detail, domain);
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
-  if (start.code !== 0) {
-    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+  const retry = await execLaunchctl(["kickstart", "-k", serviceId]);
+  if (retry.code !== 0) {
+    throw new Error(`launchctl kickstart failed: ${retry.stderr || retry.stdout}`.trim());
   }
   try {
-    stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+    stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
       throw err;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: macOS `restartLaunchAgent()` still used a destructive synchronous restart path that could unload the service, and it could kill its own caller when `openclaw gateway restart` was invoked from inside the managed gateway process tree.
- Why it matters: assistant/tool-driven restarts can strand the LaunchAgent offline, and even normal macOS restarts took a more fragile unload/re-bootstrap path than necessary.
- What changed: `restartLaunchAgent()` now tries `launchctl kickstart -k` first, falls back to `enable -> bootstrap -> kickstart` only when the service is not loaded, and schedules a detached helper when the caller is already inside the managed gateway process tree.
- What did NOT change (scope boundary): install/stop/uninstall flows and non-macOS service managers are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41815
- Related #40905
- Related #41198
- Related #41311
- Related #41353

## User-visible / Behavior Changes

On macOS, `openclaw gateway restart` now:

- uses `launchctl kickstart -k` as the primary restart path for a loaded LaunchAgent,
- re-bootstraps from the existing plist only when launchd says the service is not loaded,
- and schedules a detached restart helper instead of tearing down its own process tree when the caller is already running under the managed gateway LaunchAgent.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (Yes)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

This adds an internal-only detached `/bin/sh` helper on the macOS LaunchAgent restart path. The script is generated from internal launchd identifiers and plist paths, all values are shell-escaped, the file is written with mode `0700`, and it deletes itself after execution.

## Repro + Verification

### Environment

- OS: macOS 26.3 (Apple Silicon)
- Runtime/container: Node v25.6.1
- Model/provider: N/A
- Integration/channel (if any): macOS launchd LaunchAgent
- Relevant config (redacted): running LaunchAgent env exposes `OPENCLAW_SERVICE_MARKER=openclaw`, `OPENCLAW_SERVICE_KIND=gateway`, `XPC_SERVICE_NAME=ai.openclaw.gateway`

### Steps

1. Install the gateway as a macOS LaunchAgent.
2. Invoke restart while the service is already loaded, or invoke restart from a child of the managed gateway process tree.
3. Observe whether the service restarts atomically or gets unloaded before recovery can run.

### Expected

- Loaded LaunchAgents restart via `kickstart -k`.
- Unloaded-but-installed LaunchAgents recover via `enable -> bootstrap -> kickstart`.
- Managed self-restart paths survive gateway teardown by delegating recovery to a detached helper.

### Actual

- Before this change, the same path used a synchronous unload/re-bootstrap flow and could kill its own caller before bootstrap happened.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run locally:

```bash
pnpm exec vitest run src/daemon/launchd.test.ts
pnpm exec vitest run --config vitest.e2e.config.ts src/daemon/launchd.integration.e2e.test.ts
NODE_OPTIONS=--max-old-space-size=4096 pnpm exec tsc -p tsconfig.json --noEmit --pretty false
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: updated unit coverage for loaded launch agent restart, unloaded bootstrap recovery, and managed-process-tree detached restart; ran the macOS launchd integration test successfully on a local Apple Silicon machine.
- Edge cases checked: GUI-domain bootstrap errors still surface actionable guidance; detached helper path only activates when gateway supervision markers are present.
- What you did **not** verify: I did not intentionally break the live gateway on the running machine by reproducing the agent-exec outage path against the production service.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/daemon/launchd.ts`, `src/daemon/launchd.test.ts`
- Known bad symptoms reviewers should watch for: restart prints `Scheduled LaunchAgent restart` or `Restarted LaunchAgent` but the macOS LaunchAgent does not come back.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: temp-script creation can fail on unusual environments.
  - Mitigation: the code falls back to the in-process `kickstart/bootstrap` path instead of failing the restart upfront.
- Risk: detached helper could mis-handle shell values.
  - Mitigation: launchd identifiers and plist paths are shell-escaped before script generation, and coverage asserts the helper content/path creation path.
