### PR TITLE
feat(feishu): add mentionTriggers support for text-based keyword triggers in groups

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1050,7 +1050,11 @@ export async function handleFeishuMessage(params: {
       groupConfig,
     }));
 
-    if (requireMention && !ctx.mentionedBot) {
+    const mentionTriggers = feishuCfg?.mentionTriggers ?? [];
+    const triggeredByKeyword =
+      mentionTriggers.length > 0 &&
+      mentionTriggers.some((t) => t !== "@_bot_" && ctx.content.includes(t));
+    if (requireMention && !ctx.mentionedBot && !triggeredByKeyword) {
       log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
       // Record to pending history for non-broadcast groups only. For broadcast groups,
       // the mentioned handler's broadcast dispatch writes the turn directly into all

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -157,6 +157,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  mentionTriggers: z.array(z.string()).optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary

Add `mentionTriggers` config field to the Feishu channel, allowing the bot to respond to group messages containing specified keywords (e.g. `小七`) in addition to `@mentions`.

Previously, `requireMention: true` only checked for actual Feishu `@mentions` via the mentions API. Text-based trigger words in `mentionTriggers` were silently ignored because the field was not in the schema and had no implementation.

## Changes

- `extensions/feishu/src/config-schema.ts`: Add `mentionTriggers: z.array(z.string()).optional()` to `FeishuSharedConfigShape`
- `extensions/feishu/src/bot.ts`: When `requireMention` is true, also check if message content contains any configured trigger keyword (skipping `@_bot_` which is already handled by `checkBotMentioned()`)

## Config example

```json
"channels": {
  "feishu": {
    "requireMention": true,
    "mentionTriggers": ["@_bot_", "小七"]
  }
}
```

With this config, the bot responds to `@mentions` **and** messages containing `小七`, while ignoring all other group messages.