### PR TITLE
Fix/issue 41993 ssrf mixed dns

### DIFF
--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -81,14 +81,18 @@ describe("ssrf pinning", () => {
     const lookup = vi.fn(async () => [
       { address: "::", family: 6 },
       { address: "93.184.216.35", family: 4 },
-      { address: "2001:db8::1", family: 6 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
       { address: "93.184.216.34", family: 4 },
       { address: "93.184.216.35", family: 4 },
-      { address: "2001:db8::1", family: 6 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
     ]) as unknown as LookupFn;
 
     const pinned = await resolvePinnedHostname("example.com", lookup);
-    expect(pinned.addresses).toEqual(["93.184.216.35", "93.184.216.34", "2001:db8::1"]);
+    expect(pinned.addresses).toEqual([
+      "93.184.216.35",
+      "93.184.216.34",
+      "2606:2800:220:1:248:1893:25c8:1946",
+    ]);
   });
 
   it("allows RFC2544 benchmark range addresses only when policy explicitly opts in", async () => {

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -68,6 +68,29 @@ describe("ssrf pinning", () => {
     expect(pinned.addresses).toEqual(["93.184.216.34"]);
   });
 
+  it("rejects mixed DNS answers when all resolved addresses are blocked", async () => {
+    const lookup = vi.fn(async () => [
+      { address: "::", family: 6 },
+      { address: "127.0.0.1", family: 4 },
+    ]) as unknown as LookupFn;
+
+    await expect(resolvePinnedHostname("example.com", lookup)).rejects.toThrow(/private|internal/i);
+  });
+
+  it("preserves dedupe and ipv4-first ordering after filtering blocked mixed answers", async () => {
+    const lookup = vi.fn(async () => [
+      { address: "::", family: 6 },
+      { address: "93.184.216.35", family: 4 },
+      { address: "2001:db8::1", family: 6 },
+      { address: "93.184.216.34", family: 4 },
+      { address: "93.184.216.35", family: 4 },
+      { address: "2001:db8::1", family: 6 },
+    ]) as unknown as LookupFn;
+
+    const pinned = await resolvePinnedHostname("example.com", lookup);
+    expect(pinned.addresses).toEqual(["93.184.216.35", "93.184.216.34", "2001:db8::1"]);
+  });
+
   it("allows RFC2544 benchmark range addresses only when policy explicitly opts in", async () => {
     const lookup = vi.fn(async () => [
       { address: "198.18.0.153", family: 4 },

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -58,6 +58,16 @@ describe("ssrf pinning", () => {
     await expect(resolvePinnedHostname("example.com", lookup)).rejects.toThrow(/private|internal/i);
   });
 
+  it("allows mixed DNS answers when at least one resolved address is public", async () => {
+    const lookup = vi.fn(async () => [
+      { address: "::", family: 6 },
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+
+    const pinned = await resolvePinnedHostname("example.com", lookup);
+    expect(pinned.addresses).toEqual(["93.184.216.34"]);
+  });
+
   it("allows RFC2544 benchmark range addresses only when policy explicitly opts in", async () => {
     const lookup = vi.fn(async () => [
       { address: "198.18.0.153", family: 4 },

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -180,19 +180,6 @@ function assertAllowedHostOrIpOrThrow(hostnameOrIp: string, policy?: SsrFPolicy)
   }
 }
 
-function assertAllowedResolvedAddressesOrThrow(
-  results: readonly LookupAddress[],
-  policy?: SsrFPolicy,
-): void {
-  // Reject only when every DNS answer is blocked. In dual-stack environments,
-  // polluted/special-use AAAA records can co-exist with valid public A records.
-  // The connection path will still use pinned + ordered addresses downstream.
-  const hasAllowedAddress = results.some((entry) => !isBlockedHostnameOrIp(entry.address, policy));
-  if (!hasAllowedAddress) {
-    throw new SsrFBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
-  }
-}
-
 export function createPinnedLookup(params: {
   hostname: string;
   addresses: string[];
@@ -324,9 +311,9 @@ export async function resolvePinnedHostnameWithPolicy(
     ? results
     : results.filter((entry) => !isBlockedHostnameOrIp(entry.address, params.policy));
 
-  if (!skipPrivateNetworkChecks) {
-    // Phase 2: re-check DNS answers so public hostnames cannot pivot to private targets.
-    assertAllowedResolvedAddressesOrThrow(results, params.policy);
+  if (!skipPrivateNetworkChecks && allowedResults.length === 0) {
+    // Phase 2: ensure public hostnames cannot pivot to private/special-use targets.
+    throw new SsrFBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
   }
 
   // Prefer addresses returned as IPv4 by DNS family metadata before other

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -184,11 +184,12 @@ function assertAllowedResolvedAddressesOrThrow(
   results: readonly LookupAddress[],
   policy?: SsrFPolicy,
 ): void {
-  for (const entry of results) {
-    // Reuse the exact same host/IP classifier as the pre-DNS check to avoid drift.
-    if (isBlockedHostnameOrIp(entry.address, policy)) {
-      throw new SsrFBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
-    }
+  // Reject only when every DNS answer is blocked. In dual-stack environments,
+  // polluted/special-use AAAA records can co-exist with valid public A records.
+  // The connection path will still use pinned + ordered addresses downstream.
+  const hasAllowedAddress = results.some((entry) => !isBlockedHostnameOrIp(entry.address, policy));
+  if (!hasAllowedAddress) {
+    throw new SsrFBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
   }
 }
 
@@ -319,6 +320,10 @@ export async function resolvePinnedHostnameWithPolicy(
     throw new Error(`Unable to resolve hostname: ${hostname}`);
   }
 
+  const allowedResults = skipPrivateNetworkChecks
+    ? results
+    : results.filter((entry) => !isBlockedHostnameOrIp(entry.address, params.policy));
+
   if (!skipPrivateNetworkChecks) {
     // Phase 2: re-check DNS answers so public hostnames cannot pivot to private targets.
     assertAllowedResolvedAddressesOrThrow(results, params.policy);
@@ -326,7 +331,7 @@ export async function resolvePinnedHostnameWithPolicy(
 
   // Prefer addresses returned as IPv4 by DNS family metadata before other
   // families so Happy Eyeballs and pinned round-robin both attempt IPv4 first.
-  const addresses = dedupeAndPreferIpv4(results);
+  const addresses = dedupeAndPreferIpv4(allowedResults);
   if (addresses.length === 0) {
     throw new Error(`Unable to resolve hostname: ${hostname}`);
   }


### PR DESCRIPTION
## Summary

- **Problem:** `web_fetch` regressed in dual-stack environments where DNS returns both valid public IPv4 and blocked/special-use IPv6 answers; requests were rejected if any resolved address was blocked.
- **Why it matters:** This breaks legitimate public fetches in real-world networks (notably DNS-polluted environments), even when a safe public address is available.
- **What changed:**
- Updated SSRF DNS-result validation to reject only when **all** resolved addresses are blocked.
- Added filtering so downstream pinned lookup candidates include only allowed addresses.
- Preserved existing dedupe + IPv4-first ordering behavior on the filtered set.
- Added tests for mixed-answer allow/deny behavior and post-filter ordering.
- **What did NOT change (scope boundary):**
- No relaxation of host allowlist checks.
- No relaxation of private/internal/special-use blocking when all answers are blocked.
- No change to policy flags or tool API surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41993
- Related #41917

## User-visible / Behavior Changes

- `web_fetch` now succeeds in mixed DNS-answer scenarios when at least one resolved address is allowed.
- If all resolved addresses are blocked, behavior remains blocked as before.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed?
(No)

• If any Yes, explain risk + mitigation:
  • N/A

Repro + Verification

Environment

• OS: macOS/Linux (logic-level repro; DNS behavior is network-dependent)
• Runtime/container: Node.js CLI runtime
• Model/provider: N/A
• Integration/channel (if any): N/A
• Relevant config (redacted): default SSRF policy (private/internal blocked)

Steps

1. Resolve a hostname to mixed answers, e.g. one blocked special-use IPv6 + one public IPv4.
2. Call pinned hostname resolution through SSRF path.
3. Observe resulting allow/deny and pinned address list.

Expected

• Resolution should pass when at least one allowed address exists.
• Resolution should fail when all answers are blocked.
• Returned pinned addresses should remain deduped and IPv4-first.

Actual

• Before fix: any blocked
DNS answer caused rejection.

• After fix: only all-blocked result sets are rejected.

Evidence

Attach at least one:

• [x] Failing test/log before + passing after
• [ ] Trace/log snippets
• [ ] Screenshot/recording
• [ ] Perf numbers (if relevant)

Human Verification (required)

• Verified scenarios:
  • Mixed DNS (:: + public IPv4) now resolves successfully and returns only allowed addresses.
  • Mixed DNS all-blocked (:: + 127.0.0.1) is rejected.
  • Filtered results still dedupe and preserve IPv4-first ordering.
• Edge cases checked:
  • Duplicate addresses in mixed answers.
  • Mixed families with blocked + allowed entries.
• What you did not verify:
  • Live end-to-end against external DNS pollution infrastructure in this environment.

Review Conversations

• [x] I replied
to or resolved every bot review conversation I addressed in this PR.

• [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Compatibility / Migration

• Backward compatible? (Yes)
• Config/env changes? (No)
• Migration needed? (No)
• If yes, exact upgrade steps:
  • N/A

Failure Recovery (if this breaks)

• How to disable/revert this change quickly:
  • Revert commits from this PR branch.
• Files/config to restore:
  • src/infra/net/ssrf.ts
  • src/infra/net/ssrf.pinning.test.ts
• Known bad symptoms reviewers should watch for:
  • Public hostnames incorrectly blocked when a valid public answer exists.
  • Any case where blocked addresses appear in pinned candidate list.

Risks and Mitigations

• Risk: Allowing mixed DNS answers could unintentionally permit unsafe endpoints if filtering is incomplete.

• Mitigation: Allowed candidate set is explicitly filtered before pinning; all-blocked still hard-fails.
• Risk: Behavioral shift may affect callers relying on previous strict-any-blocked semantics.
  • Mitigation: Added focused tests for allow/deny boundary and ordering behavior; change is scoped to DNS answer handling only.