### PR TITLE
Memory: add session sync status observability

### DIFF
--- a/src/cli/memory-cli.test.ts
+++ b/src/cli/memory-cli.test.ts
@@ -296,6 +296,38 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("prints session sync status in memory status output", async () => {
+    const close = vi.fn(async () => {});
+    const probeEmbeddingAvailability = vi.fn(async () => ({ ok: true }));
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      probeEmbeddingAvailability,
+      status: () =>
+        makeMemoryStatus({
+          custom: {
+            sessionSync: {
+              enabled: true,
+              dirty: true,
+              dirtyFiles: 2,
+              pendingBytes: 10,
+              pendingMessages: 3,
+              lastSyncAt: Date.now() - 1500,
+            },
+          },
+        }),
+      close,
+    });
+
+    const log = spyRuntimeLogs();
+    await runMemoryCli(["status", "--deep"]);
+
+    expect(probeEmbeddingAvailability).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Sessions: enabled"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Session state: dirty (2)"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Session pending: 10 bytes, 3 msgs"));
+    expect(close).toHaveBeenCalled();
+  });
+
   it("enables verbose logging with --verbose", async () => {
     const close = vi.fn(async () => {});
     mockManager({

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -577,9 +577,7 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
         const pendingBytes = sessionSync.pendingBytes ?? 0;
         const pendingMessages = sessionSync.pendingMessages ?? 0;
         lines.push(
-          `${label("Session pending")} ${muted(
-            `${pendingBytes} bytes, ${pendingMessages} msgs`,
-          )}`,
+          `${label("Session pending")} ${muted(`${pendingBytes} bytes, ${pendingMessages} msgs`)}`,
         );
       }
     }

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -545,6 +545,44 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
         lines.push(`${label("Cache cap")} ${info(String(status.cache.maxEntries))}`);
       }
     }
+    const sessionSync = (status.custom as { sessionSync?: Record<string, unknown> } | undefined)
+      ?.sessionSync as
+      | {
+          enabled?: boolean;
+          dirty?: boolean;
+          dirtyFiles?: number;
+          pendingFiles?: number;
+          pendingBytes?: number;
+          pendingMessages?: number;
+          lastSyncAt?: number | null;
+          lastSyncError?: string | null;
+        }
+      | undefined;
+    if (sessionSync) {
+      const sessionsEnabled = sessionSync.enabled ? "enabled" : "disabled";
+      const sessionsColor = sessionSync.enabled ? theme.success : theme.muted;
+      lines.push(`${label("Sessions")} ${colorize(rich, sessionsColor, sessionsEnabled)}`);
+      const dirtyFiles = sessionSync.dirtyFiles ?? 0;
+      const stateLabel = sessionSync.dirty ? `dirty (${dirtyFiles})` : "clean";
+      const stateColor = sessionSync.dirty ? theme.warn : theme.muted;
+      const sessionStateParts: string[] = [colorize(rich, stateColor, stateLabel)];
+      if (sessionSync.lastSyncError) {
+        sessionStateParts.push(muted(`error: ${sessionSync.lastSyncError}`));
+      } else if (typeof sessionSync.lastSyncAt === "number") {
+        const ageSeconds = Math.max(0, Math.floor((Date.now() - sessionSync.lastSyncAt) / 1000));
+        sessionStateParts.push(muted(`last sync ${ageSeconds}s ago`));
+      }
+      lines.push(`${label("Session state")} ${sessionStateParts.join(" ")}`);
+      if (opts.deep) {
+        const pendingBytes = sessionSync.pendingBytes ?? 0;
+        const pendingMessages = sessionSync.pendingMessages ?? 0;
+        lines.push(
+          `${label("Session pending")} ${muted(
+            `${pendingBytes} bytes, ${pendingMessages} msgs`,
+          )}`,
+        );
+      }
+    }
     if (status.batch) {
       const batchState = status.batch.enabled ? "enabled" : "disabled";
       const batchColor = status.batch.enabled ? theme.success : theme.warn;

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -291,6 +291,97 @@ describe("memory index", () => {
     }
   });
 
+  it("records session sync status after indexing", async () => {
+    const stateDir = path.join(fixtureRoot, "state-session-status");
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    await fs.rm(stateDir, { recursive: true, force: true });
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionDir, "session-status.jsonl"),
+      `${sourceChangeSessionLogLines}\n`,
+    );
+
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-session-status.sqlite"),
+      sources: ["memory", "sessions"],
+      sessionMemory: true,
+    });
+
+    try {
+      const result = await getMemorySearchManager({ cfg, agentId: "main" });
+      const manager = requireManager(result);
+      await manager.sync?.({ reason: "test", force: true });
+      const status = manager.status();
+      const sessionSync = (status.custom as { sessionSync?: Record<string, unknown> } | undefined)
+        ?.sessionSync as
+        | {
+            enabled?: boolean;
+            dirty?: boolean;
+            dirtyFiles?: number;
+            pendingFiles?: number;
+            pendingBytes?: number;
+            pendingMessages?: number;
+            lastSyncAt?: number | null;
+            lastSyncReason?: string | null;
+            lastSyncError?: string | null;
+          }
+        | undefined;
+      expect(sessionSync?.enabled).toBe(true);
+      expect(sessionSync?.dirty).toBe(false);
+      expect(sessionSync?.lastSyncAt).toEqual(expect.any(Number));
+      expect(sessionSync?.lastSyncReason).toBe("test");
+      expect(sessionSync?.lastSyncError).toBeNull();
+      expect(sessionSync?.pendingFiles).toBeGreaterThanOrEqual(0);
+      expect(sessionSync?.pendingBytes).toBeGreaterThanOrEqual(0);
+      expect(sessionSync?.pendingMessages).toBeGreaterThanOrEqual(0);
+      await manager.close?.();
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves dirty state and records session sync error on failure", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-session-error.sqlite"),
+      sources: ["memory", "sessions"],
+      sessionMemory: true,
+    });
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager = requireManager(result);
+    const syncSessionFiles = vi
+      .spyOn(manager as unknown as { syncSessionFiles: () => Promise<void> }, "syncSessionFiles")
+      .mockRejectedValue(new Error("session sync boom"));
+    (manager as unknown as { sessionsDirty: boolean }).sessionsDirty = true;
+    (manager as unknown as { sessionsDirtyFiles: Set<string> }).sessionsDirtyFiles.add(
+      "dummy-session.jsonl",
+    );
+
+    await expect(manager.sync?.({ reason: "test", force: true })).rejects.toThrow(
+      "session sync boom",
+    );
+    const status = manager.status();
+    const sessionSync = (status.custom as { sessionSync?: Record<string, unknown> } | undefined)
+      ?.sessionSync as
+      | {
+          dirty?: boolean;
+          lastSyncError?: string | null;
+        }
+      | undefined;
+    expect(syncSessionFiles).toHaveBeenCalled();
+    expect(status.dirty).toBe(true);
+    expect(sessionSync?.dirty).toBe(true);
+    expect(sessionSync?.lastSyncError).toBe("session sync boom");
+    await manager.close?.();
+  });
+
   it("reindexes when the embedding model changes", async () => {
     const base = createCfg({ storePath: indexModelPath });
     const baseAgents = base.agents!;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -136,6 +136,9 @@ export abstract class MemoryManagerSyncOps {
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
   >();
+  protected lastSessionSyncAt: number | null = null;
+  protected lastSessionSyncReason: string | null = null;
+  protected lastSessionSyncError: string | null = null;
   private lastMetaSerialized: string | null = null;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
@@ -427,13 +430,18 @@ export abstract class MemoryManagerSyncOps {
 
   private scheduleSessionDirty(sessionFile: string) {
     this.sessionPendingFiles.add(sessionFile);
+    log.debug("memory session delta scheduled", {
+      pendingFiles: this.sessionPendingFiles.size,
+    });
     if (this.sessionWatchTimer) {
       return;
     }
     this.sessionWatchTimer = setTimeout(() => {
       this.sessionWatchTimer = null;
       void this.processSessionDeltaBatch().catch((err) => {
-        log.warn(`memory session delta failed: ${String(err)}`);
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn(`memory session delta failed: ${message}`);
+        this.lastSessionSyncError = message;
       });
     }, SESSION_DIRTY_DEBOUNCE_MS);
   }
@@ -470,8 +478,13 @@ export abstract class MemoryManagerSyncOps {
       shouldSync = true;
     }
     if (shouldSync) {
+      log.debug("memory session delta marked dirty", {
+        dirtyFiles: this.sessionsDirtyFiles.size,
+      });
       void this.sync({ reason: "session-delta" }).catch((err) => {
-        log.warn(`memory sync failed (session-delta): ${String(err)}`);
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn(`memory sync failed (session-delta): ${message}`);
+        this.lastSessionSyncError = message;
       });
     }
   }
@@ -909,7 +922,27 @@ export abstract class MemoryManagerSyncOps {
       }
 
       if (shouldSyncSessions) {
-        await this.syncSessionFiles({ needsFullReindex, progress: progress ?? undefined });
+        this.lastSessionSyncReason = params?.reason ?? "unspecified";
+        this.lastSessionSyncError = null;
+        log.debug("memory session sync start", {
+          reason: this.lastSessionSyncReason,
+          needsFullReindex,
+          dirtyFiles: this.sessionsDirtyFiles.size,
+          pendingFiles: this.sessionPendingFiles.size,
+        });
+        try {
+          await this.syncSessionFiles({ needsFullReindex, progress: progress ?? undefined });
+          this.lastSessionSyncAt = Date.now();
+          log.debug("memory session sync complete", {
+            reason: this.lastSessionSyncReason,
+            dirtyFiles: this.sessionsDirtyFiles.size,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.lastSessionSyncError = message;
+          log.warn(`memory session sync failed: ${message}`);
+          throw err;
+        }
         this.sessionsDirty = false;
         this.sessionsDirtyFiles.clear();
       } else if (this.sessionsDirtyFiles.size > 0) {
@@ -1073,7 +1106,30 @@ export abstract class MemoryManagerSyncOps {
       }
 
       if (shouldSyncSessions) {
-        await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
+        const sessionStart = performance.now();
+        this.lastSessionSyncError = null;
+        this.lastSessionSyncReason = params.reason ?? "reindex";
+        log.debug("memory sessions: sync starting", {
+          pendingFiles: this.sessionPendingFiles.size,
+          dirtyFiles: this.sessionsDirtyFiles.size,
+          pendingBytes: this.sessionDeltas.pendingBytes,
+          pendingMessages: this.sessionDeltas.pendingMessages,
+          reason: this.lastSessionSyncReason,
+        });
+        try {
+          await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
+          this.lastSessionSyncAt = new Date();
+          log.debug("memory sessions: sync completed", {
+            durationMs: Math.round(performance.now() - sessionStart),
+            pendingFiles: this.sessionPendingFiles.size,
+            dirtyFiles: this.sessionsDirtyFiles.size,
+          });
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          this.lastSessionSyncError = errorMessage;
+          log.warn("memory sessions: sync failed", { err: errorMessage, reason: this.lastSessionSyncReason });
+          throw err;
+        }
         this.sessionsDirty = false;
         this.sessionsDirtyFiles.clear();
       } else if (this.sessionsDirtyFiles.size > 0) {
@@ -1144,7 +1200,30 @@ export abstract class MemoryManagerSyncOps {
     }
 
     if (shouldSyncSessions) {
-      await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
+      const sessionStart = performance.now();
+      this.lastSessionSyncError = null;
+      this.lastSessionSyncReason = params.reason ?? "reindex";
+      log.debug("memory sessions: sync starting", {
+        pendingFiles: this.sessionPendingFiles.size,
+        dirtyFiles: this.sessionsDirtyFiles.size,
+        pendingBytes: this.sessionDeltas.pendingBytes,
+        pendingMessages: this.sessionDeltas.pendingMessages,
+        reason: this.lastSessionSyncReason,
+      });
+      try {
+        await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
+        this.lastSessionSyncAt = new Date();
+        log.debug("memory sessions: sync completed", {
+          durationMs: Math.round(performance.now() - sessionStart),
+          pendingFiles: this.sessionPendingFiles.size,
+          dirtyFiles: this.sessionsDirtyFiles.size,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        this.lastSessionSyncError = errorMessage;
+        log.warn("memory sessions: sync failed", { err: errorMessage, reason: this.lastSessionSyncReason });
+        throw err;
+      }
       this.sessionsDirty = false;
       this.sessionsDirtyFiles.clear();
     } else if (this.sessionsDirtyFiles.size > 0) {

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -1133,7 +1133,10 @@ export abstract class MemoryManagerSyncOps {
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : String(err);
           this.lastSessionSyncError = errorMessage;
-          log.warn("memory sessions: sync failed", { err: errorMessage, reason: this.lastSessionSyncReason });
+          log.warn("memory sessions: sync failed", {
+            err: errorMessage,
+            reason: this.lastSessionSyncReason,
+          });
           throw err;
         }
         this.sessionsDirty = false;
@@ -1233,7 +1236,10 @@ export abstract class MemoryManagerSyncOps {
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
         this.lastSessionSyncError = errorMessage;
-        log.warn("memory sessions: sync failed", { err: errorMessage, reason: this.lastSessionSyncReason });
+        log.warn("memory sessions: sync failed", {
+          err: errorMessage,
+          reason: this.lastSessionSyncReason,
+        });
         throw err;
       }
       this.sessionsDirty = false;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -136,7 +136,7 @@ export abstract class MemoryManagerSyncOps {
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
   >();
-  protected lastSessionSyncAt: number | null = null;
+  protected lastSessionSyncAt: Date | null = null;
   protected lastSessionSyncReason: string | null = null;
   protected lastSessionSyncError: string | null = null;
   private lastMetaSerialized: string | null = null;
@@ -932,7 +932,7 @@ export abstract class MemoryManagerSyncOps {
         });
         try {
           await this.syncSessionFiles({ needsFullReindex, progress: progress ?? undefined });
-          this.lastSessionSyncAt = Date.now();
+          this.lastSessionSyncAt = new Date();
           log.debug("memory session sync complete", {
             reason: this.lastSessionSyncReason,
             dirtyFiles: this.sessionsDirtyFiles.size,
@@ -1112,8 +1112,14 @@ export abstract class MemoryManagerSyncOps {
         log.debug("memory sessions: sync starting", {
           pendingFiles: this.sessionPendingFiles.size,
           dirtyFiles: this.sessionsDirtyFiles.size,
-          pendingBytes: this.sessionDeltas.pendingBytes,
-          pendingMessages: this.sessionDeltas.pendingMessages,
+          pendingBytes: Array.from(this.sessionDeltas.values()).reduce(
+            (sum, entry) => sum + entry.pendingBytes,
+            0,
+          ),
+          pendingMessages: Array.from(this.sessionDeltas.values()).reduce(
+            (sum, entry) => sum + entry.pendingMessages,
+            0,
+          ),
           reason: this.lastSessionSyncReason,
         });
         try {
@@ -1206,8 +1212,14 @@ export abstract class MemoryManagerSyncOps {
       log.debug("memory sessions: sync starting", {
         pendingFiles: this.sessionPendingFiles.size,
         dirtyFiles: this.sessionsDirtyFiles.size,
-        pendingBytes: this.sessionDeltas.pendingBytes,
-        pendingMessages: this.sessionDeltas.pendingMessages,
+        pendingBytes: Array.from(this.sessionDeltas.values()).reduce(
+          (sum, entry) => sum + entry.pendingBytes,
+          0,
+        ),
+        pendingMessages: Array.from(this.sessionDeltas.values()).reduce(
+          (sum, entry) => sum + entry.pendingMessages,
+          0,
+        ),
         reason: this.lastSessionSyncReason,
       });
       try {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -733,6 +733,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           failures: this.readonlyRecoveryFailures,
           lastError: this.readonlyRecoveryLastError,
         },
+        sessionSync: {
+          enabled: this.sources.has("sessions"),
+          dirty: this.sessionsDirty,
+          dirtyFiles: this.sessionsDirtyFiles.size,
+          pendingFiles: this.sessionPendingFiles.size,
+          pendingBytes: Array.from(this.sessionDeltas.values()).reduce(
+            (sum, entry) => sum + entry.pendingBytes,
+            0,
+          ),
+          pendingMessages: Array.from(this.sessionDeltas.values()).reduce(
+            (sum, entry) => sum + entry.pendingMessages,
+            0,
+          ),
+          lastSyncAt: this.lastSessionSyncAt ? this.lastSessionSyncAt.getTime() : null,
+          lastSyncReason: this.lastSessionSyncReason,
+          lastSyncError: this.lastSessionSyncError,
+        },
       },
     };
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Session memory indexing had no explicit status/observability surface in CLI or status output.
- Why it matters: Hard to diagnose session sync health, pending work, and failures.
- What changed: Added session sync status fields, CLI display, and tests; added warn logs on failure and debug logs on normal sync.
- What did NOT change (scope boundary): No indexing strategy changes, no new dependencies, no external API changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `openclaw memory status` now includes session sync summary; `--deep` adds pending bytes/messages.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node 22.22.1 + pnpm 10.23.0
- Model/provider: N/A (tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm test -- src/memory/index.test.ts src/cli/memory-cli.test.ts`

### Expected

- Session sync status fields populate after indexing; CLI outputs session status lines.

### Actual

- As expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local tests for memory index status + CLI output.
- Edge cases checked: session sync error path preserves dirty + records error.
- What you did **not** verify: no manual CLI run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/memory/manager-sync-ops.ts`, `src/memory/manager.ts`, `src/cli/memory-cli.ts`.
- Known bad symptoms reviewers should watch for: missing or noisy CLI status output.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: additional debug logging could be noisy in some workflows.
  - Mitigation: logs are debug-only for normal paths; warn-only on failures.
