### PR TITLE
build(i18n): auto-prefix internal links with locale path in translated docs

### DIFF
--- a/scripts/docs-i18n/doc_mode.go
+++ b/scripts/docs-i18n/doc_mode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -75,6 +76,7 @@ func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, fil
 		return false, err
 	}
 
+	translatedBody = rewriteInternalLinks(translatedBody, tgtLang)
 	output := updatedFront + translatedBody
 	return false, os.WriteFile(outputPath, []byte(output), 0o644)
 }
@@ -269,4 +271,100 @@ func resolveDocsPath(docsRoot, filePath string) (string, string, error) {
 		return "", "", fmt.Errorf("file %s not under docs root %s", absPath, docsRoot)
 	}
 	return absPath, relPath, nil
+}
+
+func rewriteInternalLinks(body string, tgtLang string) string {
+	if tgtLang == "en" || tgtLang == "" {
+		return body
+	}
+
+	localePrefix := "/" + tgtLang
+
+	// Rewrite Markdown links: [text](/path) -> [text](/zh-CN/path)
+	body = linkURLRe.ReplaceAllStringFunc(body, func(match string) string {
+		// Extract the URL part from [text](url)
+		idx := strings.Index(match, "](")
+		if idx == -1 {
+			return match
+		}
+		prefix := match[:idx+2] // [text](
+		url := match[idx+2:]
+
+		// Skip if already has locale prefix or is external
+		if strings.HasPrefix(url, localePrefix) ||
+			strings.HasPrefix(url, "http://") ||
+			strings.HasPrefix(url, "https://") ||
+			strings.HasPrefix(url, "#") ||
+			strings.HasPrefix(url, "mailto:") {
+			return match
+		}
+
+		// Rewrite internal absolute links
+		if strings.HasPrefix(url, "/") {
+			return prefix + localePrefix + url
+		}
+
+		return match
+	})
+
+	// Rewrite HTML href attributes
+	body = rewriteHTMLHref(body, localePrefix)
+
+	return body
+}
+
+func rewriteHTMLHref(body string, localePrefix string) string {
+	// Pattern to match href="/path" in HTML tags
+	// This handles both href="/path" and href = "/path"
+	hrefPattern := `href\s*=\s*["'](/[^"']*)["']`
+	re := regexp.MustCompile(hrefPattern)
+
+	return re.ReplaceAllStringFunc(body, func(match string) string {
+		// Extract the URL from href="/url"
+		idx := strings.Index(match, "href=")
+		if idx == -1 {
+			return match
+		}
+
+		// Find the quote character
+		quoteStart := idx + 5
+		for quoteStart < len(match) && (match[quoteStart] == ' ' || match[quoteStart] == '=') {
+			quoteStart++
+		}
+		if quoteStart >= len(match) {
+			return match
+		}
+
+		quoteChar := match[quoteStart]
+		if quoteChar != '"' && quoteChar != '\'' {
+			return match
+		}
+
+		urlStart := quoteStart + 1
+		urlEnd := strings.Index(match[urlStart:], string(quoteChar))
+		if urlEnd == -1 {
+			return match
+		}
+		urlEnd += urlStart
+
+		url := match[urlStart:urlEnd]
+
+		// Skip if already has locale prefix or is external
+		if strings.HasPrefix(url, localePrefix) ||
+			strings.HasPrefix(url, "http://") ||
+			strings.HasPrefix(url, "https://") ||
+			strings.HasPrefix(url, "#") ||
+			strings.HasPrefix(url, "mailto:") {
+			return match
+		}
+
+		// Rewrite internal absolute links
+		if strings.HasPrefix(url, "/") {
+			prefix := match[:urlStart]
+			suffix := match[urlEnd:]
+			return prefix + localePrefix + url + suffix
+		}
+
+		return match
+	})
 }


### PR DESCRIPTION
## Summary

- Problem: zh-CN homepage links were pointing to English paths instead of Chinese locale paths
- Why it matters: Chinese users were redirected to English docs instead of Chinese translations
- What changed: Modified scripts/docs-i18n/doc_mode.go to add rewriteInternalLinks() function
- What did NOT change: No changes to English documentation

## Change Type

- Bug fix
- Chore/infra

## Scope

- UI / DX
- CI/CD / infra

## Linked Issue/PR

- Closes #41731
- Replaces #41727 (direct edit approach, does not meet i18n workflow)

## User-visible Changes

After regenerating zh-CN docs with scripts/docs-i18n, Chinese users will correctly navigate to Chinese documentation pages.

## Security Impact

- New permissions: No
- Secrets changed: No
- Network calls: No
- Command surface: No
- Data access: No

## Repro

### Steps

1. Install Pi CLI: npm install -g @mariozechner/pi-coding-agent
2. Run: ./scripts/docs-i18n/docs-i18n --mode=doc --overwrite docs/index.md
3. Check: grep href= docs/zh-CN/index.md | head -5

### Expected

Links should be prefixed with /zh-CN/:
- href="/zh-CN/start/getting-started"
- href="/zh-CN/start/wizard"

### Actual (before fix)

Links were not prefixed:
- href="/start/getting-started"
- href="/start/wizard"

## Evidence

- Unit test verified: /start/getting-started -> /zh-CN/start/getting-started
- External URLs preserved: https://example.com unchanged
- Anchors preserved: #section unchanged

## Human Verification

Verified scenarios:
- Internal absolute links are correctly prefixed
- External URLs (http/https) are not modified
- Anchor links (#) are not modified
- Already-prefixed links are not double-prefixed

## Compatibility

- Backward compatible: Yes
- Config changes: No
- Migration: No

Note: zh-CN docs need to be regenerated after this fix.

## Risks

Risk: Link rewriting could incorrectly modify external URLs
Mitigation: Added explicit checks for http/https and anchors