### PR TITLE
CLI: stop Windows self-update file lock failures

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -491,6 +491,17 @@ describe("update-cli", () => {
     expect(jsonOutput).toBeDefined();
   });
 
+  it("uses daemon restart lifecycle in JSON mode when restart script is unavailable", async () => {
+    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+    serviceLoaded.mockResolvedValue(true);
+    prepareRestartScript.mockResolvedValue(null);
+
+    await updateCommand({ json: true });
+
+    expect(runDaemonRestart).toHaveBeenCalledWith({ json: true });
+    expect(serviceRestart).not.toHaveBeenCalled();
+  });
+
   it("updateCommand exits with error on failure", async () => {
     const mockResult: UpdateRunResult = {
       status: "error",
@@ -641,19 +652,14 @@ describe("update-cli", () => {
       await updateCommand({ json: true });
 
       expect(runDaemonStop).not.toHaveBeenCalled();
-      expect(runDaemonRestart).not.toHaveBeenCalled();
+      expect(runDaemonRestart).toHaveBeenCalledWith({ json: true });
       expect(serviceStop).toHaveBeenCalledWith(
         expect.objectContaining({
           env: process.env,
           stdout: expect.anything(),
         }),
       );
-      expect(serviceRestart).toHaveBeenCalledWith(
-        expect.objectContaining({
-          env: process.env,
-          stdout: expect.anything(),
-        }),
-      );
+      expect(serviceRestart).not.toHaveBeenCalled();
       expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -16,6 +16,7 @@ const serviceLoaded = vi.fn();
 const prepareRestartScript = vi.fn();
 const runRestartScript = vi.fn();
 const mockedRunDaemonInstall = vi.fn();
+const mockedRunDaemonStop = vi.fn();
 const serviceReadRuntime = vi.fn();
 const inspectPortUsage = vi.fn();
 const classifyPortListener = vi.fn();
@@ -123,6 +124,7 @@ vi.mock("../commands/doctor.js", () => ({
 // Mock the daemon-cli module
 vi.mock("./daemon-cli.js", () => ({
   runDaemonInstall: mockedRunDaemonInstall,
+  runDaemonStop: mockedRunDaemonStop,
   runDaemonRestart: vi.fn(),
 }));
 
@@ -141,7 +143,7 @@ const { readConfigFileSnapshot, writeConfigFile } = await import("../config/conf
 const { checkUpdateStatus, fetchNpmTagVersion, resolveNpmChannelTag } =
   await import("../infra/update-check.js");
 const { runCommandWithTimeout } = await import("../process/exec.js");
-const { runDaemonRestart, runDaemonInstall } = await import("./daemon-cli.js");
+const { runDaemonRestart, runDaemonInstall, runDaemonStop } = await import("./daemon-cli.js");
 const { doctorCommand } = await import("../commands/doctor.js");
 const { defaultRuntime } = await import("../runtime.js");
 const { updateCommand, updateStatusCommand, updateWizardCommand } = await import("./update-cli.js");
@@ -337,6 +339,7 @@ describe("update-cli", () => {
       outcomes: [],
     });
     vi.mocked(runDaemonInstall).mockResolvedValue(undefined);
+    vi.mocked(runDaemonStop).mockResolvedValue(undefined);
     vi.mocked(runDaemonRestart).mockResolvedValue(true);
     vi.mocked(doctorCommand).mockResolvedValue(undefined);
     confirm.mockResolvedValue(false);
@@ -497,6 +500,62 @@ describe("update-cli", () => {
     await updateCommand({});
 
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("stops loaded service before package updates on Windows", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      mockPackageInstallStatus(tempDir);
+      serviceLoaded.mockResolvedValue(true);
+      vi.mocked(runGatewayUpdate).mockResolvedValue(
+        makeOkUpdateResult({
+          mode: "npm",
+        }),
+      );
+
+      await updateCommand({});
+
+      expect(runDaemonStop).toHaveBeenCalledWith({
+        json: undefined,
+      });
+      const stopOrder = vi.mocked(runDaemonStop).mock.invocationCallOrder[0];
+      const updateOrder = vi.mocked(runGatewayUpdate).mock.invocationCallOrder[0];
+      expect(stopOrder).toBeLessThan(updateOrder);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("tries to restore service after a failed Windows package update", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      mockPackageInstallStatus(tempDir);
+      serviceLoaded.mockResolvedValue(true);
+      prepareRestartScript.mockResolvedValue(null);
+      vi.mocked(runGatewayUpdate).mockResolvedValue({
+        status: "error",
+        mode: "npm",
+        reason: "global update",
+        steps: [],
+        durationMs: 100,
+      });
+
+      await updateCommand({});
+
+      expect(runDaemonStop).toHaveBeenCalledWith({
+        json: undefined,
+      });
+      expect(runDaemonRestart).toHaveBeenCalled();
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
   });
 
   it("updateCommand refreshes gateway service env when service is already installed", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -13,6 +13,8 @@ const readPackageName = vi.fn();
 const readPackageVersion = vi.fn();
 const resolveGlobalManager = vi.fn();
 const serviceLoaded = vi.fn();
+const serviceStop = vi.fn();
+const serviceRestart = vi.fn();
 const prepareRestartScript = vi.fn();
 const runRestartScript = vi.fn();
 const mockedRunDaemonInstall = vi.fn();
@@ -102,6 +104,8 @@ vi.mock("./update-cli/shared.js", async (importOriginal) => {
 vi.mock("../daemon/service.js", () => ({
   resolveGatewayService: vi.fn(() => ({
     isLoaded: (...args: unknown[]) => serviceLoaded(...args),
+    stop: (...args: unknown[]) => serviceStop(...args),
+    restart: (...args: unknown[]) => serviceRestart(...args),
     readRuntime: (...args: unknown[]) => serviceReadRuntime(...args),
   })),
 }));
@@ -307,6 +311,8 @@ describe("update-cli", () => {
     readPackageVersion.mockResolvedValue("1.0.0");
     resolveGlobalManager.mockResolvedValue("npm");
     serviceLoaded.mockResolvedValue(false);
+    serviceStop.mockResolvedValue(undefined);
+    serviceRestart.mockResolvedValue(undefined);
     serviceReadRuntime.mockResolvedValue({
       status: "running",
       pid: 4242,
@@ -545,9 +551,13 @@ describe("update-cli", () => {
 
       await updateCommand({ json: true });
 
-      expect(runDaemonStop).toHaveBeenCalledWith({
-        json: undefined,
-      });
+      expect(runDaemonStop).not.toHaveBeenCalled();
+      expect(serviceStop).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: process.env,
+          stdout: expect.anything(),
+        }),
+      );
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     }
@@ -606,6 +616,45 @@ describe("update-cli", () => {
       });
       expect(runDaemonRestart).toHaveBeenCalled();
       expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("restores service silently in JSON mode after a failed Windows package update", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      mockPackageInstallStatus(tempDir);
+      serviceLoaded.mockResolvedValue(true);
+      prepareRestartScript.mockResolvedValue(null);
+      vi.mocked(runGatewayUpdate).mockResolvedValue({
+        status: "error",
+        mode: "npm",
+        reason: "global update",
+        steps: [],
+        durationMs: 100,
+      });
+
+      await updateCommand({ json: true });
+
+      expect(runDaemonStop).not.toHaveBeenCalled();
+      expect(runDaemonRestart).not.toHaveBeenCalled();
+      expect(serviceStop).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: process.env,
+          stdout: expect.anything(),
+        }),
+      );
+      expect(serviceRestart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: process.env,
+          stdout: expect.anything(),
+        }),
+      );
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     }

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -529,6 +529,30 @@ describe("update-cli", () => {
     }
   });
 
+  it("does not forward update --json mode into daemon stop output", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      mockPackageInstallStatus(tempDir);
+      serviceLoaded.mockResolvedValue(true);
+      vi.mocked(runGatewayUpdate).mockResolvedValue(
+        makeOkUpdateResult({
+          mode: "npm",
+        }),
+      );
+
+      await updateCommand({ json: true });
+
+      expect(runDaemonStop).toHaveBeenCalledWith({
+        json: undefined,
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
   it("tries to restore service after a failed Windows package update", async () => {
     const tempDir = createCaseDir("openclaw-update");
     const originalPlatform = process.platform;
@@ -553,6 +577,62 @@ describe("update-cli", () => {
       });
       expect(runDaemonRestart).toHaveBeenCalled();
       expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("tries to restore service after a skipped Windows package update", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      mockPackageInstallStatus(tempDir);
+      serviceLoaded.mockResolvedValue(true);
+      prepareRestartScript.mockResolvedValue(null);
+      vi.mocked(runGatewayUpdate).mockResolvedValue({
+        status: "skipped",
+        mode: "npm",
+        reason: "not-git-install",
+        steps: [],
+        durationMs: 100,
+      });
+
+      await updateCommand({});
+
+      expect(runDaemonStop).toHaveBeenCalledWith({
+        json: undefined,
+      });
+      expect(runDaemonRestart).toHaveBeenCalled();
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("tries to restore service when post-update steps throw after Windows package update", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      mockPackageInstallStatus(tempDir);
+      serviceLoaded.mockResolvedValue(true);
+      prepareRestartScript.mockResolvedValue(null);
+      vi.mocked(runGatewayUpdate).mockResolvedValue(
+        makeOkUpdateResult({
+          mode: "npm",
+        }),
+      );
+      syncPluginsForUpdateChannel.mockRejectedValueOnce(new Error("plugin sync failed"));
+
+      await expect(updateCommand({})).rejects.toThrow("plugin sync failed");
+
+      expect(runDaemonStop).toHaveBeenCalledWith({
+        json: undefined,
+      });
+      expect(runDaemonRestart).toHaveBeenCalled();
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     }

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -76,6 +76,7 @@ describe("restart-helper", () => {
       expect(content).toContain("systemctl --user restart 'openclaw-gateway.service'");
       // Script should self-cleanup
       expect(content).toContain('rm -f "$0"');
+      expect(content).toContain('rmdir "$(dirname "$0")" 2>/dev/null || true');
       await cleanupScript(scriptPath);
     });
 
@@ -130,6 +131,7 @@ describe("restart-helper", () => {
       expectWindowsRestartWaitOrdering(content);
       // Batch self-cleanup
       expect(content).toContain('del "%~f0"');
+      expect(content).toContain('rmdir "%~dp0" 2>nul');
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { prepareRestartScript, runRestartScript } from "./restart-helper.js";
 
@@ -19,7 +20,7 @@ describe("restart-helper", () => {
   }
 
   async function cleanupScript(scriptPath: string) {
-    await fs.unlink(scriptPath);
+    await fs.rm(path.dirname(scriptPath), { recursive: true, force: true });
   }
 
   function expectWindowsRestartWaitOrdering(content: string, port = 18789) {
@@ -202,8 +203,8 @@ describe("restart-helper", () => {
 
     it("returns null when script creation fails", async () => {
       Object.defineProperty(process, "platform", { value: "linux" });
-      const writeFileSpy = vi
-        .spyOn(fs, "writeFile")
+      const mkdtempSpy = vi
+        .spyOn(fs, "mkdtemp")
         .mockRejectedValueOnce(new Error("simulated write failure"));
 
       const scriptPath = await prepareRestartScript({
@@ -211,7 +212,7 @@ describe("restart-helper", () => {
       });
 
       expect(scriptPath).toBeNull();
-      writeFileSpy.mockRestore();
+      mkdtempSpy.mockRestore();
     });
 
     it("escapes single quotes in profile names for shell scripts", async () => {

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -76,6 +76,7 @@ sleep 1
 systemctl --user restart '${escaped}'
 # Self-cleanup
 rm -f "$0"
+rmdir "$(dirname "$0")" 2>/dev/null || true
 `;
     } else if (platform === "darwin") {
       const label = resolveLaunchdLabel(env);
@@ -100,6 +101,7 @@ if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
 fi
 # Self-cleanup
 rm -f "$0"
+rmdir "$(dirname "$0")" 2>/dev/null || true
 `;
     } else if (platform === "win32") {
       const taskName = resolveWindowsTaskName(env);
@@ -132,6 +134,7 @@ for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":${port} .*LISTENING"'
 schtasks /Run /TN "${taskName}"
 REM Self-cleanup
 del "%~f0"
+rmdir "%~dp0" 2>nul
 `;
     } else {
       return null;

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -59,18 +59,16 @@ export async function prepareRestartScript(
   env: NodeJS.ProcessEnv = process.env,
   gatewayPort: number = DEFAULT_GATEWAY_PORT,
 ): Promise<string | null> {
-  const tmpDir = os.tmpdir();
-  const timestamp = Date.now();
   const platform = process.platform;
 
   let scriptContent = "";
-  let filename = "";
+  let scriptFilename = "";
 
   try {
     if (platform === "linux") {
       const unitName = resolveSystemdUnit(env);
       const escaped = shellEscape(unitName);
-      filename = `openclaw-restart-${timestamp}.sh`;
+      scriptFilename = "restart.sh";
       scriptContent = `#!/bin/sh
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
@@ -89,7 +87,7 @@ rm -f "$0"
       const home = env.HOME?.trim() || process.env.HOME || os.homedir();
       const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
       const escapedPlistPath = shellEscape(plistPath);
-      filename = `openclaw-restart-${timestamp}.sh`;
+      scriptFilename = "restart.sh";
       scriptContent = `#!/bin/sh
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
@@ -110,7 +108,7 @@ rm -f "$0"
       }
       const port =
         Number.isFinite(gatewayPort) && gatewayPort > 0 ? gatewayPort : DEFAULT_GATEWAY_PORT;
-      filename = `openclaw-restart-${timestamp}.bat`;
+      scriptFilename = "restart.bat";
       scriptContent = `@echo off
 REM Standalone restart script — survives parent process termination.
 REM Wait briefly to ensure file locks are released after update.
@@ -139,8 +137,15 @@ del "%~f0"
       return null;
     }
 
-    const scriptPath = path.join(tmpDir, filename);
-    await fs.writeFile(scriptPath, scriptContent, { mode: 0o755 });
+    const scriptDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-"));
+    await fs.chmod(scriptDir, 0o700).catch(() => undefined);
+    const scriptPath = path.join(scriptDir, scriptFilename);
+    const scriptFile = await fs.open(scriptPath, "wx", 0o700);
+    try {
+      await scriptFile.writeFile(scriptContent, "utf-8");
+    } finally {
+      await scriptFile.close();
+    }
     return scriptPath;
   } catch {
     // If we can't write the script, we'll fall back to the standard restart method

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -544,15 +544,7 @@ async function maybeRestartService(params: {
         await runRestartScript(params.restartScriptPath);
         restartInitiated = true;
       } else {
-        if (params.opts.json) {
-          await resolveGatewayService().restart({
-            env: process.env,
-            stdout: createNullWriter(),
-          });
-          restarted = true;
-        } else {
-          restarted = await runDaemonRestart();
-        }
+        restarted = await runDaemonRestart({ json: params.opts.json || undefined });
       }
 
       if (!params.opts.json && restarted) {
@@ -659,14 +651,7 @@ async function restoreServiceAfterStoppedWindowsPackageUpdate(params: {
     if (params.restartScriptPath) {
       await runRestartScript(params.restartScriptPath);
     } else {
-      if (params.opts.json) {
-        await resolveGatewayService().restart({
-          env: process.env,
-          stdout: createNullWriter(),
-        });
-      } else {
-        await runDaemonRestart();
-      }
+      await runDaemonRestart({ json: params.opts.json || undefined });
     }
   } catch (err) {
     if (!params.opts.json) {
@@ -878,6 +863,10 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   let serviceStoppedForWindowsPackageUpdate = false;
   let updateResult: UpdateRunResult | null = null;
   let completedSuccessfully = false;
+  let deferredExitCode: number | null = null;
+  const deferExitUntilCleanup = (code: number) => {
+    deferredExitCode = code;
+  };
   const gatewayPort = resolveGatewayPort(
     configSnapshot.valid ? configSnapshot.config : undefined,
     process.env,
@@ -912,7 +901,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
                   `Run \`${replaceCliName(formatCliCommand("openclaw gateway stop"), CLI_NAME)}\` and retry.`,
                 ].join("\n"),
               );
-              defaultRuntime.exit(1);
+              deferExitUntilCleanup(1);
               return;
             }
           }
@@ -949,7 +938,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     printResult(updateResult, { ...opts, hideSteps: showProgress });
 
     if (updateResult.status === "error") {
-      defaultRuntime.exit(1);
+      deferExitUntilCleanup(1);
       return;
     }
 
@@ -975,7 +964,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
           );
         }
       }
-      defaultRuntime.exit(0);
+      deferExitUntilCleanup(0);
       return;
     }
 
@@ -1015,5 +1004,8 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       opts,
       restartScriptPath,
     });
+    if (deferredExitCode !== null) {
+      defaultRuntime.exit(deferredExitCode);
+    }
   }
 }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -38,7 +38,7 @@ import { pathExists } from "../../utils.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { installCompletion } from "../completion-cli.js";
-import { runDaemonInstall, runDaemonRestart } from "../daemon-cli.js";
+import { runDaemonInstall, runDaemonRestart, runDaemonStop } from "../daemon-cli.js";
 import {
   renderRestartDiagnostics,
   terminateStaleGatewayPids,
@@ -819,6 +819,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
 
   let restartScriptPath: string | null = null;
   let refreshGatewayServiceEnv = false;
+  let serviceStoppedForWindowsPackageUpdate = false;
   const gatewayPort = resolveGatewayPort(
     configSnapshot.valid ? configSnapshot.config : undefined,
     process.env,
@@ -829,6 +830,26 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       if (loaded) {
         restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
         refreshGatewayServiceEnv = true;
+        if (process.platform === "win32" && updateInstallKind === "package") {
+          if (!opts.json) {
+            defaultRuntime.log(
+              theme.muted("Stopping service before package update to release file locks..."),
+            );
+          }
+          try {
+            await runDaemonStop({ json: opts.json || undefined });
+            serviceStoppedForWindowsPackageUpdate = true;
+          } catch (err) {
+            defaultRuntime.error(
+              [
+                `Failed to stop gateway before update: ${String(err)}`,
+                `Run \`${replaceCliName(formatCliCommand("openclaw gateway stop"), CLI_NAME)}\` and retry.`,
+              ].join("\n"),
+            );
+            defaultRuntime.exit(1);
+            return;
+          }
+        }
       }
     } catch {
       // Ignore errors during pre-check; fallback to standard restart
@@ -862,6 +883,24 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   printResult(result, { ...opts, hideSteps: showProgress });
 
   if (result.status === "error") {
+    if (serviceStoppedForWindowsPackageUpdate && shouldRestart) {
+      if (!opts.json) {
+        defaultRuntime.log(
+          theme.warn("Update failed after stopping the service. Attempting to restore it..."),
+        );
+      }
+      try {
+        if (restartScriptPath) {
+          await runRestartScript(restartScriptPath);
+        } else {
+          await runDaemonRestart();
+        }
+      } catch (err) {
+        if (!opts.json) {
+          defaultRuntime.log(theme.warn(`Failed to restore service automatically: ${String(err)}`));
+        }
+      }
+    }
     defaultRuntime.exit(1);
     return;
   }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -627,6 +627,34 @@ async function maybeRestartService(params: {
   }
 }
 
+async function restoreServiceAfterStoppedWindowsPackageUpdate(params: {
+  shouldRestore: boolean;
+  opts: UpdateCommandOptions;
+  restartScriptPath: string | null;
+}): Promise<void> {
+  if (!params.shouldRestore) {
+    return;
+  }
+
+  if (!params.opts.json) {
+    defaultRuntime.log(
+      theme.warn("Update exited after stopping the service. Attempting to restore it..."),
+    );
+  }
+
+  try {
+    if (params.restartScriptPath) {
+      await runRestartScript(params.restartScriptPath);
+    } else {
+      await runDaemonRestart();
+    }
+  } catch (err) {
+    if (!params.opts.json) {
+      defaultRuntime.log(theme.warn(`Failed to restore service automatically: ${String(err)}`));
+    }
+  }
+}
+
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
 
@@ -816,142 +844,150 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
 
   const { progress, stop } = createUpdateProgress(showProgress);
   const startedAt = Date.now();
+  let progressStopped = false;
+  const stopProgress = () => {
+    if (progressStopped) {
+      return;
+    }
+    stop();
+    progressStopped = true;
+  };
 
   let restartScriptPath: string | null = null;
   let refreshGatewayServiceEnv = false;
   let serviceStoppedForWindowsPackageUpdate = false;
+  let updateResult: UpdateRunResult | null = null;
+  let completedSuccessfully = false;
   const gatewayPort = resolveGatewayPort(
     configSnapshot.valid ? configSnapshot.config : undefined,
     process.env,
   );
-  if (shouldRestart) {
-    try {
-      const loaded = await resolveGatewayService().isLoaded({ env: process.env });
-      if (loaded) {
-        restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
-        refreshGatewayServiceEnv = true;
-        if (process.platform === "win32" && updateInstallKind === "package") {
-          if (!opts.json) {
-            defaultRuntime.log(
-              theme.muted("Stopping service before package update to release file locks..."),
-            );
-          }
-          try {
-            await runDaemonStop({ json: opts.json || undefined });
-            serviceStoppedForWindowsPackageUpdate = true;
-          } catch (err) {
-            defaultRuntime.error(
-              [
-                `Failed to stop gateway before update: ${String(err)}`,
-                `Run \`${replaceCliName(formatCliCommand("openclaw gateway stop"), CLI_NAME)}\` and retry.`,
-              ].join("\n"),
-            );
-            defaultRuntime.exit(1);
-            return;
-          }
-        }
-      }
-    } catch {
-      // Ignore errors during pre-check; fallback to standard restart
-    }
-  }
-
-  const result = switchToPackage
-    ? await runPackageInstallUpdate({
-        root,
-        installKind,
-        tag,
-        timeoutMs: timeoutMs ?? 20 * 60_000,
-        startedAt,
-        progress,
-      })
-    : await runGitUpdate({
-        root,
-        switchToGit,
-        installKind,
-        timeoutMs,
-        startedAt,
-        progress,
-        channel,
-        tag,
-        showProgress,
-        opts,
-        stop,
-      });
-
-  stop();
-  printResult(result, { ...opts, hideSteps: showProgress });
-
-  if (result.status === "error") {
-    if (serviceStoppedForWindowsPackageUpdate && shouldRestart) {
-      if (!opts.json) {
-        defaultRuntime.log(
-          theme.warn("Update failed after stopping the service. Attempting to restore it..."),
-        );
-      }
+  try {
+    if (shouldRestart) {
       try {
-        if (restartScriptPath) {
-          await runRestartScript(restartScriptPath);
-        } else {
-          await runDaemonRestart();
+        const loaded = await resolveGatewayService().isLoaded({ env: process.env });
+        if (loaded) {
+          restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
+          refreshGatewayServiceEnv = true;
+          if (process.platform === "win32" && updateInstallKind === "package") {
+            if (!opts.json) {
+              defaultRuntime.log(
+                theme.muted("Stopping service before package update to release file locks..."),
+              );
+            }
+            try {
+              // Keep `update --json` output as a single JSON payload.
+              await runDaemonStop({ json: undefined });
+              serviceStoppedForWindowsPackageUpdate = true;
+            } catch (err) {
+              defaultRuntime.error(
+                [
+                  `Failed to stop gateway before update: ${String(err)}`,
+                  `Run \`${replaceCliName(formatCliCommand("openclaw gateway stop"), CLI_NAME)}\` and retry.`,
+                ].join("\n"),
+              );
+              defaultRuntime.exit(1);
+              return;
+            }
+          }
         }
-      } catch (err) {
-        if (!opts.json) {
-          defaultRuntime.log(theme.warn(`Failed to restore service automatically: ${String(err)}`));
-        }
+      } catch {
+        // Ignore errors during pre-check; fallback to standard restart
       }
     }
-    defaultRuntime.exit(1);
-    return;
-  }
 
-  if (result.status === "skipped") {
-    if (result.reason === "dirty") {
-      defaultRuntime.log(
-        theme.warn(
-          "Skipped: working directory has uncommitted changes. Commit or stash them first.",
-        ),
-      );
+    updateResult = switchToPackage
+      ? await runPackageInstallUpdate({
+          root,
+          installKind,
+          tag,
+          timeoutMs: timeoutMs ?? 20 * 60_000,
+          startedAt,
+          progress,
+        })
+      : await runGitUpdate({
+          root,
+          switchToGit,
+          installKind,
+          timeoutMs,
+          startedAt,
+          progress,
+          channel,
+          tag,
+          showProgress,
+          opts,
+          stop: stopProgress,
+        });
+
+    stopProgress();
+    printResult(updateResult, { ...opts, hideSteps: showProgress });
+
+    if (updateResult.status === "error") {
+      defaultRuntime.exit(1);
+      return;
     }
-    if (result.reason === "not-git-install") {
-      defaultRuntime.log(
-        theme.warn(
-          `Skipped: this OpenClaw install isn't a git checkout, and the package manager couldn't be detected. Update via your package manager, then run \`${replaceCliName(formatCliCommand("openclaw doctor"), CLI_NAME)}\` and \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\`.`,
-        ),
-      );
-      defaultRuntime.log(
-        theme.muted(
-          `Examples: \`${replaceCliName("npm i -g openclaw@latest", CLI_NAME)}\` or \`${replaceCliName("pnpm add -g openclaw@latest", CLI_NAME)}\``,
-        ),
-      );
+
+    if (updateResult.status === "skipped") {
+      if (!opts.json) {
+        if (updateResult.reason === "dirty") {
+          defaultRuntime.log(
+            theme.warn(
+              "Skipped: working directory has uncommitted changes. Commit or stash them first.",
+            ),
+          );
+        }
+        if (updateResult.reason === "not-git-install") {
+          defaultRuntime.log(
+            theme.warn(
+              `Skipped: this OpenClaw install isn't a git checkout, and the package manager couldn't be detected. Update via your package manager, then run \`${replaceCliName(formatCliCommand("openclaw doctor"), CLI_NAME)}\` and \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\`.`,
+            ),
+          );
+          defaultRuntime.log(
+            theme.muted(
+              `Examples: \`${replaceCliName("npm i -g openclaw@latest", CLI_NAME)}\` or \`${replaceCliName("pnpm add -g openclaw@latest", CLI_NAME)}\``,
+            ),
+          );
+        }
+      }
+      defaultRuntime.exit(0);
+      return;
     }
-    defaultRuntime.exit(0);
-    return;
-  }
 
-  await updatePluginsAfterCoreUpdate({
-    root,
-    channel,
-    configSnapshot,
-    opts,
-  });
+    await updatePluginsAfterCoreUpdate({
+      root,
+      channel,
+      configSnapshot,
+      opts,
+    });
 
-  await tryWriteCompletionCache(root, Boolean(opts.json));
-  await tryInstallShellCompletion({
-    jsonMode: Boolean(opts.json),
-    skipPrompt: Boolean(opts.yes),
-  });
+    await tryWriteCompletionCache(root, Boolean(opts.json));
+    await tryInstallShellCompletion({
+      jsonMode: Boolean(opts.json),
+      skipPrompt: Boolean(opts.yes),
+    });
 
-  await maybeRestartService({
-    shouldRestart,
-    result,
-    opts,
-    refreshServiceEnv: refreshGatewayServiceEnv,
-    gatewayPort,
-    restartScriptPath,
-  });
+    await maybeRestartService({
+      shouldRestart,
+      result: updateResult,
+      opts,
+      refreshServiceEnv: refreshGatewayServiceEnv,
+      gatewayPort,
+      restartScriptPath,
+    });
+    completedSuccessfully = true;
 
-  if (!opts.json) {
-    defaultRuntime.log(theme.muted(pickUpdateQuip()));
+    if (!opts.json) {
+      defaultRuntime.log(theme.muted(pickUpdateQuip()));
+    }
+  } finally {
+    stopProgress();
+    await restoreServiceAfterStoppedWindowsPackageUpdate({
+      shouldRestore:
+        serviceStoppedForWindowsPackageUpdate &&
+        shouldRestart &&
+        (!completedSuccessfully || (updateResult !== null && updateResult.status !== "ok")),
+      opts,
+      restartScriptPath,
+    });
   }
 }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -39,6 +39,7 @@ import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { installCompletion } from "../completion-cli.js";
 import { runDaemonInstall, runDaemonRestart, runDaemonStop } from "../daemon-cli.js";
+import { createNullWriter } from "../daemon-cli/response.js";
 import {
   renderRestartDiagnostics,
   terminateStaleGatewayPids,
@@ -198,6 +199,10 @@ async function refreshGatewayServiceEnv(params: {
     );
   }
 
+  // Avoid emitting extra daemon output in `update --json` mode.
+  if (params.jsonMode) {
+    return;
+  }
   await runDaemonInstall({ force: true, json: params.jsonMode || undefined });
 }
 
@@ -539,7 +544,15 @@ async function maybeRestartService(params: {
         await runRestartScript(params.restartScriptPath);
         restartInitiated = true;
       } else {
-        restarted = await runDaemonRestart();
+        if (params.opts.json) {
+          await resolveGatewayService().restart({
+            env: process.env,
+            stdout: createNullWriter(),
+          });
+          restarted = true;
+        } else {
+          restarted = await runDaemonRestart();
+        }
       }
 
       if (!params.opts.json && restarted) {
@@ -646,7 +659,14 @@ async function restoreServiceAfterStoppedWindowsPackageUpdate(params: {
     if (params.restartScriptPath) {
       await runRestartScript(params.restartScriptPath);
     } else {
-      await runDaemonRestart();
+      if (params.opts.json) {
+        await resolveGatewayService().restart({
+          env: process.env,
+          stdout: createNullWriter(),
+        });
+      } else {
+        await runDaemonRestart();
+      }
     }
   } catch (err) {
     if (!params.opts.json) {
@@ -876,8 +896,14 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
               );
             }
             try {
-              // Keep `update --json` output as a single JSON payload.
-              await runDaemonStop({ json: undefined });
+              if (opts.json) {
+                await resolveGatewayService().stop({
+                  env: process.env,
+                  stdout: createNullWriter(),
+                });
+              } else {
+                await runDaemonStop({ json: undefined });
+              }
               serviceStoppedForWindowsPackageUpdate = true;
             } catch (err) {
               defaultRuntime.error(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: On Windows global installs, `openclaw update` could fail with `npm ERR! EBUSY ... rename ...\\openclaw -> ...\\.openclaw-*` when the gateway service was loaded.
- Why it matters: The updater reports failure and leaves users stuck on old versions for a common default flow.
- What changed: In `openclaw update`, when running a package-manager update on Windows and the gateway service is loaded, we now stop the service first to release file locks, then proceed with update.
- What changed: If that update still fails after the pre-stop, we now attempt a best-effort service restore before exiting.
- What did NOT change (scope boundary): No git-update flow changes, no channel/tag logic changes, no daemon lifecycle behavior changes outside this update path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41773
- Related #

## User-visible / Behavior Changes

- On Windows package installs with a loaded gateway service, `openclaw update` now stops the service before global package update to avoid npm `EBUSY` rename lock failures.
- If update fails after that pre-stop, OpenClaw attempts to bring the service back up automatically.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (unit-test validation); issue repro context is Windows 11
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default update flow

### Steps

1. Simulate package install update path with loaded service in `src/cli/update-cli.test.ts`.
2. Force `process.platform = "win32"` and run `updateCommand({})`.
3. Verify daemon stop is called before updater execution, and verify failed update triggers restore attempt.

### Expected

- Service is stopped before package update on Windows.
- Failed update after pre-stop attempts service restore before exit.

### Actual

- Both behaviors are covered and passing in unit tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before (from issue screenshot):
- `npm ERR! code EBUSY`
- `npm ERR! syscall rename`
- `npm ERR! ...\\openclaw -> ...\\.openclaw-*`

Validation run:
- `pnpm test src/cli/update-cli.test.ts`
  - Result: `✓ src/cli/update-cli.test.ts (28 tests)`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Windows package-update code path now performs pre-stop and preserves ordering (stop before update call).
- Edge cases checked: Failed update after pre-stop triggers best-effort restore path.
- What you did **not** verify: Live manual run on a real Windows host with active `schtasks` service.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/cli/update-cli/update-command.ts`
- Known bad symptoms reviewers should watch for: Update command unexpectedly stopping service in non-Windows or git-update flows (should not happen).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Service stop may fail on some Windows environments, preventing update.
  - Mitigation: Clear error output now guides manual `openclaw gateway stop` + retry; flow exits before running a likely-failing update.
- Risk: Update failure after pre-stop could leave service down.
  - Mitigation: Added best-effort automatic restore attempt before exit.
