### PR TITLE
feat(acpx): expose agentCommand config option to support custom ACP agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: add an expand-to-canvas button on assistant chat bubbles and in-app session navigation from Sessions and Cron views. Thanks @BunsDev.
 - Plugins/context engines: expose `delegateCompactionToRuntime(...)` on the public plugin SDK, refactor the legacy engine to use the shared helper, and clarify `ownsCompaction` delegation semantics for non-owning engines. (#49061) Thanks @jalehman.
 - Plugins/MiniMax: add MiniMax-M2.7 and MiniMax-M2.7-highspeed models and update the default model from M2.5 to M2.7. (#49691) Thanks @liyuan97.
+- ACP/acpx: support custom ACP-compatible agents via `plugins.acpx.agentCommand` config option, allowing any agent process to be used without code changes. (#41945) Thanks @kimptoc.
 
 ### Fixes
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -565,6 +565,40 @@ Notes:
 
 See [Plugins](/tools/plugin).
 
+## Custom agent command
+
+By default, the agent ID (e.g. `claude`, `codex`) is passed to `acpx` as a positional subcommand, and `acpx` resolves it to a built-in agent binary. To use a custom ACP-compatible agent that `acpx` does not ship with, set `agentCommand`:
+
+```bash
+openclaw config set plugins.entries.acpx.config.agentCommand "npx --yes kilocode@latest"
+openclaw config set acp.defaultAgent kilocode
+```
+
+Or in JSON config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "acpx": {
+        "enabled": true,
+        "config": {
+          "agentCommand": "npx --yes kilocode@latest"
+        }
+      }
+    }
+  }
+}
+```
+
+When `agentCommand` is set, it is passed to `acpx` via `--agent <agentCommand>` for all session lifecycle operations (ensure, prompt, status, cancel, close, etc.). The `agentId` is still used for session naming and routing — only the spawned process changes.
+
+**Notes:**
+
+- If `mcpServers` are also configured, the custom agent command is automatically wrapped with the MCP proxy so configured MCP tools remain available.
+- Omitting `agentCommand` preserves the default behavior — `acpx` resolves the agent ID to its built-in command.
+- On Windows, paths with spaces work as-is since the value is passed as a single `--agent` argument (e.g. `"C:\\Program Files\\my-agent\\agent.exe --flag"`).
+
 ## Permission configuration
 
 ACP sessions run non-interactively — there is no TTY to approve or deny file-write and shell-exec permission prompts. The acpx plugin provides two config keys that control how permissions are handled:

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -24,6 +24,9 @@
         "type": "string",
         "enum": ["deny", "fail"]
       },
+      "agentCommand": {
+        "type": "string"
+      },
       "strictWindowsCmdWrapper": {
         "type": "boolean"
       },
@@ -80,6 +83,10 @@
     "nonInteractivePermissions": {
       "label": "Non-Interactive Permission Policy",
       "help": "acpx policy when interactive permission prompts are unavailable."
+    },
+    "agentCommand": {
+      "label": "Agent Command",
+      "help": "Custom ACP-compatible agent command to use instead of the default acpx agent (for example 'npx --yes kilocode@latest'). Leave unset to use the built-in acpx agent."
     },
     "strictWindowsCmdWrapper": {
       "label": "Strict Windows cmd Wrapper",

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -9,6 +9,7 @@ import {
   createAcpxPluginConfigSchema,
   resolveAcpxPluginRoot,
   resolveAcpxPluginConfig,
+  toAcpMcpServers,
 } from "./config.js";
 
 describe("acpx plugin config parsing", () => {
@@ -72,6 +73,19 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.stripProviderAuthEnvVars).toBe(true);
     expect(resolved.cwd).toBe(path.resolve("/tmp/workspace"));
     expect(resolved.strictWindowsCmdWrapper).toBe(true);
+  });
+
+  it("does not strip provider auth env vars when agentCommand is set", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agentCommand: "npx --yes kilocode@latest",
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.command).toBe(ACPX_BUNDLED_BIN);
+    expect(resolved.stripProviderAuthEnvVars).toBe(false);
+    expect(resolved.agentCommand).toBe("npx --yes kilocode@latest");
   });
 
   it("accepts command override and disables plugin-local auto-install", () => {

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -187,4 +187,161 @@ describe("acpx plugin config parsing", () => {
       }),
     ).toThrow("strictWindowsCmdWrapper must be a boolean");
   });
+
+  it("accepts mcp server maps", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        mcpServers: {
+          canva: {
+            command: "npx",
+            args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+            env: {
+              CANVA_TOKEN: "secret",
+            },
+          },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.mcpServers).toEqual({
+      canva: {
+        command: "npx",
+        args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+        env: {
+          CANVA_TOKEN: "secret",
+        },
+      },
+    });
+  });
+
+  it("rejects invalid mcp server definitions", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          mcpServers: {
+            canva: {
+              command: "npx",
+              args: ["-y", 1],
+            },
+          },
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow(
+      "mcpServers.canva must have a command string, optional args array, and optional env object",
+    );
+  });
+
+  it("accepts agentCommand override", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agentCommand: "npx --yes kilocode@latest",
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.agentCommand).toBe("npx --yes kilocode@latest");
+  });
+
+  it("trims agentCommand whitespace", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agentCommand: "  npx --yes kilocode@latest  ",
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.agentCommand).toBe("npx --yes kilocode@latest");
+  });
+
+  it("resolves agentCommand as undefined when not set", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.agentCommand).toBeUndefined();
+  });
+
+  it("rejects empty agentCommand", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          agentCommand: "",
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("agentCommand must be a non-empty string");
+  });
+
+  it("rejects whitespace-only agentCommand", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          agentCommand: "   ",
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("agentCommand must be a non-empty string");
+  });
+
+  it("rejects non-string agentCommand", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          agentCommand: 42,
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("agentCommand must be a non-empty string");
+  });
+
+  it("schema accepts mcp server config", () => {
+    const schema = createAcpxPluginConfigSchema();
+    if (!schema.safeParse) {
+      throw new Error("acpx config schema missing safeParse");
+    }
+    const parsed = schema.safeParse({
+      mcpServers: {
+        canva: {
+          command: "npx",
+          args: ["-y", "mcp-remote@latest"],
+          env: {
+            CANVA_TOKEN: "secret",
+          },
+        },
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe("toAcpMcpServers", () => {
+  it("converts plugin config maps into ACP stdio MCP entries", () => {
+    expect(
+      toAcpMcpServers({
+        canva: {
+          command: "npx",
+          args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+          env: {
+            CANVA_TOKEN: "secret",
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        name: "canva",
+        command: "npx",
+        args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+        env: [
+          {
+            name: "CANVA_TOKEN",
+            value: "secret",
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -390,7 +390,10 @@ export function resolveAcpxPluginConfig(params: {
     workspaceDir: params.workspaceDir,
   });
   const allowPluginLocalInstall = command === ACPX_BUNDLED_BIN;
-  const stripProviderAuthEnvVars = command === ACPX_BUNDLED_BIN;
+  // Strip provider auth env vars only when using the bundled acpx binary AND no
+  // custom agentCommand is set. A custom agentCommand is a third-party process
+  // that may rely on env vars like OPENAI_API_KEY for its own auth.
+  const stripProviderAuthEnvVars = command === ACPX_BUNDLED_BIN && !normalized.agentCommand;
   const configuredExpectedVersion = normalized.expectedVersion;
   const expectedVersion =
     configuredExpectedVersion === ACPX_VERSION_ANY

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -405,7 +405,7 @@ export function resolveAcpxPluginConfig(params: {
     stripProviderAuthEnvVars,
     installCommand,
     cwd,
-    agentCommand: normalized.agentCommand?.trim() || undefined,
+    agentCommand: normalized.agentCommand || undefined,
     permissionMode: normalized.permissionMode ?? DEFAULT_PERMISSION_MODE,
     nonInteractivePermissions:
       normalized.nonInteractivePermissions ?? DEFAULT_NON_INTERACTIVE_POLICY,

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -79,6 +79,7 @@ export type AcpxPluginConfig = {
   command?: string;
   expectedVersion?: string;
   cwd?: string;
+  agentCommand?: string;
   permissionMode?: AcpxPermissionMode;
   nonInteractivePermissions?: AcpxNonInteractivePermissionPolicy;
   strictWindowsCmdWrapper?: boolean;
@@ -94,6 +95,7 @@ export type ResolvedAcpxPluginConfig = {
   stripProviderAuthEnvVars: boolean;
   installCommand: string;
   cwd: string;
+  agentCommand?: string;
   permissionMode: AcpxPermissionMode;
   nonInteractivePermissions: AcpxNonInteractivePermissionPolicy;
   strictWindowsCmdWrapper: boolean;
@@ -166,6 +168,7 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
     "command",
     "expectedVersion",
     "cwd",
+    "agentCommand",
     "permissionMode",
     "nonInteractivePermissions",
     "strictWindowsCmdWrapper",
@@ -195,6 +198,14 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
   const cwd = value.cwd;
   if (cwd !== undefined && (typeof cwd !== "string" || cwd.trim() === "")) {
     return { ok: false, message: "cwd must be a non-empty string" };
+  }
+
+  const agentCommand = value.agentCommand;
+  if (
+    agentCommand !== undefined &&
+    (typeof agentCommand !== "string" || agentCommand.trim() === "")
+  ) {
+    return { ok: false, message: "agentCommand must be a non-empty string" };
   }
 
   const permissionMode = value.permissionMode;
@@ -264,6 +275,7 @@ function parseAcpxPluginConfig(value: unknown): ParseResult {
       command: typeof command === "string" ? command.trim() : undefined,
       expectedVersion: typeof expectedVersion === "string" ? expectedVersion.trim() : undefined,
       cwd: typeof cwd === "string" ? cwd.trim() : undefined,
+      agentCommand: typeof agentCommand === "string" ? agentCommand.trim() : undefined,
       permissionMode: typeof permissionMode === "string" ? permissionMode : undefined,
       nonInteractivePermissions:
         typeof nonInteractivePermissions === "string" ? nonInteractivePermissions : undefined,
@@ -315,6 +327,7 @@ export function createAcpxPluginConfigSchema(): OpenClawPluginConfigSchema {
         command: { type: "string" },
         expectedVersion: { type: "string" },
         cwd: { type: "string" },
+        agentCommand: { type: "string" },
         permissionMode: {
           type: "string",
           enum: [...ACPX_PERMISSION_MODES],
@@ -392,6 +405,7 @@ export function resolveAcpxPluginConfig(params: {
     stripProviderAuthEnvVars,
     installCommand,
     cwd,
+    agentCommand: normalized.agentCommand?.trim() || undefined,
     permissionMode: normalized.permissionMode ?? DEFAULT_PERMISSION_MODE,
     nonInteractivePermissions:
       normalized.nonInteractivePermissions ?? DEFAULT_NON_INTERACTIVE_POLICY,

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
@@ -106,13 +106,64 @@ export async function resolveAcpxAgentCommand(params: {
   return overrides[normalizedAgent] ?? ACPX_BUILTIN_AGENT_COMMANDS[normalizedAgent] ?? params.agent;
 }
 
+/** Split a shell-style command string into command + args (POSIX quoting rules). */
+function splitCommandLineParts(value: string): { command: string; args: string[] } {
+  const parts: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  let escaping = false;
+
+  for (const ch of value) {
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\" && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current.length > 0) {
+    parts.push(current);
+  }
+  if (parts.length === 0) {
+    throw new Error("Invalid agent command: empty command");
+  }
+  return { command: parts[0], args: parts.slice(1) };
+}
+
 export function buildMcpProxyAgentCommand(params: {
   targetCommand: string;
   mcpServers: AcpMcpServer[];
 }): string {
+  // Pre-split so mcp-proxy.mjs can spawn without re-parsing the command string.
+  // This avoids platform-specific quoting issues (e.g. Windows paths) in the proxy.
+  const targetCommandParts = splitCommandLineParts(params.targetCommand);
   const payload = Buffer.from(
     JSON.stringify({
       targetCommand: params.targetCommand,
+      targetCommandParts,
       mcpServers: params.mcpServers,
     }),
     "utf8",

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
@@ -15,9 +15,7 @@ function splitCommandLine(value) {
       escaping = false;
       continue;
     }
-    if (ch === "\\" && quote === null) {
-      // Only treat backslash as an escape when completely unquoted.
-      // Inside double-quoted strings backslashes are literal (Windows paths).
+    if (ch === "\\" && quote !== "'") {
       escaping = true;
       continue;
     }
@@ -74,14 +72,19 @@ function decodePayload(argv) {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("Invalid MCP proxy payload");
   }
+  const mcpServers = Array.isArray(parsed.mcpServers) ? parsed.mcpServers : [];
+  // Prefer pre-split parts to avoid re-parsing platform-specific command strings.
+  if (
+    parsed.targetCommandParts &&
+    typeof parsed.targetCommandParts.command === "string" &&
+    Array.isArray(parsed.targetCommandParts.args)
+  ) {
+    return { targetCommandParts: parsed.targetCommandParts, mcpServers };
+  }
   if (typeof parsed.targetCommand !== "string" || parsed.targetCommand.trim() === "") {
     throw new Error("MCP proxy payload missing targetCommand");
   }
-  const mcpServers = Array.isArray(parsed.mcpServers) ? parsed.mcpServers : [];
-  return {
-    targetCommand: parsed.targetCommand,
-    mcpServers,
-  };
+  return { targetCommand: parsed.targetCommand, mcpServers };
 }
 
 function shouldInject(method) {
@@ -118,8 +121,9 @@ function rewriteLine(line, mcpServers) {
   }
 }
 
-const { targetCommand, mcpServers } = decodePayload(process.argv.slice(2));
-const target = splitCommandLine(targetCommand);
+const { targetCommand, targetCommandParts, mcpServers } = decodePayload(process.argv.slice(2));
+// Use pre-split parts when available (avoids re-parsing platform-specific paths).
+const target = targetCommandParts ?? splitCommandLine(targetCommand);
 const child = spawn(target.command, target.args, {
   stdio: ["pipe", "pipe", "inherit"],
   env: process.env,

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
@@ -15,7 +15,9 @@ function splitCommandLine(value) {
       escaping = false;
       continue;
     }
-    if (ch === "\\" && quote !== "'") {
+    if (ch === "\\" && quote === null) {
+      // Only treat backslash as an escape when completely unquoted.
+      // Inside double-quoted strings backslashes are literal (Windows paths).
       escaping = true;
       continue;
     }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -595,6 +595,8 @@ describe("AcpxRuntime", () => {
     for await (const event of runtime.runTurn({
       handle,
       text: "hello",
+      mode: "prompt",
+      requestId: "req-agent-cmd-prompt",
     })) {
       events.push(event);
     }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -553,6 +553,111 @@ describe("AcpxRuntime", () => {
     }
   });
 
+  it("injects --agent flag for all operations when agentCommand is configured", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture({
+      agentCommand: "npx --yes kilocode@latest",
+    });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:kilocode:acp:custom",
+      agent: "kilocode",
+      mode: "persistent",
+    });
+    await runtime.setMode({ handle, mode: "plan" });
+    await runtime.getStatus({ handle });
+    await runtime.setConfigOption({ handle, key: "model", value: "gpt-4" });
+    await runtime.cancel({ handle, reason: "test" });
+    await runtime.close({ handle, reason: "done" });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const kinds = ["ensure", "set-mode", "status", "set", "cancel", "close"];
+    for (const kind of kinds) {
+      const entry = logs.find((e) => e.kind === kind);
+      expect(entry, `expected log entry for ${kind}`).toBeDefined();
+      const args = (entry?.args as string[]) ?? [];
+      const agentFlagIndex = args.indexOf("--agent");
+      expect(agentFlagIndex, `--agent flag missing for ${kind}`).toBeGreaterThanOrEqual(0);
+      expect(args[agentFlagIndex + 1]).toBe("npx --yes kilocode@latest");
+    }
+  });
+
+  it("injects --agent flag in prompt args when agentCommand is configured", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture({
+      agentCommand: "npx --yes kilocode@latest",
+    });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:kilocode:acp:prompt",
+      agent: "kilocode",
+      mode: "persistent",
+    });
+    const events: unknown[] = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "hello",
+    })) {
+      events.push(event);
+    }
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const prompt = logs.find((e) => e.kind === "prompt");
+    expect(prompt).toBeDefined();
+    const promptArgs = (prompt?.args as string[]) ?? [];
+    const agentFlagIndex = promptArgs.indexOf("--agent");
+    expect(agentFlagIndex).toBeGreaterThanOrEqual(0);
+    expect(promptArgs[agentFlagIndex + 1]).toBe("npx --yes kilocode@latest");
+  });
+
+  it("does not inject --agent flag when agentCommand is not configured", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture();
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:no-agent-cmd",
+      agent: "codex",
+      mode: "persistent",
+    });
+    await runtime.setMode({ handle, mode: "plan" });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    for (const kind of ["ensure", "set-mode"]) {
+      const entry = logs.find((e) => e.kind === kind);
+      expect(entry).toBeDefined();
+      const args = (entry?.args as string[]) ?? [];
+      expect(args.indexOf("--agent")).toBe(-1);
+    }
+  });
+
+  it("wraps agentCommand with MCP proxy when both agentCommand and mcpServers are configured", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture({
+      agentCommand: "npx --yes kilocode@latest",
+      mcpServers: {
+        canva: {
+          command: "npx",
+          args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+        },
+      },
+    });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:kilocode:acp:mcp-proxy",
+      agent: "kilocode",
+      mode: "persistent",
+    });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const ensureArgs = (logs.find((e) => e.kind === "ensure")?.args as string[]) ?? [];
+    const agentFlagIndex = ensureArgs.indexOf("--agent");
+    expect(agentFlagIndex).toBeGreaterThanOrEqual(0);
+    const rawAgentCommand = ensureArgs[agentFlagIndex + 1];
+    expect(rawAgentCommand).toContain("mcp-proxy.mjs");
+    const payloadMatch = rawAgentCommand.match(/--payload\s+([A-Za-z0-9_-]+)/);
+    expect(payloadMatch?.[1]).toBeDefined();
+    const payload = JSON.parse(
+      Buffer.from(String(payloadMatch?.[1]), "base64url").toString("utf8"),
+    ) as { targetCommand: string };
+    expect(payload.targetCommand).toBe("npx --yes kilocode@latest");
+  });
+
   it("skips prompt execution when runTurn starts with an already-aborted signal", async () => {
     const { runtime, logPath } = await createMockRuntimeFixture();
     const handle = await runtime.ensureSession({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -921,11 +921,26 @@ export class AcpxRuntime implements AcpRuntime {
     agent: string;
     cwd: string;
   }): Promise<string | null> {
+    const hasMcpServers = Object.keys(this.config.mcpServers).length > 0;
     // Config-driven agent command overrides the default acpx subcommand.
+    // When MCP servers are also configured, wrap it with the MCP proxy.
     if (this.config.agentCommand) {
-      return this.config.agentCommand;
+      if (!hasMcpServers) {
+        return this.config.agentCommand;
+      }
+      const cacheKey = `${params.cwd}::agentCommand`;
+      const cached = this.mcpProxyAgentCommandCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+      const resolved = buildMcpProxyAgentCommand({
+        targetCommand: this.config.agentCommand,
+        mcpServers: toAcpMcpServers(this.config.mcpServers),
+      });
+      this.mcpProxyAgentCommandCache.set(cacheKey, resolved);
+      return resolved;
     }
-    if (Object.keys(this.config.mcpServers).length === 0) {
+    if (!hasMcpServers) {
       return null;
     }
     const cacheKey = `${params.cwd}::${params.agent}`;

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -921,6 +921,10 @@ export class AcpxRuntime implements AcpRuntime {
     agent: string;
     cwd: string;
   }): Promise<string | null> {
+    // Config-driven agent command overrides the default acpx subcommand.
+    if (this.config.agentCommand) {
+      return this.config.agentCommand;
+    }
     if (Object.keys(this.config.mcpServers).length === 0) {
       return null;
     }

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -328,6 +328,7 @@ process.exit(2);
 export async function createMockRuntimeFixture(params?: {
   permissionMode?: ResolvedAcpxPluginConfig["permissionMode"];
   queueOwnerTtlSeconds?: number;
+  agentCommand?: string;
   mcpServers?: ResolvedAcpxPluginConfig["mcpServers"];
 }): Promise<{
   runtime: AcpxRuntime;
@@ -345,6 +346,7 @@ export async function createMockRuntimeFixture(params?: {
     stripProviderAuthEnvVars: false,
     installCommand: "n/a",
     cwd: dir,
+    agentCommand: params?.agentCommand,
     permissionMode: params?.permissionMode ?? "approve-all",
     nonInteractivePermissions: "fail",
     strictWindowsCmdWrapper: true,


### PR DESCRIPTION
## Summary

Option B for #40274 — a generic, config-driven approach with no hardcoding.

Adds `agentCommand` to the ACPX plugin config. When set, it is passed to `acpx` via `--agent <agentCommand>`, decoupling the agent process from `acpx`'s built-in subcommands. The `agentId` (used for session naming) remains independent.

- `extensions/acpx/src/config.ts`: adds `agentCommand?: string` to types, parser, resolver, and JSON schema
- `extensions/acpx/src/runtime.ts`: `resolveRawAgentCommand` returns `agentCommand` when configured, causing `buildVerbArgs` to inject `--agent <agentCommand>` for all operations

### Example — using Kilo Code

```yaml
plugins:
  acpx:
    agentCommand: "npx --yes kilocode@latest"
acp:
  defaultAgent: kilocode
```

Any ACP-compatible agent can be used this way without changes to openclaw.

**Option A** (hardcoded kilocode shortcut) is in a separate PR.

## Test plan

- [ ] All existing acpx tests pass (`pnpm test extensions/acpx`)
- [ ] `pnpm check` passes
- [ ] Set `plugins.acpx.agentCommand` and spawn an ACP session to verify the custom agent is invoked
- [ ] Omitting `agentCommand` leaves behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)