### PR TITLE
fix(discord): honor steer mode in inbound worker

### DIFF
--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -175,42 +175,45 @@ describe("createDiscordMessageHandler queue behavior", () => {
     });
   });
 
-  it("allows steer-mode Discord messages for the same session to start without waiting for the prior run to finish", async () => {
-    preflightDiscordMessageMock.mockReset();
-    processDiscordMessageMock.mockReset();
+  it.each(["steer", "steer-backlog"] as const)(
+    "allows %s-mode Discord messages for the same session to start without waiting for the prior run to finish",
+    async (queueMode) => {
+      preflightDiscordMessageMock.mockReset();
+      processDiscordMessageMock.mockReset();
 
-    const firstRun = createDeferred();
-    const secondRun = createDeferred();
-    processDiscordMessageMock
-      .mockImplementationOnce(async () => {
-        await firstRun.promise;
-      })
-      .mockImplementationOnce(async () => {
-        await secondRun.promise;
+      const firstRun = createDeferred();
+      const secondRun = createDeferred();
+      processDiscordMessageMock
+        .mockImplementationOnce(async () => {
+          await firstRun.promise;
+        })
+        .mockImplementationOnce(async () => {
+          await secondRun.promise;
+        });
+      preflightDiscordMessageMock.mockImplementation(
+        async (params: { data: { channel_id: string } }) =>
+          createPreflightContext(params.data.channel_id),
+      );
+
+      const handler = createDiscordMessageHandler(createHandlerParams({ queueMode }));
+
+      await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
+      await vi.waitFor(() => {
+        expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
       });
-    preflightDiscordMessageMock.mockImplementation(
-      async (params: { data: { channel_id: string } }) =>
-        createPreflightContext(params.data.channel_id),
-    );
 
-    const handler = createDiscordMessageHandler(createHandlerParams({ queueMode: "steer" }));
+      await expect(handler(createMessageData("m-2") as never, {} as never)).resolves.toBeUndefined();
 
-    await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-    });
+      await vi.waitFor(() => {
+        expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      });
 
-    await expect(handler(createMessageData("m-2") as never, {} as never)).resolves.toBeUndefined();
-
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
-    });
-
-    firstRun.resolve();
-    secondRun.resolve();
-    await firstRun.promise;
-    await secondRun.promise;
-  });
+      firstRun.resolve();
+      secondRun.resolve();
+      await firstRun.promise;
+      await secondRun.promise;
+    },
+  );
 
   it("applies listener timeout to queued runs so stalled runs do not block the queue", async () => {
     vi.useFakeTimers();

--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -27,6 +27,7 @@ function createHandlerParams(overrides?: {
   setStatus?: (patch: Record<string, unknown>) => void;
   abortSignal?: AbortSignal;
   listenerTimeoutMs?: number;
+  queueMode?: "collect" | "followup" | "interrupt" | "steer" | "steer-backlog";
 }) {
   const cfg: OpenClawConfig = {
     channels: {
@@ -40,6 +41,11 @@ function createHandlerParams(overrides?: {
       inbound: {
         debounceMs: 0,
       },
+      queue: overrides?.queueMode
+        ? {
+            mode: overrides.queueMode,
+          }
+        : undefined,
     },
   };
   return {
@@ -167,6 +173,43 @@ describe("createDiscordMessageHandler queue behavior", () => {
         }),
       );
     });
+  });
+
+  it("allows steer-mode Discord messages for the same session to start without waiting for the prior run to finish", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const firstRun = createDeferred();
+    const secondRun = createDeferred();
+    processDiscordMessageMock
+      .mockImplementationOnce(async () => {
+        await firstRun.promise;
+      })
+      .mockImplementationOnce(async () => {
+        await secondRun.promise;
+      });
+    preflightDiscordMessageMock.mockImplementation(
+      async (params: { data: { channel_id: string } }) =>
+        createPreflightContext(params.data.channel_id),
+    );
+
+    const handler = createDiscordMessageHandler(createHandlerParams({ queueMode: "steer" }));
+
+    await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    await expect(handler(createMessageData("m-2") as never, {} as never)).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+    });
+
+    firstRun.resolve();
+    secondRun.resolve();
+    await firstRun.promise;
+    await secondRun.promise;
   });
 
   it("applies listener timeout to queued runs so stalled runs do not block the queue", async () => {

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -8,6 +8,7 @@ import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-grou
 import { danger } from "../../globals.js";
 import { formatDurationSeconds } from "../../infra/format-time/format-duration.ts";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
+import { resolveQueueSettings } from "../../auto-reply/reply/queue.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
 import type {
@@ -176,6 +177,17 @@ function resolveDiscordRunQueueKey(ctx: DiscordMessagePreflightContext): string 
   return ctx.messageChannelId;
 }
 
+function shouldBypassDiscordSessionQueue(params: {
+  cfg: DiscordMessageHandlerParams["cfg"];
+  ctx: DiscordMessagePreflightContext;
+}): boolean {
+  const resolved = resolveQueueSettings({
+    cfg: params.cfg,
+    channel: "discord",
+  });
+  return resolved.mode === "steer";
+}
+
 export function createDiscordMessageHandler(
   params: DiscordMessageHandlerParams,
 ): DiscordMessageHandlerWithLifecycle {
@@ -195,30 +207,33 @@ export function createDiscordMessageHandler(
   });
 
   const enqueueDiscordRun = (ctx: DiscordMessagePreflightContext) => {
-    const queueKey = resolveDiscordRunQueueKey(ctx);
-    void runQueue
-      .enqueue(queueKey, async () => {
+    const runTask = async () => {
+      if (!runState.isActive()) {
+        return;
+      }
+      runState.onRunStart();
+      try {
         if (!runState.isActive()) {
           return;
         }
-        runState.onRunStart();
-        try {
-          if (!runState.isActive()) {
-            return;
-          }
-          await processDiscordRunWithTimeout({
-            ctx,
-            runtime: params.runtime,
-            lifecycleSignal: params.abortSignal,
-            timeoutMs: params.listenerTimeoutMs,
-          });
-        } finally {
-          runState.onRunEnd();
-        }
-      })
-      .catch((err) => {
-        params.runtime.error?.(danger(`discord process failed: ${String(err)}`));
-      });
+        await processDiscordRunWithTimeout({
+          ctx,
+          runtime: params.runtime,
+          lifecycleSignal: params.abortSignal,
+          timeoutMs: params.listenerTimeoutMs,
+        });
+      } finally {
+        runState.onRunEnd();
+      }
+    };
+
+    const runPromise = shouldBypassDiscordSessionQueue({ cfg: params.cfg, ctx })
+      ? runTask()
+      : runQueue.enqueue(resolveDiscordRunQueueKey(ctx), runTask);
+
+    void runPromise.catch((err) => {
+      params.runtime.error?.(danger(`discord process failed: ${String(err)}`));
+    });
   };
 
   const { debouncer } = createChannelInboundDebouncer<{

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -179,13 +179,12 @@ function resolveDiscordRunQueueKey(ctx: DiscordMessagePreflightContext): string 
 
 function shouldBypassDiscordSessionQueue(params: {
   cfg: DiscordMessageHandlerParams["cfg"];
-  ctx: DiscordMessagePreflightContext;
 }): boolean {
   const resolved = resolveQueueSettings({
     cfg: params.cfg,
     channel: "discord",
   });
-  return resolved.mode === "steer";
+  return resolved.mode === "steer" || resolved.mode === "steer-backlog";
 }
 
 export function createDiscordMessageHandler(
@@ -227,7 +226,7 @@ export function createDiscordMessageHandler(
       }
     };
 
-    const runPromise = shouldBypassDiscordSessionQueue({ cfg: params.cfg, ctx })
+    const runPromise = shouldBypassDiscordSessionQueue({ cfg: params.cfg })
       ? runTask()
       : runQueue.enqueue(resolveDiscordRunQueueKey(ctx), runTask);
 


### PR DESCRIPTION
## Summary
- bypass the outer Discord inbound worker queue when `messages.queue.mode` resolves to `"steer"`
- keep non-steer modes on the existing per-session queue path
- add a regression test that proves a second same-session Discord message can start before the prior run finishes in steer mode

## Root cause
Discord follow-up messages were being serialized by the outer `KeyedAsyncQueue` in the Discord inbound worker before the inner steer/interrupt logic had a chance to run. That made steer appear broken in Discord threads even though the inner run-control path was still intact.

## Testing
- `pnpm exec vitest run src/discord/monitor/message-handler.queue.test.ts src/discord/monitor/message-handler.process.test.ts`
