### PR TITLE
fix(agents): strip leaked to=... JSON tool-call prefixes in user-faci…

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -15,6 +15,17 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips leaked tool-call prefixes that start with to=... and JSON args", () => {
+    const input =
+      'to=cron ... {"action":"create","schedule":"in 2 minutes","message":"check reminders"}\nSet.';
+    expect(sanitizeUserFacingText(input)).toBe("Set.");
+  });
+
+  it("does not clobber normal prose that happens to include to=... text", () => {
+    const input = 'Use to=cron as an example string in docs: {"note":"not a tool call"}';
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -405,6 +405,67 @@ function stripFinalTagsFromText(text: string): string {
   return text.replace(FINAL_TAG_RE, "");
 }
 
+function findBalancedJsonObjectEnd(text: string, startIndex: number): number | null {
+  if (startIndex < 0 || startIndex >= text.length || text[startIndex] !== "{") {
+    return null;
+  }
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+  for (let i = startIndex; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (ch === "\\") {
+        escaping = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      depth += 1;
+      continue;
+    }
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return i + 1;
+      }
+    }
+  }
+  return null;
+}
+
+function stripLeakedToolCallPrefix(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const header = text.match(/^\s*to=[^\s]+[^\n{]*\{/i);
+  if (!header) {
+    return text;
+  }
+  const braceIndex = text.indexOf("{", header.index ?? 0);
+  if (braceIndex < 0) {
+    return text;
+  }
+  const objectEnd = findBalancedJsonObjectEnd(text, braceIndex);
+  if (!objectEnd) {
+    return text;
+  }
+  const objectText = text.slice(braceIndex, objectEnd);
+  // Only strip if it looks like JSON tool-call arguments, not arbitrary prose.
+  if (!/"[a-zA-Z0-9_]+"\s*:/.test(objectText)) {
+    return text;
+  }
+  return text.slice(objectEnd).replace(/^[ \t]*(?:\r?\n)?/, "");
+}
+
 function collapseConsecutiveDuplicateBlocks(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -722,7 +783,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return text;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripFinalTagsFromText(text);
+  const stripped = stripLeakedToolCallPrefix(stripFinalTagsFromText(text));
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";


### PR DESCRIPTION
## Summary

Fixes a sanitization gap where raw tool-call prefixes could leak into user-facing output, e.g.
`to=cron ... {"action":"create", ...}` (see #41844).

- Problem: leaked `to=...` + JSON argument block appeared in outbound text.
- Why it matters: exposes internal tool-call scaffolding in user-visible replies.
- What changed: added a conservative prefix-strip pass in `sanitizeUserFacingText` that removes leading `to=...` tool-call style JSON blocks.
- Scope boundary: only strips when the prefix starts the message and the JSON looks like key/value args.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Tests

- Added regression test for stripping leaked `to=... {json}` prefixes.
- Added regression test to ensure normal prose containing `to=...` is not clobbered.

## Notes

Local test execution was not completed in this environment because `pnpm/corepack` is unavailable.
