### PR TITLE
fix(message): reject attachment-only params on send

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12615,7 +12615,7 @@
         "filename": "src/infra/outbound/message-action-runner.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 529
+        "line_number": 551
       }
     ],
     "src/infra/outbound/outbound.test.ts": [

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -302,6 +302,28 @@ describe("runMessageAction context isolation", () => {
     expect(result.kind).toBe("send");
   });
 
+  it("rejects send actions that include attachment-only params", async () => {
+    await expect(
+      runDrySend({
+        cfg: {
+          channels: {
+            telegram: {
+              token: "tg-test",
+            },
+          },
+        } as OpenClawConfig,
+        actionParams: {
+          channel: "telegram",
+          target: "telegram:12345",
+          message: "test attachment",
+          buffer: Buffer.from("hello").toString("base64"),
+          filename: "test.txt",
+          mimeType: "text/plain",
+        },
+      }),
+    ).rejects.toThrow(/action "sendAttachment"/i);
+  });
+
   it("blocks send when target differs from current channel", async () => {
     const result = await runDrySend({
       cfg: slackConfig,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -158,6 +158,18 @@ export function getToolResult(
   return "toolResult" in result ? result.toolResult : undefined;
 }
 
+function rejectUnsupportedSendAttachmentParams(params: Record<string, unknown>): void {
+  const unsupported = ["buffer", "filename", "contentType", "mimeType"].filter(
+    (key) => params[key] != null,
+  );
+  if (unsupported.length === 0) {
+    return;
+  }
+  throw new Error(
+    `send does not support ${unsupported.join(", ")}; use media/path/filePath or action "sendAttachment" instead.`,
+  );
+}
+
 function applyCrossContextMessageDecoration({
   params,
   message,
@@ -769,6 +781,9 @@ export async function runMessageAction(
 
   if (action === "send" && hasPollCreationParams(params)) {
     throw new Error('Poll fields require action "poll"; use action "poll" instead of "send".');
+  }
+  if (action === "send") {
+    rejectUnsupportedSendAttachmentParams(params);
   }
 
   const gateway = resolveGateway(input);


### PR DESCRIPTION
## Summary

- Problem: `action="send"` advertises attachment-style params (`buffer`, `filename`, `contentType`, `mimeType`) but the send execution path only consumes `media/path/filePath`, so those fields are silently ignored.
- Why it matters: callers can get `ok: true` for Telegram sends while the expected attachment never gets delivered.
- What changed: `runMessageAction` now rejects attachment-only params on `send` and points callers to `media/path/filePath` or `action="sendAttachment"`, plus a focused Telegram-shaped regression test.
- What did NOT change (scope boundary): this PR does not add new attachment-upload support to `action="send"`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41779
- Related #13273

## User-visible / Behavior Changes

`action="send"` now fails with an explicit error when attachment-upload-only params such as `buffer` or `filename` are supplied.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node v20.20.1, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): outbound message runner / Telegram-shaped send
- Relevant config (redacted): test Telegram config with `token: "tg-test"`

### Steps

1. Call `runMessageAction` with `action: "send"`, `channel: "telegram"`, a normal `target`, and attachment-only params like `buffer`, `filename`, and `mimeType`.
2. Observe behavior before this patch.
3. Re-run after this patch.

### Expected

- `send` should not report success when it ignores attachment-upload params.

### Actual

- The old path accepted those fields, never hydrated them for `send`, and continued with a normal text/media send flow.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused regression test passes:

- `cmd /c node_modules\.bin\vitest.CMD run src/infra/outbound/message-action-runner.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Telegram-shaped dry-run sends with `buffer`/`filename`/`mimeType` now reject, and the full targeted outbound runner suite still passes.
- Edge cases checked: existing poll validation still runs separately, and normal `send` tests in `message-action-runner.test.ts` continue to pass.
- What you did **not** verify: live Telegram delivery against a real bot/chat.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `dafc68764`
- Files/config to restore: `src/infra/outbound/message-action-runner.ts`, `src/infra/outbound/message-action-runner.test.ts`
- Known bad symptoms reviewers should watch for: plain text/media `send` calls failing without attachment-only params present

## Risks and Mitigations

- Risk: some callers may currently rely on the buggy silent success path for `send + buffer`.
  - Mitigation: the new error is narrow, explicit, and matches the issue's minimum acceptable behavior while avoiding false-success delivery reports.
