### PR TITLE
fix(slack): reject messageId on read actions

### DIFF
--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -64,4 +64,25 @@ describe("handleSlackMessageAction", () => {
       expect.any(Object),
     );
   });
+
+  it("rejects messageId for read", async () => {
+    const invoke = createInvokeSpy();
+
+    await expect(
+      handleSlackMessageAction({
+        providerId: "slack",
+        ctx: {
+          action: "read",
+          cfg: {},
+          params: {
+            channelId: "C1",
+            messageId: "123.456",
+          },
+        } as never,
+        invoke: invoke as never,
+      }),
+    ).rejects.toThrow("Slack read does not support messageId.");
+
+    expect(invoke).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -98,6 +98,10 @@ export async function handleSlackMessageAction(params: {
   }
 
   if (action === "read") {
+    if (actionParams.messageId != null) {
+      readStringParam(actionParams, "messageId");
+      throw new Error("Slack read does not support messageId.");
+    }
     const limit = readNumberParam(actionParams, "limit", { integer: true });
     const readAction: Record<string, unknown> = {
       action: "readMessages",


### PR DESCRIPTION
## Summary

- Problem: Slack `action=read` accepts `messageId` in the flattened message-tool schema but silently drops it before dispatch.
- Why it matters: agents think they requested a single message, but they actually fetch channel history and waste context/tokens.
- What changed: `handleSlackMessageAction` now rejects `messageId` on `read` with an explicit error, and a regression test asserts the parameter is not silently ignored.
- What did NOT change (scope boundary): this PR does not add single-message Slack reads or change the shared message-tool schema.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #13273
- Related #2454

## User-visible / Behavior Changes

Slack `message`/plugin action calls now fail loudly with `Slack read does not support messageId.` when `action=read` is combined with `messageId`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node v20.20.1, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Slack plugin-sdk message actions
- Relevant config (redacted): N/A

### Steps

1. Call `handleSlackMessageAction` with `action: "read"`, `channelId: "C1"`, and `messageId: "123.456"`.
2. Observe behavior before this patch.
3. Re-run after this patch.

### Expected

- Slack read should not silently accept a parameter it does not implement.

### Actual

- The old code ignored `messageId` and still invoked `readMessages`, which can return channel history instead of one message.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused regression test passes:

- `cmd /c node_modules\.bin\vitest.CMD run src/plugin-sdk/slack-message-actions.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `download-file` mappings still work, and `read + messageId` now rejects before invoking the downstream action.
- Edge cases checked: the new test asserts `invoke` is not called when the unsupported parameter is supplied.
- What you did **not** verify: end-to-end Slack channel behavior with a live workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `7682b09d9`
- Files/config to restore: `src/plugin-sdk/slack-message-actions.ts`, `src/plugin-sdk/slack-message-actions.test.ts`
- Known bad symptoms reviewers should watch for: valid Slack `read` calls without `messageId` unexpectedly failing

## Risks and Mitigations

- Risk: some callers may currently rely on the buggy silent-ignore behavior.
  - Mitigation: the new explicit error is narrow to `read + messageId`, matches the issue's acceptable behavior, and prevents hidden over-fetching.
