### PR TITLE
fix(msteams): use General channel conversation ID as team key for Bot Framework compatibility

### DIFF
--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -54,10 +54,12 @@ describe("resolveMSTeamsUserAllowlist", () => {
 
 describe("resolveMSTeamsChannelAllowlist", () => {
   it("resolves team/channel by team name + channel display name", async () => {
-    listTeamsByName.mockResolvedValueOnce([{ id: "team-1", displayName: "Product Team" }]);
+    // After the fix, listChannelsForTeam is called once and reused for both
+    // General channel resolution and channel matching.
+    listTeamsByName.mockResolvedValueOnce([{ id: "team-guid-1", displayName: "Product Team" }]);
     listChannelsForTeam.mockResolvedValueOnce([
-      { id: "channel-1", displayName: "General" },
-      { id: "channel-2", displayName: "Roadmap" },
+      { id: "19:general-conv-id@thread.tacv2", displayName: "General" },
+      { id: "19:roadmap-conv-id@thread.tacv2", displayName: "Roadmap" },
     ]);
 
     const [result] = await resolveMSTeamsChannelAllowlist({
@@ -65,14 +67,60 @@ describe("resolveMSTeamsChannelAllowlist", () => {
       entries: ["Product Team/Roadmap"],
     });
 
+    // teamId is now the General channel's conversation ID — not the Graph GUID —
+    // because that's what Bot Framework sends as channelData.team.id at runtime.
     expect(result).toEqual({
       input: "Product Team/Roadmap",
       resolved: true,
-      teamId: "team-1",
+      teamId: "19:general-conv-id@thread.tacv2",
       teamName: "Product Team",
-      channelId: "channel-2",
+      channelId: "19:roadmap-conv-id@thread.tacv2",
       channelName: "Roadmap",
       note: "multiple channels; chose first",
+    });
+  });
+
+  it("uses General channel conversation ID as team key for team-only entry", async () => {
+    // When no channel is specified we still resolve the General channel so the
+    // stored key matches what Bot Framework sends as channelData.team.id.
+    listTeamsByName.mockResolvedValueOnce([{ id: "guid-engineering", displayName: "Engineering" }]);
+    listChannelsForTeam.mockResolvedValueOnce([
+      { id: "19:eng-general@thread.tacv2", displayName: "General" },
+      { id: "19:eng-standups@thread.tacv2", displayName: "Standups" },
+    ]);
+
+    const [result] = await resolveMSTeamsChannelAllowlist({
+      cfg: {},
+      entries: ["Engineering"],
+    });
+
+    expect(result).toEqual({
+      input: "Engineering",
+      resolved: true,
+      teamId: "19:eng-general@thread.tacv2",
+      teamName: "Engineering",
+    });
+  });
+
+  it("falls back to Graph GUID when General channel is not found", async () => {
+    // Edge case: General channel was renamed or deleted. We fall back to the
+    // Graph GUID so resolution still succeeds rather than silently breaking.
+    listTeamsByName.mockResolvedValueOnce([{ id: "guid-ops", displayName: "Operations" }]);
+    listChannelsForTeam.mockResolvedValueOnce([
+      { id: "19:ops-announce@thread.tacv2", displayName: "Announcements" },
+      { id: "19:ops-random@thread.tacv2", displayName: "Random" },
+    ]);
+
+    const [result] = await resolveMSTeamsChannelAllowlist({
+      cfg: {},
+      entries: ["Operations"],
+    });
+
+    expect(result).toEqual({
+      input: "Operations",
+      resolved: true,
+      teamId: "guid-ops",
+      teamName: "Operations",
     });
   });
 });

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -120,11 +120,21 @@ export async function resolveMSTeamsChannelAllowlist(params: {
         return { input, resolved: false, note: "team not found" };
       }
       const teamMatch = teams[0];
-      const teamId = teamMatch.id?.trim();
+      const graphTeamId = teamMatch.id?.trim();
       const teamName = teamMatch.displayName?.trim() || team;
-      if (!teamId) {
+      if (!graphTeamId) {
         return { input, resolved: false, note: "team id missing" };
       }
+      // Bot Framework sends the General channel's conversation ID as
+      // channelData.team.id at runtime, NOT the Graph API group GUID.
+      // Fetch channels upfront so we can resolve the correct key format for
+      // runtime matching and reuse the list for channel lookups.
+      const teamChannels = await listChannelsForTeam(token, graphTeamId);
+      const generalChannel = teamChannels.find((ch) => ch.displayName?.toLowerCase() === "general");
+      // Use the General channel's conversation ID as the team key — this
+      // matches what Bot Framework sends at runtime. Fall back to the Graph
+      // GUID if the General channel isn't found (renamed or deleted).
+      const teamId = generalChannel?.id ?? graphTeamId;
       if (!channel) {
         return {
           input,
@@ -134,11 +144,11 @@ export async function resolveMSTeamsChannelAllowlist(params: {
           note: teams.length > 1 ? "multiple teams; chose first" : undefined,
         };
       }
-      const channels = await listChannelsForTeam(token, teamId);
+      // Reuse teamChannels — already fetched above
       const channelMatch =
-        channels.find((item) => item.id === channel) ??
-        channels.find((item) => item.displayName?.toLowerCase() === channel.toLowerCase()) ??
-        channels.find((item) =>
+        teamChannels.find((item) => item.id === channel) ??
+        teamChannels.find((item) => item.displayName?.toLowerCase() === channel.toLowerCase()) ??
+        teamChannels.find((item) =>
           item.displayName?.toLowerCase().includes(channel.toLowerCase() ?? ""),
         );
       if (!channelMatch?.id) {
@@ -151,7 +161,7 @@ export async function resolveMSTeamsChannelAllowlist(params: {
         teamName,
         channelId: channelMatch.id,
         channelName: channelMatch.displayName ?? channel,
-        note: channels.length > 1 ? "multiple channels; chose first" : undefined,
+        note: teamChannels.length > 1 ? "multiple channels; chose first" : undefined,
       };
     },
   });


### PR DESCRIPTION
Rebased version of #41453 (closed due to merge conflicts from force-push/rebase).

## Summary

When OpenClaw starts up and resolves the MS Teams channel allowlist, it queries the Microsoft Graph API for team info and stores the **Graph API group GUID** (e.g. `fa101332-cf00-431b-b0ea-f701a85fde81`) as the team key in its allowlist config. At runtime, the Bot Framework sends `activity.channelData.team.id` as the **General channel's conversation ID** (e.g. `19:rcybyx4n54wO1UF__3XVOyW8YwwPLibpjTNmQpCRUSQ1@thread.tacv2`) — a completely different format. The two keys never match, so every inbound channel message is silently dropped regardless of config. This PR fixes the mismatch by resolving the General channel's conversation ID during startup and storing that as the team key instead.

## Fix

In `resolveMSTeamsChannelAllowlist`'s `mapInput` callback, after obtaining `graphTeamId` (the Graph GUID), the fix:

1. **Always calls `listChannelsForTeam(token, graphTeamId)`** — necessary to find the General channel regardless of whether a specific channel was requested.
2. **Finds the General channel** by `displayName === "general"` (case-insensitive).
3. **Uses the General channel's conversation ID as `teamId`** — this matches what Bot Framework sends as `channelData.team.id` at runtime.
4. **Falls back to the Graph GUID** if the General channel is not found (renamed or deleted edge case) so resolution still succeeds rather than silently breaking.
5. **Reuses the channel list** when a specific channel is also configured, avoiding a redundant second API call.

## Testing

All 5 unit tests pass (`extensions/msteams/src/resolve-allowlist.test.ts`):
- Updated existing test to assert `teamId` is the General channel's conversation ID
- Added "uses General channel conversation ID as team key for team-only entry"
- Added "falls back to Graph GUID when General channel not found"

## Breaking Changes

None. Fully backward compatible.

Fixes #41390