### PR TITLE
fix: resolve exec PATH fallback, layered browser diagnostics, and cron force-run deadlock

### DIFF
--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -95,6 +95,24 @@ describe("exec PATH login shell merge", () => {
     expect(shellPathMock).toHaveBeenCalledTimes(1);
   });
 
+  it("merges login-shell PATH for default sandbox host when runtime is unavailable", async () => {
+    if (isWin) {
+      return;
+    }
+    process.env.PATH = "/usr/bin";
+
+    const shellPathMock = vi.mocked(getShellPathFromLoginShell);
+    shellPathMock.mockClear();
+    shellPathMock.mockReturnValue("/custom/bin:/opt/bin");
+
+    const tool = createExecTool({ security: "full", ask: "off" });
+    const result = await tool.execute("call-phantom-sandbox", { command: "echo $PATH" });
+    const entries = normalizePathEntries(result.content.find((c) => c.type === "text")?.text);
+
+    expect(entries).toEqual(["/custom/bin", "/opt/bin", "/usr/bin"]);
+    expect(shellPathMock).toHaveBeenCalledTimes(1);
+  });
+
   it("sets OPENCLAW_SHELL for host=gateway commands", async () => {
     if (isWin) {
       return;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -381,7 +381,10 @@ export function createExecTool(
           })
         : mergedEnv;
 
-      if (!sandbox && host === "gateway" && !params.env?.PATH) {
+      // When exec falls back from the default sandbox host to direct local execution because
+      // no sandbox runtime is available, it still needs the login-shell PATH probe. Otherwise
+      // version-manager-installed tools (nvm/fnm/volta, etc.) can disappear from PATH.
+      if (!sandbox && (host === "gateway" || host === "sandbox") && !params.env?.PATH) {
         const shellPath = getShellPathFromLoginShell({
           env: process.env,
           timeoutMs: resolveShellEnvFallbackTimeoutMs(process.env),

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -154,6 +154,40 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
   );
 }
 
+function stripHtmlErrorText(input: string): string {
+  return input
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function summarizeBrowserServiceHttpError(status: number, bodyText: string): string {
+  const trimmed = bodyText.trim();
+  if (!trimmed) {
+    return `HTTP ${status}`;
+  }
+  if (!/^<!doctype html[\s>]|^<html[\s>]/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  const titleMatch = trimmed.match(/<title>([^<]+)<\/title>/i);
+  const headingMatch = trimmed.match(/<h1[^>]*>([^<]+)<\/h1>/i);
+  const serverMatch = [...trimmed.matchAll(/<center>([^<]+)<\/center>/gi)]
+    .map((match) => match[1]?.trim())
+    .filter(Boolean)
+    .at(-1);
+  const summary =
+    titleMatch?.[1]?.trim() ?? headingMatch?.[1]?.trim() ?? stripHtmlErrorText(trimmed);
+  if (!summary) {
+    return `HTTP ${status}`;
+  }
+  return serverMatch
+    ? `${summary} (${serverMatch} HTML error page)`
+    : `${summary} (HTML error page)`;
+}
+
 async function fetchHttpJson<T>(
   url: string,
   init: RequestInit & { timeoutMs?: number },
@@ -176,7 +210,7 @@ async function fetchHttpJson<T>(
     const res = await fetch(url, { ...init, signal: ctrl.signal });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      throw new BrowserServiceError(text || `HTTP ${res.status}`);
+      throw new BrowserServiceError(summarizeBrowserServiceHttpError(res.status, text));
     }
     return (await res.json()) as T;
   } finally {

--- a/src/browser/client.test.ts
+++ b/src/browser/client.test.ts
@@ -67,6 +67,30 @@ describe("browser client", () => {
     ).rejects.toThrow(/conflict/i);
   });
 
+  it("summarizes HTML upstream errors instead of dumping raw markup", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () =>
+          "<html><head><title>400 Bad Request</title></head><body><center><h1>400 Bad Request</h1></center><hr><center>nginx</center></body></html>",
+      } as unknown as Response),
+    );
+
+    const thrown = await browserStatus("http://browser.example/status").catch(
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) {
+      throw new Error(`Expected Error, got ${String(thrown)}`);
+    }
+    expect(thrown.message).toContain("400 Bad Request");
+    expect(thrown.message).toContain("nginx HTML error page");
+    expect(thrown.message).not.toContain("<html>");
+  });
+
   it("adds labels + efficient mode query params to snapshots", async () => {
     const calls: string[] = [];
     stubSnapshotFetch(calls);

--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -1,4 +1,6 @@
 import { fetchBrowserJson } from "./client-fetch.js";
+import type { BrowserStatusDiagnostic } from "./status-diagnostics.js";
+export type { BrowserStatusDiagnostic } from "./status-diagnostics.js";
 
 export type BrowserStatus = {
   enabled: boolean;
@@ -19,6 +21,7 @@ export type BrowserStatus = {
   noSandbox?: boolean;
   executablePath?: string | null;
   attachOnly: boolean;
+  diagnostics?: BrowserStatusDiagnostic[];
 };
 
 export type ProfileStatus = {

--- a/src/browser/routes/basic.ts
+++ b/src/browser/routes/basic.ts
@@ -2,6 +2,7 @@ import { resolveBrowserExecutableForPlatform } from "../chrome.executables.js";
 import { toBrowserErrorResponse } from "../errors.js";
 import { createBrowserProfilesService } from "../profiles-service.js";
 import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
+import { deriveBrowserStatusDiagnostics } from "../status-diagnostics.js";
 import { resolveProfileContext } from "./agent.shared.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import { getProfileContext, jsonError, toStringOrEmpty } from "./utils.js";
@@ -73,7 +74,7 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
       detectError = String(err);
     }
 
-    res.json({
+    const status = {
       enabled: current.resolved.enabled,
       profile: profileCtx.profile.name,
       running: cdpReady,
@@ -92,6 +93,11 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
       noSandbox: current.resolved.noSandbox,
       executablePath: current.resolved.executablePath ?? null,
       attachOnly: profileCtx.profile.attachOnly,
+    };
+
+    res.json({
+      ...status,
+      diagnostics: deriveBrowserStatusDiagnostics(status),
     });
   });
 

--- a/src/browser/server.status-diagnostics.test.ts
+++ b/src/browser/server.status-diagnostics.test.ts
@@ -1,0 +1,38 @@
+import { fetch as realFetch } from "undici";
+import { describe, expect, it } from "vitest";
+import {
+  getBrowserControlServerBaseUrl,
+  installBrowserControlServerHooks,
+  setBrowserControlServerAttachOnly,
+  setBrowserControlServerReachable,
+  startBrowserControlServerFromConfig,
+} from "./server.control-server.test-harness.js";
+
+describe("browser control server status diagnostics", () => {
+  installBrowserControlServerHooks();
+
+  it("includes CDP reachability diagnostics in GET /", async () => {
+    setBrowserControlServerAttachOnly(true);
+    setBrowserControlServerReachable(false);
+
+    await startBrowserControlServerFromConfig();
+    const base = getBrowserControlServerBaseUrl();
+
+    const response = await realFetch(`${base}/`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      diagnostics?: Array<{ code?: string; layer?: string; level?: string; summary?: string }>;
+    };
+
+    expect(body.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "LOCAL_CDP_HTTP_UNREACHABLE",
+          layer: "cdp",
+          level: "warn",
+          summary: expect.stringContaining("/json/version"),
+        }),
+      ]),
+    );
+  });
+});

--- a/src/browser/status-diagnostics.test.ts
+++ b/src/browser/status-diagnostics.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  combineBrowserStatusDiagnostics,
+  deriveBrowserStatusDiagnostics,
+  deriveGatewayControlUiDiagnostics,
+} from "./status-diagnostics.js";
+
+describe("deriveBrowserStatusDiagnostics", () => {
+  it("reports remote HTTP reachability failures", () => {
+    expect(
+      deriveBrowserStatusDiagnostics({
+        running: false,
+        cdpReady: false,
+        cdpHttp: false,
+        cdpPort: 9222,
+        cdpUrl: "http://10.0.0.42:9222",
+        attachOnly: true,
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ATTACH_ONLY_PROFILE",
+          layer: "profile",
+          level: "info",
+        }),
+        expect.objectContaining({
+          code: "REMOTE_CDP_HTTP_UNREACHABLE",
+          layer: "cdp",
+          level: "danger",
+          summary: expect.stringContaining("http://10.0.0.42:9222/json/version"),
+        }),
+      ]),
+    );
+  });
+
+  it("reports remote websocket readiness separately from HTTP reachability", () => {
+    expect(
+      deriveBrowserStatusDiagnostics({
+        running: false,
+        cdpReady: false,
+        cdpHttp: true,
+        cdpPort: 9222,
+        cdpUrl: "https://browser.example:9443?token=abc",
+        attachOnly: false,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        code: "REMOTE_CDP_WS_NOT_READY",
+        layer: "cdp",
+        level: "warn",
+      }),
+    ]);
+  });
+
+  it("reports local relay reachability failures with a local hint", () => {
+    expect(
+      deriveBrowserStatusDiagnostics({
+        running: false,
+        cdpReady: false,
+        cdpHttp: false,
+        cdpPort: 18792,
+        cdpUrl: "http://127.0.0.1:18792",
+        attachOnly: false,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        code: "LOCAL_CDP_HTTP_UNREACHABLE",
+        layer: "cdp",
+        level: "warn",
+        summary: expect.stringContaining("http://127.0.0.1:18792/json/version"),
+      }),
+    ]);
+  });
+
+  it("returns only attach-only info when CDP is fully ready", () => {
+    expect(
+      deriveBrowserStatusDiagnostics({
+        running: true,
+        cdpReady: true,
+        cdpHttp: true,
+        cdpPort: 9222,
+        cdpUrl: "ws://127.0.0.1:9222/devtools/browser/ABC?token=abc",
+        attachOnly: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        code: "ATTACH_ONLY_PROFILE",
+        layer: "profile",
+        level: "info",
+        hint: expect.stringContaining("http://127.0.0.1:9222/json/version?token=abc"),
+      }),
+    ]);
+  });
+});
+
+describe("deriveGatewayControlUiDiagnostics", () => {
+  it("flags missing allowedOrigins for non-loopback binds", () => {
+    expect(
+      deriveGatewayControlUiDiagnostics({
+        gateway: {
+          bind: "lan",
+          port: 18789,
+          auth: { mode: "token", token: "[REDACTED]" },
+          controlUi: { enabled: true, allowedOrigins: [] },
+        },
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "CONTROL_UI_ALLOWED_ORIGINS_REQUIRED",
+          layer: "control-ui",
+          level: "danger",
+        }),
+        expect.objectContaining({
+          code: "CONTROL_UI_TOKEN_AUTH",
+          layer: "control-ui",
+          level: "info",
+        }),
+      ]),
+    );
+  });
+
+  it("reports loopback-only control-ui access distinctly from CDP errors", () => {
+    const diagnostics = combineBrowserStatusDiagnostics(
+      deriveGatewayControlUiDiagnostics({
+        gateway: {
+          bind: "loopback",
+          port: 18789,
+          auth: { mode: "none" },
+          controlUi: { enabled: true },
+        },
+      }),
+      deriveBrowserStatusDiagnostics({
+        running: false,
+        cdpReady: false,
+        cdpHttp: false,
+        cdpPort: 9222,
+        cdpUrl: "http://10.0.0.42:9222",
+        attachOnly: true,
+      }),
+    );
+
+    expect(diagnostics.map((entry) => entry.code)).toEqual([
+      "CONTROL_UI_LOOPBACK_ONLY",
+      "CONTROL_UI_AUTH_DISABLED",
+      "ATTACH_ONLY_PROFILE",
+      "REMOTE_CDP_HTTP_UNREACHABLE",
+    ]);
+  });
+});

--- a/src/browser/status-diagnostics.ts
+++ b/src/browser/status-diagnostics.ts
@@ -1,0 +1,302 @@
+import {
+  isGatewayNonLoopbackBindMode,
+  resolveGatewayPortWithDefault,
+} from "../config/gateway-control-ui-origins.js";
+import { isLoopbackHost } from "../gateway/net.js";
+import { appendCdpPath, normalizeCdpHttpBaseForJsonEndpoints } from "./cdp.helpers.js";
+
+export type BrowserStatusDiagnostic = {
+  code:
+    | "ATTACH_ONLY_PROFILE"
+    | "CONTROL_UI_ALLOWED_ORIGINS_CONFIGURED"
+    | "CONTROL_UI_ALLOWED_ORIGINS_REQUIRED"
+    | "CONTROL_UI_AUTH_DISABLED"
+    | "CONTROL_UI_DISABLED"
+    | "CONTROL_UI_HOST_HEADER_FALLBACK"
+    | "CONTROL_UI_LOOPBACK_ONLY"
+    | "CONTROL_UI_PASSWORD_AUTH"
+    | "CONTROL_UI_TOKEN_AUTH"
+    | "REMOTE_CDP_HTTP_UNREACHABLE"
+    | "REMOTE_CDP_WS_NOT_READY"
+    | "LOCAL_CDP_HTTP_UNREACHABLE"
+    | "LOCAL_CDP_WS_NOT_READY";
+  layer: "control-ui" | "profile" | "cdp";
+  level: "info" | "warn" | "danger";
+  summary: string;
+  hint?: string;
+};
+
+type BrowserStatusLike = {
+  running: boolean;
+  cdpReady?: boolean;
+  cdpHttp?: boolean;
+  cdpPort: number;
+  cdpUrl?: string;
+  attachOnly: boolean;
+};
+
+type GatewayControlUiStatusLike = {
+  gateway?: {
+    bind?: unknown;
+    port?: unknown;
+    auth?: {
+      mode?: unknown;
+      token?: unknown;
+      password?: unknown;
+    };
+    controlUi?: {
+      enabled?: unknown;
+      allowedOrigins?: unknown;
+      dangerouslyAllowHostHeaderOriginFallback?: unknown;
+    };
+  };
+};
+
+function resolveCdpUrl(status: BrowserStatusLike): string {
+  const raw = status.cdpUrl?.trim();
+  if (raw) {
+    return raw;
+  }
+  return `http://127.0.0.1:${status.cdpPort}`;
+}
+
+function isRemoteCdpUrl(cdpUrl: string): boolean {
+  try {
+    return !isLoopbackHost(new URL(cdpUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function resolveVersionEndpoint(cdpUrl: string): string {
+  try {
+    return appendCdpPath(normalizeCdpHttpBaseForJsonEndpoints(cdpUrl), "/json/version");
+  } catch {
+    return `${cdpUrl.replace(/\/$/, "")}/json/version`;
+  }
+}
+
+export function deriveBrowserStatusDiagnostics(
+  status: BrowserStatusLike,
+): BrowserStatusDiagnostic[] {
+  const diagnostics: BrowserStatusDiagnostic[] = [];
+  const cdpUrl = resolveCdpUrl(status);
+  const versionEndpoint = resolveVersionEndpoint(cdpUrl);
+  const isRemote = isRemoteCdpUrl(cdpUrl);
+  const cdpHttp = status.cdpHttp ?? status.running;
+  const cdpReady = status.cdpReady ?? status.running;
+
+  if (status.attachOnly) {
+    diagnostics.push({
+      code: "ATTACH_ONLY_PROFILE",
+      layer: "profile",
+      level: "info",
+      summary:
+        "Attach-only profile: OpenClaw will connect to an existing browser instead of launching one.",
+      hint: `Expected CDP endpoint: ${versionEndpoint}`,
+    });
+  }
+
+  if (!cdpHttp) {
+    diagnostics.push(
+      isRemote
+        ? {
+            code: "REMOTE_CDP_HTTP_UNREACHABLE",
+            layer: "cdp",
+            level: "danger",
+            summary: `Remote CDP HTTP unreachable at ${versionEndpoint}.`,
+            hint: "Check port forwarding, Windows firewall, and the browser bind address.",
+          }
+        : {
+            code: "LOCAL_CDP_HTTP_UNREACHABLE",
+            layer: "cdp",
+            level: "warn",
+            summary: `CDP HTTP unreachable at ${versionEndpoint}.`,
+            hint: status.attachOnly
+              ? "Make sure the target browser is already running and exposing remote debugging at this address."
+              : "Start the selected browser profile, or verify that the active profile points at the expected local relay.",
+          },
+    );
+  } else if (!cdpReady) {
+    diagnostics.push(
+      isRemote
+        ? {
+            code: "REMOTE_CDP_WS_NOT_READY",
+            layer: "cdp",
+            level: "warn",
+            summary: "Remote CDP WebSocket is not ready even though HTTP responds.",
+            hint: "The browser may be up but not accepting attach sessions yet; retry after startup finishes.",
+          }
+        : {
+            code: "LOCAL_CDP_WS_NOT_READY",
+            layer: "cdp",
+            level: "warn",
+            summary: "CDP HTTP responds but the browser attach session is not ready.",
+            hint: status.attachOnly
+              ? "Retry after the browser finishes starting, or verify that another client is not holding the profile in a stale state."
+              : "Retry after startup finishes, or restart the selected browser profile.",
+          },
+    );
+  }
+
+  return diagnostics;
+}
+
+function isConfiguredSecret(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeOrigins(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean);
+}
+
+function summarizeOrigins(origins: readonly string[]): string {
+  if (origins.length <= 2) {
+    return origins.join(", ");
+  }
+  return `${origins.slice(0, 2).join(", ")} (+${origins.length - 2} more)`;
+}
+
+export function deriveGatewayControlUiDiagnostics(
+  snapshot: GatewayControlUiStatusLike,
+): BrowserStatusDiagnostic[] {
+  const diagnostics: BrowserStatusDiagnostic[] = [];
+  const gateway = snapshot.gateway ?? {};
+  const controlUi = gateway.controlUi ?? {};
+  const controlUiEnabled = controlUi.enabled !== false;
+  const port = resolveGatewayPortWithDefault(gateway.port);
+  const allowedOrigins = normalizeOrigins(controlUi.allowedOrigins);
+  const hostHeaderFallback = controlUi.dangerouslyAllowHostHeaderOriginFallback === true;
+  const bind = gateway.bind;
+  const auth = gateway.auth ?? {};
+  const authMode =
+    auth.mode === "token" || auth.mode === "password" || auth.mode === "none"
+      ? auth.mode
+      : undefined;
+
+  if (!controlUiEnabled) {
+    diagnostics.push({
+      code: "CONTROL_UI_DISABLED",
+      layer: "control-ui",
+      level: "warn",
+      summary: "Control UI is disabled in gateway config.",
+      hint: "Enable gateway.controlUi.enabled before debugging browser attach issues in the dashboard.",
+    });
+    return diagnostics;
+  }
+
+  if (isGatewayNonLoopbackBindMode(bind)) {
+    if (allowedOrigins.length === 0 && !hostHeaderFallback) {
+      diagnostics.push({
+        code: "CONTROL_UI_ALLOWED_ORIGINS_REQUIRED",
+        layer: "control-ui",
+        level: "danger",
+        summary: "Non-loopback Control UI access is missing gateway.controlUi.allowedOrigins.",
+        hint: `Add the exact dashboard origins you open from Windows/WSL, for example http://localhost:${port}.`,
+      });
+    } else if (hostHeaderFallback) {
+      diagnostics.push({
+        code: "CONTROL_UI_HOST_HEADER_FALLBACK",
+        layer: "control-ui",
+        level: "warn",
+        summary: "Control UI origin checks currently rely on Host-header fallback mode.",
+        hint: "Prefer explicit gateway.controlUi.allowedOrigins entries so origin/auth failures are easier to diagnose.",
+      });
+    } else {
+      diagnostics.push({
+        code: "CONTROL_UI_ALLOWED_ORIGINS_CONFIGURED",
+        layer: "control-ui",
+        level: "info",
+        summary: "Control UI origin allowlist is configured for non-loopback access.",
+        hint: `Allowed origins: ${summarizeOrigins(allowedOrigins)}`,
+      });
+    }
+  } else {
+    diagnostics.push({
+      code: "CONTROL_UI_LOOPBACK_ONLY",
+      layer: "control-ui",
+      level: "info",
+      summary: "Control UI is limited to loopback origins on this gateway.",
+      hint: `Open it from http://localhost:${port} or http://127.0.0.1:${port}.`,
+    });
+  }
+
+  if (authMode === "token") {
+    diagnostics.push({
+      code: "CONTROL_UI_TOKEN_AUTH",
+      layer: "control-ui",
+      level: isConfiguredSecret(auth.token) ? "info" : "danger",
+      summary: isConfiguredSecret(auth.token)
+        ? "Gateway Control UI requires a gateway token."
+        : "Gateway auth mode is token, but no token is configured.",
+      hint: isConfiguredSecret(auth.token)
+        ? "If Control UI reports unauthorized, paste the gateway token into Control UI settings."
+        : "Set gateway.auth.token (or OPENCLAW_GATEWAY_TOKEN) before debugging browser reachability.",
+    });
+  } else if (authMode === "password") {
+    diagnostics.push({
+      code: "CONTROL_UI_PASSWORD_AUTH",
+      layer: "control-ui",
+      level: isConfiguredSecret(auth.password) ? "info" : "danger",
+      summary: isConfiguredSecret(auth.password)
+        ? "Gateway Control UI requires a gateway password."
+        : "Gateway auth mode is password, but no password is configured.",
+      hint: isConfiguredSecret(auth.password)
+        ? "If Control UI reports unauthorized, enter the gateway password in Control UI settings."
+        : "Set gateway.auth.password (or OPENCLAW_GATEWAY_PASSWORD) before debugging browser reachability.",
+    });
+  } else if (authMode === "none") {
+    diagnostics.push({
+      code: "CONTROL_UI_AUTH_DISABLED",
+      layer: "control-ui",
+      level: "info",
+      summary: "Gateway auth is disabled for Control UI connections.",
+      hint: "If the dashboard still fails, the blocker is likely origin policy or browser/CDP reachability instead of token auth.",
+    });
+  }
+
+  return diagnostics;
+}
+
+const diagnosticLayerOrder: Record<BrowserStatusDiagnostic["layer"], number> = {
+  "control-ui": 0,
+  profile: 1,
+  cdp: 2,
+};
+
+const diagnosticLevelOrder: Record<BrowserStatusDiagnostic["level"], number> = {
+  danger: 0,
+  warn: 1,
+  info: 2,
+};
+
+export function combineBrowserStatusDiagnostics(
+  ...groups: ReadonlyArray<readonly BrowserStatusDiagnostic[] | undefined>
+): BrowserStatusDiagnostic[] {
+  const deduped = new Map<string, BrowserStatusDiagnostic>();
+  for (const group of groups) {
+    if (!group) {
+      continue;
+    }
+    for (const diagnostic of group) {
+      const key = `${diagnostic.code}:${diagnostic.summary}:${diagnostic.hint ?? ""}`;
+      if (!deduped.has(key)) {
+        deduped.set(key, diagnostic);
+      }
+    }
+  }
+  return [...deduped.values()].toSorted((left, right) => {
+    const layerCmp = diagnosticLayerOrder[left.layer] - diagnosticLayerOrder[right.layer];
+    if (layerCmp !== 0) {
+      return layerCmp;
+    }
+    const levelCmp = diagnosticLevelOrder[left.level] - diagnosticLevelOrder[right.level];
+    if (levelCmp !== 0) {
+      return levelCmp;
+    }
+    return left.summary.localeCompare(right.summary);
+  });
+}

--- a/src/cli/browser-cli-manage.status-diagnostics.test.ts
+++ b/src/cli/browser-cli-manage.status-diagnostics.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerBrowserManageCommands } from "./browser-cli-manage.js";
+import { createBrowserProgram } from "./browser-cli-test-helpers.js";
+
+const mocks = vi.hoisted(() => {
+  const runtimeLog = vi.fn();
+  const runtimeError = vi.fn();
+  const runtimeExit = vi.fn();
+  return {
+    callBrowserRequest: vi.fn(async (_opts: unknown, req: { path?: string }) =>
+      req.path === "/"
+        ? {
+            enabled: true,
+            profile: "remote",
+            running: false,
+            cdpPort: 9222,
+            cdpUrl: "http://10.0.0.42:9222",
+            chosenBrowser: null,
+            detectedBrowser: "chrome",
+            detectedExecutablePath: "/tmp/chrome",
+            userDataDir: null,
+            color: "#0066CC",
+            headless: false,
+            noSandbox: false,
+            executablePath: null,
+            attachOnly: true,
+            diagnostics: [
+              {
+                code: "ATTACH_ONLY_PROFILE",
+                layer: "profile",
+                level: "info",
+                summary:
+                  "Attach-only profile: OpenClaw will connect to an existing browser instead of launching one.",
+                hint: "Expected CDP endpoint: http://10.0.0.42:9222/json/version",
+              },
+              {
+                code: "REMOTE_CDP_HTTP_UNREACHABLE",
+                layer: "cdp",
+                level: "danger",
+                summary: "Remote CDP HTTP unreachable at http://10.0.0.42:9222/json/version.",
+                hint: "Check port forwarding, Windows firewall, and the browser bind address.",
+              },
+            ],
+          }
+        : {},
+    ),
+    callGatewayConfigSnapshot: vi.fn(async () => ({
+      resolved: {
+        gateway: {
+          bind: "lan",
+          port: 18789,
+          auth: { mode: "token", token: "[REDACTED]" },
+          controlUi: {
+            enabled: true,
+            allowedOrigins: ["http://localhost:18789", "http://127.0.0.1:18789"],
+          },
+        },
+      },
+    })),
+    runtimeLog,
+    runtimeError,
+    runtimeExit,
+    runtime: {
+      log: runtimeLog,
+      error: runtimeError,
+      exit: runtimeExit,
+    },
+  };
+});
+
+vi.mock("./browser-cli-shared.js", () => ({
+  callBrowserRequest: mocks.callBrowserRequest,
+  callGatewayConfigSnapshot: mocks.callGatewayConfigSnapshot,
+}));
+
+vi.mock("./cli-utils.js", () => ({
+  runCommandWithRuntime: async (
+    _runtime: unknown,
+    action: () => Promise<void>,
+    onError: (err: unknown) => void,
+  ) => await action().catch(onError),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("browser status diagnostics output", () => {
+  function createProgram() {
+    const { program, browser, parentOpts } = createBrowserProgram();
+    registerBrowserManageCommands(browser, parentOpts);
+    return program;
+  }
+
+  beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
+    mocks.callGatewayConfigSnapshot.mockClear();
+    mocks.runtimeLog.mockClear();
+    mocks.runtimeError.mockClear();
+    mocks.runtimeExit.mockClear();
+  });
+
+  it("prints layered diagnostics under browser status", async () => {
+    const program = createProgram();
+    await program.parseAsync(["browser", "status"], { from: "user" });
+
+    expect(mocks.runtimeLog).toHaveBeenCalledTimes(1);
+    const output = String(mocks.runtimeLog.mock.calls[0]?.[0] ?? "");
+    expect(output).toContain("diagnostics:");
+    expect(output).toContain("[control-ui/info] Control UI origin allowlist is configured");
+    expect(output).toContain("[control-ui/info] Gateway Control UI requires a gateway token");
+    expect(output).toContain("[profile/info] Attach-only profile");
+    expect(output).toContain("[cdp/danger] Remote CDP HTTP unreachable");
+    expect(output).toContain("Windows firewall");
+  });
+});

--- a/src/cli/browser-cli-manage.ts
+++ b/src/cli/browser-cli-manage.ts
@@ -4,13 +4,22 @@ import type {
   BrowserDeleteProfileResult,
   BrowserResetProfileResult,
   BrowserStatus,
+  BrowserStatusDiagnostic,
   BrowserTab,
   ProfileStatus,
 } from "../browser/client.js";
+import {
+  combineBrowserStatusDiagnostics,
+  deriveGatewayControlUiDiagnostics,
+} from "../browser/status-diagnostics.js";
 import { danger, info } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
-import { callBrowserRequest, type BrowserParentOpts } from "./browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  callGatewayConfigSnapshot,
+  type BrowserParentOpts,
+} from "./browser-cli-shared.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 
 function resolveProfileQuery(profile?: string) {
@@ -99,6 +108,39 @@ function logBrowserTabs(tabs: BrowserTab[], json?: boolean) {
   );
 }
 
+function formatBrowserStatusDiagnostics(
+  diagnostics: readonly BrowserStatusDiagnostic[] | undefined,
+): string[] {
+  if (!diagnostics || diagnostics.length === 0) {
+    return [];
+  }
+  const lines = ["diagnostics:"];
+  for (const diagnostic of diagnostics) {
+    lines.push(`- [${diagnostic.layer}/${diagnostic.level}] ${diagnostic.summary}`);
+    if (diagnostic.hint) {
+      lines.push(`  hint: ${diagnostic.hint}`);
+    }
+  }
+  return lines;
+}
+
+async function resolveBrowserStatusDiagnostics(
+  parent: BrowserParentOpts,
+  status: BrowserStatus,
+): Promise<BrowserStatusDiagnostic[] | undefined> {
+  try {
+    const snapshot = await callGatewayConfigSnapshot(parent);
+    const controlUiDiagnostics = deriveGatewayControlUiDiagnostics(
+      (snapshot.resolved && typeof snapshot.resolved === "object"
+        ? snapshot.resolved
+        : snapshot.config) ?? {},
+    );
+    return combineBrowserStatusDiagnostics(controlUiDiagnostics, status.diagnostics);
+  } catch {
+    return status.diagnostics;
+  }
+}
+
 export function registerBrowserManageCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
@@ -110,11 +152,17 @@ export function registerBrowserManageCommands(
       const parent = parentOpts(cmd);
       await runBrowserCommand(async () => {
         const status = await fetchBrowserStatus(parent, parent?.browserProfile);
-        if (printJsonResult(parent, status)) {
+        const diagnostics = await resolveBrowserStatusDiagnostics(parent, status);
+        const statusWithDiagnostics = {
+          ...status,
+          diagnostics,
+        } satisfies BrowserStatus;
+        if (printJsonResult(parent, statusWithDiagnostics)) {
           return;
         }
         const detectedPath = status.detectedExecutablePath ?? status.executablePath;
         const detectedDisplay = detectedPath ? shortenHomePath(detectedPath) : "auto";
+        const formattedDiagnostics = formatBrowserStatusDiagnostics(diagnostics);
         defaultRuntime.log(
           [
             `profile: ${status.profile ?? "openclaw"}`,
@@ -127,6 +175,7 @@ export function registerBrowserManageCommands(
             `detectedPath: ${detectedDisplay}`,
             `profileColor: ${status.color}`,
             ...(status.detectError ? [`detectError: ${status.detectError}`] : []),
+            ...formattedDiagnostics,
           ].join("\n"),
         );
       });

--- a/src/cli/browser-cli-shared.ts
+++ b/src/cli/browser-cli-shared.ts
@@ -61,6 +61,64 @@ export async function callBrowserRequest<T>(
   return payload as T;
 }
 
+export async function callGatewayConfigSnapshot(opts: BrowserParentOpts): Promise<{
+  config?: {
+    gateway?: {
+      bind?: unknown;
+      port?: unknown;
+      auth?: { mode?: unknown; token?: unknown; password?: unknown };
+      controlUi?: {
+        enabled?: unknown;
+        allowedOrigins?: unknown;
+        dangerouslyAllowHostHeaderOriginFallback?: unknown;
+      };
+    };
+  };
+  resolved?: {
+    gateway?: {
+      bind?: unknown;
+      port?: unknown;
+      auth?: { mode?: unknown; token?: unknown; password?: unknown };
+      controlUi?: {
+        enabled?: unknown;
+        allowedOrigins?: unknown;
+        dangerouslyAllowHostHeaderOriginFallback?: unknown;
+      };
+    };
+  };
+}> {
+  const payload = await callGatewayFromCli("config.get", opts, {});
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Unexpected config.get response");
+  }
+  return payload as {
+    config?: {
+      gateway?: {
+        bind?: unknown;
+        port?: unknown;
+        auth?: { mode?: unknown; token?: unknown; password?: unknown };
+        controlUi?: {
+          enabled?: unknown;
+          allowedOrigins?: unknown;
+          dangerouslyAllowHostHeaderOriginFallback?: unknown;
+        };
+      };
+    };
+    resolved?: {
+      gateway?: {
+        bind?: unknown;
+        port?: unknown;
+        auth?: { mode?: unknown; token?: unknown; password?: unknown };
+        controlUi?: {
+          enabled?: unknown;
+          allowedOrigins?: unknown;
+          dangerouslyAllowHostHeaderOriginFallback?: unknown;
+        };
+      };
+    };
+  };
+}
+
 export async function callBrowserResize(
   opts: BrowserParentOpts,
   params: { profile?: string; width: number; height: number; targetId?: string },

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
-import { clearCommandLane, setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import * as schedule from "./schedule.js";
 import {
@@ -1492,10 +1496,12 @@ describe("Cron issue regressions", () => {
     expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
   });
 
-  it("queues manual cron.run requests behind the cron execution lane", async () => {
+  it("queues manual cron.run requests on the detached manual lane", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronManual);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronManual, 1);
 
     const store = makeStorePath();
     const dueAt = Date.parse("2026-02-06T10:05:02.000Z");
@@ -1566,12 +1572,15 @@ describe("Cron issue regressions", () => {
     });
 
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronManual);
   });
 
   it("logs unexpected queued manual run background failures once", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronManual);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronManual, 1);
 
     const dueAt = Date.parse("2026-02-06T10:05:03.000Z");
     const job = createDueIsolatedJob({ id: "queued-failure", nowMs: dueAt, nextRunAtMs: dueAt });
@@ -1594,6 +1603,65 @@ describe("Cron issue regressions", () => {
     );
 
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronManual);
+  });
+
+  it("lets detached cron.run force-runs reuse the cron execution lane without self-deadlocking (#41558)", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronManual);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronManual, 1);
+
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const job = createIsolatedRegressionJob({
+      id: "force-run-cron-lane-41558",
+      name: "force run cron lane",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 13 * * *", tz: "UTC" },
+      payload: { kind: "agentTurn", message: "ping", timeoutSeconds: 0.5 },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(
+      async ({ abortSignal }: { abortSignal?: AbortSignal }) =>
+        await enqueueCommandInLane(CommandLane.Cron, async () => {
+          if (abortSignal?.aborted) {
+            throw new Error("nested cron run started after outer timeout");
+          }
+          now += 5;
+          return { status: "ok" as const, summary: "nested cron lane ok" };
+        }),
+    );
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const ack = await enqueueRun(state, job.id, "force");
+    expect(ack).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    await vi.waitFor(() => {
+      const updated = state.store?.jobs.find((entry) => entry.id === job.id);
+      if (updated?.state.lastStatus === "error") {
+        throw new Error(String(updated.state.lastError));
+      }
+      expect(updated?.state.lastStatus).toBe("ok");
+      expect(updated?.state.lastError).toBeUndefined();
+    });
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronManual);
   });
 
   // Regression: isolated cron runs must not abort at 1/3 of configured timeoutSeconds.

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -532,7 +532,11 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
 
   const runId = `manual:${id}:${state.deps.nowMs()}:${nextManualRunId++}`;
   void enqueueCommandInLane(
-    CommandLane.Cron,
+    // Keep detached `cron.run` requests off the main cron execution lane.
+    // Isolated cron jobs enqueue their embedded agent work onto `CommandLane.Cron`,
+    // so reusing that lane here can deadlock a force-run against its own nested
+    // model execution until the outer cron timeout fires.
+    CommandLane.CronManual,
     async () => {
       const result = await run(state, id, mode);
       if (result.ok && "ran" in result && !result.ran) {

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -4,7 +4,9 @@ import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
-  setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
+  const cronConcurrency = cfg.cron?.maxConcurrentRuns ?? 1;
+  setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
+  setCommandLaneConcurrency(CommandLane.CronManual, cronConcurrency);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -131,7 +131,9 @@ export function createGatewayReloadHandlers(params: {
       }
     }
 
-    setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
+    const cronConcurrency = nextConfig.cron?.maxConcurrentRuns ?? 1;
+    setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
+    setCommandLaneConcurrency(CommandLane.CronManual, cronConcurrency);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
 

--- a/src/process/lanes.ts
+++ b/src/process/lanes.ts
@@ -1,6 +1,7 @@
 export const enum CommandLane {
   Main = "main",
   Cron = "cron",
+  CronManual = "cron:manual",
   Subagent = "subagent",
   Nested = "nested",
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2�C4 bullets:

- Problem: #41549 left exec in a phantom-sandbox state that skipped login-shell PATH recovery, #41553 made WSL2 + Windows browser failures hard to triage across Control UI/auth/origin/CDP layers, and #41558 let detached cron force-runs block on their own cron lane until timeout.
- Why it matters: these failures look like broken tooling even when the underlying install, browser profile, or model path is otherwise valid.
- What changed: exec now probes login-shell PATH when sandbox host falls back locally; browser status now emits layered control-ui/profile/CDP diagnostics and cleaner HTML upstream errors; cron force-runs now use a detached manual lane so nested cron work can still reuse the cron execution lane.
- What did NOT change (scope boundary): this does not add new browser capabilities, does not change sandbox policy beyond PATH recovery for local fallback, and does not redesign cron scheduling semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41549
- Closes #41553
- Closes #41558

## User-visible / Behavior Changes

- Exec tool can now find login-shell-managed binaries when the default sandbox host falls back to direct local execution.
- `openclaw browser status` now surfaces layered diagnostics for Control UI auth/origin configuration, browser profile attach mode, and remote/local CDP reachability.
- Browser HTTP errors now summarize proxy HTML error pages instead of dumping raw markup.
- Detached `cron.run --force` no longer self-deadlocks when isolated cron work reuses the cron execution lane.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Exec PATH recovery now also runs for local fallback from the default sandbox host, but only when no sandbox runtime exists and no explicit PATH override was provided.
  - Browser CLI status now reads the existing redacted `config.get` snapshot through the authenticated gateway path to derive operator diagnostics; it does not expose unredacted secrets.

## Repro + Verification

### Environment

- OS: Windows workstation, repo validation run locally
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A for repro validation
- Integration/channel (if any): Browser control + cron
- Relevant config (redacted): default exec host, browser remote CDP profile, recurring isolated cron jobs

### Steps

1. Leave `tools.exec.host` unset, disable sandbox runtime, and run an exec command that depends on login-shell PATH.
2. Run `openclaw browser status` against a remote CDP profile in a WSL2 + Windows style setup.
3. Force-run a recurring isolated cron job whose nested work reuses the cron lane.

### Expected

- Exec finds login-shell-managed binaries.
- Browser status points to the failing layer instead of a generic connection failure.
- Force-run completes instead of timing out behind its own lane.

### Actual

- Covered by the targeted tests below; all now pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm check`; `pnpm test -- --run src/agents/bash-tools.exec.path.test.ts src/browser/status-diagnostics.test.ts src/browser/server.status-diagnostics.test.ts src/cli/browser-cli-manage.status-diagnostics.test.ts src/browser/client.test.ts src/cron/service.issue-regressions.test.ts`; `pnpm build`.
- Edge cases checked: phantom sandbox PATH fallback, remote/local CDP diagnostics ordering, HTML proxy error summarization, detached cron force-run lane reuse.
- What you did **not** verify: live remote CDP against a real Windows browser host, or a live LLM-backed recurring cron on production credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the three commits in this PR.
- Files/config to restore: `src/agents/bash-tools.exec.ts`, `src/browser/*status*`, `src/cli/browser-cli-*`, `src/cron/service/ops.ts`, `src/process/lanes.ts`, gateway lane config wiring.
- Known bad symptoms reviewers should watch for: missing PATH recovery on macOS launch agents, noisy browser diagnostics ordering, cron force-runs stuck until timeout.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Browser status now includes more diagnostics and merges CLI-derived gateway config checks with server-side CDP checks.
  - Mitigation: diagnostics are additive, optional in the payload, redacted, and covered by route + CLI tests.
- Risk: The new detached cron manual lane could drift from cron concurrency settings.
  - Mitigation: gateway startup and hot-reload now set `CommandLane.Cron` and `CommandLane.CronManual` together, with regression coverage for the deadlock case.
