### PR TITLE
fix: respect agents.defaults.heartbeat in isHeartbeatEnabledForAgent

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -195,7 +195,7 @@ describe("isHeartbeatEnabledForAgent", () => {
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
-  it("falls back to default agent when no explicit heartbeat entries", () => {
+  it("enables all agents when defaults.heartbeat is set but no per-agent overrides", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
@@ -203,6 +203,16 @@ describe("isHeartbeatEnabledForAgent", () => {
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("disables all agents when no heartbeat is configured anywhere", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -127,7 +127,13 @@ export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string
       (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
     );
   }
-  return resolvedAgentId === resolveDefaultAgentId(cfg);
+  const hasDefaults = Boolean(cfg.agents?.defaults?.heartbeat);
+  if (hasDefaults) {
+    // defaults.heartbeat is set but no per-agent overrides — all agents are enabled
+    return true;
+  }
+  // no heartbeat configured anywhere — disabled for all agents
+  return false;
 }
 
 function resolveHeartbeatConfig(


### PR DESCRIPTION
Fixes #41879

`isHeartbeatEnabledForAgent` had two issues:

1. With zero heartbeat config, the default agent still got heartbeat enabled via the fallback — even though nobody asked for it
2. Setting `agents.defaults.heartbeat` without per-agent entries only enabled heartbeat for the default agent, ignoring the intent to apply defaults to all agents

The root cause is that `hasExplicitHeartbeatAgents()` only checks per-agent `heartbeat` properties. When it returns false, the function falls through to `return resolvedAgentId === resolveDefaultAgentId(cfg)` which unconditionally enables the default agent.

**Fix:** After the explicit-agents check, look at `agents.defaults.heartbeat`. If set, enable all agents (the user configured defaults for a reason). If nothing is configured anywhere, return false.

| Config | Before | After |
|---|---|---|
| No heartbeat anywhere | default agent enabled | all disabled |
| `defaults.heartbeat` only | default agent only | all agents enabled |
| Per-agent on some | those agents | those agents (unchanged) |
| Both defaults + per-agent | per-agent only | per-agent only (unchanged) |

Tests updated to match — added a case for the "nothing configured" scenario and fixed the defaults-only test to expect all agents enabled.