### PR TITLE
fix(ui): avoid auth hint for generic connect failures

### DIFF
--- a/ui/src/ui/views/overview-hints.ts
+++ b/ui/src/ui/views/overview-hints.ts
@@ -14,3 +14,57 @@ export function shouldShowPairingHint(
   }
   return lastError.toLowerCase().includes("pairing required");
 }
+
+type AuthHintKind = "required" | "failed";
+
+const authRequiredCodes = new Set<string>([
+  ConnectErrorDetailCodes.AUTH_REQUIRED,
+  ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+  ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
+  ConnectErrorDetailCodes.AUTH_TOKEN_NOT_CONFIGURED,
+  ConnectErrorDetailCodes.AUTH_PASSWORD_NOT_CONFIGURED,
+]);
+
+const authFailureCodes = new Set<string>([
+  ...authRequiredCodes,
+  ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
+  ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
+  ConnectErrorDetailCodes.AUTH_TAILSCALE_IDENTITY_MISSING,
+  ConnectErrorDetailCodes.AUTH_TAILSCALE_PROXY_MISSING,
+  ConnectErrorDetailCodes.AUTH_TAILSCALE_WHOIS_FAILED,
+  ConnectErrorDetailCodes.AUTH_TAILSCALE_IDENTITY_MISMATCH,
+]);
+
+/**
+ * Return the overview auth hint to show, if any.
+ *
+ * Keep fallback string matching narrow so generic "connect failed" close reasons
+ * do not get misclassified as token/password problems.
+ */
+export function resolveAuthHintKind(params: {
+  connected: boolean;
+  lastError: string | null;
+  lastErrorCode?: string | null;
+  hasToken: boolean;
+  hasPassword: boolean;
+}): AuthHintKind | null {
+  if (params.connected || !params.lastError) {
+    return null;
+  }
+  if (params.lastErrorCode) {
+    if (!authFailureCodes.has(params.lastErrorCode)) {
+      return null;
+    }
+    return authRequiredCodes.has(params.lastErrorCode) ? "required" : "failed";
+  }
+
+  const lower = params.lastError.toLowerCase();
+  const authFailed = lower.includes("unauthorized");
+  if (!authFailed) {
+    return null;
+  }
+  return !params.hasToken && !params.hasPassword ? "required" : "failed";
+}

--- a/ui/src/ui/views/overview.node.test.ts
+++ b/ui/src/ui/views/overview.node.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../../src/gateway/protocol/connect-error-details.js";
-import { shouldShowPairingHint } from "./overview-hints.ts";
+import { resolveAuthHintKind, shouldShowPairingHint } from "./overview-hints.ts";
 
 describe("shouldShowPairingHint", () => {
   it("returns true for 'pairing required' close reason", () => {
@@ -35,5 +35,55 @@ describe("shouldShowPairingHint", () => {
         ConnectErrorDetailCodes.PAIRING_REQUIRED,
       ),
     ).toBe(true);
+  });
+});
+
+describe("resolveAuthHintKind", () => {
+  it("returns required for structured auth-required codes", () => {
+    expect(
+      resolveAuthHintKind({
+        connected: false,
+        lastError: "disconnected (4008): connect failed",
+        lastErrorCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+        hasToken: false,
+        hasPassword: false,
+      }),
+    ).toBe("required");
+  });
+
+  it("returns failed for structured auth mismatch codes", () => {
+    expect(
+      resolveAuthHintKind({
+        connected: false,
+        lastError: "disconnected (4008): connect failed",
+        lastErrorCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+        hasToken: true,
+        hasPassword: false,
+      }),
+    ).toBe("failed");
+  });
+
+  it("does not treat generic connect failures as auth failures", () => {
+    expect(
+      resolveAuthHintKind({
+        connected: false,
+        lastError: "disconnected (4008): connect failed",
+        lastErrorCode: ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED,
+        hasToken: true,
+        hasPassword: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to unauthorized string matching without structured codes", () => {
+    expect(
+      resolveAuthHintKind({
+        connected: false,
+        lastError: "disconnected (4008): unauthorized",
+        lastErrorCode: null,
+        hasToken: true,
+        hasPassword: false,
+      }),
+    ).toBe("failed");
   });
 });

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -6,7 +6,7 @@ import { formatRelativeTimestamp, formatDurationHuman } from "../format.ts";
 import type { GatewayHelloOk } from "../gateway.ts";
 import { formatNextRun } from "../presenter.ts";
 import type { UiSettings } from "../storage.ts";
-import { shouldShowPairingHint } from "./overview-hints.ts";
+import { resolveAuthHintKind, shouldShowPairingHint } from "./overview-hints.ts";
 
 export type OverviewProps = {
   connected: boolean;
@@ -71,41 +71,17 @@ export function renderOverview(props: OverviewProps) {
   })();
 
   const authHint = (() => {
-    if (props.connected || !props.lastError) {
+    const authHintKind = resolveAuthHintKind({
+      connected: props.connected,
+      lastError: props.lastError,
+      lastErrorCode: props.lastErrorCode,
+      hasToken: Boolean(props.settings.token.trim()),
+      hasPassword: Boolean(props.password.trim()),
+    });
+    if (authHintKind == null) {
       return null;
     }
-    const lower = props.lastError.toLowerCase();
-    const authRequiredCodes = new Set<string>([
-      ConnectErrorDetailCodes.AUTH_REQUIRED,
-      ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
-      ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
-      ConnectErrorDetailCodes.AUTH_TOKEN_NOT_CONFIGURED,
-      ConnectErrorDetailCodes.AUTH_PASSWORD_NOT_CONFIGURED,
-    ]);
-    const authFailureCodes = new Set<string>([
-      ...authRequiredCodes,
-      ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
-      ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
-      ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
-      ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
-      ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
-      ConnectErrorDetailCodes.AUTH_TAILSCALE_IDENTITY_MISSING,
-      ConnectErrorDetailCodes.AUTH_TAILSCALE_PROXY_MISSING,
-      ConnectErrorDetailCodes.AUTH_TAILSCALE_WHOIS_FAILED,
-      ConnectErrorDetailCodes.AUTH_TAILSCALE_IDENTITY_MISMATCH,
-    ]);
-    const authFailed = props.lastErrorCode
-      ? authFailureCodes.has(props.lastErrorCode)
-      : lower.includes("unauthorized") || lower.includes("connect failed");
-    if (!authFailed) {
-      return null;
-    }
-    const hasToken = Boolean(props.settings.token.trim());
-    const hasPassword = Boolean(props.password.trim());
-    const isAuthRequired = props.lastErrorCode
-      ? authRequiredCodes.has(props.lastErrorCode)
-      : !hasToken && !hasPassword;
-    if (isAuthRequired) {
+    if (authHintKind === "required") {
       return html`
         <div class="muted" style="margin-top: 8px">
           ${t("overview.auth.required")}


### PR DESCRIPTION
## Summary

- Problem: Control UI overview can show auth-token remediation for generic `connect failed` errors even when the structured error code points at a non-auth root cause.
- Why it matters: users get sent down the wrong recovery path for pairing/device-identity failures and other non-auth connection problems.
- What changed: extracted auth-hint classification into a helper that trusts structured auth codes and only falls back to unstructured `unauthorized` text, plus added focused regression tests.
- What did NOT change (scope boundary): this PR does not change the underlying gateway error messages or the insecure-context/pairing hint flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41618
- Related #41605

## User-visible / Behavior Changes

When the overview gets a generic `connect failed` error with a non-auth structured detail code such as `CONTROL_UI_DEVICE_IDENTITY_REQUIRED`, it no longer shows the auth-token remediation hint.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node v20.20.1, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Control UI overview
- Relevant config (redacted): N/A

### Steps

1. Disconnect the Control UI so the overview renders the `lastError` callout.
2. Provide `lastError="disconnected (4008): connect failed"` and `lastErrorCode=CONTROL_UI_DEVICE_IDENTITY_REQUIRED`.
3. Observe the auth-token hint before and after this patch.

### Expected

- Non-auth structured error codes should not trigger auth-token remediation guidance.

### Actual

- The previous fallback treated generic `connect failed` text as an auth failure, so the overview could show the wrong auth hint.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused regression test now passes:

- `cmd /c ..\node_modules\.bin\vitest.CMD run --config vitest.node.config.ts src/ui/views/overview.node.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: helper returns `required` for `AUTH_TOKEN_MISSING`, `failed` for `AUTH_TOKEN_MISMATCH`, `null` for `CONTROL_UI_DEVICE_IDENTITY_REQUIRED` with generic `connect failed`, and still falls back to unstructured `unauthorized`.
- Edge cases checked: structured auth-required and auth-mismatch codes still map to the existing hint variants.
- What you did **not** verify: full browser/manual UI walkthrough.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f0c736839`
- Files/config to restore: `ui/src/ui/views/overview-hints.ts`, `ui/src/ui/views/overview.ts`, `ui/src/ui/views/overview.node.test.ts`
- Known bad symptoms reviewers should watch for: real auth failures no longer showing any hint

## Risks and Mitigations

- Risk: some legacy/unstructured non-English auth error text may no longer match the fallback.
  - Mitigation: structured error codes still take precedence, and the old fallback for explicit `unauthorized` text remains covered by regression tests.
