### PR TITLE
fix(feishu): preserve Chinese filenames in file uploads

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -226,14 +226,12 @@ export async function uploadImageFeishu(params: {
  * Feishu's server decodes and preserves the original display name.
  */
 export function sanitizeFileNameForUpload(fileName: string): string {
+  // Do NOT encode non-ASCII characters - causes encoded filename to display
   const ASCII_ONLY = /^[\x20-\x7E]+$/;
   if (ASCII_ONLY.test(fileName)) {
     return fileName;
   }
-  return encodeURIComponent(fileName)
-    .replace(/'/g, "%27")
-    .replace(/\(/g, "%28")
-    .replace(/\)/g, "%29");
+  return fileName;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Problem: When uploading attachments with Chinese filenames via Feishu extension, the filename gets URL-encoded (e.g., `%E6%80%9D...`), causing users to see encoded filename instead of original Chinese characters.
- Why it matters: Users cannot identify files by their original Chinese names, causing confusion.
- What changed: Removed URL encoding in `sanitizeFileNameForUpload` function - now returns original filename directly.
- What did NOT change: The SDK upload logic remains the same; only the filename sanitization was simplified.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (Feishu)

## Linked Issue/PR

- Related: User reported Chinese filenames showing as URL-encoded in Feishu messages

## User-visible / Behavior Changes

- Chinese filenames (e.g., `思想汇报.docx`) now display correctly in Feishu messages instead of `%E6%80%9D...`

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: OpenClaw Gateway
- Integration/channel: Feishu

### Steps

1. Create a file with Chinese filename (e.g., `思想汇报.docx`)
2. Send file via Feishu message using message tool
3. Check the received message attachment name

### Expected

- File displays as `思想汇报.docx`

### Actual (before fix)

- File displays as `%E6%80%9D%E6%83%B3%E6%B1%87%E6%8A%A5.docx`

## Evidence

- [x] Tested locally - Chinese filenames now display correctly

## Human Verification

- Verified scenarios: Sent test files with Chinese names via Feishu, confirmed they display correctly
- Edge cases checked: Pure ASCII filenames still work correctly
- What did NOT verify: Performance impact (negligible - one string operation removed)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: Revert the change in `extensions/feishu/src/media.ts` to add back the encodeURIComponent call
- Files/config to restore: `extensions/feishu/src/media.ts`

## Risks and Mitigations

- None - the encoding was unnecessary as Feishu SDK handles UTF-8 correctly