### PR TITLE
fix(matrix): resolve keyed-async-queue import from barrel export

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/compat";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 


### PR DESCRIPTION
## Summary

- Fixes the Matrix extension failing to load due to `keyed-async-queue` subpath not resolving in the bundled extension's TypeScript compilation context
- Changes the import in `send-queue.ts` to use the main `openclaw/plugin-sdk` barrel export, which resolves correctly in all contexts
- One-line change in a single file

## Context

The `package.json` exports map declares `./plugin-sdk/keyed-async-queue` and the corresponding `.js`/`.d.ts` files exist in `dist/`. However, when the Matrix extension is loaded from TypeScript source via the embedded tsx/esbuild compiler, this subpath fails to resolve. The `KeyedAsyncQueue` class is already re-exported from the barrel (`openclaw/plugin-sdk` — see `src/plugin-sdk/index.ts:147`), so importing from there is both correct and simpler.

Multiple users have reported this issue since v2026.2.26. The workaround has been a manual `sed` fix after every update.

Fixes #31231

## Test plan

- [ ] Fresh install: verify Matrix extension loads without errors
- [ ] Verify `enqueueSend()` correctly serializes per-room message sends
- [ ] Verify existing Matrix E2EE sessions continue working
- [ ] Run `send-queue.test.ts` (imports from relative path, unaffected by this change)