### PR TITLE
feat(telegram): persist forum topic icons via config (iconCustomEmojiId)

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -212,6 +212,8 @@ export type TelegramTopicConfig = {
   disableAudioPreflight?: boolean;
   /** Route this topic to a specific agent (overrides group-level and binding routing). */
   agentId?: string;
+  /** Custom emoji ID for the topic icon. Use getForumTopicIconStickers to get valid IDs. Icon is applied on gateway start. */
+  iconCustomEmojiId?: string;
 };
 
 export type TelegramGroupConfig = {

--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -123,6 +123,8 @@ export const sendMessageSpy: AnyAsyncMock = vi.fn(async () => ({ message_id: 77 
 export const sendAnimationSpy: AnyAsyncMock = vi.fn(async () => ({ message_id: 78 }));
 export const sendPhotoSpy: AnyAsyncMock = vi.fn(async () => ({ message_id: 79 }));
 export const getFileSpy: AnyAsyncMock = vi.fn(async () => ({ file_path: "media/file.jpg" }));
+export const editForumTopicSpy: AnyAsyncMock = vi.fn(async () => undefined);
+export const botInitSpy: AnyAsyncMock = vi.fn(async () => undefined);
 
 type ApiStub = {
   config: { use: (arg: unknown) => void };
@@ -138,6 +140,7 @@ type ApiStub = {
   sendAnimation: typeof sendAnimationSpy;
   sendPhoto: typeof sendPhotoSpy;
   getFile: typeof getFileSpy;
+  editForumTopic: typeof editForumTopicSpy;
 };
 
 const apiStub: ApiStub = {
@@ -154,6 +157,7 @@ const apiStub: ApiStub = {
   sendAnimation: sendAnimationSpy,
   sendPhoto: sendPhotoSpy,
   getFile: getFileSpy,
+  editForumTopic: editForumTopicSpy,
 };
 
 vi.mock("grammy", () => ({
@@ -162,6 +166,7 @@ vi.mock("grammy", () => ({
     use = middlewareUseSpy;
     on = onSpy;
     stop = stopSpy;
+    init = botInitSpy;
     command = commandSpy;
     catch = vi.fn();
     constructor(
@@ -330,5 +335,9 @@ beforeEach(() => {
   middlewareUseSpy.mockReset();
   sequentializeSpy.mockReset();
   botCtorSpy.mockReset();
+  editForumTopicSpy.mockReset();
+  editForumTopicSpy.mockResolvedValue(undefined);
+  botInitSpy.mockReset();
+  botInitSpy.mockResolvedValue(undefined);
   sequentializeKey = undefined;
 });

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -8,7 +8,9 @@ import { useFrozenTime, useRealTime } from "../test-utils/frozen-time.js";
 import {
   answerCallbackQuerySpy,
   botCtorSpy,
+  botInitSpy,
   commandSpy,
+  editForumTopicSpy,
   getLoadConfigMock,
   getLoadWebMediaMock,
   getOnHandler,
@@ -2258,5 +2260,126 @@ describe("createTelegramBot", () => {
     await handler(ctx);
 
     expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  describe("topic icon restoration on init", () => {
+    it("calls editForumTopic for each topic with iconCustomEmojiId on bot.init()", async () => {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: {
+            token: "tok",
+            groups: {
+              "-100123": {
+                topics: {
+                  "42": { iconCustomEmojiId: "5422992822657130530" },
+                  "99": { iconCustomEmojiId: "5417915203100613993" },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const bot = createTelegramBot({ token: "tok" });
+      await bot.init();
+
+      expect(editForumTopicSpy).toHaveBeenCalledTimes(2);
+      expect(editForumTopicSpy).toHaveBeenCalledWith(-100123, 42, {
+        icon_custom_emoji_id: "5422992822657130530",
+      });
+      expect(editForumTopicSpy).toHaveBeenCalledWith(-100123, 99, {
+        icon_custom_emoji_id: "5417915203100613993",
+      });
+    });
+
+    it("skips topics without iconCustomEmojiId", async () => {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: {
+            token: "tok",
+            groups: {
+              "-100456": {
+                topics: {
+                  "10": { iconCustomEmojiId: "5422992822657130530" },
+                  "20": { requireMention: true },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const bot = createTelegramBot({ token: "tok" });
+      await bot.init();
+
+      expect(editForumTopicSpy).toHaveBeenCalledTimes(1);
+      expect(editForumTopicSpy).toHaveBeenCalledWith(-100456, 10, {
+        icon_custom_emoji_id: "5422992822657130530",
+      });
+    });
+
+    it("does not call editForumTopic when no groups are configured", async () => {
+      loadConfig.mockReturnValue({
+        channels: { telegram: { token: "tok" } },
+      });
+
+      const bot = createTelegramBot({ token: "tok" });
+      await bot.init();
+
+      expect(editForumTopicSpy).not.toHaveBeenCalled();
+    });
+
+    it("continues applying remaining icons when one editForumTopic call fails", async () => {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: {
+            token: "tok",
+            groups: {
+              "-100789": {
+                topics: {
+                  "1": { iconCustomEmojiId: "emojiA" },
+                  "2": { iconCustomEmojiId: "emojiB" },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      editForumTopicSpy.mockRejectedValueOnce(new Error("Telegram API error"));
+
+      const bot = createTelegramBot({ token: "tok" });
+      await expect(bot.init()).resolves.not.toThrow();
+
+      expect(editForumTopicSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("still calls originalInit before applying topic icons", async () => {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: {
+            token: "tok",
+            groups: {
+              "-100111": {
+                topics: { "5": { iconCustomEmojiId: "emoji123" } },
+              },
+            },
+          },
+        },
+      });
+
+      const callOrder: string[] = [];
+      botInitSpy.mockImplementation(async () => {
+        callOrder.push("init");
+      });
+      editForumTopicSpy.mockImplementation(async () => {
+        callOrder.push("editForumTopic");
+      });
+
+      const bot = createTelegramBot({ token: "tok" });
+      await bot.init();
+
+      expect(callOrder).toEqual(["init", "editForumTopic"]);
+    });
   });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -458,5 +458,58 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     return originalStop(...args);
   }) as typeof bot.stop;
 
+  // Wrap bot.init() to apply configured topic icons after bot info is fetched.
+  const originalInit = bot.init.bind(bot);
+  bot.init = async function (...args: Parameters<typeof originalInit>) {
+    await originalInit(...args);
+    await applyConfiguredTopicIcons(bot, telegramCfg, logger);
+  } as typeof bot.init;
+
   return bot;
+}
+
+/**
+ * Iterates all configured groups and their topics; for each topic with
+ * `iconCustomEmojiId` set, calls editForumTopic to restore the icon.
+ * Per-topic errors are caught and logged so one failure cannot abort the rest.
+ */
+async function applyConfiguredTopicIcons(
+  bot: Bot,
+  telegramCfg: {
+    groups?: Record<string, { topics?: Record<string, { iconCustomEmojiId?: string }> }>;
+  },
+  logger: ReturnType<typeof getChildLogger> | undefined,
+): Promise<void> {
+  const groups = telegramCfg.groups;
+  if (!groups) {
+    return;
+  }
+  for (const [chatIdStr, groupCfg] of Object.entries(groups)) {
+    const topics = groupCfg.topics;
+    if (!topics) {
+      continue;
+    }
+    for (const [threadIdStr, topicCfg] of Object.entries(topics)) {
+      if (!topicCfg.iconCustomEmojiId) {
+        continue;
+      }
+      const chatId = Number(chatIdStr);
+      const threadId = Number(threadIdStr);
+      if (!Number.isFinite(chatId) || !Number.isFinite(threadId)) {
+        continue;
+      }
+      try {
+        await bot.api.editForumTopic(chatId, threadId, {
+          icon_custom_emoji_id: topicCfg.iconCustomEmojiId,
+        });
+        logger?.info(
+          `telegram: applied topic icon (chat=${chatIdStr} thread=${threadIdStr} emoji=${topicCfg.iconCustomEmojiId})`,
+        );
+      } catch (err) {
+        logger?.warn(
+          `telegram: failed to apply topic icon (chat=${chatIdStr} thread=${threadIdStr}): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Add `iconCustomEmojiId` field to `TelegramTopicConfig` so topic icons survive gateway restarts. On `bot.init()`, iterate all configured groups/topics and call `editForumTopic` for each topic that has an icon emoji ID set.

Closes #41982

## Changes

### `src/config/types.telegram.ts`
- Added `iconCustomEmojiId?: string` to `TelegramTopicConfig` with JSDoc

### `src/telegram/bot.ts`
- Wrapped `bot.init()` to call `applyConfiguredTopicIcons()` after initialization
- New `applyConfiguredTopicIcons()` function iterates groups/topics and calls `editForumTopic` for configured icons
- Per-topic errors caught and logged (one failure does not block others)

### `src/telegram/bot.create-telegram-bot.test-harness.ts`
- Added `editForumTopicSpy` and `botInitSpy` mocks

### `src/telegram/bot.create-telegram-bot.test.ts`
- 5 new tests covering: icon application, skipping topics without icons, no groups configured, error resilience, init ordering

## Config Example

```yaml
channels:
  telegram:
    groups:
      "-1001234567890":
        topics:
          "5":
            agentId: "nehemiah"
            iconCustomEmojiId: "5350554349074391003"
```