### PR TITLE
fix(telegram,auto-reply): reduce false stall and timeout churn

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
+import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
@@ -610,11 +611,16 @@ export async function runAgentTurnWithFallback(params: {
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
+      const isTimeoutFailure =
+        resolveFailoverReasonFromError(err) === "timeout" ||
+        /\b(?:timed?\s*out|timeout)\b/i.test(safeMessage);
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : isTimeoutFailure
+            ? "⚠️ Model run timed out before reply. This run has ended and will not continue in the background.\nSend a new message (or /retry) to start a fresh run.\nLogs: openclaw logs --follow"
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1422,6 +1422,40 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("surfaces explicit timeout guidance when the run times out", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-timeout";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const sessionEntry: SessionEntry = {
+        sessionId,
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error("Request timed out");
+      });
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      expect(res).toMatchObject({
+        text: expect.stringContaining("timed out before reply"),
+      });
+      expect(res).toMatchObject({
+        text: expect.stringContaining("run has ended"),
+      });
+    });
+  });
+
   it("still replies even if session reset fails to persist", async () => {
     await withTempStateDir(async (stateDir) => {
       const saveSpy = vi

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -4,6 +4,7 @@ export function registerGetReplyCommonMocks(): void {
   vi.mock("../../agents/agent-scope.js", () => ({
     resolveAgentDir: vi.fn(() => "/tmp/agent"),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+    resolveRunModelFallbacksOverride: vi.fn(() => undefined),
     resolveSessionAgentId: vi.fn(() => "main"),
     resolveAgentSkillsFilter: vi.fn(() => undefined),
   }));
@@ -20,9 +21,14 @@ export function registerGetReplyCommonMocks(): void {
   vi.mock("../../channels/model-overrides.js", () => ({
     resolveChannelModelOverride: vi.fn(() => undefined),
   }));
-  vi.mock("../../config/config.js", () => ({
-    loadConfig: vi.fn(() => ({})),
-  }));
+  vi.mock("../../config/config.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../config/config.js")>();
+    return {
+      ...actual,
+      loadConfig: vi.fn(() => ({})),
+      STATE_DIR: "/tmp/openclaw-state",
+    };
+  });
   vi.mock("../../runtime.js", () => ({
     defaultRuntime: { log: vi.fn() },
   }));

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,6 +1,7 @@
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
+  resolveRunModelFallbacksOverride,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
@@ -9,6 +10,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -52,6 +54,34 @@ function mergeSkillFilters(channelFilter?: string[], agentFilter?: string[]): st
   }
   const agentSet = new Set(agent);
   return channel.filter((name) => agentSet.has(name));
+}
+
+// Keep typing alive long enough for multi-attempt runs, but cap it to avoid
+// indefinite typing loops when timeouts are very large or disabled.
+const MIN_TYPING_TTL_MS = 2 * 60_000;
+const MAX_TYPING_TTL_MS = 120 * 60_000;
+const TRANSIENT_RETRY_CYCLES = 2;
+const TYPING_TTL_BUFFER_MS = 15_000;
+
+function resolveTypingTtlMs(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+  timeoutMs: number;
+}): number {
+  const fallbackOverrides = resolveRunModelFallbacksOverride({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  const configuredFallbacks = resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
+  const fallbackCount = Math.max(0, (fallbackOverrides ?? configuredFallbacks).length);
+  const projectedAttemptCount = Math.max(1, 1 + fallbackCount);
+  // One transient HTTP retry can replay the full model chain; keep typing alive
+  // long enough to cover both cycles so users do not see false "dead" runs.
+  const projectedTtlMs =
+    params.timeoutMs * projectedAttemptCount * TRANSIENT_RETRY_CYCLES + TYPING_TTL_BUFFER_MS;
+  return Math.max(MIN_TYPING_TTL_MS, Math.min(projectedTtlMs, MAX_TYPING_TTL_MS));
 }
 
 export async function getReplyFromConfig(
@@ -114,10 +144,17 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
+  const typingTtlMs = resolveTypingTtlMs({
+    cfg,
+    agentId,
+    sessionKey: agentSessionKey,
+    timeoutMs,
+  });
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
     typingIntervalSeconds,
+    typingTtlMs,
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
   });

--- a/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
+++ b/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../templating.js";
+import { registerGetReplyCommonMocks } from "./get-reply.test-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  initSessionState: vi.fn(),
+}));
+
+registerGetReplyCommonMocks();
+
+vi.mock("../../link-understanding/apply.js", () => ({
+  applyLinkUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("../../media-understanding/apply.js", () => ({
+  applyMediaUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("./commands-core.js", () => ({
+  emitResetCommandHooks: vi.fn(async () => undefined),
+}));
+vi.mock("./get-reply-directives.js", () => ({
+  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
+}));
+vi.mock("./session.js", () => ({
+  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
+}));
+
+const { getReplyFromConfig } = await import("./get-reply.js");
+const { createTypingController } = await import("./typing.js");
+const { resolveAgentTimeoutMs } = await import("../../agents/timeout.js");
+const { resolveRunModelFallbacksOverride } = await import("../../agents/agent-scope.js");
+
+function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    Provider: "telegram",
+    Surface: "telegram",
+    OriginatingChannel: "telegram",
+    OriginatingTo: "telegram:-100123",
+    ChatType: "group",
+    Body: "hello",
+    BodyForAgent: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    SessionKey: "agent:main:telegram:-100123",
+    From: "telegram:user:42",
+    To: "telegram:-100123",
+    GroupChannel: "ops",
+    Timestamp: 1710000000000,
+    ...overrides,
+  };
+}
+
+describe("getReply typing timeout budget", () => {
+  beforeEach(() => {
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.initSessionState.mockReset();
+    vi.mocked(createTypingController).mockClear();
+    vi.mocked(resolveAgentTimeoutMs).mockReset();
+    vi.mocked(resolveRunModelFallbacksOverride).mockReset();
+
+    mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: {},
+      sessionEntry: {},
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:-100123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: true,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+  });
+
+  it("extends typing TTL based on timeout and fallback chain budget", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(90_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
+      "openai/gpt-5.2",
+      "openai/gpt-5.1",
+    ]);
+
+    await getReplyFromConfig(buildCtx(), undefined, {});
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 555_000,
+      }),
+    );
+  });
+
+  it("keeps a minimum typing TTL for short timeout chains", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(30_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([]);
+
+    await getReplyFromConfig(buildCtx(), undefined, {});
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 120_000,
+      }),
+    );
+  });
+
+  it("caps typing TTL to avoid unbounded typing loops", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(4_000_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
+      "openai/gpt-5.2",
+      "openai/gpt-5.1",
+      "openai/gpt-5.0",
+    ]);
+
+    await getReplyFromConfig(buildCtx(), undefined, {});
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 7_200_000,
+      }),
+    );
+  });
+});

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -116,6 +116,18 @@ describe("createTelegramBot", () => {
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(sequentializeKey).toBe(getTelegramSequentialKey);
   });
+  it("registers pre-handler middleware before Telegram handlers", () => {
+    const preHandlerHook = vi.fn();
+    createTelegramBot({
+      token: "tok",
+      onBeforeHandlersRegister: preHandlerHook,
+    });
+
+    expect(preHandlerHook).toHaveBeenCalledWith(expect.any(Object));
+    const hookOrder = preHandlerHook.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER;
+    const firstHandlerOrder = onSpy.mock.invocationCallOrder[0] ?? 0;
+    expect(hookOrder).toBeLessThan(firstHandlerOrder);
+  });
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,6 +1,6 @@
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
-import type { ApiClientOptions, Context } from "grammy";
+import type { ApiClientOptions } from "grammy";
 import { Bot } from "grammy";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,6 +1,6 @@
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
-import type { ApiClientOptions } from "grammy";
+import type { ApiClientOptions, Context } from "grammy";
 import { Bot } from "grammy";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
@@ -64,6 +64,11 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /**
+   * Optional hook for middleware that must run before bot handlers are registered.
+   * Useful for cross-cutting update lifecycle tracking used by polling watchdogs.
+   */
+  onBeforeHandlersRegister?: (bot: Bot) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -413,6 +418,10 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     textLimit,
     opts,
   });
+
+  // Allow callers to attach middleware that must execute before the first
+  // handler layer. This avoids relying on post-handler middleware ordering.
+  opts.onBeforeHandlersRegister?.(bot);
 
   registerTelegramNativeCommands({
     bot,

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -66,6 +66,9 @@ const { createTelegramBotErrors } = vi.hoisted(() => ({
 const { createTelegramBotCalls } = vi.hoisted(() => ({
   createTelegramBotCalls: [] as Array<Record<string, unknown>>,
 }));
+const { createTelegramBotUseSpies } = vi.hoisted(() => ({
+  createTelegramBotUseSpies: [] as Array<ReturnType<typeof vi.fn>>,
+}));
 
 const { createdBotStops } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
@@ -166,15 +169,22 @@ vi.mock("./bot.js", () => ({
       }
       await api.sendMessage(chatId, `echo:${text}`, { parse_mode: "HTML" });
     };
-    return {
+    const use = vi.fn();
+    const bot = {
       on: vi.fn(),
-      use: vi.fn(),
+      use,
       api,
       me: { username: "mybot" },
       init: initSpy,
       stop,
       start: vi.fn(),
     };
+    const onBeforeHandlersRegister = opts.onBeforeHandlersRegister;
+    if (typeof onBeforeHandlersRegister === "function") {
+      onBeforeHandlersRegister(bot);
+    }
+    createTelegramBotUseSpies.push(use);
+    return bot;
   },
 }));
 
@@ -224,6 +234,7 @@ describe("monitorTelegramProvider (grammY)", () => {
       }),
     );
     createTelegramBotCalls.length = 0;
+    createTelegramBotUseSpies.length = 0;
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
     startTelegramWebhookSpy.mockClear();
@@ -567,6 +578,56 @@ describe("monitorTelegramProvider (grammY)", () => {
 
     // Advance time past the stall threshold (90s) + watchdog interval (30s)
     vi.advanceTimersByTime(120_000);
+    await monitor;
+
+    expect(stop.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(computeBackoff).toHaveBeenCalled();
+    expect(runSpy).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("force-restarts polling when a handler stays active beyond watchdog bypass max", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    let running = true;
+    let releaseTask: (() => void) | undefined;
+    const stop = vi.fn(async () => {
+      running = false;
+      releaseTask?.();
+    });
+
+    runSpy
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () =>
+            new Promise<void>((resolve) => {
+              releaseTask = resolve;
+            }),
+          stop,
+          isRunning: () => running,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: async () => {
+            abort.abort();
+          },
+        }),
+      );
+
+    const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+    await vi.waitFor(() => expect(runSpy).toHaveBeenCalledTimes(1));
+
+    const firstUse = createTelegramBotUseSpies[0];
+    const lifecycleMiddleware = firstUse?.mock.calls[0]?.[0] as
+      | ((ctx: unknown, next: () => Promise<void>) => Promise<void>)
+      | undefined;
+    expect(lifecycleMiddleware).toBeTypeOf("function");
+    void lifecycleMiddleware?.({}, async () => await new Promise<void>(() => undefined));
+    await Promise.resolve();
+
+    // Past stall threshold and watchdog interval, plus active-handler bypass max.
+    vi.advanceTimersByTime(750_000);
     await monitor;
 
     expect(stop.mock.calls.length).toBeGreaterThanOrEqual(1);

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -168,6 +168,7 @@ vi.mock("./bot.js", () => ({
     };
     return {
       on: vi.fn(),
+      use: vi.fn(),
       api,
       me: { username: "mybot" },
       init: initSpy,

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -164,11 +164,22 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
+    // Track active update handlers so the watchdog does not treat
+    // "busy processing updates" as a stalled poller.
+    let activeUpdateHandlers = 0;
     bot.api.config.use((prev, method, payload, signal) => {
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
       }
       return prev(method, payload, signal);
+    });
+    bot.use(async (_ctx, next) => {
+      activeUpdateHandlers += 1;
+      try {
+        await next();
+      } finally {
+        activeUpdateHandlers = Math.max(0, activeUpdateHandlers - 1);
+      }
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -200,6 +211,9 @@ export class TelegramPollingSession {
 
     const watchdog = setInterval(() => {
       if (this.opts.abortSignal?.aborted) {
+        return;
+      }
+      if (activeUpdateHandlers > 0) {
         return;
       }
       const elapsed = Date.now() - lastGetUpdatesAt;

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -15,6 +15,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
+const ACTIVE_HANDLER_WATCHDOG_BYPASS_MAX_MS = 10 * 60_000;
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
@@ -36,6 +37,7 @@ export class TelegramPollingSession {
   #webhookCleared = false;
   #forceRestarted = false;
   #activeUpdateHandlers = 0;
+  #activeUpdateHandlersSinceMs: number | null = null;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
 
@@ -107,6 +109,7 @@ export class TelegramPollingSession {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
     this.#activeUpdateHandlers = 0;
+    this.#activeUpdateHandlersSinceMs = null;
     try {
       return createTelegramBot({
         token: this.opts.token,
@@ -122,10 +125,17 @@ export class TelegramPollingSession {
         onBeforeHandlersRegister: (bot) => {
           bot.use(async (_ctx, next) => {
             this.#activeUpdateHandlers += 1;
+            if (this.#activeUpdateHandlers === 1) {
+              // Track when active processing started so watchdog bypass is bounded.
+              this.#activeUpdateHandlersSinceMs = Date.now();
+            }
             try {
               await next();
             } finally {
               this.#activeUpdateHandlers = Math.max(0, this.#activeUpdateHandlers - 1);
+              if (this.#activeUpdateHandlers === 0) {
+                this.#activeUpdateHandlersSinceMs = null;
+              }
             }
           });
         },
@@ -214,10 +224,18 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
+      const now = Date.now();
+      const elapsed = now - lastGetUpdatesAt;
       if (this.#activeUpdateHandlers > 0) {
-        return;
+        const activeElapsed =
+          this.#activeUpdateHandlersSinceMs === null ? 0 : now - this.#activeUpdateHandlersSinceMs;
+        if (activeElapsed <= ACTIVE_HANDLER_WATCHDOG_BYPASS_MAX_MS) {
+          return;
+        }
+        this.opts.log(
+          `[telegram] Polling watchdog bypass expired (${this.#activeUpdateHandlers} active handler(s) for ${formatDurationPrecise(activeElapsed)}); forcing restart.`,
+        );
       }
-      const elapsed = Date.now() - lastGetUpdatesAt;
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
         stalledRestart = true;
         this.opts.log(

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -35,6 +35,7 @@ export class TelegramPollingSession {
   #restartAttempts = 0;
   #webhookCleared = false;
   #forceRestarted = false;
+  #activeUpdateHandlers = 0;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
 
@@ -105,6 +106,7 @@ export class TelegramPollingSession {
   async #createPollingBot(): Promise<TelegramBot | undefined> {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
+    this.#activeUpdateHandlers = 0;
     try {
       return createTelegramBot({
         token: this.opts.token,
@@ -116,6 +118,16 @@ export class TelegramPollingSession {
         updateOffset: {
           lastUpdateId: this.opts.getLastUpdateId(),
           onUpdateId: this.opts.persistUpdateId,
+        },
+        onBeforeHandlersRegister: (bot) => {
+          bot.use(async (_ctx, next) => {
+            this.#activeUpdateHandlers += 1;
+            try {
+              await next();
+            } finally {
+              this.#activeUpdateHandlers = Math.max(0, this.#activeUpdateHandlers - 1);
+            }
+          });
         },
       });
     } catch (err) {
@@ -164,22 +176,11 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    // Track active update handlers so the watchdog does not treat
-    // "busy processing updates" as a stalled poller.
-    let activeUpdateHandlers = 0;
     bot.api.config.use((prev, method, payload, signal) => {
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
       }
       return prev(method, payload, signal);
-    });
-    bot.use(async (_ctx, next) => {
-      activeUpdateHandlers += 1;
-      try {
-        await next();
-      } finally {
-        activeUpdateHandlers = Math.max(0, activeUpdateHandlers - 1);
-      }
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -213,7 +214,7 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
-      if (activeUpdateHandlers > 0) {
+      if (this.#activeUpdateHandlers > 0) {
         return;
       }
       const elapsed = Date.now() - lastGetUpdatesAt;

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -226,17 +226,25 @@ export class TelegramPollingSession {
       }
       const now = Date.now();
       const elapsed = now - lastGetUpdatesAt;
+      let bypassExpired = false;
       if (this.#activeUpdateHandlers > 0) {
         const activeElapsed =
           this.#activeUpdateHandlersSinceMs === null ? 0 : now - this.#activeUpdateHandlersSinceMs;
         if (activeElapsed <= ACTIVE_HANDLER_WATCHDOG_BYPASS_MAX_MS) {
           return;
         }
-        this.opts.log(
-          `[telegram] Polling watchdog bypass expired (${this.#activeUpdateHandlers} active handler(s) for ${formatDurationPrecise(activeElapsed)}); forcing restart.`,
-        );
+        bypassExpired = true;
       }
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
+        if (bypassExpired) {
+          const activeElapsed =
+            this.#activeUpdateHandlersSinceMs === null
+              ? 0
+              : now - this.#activeUpdateHandlersSinceMs;
+          this.opts.log(
+            `[telegram] Polling watchdog bypass expired (${this.#activeUpdateHandlers} active handler(s) for ${formatDurationPrecise(activeElapsed)}); forcing restart.`,
+          );
+        }
         stalledRestart = true;
         this.opts.log(
           `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram watchdog could trigger unnecessary restart behavior while updates were still actively being processed, and auto-reply typing visibility could timeout too aggressively for slower valid runs.
- Why it matters: false-stall signals and early typing timeout noise can degrade reliability and increase operator intervention in live channels.
- What changed: add active-handler aware stall guard in Telegram polling session watchdog path and extend/clarify typing timeout budgeting in auto-reply flow with matching test coverage updates.
- What did NOT change (scope boundary): no model routing/auth behavior changes, no channel onboarding flow changes, no new feature flags.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Telegram long-poll watchdog is less likely to treat active processing as stalled.
- Auto-reply typing timeout handling is more tolerant and logs are clearer when a timeout budget is consumed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Darwin 25.3.0 arm64
- Runtime/container: local Node v25.6.1 / pnpm 10.23.0
- Model/provider: N/A for these unit tests
- Integration/channel (if any): Telegram + auto-reply internals
- Relevant config (redacted): default repo test config

### Steps

1. Checkout branch from latest `upstream/main`.
2. Apply both commits in this PR.
3. Run `pnpm exec vitest run src/telegram/monitor.test.ts src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts`.

### Expected

- Monitor and typing-timeout tests pass with watchdog guard + timeout budget behavior covered.

### Actual

- Passed: 2 files, 24 tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted vitest run for telegram monitor + typing-timeout budget behavior.
- Edge cases checked: active processing watchdog skip path and typing timeout budget boundary checks.
- What you did **not** verify: full live Telegram runtime and `*.e2e.test.ts` (excluded by repo default vitest config).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8cafb08f8` and/or `3b53bc64e`.
- Files/config to restore: `src/telegram/polling-session.ts`, `src/auto-reply/reply/get-reply.ts`, `src/auto-reply/reply/agent-runner-execution.ts` and associated tests.
- Known bad symptoms reviewers should watch for: recurring restart loops, missing typing timeout notices, or unexpectedly delayed timeout signaling.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: watchdog may now suppress a genuine stall if active-handler bookkeeping is inaccurate.
  - Mitigation: explicit monitor tests around active-processing behavior.
- Risk: longer typing budget can delay timeout visibility in edge cases.
  - Mitigation: bounded extension with deterministic budget tests.


## AI Assistance

- AI-assisted: Yes (Codex + review bots)
- Testing degree: Fully tested for repo baseline (pnpm build && pnpm check && pnpm test), plus targeted regression runs; live Telegram runtime and .e2e suite still not run
- Prompt/session logs: Available on request
- Code understanding confirmation: Yes


## Additional Verification After Review Feedback

- Ran full `CONTRIBUTING.md` baseline on this branch: `pnpm build && pnpm check && pnpm test`
- Result: pass (`880` test files, `7174` tests passed, `2` skipped)
- Added regression test for middleware ordering: `registers pre-handler middleware before Telegram handlers`
- Addressed Codex inline middleware-ordering and watchdog-bypass reviews in commits `5b34e8518`, `3a51ccb46`, and `9ace715c4`

