### PR TITLE
fix: preserve code block indentation in duplicate block collapsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+openclaw-*.log

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -424,7 +424,7 @@ function collapseConsecutiveDuplicateBlocks(text: string): string {
     if (lastNormalized && normalized === lastNormalized) {
       continue;
     }
-    result.push(block.trim());
+    result.push(block);
     lastNormalized = normalized;
   }
 


### PR DESCRIPTION
Closes #41699

## Problem

`collapseConsecutiveDuplicateBlocks()` in `src/agents/pi-embedded-helpers/errors.ts` uses `block.trim()` when rebuilding text after removing consecutive duplicate blocks. This strips leading whitespace (indentation) from code blocks, making JSON/Python/YAML output harder to read.

## Fix

Replace `result.push(block.trim())` with `result.push(block)`.

The comparison logic already uses a separate `normalizeBlock()` that trims and collapses whitespace for dedup purposes — the output block itself does not need to be trimmed.

## Impact

Only affects messages where consecutive duplicate text blocks exist AND the text contains indented code blocks. The early-return path (`result.length === blocks.length → return text`) is unchanged, so messages without duplicates are not affected at all.