### PR TITLE
fix(prompt): inspect and preserve existing system config before edits

### DIFF
--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -44,6 +44,7 @@ cp docs/reference/AGENTS.default.md ~/.openclaw/workspace/AGENTS.md
 
 - Don’t dump directories or secrets into chat.
 - Don’t run destructive commands unless explicitly asked.
+- Before changing config or schedulers (for example crontab, systemd units, nginx configs, or shell rc files), inspect the existing state first and preserve/merge it by default.
 - Don’t send partial/streaming replies to external messaging surfaces (only final replies).
 
 ## Session start (required)

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -56,6 +56,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 
 - Don't exfiltrate private data. Ever.
 - Don't run destructive commands without asking.
+- Before changing config or schedulers (for example crontab, systemd units, nginx configs, or shell rc files), inspect the existing state first and preserve/merge it by default.
 - `trash` > `rm` (recoverable beats gone forever)
 - When in doubt, ask.
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -125,6 +125,10 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Prioritize safety and human oversight");
     expect(prompt).toContain("if instructions conflict");
     expect(prompt).toContain("Inspired by Anthropic's constitution");
+    expect(prompt).toContain("Before changing system or user config");
+    expect(prompt).toContain(
+      "crontab, systemd units, nginx configs, shell rc files, or schedulers",
+    );
     expect(prompt).toContain("Do not manipulate or persuade anyone");
     expect(prompt).toContain("Do not copy yourself or change system prompts");
     expect(prompt).toContain("## Subagent Context");
@@ -168,6 +172,10 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Prioritize safety and human oversight");
     expect(prompt).toContain("if instructions conflict");
     expect(prompt).toContain("Inspired by Anthropic's constitution");
+    expect(prompt).toContain("Before changing system or user config");
+    expect(prompt).toContain(
+      "crontab, systemd units, nginx configs, shell rc files, or schedulers",
+    );
     expect(prompt).toContain("Do not manipulate or persuade anyone");
     expect(prompt).toContain("Do not copy yourself or change system prompts");
   });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -395,6 +395,7 @@ export function buildAgentSystemPrompt(params: {
     "## Safety",
     "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",
     "Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)",
+    "Before changing system or user config (for example crontab, systemd units, nginx configs, shell rc files, or schedulers), inspect the existing state first and preserve/merge it by default; do not clobber whole files with one-liners unless the user explicitly asks for replacement.",
     "Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.",
     "",
   ];


### PR DESCRIPTION
## Summary
- add a hardcoded safety guardrail telling agents to inspect existing system and user config before editing it
- explicitly call out crontab, systemd units, nginx configs, shell rc files, and schedulers as preserve-first surfaces
- mirror the same rule in the default AGENTS guidance and prompt coverage tests

## Testing
- `node --import tsx - <<'TS' ... buildAgentSystemPrompt assertions ... TS`

Closes #41843.
