### PR TITLE
Fix the issue where login requests to the internal Matrix channel were blocked by SSRF Guard.

### DIFF
--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -185,11 +185,14 @@ export async function resolveMatrixAuth(params?: {
     );
   }
 
-  const homeserverHostname = (() => {
+  // Validate homeserver URL upfront to catch missing scheme early.
+  const homeserverUrl = (() => {
     try {
-      return new URL(resolved.homeserver).hostname;
+      return new URL(resolved.homeserver);
     } catch {
-      return undefined;
+      throw new Error(
+        `Invalid Matrix homeserver URL: "${resolved.homeserver}". URL must include a scheme (e.g., https://matrix.example.org).`,
+      );
     }
   })();
 
@@ -206,7 +209,7 @@ export async function resolveMatrixAuth(params?: {
         initial_device_display_name: resolved.deviceName ?? "OpenClaw Gateway",
       }),
     },
-    policy: homeserverHostname ? { allowedHostnames: [homeserverHostname] } : undefined,
+    policy: { allowedHostnames: [homeserverUrl.hostname] },
     auditContext: "matrix.login",
   });
   const login = await (async () => {

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -185,6 +185,14 @@ export async function resolveMatrixAuth(params?: {
     );
   }
 
+  const homeserverHostname = (() => {
+    try {
+      return new URL(resolved.homeserver).hostname;
+    } catch {
+      return undefined;
+    }
+  })();
+
   // Login with password using HTTP API.
   const { response: loginResponse, release: releaseLoginResponse } = await fetchWithSsrFGuard({
     url: `${resolved.homeserver}/_matrix/client/v3/login`,
@@ -198,6 +206,7 @@ export async function resolveMatrixAuth(params?: {
         initial_device_display_name: resolved.deviceName ?? "OpenClaw Gateway",
       }),
     },
+    policy: homeserverHostname ? { allowedHostnames: [homeserverHostname] } : undefined,
     auditContext: "matrix.login",
   });
   const login = await (async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Can't setup matrix channel if connect to a self-hosted, Private IP homeserver
- Why it matters: Block matrix setup
- What changed: 
- What did NOT change (scope boundary): 

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38126
- Related #38126

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Need to disable SSRF protect when request homeserver'domain while do login request. No risk was introduced.

## Repro + Verification

### Environment

- OS: Linux (debian 13)
- Runtime/container: any
- Model/provider: any
- Integration/channel (if any): Matrix
- Relevant config (redacted):

### Steps

1. config openclaw to use a Matrix channel, and the Homeserve's domain resolve to a Private IP (like 192.168.x.x)
2. run openclaw
3. send message to the Matrix

### Expected

- openclaw can reply me in matrix

### Actual

- No reply received

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing log before:
```log
13:56:36 info gateway/channels/matrix [default] starting provider (https://xxxxxx)
13:56:36 warn security blocked URL fetch (matrix.login) target=https://xxxxxx/_matrix/client/v3/login reason=Blocked: resolves to private/internal/special-use IP address
13:56:36 warn [security] blocked URL fetch (matrix.login) target=https://xxxxxx/_matrix/client/v3/login reason=Blocked: resolves to private/internal/special-use IP address
13:56:36 error gateway/channels/matrix [default] channel exited: Blocked: resolves to private/internal/special-use IP address
```
No error logs like ⬆️ after fixed, matrix setup successfully. 
<img width="404" height="202" alt="ScreenShot 2026-03-10 at 14 45 34@2x" src="https://github.com/user-attachments/assets/f40c4884-bead-43b2-85ea-010999d09ceb" />


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Just revert
- Files/config to restore: Nothing need to restore
- Known bad symptoms reviewers should watch for: Nothing

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
