### PR TITLE
Agents: characterize failover and auth-profile pipeline boundaries

### DIFF
--- a/docs/experiments/plans/agent-core-failover-auth-profile-pipeline.md
+++ b/docs/experiments/plans/agent-core-failover-auth-profile-pipeline.md
@@ -1,0 +1,219 @@
+---
+summary: "Agent Core Phase 4A subplan for reducing failover and auth-profile pipeline entropy without changing policy."
+owner: "liu_y"
+status: "proposed"
+last_updated: "2026-03-10"
+title: "Agent Core Failover And Auth-Profile Pipeline Plan"
+---
+
+# Agent Core Failover And Auth-Profile Pipeline Plan
+
+## Why this plan exists
+
+Phase 1 through Phase 3 of the Agent Core flush / compaction boundary work have landed:
+
+- PR #54: characterization
+- PR #56: flush boundary helper consolidation
+- PR #58: bounded compaction retry wait after idle timeout
+- PR #61: restart drain for active embedded runs
+
+That means the next Agent Core step should not keep stretching the flush / compaction seam.
+The next highest-entropy seam is the failover and auth-profile pipeline inside the embedded runner.
+
+Today, one path still carries too many responsibilities at once:
+
+- auth-profile ordering and advancement
+- cooldown interpretation
+- failover reason classification
+- prompt-error vs assistant-error handling
+- timeout vs compaction-timeout distinctions
+- fallback handoff to broader model fallback
+
+The goal here is not to redesign failover policy.
+The goal is to make the existing policy easier to reason about, test, and change safely.
+
+## Current local baseline
+
+Already landed in local repo:
+
+- overloaded failover handling is split from generic failover semantics
+- post-prompt compaction timeout is bounded and does not poison restart semantics
+- restart drain now accounts for active embedded runs
+
+These give us a stable base for a narrower cleanup pass on auth-profile and failover control flow.
+
+## In-scope seam
+
+Primary code paths:
+
+- `src/agents/pi-embedded-runner/run.ts`
+- `src/agents/model-fallback.ts`
+- `src/agents/model-auth.ts`
+- `src/auto-reply/reply/get-reply-run.ts`
+- `src/auto-reply/reply/directive-handling.auth.ts`
+- `src/agents/pi-embedded-runner/run/attempt.ts`
+
+Primary coordination points:
+
+- `resolveAuthProfileOrder()`
+- `resolveModelAuthMode()`
+- `advanceAuthProfile()`
+- `maybeMarkAuthProfileFailure()`
+- `throwAuthProfileFailover()`
+- `resolveAuthProfileFailoverReason()`
+- `FailoverError` / `resolveFailoverStatus()`
+- `timedOutDuringCompaction`
+- session auth-profile override resolution
+
+## Non-goals
+
+This plan explicitly does not include:
+
+- broad failover policy rewrites
+- auth-profile storage/schema changes
+- new cooldown heuristics
+- provider-specific auth refresh redesigns
+- channel-level reply behavior changes
+- broader lifecycle contract cleanup outside the failover/auth-profile seam
+
+## Why this seam is still high entropy
+
+Current code mixes policy and orchestration in ways that make review harder than necessary:
+
+- `run.ts` decides when to rotate auth profiles, when to mark failures, and when to escalate to model fallback.
+- timeout and failover distinctions are partly made in `run/attempt.ts` and partly reinterpreted in `run.ts`.
+- auth-profile ordering and model auth-mode resolution live in shared helpers, but the embedded runner still owns several cross-cutting decisions around when those results matter.
+- session-level auth-profile overrides enter through reply-side setup, but the runner path still has to reconcile them with per-provider auth ordering and cooldown state.
+
+The cleanup target is not “fewer lines at any cost”.
+The target is clearer boundaries for who decides what.
+
+## Boundary invariants
+
+These invariants must hold after every step:
+
+1. post-prompt compaction timeouts must not rotate or cooldown-poison auth profiles
+2. explicit session auth-profile override precedence must remain unchanged
+3. auth-profile exhaustion must still surface a structured `FailoverError` when fallback is configured
+4. non-timeout auth failures must still be eligible for auth-profile failure marking
+5. same-provider auth-profile rotation must remain narrower than broader model fallback
+6. all-in-cooldown vs transient unavailability must remain distinguishable in logs and failover status
+7. fallback abort semantics must remain explicit and not collapse timeouts into generic aborts
+8. cleanup commits must preserve current user-visible behavior unless a test proves a bug
+
+## Execution phases
+
+### Phase 4A.1: Characterization
+
+Goal:
+
+- lock the current contract around auth-profile rotation, failure marking, and failover escalation before moving code
+
+Expected output:
+
+- no intended behavior change
+- tighter tests for timeout, cooldown, and override boundaries
+
+Candidate tests:
+
+- `timedOutDuringCompaction` does not trigger auth-profile rotation or cooldown marking
+- auth-profile exhaustion maps to the same failover reason/status as the cooldown store says
+- explicit session auth-profile override keeps precedence when present
+- timeout failures do not mark auth-profile failure, while auth/rate-limit failures still can
+- broader model fallback still only runs after same-provider auth-profile advancement is exhausted
+
+Regression minimum:
+
+```bash
+pnpm vitest run \
+  src/agents/model-fallback.test.ts \
+  src/agents/model-auth.test.ts \
+  src/agents/model-auth.profiles.test.ts \
+  src/agents/failover-error.test.ts \
+  src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+```
+
+### Phase 4A.2: Decision helper extraction
+
+Goal:
+
+- separate policy decisions from runner loop orchestration without changing behavior
+
+Expected output:
+
+- smaller decision helpers for:
+  - auth-profile failover reason resolution
+  - auth-profile failure marking eligibility
+  - auth-profile rotation eligibility
+  - escalation boundary from profile rotation to model fallback
+
+Acceptance:
+
+- Phase 4A.1 tests remain green
+- diff is mostly helper extraction and callsite narrowing
+- runner loop becomes easier to read without changing retry order
+
+### Phase 4A.3: Pipeline cleanup
+
+Goal:
+
+- tighten boundary ownership between runner auth-profile handling and broader model fallback
+
+Expected output:
+
+- fewer duplicated reason/classification branches
+- clearer handoff between `run.ts` and `model-fallback.ts`
+- narrower interface between reply-side auth-profile override resolution and runner execution
+
+Acceptance:
+
+- no change to configured fallback order
+- no change to auth-profile override precedence
+- timeout/abort semantics stay test-covered and explicit
+
+### Phase 4A.4: Optional follow-ups
+
+Only after the above are stable:
+
+- provider-specific token refresh cleanup
+- logging/observability cleanup for failover reason reporting
+- total retry budget documentation across auth-profile rotation and broader model fallback
+
+These should be separate issues unless the diff stays trivially reviewable.
+
+## Recommended issue breakdown
+
+Create and execute these in order:
+
+1. Agent Core: characterize failover and auth-profile pipeline boundaries
+2. Agent Core: extract auth-profile failover decision helpers without changing behavior
+3. Agent Core: narrow runner-to-fallback handoff for auth-profile rotation
+
+Do not open step 2 or 3 until step 1 has landed or exposed a concrete bug.
+
+## Commit strategy
+
+Use the same low-entropy pattern as the Phase 1 to 3 work:
+
+1. semantic/characterization commit first
+2. cleanup/extraction commit second
+3. never mix a behavior change with unrelated movement unless the diff is trivially reviewable
+
+Example commit shape:
+
+1. `Agents: lock failover and auth-profile pipeline invariants`
+2. `Agents: extract auth-profile failover decision helpers`
+3. if needed, a tiny semantic fix:
+   `Agents: fix <single failover/auth-profile behavior>`
+
+## Immediate next step
+
+Start with Phase 4A.1.
+
+Definition of done for the first working step:
+
+- create a local issue for failover/auth-profile characterization
+- add missing characterization tests around timeout, cooldown, and override boundaries
+- run the Phase 4A.1 regression minimum
+- if tests expose a real bug, fix only that bug
+- stop before helper extraction

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -990,6 +990,50 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
     });
   });
 
+  it("fails over with overloaded reason when all profiles are cooldowned by overload", async () => {
+    await withTimedAgentWorkspace(async ({ agentDir, workspaceDir, now }) => {
+      await writeAuthStore(agentDir, {
+        usageStats: {
+          "openai:p1": {
+            lastUsed: 1,
+            cooldownUntil: now + 60 * 60 * 1000,
+            failureCounts: { overloaded: 4 },
+          },
+          "openai:p2": {
+            lastUsed: 2,
+            cooldownUntil: now + 60 * 60 * 1000,
+            failureCounts: { overloaded: 2 },
+          },
+        },
+      });
+
+      await expect(
+        runEmbeddedPiAgent({
+          sessionId: "session:test",
+          sessionKey: "agent:test:overloaded-cooldown-failover",
+          sessionFile: path.join(workspaceDir, "session.jsonl"),
+          workspaceDir,
+          agentDir,
+          config: makeConfig({ fallbacks: ["openai/mock-2"] }),
+          prompt: "hello",
+          provider: "openai",
+          model: "mock-1",
+          authProfileIdSource: "auto",
+          timeoutMs: 5_000,
+          runId: "run:overloaded-cooldown-failover",
+        }),
+      ).rejects.toMatchObject({
+        name: "FailoverError",
+        reason: "overloaded",
+        status: 503,
+        provider: "openai",
+        model: "mock-1",
+      });
+
+      expect(runEmbeddedAttemptMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("can probe one cooldowned profile when transient cooldown probe is explicitly allowed", async () => {
     await withTimedAgentWorkspace(async ({ agentDir, workspaceDir, now }) => {
       await writeAuthStore(agentDir, {


### PR DESCRIPTION
## Summary

- Problem: the next Agent Core entropy seam is the embedded runner failover/auth-profile pipeline, but one missing characterization gap remained around cooldown exhaustion caused by overload.
- Why it matters: later helper extraction is safer only if failover reason/status mapping is locked first.
- What changed: added the Phase 4A plan doc and a characterization e2e that asserts all-cooldown overload exhaustion fails over as `overloaded`/`503` without attempting a run.
- What did NOT change (scope boundary): no failover policy rewrite, no helper extraction, no auth-profile storage/schema changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41961
- Related #58
- Related #61

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: mocked `openai`
- Integration/channel (if any): embedded runner only
- Relevant config (redacted): auth-profile store with cooldowned OpenAI profiles and fallback configured

### Steps

1. Seed the auth-profile store with two `openai:*` profiles, each in cooldown with `failureCounts.overloaded` set.
2. Run `runEmbeddedPiAgent()` with `fallbacks: ["openai/mock-2"]` and no explicit profile lock.
3. Observe the thrown failover error and whether any embedded attempt is started.

### Expected

- The runner throws `FailoverError` with `reason: "overloaded"` and `status: 503`.
- `runEmbeddedAttempt` is not called because all profiles are already cooldowned out.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts`

- `1 passed`, `20 passed`

`pnpm exec vitest run src/agents/model-fallback.test.ts src/agents/model-auth.test.ts src/agents/model-auth.profiles.test.ts src/agents/failover-error.test.ts`

- `4 passed`, `96 passed`

`pnpm check`

- passed

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: overload-driven all-cooldown exhaustion now has explicit characterization coverage; existing auth-profile rotation/cooldown/override e2e scenarios still pass.
- Edge cases checked: compaction timeout non-rotation, timeout-without-cooldown rotation, user-pinned profile behavior, disabled/auth/rate-limit failover paths via the targeted regression set.
- What you did **not** verify: no live-provider runs; no helper extraction yet.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR; it only adds docs and characterization coverage.
- Files/config to restore: `docs/experiments/plans/agent-core-failover-auth-profile-pipeline.md`, `src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts`
- Known bad symptoms reviewers should watch for: unexpected failover reason/status changes in auth-profile exhaustion cases.

## Risks and Mitigations

- Risk: the new characterization could be asserting an accidental current behavior rather than an intended contract.
  - Mitigation: the plan doc scopes this PR as characterization-only so any semantic disagreement is isolated before helper extraction.
