### PR TITLE
fix(discord): add missing autoThread field to DiscordGuildChannelConfig type

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -52,6 +52,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** If true, automatically create threads for messages in this channel (default: false). */
+  autoThread?: boolean;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";


### PR DESCRIPTION
## Bug Fix

Fixes #35607

### Problem
The autoThread field was present in the Zod schema (DiscordGuildChannelSchema) and used in runtime code, but missing from the TypeScript type definition. This caused type safety gaps and required workarounds in allow-list.ts

### Solution
Added autoThread?: boolean field to the DiscordGuildChannelConfig type definition.

### Testing
- [x] Ran pnpm check - passed with 0 errors

### AI-Assisted
This fix was prepared with AI assistance (Claude).