### PR TITLE
fix(process): use globalThis singleton for command-queue state to survive code-splitting

### DIFF
--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -23,9 +23,6 @@ export class GatewayDrainingError extends Error {
   }
 }
 
-// Set while gateway is draining for restart; new enqueues are rejected.
-let gatewayDraining = false;
-
 // Minimal in-process queue to serialize command executions.
 // Default lane ("main") preserves the existing behavior. Additional lanes allow
 // low-risk parallelism (e.g. cron jobs) without interleaving stdin / logs for
@@ -49,10 +46,35 @@ type LaneState = {
   generation: number;
 };
 
-const lanes = new Map<string, LaneState>();
-let nextTaskId = 1;
+// ---------------------------------------------------------------------------
+// Process-global singleton state – survives tsdown code-splitting that may
+// duplicate this module into separate chunks (reply-*.js, pi-embedded-*.js,
+// compact-*.js, plugin-sdk/*.js).  Follows the same pattern as
+// internal-hooks.ts and context-engine/registry.ts.
+// ---------------------------------------------------------------------------
+const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
+
+type CommandQueueState = {
+  gatewayDraining: boolean;
+  lanes: Map<string, LaneState>;
+  nextTaskId: number;
+};
+
+// Keep command-queue runtime state process-global so duplicated dist chunks
+// still share one set of lanes and task IDs at runtime.
+function getCommandQueueState(): CommandQueueState {
+  const globalStore = globalThis as typeof globalThis & {
+    [COMMAND_QUEUE_STATE_KEY]?: CommandQueueState;
+  };
+  return (globalStore[COMMAND_QUEUE_STATE_KEY] ??= {
+    gatewayDraining: false,
+    lanes: new Map<string, LaneState>(),
+    nextTaskId: 1,
+  });
+}
 
 function getLaneState(lane: string): LaneState {
+  const { lanes } = getCommandQueueState();
   const existing = lanes.get(lane);
   if (existing) {
     return existing;
@@ -78,6 +100,7 @@ function completeTask(state: LaneState, taskId: number, taskGeneration: number):
 }
 
 function drainLane(lane: string) {
+  const commandQueueState = getCommandQueueState();
   const state = getLaneState(lane);
   if (state.draining) {
     if (state.activeTaskIds.size === 0 && state.queue.length > 0) {
@@ -105,7 +128,7 @@ function drainLane(lane: string) {
           );
         }
         logLaneDequeue(lane, waitedMs, state.queue.length);
-        const taskId = nextTaskId++;
+        const taskId = commandQueueState.nextTaskId++;
         const taskGeneration = state.generation;
         state.activeTaskIds.add(taskId);
         void (async () => {
@@ -148,7 +171,7 @@ function drainLane(lane: string) {
  * `GatewayDrainingError` instead of being silently killed on shutdown.
  */
 export function markGatewayDraining(): void {
-  gatewayDraining = true;
+  getCommandQueueState().gatewayDraining = true;
 }
 
 export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
@@ -166,7 +189,8 @@ export function enqueueCommandInLane<T>(
     onWait?: (waitMs: number, queuedAhead: number) => void;
   },
 ): Promise<T> {
-  if (gatewayDraining) {
+  const commandQueueState = getCommandQueueState();
+  if (commandQueueState.gatewayDraining) {
     return Promise.reject(new GatewayDrainingError());
   }
   const cleaned = lane.trim() || CommandLane.Main;
@@ -198,7 +222,7 @@ export function enqueueCommand<T>(
 
 export function getQueueSize(lane: string = CommandLane.Main) {
   const resolved = lane.trim() || CommandLane.Main;
-  const state = lanes.get(resolved);
+  const state = getCommandQueueState().lanes.get(resolved);
   if (!state) {
     return 0;
   }
@@ -207,7 +231,7 @@ export function getQueueSize(lane: string = CommandLane.Main) {
 
 export function getTotalQueueSize() {
   let total = 0;
-  for (const s of lanes.values()) {
+  for (const s of getCommandQueueState().lanes.values()) {
     total += s.queue.length + s.activeTaskIds.size;
   }
   return total;
@@ -215,7 +239,7 @@ export function getTotalQueueSize() {
 
 export function clearCommandLane(lane: string = CommandLane.Main) {
   const cleaned = lane.trim() || CommandLane.Main;
-  const state = lanes.get(cleaned);
+  const state = getCommandQueueState().lanes.get(cleaned);
   if (!state) {
     return 0;
   }
@@ -242,9 +266,10 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
  * `enqueueCommandInLane()` call (which may never come).
  */
 export function resetAllLanes(): void {
-  gatewayDraining = false;
+  const commandQueueState = getCommandQueueState();
+  commandQueueState.gatewayDraining = false;
   const lanesToDrain: string[] = [];
-  for (const state of lanes.values()) {
+  for (const state of commandQueueState.lanes.values()) {
     state.generation += 1;
     state.activeTaskIds.clear();
     state.draining = false;
@@ -264,7 +289,7 @@ export function resetAllLanes(): void {
  */
 export function getActiveTaskCount(): number {
   let total = 0;
-  for (const s of lanes.values()) {
+  for (const s of getCommandQueueState().lanes.values()) {
     total += s.activeTaskIds.size;
   }
   return total;
@@ -283,7 +308,7 @@ export function waitForActiveTasks(timeoutMs: number): Promise<{ drained: boolea
   const POLL_INTERVAL_MS = 50;
   const deadline = Date.now() + timeoutMs;
   const activeAtStart = new Set<number>();
-  for (const state of lanes.values()) {
+  for (const state of getCommandQueueState().lanes.values()) {
     for (const taskId of state.activeTaskIds) {
       activeAtStart.add(taskId);
     }
@@ -297,7 +322,7 @@ export function waitForActiveTasks(timeoutMs: number): Promise<{ drained: boolea
       }
 
       let hasPending = false;
-      for (const state of lanes.values()) {
+      for (const state of getCommandQueueState().lanes.values()) {
         for (const taskId of state.activeTaskIds) {
           if (activeAtStart.has(taskId)) {
             hasPending = true;


### PR DESCRIPTION
## Summary

- Problem: `command-queue.ts` stores shared runtime state (`lanes`, `gatewayDraining`, `nextTaskId`) as module-scoped variables. tsdown code-splitting duplicates this module into 10 independent chunks, each with isolated state. `setCommandLaneConcurrency()` only updates one chunk; actual message processing uses different chunks stuck at `maxConcurrent=1`.
- Why it matters: `agents.defaults.maxConcurrent` config is **completely ignored** for all users. All requests serialize regardless of configuration. Additionally, `resetAllLanes()` and `markGatewayDraining()` only affect one chunk.
- What changed: Replaced 3 module-scoped variables with a `globalThis` singleton via `Symbol.for('openclaw.commandQueueState')`, following the same pattern used in `internal-hooks.ts` and `context-engine/registry.ts`. Updated 14 call sites.
- What did NOT change (scope boundary): No changes to tests, build config, other modules, or the `lanes.ts` lane-name helpers. Error classes remain module-scoped (separate concern).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41901
- Related #16055

## User-visible / Behavior Changes

- `agents.defaults.maxConcurrent` now actually takes effect across all chunks (was silently ignored)
- `resetAllLanes()` on SIGUSR1 now correctly resets lanes in all chunks (was only resetting one)
- `markGatewayDraining()` now visible to pi-embedded chunks during shutdown (was invisible)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.12.73+deb13-amd64 (x64)
- Runtime/container: Node.js v22.22.0
- Model/provider: Any (bug is model-independent)
- Integration/channel: Telegram + Discord (any multi-channel setup)
- Relevant config: `agents.defaults.maxConcurrent: 10`

### Steps

1. Configure `agents.defaults.maxConcurrent: 10`
2. Send messages to two channels simultaneously
3. Observe both process concurrently (before fix: second waits for first)

### Expected

- Messages on different channels process concurrently up to configured limit

### Actual

- Before fix: all requests serialize through `maxConcurrent=1`
- After fix: configured concurrency is respected

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

All 16 existing `command-queue.test.ts` tests pass unchanged:
```
✓ src/process/command-queue.test.ts > command queue > resetAllLanes is safe when no lanes have been created
✓ src/process/command-queue.test.ts > command queue > runs tasks one at a time in order
✓ src/process/command-queue.test.ts > command queue > logs enqueue depth after push
...
Test Files  1 passed (1)
     Tests  16 passed (16)
```

dist/ state duplication confirmed:
```bash
$ rg -l 'let nextTaskId = 1;' dist/
dist/compact-BIp3lbnh.js
dist/pi-embedded-CJVNBk0y.js
dist/pi-embedded-DePf5reQ.js
dist/plugin-sdk/dispatch-C5fHAX5a.js
dist/plugin-sdk/dispatch-D36HVShU.js
dist/plugin-sdk/dispatch-DHll-mp1.js
dist/plugin-sdk/dispatch-DJpqKByO.js
dist/plugin-sdk/dispatch-vBEK_Alg.js
dist/plugin-sdk/reply-DYZ7va08.js
dist/reply-BZQv8rey.js
```

## Human Verification (required)

- Verified scenarios: All 16 existing unit tests pass; manual verification of serial blocking before fix and concurrent processing after applying the fix to dist files
- Edge cases checked: `resetAllLanes()` still correctly clears globalThis state; `markGatewayDraining()` propagates across chunks; primitive values (`gatewayDraining`, `nextTaskId`) accessed through state object (not destructured) to ensure mutations propagate
- What you did **not** verify: Full `pnpm build && pnpm check` (shallow clone, no full dev dependencies); cross-chunk `instanceof` for error classes (separate concern, noted in issue)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit; the module falls back to module-scoped variables
- Files/config to restore: `src/process/command-queue.ts`
- Known bad symptoms reviewers should watch for: If `Symbol.for` key collides with external code (extremely unlikely given namespace), queue state could leak

## Risks and Mitigations

- Risk: Error classes (`CommandLaneClearedError`, `GatewayDrainingError`) are still per-chunk; cross-chunk `instanceof` checks would fail
  - Mitigation: This is a pre-existing concern unrelated to this fix; noted in #41901 for separate consideration

## AI-Assisted Contribution

- [x] **AI-assisted**: This PR was authored by an AI agent (OpenClaw/Claude) with human review and approval by [@best](https://github.com/best)
- [x] **Degree of testing**: All 16 existing unit tests pass unchanged; manual verification of serial blocking before fix and concurrent processing after patching dist files; CI full suite (30/30 checks) passed
- [x] **Understanding confirmed**: The contributor and reviewer both understand the change — it applies an existing codebase pattern (`globalThis` singleton used in `internal-hooks.ts` and `context-engine/registry.ts`) to `command-queue.ts` which was missed
- [x] **Bot review conversations**: Greptile review addressed (5/5 confidence, no issues raised). Codex review passed (no issues found).
