### PR TITLE
fix(telegram): split watchdog stability fixes from #41883

### DIFF
--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -116,6 +116,18 @@ describe("createTelegramBot", () => {
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(sequentializeKey).toBe(getTelegramSequentialKey);
   });
+  it("registers pre-handler middleware before Telegram handlers", () => {
+    const preHandlerHook = vi.fn();
+    createTelegramBot({
+      token: "tok",
+      onBeforeHandlersRegister: preHandlerHook,
+    });
+
+    expect(preHandlerHook).toHaveBeenCalledWith(expect.any(Object));
+    const hookOrder = preHandlerHook.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER;
+    const firstHandlerOrder = onSpy.mock.invocationCallOrder[0] ?? 0;
+    expect(hookOrder).toBeLessThan(firstHandlerOrder);
+  });
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,6 +1,6 @@
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
-import type { ApiClientOptions, Context } from "grammy";
+import type { ApiClientOptions } from "grammy";
 import { Bot } from "grammy";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,6 +1,6 @@
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
-import type { ApiClientOptions } from "grammy";
+import type { ApiClientOptions, Context } from "grammy";
 import { Bot } from "grammy";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
@@ -64,6 +64,11 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /**
+   * Optional hook for middleware that must run before bot handlers are registered.
+   * Useful for cross-cutting update lifecycle tracking used by polling watchdogs.
+   */
+  onBeforeHandlersRegister?: (bot: Bot) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -413,6 +418,10 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     textLimit,
     opts,
   });
+
+  // Allow callers to attach middleware that must execute before the first
+  // handler layer. This avoids relying on post-handler middleware ordering.
+  opts.onBeforeHandlersRegister?.(bot);
 
   registerTelegramNativeCommands({
     bot,

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -66,6 +66,9 @@ const { createTelegramBotErrors } = vi.hoisted(() => ({
 const { createTelegramBotCalls } = vi.hoisted(() => ({
   createTelegramBotCalls: [] as Array<Record<string, unknown>>,
 }));
+const { createTelegramBotUseSpies } = vi.hoisted(() => ({
+  createTelegramBotUseSpies: [] as Array<ReturnType<typeof vi.fn>>,
+}));
 
 const { createdBotStops } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
@@ -166,15 +169,22 @@ vi.mock("./bot.js", () => ({
       }
       await api.sendMessage(chatId, `echo:${text}`, { parse_mode: "HTML" });
     };
-    return {
+    const use = vi.fn();
+    const bot = {
       on: vi.fn(),
-      use: vi.fn(),
+      use,
       api,
       me: { username: "mybot" },
       init: initSpy,
       stop,
       start: vi.fn(),
     };
+    const onBeforeHandlersRegister = opts.onBeforeHandlersRegister;
+    if (typeof onBeforeHandlersRegister === "function") {
+      onBeforeHandlersRegister(bot);
+    }
+    createTelegramBotUseSpies.push(use);
+    return bot;
   },
 }));
 
@@ -224,6 +234,7 @@ describe("monitorTelegramProvider (grammY)", () => {
       }),
     );
     createTelegramBotCalls.length = 0;
+    createTelegramBotUseSpies.length = 0;
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
     startTelegramWebhookSpy.mockClear();
@@ -567,6 +578,56 @@ describe("monitorTelegramProvider (grammY)", () => {
 
     // Advance time past the stall threshold (90s) + watchdog interval (30s)
     vi.advanceTimersByTime(120_000);
+    await monitor;
+
+    expect(stop.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(computeBackoff).toHaveBeenCalled();
+    expect(runSpy).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("force-restarts polling when a handler stays active beyond watchdog bypass max", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    let running = true;
+    let releaseTask: (() => void) | undefined;
+    const stop = vi.fn(async () => {
+      running = false;
+      releaseTask?.();
+    });
+
+    runSpy
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () =>
+            new Promise<void>((resolve) => {
+              releaseTask = resolve;
+            }),
+          stop,
+          isRunning: () => running,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: async () => {
+            abort.abort();
+          },
+        }),
+      );
+
+    const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+    await vi.waitFor(() => expect(runSpy).toHaveBeenCalledTimes(1));
+
+    const firstUse = createTelegramBotUseSpies[0];
+    const lifecycleMiddleware = firstUse?.mock.calls[0]?.[0] as
+      | ((ctx: unknown, next: () => Promise<void>) => Promise<void>)
+      | undefined;
+    expect(lifecycleMiddleware).toBeTypeOf("function");
+    void lifecycleMiddleware?.({}, async () => await new Promise<void>(() => undefined));
+    await Promise.resolve();
+
+    // Past stall threshold and watchdog interval, plus active-handler bypass max.
+    vi.advanceTimersByTime(750_000);
     await monitor;
 
     expect(stop.mock.calls.length).toBeGreaterThanOrEqual(1);

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -168,6 +168,7 @@ vi.mock("./bot.js", () => ({
     };
     return {
       on: vi.fn(),
+      use: vi.fn(),
       api,
       me: { username: "mybot" },
       init: initSpy,

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -164,11 +164,22 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
+    // Track active update handlers so the watchdog does not treat
+    // "busy processing updates" as a stalled poller.
+    let activeUpdateHandlers = 0;
     bot.api.config.use((prev, method, payload, signal) => {
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
       }
       return prev(method, payload, signal);
+    });
+    bot.use(async (_ctx, next) => {
+      activeUpdateHandlers += 1;
+      try {
+        await next();
+      } finally {
+        activeUpdateHandlers = Math.max(0, activeUpdateHandlers - 1);
+      }
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -200,6 +211,9 @@ export class TelegramPollingSession {
 
     const watchdog = setInterval(() => {
       if (this.opts.abortSignal?.aborted) {
+        return;
+      }
+      if (activeUpdateHandlers > 0) {
         return;
       }
       const elapsed = Date.now() - lastGetUpdatesAt;

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -15,6 +15,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
+const ACTIVE_HANDLER_WATCHDOG_BYPASS_MAX_MS = 10 * 60_000;
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
@@ -36,6 +37,7 @@ export class TelegramPollingSession {
   #webhookCleared = false;
   #forceRestarted = false;
   #activeUpdateHandlers = 0;
+  #activeUpdateHandlersSinceMs: number | null = null;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
 
@@ -107,6 +109,7 @@ export class TelegramPollingSession {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
     this.#activeUpdateHandlers = 0;
+    this.#activeUpdateHandlersSinceMs = null;
     try {
       return createTelegramBot({
         token: this.opts.token,
@@ -122,10 +125,17 @@ export class TelegramPollingSession {
         onBeforeHandlersRegister: (bot) => {
           bot.use(async (_ctx, next) => {
             this.#activeUpdateHandlers += 1;
+            if (this.#activeUpdateHandlers === 1) {
+              // Track when active processing started so watchdog bypass is bounded.
+              this.#activeUpdateHandlersSinceMs = Date.now();
+            }
             try {
               await next();
             } finally {
               this.#activeUpdateHandlers = Math.max(0, this.#activeUpdateHandlers - 1);
+              if (this.#activeUpdateHandlers === 0) {
+                this.#activeUpdateHandlersSinceMs = null;
+              }
             }
           });
         },
@@ -214,10 +224,18 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
+      const now = Date.now();
+      const elapsed = now - lastGetUpdatesAt;
       if (this.#activeUpdateHandlers > 0) {
-        return;
+        const activeElapsed =
+          this.#activeUpdateHandlersSinceMs === null ? 0 : now - this.#activeUpdateHandlersSinceMs;
+        if (activeElapsed <= ACTIVE_HANDLER_WATCHDOG_BYPASS_MAX_MS) {
+          return;
+        }
+        this.opts.log(
+          `[telegram] Polling watchdog bypass expired (${this.#activeUpdateHandlers} active handler(s) for ${formatDurationPrecise(activeElapsed)}); forcing restart.`,
+        );
       }
-      const elapsed = Date.now() - lastGetUpdatesAt;
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
         stalledRestart = true;
         this.opts.log(

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -236,18 +236,19 @@ export class TelegramPollingSession {
         bypassExpired = true;
       }
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
-        if (bypassExpired) {
+        stalledRestart = true;
+        const bypassDetail = (() => {
+          if (!bypassExpired) {
+            return "";
+          }
           const activeElapsed =
             this.#activeUpdateHandlersSinceMs === null
               ? 0
               : now - this.#activeUpdateHandlersSinceMs;
-          this.opts.log(
-            `[telegram] Polling watchdog bypass expired (${this.#activeUpdateHandlers} active handler(s) for ${formatDurationPrecise(activeElapsed)}); forcing restart.`,
-          );
-        }
-        stalledRestart = true;
+          return `; watchdog bypass expired after ${formatDurationPrecise(activeElapsed)} with ${this.#activeUpdateHandlers} active handler(s)`;
+        })();
         this.opts.log(
-          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
+          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}${bypassDetail}); forcing restart.`,
         );
         void stopRunner();
       }

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -35,6 +35,7 @@ export class TelegramPollingSession {
   #restartAttempts = 0;
   #webhookCleared = false;
   #forceRestarted = false;
+  #activeUpdateHandlers = 0;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
 
@@ -105,6 +106,7 @@ export class TelegramPollingSession {
   async #createPollingBot(): Promise<TelegramBot | undefined> {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
+    this.#activeUpdateHandlers = 0;
     try {
       return createTelegramBot({
         token: this.opts.token,
@@ -116,6 +118,16 @@ export class TelegramPollingSession {
         updateOffset: {
           lastUpdateId: this.opts.getLastUpdateId(),
           onUpdateId: this.opts.persistUpdateId,
+        },
+        onBeforeHandlersRegister: (bot) => {
+          bot.use(async (_ctx, next) => {
+            this.#activeUpdateHandlers += 1;
+            try {
+              await next();
+            } finally {
+              this.#activeUpdateHandlers = Math.max(0, this.#activeUpdateHandlers - 1);
+            }
+          });
         },
       });
     } catch (err) {
@@ -164,22 +176,11 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    // Track active update handlers so the watchdog does not treat
-    // "busy processing updates" as a stalled poller.
-    let activeUpdateHandlers = 0;
     bot.api.config.use((prev, method, payload, signal) => {
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
       }
       return prev(method, payload, signal);
-    });
-    bot.use(async (_ctx, next) => {
-      activeUpdateHandlers += 1;
-      try {
-        await next();
-      } finally {
-        activeUpdateHandlers = Math.max(0, activeUpdateHandlers - 1);
-      }
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -213,7 +214,7 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
-      if (activeUpdateHandlers > 0) {
+      if (this.#activeUpdateHandlers > 0) {
         return;
       }
       const elapsed = Date.now() - lastGetUpdatesAt;

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -226,17 +226,25 @@ export class TelegramPollingSession {
       }
       const now = Date.now();
       const elapsed = now - lastGetUpdatesAt;
+      let bypassExpired = false;
       if (this.#activeUpdateHandlers > 0) {
         const activeElapsed =
           this.#activeUpdateHandlersSinceMs === null ? 0 : now - this.#activeUpdateHandlersSinceMs;
         if (activeElapsed <= ACTIVE_HANDLER_WATCHDOG_BYPASS_MAX_MS) {
           return;
         }
-        this.opts.log(
-          `[telegram] Polling watchdog bypass expired (${this.#activeUpdateHandlers} active handler(s) for ${formatDurationPrecise(activeElapsed)}); forcing restart.`,
-        );
+        bypassExpired = true;
       }
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
+        if (bypassExpired) {
+          const activeElapsed =
+            this.#activeUpdateHandlersSinceMs === null
+              ? 0
+              : now - this.#activeUpdateHandlersSinceMs;
+          this.opts.log(
+            `[telegram] Polling watchdog bypass expired (${this.#activeUpdateHandlers} active handler(s) for ${formatDurationPrecise(activeElapsed)}); forcing restart.`,
+          );
+        }
         stalledRestart = true;
         this.opts.log(
           `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram watchdog/polling stability fixes from #41883 were bundled with unrelated auto-reply changes.
- Why it matters: This isolates Telegram restart/watchdog fixes so they can be reviewed and shipped without cross-subsystem risk.
- What changed: Cherry-picked only Telegram commits for active-handler bypass handling, middleware registration order, watchdog logging guardrails, and related test updates.
- What did NOT change (scope boundary): No auto-reply typing/timeout logic changes are included.
- AI-assisted: Yes (Codex). Human-reviewed before submission.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #41883

## User-visible / Behavior Changes

- Telegram watchdog no longer treats active handlers as stalls; restart bypass is bounded and quieter.
- Middleware registration order is explicit before handler registration.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v25.6.1, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): test defaults

### Steps

1. `pnpm test -- --run src/telegram/monitor.test.ts src/telegram/bot.create-telegram-bot.test.ts -t "registers pre-handler middleware before Telegram handlers"`

### Expected

- Telegram watchdog coverage and the middleware-order assertion pass.

### Actual

- Passed: `1 passed | 1 skipped` test files, `1 passed | 68 skipped` tests.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: branch contains only Telegram commit set from #41883; focused Telegram test target passes.
- Edge cases checked: watchdog-specific monitor coverage and middleware ordering assertion.
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test` suite not run in this split pass.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the 5 commits in this branch.
- Files/config to restore: `src/telegram/bot.ts`, `src/telegram/polling-session.ts`, and touched Telegram tests.
- Known bad symptoms reviewers should watch for: Telegram restarts while handlers are active; watchdog log spam.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Telegram behavior has broad test surface outside focused watchdog assertions.
  - Mitigation: isolated commit scope + focused test coverage + separate PR to reduce blast radius.


## Additional Verification

- `pnpm check` passed on this split branch.
- `pnpm exec vitest run src/telegram/monitor.test.ts` passed (`22/22`).
- Applied log-noise follow-up in `d90ffc681` so bypass-expiry detail is emitted once per actual restart path.
