### PR TITLE
fix(auto-reply): split typing-timeout stability fix from #41883

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply: compute typing timeout budgets from the same effective fallback chain used by runtime runs, including configured-primary append cases, while keeping non-timeout network failures out of timeout-specific final copy. Carries forward #41957 with review context from #40760 and #41883. Thanks @artemgetmann.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -555,6 +555,16 @@ function resolveFallbackCandidates(params: {
   return candidates;
 }
 
+export function resolveModelFallbackCandidateCount(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  model: string;
+  /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
+  fallbacksOverride?: string[];
+}): number {
+  return resolveFallbackCandidates(params).length;
+}
+
 const lastProbeAttempt = new Map<string, number>();
 const MIN_PROBE_INTERVAL_MS = 30_000; // 30 seconds between probes per key
 const PROBE_MARGIN_MS = 2 * 60 * 1000;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1879,12 +1879,14 @@ export async function runAgentTurnWithFallback(params: {
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
+      const isExplicitTimeoutFailure = /\b(?:timed?\s*out|timeout)\b/i.test(safeMessage);
       const externalRunFailureReply =
         !isBilling &&
         !(isRateLimit && !isOverloadedErrorMessage(message)) &&
         !rateLimitOrOverloadedCopy &&
         !isContextOverflow &&
         !isRoleOrderingError &&
+        !isExplicitTimeoutFailure &&
         !shouldSurfaceToControlUi
           ? buildExternalRunFailureReply(message, {
               includeDetails: isVerboseFailureDetailEnabled(params.resolvedVerboseLevel),
@@ -1900,9 +1902,11 @@ export async function runAgentTurnWithFallback(params: {
               ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
               : isRoleOrderingError
                 ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-                : shouldSurfaceToControlUi
-                  ? `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`
-                  : (externalRunFailureReply?.text ?? GENERIC_EXTERNAL_RUN_FAILURE_TEXT);
+                : isExplicitTimeoutFailure
+                  ? "⚠️ Model run timed out before reply. This run has ended and will not continue in the background.\nSend a new message (or /retry) to start a fresh run.\nLogs: openclaw logs --follow"
+                  : shouldSurfaceToControlUi
+                    ? `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`
+                    : (externalRunFailureReply?.text ?? GENERIC_EXTERNAL_RUN_FAILURE_TEXT);
       const userVisibleFallbackText = resolveExternalRunFailureTextForConversation({
         text: fallbackText,
         sessionCtx: params.sessionCtx,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1081,6 +1081,38 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(payload.text).toContain("/new");
   });
 
+  it("surfaces explicit timeout guidance when the run times out", async () => {
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      throw new Error("Request timed out");
+    });
+
+    const { run } = createMinimalRun();
+    const res = await run();
+
+    expect(res).toMatchObject({
+      text: expect.stringContaining("timed out before reply"),
+    });
+    expect(res).toMatchObject({
+      text: expect.stringContaining("run has ended"),
+    });
+  });
+
+  it("does not label non-timeout network errors as slow model timeouts", async () => {
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      throw new Error("Network error: ECONNREFUSED");
+    });
+
+    const { run } = createMinimalRun();
+    const res = await run();
+
+    expect(res).toMatchObject({
+      text: expect.not.stringContaining("timed out before reply"),
+    });
+    expect(res).toMatchObject({
+      text: expect.stringContaining("Something went wrong"),
+    });
+  });
+
   it("returns friendly message for role ordering errors thrown as exceptions", async () => {
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
       throw new Error("400 Incorrect role information");

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -9,6 +9,7 @@ vi.mock("../../agents/agent-scope.js", async () => {
     ...actual,
     resolveAgentDir: vi.fn(() => "/tmp/agent"),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+    resolveRunModelFallbacksOverride: vi.fn(() => undefined),
     resolveSessionAgentId: vi.fn(() => "main"),
     resolveAgentSkillsFilter: vi.fn(() => undefined),
   };

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -9,7 +9,7 @@ vi.mock("../../agents/agent-scope.js", async () => {
     ...actual,
     resolveAgentDir: vi.fn(() => "/tmp/agent"),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
-    resolveRunModelFallbacksOverride: vi.fn(() => undefined),
+    resolveEffectiveModelFallbacks: vi.fn(() => undefined),
     resolveSessionAgentId: vi.fn(() => "main"),
     resolveAgentSkillsFilter: vi.fn(() => undefined),
   };

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -2,14 +2,19 @@ import fs from "node:fs/promises";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
+  resolveRunModelFallbacksOverride,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
-import { resolveModelRefFromString } from "../../agents/model-selection.js";
+import { resolveModelRefFromString, type ModelAliasIndex } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../../config/model-input.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -172,6 +177,124 @@ async function applyLinkUnderstandingIfNeeded(params: {
   }
 }
 
+// Keep typing alive long enough for multi-attempt runs, but cap it to avoid
+// indefinite typing loops when timeouts are very large or disabled.
+const MIN_TYPING_TTL_MS = 2 * 60_000;
+const MAX_TYPING_TTL_MS = 120 * 60_000;
+const TRANSIENT_RETRY_CYCLES = 2;
+const TYPING_TTL_BUFFER_MS = 15_000;
+
+function modelCandidateKey(candidate: { provider: string; model: string }): string {
+  return `${candidate.provider.trim().toLowerCase()}/${candidate.model.trim()}`;
+}
+
+function resolveTypingAttemptCount(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+  provider: string;
+  model: string;
+  defaultProvider: string;
+  aliasIndex: ModelAliasIndex;
+}): number {
+  const candidates = new Set<string>();
+  const activeProvider = params.provider.trim() || params.defaultProvider;
+  const activeModel = params.model.trim();
+  if (activeProvider && activeModel) {
+    candidates.add(modelCandidateKey({ provider: activeProvider, model: activeModel }));
+  }
+
+  const fallbackOverrides = resolveRunModelFallbacksOverride({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  const configuredFallbacks = resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
+  const configuredPrimaryRaw = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model);
+  const configuredPrimary = configuredPrimaryRaw
+    ? resolveModelRefFromString({
+        cfg: params.cfg,
+        raw: configuredPrimaryRaw,
+        defaultProvider: params.defaultProvider,
+        aliasIndex: params.aliasIndex,
+      })?.ref
+    : undefined;
+  const normalizedConfiguredPrimary = configuredPrimary
+    ? modelCandidateKey(configuredPrimary)
+    : undefined;
+  const normalizedActivePrimary =
+    activeProvider && activeModel
+      ? modelCandidateKey({ provider: activeProvider, model: activeModel })
+      : undefined;
+
+  const fallbackValues = (() => {
+    if (fallbackOverrides !== undefined) {
+      return fallbackOverrides;
+    }
+    if (
+      configuredPrimary &&
+      normalizedActivePrimary &&
+      activeProvider.toLowerCase() !== configuredPrimary.provider.trim().toLowerCase()
+    ) {
+      const isConfiguredFallback = configuredFallbacks.some((raw) => {
+        const resolved = resolveModelRefFromString({
+          cfg: params.cfg,
+          raw,
+          defaultProvider: params.defaultProvider,
+          aliasIndex: params.aliasIndex,
+        })?.ref;
+        return resolved ? modelCandidateKey(resolved) === normalizedActivePrimary : false;
+      });
+      return isConfiguredFallback ? configuredFallbacks : [];
+    }
+    return configuredFallbacks;
+  })();
+
+  for (const raw of fallbackValues) {
+    const resolved = resolveModelRefFromString({
+      cfg: params.cfg,
+      raw,
+      defaultProvider: params.defaultProvider,
+      aliasIndex: params.aliasIndex,
+    })?.ref;
+    if (resolved) {
+      candidates.add(modelCandidateKey(resolved));
+    }
+  }
+
+  if (fallbackOverrides === undefined && normalizedConfiguredPrimary) {
+    candidates.add(normalizedConfiguredPrimary);
+  }
+
+  return Math.max(1, candidates.size);
+}
+
+function resolveTypingTtlMs(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+  timeoutMs: number;
+  provider: string;
+  model: string;
+  defaultProvider: string;
+  aliasIndex: ModelAliasIndex;
+}): number {
+  const projectedAttemptCount = resolveTypingAttemptCount({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    provider: params.provider,
+    model: params.model,
+    defaultProvider: params.defaultProvider,
+    aliasIndex: params.aliasIndex,
+  });
+  // One transient HTTP retry can replay the full model chain; keep typing alive
+  // long enough to cover both cycles so users do not see false "dead" runs.
+  const projectedTtlMs =
+    params.timeoutMs * projectedAttemptCount * TRANSIENT_RETRY_CYCLES + TYPING_TTL_BUFFER_MS;
+  return Math.max(MIN_TYPING_TTL_MS, Math.min(projectedTtlMs, MAX_TYPING_TTL_MS));
+}
+
 export async function getReplyFromConfig(
   ctx: MsgContext,
   opts?: GetReplyOptions,
@@ -250,10 +373,21 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
+  const typingTtlMs = resolveTypingTtlMs({
+    cfg,
+    agentId,
+    sessionKey: agentSessionKey,
+    timeoutMs,
+    provider,
+    model,
+    defaultProvider,
+    aliasIndex,
+  });
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
     typingIntervalSeconds,
+    typingTtlMs,
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
   });

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -2,19 +2,16 @@ import fs from "node:fs/promises";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  resolveRunModelFallbacksOverride,
+  resolveEffectiveModelFallbacks,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
-import { resolveModelRefFromString, type ModelAliasIndex } from "../../agents/model-selection.js";
+import { resolveModelFallbackCandidateCount } from "../../agents/model-fallback.js";
+import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
-import {
-  resolveAgentModelFallbackValues,
-  resolveAgentModelPrimaryValue,
-} from "../../config/model-input.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -184,109 +181,35 @@ const MAX_TYPING_TTL_MS = 120 * 60_000;
 const TRANSIENT_RETRY_CYCLES = 2;
 const TYPING_TTL_BUFFER_MS = 15_000;
 
-function modelCandidateKey(candidate: { provider: string; model: string }): string {
-  return `${candidate.provider.trim().toLowerCase()}/${candidate.model.trim()}`;
-}
-
 function resolveTypingAttemptCount(params: {
   cfg: OpenClawConfig;
-  agentId: string;
-  sessionKey?: string;
   provider: string;
   model: string;
-  defaultProvider: string;
-  aliasIndex: ModelAliasIndex;
+  fallbacksOverride?: string[];
 }): number {
-  const candidates = new Set<string>();
-  const activeProvider = params.provider.trim() || params.defaultProvider;
-  const activeModel = params.model.trim();
-  if (activeProvider && activeModel) {
-    candidates.add(modelCandidateKey({ provider: activeProvider, model: activeModel }));
-  }
-
-  const fallbackOverrides = resolveRunModelFallbacksOverride({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
-  });
-  const configuredFallbacks = resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
-  const configuredPrimaryRaw = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model);
-  const configuredPrimary = configuredPrimaryRaw
-    ? resolveModelRefFromString({
-        cfg: params.cfg,
-        raw: configuredPrimaryRaw,
-        defaultProvider: params.defaultProvider,
-        aliasIndex: params.aliasIndex,
-      })?.ref
-    : undefined;
-  const normalizedConfiguredPrimary = configuredPrimary
-    ? modelCandidateKey(configuredPrimary)
-    : undefined;
-  const normalizedActivePrimary =
-    activeProvider && activeModel
-      ? modelCandidateKey({ provider: activeProvider, model: activeModel })
-      : undefined;
-
-  const fallbackValues = (() => {
-    if (fallbackOverrides !== undefined) {
-      return fallbackOverrides;
-    }
-    if (
-      configuredPrimary &&
-      normalizedActivePrimary &&
-      activeProvider.toLowerCase() !== configuredPrimary.provider.trim().toLowerCase()
-    ) {
-      const isConfiguredFallback = configuredFallbacks.some((raw) => {
-        const resolved = resolveModelRefFromString({
-          cfg: params.cfg,
-          raw,
-          defaultProvider: params.defaultProvider,
-          aliasIndex: params.aliasIndex,
-        })?.ref;
-        return resolved ? modelCandidateKey(resolved) === normalizedActivePrimary : false;
-      });
-      return isConfiguredFallback ? configuredFallbacks : [];
-    }
-    return configuredFallbacks;
-  })();
-
-  for (const raw of fallbackValues) {
-    const resolved = resolveModelRefFromString({
+  return Math.max(
+    1,
+    resolveModelFallbackCandidateCount({
       cfg: params.cfg,
-      raw,
-      defaultProvider: params.defaultProvider,
-      aliasIndex: params.aliasIndex,
-    })?.ref;
-    if (resolved) {
-      candidates.add(modelCandidateKey(resolved));
-    }
-  }
-
-  if (fallbackOverrides === undefined && normalizedConfiguredPrimary) {
-    candidates.add(normalizedConfiguredPrimary);
-  }
-
-  return Math.max(1, candidates.size);
+      provider: params.provider,
+      model: params.model,
+      fallbacksOverride: params.fallbacksOverride,
+    }),
+  );
 }
 
 function resolveTypingTtlMs(params: {
   cfg: OpenClawConfig;
-  agentId: string;
-  sessionKey?: string;
   timeoutMs: number;
   provider: string;
   model: string;
-  defaultProvider: string;
-  aliasIndex: ModelAliasIndex;
+  fallbacksOverride?: string[];
 }): number {
   const projectedAttemptCount = resolveTypingAttemptCount({
     cfg: params.cfg,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
     provider: params.provider,
     model: params.model,
-    defaultProvider: params.defaultProvider,
-    aliasIndex: params.aliasIndex,
+    fallbacksOverride: params.fallbacksOverride,
   });
   // One transient HTTP retry can replay the full model chain; keep typing alive
   // long enough to cover both cycles so users do not see false "dead" runs.
@@ -373,25 +296,6 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
-  const typingTtlMs = resolveTypingTtlMs({
-    cfg,
-    agentId,
-    sessionKey: agentSessionKey,
-    timeoutMs,
-    provider,
-    model,
-    defaultProvider,
-    aliasIndex,
-  });
-  const typing = createTypingController({
-    onReplyStart: opts?.onReplyStart,
-    onCleanup: opts?.onTypingCleanup,
-    typingIntervalSeconds,
-    typingTtlMs,
-    silentToken: SILENT_REPLY_TOKEN,
-    log: defaultRuntime.log,
-  });
-  opts?.onTypingController?.(typing);
 
   const finalized = finalizeInboundContext(ctx);
 
@@ -512,6 +416,28 @@ export async function getReplyFromConfig(
       model = resolved.ref.model;
     }
   }
+  const fallbackOverride = resolveEffectiveModelFallbacks({
+    cfg,
+    agentId,
+    hasSessionModelOverride,
+    modelOverrideSource: hasSessionModelOverride ? sessionEntry.modelOverrideSource : undefined,
+  });
+  const typingTtlMs = resolveTypingTtlMs({
+    cfg,
+    timeoutMs,
+    provider,
+    model,
+    fallbacksOverride: fallbackOverride,
+  });
+  const typing = createTypingController({
+    onReplyStart: opts?.onReplyStart,
+    onCleanup: opts?.onTypingCleanup,
+    typingIntervalSeconds,
+    typingTtlMs,
+    silentToken: SILENT_REPLY_TOKEN,
+    log: defaultRuntime.log,
+  });
+  opts?.onTypingController?.(typing);
 
   if (
     shouldUseReplyFastDirectiveExecution({

--- a/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
+++ b/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../templating.js";
+import { withFastReplyConfig } from "./get-reply-fast-path.js";
+import { registerGetReplyCommonMocks } from "./get-reply.test-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  initSessionState: vi.fn(),
+}));
+
+registerGetReplyCommonMocks();
+
+vi.mock("../../link-understanding/apply.js", () => ({
+  applyLinkUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("../../media-understanding/apply.js", () => ({
+  applyMediaUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("./commands-core.js", () => ({
+  emitResetCommandHooks: vi.fn(async () => undefined),
+}));
+vi.mock("./get-reply-directives.js", () => ({
+  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
+}));
+vi.mock("./session.js", () => ({
+  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
+}));
+
+const { getReplyFromConfig } = await import("./get-reply.js");
+const { createTypingController } = await import("./typing.js");
+const { resolveAgentTimeoutMs } = await import("../../agents/timeout.js");
+const { resolveRunModelFallbacksOverride } = await import("../../agents/agent-scope.js");
+const { resolveModelRefFromString } = await import("../../agents/model-selection.js");
+
+function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    Provider: "telegram",
+    Surface: "telegram",
+    OriginatingChannel: "telegram",
+    OriginatingTo: "telegram:-100123",
+    ChatType: "group",
+    Body: "hello",
+    BodyForAgent: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    SessionKey: "agent:main:telegram:-100123",
+    From: "telegram:user:42",
+    To: "telegram:-100123",
+    GroupChannel: "ops",
+    Timestamp: 1710000000000,
+    ...overrides,
+  };
+}
+
+describe("getReply typing timeout budget", () => {
+  beforeEach(() => {
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.initSessionState.mockReset();
+    vi.mocked(createTypingController).mockClear();
+    vi.mocked(resolveAgentTimeoutMs).mockReset();
+    vi.mocked(resolveRunModelFallbacksOverride).mockReset();
+    vi.mocked(resolveModelRefFromString).mockImplementation(({ raw, defaultProvider }) => {
+      const trimmed = raw.trim();
+      const slashIndex = trimmed.indexOf("/");
+      const ref =
+        slashIndex === -1
+          ? { provider: defaultProvider, model: trimmed }
+          : {
+              provider: trimmed.slice(0, slashIndex),
+              model: trimmed.slice(slashIndex + 1),
+            };
+      return { ref };
+    });
+
+    mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: {},
+      sessionEntry: {},
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:-100123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: true,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+  });
+
+  it("extends typing TTL based on timeout and fallback chain budget", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(90_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
+      "openai/gpt-5.2",
+      "openai/gpt-5.1",
+    ]);
+
+    await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 555_000,
+      }),
+    );
+  });
+
+  it("keeps a minimum typing TTL for short timeout chains", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(30_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([]);
+
+    await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 120_000,
+      }),
+    );
+  });
+
+  it("caps typing TTL to avoid unbounded typing loops", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(4_000_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
+      "openai/gpt-5.2",
+      "openai/gpt-5.1",
+      "openai/gpt-5.0",
+    ]);
+
+    await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 7_200_000,
+      }),
+    );
+  });
+
+  it("includes the configured primary appended to an override run", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(60_000);
+
+    await getReplyFromConfig(
+      buildCtx(),
+      { isHeartbeat: true, heartbeatModelOverride: "google/gemini-2.5-pro" },
+      withFastReplyConfig({
+        agents: {
+          defaults: {
+            heartbeat: { model: "google/gemini-2.5-pro" },
+            model: { primary: "anthropic/claude-sonnet-4.6" },
+          },
+        },
+      }),
+    );
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 255_000,
+      }),
+    );
+  });
+});

--- a/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
+++ b/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../templating.js";
-import { withFastReplyConfig } from "./get-reply-fast-path.js";
+import { withFastReplyConfig, withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
 import { registerGetReplyCommonMocks } from "./get-reply.test-mocks.js";
 
 const mocks = vi.hoisted(() => ({
@@ -29,7 +29,7 @@ vi.mock("./session.js", () => ({
 const { getReplyFromConfig } = await import("./get-reply.js");
 const { createTypingController } = await import("./typing.js");
 const { resolveAgentTimeoutMs } = await import("../../agents/timeout.js");
-const { resolveRunModelFallbacksOverride } = await import("../../agents/agent-scope.js");
+const { resolveEffectiveModelFallbacks } = await import("../../agents/agent-scope.js");
 const { resolveModelRefFromString } = await import("../../agents/model-selection.js");
 
 function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
@@ -58,7 +58,7 @@ describe("getReply typing timeout budget", () => {
     mocks.initSessionState.mockReset();
     vi.mocked(createTypingController).mockClear();
     vi.mocked(resolveAgentTimeoutMs).mockReset();
-    vi.mocked(resolveRunModelFallbacksOverride).mockReset();
+    vi.mocked(resolveEffectiveModelFallbacks).mockReset();
     vi.mocked(resolveModelRefFromString).mockImplementation(({ raw, defaultProvider }) => {
       const trimmed = raw.trim();
       const slashIndex = trimmed.indexOf("/");
@@ -95,10 +95,7 @@ describe("getReply typing timeout budget", () => {
 
   it("extends typing TTL based on timeout and fallback chain budget", async () => {
     vi.mocked(resolveAgentTimeoutMs).mockReturnValue(90_000);
-    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
-      "openai/gpt-5.2",
-      "openai/gpt-5.1",
-    ]);
+    vi.mocked(resolveEffectiveModelFallbacks).mockReturnValue(["openai/gpt-5.2", "openai/gpt-5.1"]);
 
     await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
 
@@ -111,7 +108,7 @@ describe("getReply typing timeout budget", () => {
 
   it("keeps a minimum typing TTL for short timeout chains", async () => {
     vi.mocked(resolveAgentTimeoutMs).mockReturnValue(30_000);
-    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([]);
+    vi.mocked(resolveEffectiveModelFallbacks).mockReturnValue([]);
 
     await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
 
@@ -124,7 +121,7 @@ describe("getReply typing timeout budget", () => {
 
   it("caps typing TTL to avoid unbounded typing loops", async () => {
     vi.mocked(resolveAgentTimeoutMs).mockReturnValue(4_000_000);
-    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
+    vi.mocked(resolveEffectiveModelFallbacks).mockReturnValue([
       "openai/gpt-5.2",
       "openai/gpt-5.1",
       "openai/gpt-5.0",
@@ -158,6 +155,60 @@ describe("getReply typing timeout budget", () => {
     expect(createTypingController).toHaveBeenCalledWith(
       expect.objectContaining({
         typingTtlMs: 255_000,
+      }),
+    );
+  });
+
+  it("uses the user-selected session override budget without default fallbacks", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(60_000);
+    vi.mocked(resolveEffectiveModelFallbacks).mockReturnValue([]);
+    mocks.initSessionState.mockResolvedValueOnce({
+      sessionCtx: {},
+      sessionEntry: {
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4.6",
+        modelOverrideSource: "user",
+      },
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:-100123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: true,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+
+    await getReplyFromConfig(
+      buildCtx(),
+      undefined,
+      withFullRuntimeReplyConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5.4",
+              fallbacks: ["openai/gpt-5.2", "openai/gpt-5.1"],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(resolveEffectiveModelFallbacks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasSessionModelOverride: true,
+        modelOverrideSource: "user",
+      }),
+    );
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 135_000,
       }),
     );
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Auto-reply typing timeout/TTL fixes were bundled with Telegram stability work in #41883.
- Why it matters: Splitting lets maintainers review and merge auto-reply timing behavior independently from Telegram internals.
- What changed: Cherry-picked only `fix(auto-reply): extend typing TTL and clarify timeouts` and its related tests.
- What did NOT change (scope boundary): No Telegram watchdog/polling behavior changes are included.
- AI-assisted: Yes (Codex). Human-reviewed before submission.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #41883

## User-visible / Behavior Changes

- Auto-reply typing budget/timeout handling now uses extended TTL semantics and clearer timeout behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v25.6.1, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Auto-reply
- Relevant config (redacted): test defaults

### Steps

1. `pnpm test -- --run src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts`
2. `pnpm exec vitest run --config vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`

### Expected

- Auto-reply typing timeout budget tests and run-reply-agent E2E coverage pass.

### Actual

- Passed: `1` file / `3` tests for typing-timeout budget.
- Passed: `1` file / `43` tests for run-reply-agent E2E.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: branch contains only the single auto-reply commit from #41883.
- Edge cases checked: typing timeout budget behavior + run-reply-agent E2E path.
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test` suite not run in this split pass.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this branch commit.
- Files/config to restore: `src/auto-reply/reply/*` touched by this commit.
- Known bad symptoms reviewers should watch for: typing indicators ending too early or timeout budget not being honored.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: timeout tuning can shift perceived responsiveness in edge latency conditions.
  - Mitigation: added targeted unit + E2E coverage in this exact area.


## Additional Verification

- `pnpm check` passed on this split branch.
- E2E file execution with explicit config override passed: `pnpm exec vitest run --config vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts` (`43/43`).
- Live runtime smoke path executed from built CLI (`channels status --probe --json` showed Telegram configured/running/probe-ok in this environment).
