### PR TITLE
fix(msteams): use General channel conversation ID as team key for Bot Framework compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - CI/CodeQL Swift toolchain: select Xcode 26.1 before installing Swift build tools so the CodeQL Swift job uses Swift tools 6.2 on `macos-latest`. (#41787) thanks @BunsDev.
 - Sandbox/subagents: pass the real configured workspace through `sessions_spawn` inheritance when a parent agent runs in a copied-workspace sandbox, so child `/agent` mounts point at the configured workspace instead of the parent sandbox copy. (#40757) Thanks @dsantoreis.
 - Mattermost/plugin send actions: normalize direct `replyTo` fallback handling so threaded plugin sends trim blank IDs and reuse the correct reply target again. (#41176) Thanks @hnykda.
+- MS Teams/allowlist resolution: use the General channel conversation ID as the resolved team key (with Graph GUID fallback) so Bot Framework runtime `channelData.team.id` matching works for team and team/channel allowlist entries. (#41838) Thanks @BradGroux.
 
 ## 2026.3.8
 

--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -54,10 +54,12 @@ describe("resolveMSTeamsUserAllowlist", () => {
 
 describe("resolveMSTeamsChannelAllowlist", () => {
   it("resolves team/channel by team name + channel display name", async () => {
-    listTeamsByName.mockResolvedValueOnce([{ id: "team-1", displayName: "Product Team" }]);
+    // After the fix, listChannelsForTeam is called once and reused for both
+    // General channel resolution and channel matching.
+    listTeamsByName.mockResolvedValueOnce([{ id: "team-guid-1", displayName: "Product Team" }]);
     listChannelsForTeam.mockResolvedValueOnce([
-      { id: "channel-1", displayName: "General" },
-      { id: "channel-2", displayName: "Roadmap" },
+      { id: "19:general-conv-id@thread.tacv2", displayName: "General" },
+      { id: "19:roadmap-conv-id@thread.tacv2", displayName: "Roadmap" },
     ]);
 
     const [result] = await resolveMSTeamsChannelAllowlist({
@@ -65,14 +67,60 @@ describe("resolveMSTeamsChannelAllowlist", () => {
       entries: ["Product Team/Roadmap"],
     });
 
+    // teamId is now the General channel's conversation ID — not the Graph GUID —
+    // because that's what Bot Framework sends as channelData.team.id at runtime.
     expect(result).toEqual({
       input: "Product Team/Roadmap",
       resolved: true,
-      teamId: "team-1",
+      teamId: "19:general-conv-id@thread.tacv2",
       teamName: "Product Team",
-      channelId: "channel-2",
+      channelId: "19:roadmap-conv-id@thread.tacv2",
       channelName: "Roadmap",
       note: "multiple channels; chose first",
+    });
+  });
+
+  it("uses General channel conversation ID as team key for team-only entry", async () => {
+    // When no channel is specified we still resolve the General channel so the
+    // stored key matches what Bot Framework sends as channelData.team.id.
+    listTeamsByName.mockResolvedValueOnce([{ id: "guid-engineering", displayName: "Engineering" }]);
+    listChannelsForTeam.mockResolvedValueOnce([
+      { id: "19:eng-general@thread.tacv2", displayName: "General" },
+      { id: "19:eng-standups@thread.tacv2", displayName: "Standups" },
+    ]);
+
+    const [result] = await resolveMSTeamsChannelAllowlist({
+      cfg: {},
+      entries: ["Engineering"],
+    });
+
+    expect(result).toEqual({
+      input: "Engineering",
+      resolved: true,
+      teamId: "19:eng-general@thread.tacv2",
+      teamName: "Engineering",
+    });
+  });
+
+  it("falls back to Graph GUID when General channel is not found", async () => {
+    // Edge case: General channel was renamed or deleted. We fall back to the
+    // Graph GUID so resolution still succeeds rather than silently breaking.
+    listTeamsByName.mockResolvedValueOnce([{ id: "guid-ops", displayName: "Operations" }]);
+    listChannelsForTeam.mockResolvedValueOnce([
+      { id: "19:ops-announce@thread.tacv2", displayName: "Announcements" },
+      { id: "19:ops-random@thread.tacv2", displayName: "Random" },
+    ]);
+
+    const [result] = await resolveMSTeamsChannelAllowlist({
+      cfg: {},
+      entries: ["Operations"],
+    });
+
+    expect(result).toEqual({
+      input: "Operations",
+      resolved: true,
+      teamId: "guid-ops",
+      teamName: "Operations",
     });
   });
 });

--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -102,6 +102,26 @@ describe("resolveMSTeamsChannelAllowlist", () => {
     });
   });
 
+  it("falls back to Graph GUID when listChannelsForTeam throws", async () => {
+    // Edge case: API call fails (rate limit, network error). We fall back to
+    // the Graph GUID as the team key — the pre-fix behavior — so resolution
+    // still succeeds instead of propagating the error.
+    listTeamsByName.mockResolvedValueOnce([{ id: "guid-flaky", displayName: "Flaky Team" }]);
+    listChannelsForTeam.mockRejectedValueOnce(new Error("429 Too Many Requests"));
+
+    const [result] = await resolveMSTeamsChannelAllowlist({
+      cfg: {},
+      entries: ["Flaky Team"],
+    });
+
+    expect(result).toEqual({
+      input: "Flaky Team",
+      resolved: true,
+      teamId: "guid-flaky",
+      teamName: "Flaky Team",
+    });
+  });
+
   it("falls back to Graph GUID when General channel is not found", async () => {
     // Edge case: General channel was renamed or deleted. We fall back to the
     // Graph GUID so resolution still succeeds rather than silently breaking.

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -120,11 +120,21 @@ export async function resolveMSTeamsChannelAllowlist(params: {
         return { input, resolved: false, note: "team not found" };
       }
       const teamMatch = teams[0];
-      const teamId = teamMatch.id?.trim();
+      const graphTeamId = teamMatch.id?.trim();
       const teamName = teamMatch.displayName?.trim() || team;
-      if (!teamId) {
+      if (!graphTeamId) {
         return { input, resolved: false, note: "team id missing" };
       }
+      // Bot Framework sends the General channel's conversation ID as
+      // channelData.team.id at runtime, NOT the Graph API group GUID.
+      // Fetch channels upfront so we can resolve the correct key format for
+      // runtime matching and reuse the list for channel lookups.
+      const teamChannels = await listChannelsForTeam(token, graphTeamId);
+      const generalChannel = teamChannels.find((ch) => ch.displayName?.toLowerCase() === "general");
+      // Use the General channel's conversation ID as the team key — this
+      // matches what Bot Framework sends at runtime. Fall back to the Graph
+      // GUID if the General channel isn't found (renamed or deleted).
+      const teamId = generalChannel?.id ?? graphTeamId;
       if (!channel) {
         return {
           input,
@@ -134,11 +144,11 @@ export async function resolveMSTeamsChannelAllowlist(params: {
           note: teams.length > 1 ? "multiple teams; chose first" : undefined,
         };
       }
-      const channels = await listChannelsForTeam(token, teamId);
+      // Reuse teamChannels — already fetched above
       const channelMatch =
-        channels.find((item) => item.id === channel) ??
-        channels.find((item) => item.displayName?.toLowerCase() === channel.toLowerCase()) ??
-        channels.find((item) =>
+        teamChannels.find((item) => item.id === channel) ??
+        teamChannels.find((item) => item.displayName?.toLowerCase() === channel.toLowerCase()) ??
+        teamChannels.find((item) =>
           item.displayName?.toLowerCase().includes(channel.toLowerCase() ?? ""),
         );
       if (!channelMatch?.id) {
@@ -151,7 +161,7 @@ export async function resolveMSTeamsChannelAllowlist(params: {
         teamName,
         channelId: channelMatch.id,
         channelName: channelMatch.displayName ?? channel,
-        note: channels.length > 1 ? "multiple channels; chose first" : undefined,
+        note: teamChannels.length > 1 ? "multiple channels; chose first" : undefined,
       };
     },
   });

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -139,7 +139,7 @@ export async function resolveMSTeamsChannelAllowlist(params: {
       // Use the General channel's conversation ID as the team key — this
       // matches what Bot Framework sends at runtime. Fall back to the Graph
       // GUID if the General channel isn't found (renamed or deleted).
-      const teamId = generalChannel?.id ?? graphTeamId;
+      const teamId = generalChannel?.id?.trim() || graphTeamId;
       if (!channel) {
         return {
           input,

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -129,7 +129,12 @@ export async function resolveMSTeamsChannelAllowlist(params: {
       // channelData.team.id at runtime, NOT the Graph API group GUID.
       // Fetch channels upfront so we can resolve the correct key format for
       // runtime matching and reuse the list for channel lookups.
-      const teamChannels = await listChannelsForTeam(token, graphTeamId);
+      let teamChannels: Awaited<ReturnType<typeof listChannelsForTeam>> = [];
+      try {
+        teamChannels = await listChannelsForTeam(token, graphTeamId);
+      } catch {
+        // API failure (rate limit, network error) — fall back to Graph GUID as team key
+      }
       const generalChannel = teamChannels.find((ch) => ch.displayName?.toLowerCase() === "general");
       // Use the General channel's conversation ID as the team key — this
       // matches what Bot Framework sends at runtime. Fall back to the Graph


### PR DESCRIPTION
## Summary

When OpenClaw starts up and resolves the MS Teams channel allowlist, it queries the Microsoft Graph API for team info and stores the **Graph API group GUID** (e.g. `fa101332-cf00-431b-b0ea-f701a85fde81`) as the team key in its allowlist config. At runtime, the Bot Framework sends `activity.channelData.team.id` as the **General channel's conversation ID** (e.g. `19:rcybyx4n54wO1UF__3XVOyW8YwwPLibpjTNmQpCRUSQ1@thread.tacv2`) — a completely different format. The two keys never match, so every inbound channel message is silently dropped regardless of config. This PR fixes the mismatch by resolving the General channel's conversation ID during startup and storing that as the team key instead.

## Problem

### Observed behavior

After configuring a Teams channel in OpenClaw, channel messages are never processed. No errors appear — messages just vanish. The configured team matches by display name at startup, the `resolved: true` response looks correct, but at runtime nothing gets through.

### Diagnostic evidence

Patching the message handler to log `activity.channelData`:

```json
{
  "team": {
    "id": "19:rcybyx4n54wO1UF__3XVOyW8YwwPLibpjTNmQpCRUSQ1@thread.tacv2",
    "name": "Digital Meld"
  },
  "channel": {
    "id": "19:22ce9bf9c7c64ac9b323a7d907b87234@thread.tacv2"
  }
}
```

The startup resolver stored `fa101332-cf00-431b-b0ea-f701a85fde81` (Graph GUID). The runtime key is `19:rcybyx4n54wO1UF__3XVOyW8YwwPLibpjTNmQpCRUSQ1@thread.tacv2` (General channel conversation ID). These never match.

A workaround confirmed the root cause: manually replacing the Graph GUID in config with the General channel's conversation ID caused messages to flow correctly.

## Root Cause

The Microsoft Graph API `/teams` endpoint returns groups by their **AAD group GUID** (e.g. `fa101332-cf00-431b-b0ea-f701a85fde81`). This is what `listTeamsByName` returns as `team.id`.

The Bot Framework, however, identifies the *team context* of a channel message using the **General channel's conversation ID** — the `19:…@thread.tacv2` format used for all Teams conversations. These are two different identifiers for the same team, and there is no documented 1:1 mapping without calling the channels API.

`resolveMSTeamsChannelAllowlist` was using the Graph GUID directly as `teamId` in the resolved config entry. At runtime, the allowlist check compares `channelData.team.id` (conversation ID format) against the stored `teamId` (GUID format) — a comparison that can never succeed.

## Fix

In `resolveMSTeamsChannelAllowlist`'s `mapInput` callback, after obtaining `graphTeamId` (the Graph GUID), the fix:

1. **Always calls `listChannelsForTeam(token, graphTeamId)`** — necessary to find the General channel regardless of whether a specific channel was requested.
2. **Finds the General channel** by `displayName === "general"` (case-insensitive).
3. **Uses the General channel's conversation ID as `teamId`** — this matches what Bot Framework sends as `channelData.team.id` at runtime.
4. **Falls back to the Graph GUID** if the General channel is not found (renamed or deleted edge case) so resolution still succeeds rather than silently breaking.
5. **Wraps the channel fetch in try/catch** — if `listChannelsForTeam` throws (rate limit, network error), falls back to the Graph GUID rather than failing the entire resolution. This preserves the pre-fix behavior where team-only entries never called the channels API.
6. **Reuses the channel list** when a specific channel is also configured, avoiding a redundant second API call.

```typescript
// Before
const teamId = teamMatch.id?.trim(); // Graph GUID — wrong format at runtime

// After
const graphTeamId = teamMatch.id?.trim();
let teamChannels = [];
try {
  teamChannels = await listChannelsForTeam(token, graphTeamId);
} catch {
  // API failure — fall back to Graph GUID as team key
}
const generalChannel = teamChannels.find(
  (ch) => ch.displayName?.toLowerCase() === "general",
);
const teamId = generalChannel?.id ?? graphTeamId; // Conversation ID — matches Bot Framework
```

## Testing

**Unit tests** (`extensions/msteams/src/resolve-allowlist.test.ts`):

- Updated existing test "resolves team/channel by team name + channel display name" to assert that `teamId` is now the General channel's conversation ID, not the Graph GUID.
- Added "uses General channel conversation ID as team key for team-only entry" — verifies team-only resolution stores the correct key.
- Added "falls back to Graph GUID when General channel not found" — verifies the edge case gracefully degrades.
- Added "falls back to Graph GUID when listChannelsForTeam throws" — verifies API failures don't break resolution.

All 6 tests pass:
```
✓ extensions/msteams/src/resolve-allowlist.test.ts (6 tests) 3ms
```

**Manual validation**: Confirmed the workaround (manually setting the General channel conversation ID as config key) makes messages flow correctly. This fix automates that resolution at startup.

## Breaking Changes

None. This is fully backward compatible:

- Existing configs using a **conversation ID** as the team key (the manual workaround) continue to work — if the input matches the GUID regex (`/^[0-9a-fA-F-]{16,}$/`), it goes through `listChannelsForTeam` against that ID, which will still resolve correctly.
- Configs using a **team display name** now automatically resolve to the correct conversation ID key.
- No changes to the config file format or external-facing API.

## Secondary Issue (noted, not fixed here)

The compiled logger wrapper in the MS Teams extension swallows structured data — `debug()` and `info()` only pass the first argument to the underlying logger, silently dropping context objects. This made diagnosing the root cause significantly harder. Tracked separately.

## Related

Fixes #41390
Supersedes #41453 (closed due to branch deletion during conflict resolution)