### PR TITLE
Android: fix backward seek crash in StreamingMediaDataSource

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/StreamingMediaDataSource.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/StreamingMediaDataSource.kt
@@ -87,6 +87,10 @@ internal class StreamingMediaDataSource : MediaDataSource() {
 
   private fun findChunkIndex(position: Long): Int {
     var index = lastReadIndex
+    // Reset to linear scan when seeking backward past the cached chunk
+    if (index < chunks.size && position < chunks[index].start) {
+      index = 0
+    }
     while (index < chunks.size) {
       val chunk = chunks[index]
       if (position < chunk.start + chunk.data.size) break

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/StreamingMediaDataSource.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/StreamingMediaDataSource.kt
@@ -71,6 +71,8 @@ internal class StreamingMediaDataSource : MediaDataSource() {
           index++
         }
       }
+      // Advance cache so the next sequential read resumes near where we left off
+      lastReadIndex = index
 
       return toRead - remaining
     }


### PR DESCRIPTION
## Summary

`StreamingMediaDataSource.findChunkIndex()` uses a `lastReadIndex` optimization to avoid re-scanning from the beginning on sequential reads. However, when `readAt()` is called with a position **before** the cached chunk (backward seek), the function immediately returns the wrong chunk index.

This causes `readAt()` to compute a **negative** `inChunkOffset`, which is then passed to `System.arraycopy` — resulting in an `ArrayIndexOutOfBoundsException` crash.

**When this happens in practice:** MediaPlayer may seek backward to re-read audio container headers (common with MP3/AAC streams), or when the TTS playback is interrupted and restarted.

### Root cause

```kotlin
private fun findChunkIndex(position: Long): Int {
    var index = lastReadIndex  // e.g. 5
    // If position is before chunks[5].start, the condition
    // `position < chunk.start + chunk.data.size` is trivially true,
    // so the loop breaks immediately — returning the wrong index.
    while (index < chunks.size) { ... }
}
```

### Fix

Reset `index` to `0` when the requested position falls before the start of `chunks[lastReadIndex]`, forcing a correct linear scan from the beginning.

## Test plan

- [x] Code review: verified the fix handles all seek patterns (forward, backward, same position).
- [x] The `lastReadIndex` optimization is preserved for the common sequential-read case.
- [ ] Manual test: play TTS audio with interruptions to trigger backward seeks.

> This PR was authored with AI assistance.

Made with [Cursor](https://cursor.com)