### PR TITLE
fix(telegram): isolate DM sessions from agent:main:main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Breaking
+
+- Telegram/DM sessions: isolate default Telegram DMs from `agent:main:main` across inbound messages, native commands, model picker callbacks, and outbound sends. If you need the old shared-main behavior, set `session.dmScope: main`. (#41939) Thanks @imwyvern.
+
 ### Changes
 
 - Commands/btw: add `/btw` side questions for quick tool-less answers about the current session without changing future session context, with dismissible in-session TUI answers and explicit BTW replies on external channels. (#45444) Thanks @ngutman.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -278,6 +278,7 @@ export const registerTelegramHandlers = ({
     sessionKey: string;
     model?: string;
   } => {
+    const freshCfg = telegramDeps.loadConfig();
     const resolvedThreadId =
       params.resolvedThreadId ??
       resolveTelegramForumThreadId({
@@ -289,7 +290,7 @@ export const registerTelegramHandlers = ({
     const { topicConfig } = resolveTelegramGroupConfig(params.chatId, topicThreadId);
     const { route, configuredBinding, configuredBindingSessionKey } =
       resolveTelegramConversationRoute({
-        cfg,
+        cfg: freshCfg,
         accountId,
         chatId: params.chatId,
         isGroup: params.isGroup,
@@ -299,7 +300,7 @@ export const registerTelegramHandlers = ({
         topicAgentId: topicConfig?.agentId,
       });
     const session = resolveTelegramConversationSession({
-      cfg,
+      cfg: freshCfg,
       route,
       chatId: params.chatId,
       isGroup: params.isGroup,
@@ -309,7 +310,7 @@ export const registerTelegramHandlers = ({
       configuredBindingSessionKey,
     });
     const sessionKey = session.sessionKey;
-    const storePath = telegramDeps.resolveStorePath(cfg.session?.store, {
+    const storePath = telegramDeps.resolveStorePath(freshCfg.session?.store, {
       agentId: session.route.agentId,
     });
     const store = loadSessionStore(storePath);
@@ -339,7 +340,7 @@ export const registerTelegramHandlers = ({
         model: `${provider}/${model}`,
       };
     }
-    const modelCfg = cfg.agents?.defaults?.model;
+    const modelCfg = freshCfg.agents?.defaults?.model;
     return {
       agentId: session.route.agentId,
       sessionEntry: entry,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -33,8 +33,6 @@ import {
 } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveStoredModelOverride } from "openclaw/plugin-sdk/reply-runtime";
 import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/reply-runtime";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
-import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -68,8 +66,8 @@ import {
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import {
-  resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
+  resolveTelegramConversationSession,
 } from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
 import {
@@ -289,30 +287,30 @@ export const registerTelegramHandlers = ({
     const dmThreadId = !params.isGroup ? params.messageThreadId : undefined;
     const topicThreadId = resolvedThreadId ?? dmThreadId;
     const { topicConfig } = resolveTelegramGroupConfig(params.chatId, topicThreadId);
-    const { route } = resolveTelegramConversationRoute({
-      cfg,
-      accountId,
-      chatId: params.chatId,
-      isGroup: params.isGroup,
-      resolvedThreadId,
-      replyThreadId: topicThreadId,
-      senderId: params.senderId,
-      topicAgentId: topicConfig?.agentId,
-    });
-    const baseSessionKey = resolveTelegramConversationBaseSessionKey({
+    const { route, configuredBinding, configuredBindingSessionKey } =
+      resolveTelegramConversationRoute({
+        cfg,
+        accountId,
+        chatId: params.chatId,
+        isGroup: params.isGroup,
+        resolvedThreadId,
+        replyThreadId: topicThreadId,
+        senderId: params.senderId,
+        topicAgentId: topicConfig?.agentId,
+      });
+    const session = resolveTelegramConversationSession({
       cfg,
       route,
       chatId: params.chatId,
       isGroup: params.isGroup,
       senderId: params.senderId,
+      dmThreadId,
+      configuredBinding,
+      configuredBindingSessionKey,
     });
-    const threadKeys =
-      dmThreadId != null
-        ? resolveThreadSessionKeys({ baseSessionKey, threadId: `${params.chatId}:${dmThreadId}` })
-        : null;
-    const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
+    const sessionKey = session.sessionKey;
     const storePath = telegramDeps.resolveStorePath(cfg.session?.store, {
-      agentId: route.agentId,
+      agentId: session.route.agentId,
     });
     const store = loadSessionStore(storePath);
     const entry = resolveSessionStoreEntry({ store, sessionKey }).existing;
@@ -323,7 +321,7 @@ export const registerTelegramHandlers = ({
     });
     if (storedOverride) {
       return {
-        agentId: route.agentId,
+        agentId: session.route.agentId,
         sessionEntry: entry,
         sessionKey,
         model: storedOverride.provider
@@ -343,7 +341,7 @@ export const registerTelegramHandlers = ({
     }
     const modelCfg = cfg.agents?.defaults?.model;
     return {
-      agentId: route.agentId,
+      agentId: session.route.agentId,
       sessionEntry: entry,
       sessionKey,
       model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
@@ -829,17 +827,26 @@ export const registerTelegramHandlers = ({
       const resolvedThreadId = isForum
         ? resolveTelegramForumThreadId({ isForum, messageThreadId: undefined })
         : undefined;
-      const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
-      const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
-      // Fresh config for bindings lookup; other routing inputs are payload-derived.
-      const route = resolveAgentRoute({
-        cfg: telegramDeps.loadConfig(),
-        channel: "telegram",
-        accountId,
-        peer: { kind: isGroup ? "group" : "direct", id: peerId },
-        parentPeer,
+      const freshCfg = telegramDeps.loadConfig();
+      const { route, configuredBinding, configuredBindingSessionKey } =
+        resolveTelegramConversationRoute({
+          cfg: freshCfg,
+          accountId,
+          chatId,
+          isGroup,
+          resolvedThreadId,
+          senderId,
+        });
+      const session = resolveTelegramConversationSession({
+        cfg: freshCfg,
+        route,
+        chatId,
+        isGroup,
+        senderId,
+        configuredBinding,
+        configuredBindingSessionKey,
       });
-      const sessionKey = route.sessionKey;
+      const sessionKey = session.sessionKey;
 
       // Enqueue system event for each added reaction.
       for (const r of addedReactions) {

--- a/extensions/telegram/src/bot-message-context.dm-isolation.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-isolation.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../../../src/config/config.js";
+import {
+  baseTelegramMessageContextConfig,
+  buildTelegramMessageContextForTest,
+} from "./bot-message-context.test-harness.js";
+
+const baseConfig = baseTelegramMessageContextConfig as unknown as Record<string, unknown>;
+
+describe("buildTelegramMessageContext dm isolation", () => {
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("isolates DMs from the main session when dmScope is unset", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 7463849194, type: "private" },
+        from: { id: 7463849194, first_name: "Alice" },
+        text: "hello",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:direct:7463849194");
+  });
+
+  it("respects explicit dmScope main", async () => {
+    const cfg = {
+      ...baseConfig,
+      session: { dmScope: "main" },
+    };
+    setRuntimeConfigSnapshot(cfg as never);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg,
+      message: {
+        chat: { id: 7463849194, type: "private" },
+        from: { id: 7463849194, first_name: "Alice" },
+        text: "hello",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main");
+  });
+
+  it("does not rewrite explicit direct-peer bindings that intentionally target main", async () => {
+    const cfg = {
+      ...baseConfig,
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "telegram",
+            peer: { kind: "direct", id: "7463849194" },
+          },
+        },
+      ],
+    };
+    setRuntimeConfigSnapshot(cfg as never);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg,
+      message: {
+        chat: { id: 7463849194, type: "private" },
+        from: { id: 7463849194, first_name: "Alice" },
+        text: "hello",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("binding.peer");
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main");
+  });
+
+  it("does not rewrite explicit account bindings that intentionally target main", async () => {
+    const cfg = {
+      ...baseConfig,
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "telegram",
+            accountId: "default",
+          },
+        },
+      ],
+    };
+    setRuntimeConfigSnapshot(cfg as never);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg,
+      message: {
+        chat: { id: 7463849194, type: "private" },
+        from: { id: 7463849194, first_name: "Alice" },
+        text: "hello",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("binding.account");
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main");
+  });
+
+  it("preserves explicit per-peer isolation", async () => {
+    const cfg = {
+      ...baseConfig,
+      session: { dmScope: "per-peer" },
+    };
+    setRuntimeConfigSnapshot(cfg as never);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg,
+      message: {
+        chat: { id: 7463849194, type: "private" },
+        from: { id: 7463849194, first_name: "Alice" },
+        text: "hello",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:direct:7463849194");
+  });
+
+  it("does not affect group routing", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: -100123456, type: "supergroup", title: "Test Group" },
+        from: { id: 42, first_name: "Alice" },
+        text: "hello",
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:group:-100123456");
+  });
+});

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -9,22 +9,17 @@ import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { TelegramDirectConfig, TelegramGroupConfig } from "openclaw/plugin-sdk/config-runtime";
 import { ensureConfiguredBindingRouteReady } from "openclaw/plugin-sdk/conversation-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
-import { buildAgentSessionKey, deriveLastRoutePolicy } from "openclaw/plugin-sdk/routing";
-import { DEFAULT_ACCOUNT_ID, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, normalizeAllowFrom, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import { resolveTelegramInboundBody } from "./bot-message-context.body.js";
 import { buildTelegramInboundContextPayload } from "./bot-message-context.session.js";
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
+import { buildTypingThreadParams, resolveTelegramThreadSpec } from "./bot/helpers.js";
 import {
-  buildTypingThreadParams,
-  resolveTelegramDirectPeerId,
-  resolveTelegramThreadSpec,
-} from "./bot/helpers.js";
-import {
-  resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
+  resolveTelegramConversationSession,
 } from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
 import { evaluateTelegramGroupBaseAccess } from "./group-access.js";
@@ -227,57 +222,18 @@ export const buildTelegramMessageContext = async ({
     return false;
   };
 
-  let baseSessionKey = resolveTelegramConversationBaseSessionKey({
+  const session = resolveTelegramConversationSession({
     cfg: freshCfg,
     route,
     chatId,
     isGroup,
     senderId,
+    dmThreadId,
+    configuredBinding,
+    configuredBindingSessionKey,
   });
-  const dmScopeExplicit = freshCfg.session?.dmScope != null;
-  const isExplicitRouteBinding =
-    route.matchedBy !== "default" ||
-    configuredBinding != null ||
-    Boolean(configuredBindingSessionKey?.trim());
-  if (
-    !isGroup &&
-    !isNamedAccountFallback &&
-    !isExplicitRouteBinding &&
-    !dmScopeExplicit &&
-    baseSessionKey === route.mainSessionKey
-  ) {
-    baseSessionKey = buildAgentSessionKey({
-      agentId: route.agentId,
-      channel: "telegram",
-      accountId: route.accountId,
-      peer: {
-        kind: "direct",
-        id: resolveTelegramDirectPeerId({
-          chatId,
-          senderId,
-        }),
-      },
-      dmScope: "per-channel-peer",
-      identityLinks: freshCfg.session?.identityLinks,
-    }).toLowerCase();
-    logVerbose(
-      `telegram: DM isolation override ${route.mainSessionKey} -> ${baseSessionKey} (default route, dmScope unset)`,
-    );
-  }
-  // DMs: use thread suffix for session isolation (works regardless of dmScope)
-  const threadKeys =
-    dmThreadId != null
-      ? resolveThreadSessionKeys({ baseSessionKey, threadId: `${chatId}:${dmThreadId}` })
-      : null;
-  const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
-  route = {
-    ...route,
-    sessionKey,
-    lastRoutePolicy: deriveLastRoutePolicy({
-      sessionKey,
-      mainSessionKey: route.mainSessionKey,
-    }),
-  };
+  const sessionKey = session.sessionKey;
+  route = session.route;
   // Compute requireMention after access checks and final route selection.
   const activationOverride = resolveGroupActivation({
     chatId,

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -9,7 +9,7 @@ import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { TelegramDirectConfig, TelegramGroupConfig } from "openclaw/plugin-sdk/config-runtime";
 import { ensureConfiguredBindingRouteReady } from "openclaw/plugin-sdk/conversation-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
-import { deriveLastRoutePolicy } from "openclaw/plugin-sdk/routing";
+import { buildAgentSessionKey, deriveLastRoutePolicy } from "openclaw/plugin-sdk/routing";
 import { DEFAULT_ACCOUNT_ID, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -17,7 +17,11 @@ import { firstDefined, normalizeAllowFrom, normalizeDmAllowFromWithStore } from 
 import { resolveTelegramInboundBody } from "./bot-message-context.body.js";
 import { buildTelegramInboundContextPayload } from "./bot-message-context.session.js";
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
-import { buildTypingThreadParams, resolveTelegramThreadSpec } from "./bot/helpers.js";
+import {
+  buildTypingThreadParams,
+  resolveTelegramDirectPeerId,
+  resolveTelegramThreadSpec,
+} from "./bot/helpers.js";
 import {
   resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
@@ -223,13 +227,43 @@ export const buildTelegramMessageContext = async ({
     return false;
   };
 
-  const baseSessionKey = resolveTelegramConversationBaseSessionKey({
+  let baseSessionKey = resolveTelegramConversationBaseSessionKey({
     cfg: freshCfg,
     route,
     chatId,
     isGroup,
     senderId,
   });
+  const dmScopeExplicit = freshCfg.session?.dmScope != null;
+  const isExplicitRouteBinding =
+    route.matchedBy !== "default" ||
+    configuredBinding != null ||
+    Boolean(configuredBindingSessionKey?.trim());
+  if (
+    !isGroup &&
+    !isNamedAccountFallback &&
+    !isExplicitRouteBinding &&
+    !dmScopeExplicit &&
+    baseSessionKey === route.mainSessionKey
+  ) {
+    baseSessionKey = buildAgentSessionKey({
+      agentId: route.agentId,
+      channel: "telegram",
+      accountId: route.accountId,
+      peer: {
+        kind: "direct",
+        id: resolveTelegramDirectPeerId({
+          chatId,
+          senderId,
+        }),
+      },
+      dmScope: "per-channel-peer",
+      identityLinks: freshCfg.session?.identityLinks,
+    }).toLowerCase();
+    logVerbose(
+      `telegram: DM isolation override ${route.mainSessionKey} -> ${baseSessionKey} (default route, dmScope unset)`,
+    );
+  }
   // DMs: use thread suffix for session isolation (works regardless of dmScope)
   const threadKeys =
     dmThreadId != null

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -38,7 +38,6 @@ import {
 } from "openclaw/plugin-sdk/reply-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
-import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -63,8 +62,8 @@ import {
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import {
-  resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
+  resolveTelegramConversationSession,
 } from "./conversation-route.js";
 import { shouldSuppressLocalTelegramExecApprovalPrompt } from "./exec-approvals.js";
 import type { TelegramTransport } from "./fetch.js";
@@ -472,6 +471,7 @@ export const registerTelegramNativeCommands = ({
     chatId: number;
     threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
     route: ReturnType<typeof resolveTelegramConversationRoute>["route"];
+    sessionKey: string;
     mediaLocalRoots: readonly string[] | undefined;
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: ReturnType<typeof resolveChunkMode>;
@@ -484,16 +484,17 @@ export const registerTelegramNativeCommands = ({
       isForum,
       messageThreadId,
     });
-    let { route, configuredBinding } = resolveTelegramConversationRoute({
-      cfg,
-      accountId,
-      chatId,
-      isGroup,
-      resolvedThreadId,
-      replyThreadId: threadSpec.id,
-      senderId,
-      topicAgentId,
-    });
+    let { route, configuredBinding, configuredBindingSessionKey } =
+      resolveTelegramConversationRoute({
+        cfg,
+        accountId,
+        chatId,
+        isGroup,
+        resolvedThreadId,
+        replyThreadId: threadSpec.id,
+        senderId,
+        topicAgentId,
+      });
     if (configuredBinding) {
       const ensured = await ensureConfiguredBindingRouteReady({
         cfg,
@@ -516,6 +517,18 @@ export const registerTelegramNativeCommands = ({
         return null;
       }
     }
+    const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
+    const session = resolveTelegramConversationSession({
+      cfg,
+      route,
+      chatId,
+      isGroup,
+      senderId,
+      dmThreadId,
+      configuredBinding,
+      configuredBindingSessionKey,
+    });
+    route = session.route;
     const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
     const tableMode = resolveMarkdownTableMode({
       cfg,
@@ -523,7 +536,15 @@ export const registerTelegramNativeCommands = ({
       accountId: route.accountId,
     });
     const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
-    return { chatId, threadSpec, route, mediaLocalRoots, tableMode, chunkMode };
+    return {
+      chatId,
+      threadSpec,
+      route,
+      sessionKey: session.sessionKey,
+      mediaLocalRoots,
+      tableMode,
+      chunkMode,
+    };
   };
   const buildCommandDeliveryBaseOptions = (params: {
     chatId: string | number;
@@ -605,7 +626,8 @@ export const registerTelegramNativeCommands = ({
           if (!runtimeContext) {
             return;
           }
-          const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
+          const { threadSpec, route, sessionKey, mediaLocalRoots, tableMode, chunkMode } =
+            runtimeContext;
           const threadParams = buildTelegramThreadParams(threadSpec) ?? {};
 
           const commandDefinition = findCommandByNativeName(command.name, "telegram");
@@ -658,23 +680,6 @@ export const registerTelegramNativeCommands = ({
             });
             return;
           }
-          const baseSessionKey = resolveTelegramConversationBaseSessionKey({
-            cfg,
-            route,
-            chatId,
-            isGroup,
-            senderId,
-          });
-          // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)
-          const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
-          const threadKeys =
-            dmThreadId != null
-              ? resolveThreadSessionKeys({
-                  baseSessionKey,
-                  threadId: `${chatId}:${dmThreadId}`,
-                })
-              : null;
-          const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
           const { skillFilter, groupSystemPrompt } = resolveTelegramGroupPromptSettings({
             groupConfig,
             topicConfig,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -477,6 +477,7 @@ export const registerTelegramNativeCommands = ({
     chunkMode: ReturnType<typeof resolveChunkMode>;
   } | null> => {
     const { msg, isGroup, isForum, resolvedThreadId, senderId, topicAgentId } = params;
+    const freshCfg = telegramDeps.loadConfig();
     const chatId = msg.chat.id;
     const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
     const threadSpec = resolveTelegramThreadSpec({
@@ -486,7 +487,7 @@ export const registerTelegramNativeCommands = ({
     });
     let { route, configuredBinding, configuredBindingSessionKey } =
       resolveTelegramConversationRoute({
-        cfg,
+        cfg: freshCfg,
         accountId,
         chatId,
         isGroup,
@@ -497,7 +498,7 @@ export const registerTelegramNativeCommands = ({
       });
     if (configuredBinding) {
       const ensured = await ensureConfiguredBindingRouteReady({
-        cfg,
+        cfg: freshCfg,
         bindingResolution: configuredBinding,
       });
       if (!ensured.ok) {
@@ -519,7 +520,7 @@ export const registerTelegramNativeCommands = ({
     }
     const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
     const session = resolveTelegramConversationSession({
-      cfg,
+      cfg: freshCfg,
       route,
       chatId,
       isGroup,
@@ -529,13 +530,13 @@ export const registerTelegramNativeCommands = ({
       configuredBindingSessionKey,
     });
     route = session.route;
-    const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
+    const mediaLocalRoots = getAgentScopedMediaLocalRoots(freshCfg, route.agentId);
     const tableMode = resolveMarkdownTableMode({
-      cfg,
+      cfg: freshCfg,
       channel: "telegram",
       accountId: route.accountId,
     });
-    const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
+    const chunkMode = resolveChunkMode(freshCfg, "telegram", route.accountId);
     return {
       chatId,
       threadSpec,

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -18,7 +18,11 @@ import {
 import { buildOutboundBaseSessionKey, normalizeOutboundThreadId } from "openclaw/plugin-sdk/core";
 import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/infra-runtime";
 import { buildExecApprovalPendingReplyPayload } from "openclaw/plugin-sdk/infra-runtime";
-import { resolveThreadSessionKeys, type RoutePeer } from "openclaw/plugin-sdk/routing";
+import {
+  buildAgentMainSessionKey,
+  deriveLastRoutePolicy,
+  type RoutePeer,
+} from "openclaw/plugin-sdk/routing";
 import { parseTelegramTopicConversation } from "../runtime-api.js";
 import {
   buildTokenChannelStatusSummary,
@@ -39,6 +43,7 @@ import {
 import { buildTelegramExecApprovalButtons } from "./approval-buttons.js";
 import { auditTelegramGroupMembership, collectTelegramUnmentionedGroupIds } from "./audit.js";
 import { buildTelegramGroupPeerId } from "./bot/helpers.js";
+import { resolveTelegramConversationSession } from "./conversation-route.js";
 import {
   listTelegramDirectoryGroupsFromConfig,
   listTelegramDirectoryPeersFromConfig,
@@ -231,13 +236,31 @@ function resolveTelegramOutboundSessionRoute(params: {
     accountId: params.accountId,
     peer,
   });
-  const threadKeys =
-    resolvedThreadId && !isGroup
-      ? resolveThreadSessionKeys({ baseSessionKey, threadId: String(resolvedThreadId) })
-      : null;
+  const mainSessionKey = buildAgentMainSessionKey({
+    agentId: params.agentId,
+  }).toLowerCase();
+  const session = resolveTelegramConversationSession({
+    cfg: params.cfg,
+    route: {
+      agentId: params.agentId,
+      channel: "telegram",
+      accountId: params.accountId ?? DEFAULT_ACCOUNT_ID,
+      sessionKey: baseSessionKey,
+      mainSessionKey,
+      lastRoutePolicy: deriveLastRoutePolicy({
+        sessionKey: baseSessionKey,
+        mainSessionKey,
+      }),
+      matchedBy: "default",
+    },
+    chatId,
+    isGroup,
+    senderId: isGroup ? undefined : chatId,
+    dmThreadId: resolvedThreadId && !isGroup ? resolvedThreadId : undefined,
+  });
   return {
-    sessionKey: threadKeys?.sessionKey ?? baseSessionKey,
-    baseSessionKey,
+    sessionKey: session.sessionKey,
+    baseSessionKey: session.baseSessionKey,
     peer,
     chatType: isGroup ? ("group" as const) : ("direct" as const),
     from: isGroup

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -9,6 +9,7 @@ import {
   buildAgentSessionKey,
   deriveLastRoutePolicy,
   resolveAgentRoute,
+  resolveThreadSessionKeys,
 } from "openclaw/plugin-sdk/routing";
 import {
   buildAgentMainSessionKey,
@@ -184,4 +185,77 @@ export function resolveTelegramConversationBaseSessionKey(params: {
     dmScope: "per-account-channel-peer",
     identityLinks: params.cfg.session?.identityLinks,
   }).toLowerCase();
+}
+
+export function resolveTelegramConversationSession(params: {
+  cfg: OpenClawConfig;
+  route: ReturnType<typeof resolveAgentRoute>;
+  chatId: number | string;
+  isGroup: boolean;
+  senderId?: string | number | null;
+  dmThreadId?: number;
+  configuredBinding?: ConfiguredBindingRouteResult["bindingResolution"];
+  configuredBindingSessionKey?: string | null;
+}): {
+  baseSessionKey: string;
+  sessionKey: string;
+  route: ReturnType<typeof resolveAgentRoute>;
+} {
+  let baseSessionKey = resolveTelegramConversationBaseSessionKey({
+    cfg: params.cfg,
+    route: params.route,
+    chatId: params.chatId,
+    isGroup: params.isGroup,
+    senderId: params.senderId,
+  });
+  const isNamedAccountFallback =
+    params.route.accountId !== DEFAULT_ACCOUNT_ID && params.route.matchedBy === "default";
+  const isExplicitRouteBinding =
+    params.route.matchedBy !== "default" ||
+    params.configuredBinding != null ||
+    Boolean(params.configuredBindingSessionKey?.trim());
+  if (
+    !params.isGroup &&
+    !isNamedAccountFallback &&
+    !isExplicitRouteBinding &&
+    params.cfg.session?.dmScope == null &&
+    baseSessionKey === params.route.mainSessionKey
+  ) {
+    baseSessionKey = buildAgentSessionKey({
+      agentId: params.route.agentId,
+      channel: "telegram",
+      accountId: params.route.accountId,
+      peer: {
+        kind: "direct",
+        id: resolveTelegramDirectPeerId({
+          chatId: params.chatId,
+          senderId: params.senderId,
+        }),
+      },
+      dmScope: "per-channel-peer",
+      identityLinks: params.cfg.session?.identityLinks,
+    }).toLowerCase();
+    logVerbose(
+      `telegram: DM isolation override ${params.route.mainSessionKey} -> ${baseSessionKey} (default route, dmScope unset)`,
+    );
+  }
+  const sessionKey =
+    params.dmThreadId != null
+      ? resolveThreadSessionKeys({
+          baseSessionKey,
+          threadId: `${params.chatId}:${params.dmThreadId}`,
+        }).sessionKey
+      : baseSessionKey;
+  return {
+    baseSessionKey,
+    sessionKey,
+    route: {
+      ...params.route,
+      sessionKey,
+      lastRoutePolicy: deriveLastRoutePolicy({
+        sessionKey,
+        mainSessionKey: params.route.mainSessionKey,
+      }),
+    },
+  };
 }

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -164,7 +164,11 @@ export function maybeRetireLegacyMainDeliveryRoute(params: {
   ctx: MsgContext;
 }): LegacyMainDeliveryRetirement | undefined {
   const dmScope = params.sessionCfg?.dmScope ?? "main";
-  if (dmScope === "main" || params.isGroup) {
+  const usesImplicitTelegramDmIsolation =
+    params.sessionCfg?.dmScope == null &&
+    resolveSessionKeyChannelHint(params.sessionKey) === "telegram" &&
+    isDirectSessionKey(params.sessionKey);
+  if ((dmScope === "main" && !usesImplicitTelegramDmIsolation) || params.isGroup) {
     return undefined;
   }
   const canonicalMainSessionKey = buildAgentMainSessionKey({


### PR DESCRIPTION
## Problem

When `dmScope` is `"main"` (the default), Telegram DMs are routed to `agent:main:main` — the same session used by heartbeats and internal traffic. This causes:

- **Session pollution**: DM messages appear in the heartbeat session history
- **Token waste**: heartbeat turns process irrelevant DM context
- **Context leakage**: DM content may bleed into system-initiated turns

PR #40519 mitigated duplicate *replies* via inbound dedupe scoping, but the underlying routing issue persists: DMs still land in `agent:main:main`.

## Solution

In `buildTelegramMessageContext`, when a Telegram DM would route to `agent:main:main` (i.e. `baseSessionKey === route.mainSessionKey` and `!isGroup`), force `per-channel-peer` isolation. This produces session keys like `agent:main:telegram:direct:<peer-id>` instead.

### What changes:

- **DMs with default `dmScope: "main"`**: now route to `agent:main:telegram:direct:<id>` instead of `agent:main:main`
- **DMs with explicit `per-peer` / `per-channel-peer` / `per-account-channel-peer`**: unchanged (already isolated)
- **Group messages**: unchanged
- **Named-account DM fallback**: unchanged (already uses `per-account-channel-peer`)

### Why at the context layer (not the routing layer):

Changing `buildAgentPeerSessionKey` globally would affect all channels. Telegram is the primary channel where DM-to-main pollution is reported (#41165), and the fix is scoped to the Telegram message context builder.

## Tests

- New: `bot-message-context.dm-isolation.test.ts` — 4 tests covering default dmScope, per-peer, per-channel-peer, and group routing
- Updated: `bot-message-context.dm-threads.test.ts` and `bot-message-context.named-account-dm.test.ts` to reflect the corrected session keys
- All 53 existing bot-message-context tests pass

## Breaking change note

Users who rely on `dmScope: "main"` for Telegram to intentionally share the main session with DMs will see DMs move to isolated sessions. This is considered a bugfix since the documented purpose of `dmScope: "main"` is to collapse *cross-channel* DMs into one session, not to merge DMs with heartbeat/system traffic.

Fixes #41165
Supersedes the routing-level investigation from #40005