### PR TITLE
feat(acpx): add hardcoded kilocode agent support via --agent flag

### DIFF
--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -47,6 +47,8 @@ export const ACPX_BACKEND_ID = "acpx";
 const ACPX_RUNTIME_HANDLE_PREFIX = "acpx:v1:";
 const DEFAULT_AGENT_FALLBACK = "codex";
 const ACPX_EXIT_CODE_PERMISSION_DENIED = 5;
+const KILOCODE_AGENT_ID = "kilocode";
+const KILOCODE_AGENT_COMMAND = "npx --yes kilocode@latest";
 const ACPX_CAPABILITIES: AcpRuntimeCapabilities = {
   controls: ["session/set_mode", "session/set_config_option", "session/status"],
 };
@@ -665,6 +667,10 @@ export class AcpxRuntime implements AcpRuntime {
     agent: string;
     cwd: string;
   }): Promise<string | null> {
+    // Hardcoded support for kilocode: use npx to run kilocode as the agent process.
+    if (params.agent === KILOCODE_AGENT_ID) {
+      return KILOCODE_AGENT_COMMAND;
+    }
     if (Object.keys(this.config.mcpServers).length === 0) {
       return null;
     }


### PR DESCRIPTION
## Summary

Option A for #40274 — hardcoded kilocode support in the ACPX plugin.

When `agentId` is `"kilocode"`, `resolveRawAgentCommand` returns the kilocode npm invocation so `buildVerbArgs` injects `--agent npx --yes kilocode@latest` into the `acpx` command args. The agent ID is still used for session naming as before.

- Adds `KILOCODE_AGENT_ID` and `KILOCODE_AGENT_COMMAND` constants in `runtime.ts`
- `resolveRawAgentCommand` returns the kilocode command when agent is `kilocode`, causing `buildVerbArgs` to inject `--agent <command>` for all control and prompt operations
- No config changes needed — just set `acp.defaultAgent: kilocode` or pass `agentId: kilocode` at spawn time

**Option B** (expose a generic `agentCommand` config option with no hardcoding) is in a separate PR.

Note: depends on https://github.com/openclaw/acpx/pull/62 being merged for kilocode support in acpx itself.

## Test plan

- [ ] All existing acpx tests pass (`pnpm test extensions/acpx`)
- [ ] `pnpm check` passes
- [ ] Set `acp.defaultAgent: kilocode` and spawn an ACP session to verify kilocode is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)