### PR TITLE
Android: fix temp file leak in CameraHandler.handleClip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,6 +558,7 @@ Docs: https://docs.openclaw.ai
 - macOS/remote gateway: stop PortGuardian from killing Docker Desktop and other external listeners on the gateway port in remote mode, so containerized and tunneled gateway setups no longer lose their port-forward owner on app startup. (#6755) Thanks @teslamint.
 - Feishu/streaming recovery: clear stale `streamingStartPromise` when card creation fails (HTTP 400) so subsequent messages can retry streaming instead of silently dropping all future replies. Fixes #43322.
 - Exec/env sandbox: block JVM agent injection (`JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`), Python breakpoint hijack (`PYTHONBREAKPOINT`), and .NET startup hooks (`DOTNET_STARTUP_HOOKS`) from the host exec environment. (#49025)
+- Android/camera clip cleanup: delete temporary clip files even when `readBytes()` fails so failed clip captures do not leak cache storage. (#41890) Thanks @Kaneki-x.
 
 ### Security
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt
@@ -134,9 +134,11 @@ class CameraHandler(
       }
 
       val bytes = withContext(Dispatchers.IO) {
-        val b = filePayload.file.readBytes()
-        filePayload.file.delete()
-        b
+        try {
+          filePayload.file.readBytes()
+        } finally {
+          filePayload.file.delete()
+        }
       }
       val base64 = android.util.Base64.encodeToString(bytes, android.util.Base64.NO_WRAP)
       clipLog("returning base64 payload")


### PR DESCRIPTION
## Summary

- Fix a temp file leak in `CameraHandler.handleClip()` when `readBytes()` fails
- Previously, `filePayload.file.delete()` only ran after a successful `readBytes()` — if `readBytes()` threw (e.g. `IOException`, `OutOfMemoryError`), the recorded clip file in the cache dir was orphaned
- Move `file.delete()` into a `finally` block so cleanup happens on all exit paths

Each leaked clip file can be several MB (up to 18 MB max). Over time, repeated failures would accumulate orphaned files in the app cache.

## Test plan

- [x] `./gradlew :app:assembleDebug` builds successfully
- [x] `./gradlew :app:ktlintCheck` passes
- [x] Code review: `File.delete()` returns boolean (never throws), so the finally block is safe; on success the bytes are already read into memory before delete runs
- [ ] Manual: simulate a `readBytes()` failure (e.g. fill disk) and verify the temp file is still cleaned up

AI-assisted: yes (Claude). Fully tested locally (build + lint). I understand what the code does.

Made with [Cursor](https://cursor.com)