### PR TITLE
Android: fix Bitmap memory leaks in CanvasController snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@ Docs: https://docs.openclaw.ai
 - Discord/pickers: keep `/codex_resume --browse-projects` picker callbacks alive in Discord by sharing component callback state across duplicate module graphs, preserving callback fallbacks, and acknowledging matched plugin interactions before dispatch. (#51260) Thanks @huntharo.
 - Agents/memory flush: keep transcript-hash dedup active across memory-flush fallback retries so a write-then-throw flush attempt cannot append duplicate `MEMORY.md` entries before the fallback cycle completes. (#34222) Thanks @lml2468.
 - make `openclaw update status` explicitly say `up to date` when the local version already matches npm latest, while keeping the availability logic unchanged. (#51409) Thanks @dongzhenye.
+- Android/canvas: recycle captured and scaled snapshot bitmaps so repeated canvas snapshots do not leak native image memory. (#41889) Thanks @Kaneki-x.
 
 ### Breaking
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CanvasController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CanvasController.kt
@@ -180,27 +180,41 @@ class CanvasController {
     withContext(Dispatchers.Main) {
       val wv = webView ?: throw IllegalStateException("no webview")
       val bmp = wv.captureBitmap()
-      val scaled = bmp.scaleForMaxWidth(maxWidth)
-
-      val out = ByteArrayOutputStream()
-      scaled.compress(Bitmap.CompressFormat.PNG, 100, out)
-      Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+      try {
+        val scaled = bmp.scaleForMaxWidth(maxWidth)
+        try {
+          val out = ByteArrayOutputStream()
+          scaled.compress(Bitmap.CompressFormat.PNG, 100, out)
+          Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+        } finally {
+          if (scaled !== bmp) scaled.recycle()
+        }
+      } finally {
+        bmp.recycle()
+      }
     }
 
   suspend fun snapshotBase64(format: SnapshotFormat, quality: Double?, maxWidth: Int?): String =
     withContext(Dispatchers.Main) {
       val wv = webView ?: throw IllegalStateException("no webview")
       val bmp = wv.captureBitmap()
-      val scaled = bmp.scaleForMaxWidth(maxWidth)
-
-      val out = ByteArrayOutputStream()
-      val (compressFormat, compressQuality) =
-        when (format) {
-          SnapshotFormat.Png -> Bitmap.CompressFormat.PNG to 100
-          SnapshotFormat.Jpeg -> Bitmap.CompressFormat.JPEG to clampJpegQuality(quality)
+      try {
+        val scaled = bmp.scaleForMaxWidth(maxWidth)
+        try {
+          val out = ByteArrayOutputStream()
+          val (compressFormat, compressQuality) =
+            when (format) {
+              SnapshotFormat.Png -> Bitmap.CompressFormat.PNG to 100
+              SnapshotFormat.Jpeg -> Bitmap.CompressFormat.JPEG to clampJpegQuality(quality)
+            }
+          scaled.compress(compressFormat, compressQuality, out)
+          Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+        } finally {
+          if (scaled !== bmp) scaled.recycle()
         }
-      scaled.compress(compressFormat, compressQuality, out)
-      Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+      } finally {
+        bmp.recycle()
+      }
     }
 
   private suspend fun WebView.captureBitmap(): Bitmap =


### PR DESCRIPTION
## Summary

- Fix native memory leaks in `CanvasController.snapshotPngBase64()` and `snapshotBase64()`
- Bitmaps from `captureBitmap()` and `scaleForMaxWidth()` were never recycled after compression
- Wrap both methods in nested `try/finally` blocks to guarantee cleanup:
  - Outer block always recycles the captured bitmap
  - Inner block recycles the scaled bitmap only when it is a different object (identity check `!==` prevents double-recycle when no scaling occurred)

On high-resolution devices, each canvas snapshot leaks a full-screen ARGB_8888 bitmap (potentially 10+ MB). Frequent snapshots (e.g. A2UI polling) could cause OOM or severe GC pressure.

## Test plan

- [x] `./gradlew :app:assembleDebug` builds successfully
- [x] `./gradlew :app:ktlintCheck` passes
- [x] Code review: verified `scaleForMaxWidth()` returns `this` when no scaling needed, so `scaled !== bmp` is false and only the outer finally recycles
- [ ] Manual: trigger repeated canvas snapshots on a real device; confirm no native memory growth (Android Profiler)

AI-assisted: yes (Claude). Fully tested locally (build + lint). I understand what the code does.

Made with [Cursor](https://cursor.com)