### PR TITLE
fix(telegram): prevent duplicate messages with slow LLM providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web search: treat Brave `llm-context` grounding snippets as plain strings so `web_search` no longer returns empty snippet arrays in LLM Context mode. (#41387) thanks @zheliu2.
 - Telegram/exec approvals: reject `/approve` commands aimed at other bots, keep deterministic approval prompts visible when tool-result delivery fails, and stop resolved exact IDs from matching other pending approvals by prefix. (#37233) Thanks @huntharo.
 - Control UI/Sessions: restore single-column session table collapse on narrow viewport or container widths by moving the responsive table override next to the base grid rule and enabling inline-size container queries. (#12175) Thanks @benjipeng.
+- Telegram/final preview delivery: split active preview lifecycle from cleanup retention so missing archived preview edits avoid duplicate fallback sends without clearing the live preview or blocking later in-place finalization. (#41662) thanks @hougangdev.
 
 ## 2026.3.8
 

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -963,6 +963,74 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("still finalizes the active preview after an archived final edit is retained", async () => {
+    let answerMessageId: number | undefined;
+    let answerDraftParams:
+      | {
+          onSupersededPreview?: (preview: { messageId: number; textSnapshot: string }) => void;
+        }
+      | undefined;
+    const answerDraftStream = {
+      update: vi.fn().mockImplementation((text: string) => {
+        if (text.includes("Message B")) {
+          answerMessageId = 1002;
+        }
+      }),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockImplementation(() => answerMessageId),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn().mockImplementation(() => {
+        answerMessageId = undefined;
+      }),
+    };
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce((params) => {
+        answerDraftParams = params as typeof answerDraftParams;
+        return answerDraftStream;
+      })
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        answerDraftParams?.onSupersededPreview?.({
+          messageId: 1001,
+          textSnapshot: "Message A partial",
+        });
+
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram
+      .mockRejectedValueOnce(new Error("400: Bad Request: message to edit not found"))
+      .mockResolvedValueOnce({ ok: true, chatId: "123", messageId: "1002" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      1002,
+      "Message B final",
+      expect.any(Object),
+    );
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it.each(["partial", "block"] as const)(
     "keeps finalized text preview when the next assistant message is media-only (%s mode)",
     async (streamMode) => {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -906,6 +906,63 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("keeps the active preview when an archived final edit target is missing", async () => {
+    let answerMessageId: number | undefined;
+    let answerDraftParams:
+      | {
+          onSupersededPreview?: (preview: { messageId: number; textSnapshot: string }) => void;
+        }
+      | undefined;
+    const answerDraftStream = {
+      update: vi.fn().mockImplementation((text: string) => {
+        if (text.includes("Message B")) {
+          answerMessageId = 1002;
+        }
+      }),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockImplementation(() => answerMessageId),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn().mockImplementation(() => {
+        answerMessageId = undefined;
+      }),
+    };
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce((params) => {
+        answerDraftParams = params as typeof answerDraftParams;
+        return answerDraftStream;
+      })
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        answerDraftParams?.onSupersededPreview?.({
+          messageId: 1001,
+          textSnapshot: "Message A partial",
+        });
+
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it.each(["partial", "block"] as const)(
     "keeps finalized text preview when the next assistant message is media-only (%s mode)",
     async (streamMode) => {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1903,4 +1903,60 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftA.clear).toHaveBeenCalledTimes(1);
     expect(draftB.clear).toHaveBeenCalledTimes(1);
   });
+
+  it("swallows post-connect network timeout on preview edit to prevent duplicate messages", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Streaming..." });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    // Simulate a post-connect timeout: editMessageTelegram throws a network
+    // error even though Telegram's server already processed the edit.
+    editMessageTelegram.mockRejectedValue(new Error("timeout: request timed out after 30000ms"));
+
+    await dispatchWithContext({ context: createContext() });
+
+    // The edit was attempted (and may have succeeded server-side).
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    // The fix: no fallback sendPayload via deliverReplies for the final text,
+    // because the editPreview callback swallowed the network timeout.
+    // deliverReplies should NOT have been called with the "Final answer" text
+    // (it would only be called if the fallback chain fired).
+    const deliverCalls = deliverReplies.mock.calls;
+    const finalTextSentViaDeliverReplies = deliverCalls.some((call: unknown[]) =>
+      (call[0] as { replies?: Array<{ text?: string }> })?.replies?.some(
+        (r: { text?: string }) => r.text === "Final answer",
+      ),
+    );
+    expect(finalTextSentViaDeliverReplies).toBe(false);
+  });
+
+  it("re-throws pre-connect errors on preview edit so fallback can send", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Streaming..." });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    // Simulate a pre-connect error: the edit never reached Telegram.
+    const preConnectErr = new Error("connect ECONNREFUSED 149.154.167.220:443");
+    (preConnectErr as NodeJS.ErrnoException).code = "ECONNREFUSED";
+    editMessageTelegram.mockRejectedValue(preConnectErr);
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    // Pre-connect error is re-thrown, so the fallback chain fires and
+    // deliverReplies sends the final text as a new message.
+    expect(deliverReplies).toHaveBeenCalled();
+  });
 });

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1958,7 +1958,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(finalTextSentViaDeliverReplies).toBe(true);
   });
 
-  it("keeps preview when Telegram reports the final edit target missing", async () => {
+  it("falls back when Telegram reports the current final edit target missing", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -1980,6 +1980,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
         (r: { text?: string }) => r.text === "Final answer",
       ),
     );
-    expect(finalTextSentViaDeliverReplies).toBe(false);
+    expect(finalTextSentViaDeliverReplies).toBe(true);
   });
 });

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1936,7 +1936,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(finalTextSentViaDeliverReplies).toBe(false);
   });
 
-  it("re-throws pre-connect errors on preview edit so fallback can send", async () => {
+  it("keeps preview on pre-connect error during final edit (lane deliverer treats as delivered)", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -1947,7 +1947,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     );
     deliverReplies.mockResolvedValue({ delivered: true });
-    // Simulate a pre-connect error: the edit never reached Telegram.
+    // Pre-connect error: edit never reached Telegram. The dispatch-level
+    // callback re-throws it, but the lane deliverer catches it and treats
+    // the final edit failure as delivered to avoid a duplicate message.
     const preConnectErr = new Error("connect ECONNREFUSED 149.154.167.220:443");
     (preConnectErr as NodeJS.ErrnoException).code = "ECONNREFUSED";
     editMessageTelegram.mockRejectedValue(preConnectErr);
@@ -1955,8 +1957,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(editMessageTelegram).toHaveBeenCalledTimes(1);
-    // Pre-connect error is re-thrown, so the fallback chain fires and
-    // deliverReplies sends the final text as a new message.
-    expect(deliverReplies).toHaveBeenCalled();
+    // Lane deliverer keeps the preview — no fallback sendPayload.
+    const deliverCalls = deliverReplies.mock.calls;
+    const finalTextSentViaDeliverReplies = deliverCalls.some((call: unknown[]) =>
+      (call[0] as { replies?: Array<{ text?: string }> })?.replies?.some(
+        (r: { text?: string }) => r.text === "Final answer",
+      ),
+    );
+    expect(finalTextSentViaDeliverReplies).toBe(false);
   });
 });

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1921,12 +1921,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext() });
 
-    // The edit was attempted (and may have succeeded server-side).
     expect(editMessageTelegram).toHaveBeenCalledTimes(1);
-    // The fix: no fallback sendPayload via deliverReplies for the final text,
-    // because the editPreview callback swallowed the network timeout.
-    // deliverReplies should NOT have been called with the "Final answer" text
-    // (it would only be called if the fallback chain fired).
     const deliverCalls = deliverReplies.mock.calls;
     const finalTextSentViaDeliverReplies = deliverCalls.some((call: unknown[]) =>
       (call[0] as { replies?: Array<{ text?: string }> })?.replies?.some(
@@ -1936,7 +1931,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(finalTextSentViaDeliverReplies).toBe(false);
   });
 
-  it("keeps preview on pre-connect error during final edit (lane deliverer treats as delivered)", async () => {
+  it("falls back to sendPayload on pre-connect error during final edit", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -1947,9 +1942,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     );
     deliverReplies.mockResolvedValue({ delivered: true });
-    // Pre-connect error: edit never reached Telegram. The dispatch-level
-    // callback re-throws it, but the lane deliverer catches it and treats
-    // the final edit failure as delivered to avoid a duplicate message.
     const preConnectErr = new Error("connect ECONNREFUSED 149.154.167.220:443");
     (preConnectErr as NodeJS.ErrnoException).code = "ECONNREFUSED";
     editMessageTelegram.mockRejectedValue(preConnectErr);
@@ -1957,7 +1949,31 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(editMessageTelegram).toHaveBeenCalledTimes(1);
-    // Lane deliverer keeps the preview — no fallback sendPayload.
+    const deliverCalls = deliverReplies.mock.calls;
+    const finalTextSentViaDeliverReplies = deliverCalls.some((call: unknown[]) =>
+      (call[0] as { replies?: Array<{ text?: string }> })?.replies?.some(
+        (r: { text?: string }) => r.text === "Final answer",
+      ),
+    );
+    expect(finalTextSentViaDeliverReplies).toBe(true);
+  });
+
+  it("keeps preview when Telegram reports the final edit target missing", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Streaming..." });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
     const deliverCalls = deliverReplies.mock.calls;
     const finalTextSentViaDeliverReplies = deliverCalls.some((call: unknown[]) =>
       (call[0] as { replies?: Array<{ text?: string }> })?.replies?.some(

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -38,7 +38,7 @@ import {
   createLaneTextDeliverer,
   type DraftLaneState,
   type LaneName,
-  type LanePreviewDisposition,
+  type LanePreviewLifecycle,
 } from "./lane-delivery.js";
 import {
   createTelegramReasoningStepState,
@@ -240,9 +240,16 @@ export const dispatchTelegramMessage = async ({
     answer: createDraftLane("answer", canStreamAnswerDraft),
     reasoning: createDraftLane("reasoning", canStreamReasoningDraft),
   };
-  const previewDispositionByLane: Record<LaneName, LanePreviewDisposition> = {
+  // Active preview lifecycle answers "can this current preview still be
+  // finalized?" Cleanup retention is separate so archived-preview decisions do
+  // not poison the active lane.
+  const activePreviewLifecycleByLane: Record<LaneName, LanePreviewLifecycle> = {
     answer: "transient",
     reasoning: "transient",
+  };
+  const retainPreviewOnCleanupByLane: Record<LaneName, boolean> = {
+    answer: false,
+    reasoning: false,
   };
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
@@ -289,7 +296,10 @@ export const dispatchTelegramMessage = async ({
       // so it remains visible across tool boundaries.
       const materializedId = await answerLane.stream?.materialize?.();
       const previewMessageId = materializedId ?? answerLane.stream?.messageId();
-      if (typeof previewMessageId === "number" && previewDispositionByLane.answer === "transient") {
+      if (
+        typeof previewMessageId === "number" &&
+        activePreviewLifecycleByLane.answer === "transient"
+      ) {
         archivedAnswerPreviews.push({
           messageId: previewMessageId,
           textSnapshot: answerLane.lastPartialText,
@@ -302,7 +312,8 @@ export const dispatchTelegramMessage = async ({
     resetDraftLaneState(answerLane);
     if (didForceNewMessage) {
       // New assistant message boundary: this lane now tracks a fresh preview lifecycle.
-      previewDispositionByLane.answer = "transient";
+      activePreviewLifecycleByLane.answer = "transient";
+      retainPreviewOnCleanupByLane.answer = false;
     }
     return didForceNewMessage;
   };
@@ -332,7 +343,7 @@ export const dispatchTelegramMessage = async ({
   const ingestDraftLaneSegments = async (text: string | undefined) => {
     const split = splitTextIntoLaneSegments(text);
     const hasAnswerSegment = split.segments.some((segment) => segment.lane === "answer");
-    if (hasAnswerSegment && previewDispositionByLane.answer !== "transient") {
+    if (hasAnswerSegment && activePreviewLifecycleByLane.answer !== "transient") {
       // Some providers can emit the first partial of a new assistant message before
       // onAssistantMessageStart() arrives. Rotate preemptively so we do not edit
       // the previously finalized preview message with the next message's text.
@@ -470,7 +481,8 @@ export const dispatchTelegramMessage = async ({
   const deliverLaneText = createLaneTextDeliverer({
     lanes,
     archivedAnswerPreviews,
-    previewDispositionByLane,
+    activePreviewLifecycleByLane,
+    retainPreviewOnCleanupByLane,
     draftMaxChars,
     applyTextToPayload,
     sendPayload,
@@ -597,7 +609,8 @@ export const dispatchTelegramMessage = async ({
             }
             if (info.kind === "final") {
               if (reasoningLane.hasStreamedMessage) {
-                previewDispositionByLane.reasoning = "finalized";
+                activePreviewLifecycleByLane.reasoning = "complete";
+                retainPreviewOnCleanupByLane.reasoning = true;
               }
               reasoningStepState.resetForNextStep();
             }
@@ -675,7 +688,8 @@ export const dispatchTelegramMessage = async ({
                 reasoningStepState.resetForNextStep();
                 if (skipNextAnswerMessageStartRotation) {
                   skipNextAnswerMessageStartRotation = false;
-                  previewDispositionByLane.answer = "transient";
+                  activePreviewLifecycleByLane.answer = "transient";
+                  retainPreviewOnCleanupByLane.answer = false;
                   return;
                 }
                 await rotateAnswerLaneForNewAssistantMessage();
@@ -683,7 +697,8 @@ export const dispatchTelegramMessage = async ({
                 // Even when no forceNewMessage happened (e.g. prior answer had no
                 // streamed partials), the next partial belongs to a fresh lifecycle
                 // and must not trigger late pre-rotation mid-message.
-                previewDispositionByLane.answer = "transient";
+                activePreviewLifecycleByLane.answer = "transient";
+                retainPreviewOnCleanupByLane.answer = false;
               })
           : undefined,
         onReasoningEnd: reasoningLane.stream
@@ -732,8 +747,7 @@ export const dispatchTelegramMessage = async ({
           (p) => p.deleteIfUnused === false && p.messageId === activePreviewMessageId,
         );
       const shouldClear =
-        previewDispositionByLane[laneState.laneName] === "transient" &&
-        !hasBoundaryFinalizedActivePreview;
+        !retainPreviewOnCleanupByLane[laneState.laneName] && !hasBoundaryFinalizedActivePreview;
       const existing = streamCleanupStates.get(stream);
       if (!existing) {
         streamCleanupStates.set(stream, { shouldClear });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -39,6 +39,7 @@ import {
   type DraftLaneState,
   type LaneName,
 } from "./lane-delivery.js";
+import { isSafeToRetrySendError } from "./network-errors.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -478,13 +479,35 @@ export const dispatchTelegramMessage = async ({
       await lane.stream?.stop();
     },
     editPreview: async ({ messageId, text, previewButtons }) => {
-      await editMessageTelegram(chatId, messageId, text, {
-        api: bot.api,
-        cfg,
-        accountId: route.accountId,
-        linkPreview: telegramCfg.linkPreview,
-        buttons: previewButtons,
-      });
+      try {
+        await editMessageTelegram(chatId, messageId, text, {
+          api: bot.api,
+          cfg,
+          accountId: route.accountId,
+          linkPreview: telegramCfg.linkPreview,
+          buttons: previewButtons,
+        });
+      } catch (err) {
+        // Post-connect network errors (timeout, connection reset) mean the edit
+        // may have already landed on Telegram's server. Swallow these to prevent
+        // the fallback chain from sending a duplicate message via sendPayload.
+        // Only re-throw pre-connect errors (DNS, connection refused — edit
+        // definitely never reached Telegram) and API errors (400/500 — Telegram
+        // explicitly rejected the edit).
+        if (isSafeToRetrySendError(err)) {
+          throw err;
+        }
+        const isNetworkError =
+          err instanceof Error &&
+          /timeout|timed out|reset|closed|network|fetch failed|socket/i.test(err.message);
+        if (isNetworkError) {
+          logVerbose(
+            `telegram: preview edit may have succeeded despite network error; treating as delivered to avoid duplicate (${String(err)})`,
+          );
+          return;
+        }
+        throw err;
+      }
     },
     deletePreviewMessage: async (messageId) => {
       await bot.api.deleteMessage(chatId, messageId);

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -39,7 +39,7 @@ import {
   type DraftLaneState,
   type LaneName,
 } from "./lane-delivery.js";
-import { isSafeToRetrySendError } from "./network-errors.js";
+import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -497,10 +497,7 @@ export const dispatchTelegramMessage = async ({
         if (isSafeToRetrySendError(err)) {
           throw err;
         }
-        const isNetworkError =
-          err instanceof Error &&
-          /timeout|timed out|reset|closed|network|fetch failed|socket/i.test(err.message);
-        if (isNetworkError) {
+        if (isRecoverableTelegramNetworkError(err, { allowMessageMatch: true })) {
           logVerbose(
             `telegram: preview edit may have succeeded despite network error; treating as delivered to avoid duplicate (${String(err)})`,
           );

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -38,8 +38,8 @@ import {
   createLaneTextDeliverer,
   type DraftLaneState,
   type LaneName,
+  type LanePreviewDisposition,
 } from "./lane-delivery.js";
-import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -240,9 +240,9 @@ export const dispatchTelegramMessage = async ({
     answer: createDraftLane("answer", canStreamAnswerDraft),
     reasoning: createDraftLane("reasoning", canStreamReasoningDraft),
   };
-  const finalizedPreviewByLane: Record<LaneName, boolean> = {
-    answer: false,
-    reasoning: false,
+  const previewDispositionByLane: Record<LaneName, LanePreviewDisposition> = {
+    answer: "transient",
+    reasoning: "transient",
   };
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
@@ -289,7 +289,7 @@ export const dispatchTelegramMessage = async ({
       // so it remains visible across tool boundaries.
       const materializedId = await answerLane.stream?.materialize?.();
       const previewMessageId = materializedId ?? answerLane.stream?.messageId();
-      if (typeof previewMessageId === "number" && !finalizedPreviewByLane.answer) {
+      if (typeof previewMessageId === "number" && previewDispositionByLane.answer === "transient") {
         archivedAnswerPreviews.push({
           messageId: previewMessageId,
           textSnapshot: answerLane.lastPartialText,
@@ -302,7 +302,7 @@ export const dispatchTelegramMessage = async ({
     resetDraftLaneState(answerLane);
     if (didForceNewMessage) {
       // New assistant message boundary: this lane now tracks a fresh preview lifecycle.
-      finalizedPreviewByLane.answer = false;
+      previewDispositionByLane.answer = "transient";
     }
     return didForceNewMessage;
   };
@@ -332,7 +332,7 @@ export const dispatchTelegramMessage = async ({
   const ingestDraftLaneSegments = async (text: string | undefined) => {
     const split = splitTextIntoLaneSegments(text);
     const hasAnswerSegment = split.segments.some((segment) => segment.lane === "answer");
-    if (hasAnswerSegment && finalizedPreviewByLane.answer) {
+    if (hasAnswerSegment && previewDispositionByLane.answer !== "transient") {
       // Some providers can emit the first partial of a new assistant message before
       // onAssistantMessageStart() arrives. Rotate preemptively so we do not edit
       // the previously finalized preview message with the next message's text.
@@ -470,7 +470,7 @@ export const dispatchTelegramMessage = async ({
   const deliverLaneText = createLaneTextDeliverer({
     lanes,
     archivedAnswerPreviews,
-    finalizedPreviewByLane,
+    previewDispositionByLane,
     draftMaxChars,
     applyTextToPayload,
     sendPayload,
@@ -479,32 +479,13 @@ export const dispatchTelegramMessage = async ({
       await lane.stream?.stop();
     },
     editPreview: async ({ messageId, text, previewButtons }) => {
-      try {
-        await editMessageTelegram(chatId, messageId, text, {
-          api: bot.api,
-          cfg,
-          accountId: route.accountId,
-          linkPreview: telegramCfg.linkPreview,
-          buttons: previewButtons,
-        });
-      } catch (err) {
-        // Post-connect network errors (timeout, connection reset) mean the edit
-        // may have already landed on Telegram's server. Swallow these to prevent
-        // the fallback chain from sending a duplicate message via sendPayload.
-        // Only re-throw pre-connect errors (DNS, connection refused — edit
-        // definitely never reached Telegram) and API errors (400/500 — Telegram
-        // explicitly rejected the edit).
-        if (isSafeToRetrySendError(err)) {
-          throw err;
-        }
-        if (isRecoverableTelegramNetworkError(err, { allowMessageMatch: true })) {
-          logVerbose(
-            `telegram: preview edit may have succeeded despite network error; treating as delivered to avoid duplicate (${String(err)})`,
-          );
-          return;
-        }
-        throw err;
-      }
+      await editMessageTelegram(chatId, messageId, text, {
+        api: bot.api,
+        cfg,
+        accountId: route.accountId,
+        linkPreview: telegramCfg.linkPreview,
+        buttons: previewButtons,
+      });
     },
     deletePreviewMessage: async (messageId) => {
       await bot.api.deleteMessage(chatId, messageId);
@@ -616,7 +597,7 @@ export const dispatchTelegramMessage = async ({
             }
             if (info.kind === "final") {
               if (reasoningLane.hasStreamedMessage) {
-                finalizedPreviewByLane.reasoning = true;
+                previewDispositionByLane.reasoning = "finalized";
               }
               reasoningStepState.resetForNextStep();
             }
@@ -694,7 +675,7 @@ export const dispatchTelegramMessage = async ({
                 reasoningStepState.resetForNextStep();
                 if (skipNextAnswerMessageStartRotation) {
                   skipNextAnswerMessageStartRotation = false;
-                  finalizedPreviewByLane.answer = false;
+                  previewDispositionByLane.answer = "transient";
                   return;
                 }
                 await rotateAnswerLaneForNewAssistantMessage();
@@ -702,7 +683,7 @@ export const dispatchTelegramMessage = async ({
                 // Even when no forceNewMessage happened (e.g. prior answer had no
                 // streamed partials), the next partial belongs to a fresh lifecycle
                 // and must not trigger late pre-rotation mid-message.
-                finalizedPreviewByLane.answer = false;
+                previewDispositionByLane.answer = "transient";
               })
           : undefined,
         onReasoningEnd: reasoningLane.stream
@@ -751,7 +732,8 @@ export const dispatchTelegramMessage = async ({
           (p) => p.deleteIfUnused === false && p.messageId === activePreviewMessageId,
         );
       const shouldClear =
-        !finalizedPreviewByLane[laneState.laneName] && !hasBoundaryFinalizedActivePreview;
+        previewDispositionByLane[laneState.laneName] === "transient" &&
+        !hasBoundaryFinalizedActivePreview;
       const existing = streamCleanupStates.get(stream);
       if (!existing) {
         streamCleanupStates.set(stream, { shouldClear });

--- a/src/telegram/draft-stream.test-helpers.ts
+++ b/src/telegram/draft-stream.test-helpers.ts
@@ -13,6 +13,7 @@ export type TestDraftStream = {
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   materialize: ReturnType<typeof vi.fn<() => Promise<number | undefined>>>;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
+  sendMayHaveLanded: ReturnType<typeof vi.fn<() => boolean>>;
   setMessageId: (value: number | undefined) => void;
 };
 
@@ -47,6 +48,7 @@ export function createTestDraftStream(params?: {
         messageId = undefined;
       }
     }),
+    sendMayHaveLanded: vi.fn().mockReturnValue(false),
     setMessageId: (value: number | undefined) => {
       messageId = value;
     },
@@ -77,6 +79,7 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
     }),
+    sendMayHaveLanded: vi.fn().mockReturnValue(false),
     setMessageId: (value: number | undefined) => {
       activeMessageId = value;
     },

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -66,6 +66,8 @@ export type TelegramDraftStream = {
   materialize?: () => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
+  /** True when a preview sendMessage was attempted but the response was lost. */
+  sendMayHaveLanded?: () => boolean;
 };
 
 type TelegramDraftPreview = {
@@ -126,6 +128,7 @@ export function createTelegramDraftStream(params: {
   }
 
   const streamState = { stopped: false, final: false };
+  let messageSendAttempted = false;
   let streamMessageId: number | undefined;
   let streamDraftId = usesDraftTransport ? allocateTelegramDraftId() : undefined;
   let previewTransport: "message" | "draft" = usesDraftTransport ? "draft" : "message";
@@ -192,6 +195,7 @@ export function createTelegramDraftStream(params: {
       }
       return true;
     }
+    messageSendAttempted = true;
     const { sent } = await sendRenderedMessageWithThreadFallback({
       renderedText,
       renderedParseMode,
@@ -345,6 +349,7 @@ export function createTelegramDraftStream(params: {
     // Re-open the stream lifecycle for the next assistant segment.
     streamState.final = false;
     generation += 1;
+    messageSendAttempted = false;
     streamMessageId = undefined;
     if (previewTransport === "draft") {
       streamDraftId = allocateTelegramDraftId();
@@ -421,5 +426,6 @@ export function createTelegramDraftStream(params: {
     stop,
     materialize,
     forceNewMessage,
+    sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
   };
 }

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -49,7 +49,7 @@ export type ArchivedPreview = {
   deleteIfUnused?: boolean;
 };
 
-export type LanePreviewDisposition = "transient" | "retained" | "finalized";
+export type LanePreviewLifecycle = "transient" | "complete";
 
 export type LaneDeliveryResult =
   | "preview-finalized"
@@ -61,7 +61,8 @@ export type LaneDeliveryResult =
 type CreateLaneTextDelivererParams = {
   lanes: Record<LaneName, DraftLaneState>;
   archivedAnswerPreviews: ArchivedPreview[];
-  previewDispositionByLane: Record<LaneName, LanePreviewDisposition>;
+  activePreviewLifecycleByLane: Record<LaneName, LanePreviewLifecycle>;
+  retainPreviewOnCleanupByLane: Record<LaneName, boolean>;
   draftMaxChars: number;
   applyTextToPayload: (payload: ReplyPayload, text: string) => ReplyPayload;
   sendPayload: (payload: ReplyPayload) => Promise<boolean>;
@@ -162,6 +163,10 @@ function resolvePreviewTarget(params: ResolvePreviewTargetParams): PreviewTarget
 
 export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
   const getLanePreviewText = (lane: DraftLaneState) => lane.lastPartialText;
+  const markActivePreviewComplete = (laneName: LaneName) => {
+    params.activePreviewLifecycleByLane[laneName] = "complete";
+    params.retainPreviewOnCleanupByLane[laneName] = true;
+  };
   const isDraftPreviewLane = (lane: DraftLaneState) => lane.stream?.previewMode?.() === "draft";
   const canMaterializeDraftFinal = (
     lane: DraftLaneState,
@@ -401,7 +406,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         return "preview-finalized";
       }
       if (finalized === "retained") {
-        params.previewDispositionByLane.answer = "retained";
+        params.retainPreviewOnCleanupByLane.answer = true;
         return "preview-retained";
       }
     }
@@ -448,7 +453,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           return archivedResult;
         }
       }
-      if (canEditViaPreview && params.previewDispositionByLane[laneName] === "transient") {
+      if (canEditViaPreview && params.activePreviewLifecycleByLane[laneName] === "transient") {
         await params.flushDraftLane(lane);
         if (laneName === "answer") {
           const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({
@@ -469,7 +474,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
             text,
           });
           if (materialized) {
-            params.previewDispositionByLane[laneName] = "finalized";
+            markActivePreviewComplete(laneName);
             return "preview-finalized";
           }
         }
@@ -483,11 +488,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           context: "final",
         });
         if (finalized === "edited") {
-          params.previewDispositionByLane[laneName] = "finalized";
+          markActivePreviewComplete(laneName);
           return "preview-finalized";
         }
         if (finalized === "retained") {
-          params.previewDispositionByLane[laneName] = "retained";
+          markActivePreviewComplete(laneName);
           return "preview-retained";
         }
       } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -1,7 +1,11 @@
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import type { TelegramDraftStream } from "./draft-stream.js";
-import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
+import {
+  isRecoverableTelegramNetworkError,
+  isSafeToRetrySendError,
+  isTelegramClientRejection,
+} from "./network-errors.js";
 
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
@@ -270,10 +274,18 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           params.markDelivered();
           return "retained";
         }
+        if (isTelegramClientRejection(err)) {
+          params.log(
+            `telegram: ${args.laneName} preview final edit rejected by Telegram (client error); falling back to standard send (${String(err)})`,
+          );
+          return "fallback";
+        }
+        // Default: ambiguous error — prefer incomplete over duplicate
         params.log(
-          `telegram: ${args.laneName} preview final edit rejected by Telegram; falling back to standard send (${String(err)})`,
+          `telegram: ${args.laneName} preview final edit failed with ambiguous error; keeping existing preview to avoid duplicate (${String(err)})`,
         );
-        return "fallback";
+        params.markDelivered();
+        return "retained";
       }
       params.log(
         `telegram: ${args.laneName} preview ${args.context} edit failed; falling back to standard send (${String(err)})`,
@@ -353,6 +365,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         context,
       });
       if (typeof previewTargetAfterStop.previewMessageId !== "number") {
+        if (lane.stream?.sendMayHaveLanded?.()) {
+          params.log(
+            `telegram: ${laneName} preview send may have landed despite missing message id; keeping to avoid duplicate`,
+          );
+          params.markDelivered();
+          return "retained";
+        }
         return "fallback";
       }
       return finalizePreview(previewTargetAfterStop.previewMessageId, true, false);
@@ -367,6 +386,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       context,
     });
     if (typeof previewTargetAfterStop.previewMessageId !== "number") {
+      if (lane.stream?.sendMayHaveLanded?.()) {
+        params.log(
+          `telegram: ${laneName} preview send may have landed despite missing message id; keeping to avoid duplicate`,
+        );
+        params.markDelivered();
+        return "retained";
+      }
       return "fallback";
     }
     const activePreviewMessageId = lane.stream?.messageId();

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -401,6 +401,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         return "preview-finalized";
       }
       if (finalized === "retained") {
+        params.previewDispositionByLane.answer = "retained";
         return "preview-retained";
       }
     }

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -25,8 +25,9 @@ function isMessageNotModifiedError(err: unknown): boolean {
 }
 
 /**
- * Returns true when Telegram reports the target message no longer exists.
- * In this case the preview is gone and a fallback send is safe (no duplicate).
+ * Returns true when Telegram rejects an edit because the target message can no
+ * longer be resolved or edited. The caller still needs preview context to
+ * decide whether to retain a different visible preview or fall back to send.
  */
 function isMissingPreviewMessageError(err: unknown): boolean {
   return MESSAGE_NOT_FOUND_RE.test(extractErrorText(err));
@@ -207,6 +208,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     updateLaneSnapshot: boolean;
     lane: DraftLaneState;
     finalTextAlreadyLanded: boolean;
+    retainAlternatePreviewOnMissingTarget: boolean;
   }): Promise<PreviewEditResult> => {
     try {
       await params.editPreview({
@@ -244,11 +246,17 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           return "fallback";
         }
         if (isMissingPreviewMessageError(err)) {
+          if (args.retainAlternatePreviewOnMissingTarget) {
+            params.log(
+              `telegram: ${args.laneName} preview final edit target missing; keeping alternate preview without fallback (${String(err)})`,
+            );
+            params.markDelivered();
+            return "retained";
+          }
           params.log(
-            `telegram: ${args.laneName} preview final edit target missing; keeping existing preview without fallback (${String(err)})`,
+            `telegram: ${args.laneName} preview final edit target missing with no alternate preview; falling back to standard send (${String(err)})`,
           );
-          params.markDelivered();
-          return "retained";
+          return "fallback";
         }
         if (isRecoverableTelegramNetworkError(err, { allowMessageMatch: true })) {
           params.log(
@@ -281,7 +289,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     previewMessageId: previewMessageIdOverride,
     previewTextSnapshot,
   }: TryUpdatePreviewParams): Promise<PreviewEditResult> => {
-    const editPreview = (messageId: number, finalTextAlreadyLanded: boolean) =>
+    const editPreview = (
+      messageId: number,
+      finalTextAlreadyLanded: boolean,
+      retainAlternatePreviewOnMissingTarget: boolean,
+    ) =>
       tryEditPreviewMessage({
         laneName,
         messageId,
@@ -291,11 +303,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         updateLaneSnapshot,
         lane,
         finalTextAlreadyLanded,
+        retainAlternatePreviewOnMissingTarget,
       });
     const finalizePreview = (
       previewMessageId: number,
       finalTextAlreadyLanded: boolean,
       hadPreviewMessage: boolean,
+      retainAlternatePreviewOnMissingTarget = false,
     ): PreviewEditResult | Promise<PreviewEditResult> => {
       const currentPreviewText = previewTextSnapshot ?? getLanePreviewText(lane);
       const shouldSkipRegressive = shouldSkipRegressivePreviewUpdate({
@@ -308,7 +322,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         params.markDelivered();
         return "edited";
       }
-      return editPreview(previewMessageId, finalTextAlreadyLanded);
+      return editPreview(
+        previewMessageId,
+        finalTextAlreadyLanded,
+        retainAlternatePreviewOnMissingTarget,
+      );
     };
     if (!lane.stream) {
       return "fallback";
@@ -346,10 +364,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     if (typeof previewTargetAfterStop.previewMessageId !== "number") {
       return "fallback";
     }
+    const activePreviewMessageId = lane.stream?.messageId();
     return finalizePreview(
       previewTargetAfterStop.previewMessageId,
       false,
       previewTargetAfterStop.hadPreviewMessage,
+      typeof activePreviewMessageId === "number" &&
+        activePreviewMessageId !== previewTargetAfterStop.previewMessageId,
     );
   };
 

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -4,19 +4,31 @@ import type { TelegramDraftStream } from "./draft-stream.js";
 
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
+const MESSAGE_NOT_FOUND_RE =
+  /400:\s*Bad Request:\s*message to edit not found|MESSAGE_ID_INVALID|message can't be edited/i;
+
+function extractErrorText(err: unknown): string {
+  return typeof err === "string"
+    ? err
+    : err instanceof Error
+      ? err.message
+      : typeof err === "object" && err && "description" in err
+        ? typeof err.description === "string"
+          ? err.description
+          : ""
+        : "";
+}
 
 function isMessageNotModifiedError(err: unknown): boolean {
-  const text =
-    typeof err === "string"
-      ? err
-      : err instanceof Error
-        ? err.message
-        : typeof err === "object" && err && "description" in err
-          ? typeof err.description === "string"
-            ? err.description
-            : ""
-          : "";
-  return MESSAGE_NOT_MODIFIED_RE.test(text);
+  return MESSAGE_NOT_MODIFIED_RE.test(extractErrorText(err));
+}
+
+/**
+ * Returns true when Telegram reports the target message no longer exists.
+ * In this case the preview is gone and a fallback send is safe (no duplicate).
+ */
+function isMissingPreviewMessageError(err: unknown): boolean {
+  return MESSAGE_NOT_FOUND_RE.test(extractErrorText(err));
 }
 
 export type LaneName = "answer" | "reasoning";
@@ -208,8 +220,14 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         return true;
       }
       if (args.treatEditFailureAsDelivered) {
+        if (isMissingPreviewMessageError(err)) {
+          params.log(
+            `telegram: ${args.laneName} preview ${args.context} edit target missing; falling back to standard send (${String(err)})`,
+          );
+          return false;
+        }
         params.log(
-          `telegram: ${args.laneName} preview ${args.context} edit failed after stop-created flush; treating as delivered (${String(err)})`,
+          `telegram: ${args.laneName} preview ${args.context} edit failed; keeping existing preview to avoid duplicate (${String(err)})`,
         );
         params.markDelivered();
         return true;
@@ -300,7 +318,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
     return finalizePreview(
       previewTargetAfterStop.previewMessageId,
-      false,
+      context === "final",
       previewTargetAfterStop.hadPreviewMessage,
     );
   };

--- a/src/telegram/lane-delivery-text-deliverer.ts
+++ b/src/telegram/lane-delivery-text-deliverer.ts
@@ -1,6 +1,7 @@
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import type { TelegramDraftStream } from "./draft-stream.js";
+import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
 
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
@@ -47,12 +48,19 @@ export type ArchivedPreview = {
   deleteIfUnused?: boolean;
 };
 
-export type LaneDeliveryResult = "preview-finalized" | "preview-updated" | "sent" | "skipped";
+export type LanePreviewDisposition = "transient" | "retained" | "finalized";
+
+export type LaneDeliveryResult =
+  | "preview-finalized"
+  | "preview-retained"
+  | "preview-updated"
+  | "sent"
+  | "skipped";
 
 type CreateLaneTextDelivererParams = {
   lanes: Record<LaneName, DraftLaneState>;
   archivedAnswerPreviews: ArchivedPreview[];
-  finalizedPreviewByLane: Record<LaneName, boolean>;
+  previewDispositionByLane: Record<LaneName, LanePreviewDisposition>;
   draftMaxChars: number;
   applyTextToPayload: (payload: ReplyPayload, text: string) => ReplyPayload;
   sendPayload: (payload: ReplyPayload) => Promise<boolean>;
@@ -91,6 +99,8 @@ type TryUpdatePreviewParams = {
   previewMessageId?: number;
   previewTextSnapshot?: string;
 };
+
+type PreviewEditResult = "edited" | "retained" | "fallback";
 
 type ConsumeArchivedAnswerPreviewParams = {
   lane: DraftLaneState;
@@ -196,8 +206,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     previewButtons?: TelegramInlineButtons;
     updateLaneSnapshot: boolean;
     lane: DraftLaneState;
-    treatEditFailureAsDelivered: boolean;
-  }): Promise<boolean> => {
+    finalTextAlreadyLanded: boolean;
+  }): Promise<PreviewEditResult> => {
     try {
       await params.editPreview({
         laneName: args.laneName,
@@ -210,32 +220,52 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         args.lane.lastPartialText = args.text;
       }
       params.markDelivered();
-      return true;
+      return "edited";
     } catch (err) {
       if (isMessageNotModifiedError(err)) {
         params.log(
           `telegram: ${args.laneName} preview ${args.context} edit returned "message is not modified"; treating as delivered`,
         );
         params.markDelivered();
-        return true;
+        return "edited";
       }
-      if (args.treatEditFailureAsDelivered) {
+      if (args.context === "final") {
+        if (args.finalTextAlreadyLanded) {
+          params.log(
+            `telegram: ${args.laneName} preview final edit failed after stop flush; keeping existing preview (${String(err)})`,
+          );
+          params.markDelivered();
+          return "retained";
+        }
+        if (isSafeToRetrySendError(err)) {
+          params.log(
+            `telegram: ${args.laneName} preview final edit failed before reaching Telegram; falling back to standard send (${String(err)})`,
+          );
+          return "fallback";
+        }
         if (isMissingPreviewMessageError(err)) {
           params.log(
-            `telegram: ${args.laneName} preview ${args.context} edit target missing; falling back to standard send (${String(err)})`,
+            `telegram: ${args.laneName} preview final edit target missing; keeping existing preview without fallback (${String(err)})`,
           );
-          return false;
+          params.markDelivered();
+          return "retained";
+        }
+        if (isRecoverableTelegramNetworkError(err, { allowMessageMatch: true })) {
+          params.log(
+            `telegram: ${args.laneName} preview final edit may have landed despite network error; keeping existing preview (${String(err)})`,
+          );
+          params.markDelivered();
+          return "retained";
         }
         params.log(
-          `telegram: ${args.laneName} preview ${args.context} edit failed; keeping existing preview to avoid duplicate (${String(err)})`,
+          `telegram: ${args.laneName} preview final edit rejected by Telegram; falling back to standard send (${String(err)})`,
         );
-        params.markDelivered();
-        return true;
+        return "fallback";
       }
       params.log(
         `telegram: ${args.laneName} preview ${args.context} edit failed; falling back to standard send (${String(err)})`,
       );
-      return false;
+      return "fallback";
     }
   };
 
@@ -250,8 +280,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     context,
     previewMessageId: previewMessageIdOverride,
     previewTextSnapshot,
-  }: TryUpdatePreviewParams): Promise<boolean> => {
-    const editPreview = (messageId: number, treatEditFailureAsDelivered: boolean) =>
+  }: TryUpdatePreviewParams): Promise<PreviewEditResult> => {
+    const editPreview = (messageId: number, finalTextAlreadyLanded: boolean) =>
       tryEditPreviewMessage({
         laneName,
         messageId,
@@ -260,13 +290,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         previewButtons,
         updateLaneSnapshot,
         lane,
-        treatEditFailureAsDelivered,
+        finalTextAlreadyLanded,
       });
     const finalizePreview = (
       previewMessageId: number,
-      treatEditFailureAsDelivered: boolean,
+      finalTextAlreadyLanded: boolean,
       hadPreviewMessage: boolean,
-    ): boolean | Promise<boolean> => {
+    ): PreviewEditResult | Promise<PreviewEditResult> => {
       const currentPreviewText = previewTextSnapshot ?? getLanePreviewText(lane);
       const shouldSkipRegressive = shouldSkipRegressivePreviewUpdate({
         currentPreviewText,
@@ -276,12 +306,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       });
       if (shouldSkipRegressive) {
         params.markDelivered();
-        return true;
+        return "edited";
       }
-      return editPreview(previewMessageId, treatEditFailureAsDelivered);
+      return editPreview(previewMessageId, finalTextAlreadyLanded);
     };
     if (!lane.stream) {
-      return false;
+      return "fallback";
     }
     const previewTargetBeforeStop = resolvePreviewTarget({
       lane,
@@ -300,7 +330,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         context,
       });
       if (typeof previewTargetAfterStop.previewMessageId !== "number") {
-        return false;
+        return "fallback";
       }
       return finalizePreview(previewTargetAfterStop.previewMessageId, true, false);
     }
@@ -314,11 +344,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       context,
     });
     if (typeof previewTargetAfterStop.previewMessageId !== "number") {
-      return false;
+      return "fallback";
     }
     return finalizePreview(
       previewTargetAfterStop.previewMessageId,
-      context === "final",
+      false,
       previewTargetAfterStop.hadPreviewMessage,
     );
   };
@@ -346,8 +376,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         previewMessageId: archivedPreview.messageId,
         previewTextSnapshot: archivedPreview.textSnapshot,
       });
-      if (finalized) {
+      if (finalized === "edited") {
         return "preview-finalized";
+      }
+      if (finalized === "retained") {
+        return "preview-retained";
       }
     }
     // Send the replacement message first, then clean up the old preview.
@@ -393,7 +426,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           return archivedResult;
         }
       }
-      if (canEditViaPreview && !params.finalizedPreviewByLane[laneName]) {
+      if (canEditViaPreview && params.previewDispositionByLane[laneName] === "transient") {
         await params.flushDraftLane(lane);
         if (laneName === "answer") {
           const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({
@@ -414,7 +447,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
             text,
           });
           if (materialized) {
-            params.finalizedPreviewByLane[laneName] = true;
+            params.previewDispositionByLane[laneName] = "finalized";
             return "preview-finalized";
           }
         }
@@ -427,9 +460,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           skipRegressive: "existingOnly",
           context: "final",
         });
-        if (finalized) {
-          params.finalizedPreviewByLane[laneName] = true;
+        if (finalized === "edited") {
+          params.previewDispositionByLane[laneName] = "finalized";
           return "preview-finalized";
+        }
+        if (finalized === "retained") {
+          params.previewDispositionByLane[laneName] = "retained";
+          return "preview-retained";
         }
       } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {
         params.log(
@@ -470,7 +507,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         skipRegressive: "always",
         context: "update",
       });
-      if (updated) {
+      if (updated === "edited") {
         return "preview-updated";
       }
     }

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -42,7 +42,8 @@ function createHarness(params?: {
   const deletePreviewMessage = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
   const markDelivered = vi.fn();
-  const previewDispositionByLane = { answer: "transient", reasoning: "transient" } as const;
+  const activePreviewLifecycleByLane = { answer: "transient", reasoning: "transient" } as const;
+  const retainPreviewOnCleanupByLane = { answer: false, reasoning: false } as const;
   const archivedAnswerPreviews: Array<{
     messageId: number;
     textSnapshot: string;
@@ -52,7 +53,8 @@ function createHarness(params?: {
   const deliverLaneText = createLaneTextDeliverer({
     lanes,
     archivedAnswerPreviews,
-    previewDispositionByLane: { ...previewDispositionByLane },
+    activePreviewLifecycleByLane: { ...activePreviewLifecycleByLane },
+    retainPreviewOnCleanupByLane: { ...retainPreviewOnCleanupByLane },
     draftMaxChars: params?.draftMaxChars ?? 4_096,
     applyTextToPayload: (payload: ReplyPayload, text: string) => ({ ...payload, text }),
     sendPayload,

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -174,8 +174,9 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
-  it("falls back to sendPayload when an existing preview final edit is rejected", async () => {
+  it("retains preview when an existing preview final edit fails with ambiguous error", async () => {
     const harness = createHarness({ answerMessageId: 999 });
+    // Plain Error with no error_code → ambiguous, prefer incomplete over duplicate
     harness.editPreview.mockRejectedValue(new Error("500: preview edit failed"));
 
     const result = await harness.deliverLaneText({
@@ -185,13 +186,11 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("sent");
+    expect(result).toBe("preview-retained");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Hello final" }),
-    );
+    expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.log).toHaveBeenCalledWith(
-      expect.stringContaining("edit rejected by Telegram; falling back"),
+      expect.stringContaining("ambiguous error; keeping existing preview to avoid duplicate"),
     );
   });
 
@@ -433,8 +432,9 @@ describe("createLaneTextDeliverer", () => {
   // During final delivery, only ambiguous post-connect failures keep the
   // preview. Definite non-delivery falls back to a real send.
 
-  it("falls back on API error during final", async () => {
+  it("retains preview on ambiguous API error during final", async () => {
     const harness = createHarness({ answerMessageId: 999 });
+    // Plain Error with no error_code → ambiguous, prefer incomplete over duplicate
     harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
 
     const result = await harness.deliverLaneText({
@@ -444,9 +444,9 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("sent");
+    expect(result).toBe("preview-retained");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
   it("falls back when an archived preview edit target is missing and no alternate preview exists", async () => {
@@ -494,6 +494,67 @@ describe("createLaneTextDeliverer", () => {
     expect(result).toBe("preview-retained");
     expect(harness.log).toHaveBeenCalledWith(
       expect.stringContaining("edit target missing; keeping alternate preview without fallback"),
+    );
+  });
+
+  it("falls back on 4xx client rejection with error_code during final", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    const err = Object.assign(new Error("403: Forbidden"), { error_code: 403 });
+    harness.editPreview.mockRejectedValue(err);
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(harness.editPreview).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hello final" }),
+    );
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("rejected by Telegram (client error); falling back"),
+    );
+  });
+
+  it("retains preview on 502 with error_code during final (ambiguous server error)", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    const err = Object.assign(new Error("502: Bad Gateway"), { error_code: 502 });
+    harness.editPreview.mockRejectedValue(err);
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-retained");
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous error; keeping existing preview to avoid duplicate"),
+    );
+  });
+
+  it("retains preview when sendMayHaveLanded is true and no messageId", async () => {
+    const stream = createTestDraftStream();
+    stream.sendMayHaveLanded.mockReturnValue(true);
+    // No messageId → resolvePreviewTarget returns undefined
+    const harness = createHarness({ answerStream: stream });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-retained");
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("preview send may have landed despite missing message id"),
     );
   });
 

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -193,7 +193,7 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
-  it("keeps preview when Telegram reports the final edit target missing", async () => {
+  it("falls back when Telegram reports the current final edit target missing", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.editPreview.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
 
@@ -204,11 +204,13 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-retained");
+    expect(result).toBe("sent");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hello final" }),
+    );
     expect(harness.log).toHaveBeenCalledWith(
-      expect.stringContaining("edit target missing; keeping existing preview without fallback"),
+      expect.stringContaining("edit target missing with no alternate preview; falling back"),
     );
   });
 
@@ -445,8 +447,32 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps archived preview when its final edit target is missing", async () => {
+  it("falls back when an archived preview edit target is missing and no alternate preview exists", async () => {
     const harness = createHarness();
+    harness.archivedAnswerPreviews.push({
+      messageId: 5555,
+      textSnapshot: "Partial streaming...",
+      deleteIfUnused: true,
+    });
+    harness.editPreview.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Complete final answer",
+      payload: { text: "Complete final answer" },
+      infoKind: "final",
+    });
+
+    expect(harness.editPreview).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Complete final answer" }),
+    );
+    expect(result).toBe("sent");
+    expect(harness.deletePreviewMessage).toHaveBeenCalledWith(5555);
+  });
+
+  it("keeps the active preview when an archived final edit target is missing", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
     harness.archivedAnswerPreviews.push({
       messageId: 5555,
       textSnapshot: "Partial streaming...",
@@ -464,6 +490,9 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(result).toBe("preview-retained");
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("edit target missing; keeping alternate preview without fallback"),
+    );
   });
 
   it("deletes consumed boundary previews after fallback final send", async () => {

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -362,6 +362,54 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.markDelivered).not.toHaveBeenCalled();
   });
 
+  // ── Duplicate message regression tests ──────────────────────────────────
+  // These document the fallback behavior at the lane-delivery layer.
+  // The real fix lives in bot-message-dispatch.ts: the editPreview callback
+  // swallows post-connect network errors (timeout, reset) so they never
+  // reach this layer. These tests verify that if a non-network API error
+  // (e.g. 500) still reaches tryEditPreviewMessage, the fallback to
+  // sendPayload still works correctly.
+
+  it("falls back to sendPayload on genuine API errors (not network timeout)", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    // A real API error (not a network timeout) — edit definitely didn't land
+    harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(harness.editPreview).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(result).toBe("sent");
+  });
+
+  it("falls back on archived preview API error and cleans up old preview", async () => {
+    const harness = createHarness();
+    harness.archivedAnswerPreviews.push({
+      messageId: 5555,
+      textSnapshot: "Partial streaming...",
+      deleteIfUnused: true,
+    });
+    // Genuine API error — edit definitely didn't land
+    harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Complete final answer",
+      payload: { text: "Complete final answer" },
+      infoKind: "final",
+    });
+
+    expect(harness.editPreview).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.deletePreviewMessage).toHaveBeenCalledWith(5555);
+    expect(result).toBe("sent");
+  });
+
   it("deletes consumed boundary previews after fallback final send", async () => {
     const harness = createHarness();
     harness.archivedAnswerPreviews.push({

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -42,7 +42,7 @@ function createHarness(params?: {
   const deletePreviewMessage = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
   const markDelivered = vi.fn();
-  const finalizedPreviewByLane: Record<LaneName, boolean> = { answer: false, reasoning: false };
+  const previewDispositionByLane = { answer: "transient", reasoning: "transient" } as const;
   const archivedAnswerPreviews: Array<{
     messageId: number;
     textSnapshot: string;
@@ -52,7 +52,7 @@ function createHarness(params?: {
   const deliverLaneText = createLaneTextDeliverer({
     lanes,
     archivedAnswerPreviews,
-    finalizedPreviewByLane,
+    previewDispositionByLane: { ...previewDispositionByLane },
     draftMaxChars: params?.draftMaxChars ?? 4_096,
     applyTextToPayload: (payload: ReplyPayload, text: string) => ({ ...payload, text }),
     sendPayload,
@@ -129,7 +129,7 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
-  it("treats stop-created preview edit failures as delivered", async () => {
+  it("keeps stop-created preview when follow-up final edit fails", async () => {
     const harness = createHarness({ answerMessageIdAfterStop: 777 });
     harness.editPreview.mockRejectedValue(new Error("500: edit failed after stop flush"));
 
@@ -140,11 +140,11 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-finalized");
+    expect(result).toBe("preview-retained");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.log).toHaveBeenCalledWith(
-      expect.stringContaining("keeping existing preview to avoid duplicate"),
+      expect.stringContaining("failed after stop flush; keeping existing preview"),
     );
   });
 
@@ -172,29 +172,9 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
-  it("treats existing preview edit failure as delivered during final to avoid duplicate", async () => {
+  it("falls back to sendPayload when an existing preview final edit is rejected", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.editPreview.mockRejectedValue(new Error("500: preview edit failed"));
-
-    const result = await harness.deliverLaneText({
-      laneName: "answer",
-      text: "Hello final",
-      payload: { text: "Hello final" },
-      infoKind: "final",
-    });
-
-    expect(result).toBe("preview-finalized");
-    expect(harness.editPreview).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).not.toHaveBeenCalled();
-    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
-    expect(harness.log).toHaveBeenCalledWith(
-      expect.stringContaining("keeping existing preview to avoid duplicate"),
-    );
-  });
-
-  it("falls back to sendPayload when preview message is missing during final edit", async () => {
-    const harness = createHarness({ answerMessageId: 999 });
-    harness.editPreview.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
 
     const result = await harness.deliverLaneText({
       laneName: "answer",
@@ -207,6 +187,67 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Hello final" }),
+    );
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("edit rejected by Telegram; falling back"),
+    );
+  });
+
+  it("keeps preview when Telegram reports the final edit target missing", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.editPreview.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-retained");
+    expect(harness.editPreview).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("edit target missing; keeping existing preview without fallback"),
+    );
+  });
+
+  it("falls back to sendPayload when the final edit fails before reaching Telegram", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    const err = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    harness.editPreview.mockRejectedValue(err);
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hello final" }),
+    );
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("failed before reaching Telegram; falling back"),
+    );
+  });
+
+  it("keeps preview when the final edit times out after the request may have landed", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.editPreview.mockRejectedValue(new Error("timeout: request timed out after 30000ms"));
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-retained");
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("may have landed despite network error; keeping existing preview"),
     );
   });
 
@@ -385,11 +426,10 @@ describe("createLaneTextDeliverer", () => {
   });
 
   // ── Duplicate message regression tests ──────────────────────────────────
-  // During final delivery, edit failures keep the existing preview to avoid
-  // sending a duplicate via sendPayload. The only exception is when the
-  // preview message itself is gone ("message to edit not found").
+  // During final delivery, only ambiguous post-connect failures keep the
+  // preview. Definite non-delivery falls back to a real send.
 
-  it("keeps preview on API error during final to avoid duplicate", async () => {
+  it("falls back on API error during final", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
 
@@ -400,13 +440,12 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-finalized");
+    expect(result).toBe("sent");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).not.toHaveBeenCalled();
-    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to sendPayload when archived preview is missing during final", async () => {
+  it("keeps archived preview when its final edit target is missing", async () => {
     const harness = createHarness();
     harness.archivedAnswerPreviews.push({
       messageId: 5555,
@@ -423,8 +462,8 @@ describe("createLaneTextDeliverer", () => {
     });
 
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
-    expect(result).toBe("sent");
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(result).toBe("preview-retained");
   });
 
   it("deletes consumed boundary previews after fallback final send", async () => {

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -143,7 +143,9 @@ describe("createLaneTextDeliverer", () => {
     expect(result).toBe("preview-finalized");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
-    expect(harness.log).toHaveBeenCalledWith(expect.stringContaining("treating as delivered"));
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("keeping existing preview to avoid duplicate"),
+    );
   });
 
   it("treats 'message is not modified' preview edit errors as delivered", async () => {
@@ -170,9 +172,29 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
-  it("falls back to normal delivery when editing an existing preview fails", async () => {
+  it("treats existing preview edit failure as delivered during final to avoid duplicate", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.editPreview.mockRejectedValue(new Error("500: preview edit failed"));
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.editPreview).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("keeping existing preview to avoid duplicate"),
+    );
+  });
+
+  it("falls back to sendPayload when preview message is missing during final edit", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.editPreview.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
 
     const result = await harness.deliverLaneText({
       laneName: "answer",
@@ -363,16 +385,12 @@ describe("createLaneTextDeliverer", () => {
   });
 
   // ── Duplicate message regression tests ──────────────────────────────────
-  // These document the fallback behavior at the lane-delivery layer.
-  // The real fix lives in bot-message-dispatch.ts: the editPreview callback
-  // swallows post-connect network errors (timeout, reset) so they never
-  // reach this layer. These tests verify that if a non-network API error
-  // (e.g. 500) still reaches tryEditPreviewMessage, the fallback to
-  // sendPayload still works correctly.
+  // During final delivery, edit failures keep the existing preview to avoid
+  // sending a duplicate via sendPayload. The only exception is when the
+  // preview message itself is gone ("message to edit not found").
 
-  it("falls back to sendPayload on genuine API errors (not network timeout)", async () => {
+  it("keeps preview on API error during final to avoid duplicate", async () => {
     const harness = createHarness({ answerMessageId: 999 });
-    // A real API error (not a network timeout) — edit definitely didn't land
     harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
 
     const result = await harness.deliverLaneText({
@@ -382,20 +400,20 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
+    expect(result).toBe("preview-finalized");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
-    expect(result).toBe("sent");
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back on archived preview API error and cleans up old preview", async () => {
+  it("falls back to sendPayload when archived preview is missing during final", async () => {
     const harness = createHarness();
     harness.archivedAnswerPreviews.push({
       messageId: 5555,
       textSnapshot: "Partial streaming...",
       deleteIfUnused: true,
     });
-    // Genuine API error — edit definitely didn't land
-    harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
+    harness.editPreview.mockRejectedValue(new Error("400: Bad Request: message to edit not found"));
 
     const result = await harness.deliverLaneText({
       laneName: "answer",
@@ -406,7 +424,6 @@ describe("createLaneTextDeliverer", () => {
 
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).toHaveBeenCalledTimes(1);
-    expect(harness.deletePreviewMessage).toHaveBeenCalledWith(5555);
     expect(result).toBe("sent");
   });
 

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -4,7 +4,7 @@ export {
   type DraftLaneState,
   type LaneDeliveryResult,
   type LaneName,
-  type LanePreviewDisposition,
+  type LanePreviewLifecycle,
 } from "./lane-delivery-text-deliverer.js";
 export {
   createLaneDeliveryStateTracker,

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -4,6 +4,7 @@ export {
   type DraftLaneState,
   type LaneDeliveryResult,
   type LaneName,
+  type LanePreviewDisposition,
 } from "./lane-delivery-text-deliverer.js";
 export {
   createLaneDeliveryStateTracker,

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
+import {
+  isRecoverableTelegramNetworkError,
+  isSafeToRetrySendError,
+  isTelegramClientRejection,
+  isTelegramServerError,
+} from "./network-errors.js";
 
 describe("isRecoverableTelegramNetworkError", () => {
   it("detects recoverable error codes", () => {
@@ -162,5 +167,53 @@ describe("isSafeToRetrySendError", () => {
     const root = Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" });
     const wrapped = Object.assign(new Error("fetch failed"), { cause: root });
     expect(isSafeToRetrySendError(wrapped)).toBe(true);
+  });
+});
+
+describe("isTelegramServerError", () => {
+  it("returns true for error_code 500", () => {
+    const err = Object.assign(new Error("Internal Server Error"), { error_code: 500 });
+    expect(isTelegramServerError(err)).toBe(true);
+  });
+
+  it("returns true for error_code 502", () => {
+    const err = Object.assign(new Error("Bad Gateway"), { error_code: 502 });
+    expect(isTelegramServerError(err)).toBe(true);
+  });
+
+  it("returns false for error_code 403", () => {
+    const err = Object.assign(new Error("Forbidden"), { error_code: 403 });
+    expect(isTelegramServerError(err)).toBe(false);
+  });
+
+  it("returns false for plain Error", () => {
+    expect(isTelegramServerError(new Error("500: Internal Server Error"))).toBe(false);
+  });
+});
+
+describe("isTelegramClientRejection", () => {
+  it("returns true for error_code 400", () => {
+    const err = Object.assign(new Error("Bad Request"), { error_code: 400 });
+    expect(isTelegramClientRejection(err)).toBe(true);
+  });
+
+  it("returns true for error_code 403", () => {
+    const err = Object.assign(new Error("Forbidden"), { error_code: 403 });
+    expect(isTelegramClientRejection(err)).toBe(true);
+  });
+
+  it("returns false for error_code 502", () => {
+    const err = Object.assign(new Error("Bad Gateway"), { error_code: 502 });
+    expect(isTelegramClientRejection(err)).toBe(false);
+  });
+
+  it("returns false for plain Error", () => {
+    expect(isTelegramClientRejection(new Error("400: Bad Request"))).toBe(false);
+  });
+
+  it("detects error_code in nested cause", () => {
+    const inner = Object.assign(new Error("Forbidden"), { error_code: 403 });
+    const outer = Object.assign(new Error("wrapped"), { cause: inner });
+    expect(isTelegramClientRejection(outer)).toBe(true);
   });
 });

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -123,6 +123,32 @@ export function isSafeToRetrySendError(err: unknown): boolean {
   return false;
 }
 
+/** Returns true for HTTP 5xx server errors (error may have been processed). */
+export function isTelegramServerError(err: unknown): boolean {
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    if (candidate && typeof candidate === "object" && "error_code" in candidate) {
+      const code = (candidate as { error_code: unknown }).error_code;
+      if (typeof code === "number" && code >= 500) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Returns true for HTTP 4xx client errors (Telegram explicitly rejected, not applied). */
+export function isTelegramClientRejection(err: unknown): boolean {
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    if (candidate && typeof candidate === "object" && "error_code" in candidate) {
+      const code = (candidate as { error_code: unknown }).error_code;
+      if (typeof code === "number" && code >= 400 && code < 500) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function isRecoverableTelegramNetworkError(
   err: unknown,
   options: { context?: TelegramNetworkErrorContext; allowMessageMatch?: boolean } = {},

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -27,7 +27,11 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
-import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
+import {
+  isRecoverableTelegramNetworkError,
+  isSafeToRetrySendError,
+  isTelegramServerError,
+} from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
@@ -995,6 +999,9 @@ export async function editMessageTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
+    shouldRetry: (err) =>
+      isRecoverableTelegramNetworkError(err, { allowMessageMatch: true }) ||
+      isTelegramServerError(err),
   });
   const requestWithEditShouldLog = <T>(
     fn: () => Promise<T>,


### PR DESCRIPTION
## Problem

Duplicate Telegram messages still occur with slow LLM providers (e.g. MiniMax via OpenRouter: 5s first token, 20 tok/s) despite #41662. Two remaining paths cause duplicates:

1. **`editMessageTelegram` doesn't retry on HTTP 5xx** — A "502 Bad Gateway" doesn't match the default `TELEGRAM_RETRY_RE`, so the error propagates to `tryEditPreviewMessage` and falls through to the unclassified default → `"fallback"` → duplicate.

2. **Draft stream `sendMessage` timeout loses messageId** — If the initial `sendMessage` for the preview times out but succeeds server-side, `streamMessageId` is never set. The final delivery path returns `"fallback"` when there's no messageId → `sendPayload` sends a duplicate.

## Solution

- **Retry 5xx in `editMessageTelegram`**: Pass `shouldRetry` covering both network errors and server errors. Edits are idempotent — retrying is safe and the 502 likely succeeds on retry, preventing the error from reaching the classifier.

- **Invert the default in `tryEditPreviewMessage`**: Ambiguous errors now default to `"retained"` (prefer incomplete over duplicate). Only explicit 4xx client rejections fall back to `sendPayload`. New `isTelegramServerError` and `isTelegramClientRejection` helpers enable this classification.

- **Track `sendMayHaveLanded` in draft stream**: When a preview `sendMessage` was attempted but the response was lost, the delivery path now returns `"retained"` instead of `"fallback"`.

## Related

- Follow-up to #41662

## Test plan

- [x] Updated 2 existing tests for inverted default behavior
- [x] Added 3 new lane-delivery tests (4xx fallback, 502 retention, sendMayHaveLanded)
- [x] Added 2 new test suites for `isTelegramServerError` and `isTelegramClientRejection` (9 cases)
- [x] `pnpm test -- src/telegram/lane-delivery.test.ts src/telegram/network-errors.test.ts src/telegram/bot-message-dispatch.test.ts` — all pass
- [x] `pnpm tsgo` — clean