### PR TITLE
Android: escape SQL LIKE wildcards in contacts search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Matrix: add a new Matrix plugin backed by the official `matrix-js-sdk`. If you are upgrading from the previous public Matrix plugin, follow the migration guide: https://docs.openclaw.ai/install/migrating-matrix Thanks @gumadeiras.
 - Discord/commands: switch native command deployment to Carbon reconcile by default so Discord restarts stop churning slash commands through OpenClaw’s local deploy path. (#46597) Thanks @huntharo and @thewilloftheshadow.
 - Plugins/Matrix: durably dedupe inbound room events across gateway restarts so previously handled Matrix messages are not replayed as new, while preserving clean-restart backlog delivery for unseen events. (#50922) thanks @gumadeiras
+- Android/contacts search: escape literal `%` and `_` in contact-name queries so searches like `100%` or `_id` no longer match unrelated contacts through SQL `LIKE` wildcards. (#41891) Thanks @Kaneki-x.
 
 ## 2026.3.13
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ContactsHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ContactsHandler.kt
@@ -76,8 +76,8 @@ private object SystemContactsDataSource : ContactsDataSource {
       selection = null
       selectionArgs = null
     } else {
-      selection = "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} LIKE ?"
-      selectionArgs = arrayOf("%${request.query}%")
+      selection = "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} LIKE ? ESCAPE '\\'"
+      selectionArgs = arrayOf("%${escapeLikePattern(request.query)}%")
     }
     val sortOrder = "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} COLLATE NOCASE ASC LIMIT ${request.limit}"
     resolver.query(
@@ -246,6 +246,9 @@ private object SystemContactsDataSource : ContactsDataSource {
       return cursor.getString(0)?.trim()?.ifEmpty { null }
     }
   }
+
+  private fun escapeLikePattern(pattern: String): String =
+    pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
   private fun loadPhones(resolver: ContentResolver, contactId: Long): List<String> {
     return queryContactValues(


### PR DESCRIPTION
## Summary

- Fix incorrect contacts search results when the query contains `%` or `_` characters
- These characters were passed directly into a SQL `LIKE` pattern, where `%` matches any sequence and `_` matches any single character
- For example, searching for `100%` would match `100`, `1000`, `100abc`, etc. instead of only contacts containing the literal string `100%`
- Add `escapeLikePattern()` helper that escapes `\`, `%`, and `_` with a backslash prefix (in correct order to avoid double-escaping)
- Add `ESCAPE '\'` clause to the SQL selection so SQLite interprets `\%` and `\_` as literal characters

## Test plan

- [x] `./gradlew :app:assembleDebug` builds successfully
- [x] `./gradlew :app:ktlintCheck` passes
- [x] Code review: escape order verified (backslash first, then `%`, then `_`); `ESCAPE` clause is standard SQL supported by Android SQLite
- [ ] Manual: search contacts with queries containing `%` and `_`; confirm results match only literal occurrences

AI-assisted: yes (Claude). Fully tested locally (build + lint). I understand what the code does.

Made with [Cursor](https://cursor.com)