### PR TITLE
Google: show detailed Gemini CLI OAuth extraction failures

### DIFF
--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -22,6 +22,14 @@ const defaultFs: CredentialFs = {
 };
 
 let credentialFs: CredentialFs = defaultFs;
+const GEMINI_CLI_TREE_SEARCH_DEPTH = 10;
+
+type GeminiCliCredentialExtractDiagnostics = {
+  searchedPaths: string[];
+  recursiveSearchRoots: string[];
+  parseFailures: string[];
+  readErrors: string[];
+};
 
 function resolveEnv(keys: string[]): string | undefined {
   for (const key of keys) {
@@ -34,9 +42,11 @@ function resolveEnv(keys: string[]): string | undefined {
 }
 
 let cachedGeminiCliCredentials: { clientId: string; clientSecret: string } | null = null;
+let geminiCliCredentialExtractError: string | null = null;
 
 export function clearCredentialsCache(): void {
   cachedGeminiCliCredentials = null;
+  geminiCliCredentialExtractError = null;
 }
 
 export function setOAuthCredentialsFsForTest(overrides?: Partial<CredentialFs>): void {
@@ -48,9 +58,19 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
     return cachedGeminiCliCredentials;
   }
 
+  geminiCliCredentialExtractError = null;
+  const diagnostics: GeminiCliCredentialExtractDiagnostics = {
+    searchedPaths: [],
+    recursiveSearchRoots: [],
+    parseFailures: [],
+    readErrors: [],
+  };
+
   try {
     const geminiPath = findInPath("gemini");
     if (!geminiPath) {
+      geminiCliCredentialExtractError =
+        "Gemini CLI binary was not found in PATH during OAuth credential extraction.";
       return null;
     }
 
@@ -58,28 +78,82 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
     const geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
 
     for (const geminiCliDir of geminiCliDirs) {
-      const directCredentials = readGeminiCliCredentialsFromKnownPaths(geminiCliDir);
+      const directCredentials = readGeminiCliCredentialsFromKnownPaths(geminiCliDir, diagnostics);
       if (directCredentials) {
         cachedGeminiCliCredentials = directCredentials;
         return directCredentials;
       }
 
-      const bundledCredentials = readGeminiCliCredentialsFromBundle(geminiCliDir);
+      const bundledCredentials = readGeminiCliCredentialsFromBundle(geminiCliDir, diagnostics);
       if (bundledCredentials) {
         cachedGeminiCliCredentials = bundledCredentials;
         return bundledCredentials;
       }
 
-      const discoveredCredentials = findGeminiCliCredentialsInTree(geminiCliDir, 10);
+      diagnostics.recursiveSearchRoots.push(geminiCliDir);
+      const discoveredCredentials = findGeminiCliCredentialsInTree(
+        geminiCliDir,
+        GEMINI_CLI_TREE_SEARCH_DEPTH,
+        diagnostics,
+      );
       if (discoveredCredentials) {
         cachedGeminiCliCredentials = discoveredCredentials;
         return discoveredCredentials;
       }
     }
-  } catch {
-    // Gemini CLI not installed or extraction failed
+    geminiCliCredentialExtractError = formatGeminiCliCredentialExtractError({
+      geminiPath,
+      resolvedPath,
+      diagnostics,
+    });
+  } catch (error) {
+    geminiCliCredentialExtractError = `Unexpected error while extracting Gemini CLI OAuth credentials: ${formatError(error)}`;
   }
   return null;
+}
+
+function formatGeminiCliCredentialExtractError({
+  geminiPath,
+  resolvedPath,
+  diagnostics,
+}: {
+  geminiPath: string;
+  resolvedPath: string;
+  diagnostics: GeminiCliCredentialExtractDiagnostics;
+}): string {
+  const prefix = [
+    "Found Gemini CLI in PATH, but could not extract OAuth credentials.",
+    `geminiPath=${geminiPath}`,
+    `resolvedPath=${resolvedPath}`,
+  ];
+
+  if (diagnostics.parseFailures.length > 0) {
+    return [
+      ...prefix,
+      "Candidate credential files did not contain a parseable OAuth client id/secret.",
+      `candidates=${diagnostics.parseFailures.join(", ")}`,
+    ].join(" ");
+  }
+
+  if (diagnostics.readErrors.length > 0) {
+    return [
+      ...prefix,
+      "Unexpected errors occurred while reading candidate credential files/directories.",
+      `errors=${diagnostics.readErrors.join(", ")}`,
+    ].join(" ");
+  }
+
+  return [
+    ...prefix,
+    "Could not locate oauth2.js or bundled credential source.",
+    `searched=${diagnostics.searchedPaths.join(", ") || "(none)"}`,
+    `recursiveSearchRoots=${diagnostics.recursiveSearchRoots.join(", ") || "(none)"}`,
+    `recursiveSearchDepth=${GEMINI_CLI_TREE_SEARCH_DEPTH}`,
+  ].join(" ");
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[] {
@@ -141,10 +215,16 @@ function findInPath(name: string): string | null {
 
 function readGeminiCliCredentialsFile(
   path: string,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   try {
-    return parseGeminiCliCredentials(credentialFs.readFileSync(path, "utf8"));
-  } catch {
+    const credentials = parseGeminiCliCredentials(credentialFs.readFileSync(path, "utf8"));
+    if (!credentials) {
+      diagnostics.parseFailures.push(path);
+    }
+    return credentials;
+  } catch (error) {
+    diagnostics.readErrors.push(`${path}: ${formatError(error)}`);
     return null;
   }
 }
@@ -166,6 +246,7 @@ function parseGeminiCliCredentials(
 
 function readGeminiCliCredentialsFromKnownPaths(
   geminiCliDir: string,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   const searchPaths = [
     join(
@@ -188,12 +269,13 @@ function readGeminiCliCredentialsFromKnownPaths(
       "oauth2.js",
     ),
   ];
+  diagnostics.searchedPaths.push(...searchPaths);
 
   for (const path of searchPaths) {
     if (!credentialFs.existsSync(path)) {
       continue;
     }
-    const credentials = readGeminiCliCredentialsFile(path);
+    const credentials = readGeminiCliCredentialsFile(path, diagnostics);
     if (credentials) {
       return credentials;
     }
@@ -204,6 +286,7 @@ function readGeminiCliCredentialsFromKnownPaths(
 
 function readGeminiCliCredentialsFromBundle(
   geminiCliDir: string,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   const bundleDir = join(geminiCliDir, "bundle");
   if (!credentialFs.existsSync(bundleDir)) {
@@ -215,12 +298,13 @@ function readGeminiCliCredentialsFromBundle(
       if (!entry.isFile() || !entry.name.endsWith(".js")) {
         continue;
       }
-      const credentials = readGeminiCliCredentialsFile(join(bundleDir, entry.name));
+      const credentials = readGeminiCliCredentialsFile(join(bundleDir, entry.name), diagnostics);
       if (credentials) {
         return credentials;
       }
     }
-  } catch {
+  } catch (error) {
+    diagnostics.readErrors.push(`${bundleDir}: ${formatError(error)}`);
     // Ignore bundle traversal failures and fall back to the recursive search.
   }
 
@@ -230,6 +314,7 @@ function readGeminiCliCredentialsFromBundle(
 function findGeminiCliCredentialsInTree(
   dir: string,
   depth: number,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   if (depth <= 0) {
     return null;
@@ -238,20 +323,22 @@ function findGeminiCliCredentialsInTree(
     for (const entry of credentialFs.readdirSync(dir, { withFileTypes: true })) {
       const path = join(dir, entry.name);
       if (entry.isFile() && entry.name === "oauth2.js") {
-        const credentials = readGeminiCliCredentialsFile(path);
+        const credentials = readGeminiCliCredentialsFile(path, diagnostics);
         if (credentials) {
           return credentials;
         }
         continue;
       }
       if (entry.isDirectory() && !entry.name.startsWith(".")) {
-        const found = findGeminiCliCredentialsInTree(path, depth - 1);
+        const found = findGeminiCliCredentialsInTree(path, depth - 1, diagnostics);
         if (found) {
           return found;
         }
       }
     }
-  } catch {}
+  } catch (error) {
+    diagnostics.readErrors.push(`${dir}: ${formatError(error)}`);
+  }
   return null;
 }
 
@@ -267,7 +354,10 @@ export function resolveOAuthClientConfig(): { clientId: string; clientSecret?: s
     return extracted;
   }
 
+  const detail = geminiCliCredentialExtractError
+    ? ` Details: ${geminiCliCredentialExtractError}`
+    : "";
   throw new Error(
-    "Gemini CLI not found. Install it first: brew install gemini-cli (or npm install -g @google/gemini-cli), or set GEMINI_CLI_OAUTH_CLIENT_ID.",
+    `Gemini CLI not found. Install it first: brew install gemini-cli (or npm install -g @google/gemini-cli), or set GEMINI_CLI_OAUTH_CLIENT_ID.${detail}`,
   );
 }

--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -305,7 +305,7 @@ function readGeminiCliCredentialsFromBundle(
     }
   } catch (error) {
     diagnostics.readErrors.push(`${bundleDir}: ${formatError(error)}`);
-    // Ignore bundle traversal failures and fall back to the recursive search.
+    // Preserve the read error for diagnostics and fall back to the recursive search.
   }
 
   return null;

--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -306,7 +306,7 @@ function readGeminiCliCredentialsFromBundle(
     }
   } catch (error) {
     diagnostics.readErrors.push(`${bundleDir}: ${formatError(error)}`);
-    // Ignore bundle traversal failures and fall back to the recursive search.
+    // Preserve the read error for diagnostics and fall back to the recursive search.
   }
 
   return null;

--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -23,6 +23,14 @@ const defaultFs: CredentialFs = {
 };
 
 let credentialFs: CredentialFs = defaultFs;
+const GEMINI_CLI_TREE_SEARCH_DEPTH = 10;
+
+type GeminiCliCredentialExtractDiagnostics = {
+  searchedPaths: string[];
+  recursiveSearchRoots: string[];
+  parseFailures: string[];
+  readErrors: string[];
+};
 
 function resolveEnv(keys: string[]): string | undefined {
   for (const key of keys) {
@@ -35,9 +43,11 @@ function resolveEnv(keys: string[]): string | undefined {
 }
 
 let cachedGeminiCliCredentials: { clientId: string; clientSecret: string } | null = null;
+let geminiCliCredentialExtractError: string | null = null;
 
 export function clearCredentialsCache(): void {
   cachedGeminiCliCredentials = null;
+  geminiCliCredentialExtractError = null;
 }
 
 export function setOAuthCredentialsFsForTest(overrides?: Partial<CredentialFs>): void {
@@ -49,9 +59,19 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
     return cachedGeminiCliCredentials;
   }
 
+  geminiCliCredentialExtractError = null;
+  const diagnostics: GeminiCliCredentialExtractDiagnostics = {
+    searchedPaths: [],
+    recursiveSearchRoots: [],
+    parseFailures: [],
+    readErrors: [],
+  };
+
   try {
     const geminiPath = findInPath("gemini");
     if (!geminiPath) {
+      geminiCliCredentialExtractError =
+        "Gemini CLI binary was not found in PATH during OAuth credential extraction.";
       return null;
     }
 
@@ -59,28 +79,82 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
     const geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
 
     for (const geminiCliDir of geminiCliDirs) {
-      const directCredentials = readGeminiCliCredentialsFromKnownPaths(geminiCliDir);
+      const directCredentials = readGeminiCliCredentialsFromKnownPaths(geminiCliDir, diagnostics);
       if (directCredentials) {
         cachedGeminiCliCredentials = directCredentials;
         return directCredentials;
       }
 
-      const bundledCredentials = readGeminiCliCredentialsFromBundle(geminiCliDir);
+      const bundledCredentials = readGeminiCliCredentialsFromBundle(geminiCliDir, diagnostics);
       if (bundledCredentials) {
         cachedGeminiCliCredentials = bundledCredentials;
         return bundledCredentials;
       }
 
-      const discoveredCredentials = findGeminiCliCredentialsInTree(geminiCliDir, 10);
+      diagnostics.recursiveSearchRoots.push(geminiCliDir);
+      const discoveredCredentials = findGeminiCliCredentialsInTree(
+        geminiCliDir,
+        GEMINI_CLI_TREE_SEARCH_DEPTH,
+        diagnostics,
+      );
       if (discoveredCredentials) {
         cachedGeminiCliCredentials = discoveredCredentials;
         return discoveredCredentials;
       }
     }
-  } catch {
-    // Gemini CLI not installed or extraction failed
+    geminiCliCredentialExtractError = formatGeminiCliCredentialExtractError({
+      geminiPath,
+      resolvedPath,
+      diagnostics,
+    });
+  } catch (error) {
+    geminiCliCredentialExtractError = `Unexpected error while extracting Gemini CLI OAuth credentials: ${formatError(error)}`;
   }
   return null;
+}
+
+function formatGeminiCliCredentialExtractError({
+  geminiPath,
+  resolvedPath,
+  diagnostics,
+}: {
+  geminiPath: string;
+  resolvedPath: string;
+  diagnostics: GeminiCliCredentialExtractDiagnostics;
+}): string {
+  const prefix = [
+    "Found Gemini CLI in PATH, but could not extract OAuth credentials.",
+    `geminiPath=${geminiPath}`,
+    `resolvedPath=${resolvedPath}`,
+  ];
+
+  if (diagnostics.parseFailures.length > 0) {
+    return [
+      ...prefix,
+      "Candidate credential files did not contain a parseable OAuth client id/secret.",
+      `candidates=${diagnostics.parseFailures.join(", ")}`,
+    ].join(" ");
+  }
+
+  if (diagnostics.readErrors.length > 0) {
+    return [
+      ...prefix,
+      "Unexpected errors occurred while reading candidate credential files/directories.",
+      `errors=${diagnostics.readErrors.join(", ")}`,
+    ].join(" ");
+  }
+
+  return [
+    ...prefix,
+    "Could not locate oauth2.js or bundled credential source.",
+    `searched=${diagnostics.searchedPaths.join(", ") || "(none)"}`,
+    `recursiveSearchRoots=${diagnostics.recursiveSearchRoots.join(", ") || "(none)"}`,
+    `recursiveSearchDepth=${GEMINI_CLI_TREE_SEARCH_DEPTH}`,
+  ].join(" ");
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[] {
@@ -142,10 +216,16 @@ function findInPath(name: string): string | null {
 
 function readGeminiCliCredentialsFile(
   path: string,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   try {
-    return parseGeminiCliCredentials(credentialFs.readFileSync(path, "utf8"));
-  } catch {
+    const credentials = parseGeminiCliCredentials(credentialFs.readFileSync(path, "utf8"));
+    if (!credentials) {
+      diagnostics.parseFailures.push(path);
+    }
+    return credentials;
+  } catch (error) {
+    diagnostics.readErrors.push(`${path}: ${formatError(error)}`);
     return null;
   }
 }
@@ -167,6 +247,7 @@ function parseGeminiCliCredentials(
 
 function readGeminiCliCredentialsFromKnownPaths(
   geminiCliDir: string,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   const searchPaths = [
     join(
@@ -189,12 +270,13 @@ function readGeminiCliCredentialsFromKnownPaths(
       "oauth2.js",
     ),
   ];
+  diagnostics.searchedPaths.push(...searchPaths);
 
   for (const path of searchPaths) {
     if (!credentialFs.existsSync(path)) {
       continue;
     }
-    const credentials = readGeminiCliCredentialsFile(path);
+    const credentials = readGeminiCliCredentialsFile(path, diagnostics);
     if (credentials) {
       return credentials;
     }
@@ -205,6 +287,7 @@ function readGeminiCliCredentialsFromKnownPaths(
 
 function readGeminiCliCredentialsFromBundle(
   geminiCliDir: string,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   const bundleDir = join(geminiCliDir, "bundle");
   if (!credentialFs.existsSync(bundleDir)) {
@@ -216,12 +299,13 @@ function readGeminiCliCredentialsFromBundle(
       if (!entry.isFile() || !entry.name.endsWith(".js")) {
         continue;
       }
-      const credentials = readGeminiCliCredentialsFile(join(bundleDir, entry.name));
+      const credentials = readGeminiCliCredentialsFile(join(bundleDir, entry.name), diagnostics);
       if (credentials) {
         return credentials;
       }
     }
-  } catch {
+  } catch (error) {
+    diagnostics.readErrors.push(`${bundleDir}: ${formatError(error)}`);
     // Ignore bundle traversal failures and fall back to the recursive search.
   }
 
@@ -231,6 +315,7 @@ function readGeminiCliCredentialsFromBundle(
 function findGeminiCliCredentialsInTree(
   dir: string,
   depth: number,
+  diagnostics: GeminiCliCredentialExtractDiagnostics,
 ): { clientId: string; clientSecret: string } | null {
   if (depth <= 0) {
     return null;
@@ -239,20 +324,22 @@ function findGeminiCliCredentialsInTree(
     for (const entry of credentialFs.readdirSync(dir, { withFileTypes: true })) {
       const path = join(dir, entry.name);
       if (entry.isFile() && entry.name === "oauth2.js") {
-        const credentials = readGeminiCliCredentialsFile(path);
+        const credentials = readGeminiCliCredentialsFile(path, diagnostics);
         if (credentials) {
           return credentials;
         }
         continue;
       }
       if (entry.isDirectory() && !entry.name.startsWith(".")) {
-        const found = findGeminiCliCredentialsInTree(path, depth - 1);
+        const found = findGeminiCliCredentialsInTree(path, depth - 1, diagnostics);
         if (found) {
           return found;
         }
       }
     }
-  } catch {}
+  } catch (error) {
+    diagnostics.readErrors.push(`${dir}: ${formatError(error)}`);
+  }
   return null;
 }
 
@@ -268,7 +355,10 @@ export function resolveOAuthClientConfig(): { clientId: string; clientSecret?: s
     return extracted;
   }
 
+  const detail = geminiCliCredentialExtractError
+    ? ` Details: ${geminiCliCredentialExtractError}`
+    : "";
   throw new Error(
-    "Gemini CLI not found. Install it first: brew install gemini-cli (or npm install -g @google/gemini-cli), or set GEMINI_CLI_OAUTH_CLIENT_ID.",
+    `Gemini CLI not found. Install it first: brew install gemini-cli (or npm install -g @google/gemini-cli), or set GEMINI_CLI_OAUTH_CLIENT_ID.${detail}`,
   );
 }

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -493,9 +493,6 @@ describe("extractGeminiCliCredentials", () => {
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
-<<<<<<< HEAD
-  it("extracts credentials from oauth2.js in known path", () => {
-=======
   it("includes missing binary details when resolving OAuth client config", async () => {
     process.env.PATH = "/nonexistent";
     mockExistsSync.mockReturnValue(false);
@@ -506,8 +503,7 @@ describe("extractGeminiCliCredentials", () => {
     );
   });
 
-  it("extracts credentials from oauth2.js in known path", async () => {
->>>>>>> 2d6bd0779e (Google: preserve Gemini CLI OAuth failure context)
+  it("extracts credentials from oauth2.js in known path", () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
     clearCredentialsCache();

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -142,6 +142,12 @@ describe("resolveGeminiCliSelectedAuthType", () => {
 });
 
 describe("extractGeminiCliCredentials", () => {
+  const ENV_KEYS = [
+    "OPENCLAW_GEMINI_OAUTH_CLIENT_ID",
+    "OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET",
+    "GEMINI_CLI_OAUTH_CLIENT_ID",
+    "GEMINI_CLI_OAUTH_CLIENT_SECRET",
+  ] as const;
   const normalizePath = (value: string) =>
     value.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
   const rootDir = parse(process.cwd()).root || "/";
@@ -153,7 +159,9 @@ describe("extractGeminiCliCredentials", () => {
   `;
 
   let originalPath: string | undefined;
+  let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
   let extractGeminiCliCredentials: typeof import("./oauth.credentials.js").extractGeminiCliCredentials;
+  let resolveOAuthClientConfig: typeof import("./oauth.credentials.js").resolveOAuthClientConfig;
   let clearCredentialsCache: typeof import("./oauth.credentials.js").clearCredentialsCache;
   let setOAuthCredentialsFsForTest: typeof import("./oauth.credentials.js").setOAuthCredentialsFsForTest;
 
@@ -446,18 +454,34 @@ describe("extractGeminiCliCredentials", () => {
   }
 
   beforeAll(async () => {
-    ({ extractGeminiCliCredentials, clearCredentialsCache, setOAuthCredentialsFsForTest } =
-      await import("./oauth.credentials.js"));
+    ({
+      extractGeminiCliCredentials,
+      resolveOAuthClientConfig,
+      clearCredentialsCache,
+      setOAuthCredentialsFsForTest,
+    } = await import("./oauth.credentials.js"));
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
     originalPath = process.env.PATH;
+    envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
     await installMockFs();
   });
 
   afterEach(async () => {
     process.env.PATH = originalPath;
+    for (const key of ENV_KEYS) {
+      const value = envSnapshot[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
     setOAuthCredentialsFsForTest();
   });
 
@@ -469,7 +493,21 @@ describe("extractGeminiCliCredentials", () => {
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
+<<<<<<< HEAD
   it("extracts credentials from oauth2.js in known path", () => {
+=======
+  it("includes missing binary details when resolving OAuth client config", async () => {
+    process.env.PATH = "/nonexistent";
+    mockExistsSync.mockReturnValue(false);
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(
+      /Details: Gemini CLI binary was not found in PATH/,
+    );
+  });
+
+  it("extracts credentials from oauth2.js in known path", async () => {
+>>>>>>> 2d6bd0779e (Google: preserve Gemini CLI OAuth failure context)
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
     clearCredentialsCache();
@@ -517,11 +555,45 @@ describe("extractGeminiCliCredentials", () => {
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
+  it("includes missing oauth2.js details when resolving OAuth client config", async () => {
+    installGeminiLayout({ oauth2Exists: false, readdir: [] });
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(/Could not locate oauth2\.js/);
+    expect(() => resolveOAuthClientConfig()).toThrow(/recursiveSearchDepth=10/);
+  });
+
   it("returns null when oauth2.js lacks credentials", () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: "// no credentials here" });
 
     clearCredentialsCache();
     expect(extractGeminiCliCredentials()).toBeNull();
+  });
+
+  it("includes parse failure details when resolving OAuth client config", async () => {
+    installGeminiLayout({
+      oauth2Exists: true,
+      oauth2Content: "// no credentials here",
+      readdir: [],
+    });
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(
+      /Candidate credential files did not contain a parseable OAuth client id\/secret/,
+    );
+  });
+
+  it("includes unexpected extraction exception details when resolving OAuth client config", async () => {
+    installGeminiLayout({ oauth2Exists: true, readdir: [] });
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("mock read failure");
+    });
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(
+      /Unexpected errors occurred while reading candidate credential files\/directories/,
+    );
+    expect(() => resolveOAuthClientConfig()).toThrow(/mock read failure/);
   });
 
   it("caches credentials after first extraction", () => {

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -492,9 +492,6 @@ describe("extractGeminiCliCredentials", () => {
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
-<<<<<<< HEAD
-  it("extracts credentials from oauth2.js in known path", () => {
-=======
   it("includes missing binary details when resolving OAuth client config", async () => {
     process.env.PATH = "/nonexistent";
     mockExistsSync.mockReturnValue(false);
@@ -505,8 +502,7 @@ describe("extractGeminiCliCredentials", () => {
     );
   });
 
-  it("extracts credentials from oauth2.js in known path", async () => {
->>>>>>> 2d6bd0779e (Google: preserve Gemini CLI OAuth failure context)
+  it("extracts credentials from oauth2.js in known path", () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
     clearCredentialsCache();

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -141,6 +141,12 @@ describe("resolveGeminiCliSelectedAuthType", () => {
 });
 
 describe("extractGeminiCliCredentials", () => {
+  const ENV_KEYS = [
+    "OPENCLAW_GEMINI_OAUTH_CLIENT_ID",
+    "OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET",
+    "GEMINI_CLI_OAUTH_CLIENT_ID",
+    "GEMINI_CLI_OAUTH_CLIENT_SECRET",
+  ] as const;
   const normalizePath = (value: string) =>
     value.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
   const rootDir = parse(process.cwd()).root || "/";
@@ -152,7 +158,9 @@ describe("extractGeminiCliCredentials", () => {
   `;
 
   let originalPath: string | undefined;
+  let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
   let extractGeminiCliCredentials: typeof import("./oauth.credentials.js").extractGeminiCliCredentials;
+  let resolveOAuthClientConfig: typeof import("./oauth.credentials.js").resolveOAuthClientConfig;
   let clearCredentialsCache: typeof import("./oauth.credentials.js").clearCredentialsCache;
   let setOAuthCredentialsFsForTest: typeof import("./oauth.credentials.js").setOAuthCredentialsFsForTest;
 
@@ -445,18 +453,34 @@ describe("extractGeminiCliCredentials", () => {
   }
 
   beforeAll(async () => {
-    ({ extractGeminiCliCredentials, clearCredentialsCache, setOAuthCredentialsFsForTest } =
-      await import("./oauth.credentials.js"));
+    ({
+      extractGeminiCliCredentials,
+      resolveOAuthClientConfig,
+      clearCredentialsCache,
+      setOAuthCredentialsFsForTest,
+    } = await import("./oauth.credentials.js"));
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
     originalPath = process.env.PATH;
+    envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
     await installMockFs();
   });
 
   afterEach(async () => {
     process.env.PATH = originalPath;
+    for (const key of ENV_KEYS) {
+      const value = envSnapshot[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
     setOAuthCredentialsFsForTest();
   });
 
@@ -468,7 +492,21 @@ describe("extractGeminiCliCredentials", () => {
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
+<<<<<<< HEAD
   it("extracts credentials from oauth2.js in known path", () => {
+=======
+  it("includes missing binary details when resolving OAuth client config", async () => {
+    process.env.PATH = "/nonexistent";
+    mockExistsSync.mockReturnValue(false);
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(
+      /Details: Gemini CLI binary was not found in PATH/,
+    );
+  });
+
+  it("extracts credentials from oauth2.js in known path", async () => {
+>>>>>>> 2d6bd0779e (Google: preserve Gemini CLI OAuth failure context)
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
     clearCredentialsCache();
@@ -516,11 +554,45 @@ describe("extractGeminiCliCredentials", () => {
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
+  it("includes missing oauth2.js details when resolving OAuth client config", async () => {
+    installGeminiLayout({ oauth2Exists: false, readdir: [] });
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(/Could not locate oauth2\.js/);
+    expect(() => resolveOAuthClientConfig()).toThrow(/recursiveSearchDepth=10/);
+  });
+
   it("returns null when oauth2.js lacks credentials", () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: "// no credentials here" });
 
     clearCredentialsCache();
     expect(extractGeminiCliCredentials()).toBeNull();
+  });
+
+  it("includes parse failure details when resolving OAuth client config", async () => {
+    installGeminiLayout({
+      oauth2Exists: true,
+      oauth2Content: "// no credentials here",
+      readdir: [],
+    });
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(
+      /Candidate credential files did not contain a parseable OAuth client id\/secret/,
+    );
+  });
+
+  it("includes unexpected extraction exception details when resolving OAuth client config", async () => {
+    installGeminiLayout({ oauth2Exists: true, readdir: [] });
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("mock read failure");
+    });
+
+    clearCredentialsCache();
+    expect(() => resolveOAuthClientConfig()).toThrow(
+      /Unexpected errors occurred while reading candidate credential files\/directories/,
+    );
+    expect(() => resolveOAuthClientConfig()).toThrow(/mock read failure/);
   });
 
   it("caches credentials after first extraction", () => {


### PR DESCRIPTION
## Summary

Improve Gemini CLI OAuth credential extraction diagnostics in the active bundled Google plugin.

This PR now targets `extensions/google/oauth.credentials.ts` instead of the removed legacy `extensions/google-gemini-cli-auth/oauth.ts` path.

## What changed

- Added extraction diagnostic state alongside the Gemini CLI credential cache.
- Preserved distinct failure details for:
  - Gemini CLI binary missing from `PATH`
  - missing `oauth2.js` or bundled credential source
  - candidate credential files that cannot be parsed for client id/secret
  - unexpected read/extraction exceptions
- Appended those details to the `resolveOAuthClientConfig()` setup error.
- Reset extraction diagnostic state from `clearCredentialsCache()`.
- Added focused regression coverage in `extensions/google/oauth.test.ts` around `resolveOAuthClientConfig()`.

## Why

Current `main` collapses multiple extraction failures into the same generic install-or-set-env-var message. That is misleading when Gemini CLI exists but OpenClaw cannot locate, read, or parse its OAuth client config source.

## Scope

Diagnostics-only. This does not change the automatic Gemini CLI credential extraction behavior.

#54289 may supersede this diagnostics-only fix if maintainers decide to remove or gate automatic Gemini CLI credential extraction.

## Validation

- `pnpm test -- extensions/google/oauth.test.ts`
- `pnpm check`
- `pnpm format:check extensions/google/oauth.credentials.ts extensions/google/oauth.test.ts`

## AI Assistance

- This PR is AI-assisted (OpenClaw + LLM coding assistant).

## Real behavior proof

Behavior or issue addressed: Gemini CLI OAuth setup failures should no longer collapse every automatic client-config extraction failure into only the generic install-or-set-env-var guidance; the setup error should include the concrete extraction reason.

Real environment tested: Windows 11 source checkout of this PR branch at `C:\Users\bgmbg\AppData\Local\Temp\openclaw-pr-41991-proof`, running Node.js v22.22.0 with tsx against the PR implementation.

Exact steps or command run after this patch:
- Checked out this PR branch in the Windows source checkout at `C:\Users\bgmbg\AppData\Local\Temp\openclaw-pr-41991-proof`.
- Installed dependencies for the source checkout and ran a live Node/tsx harness against `resolveOAuthClientConfig()`.
- Set `PATH` to `C:\definitely-not-a-real-gemini-path` to simulate an OpenClaw setup where the Gemini CLI binary is unavailable, then called the actual OAuth config resolver from `extensions/google/oauth.credentials.ts`.
- Command: `node --import tsx real-proof.mjs`

Evidence after fix:
```text
COMMAND: node --import tsx real-proof.mjs
CASE: missing Gemini CLI binary in PATH
OUTPUT:
Gemini CLI not found. Install it first: brew install gemini-cli (or npm install -g @google/gemini-cli), or set GEMINI_CLI_OAUTH_CLIENT_ID. Details: Gemini CLI binary was not found in PATH during OAuth credential extraction.
```

Observed result after fix:
The user-facing setup error now preserves the actionable extraction reason after the generic setup guidance: `Details: Gemini CLI binary was not found in PATH during OAuth credential extraction.`

What was not tested:
Full interactive browser OAuth login/token exchange was not exercised for this proof; this PR is limited to setup-error diagnostics when automatic Gemini CLI client-config discovery fails.


