### PR TITLE
fix: subagent uses target agent workspace when configured (fixes #41695)

### DIFF
--- a/src/agents/spawned-context.test.ts
+++ b/src/agents/spawned-context.test.ts
@@ -44,13 +44,66 @@ describe("mapToolContextToSpawnedRunMetadata", () => {
 });
 
 describe("resolveSpawnedWorkspaceInheritance", () => {
-  it("prefers explicit workspaceDir when provided", () => {
+  it("prefers explicit workspaceDir when provided (same-agent)", () => {
     const resolved = resolveSpawnedWorkspaceInheritance({
       config: {},
       requesterSessionKey: "agent:main:subagent:parent",
+      targetAgentId: "main",
       explicitWorkspaceDir: " /tmp/explicit ",
     });
     expect(resolved).toBe("/tmp/explicit");
+  });
+
+  it("returns undefined for cross-agent spawn when target has explicit workspace", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "orchestrator", workspace: "/home/node/.openclaw/workspace/orchestrator" },
+          { id: "programmer", workspace: "/home/node/.openclaw/workspace/programmer" },
+        ],
+      },
+    };
+    const resolved = resolveSpawnedWorkspaceInheritance({
+      config: cfg,
+      requesterSessionKey: "agent:orchestrator:subagent:parent",
+      targetAgentId: "programmer",
+      explicitWorkspaceDir: "/home/node/.openclaw/workspace/orchestrator",
+    });
+    expect(resolved).toBeUndefined();
+  });
+
+  it("inherits when cross-agent spawn but target has no workspace configured", () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "orchestrator", workspace: "/home/node/.openclaw/workspace/orchestrator" },
+          { id: "helper" },
+        ],
+      },
+    };
+    const resolved = resolveSpawnedWorkspaceInheritance({
+      config: cfg,
+      requesterSessionKey: "agent:orchestrator:subagent:parent",
+      targetAgentId: "helper",
+      explicitWorkspaceDir: "/home/node/.openclaw/workspace/orchestrator",
+    });
+    expect(resolved).toBe("/home/node/.openclaw/workspace/orchestrator");
+  });
+
+  it("inherits requester workspace for same-agent spawn", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "main", workspace: "/home/node/.openclaw/workspace/main" }],
+      },
+    };
+    const resolved = resolveSpawnedWorkspaceInheritance({
+      config: cfg,
+      requesterSessionKey: "agent:main:subagent:parent",
+      targetAgentId: "main",
+      explicitWorkspaceDir: undefined,
+    });
+    expect(resolved).toContain("workspace");
+    expect(resolved).toContain("main");
   });
 
   it("returns undefined for missing requester context", () => {

--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
-import { resolveAgentWorkspaceDir } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 
 export type SpawnedRunMetadata = {
   spawnedBy?: string | null;
@@ -59,18 +59,33 @@ export function mapToolContextToSpawnedRunMetadata(
 export function resolveSpawnedWorkspaceInheritance(params: {
   config: OpenClawConfig;
   requesterSessionKey?: string;
+  targetAgentId?: string;
   explicitWorkspaceDir?: string | null;
 }): string | undefined {
-  const explicit = normalizeOptionalText(params.explicitWorkspaceDir);
-  if (explicit) {
-    return explicit;
-  }
   const requesterAgentId = params.requesterSessionKey
     ? parseAgentSessionKey(params.requesterSessionKey)?.agentId
     : undefined;
-  return requesterAgentId
+  const targetId = params.targetAgentId ? normalizeAgentId(params.targetAgentId) : undefined;
+  const explicit = normalizeOptionalText(params.explicitWorkspaceDir);
+  const requesterWorkspace = requesterAgentId
     ? resolveAgentWorkspaceDir(params.config, normalizeAgentId(requesterAgentId))
     : undefined;
+
+  // Cross-agent spawn: target differs from requester → use target's workspace only
+  // when target has explicit workspace in agents.list; otherwise inherit.
+  if (targetId && requesterAgentId && targetId !== normalizeAgentId(requesterAgentId)) {
+    const targetWorkspace = resolveAgentConfig(params.config, targetId)?.workspace;
+    const targetHasExplicitWorkspace =
+      typeof targetWorkspace === "string" && targetWorkspace.trim().length > 0;
+    if (targetHasExplicitWorkspace) {
+      return undefined;
+    }
+  }
+
+  if (explicit) {
+    return explicit;
+  }
+  return requesterWorkspace;
 }
 
 export function resolveIngressWorkspaceOverrideForSpawnedRun(

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -549,6 +549,7 @@ export async function spawnSubagentDirect(
     workspaceDir: resolveSpawnedWorkspaceInheritance({
       config: cfg,
       requesterSessionKey: requesterInternalKey,
+      targetAgentId,
       explicitWorkspaceDir: toolSpawnMetadata.workspaceDir,
     }),
   });


### PR DESCRIPTION

## Summary

Fixes #41695: when a main agent spawns a sub-agent targeting a different agent (e.g., orchestrator → programmer), the sub-agent now uses its own configured workspace instead of inheriting the requester’s. This ensures the correct `AGENTS.md`, `TOOLS.md`, `SOUL.md`, etc. are injected into the sub-agent’s system prompt.

## Root cause

`resolveSpawnedWorkspaceInheritance()` always resolved the requester’s workspace and never considered the target agent. That workspace was passed to `resolveRunWorkspaceDir()`, which used it as-is and skipped the fallback that would resolve the target agent’s workspace from the child session key.

## Solution

- **Target agent has explicit workspace in `agents.list`** → return `undefined` so `resolveRunWorkspaceDir()` falls back to the target agent’s configured workspace.
- **Target agent has no workspace configured** (not in list, or no `workspace` in entry) → inherit requester’s workspace (unchanged behavior).
- **Same-agent spawn** (target === requester) → inherit requester’s workspace (unchanged behavior).

## Changes

- `src/agents/spawned-context.ts`: Add `targetAgentId` to `resolveSpawnedWorkspaceInheritance()`. For cross-agent spawns, only skip inheritance when the target has an explicit `workspace` in its config.
- `src/agents/subagent-spawn.ts`: Pass `targetAgentId` into `resolveSpawnedWorkspaceInheritance()`.
- `src/agents/spawned-context.test.ts`: Add tests for cross-agent spawn with explicit workspace (returns `undefined`) and cross-agent spawn without workspace (inherits).

## Testing

- `pnpm test src/agents/spawned-context.test.ts` — all 8 tests pass
- `pnpm test src/agents/workspace-run.test.ts src/agents/subagent-spawn.attachments.test.ts` — all pass