### PR TITLE
fix: wire cron catch-up tuning and allow-always warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - MS Teams/authz: keep `groupPolicy: "allowlist"` enforcing sender allowlists even when a team/channel route allowlist is configured, so route matches no longer widen group access to every sender in that route. Thanks @zpbrent.
 - Security/system.run: bind approved `bun` and `deno run` script operands to on-disk file snapshots so post-approval script rewrites are denied before execution.
 - Skills/download installs: pin the validated per-skill tools root before writing downloaded archives, so rebinding the lexical tools path cannot redirect download writes outside the intended tools directory. Thanks @tdjackey.
+- Cron/exec approvals: wire `cron.missedJobStaggerMs` and `cron.maxMissedJobsPerRestart` through the validated config/runtime path, and surface a visible session warning when `allow-always` cannot persist a reusable allowlist rule.
 
 ## 2026.3.8
 

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import {
+  ALLOW_ALWAYS_NOT_PERSISTED_WARNING,
   addAllowlistEntry,
   type ExecAsk,
   type ExecSecurity,
@@ -218,9 +219,11 @@ export async function processGatewayAllowlist(
             platform: process.platform,
           });
           if (patterns.length === 0) {
-            logWarn(
-              "exec: allow-always could not persist any allowlist patterns (command may contain only shell builtins like cd, export, etc.)",
-            );
+            logWarn(ALLOW_ALWAYS_NOT_PERSISTED_WARNING);
+            emitExecSystemEvent(ALLOW_ALWAYS_NOT_PERSISTED_WARNING, {
+              sessionKey: params.notifySessionKey,
+              contextKey,
+            });
           }
           for (const pattern of patterns) {
             if (pattern) {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -11,7 +11,7 @@ import {
 } from "../infra/exec-approvals.js";
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
-import { logInfo } from "../logger.js";
+import { logInfo, logWarn } from "../logger.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
@@ -217,6 +217,11 @@ export async function processGatewayAllowlist(
             env: params.env,
             platform: process.platform,
           });
+          if (patterns.length === 0) {
+            logWarn(
+              "exec: allow-always could not persist any allowlist patterns (command may contain only shell builtins like cd, export, etc.)",
+            );
+          }
           for (const pattern of patterns) {
             if (pattern) {
               addAllowlistEntry(approvals.file, params.agentId, pattern);

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -264,6 +264,17 @@ describe("cron webhook schema", () => {
     });
     expect(res.success).toBe(true);
   });
+
+  it("accepts cron restart catch-up tuning", () => {
+    const res = OpenClawSchema.safeParse({
+      cron: {
+        missedJobStaggerMs: 15_000,
+        maxMissedJobsPerRestart: 2,
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
 });
 
 describe("broadcast", () => {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -110,6 +110,8 @@ const TARGET_KEYS = [
   "cron.enabled",
   "cron.store",
   "cron.maxConcurrentRuns",
+  "cron.missedJobStaggerMs",
+  "cron.maxMissedJobsPerRestart",
   "cron.retry",
   "cron.retry.maxAttempts",
   "cron.retry.backoffMs",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1157,6 +1157,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Path to the cron job store file used to persist scheduled jobs across restarts. Set an explicit path only when you need custom storage layout, backups, or mounted volumes.",
   "cron.maxConcurrentRuns":
     "Limits how many cron jobs can execute at the same time when multiple schedules fire together. Use lower values to protect CPU/memory under heavy automation load, or raise carefully for higher throughput.",
+  "cron.missedJobStaggerMs":
+    "Delay in ms between deferred missed-job executions after a restart (default: `5000`). Increase this to smooth restart bursts further, or set `0` to disable spacing between deferred jobs.",
+  "cron.maxMissedJobsPerRestart":
+    "Maximum missed jobs to run immediately after a restart before deferring the rest (default: `5`). Lower this to protect the gateway during large catch-up bursts, or raise it when restart latency matters more than load smoothing.",
   "cron.retry":
     "Overrides the default retry policy for one-shot jobs when they fail with transient errors (rate limit, overloaded, network, server_error). Omit to use defaults: maxAttempts 3, backoffMs [30000, 60000, 300000], retry all transient types.",
   "cron.retry.maxAttempts":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -555,6 +555,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "cron.enabled": "Cron Enabled",
   "cron.store": "Cron Store Path",
   "cron.maxConcurrentRuns": "Cron Max Concurrent Runs",
+  "cron.missedJobStaggerMs": "Cron Missed Job Stagger (ms)",
+  "cron.maxMissedJobsPerRestart": "Cron Max Missed Jobs Per Restart",
   "cron.retry": "Cron Retry Policy",
   "cron.retry.maxAttempts": "Cron Retry Max Attempts",
   "cron.retry.backoffMs": "Cron Retry Backoff (ms)",

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -31,6 +31,10 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /** Delay in ms between deferred missed-job executions after restart (default: 5000). */
+  missedJobStaggerMs?: number;
+  /** Maximum missed jobs to run immediately on restart before deferring the rest (default: 5). */
+  maxMissedJobsPerRestart?: number;
   /** Override default retry policy for one-shot jobs on transient errors. */
   retry?: CronRetryConfig;
   /**

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -488,6 +488,8 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        missedJobStaggerMs: z.number().int().min(0).optional(),
+        maxMissedJobsPerRestart: z.number().int().min(0).optional(),
         retry: z
           .object({
             maxAttempts: z.number().int().min(0).max(10).optional(),

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -86,6 +86,36 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("passes restart catch-up tuning into CronService", () => {
+    const tmpDir = path.join(os.tmpdir(), `server-cron-tuning-${Date.now()}`);
+    const cfg = {
+      session: {
+        mainKey: "main",
+      },
+      cron: {
+        store: path.join(tmpDir, "cron.json"),
+        missedJobStaggerMs: 12_000,
+        maxMissedJobsPerRestart: 3,
+      },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const cronState = state.cron as unknown as {
+        state: { deps: { missedJobStaggerMs?: number; maxMissedJobsPerRestart?: number } };
+      };
+      expect(cronState.state.deps.missedJobStaggerMs).toBe(12_000);
+      expect(cronState.state.deps.maxMissedJobsPerRestart).toBe(3);
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("blocks private webhook URLs via SSRF-guarded fetch", async () => {
     const tmpDir = path.join(os.tmpdir(), `server-cron-ssrf-${Date.now()}`);
     const cfg = {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -235,6 +235,8 @@ export function buildGatewayCronService(params: {
     defaultAgentId,
     resolveSessionStorePath,
     sessionStorePath,
+    missedJobStaggerMs: params.cfg.cron?.missedJobStaggerMs,
+    maxMissedJobsPerRestart: params.cfg.cron?.maxMissedJobsPerRestart,
     enqueueSystemEvent: (text, opts) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(opts?.agentId);
       const sessionKey = resolveCronSessionKey({

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -141,6 +141,9 @@ export type ExecApprovalsResolved = {
   file: ExecApprovalsFile;
 };
 
+export const ALLOW_ALWAYS_NOT_PERSISTED_WARNING =
+  "Warning: allow-always approved this run, but nothing could be added to the allowlist. This can happen with shell builtins like cd or export, or wrapper-only commands, so you'll be asked again next time.";
+
 // Keep CLI + gateway defaults in sync.
 export const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 120_000;
 

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1,10 +1,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, type Mock, vi } from "vitest";
-import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import {
+  ALLOW_ALWAYS_NOT_PERSISTED_WARNING,
+  type SystemRunApprovalPlan,
+} from "../infra/exec-approvals.js";
 import { saveExecApprovals } from "../infra/exec-approvals.js";
 import type { ExecHostResponse } from "../infra/exec-host.js";
+import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import { buildSystemRunApprovalPlan } from "./invoke-system-run-plan.js";
 import { handleSystemRunInvoke, formatSystemRunAllowlistMissMessage } from "./invoke-system-run.js";
 import type { HandleSystemRunInvokeOptions } from "./invoke-system-run.js";
@@ -30,6 +34,10 @@ describe("formatSystemRunAllowlistMissMessage", () => {
 });
 
 describe("handleSystemRunInvoke mac app exec host routing", () => {
+  beforeEach(() => {
+    resetSystemEventsForTest();
+  });
+
   function createLocalRunResult(stdout = "local-ok") {
     return {
       success: true,
@@ -312,6 +320,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     security?: "full" | "allowlist";
     ask?: "off" | "on-miss" | "always";
     approved?: boolean;
+    approvalDecision?: "allow-once" | "allow-always" | null;
     runCommand?: HandleSystemRunInvokeOptions["runCommand"];
     runViaMacAppExecHost?: HandleSystemRunInvokeOptions["runViaMacAppExecHost"];
     sendInvokeResult?: HandleSystemRunInvokeOptions["sendInvokeResult"];
@@ -365,6 +374,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         systemRunPlan: params.systemRunPlan,
         cwd: params.cwd,
         approved: params.approved ?? false,
+        approvalDecision: params.approvalDecision,
         sessionKey: "agent:main:main",
       },
       skillBins: {
@@ -544,6 +554,29 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     expect(runCommand).not.toHaveBeenCalled();
     expectInvokeErrorMessage(sendInvokeResult, { message: "allowlist miss" });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "enqueues a user-visible warning when allow-always cannot persist a stable allowlist pattern",
+    async () => {
+      await withTempApprovalsHome({
+        approvals: createAllowlistOnMissApprovals(),
+        run: async () => {
+          const sessionKey = "agent:main:main";
+          const { sendInvokeResult } = await runSystemInvoke({
+            preferMacAppExecHost: false,
+            security: "allowlist",
+            ask: "on-miss",
+            approved: true,
+            approvalDecision: "allow-always",
+            command: ["/usr/bin/sudo", "/bin/echo", "ok"],
+          });
+
+          expect(peekSystemEvents(sessionKey)).toContain(ALLOW_ALWAYS_NOT_PERSISTED_WARNING);
+          expectInvokeOk(sendInvokeResult);
+        },
+      });
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "pins PATH-token executable to canonical path for approval-based runs",

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -3,6 +3,7 @@ import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import type { GatewayClient } from "../gateway/client.js";
 import {
+  ALLOW_ALWAYS_NOT_PERSISTED_WARNING,
   addAllowlistEntry,
   recordAllowlistUse,
   resolveAllowAlwaysPatterns,
@@ -14,10 +15,13 @@ import {
 } from "../infra/exec-approvals.js";
 import type { ExecHostRequest, ExecHostResponse, ExecHostRunResult } from "../infra/exec-host.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
+import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { sanitizeSystemRunEnvOverrides } from "../infra/host-env-security.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
 import { normalizeSystemRunApprovalPlan } from "../infra/system-run-approval-binding.js";
 import { resolveSystemRunCommand } from "../infra/system-run-command.js";
 import { logWarn } from "../logger.js";
+import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import { evaluateSystemRunPolicy, resolveExecApprovalDecision } from "./exec-policy.js";
 import {
   applyOutputTruncation,
@@ -104,6 +108,16 @@ function warnWritableTrustedDirOnce(message: string): void {
   }
   safeBinTrustedDirWarningCache.add(message);
   logWarn(message);
+}
+
+function notifyAllowAlwaysNotPersisted(sessionKey?: string): void {
+  logWarn(ALLOW_ALWAYS_NOT_PERSISTED_WARNING);
+  const normalizedSessionKey = sessionKey?.trim();
+  if (!normalizedSessionKey) {
+    return;
+  }
+  enqueueSystemEvent(ALLOW_ALWAYS_NOT_PERSISTED_WARNING, { sessionKey: normalizedSessionKey });
+  requestHeartbeatNow(scopedHeartbeatWakeOptions(normalizedSessionKey, { reason: "exec-event" }));
 }
 
 function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeniedReason {
@@ -292,8 +306,6 @@ async function evaluateSystemRunPolicyPhase(
     cmdInvocation,
     shellWrapperInvocation: parsed.shellCommand !== null,
   });
-  analysisOk = policy.analysisOk;
-  allowlistSatisfied = policy.allowlistSatisfied;
   if (!policy.allowed) {
     await sendSystemRunDenied(opts, parsed.execution, {
       reason: policy.eventReason,
@@ -444,7 +456,7 @@ async function executeSystemRunPhase(
   }
 
   if (phase.policy.approvalDecision === "allow-always" && phase.security === "allowlist") {
-    if (phase.policy.analysisOk) {
+    if (phase.analysisOk) {
       const patterns = resolveAllowAlwaysPatterns({
         segments: phase.segments,
         cwd: phase.cwd,
@@ -452,9 +464,7 @@ async function executeSystemRunPhase(
         platform: process.platform,
       });
       if (patterns.length === 0) {
-        logWarn(
-          "exec: allow-always could not persist any allowlist patterns (command may contain only shell builtins like cd, export, etc.)",
-        );
+        notifyAllowAlwaysNotPersisted(phase.sessionKey);
       }
       for (const pattern of patterns) {
         if (pattern) {

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -451,6 +451,11 @@ async function executeSystemRunPhase(
         env: phase.env,
         platform: process.platform,
       });
+      if (patterns.length === 0) {
+        logWarn(
+          "exec: allow-always could not persist any allowlist patterns (command may contain only shell builtins like cd, export, etc.)",
+        );
+      }
       for (const pattern of patterns) {
         if (pattern) {
           addAllowlistEntry(phase.approvals.file, phase.agentId, pattern);


### PR DESCRIPTION
## Summary

- Problem: `cron.missedJobStaggerMs` and `cron.maxMissedJobsPerRestart` existed in the cron service path but were neither accepted by the validated config surface nor wired from gateway config into production `CronService` construction.
- Why it matters: operators could not actually tune restart catch-up behavior, and `allow-always` persistence failures only wrote logs so users got no visible feedback when no reusable allowlist rule could be saved.
- What changed: added the cron config keys to the validated config/help surface, passed them through `buildGatewayCronService`, emitted a session-visible warning when `allow-always` cannot persist a reusable allowlist rule, and kept raw allowlist analysis available in `system.run` so that warning path can execute.
- What did NOT change (scope boundary): no new approval modes, no widened allowlist matching, and no changes to the unrelated browser-extension worktree files already present locally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: None
- Related: #18925

## User-visible / Behavior Changes

- `cron.missedJobStaggerMs` and `cron.maxMissedJobsPerRestart` now validate and take effect at runtime.
- `allow-always` now enqueues a visible session warning when no reusable allowlist rule can be persisted for that command shape.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): cron + exec approvals
- Relevant config (redacted): `cron.missedJobStaggerMs`, `cron.maxMissedJobsPerRestart`, `tools.exec.security=allowlist`, `tools.exec.ask=on-miss`

### Steps

1. Configure non-default cron restart catch-up tuning values and start the gateway cron service.
2. Trigger an exec approval flow where `allow-always` is selected for a command shape that cannot persist a reusable allowlist rule.
3. Verify the config is accepted/wired and the warning is surfaced to the session.

### Expected

- The cron tuning keys are accepted by config validation and passed into the live cron service.
- The session receives a visible warning when `allow-always` cannot persist a reusable rule.

### Actual

- Fixed by this PR.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new cron config keys validate; `buildGatewayCronService` passes the values into `CronService`; `handleSystemRunInvoke` enqueues the visible warning when `allow-always` cannot persist a stable rule.
- Edge cases checked: existing cron restart catch-up regressions, allow-always allowlist tests, and typechecking still pass.
- What you did **not** verify: end-to-end approval UX through an external messaging channel UI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): Yes
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f9b6944b3085e82a719e7406efb20eacbc092be4` or remove the optional cron tuning keys.
- Files/config to restore: `src/gateway/server-cron.ts`, `src/node-host/invoke-system-run.ts`, and the new cron config keys in config schema/types/help.
- Known bad symptoms reviewers should watch for: cron tuning values still being ignored at runtime, or duplicate/noisy session warnings for non-persistable `allow-always` approvals.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: visible warning events could be noisy for repeated wrapper-only commands that still cannot persist.
  - Mitigation: the warning only fires on `allow-always` decisions with zero persisted patterns, and system-event dedupe suppresses consecutive duplicates.
