### PR TITLE
Android: fix Bitmap memory leaks in CameraCaptureManager.snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/login: wait for pending creds writes before reopening after Baileys `515` pairing restarts in both QR login and `channels login` flows, and keep the restart coverage pinned to the real wrapped error shape plus per-account creds queues. (#27910) Thanks @asyncjason.
 - Telegram/message send: forward `--force-document` through the `sendPayload` path as well as `sendMedia`, so Telegram payload sends with `channelData` keep uploading images as documents instead of silently falling back to compressed photo sends. (#47119) Thanks @thepagent.
 - Android/canvas: serialize A2UI action-status event strings before evaluating WebView JS, so action ids and multiline errors do not break the callback dispatch. (#43784) Thanks @Kaneki-x.
+- Android/camera: recycle intermediate and final snap bitmaps in `camera.snap` so repeated captures do not leak native image memory. (#41902) Thanks @Kaneki-x.
 - Telegram/message chunking: preserve spaces, paragraph separators, and word boundaries when HTML overflow rechunking splits formatted replies. (#47274) Thanks @obviyus.
 - Z.AI/onboarding: detect a working default model even for explicit `zai-coding-*` endpoint choices, so Coding Plan setup can keep the selected endpoint while defaulting to `glm-5` when available or `glm-4.7` as fallback. (#45969) Thanks @obviyus.
 - CI/onboarding smoke: surface `ensure-base-commit` fetch failures as workflow warnings and fail the onboarding Docker smoke when expected setup prompts drift instead of continuing silently. Thanks @Takhoffman.

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
@@ -121,42 +121,48 @@ class CameraCaptureManager(private val context: Context) {
             (rotated.height.toDouble() * (maxWidth.toDouble() / rotated.width.toDouble()))
               .toInt()
               .coerceAtLeast(1)
-          rotated.scale(maxWidth, h)
+          val s = rotated.scale(maxWidth, h)
+          if (s !== rotated) rotated.recycle()
+          s
         } else {
           rotated
         }
 
-      val maxPayloadBytes = 5 * 1024 * 1024
-      // Base64 inflates payloads by ~4/3; cap encoded bytes so the payload stays under 5MB (API limit).
-      val maxEncodedBytes = (maxPayloadBytes / 4) * 3
-      val result =
-        JpegSizeLimiter.compressToLimit(
-          initialWidth = scaled.width,
-          initialHeight = scaled.height,
-          startQuality = (quality * 100.0).roundToInt().coerceIn(10, 100),
-          maxBytes = maxEncodedBytes,
-          encode = { width, height, q ->
-            val bitmap =
-              if (width == scaled.width && height == scaled.height) {
-                scaled
-              } else {
-                scaled.scale(width, height)
+      try {
+        val maxPayloadBytes = 5 * 1024 * 1024
+        // Base64 inflates payloads by ~4/3; cap encoded bytes so the payload stays under 5MB (API limit).
+        val maxEncodedBytes = (maxPayloadBytes / 4) * 3
+        val result =
+          JpegSizeLimiter.compressToLimit(
+            initialWidth = scaled.width,
+            initialHeight = scaled.height,
+            startQuality = (quality * 100.0).roundToInt().coerceIn(10, 100),
+            maxBytes = maxEncodedBytes,
+            encode = { width, height, q ->
+              val bitmap =
+                if (width == scaled.width && height == scaled.height) {
+                  scaled
+                } else {
+                  scaled.scale(width, height)
+                }
+              val out = ByteArrayOutputStream()
+              if (!bitmap.compress(Bitmap.CompressFormat.JPEG, q, out)) {
+                if (bitmap !== scaled) bitmap.recycle()
+                throw IllegalStateException("UNAVAILABLE: failed to encode JPEG")
               }
-            val out = ByteArrayOutputStream()
-            if (!bitmap.compress(Bitmap.CompressFormat.JPEG, q, out)) {
-              if (bitmap !== scaled) bitmap.recycle()
-              throw IllegalStateException("UNAVAILABLE: failed to encode JPEG")
-            }
-            if (bitmap !== scaled) {
-              bitmap.recycle()
-            }
-            out.toByteArray()
-          },
+              if (bitmap !== scaled) {
+                bitmap.recycle()
+              }
+              out.toByteArray()
+            },
+          )
+        val base64 = Base64.encodeToString(result.bytes, Base64.NO_WRAP)
+        Payload(
+          """{"format":"jpg","base64":"$base64","width":${result.width},"height":${result.height}}""",
         )
-      val base64 = Base64.encodeToString(result.bytes, Base64.NO_WRAP)
-      Payload(
-        """{"format":"jpg","base64":"$base64","width":${result.width},"height":${result.height}}""",
-      )
+      } finally {
+        scaled.recycle()
+      }
     }
 
   @SuppressLint("MissingPermission")


### PR DESCRIPTION
## Summary

`CameraCaptureManager.snap()` leaks native Bitmap memory on every camera snap call. After capturing, rotating, and scaling the image, the intermediate `rotated` and final `scaled` Bitmaps are never recycled:

- When scaling occurs, `rotated.scale()` creates a new Bitmap but the original `rotated` is leaked.
- After `JpegSizeLimiter.compressToLimit` returns, the `scaled` Bitmap is never recycled.
- Each snap can leak 1–2 full-resolution Bitmaps worth of native memory.

### Fix

- Recycle `rotated` immediately after `scale()` produces a different Bitmap.
- Wrap the compression + payload creation in `try/finally` to ensure `scaled.recycle()` is always called.

The `encode` lambda inside `compressToLimit` already handles its own intermediate Bitmaps correctly (recycling when `bitmap !== scaled`); this fix only addresses the outer scope leaks.

Same pattern as #41888 (PhotosHandler) and #41889 (CanvasController).

## Test plan

- [x] Code review: every Bitmap allocation path in `snap()` now has a matching `recycle()`.
- [x] Verified `rotateBitmapByExif` already recycles the input when creating a new rotated Bitmap, so no double-recycle.
- [x] Verified the `encode` lambda's identity check (`bitmap !== scaled`) remains correct after the fix.
- [ ] Manual test: take multiple photos via the Android app and confirm no OOM or increasing native memory.

> This PR was authored with AI assistance.

Made with [Cursor](https://cursor.com)