### PR TITLE
fix(feishu): inject HTTPS proxy agent for HTTP requests

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -322,3 +322,108 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toEqual({ proxyUrl: "http://upper-http:8999" });
   });
 });
+
+describe("createFeishuClient HTTP proxy handling", () => {
+  beforeEach(() => {
+    clearClientCache();
+  });
+
+  it("does not inject proxy agent when proxy env is absent", async () => {
+    createFeishuClient({ appId: "app_no_proxy", appSecret: "secret", accountId: "no-proxy" });
+
+    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1][0] as {
+      httpInstance: { get: (...args: unknown[]) => Promise<unknown> };
+    };
+    await lastCall.httpInstance.get("https://example.com/api");
+
+    expect(mockBaseHttpInstance.get).toHaveBeenCalledWith(
+      "https://example.com/api",
+      expect.not.objectContaining({ httpsAgent: expect.anything(), proxy: false }),
+    );
+    expect(httpsProxyAgentCtorMock).not.toHaveBeenCalled();
+  });
+
+  it("injects httpsAgent and proxy:false when HTTPS_PROXY is set", async () => {
+    process.env.HTTPS_PROXY = "http://proxy.test:8080";
+
+    createFeishuClient({ appId: "app_with_proxy", appSecret: "secret", accountId: "with-proxy" });
+
+    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1][0] as {
+      httpInstance: { post: (...args: unknown[]) => Promise<unknown> };
+    };
+    await lastCall.httpInstance.post("https://example.com/api", { data: 1 });
+
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith("http://proxy.test:8080");
+
+    expect(mockBaseHttpInstance.post).toHaveBeenCalledWith(
+      "https://example.com/api",
+      { data: 1 },
+      expect.objectContaining({
+        httpsAgent: { proxyUrl: "http://proxy.test:8080" },
+        proxy: false,
+      }),
+    );
+  });
+
+  it("uses https_proxy over HTTP_PROXY for HTTP client", async () => {
+    process.env.https_proxy = "http://lower-https:8001";
+    process.env.HTTP_PROXY = "http://upper-http:8004";
+
+    createFeishuClient({ appId: "app_precedence", appSecret: "secret", accountId: "precedence" });
+
+    const expectedProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+
+    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1][0] as {
+      httpInstance: { get: (...args: unknown[]) => Promise<unknown> };
+    };
+    await lastCall.httpInstance.get("https://example.com/api");
+
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith(expectedProxy);
+
+    expect(mockBaseHttpInstance.get).toHaveBeenCalledWith(
+      "https://example.com/api",
+      expect.objectContaining({
+        httpsAgent: { proxyUrl: expectedProxy },
+        proxy: false,
+      }),
+    );
+  });
+
+  it("caches proxy agent across multiple HTTP requests", async () => {
+    process.env.HTTPS_PROXY = "http://proxy.cached:9999";
+
+    createFeishuClient({ appId: "app_cached", appSecret: "secret", accountId: "cached" });
+
+    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1][0] as {
+      httpInstance: {
+        get: (...args: unknown[]) => Promise<unknown>;
+        post: (...args: unknown[]) => Promise<unknown>;
+      };
+    };
+
+    await lastCall.httpInstance.get("https://example.com/api/1");
+    await lastCall.httpInstance.post("https://example.com/api/2", { data: 2 });
+
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(mockBaseHttpInstance.get).toHaveBeenCalledWith(
+      "https://example.com/api/1",
+      expect.objectContaining({
+        httpsAgent: { proxyUrl: "http://proxy.cached:9999" },
+        proxy: false,
+      }),
+    );
+    expect(mockBaseHttpInstance.post).toHaveBeenCalledWith(
+      "https://example.com/api/2",
+      { data: 2 },
+      expect.objectContaining({
+        httpsAgent: { proxyUrl: "http://proxy.cached:9999" },
+        proxy: false,
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -7,14 +7,37 @@ export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
 export const FEISHU_HTTP_TIMEOUT_MAX_MS = 300_000;
 export const FEISHU_HTTP_TIMEOUT_ENV_VAR = "OPENCLAW_FEISHU_HTTP_TIMEOUT_MS";
 
-function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
-  const proxyUrl =
+function getProxyUrl(): string | undefined {
+  return (
     process.env.https_proxy ||
     process.env.HTTPS_PROXY ||
     process.env.http_proxy ||
-    process.env.HTTP_PROXY;
+    process.env.HTTP_PROXY
+  );
+}
+
+function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
+  const proxyUrl = getProxyUrl();
   if (!proxyUrl) return undefined;
   return new HttpsProxyAgent(proxyUrl);
+}
+
+let cachedHttpProxyAgent: HttpsProxyAgent<string> | undefined;
+let cachedHttpProxyUrl: string | undefined;
+
+function getHttpProxyAgent(): HttpsProxyAgent<string> | undefined {
+  const proxyUrl = getProxyUrl();
+  if (!proxyUrl) {
+    cachedHttpProxyAgent = undefined;
+    cachedHttpProxyUrl = undefined;
+    return undefined;
+  }
+  if (cachedHttpProxyUrl === proxyUrl && cachedHttpProxyAgent) {
+    return cachedHttpProxyAgent;
+  }
+  cachedHttpProxyUrl = proxyUrl;
+  cachedHttpProxyAgent = new HttpsProxyAgent(proxyUrl);
+  return cachedHttpProxyAgent;
 }
 
 // Multi-account client cache
@@ -40,23 +63,34 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
  * Create an HTTP instance that delegates to the Lark SDK's default instance
  * but injects a default request timeout to prevent indefinite hangs
  * (e.g. when the Feishu API is slow, causing per-chat queue deadlocks).
+ * Also injects HTTPS proxy agent when proxy env vars are configured,
+ * to properly handle HTTP CONNECT tunneling for HTTPS requests.
  */
 function createTimeoutHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
   const base: Lark.HttpInstance = Lark.defaultHttpInstance as unknown as Lark.HttpInstance;
 
-  function injectTimeout<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
-    return { timeout: defaultTimeoutMs, ...opts } as Lark.HttpRequestOptions<D>;
+  function injectOptions<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
+    const agent = getHttpProxyAgent();
+    const baseOptions = { timeout: defaultTimeoutMs, ...opts } as Lark.HttpRequestOptions<D>;
+    if (agent) {
+      return {
+        ...baseOptions,
+        httpsAgent: agent,
+        proxy: false,
+      } as Lark.HttpRequestOptions<D>;
+    }
+    return baseOptions;
   }
 
   return {
-    request: (opts) => base.request(injectTimeout(opts)),
-    get: (url, opts) => base.get(url, injectTimeout(opts)),
-    post: (url, data, opts) => base.post(url, data, injectTimeout(opts)),
-    put: (url, data, opts) => base.put(url, data, injectTimeout(opts)),
-    patch: (url, data, opts) => base.patch(url, data, injectTimeout(opts)),
-    delete: (url, opts) => base.delete(url, injectTimeout(opts)),
-    head: (url, opts) => base.head(url, injectTimeout(opts)),
-    options: (url, opts) => base.options(url, injectTimeout(opts)),
+    request: (opts) => base.request(injectOptions(opts)),
+    get: (url, opts) => base.get(url, injectOptions(opts)),
+    post: (url, data, opts) => base.post(url, data, injectOptions(opts)),
+    put: (url, data, opts) => base.put(url, data, injectOptions(opts)),
+    patch: (url, data, opts) => base.patch(url, data, injectOptions(opts)),
+    delete: (url, opts) => base.delete(url, injectOptions(opts)),
+    head: (url, opts) => base.head(url, injectOptions(opts)),
+    options: (url, opts) => base.options(url, injectOptions(opts)),
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #41820

When `HTTPS_PROXY` environment variable is set, Axios sends plain HTTP requests through the proxy instead of using HTTP CONNECT tunneling. This causes the target server to reject them with:

```
400 The plain HTTP request was sent to HTTPS port
```

## Root Cause

The Lark SDK uses Axios internally for HTTP requests. Unlike Node.js's native `https` module (which correctly uses HTTP CONNECT tunnel for HTTPS proxies), Axios sends a plain HTTP request to the proxy server, which then blindly forwards it to the target's 443 port.

## Solution

- Inject `https-proxy-agent` into the Lark SDK's HTTP instance
- The agent uses HTTP CONNECT tunneling for proper HTTPS proxy support
- Set `proxy: false` to disable Axios's default (broken) proxy handling
- Cache the proxy agent to avoid recreating it for each request

## Testing

Added comprehensive tests for:
- No proxy agent injected when proxy env is absent
- `httpsAgent` and `proxy: false` injected when `HTTPS_PROXY` is set
- Proxy env precedence (`https_proxy` > `HTTPS_PROXY` > `http_proxy` > `HTTP_PROXY`)
- Proxy agent caching across multiple HTTP requests