### PR TITLE
feat(feishu): topic session isolation, streaming card history panel

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -226,6 +226,8 @@ type ResolvedFeishuGroupSession = {
   groupSessionScope: GroupSessionScope;
   replyInThread: boolean;
   threadReply: boolean;
+  /** Topic root message ID used for thread routing (rootId ?? threadId ?? messageId). */
+  topicScope: string | null;
 };
 
 function resolveFeishuGroupSession(params: {
@@ -303,6 +305,7 @@ function resolveFeishuGroupSession(params: {
     groupSessionScope,
     replyInThread,
     threadReply,
+    topicScope,
   };
 }
 
@@ -1312,6 +1315,7 @@ export async function handleFeishuMessage(params: {
         InboundHistory: inboundHistory,
         ReplyToId: ctx.parentId,
         RootMessageId: ctx.rootId,
+        MessageThreadId: groupSession?.topicScope ?? ctx.rootId,
         RawBody: ctx.content,
         CommandBody: ctx.content,
         From: feishuFrom,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1158,14 +1158,30 @@ export async function handleFeishuMessage(params: {
     // Using a group-scoped From causes the agent to treat different users as the same person.
     const feishuFrom = `feishu:${ctx.senderOpenId}`;
     const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
-    const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
-    const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
-    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    // P2P topic isolation: when a p2p message carries root_id/thread_id (user
+    // replied inside a topic thread), scope the session to that topic so each
+    // topic gets its own conversation — matching the user's mental model of
+    // "topic = new session".
+    const p2pTopicScope = !isGroup ? ctx.rootId?.trim() || ctx.threadId?.trim() || null : null;
+    const peerId = isGroup
+      ? (groupSession?.peerId ?? ctx.chatId)
+      : p2pTopicScope
+        ? `${ctx.senderOpenId}:topic:${p2pTopicScope}`
+        : ctx.senderOpenId;
+    const parentPeer = isGroup
+      ? (groupSession?.parentPeer ?? null)
+      : p2pTopicScope
+        ? { kind: "direct" as const, id: ctx.senderOpenId }
+        : null;
+    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : Boolean(p2pTopicScope);
 
     if (isGroup && groupSession) {
       log(
         `feishu[${account.accountId}]: group session scope=${groupSession.groupSessionScope}, peer=${peerId}`,
       );
+    }
+    if (!isGroup && p2pTopicScope) {
+      log(`feishu[${account.accountId}]: p2p topic scope=${p2pTopicScope}, peer=${peerId}`);
     }
 
     let route = core.channel.routing.resolveAgentRoute({
@@ -1359,8 +1375,10 @@ export async function handleFeishuMessage(params: {
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
     const replyTargetMessageId =
-      isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
-    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+      isTopicSession || configReplyInThread || p2pTopicScope
+        ? (ctx.rootId ?? ctx.messageId)
+        : ctx.messageId;
+    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : Boolean(p2pTopicScope);
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -1,6 +1,8 @@
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
+import { sendMessageFeishu } from "./send.js";
+import { getStreamingText } from "./streaming-text-cache.js";
 
 export type FeishuCardActionEvent = {
   operator: {
@@ -44,6 +46,35 @@ export async function handleFeishuCardAction(params: {
     }
   } else {
     content = String(actionValue);
+  }
+
+  // Handle "Show full text" button: re-send cached streaming card content as
+  // a plain message instead of dispatching to the agent session.
+  if (content === "__show_full_text__") {
+    const messageId =
+      typeof actionValue === "object" && actionValue !== null
+        ? (actionValue.message_id as string | undefined)
+        : undefined;
+    const to = event.context.chat_id
+      ? `chat:${event.context.chat_id}`
+      : `user:${event.operator.open_id}`;
+    log(
+      `feishu[${account.accountId}]: show-full-text requested by ${event.operator.open_id} for message=${messageId ?? "unknown"}`,
+    );
+    if (messageId) {
+      const fullText = getStreamingText(messageId);
+      if (fullText) {
+        await sendMessageFeishu({ cfg, to, text: fullText, accountId });
+      } else {
+        await sendMessageFeishu({
+          cfg,
+          to,
+          text: "\u26A0\uFE0F \u7F13\u5B58\u5DF2\u8FC7\u671F\uFF0C\u8BF7\u91CD\u65B0\u63D0\u95EE\u3002",
+          accountId,
+        });
+      }
+    }
+    return;
   }
 
   // Construct a synthetic message event

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -43,19 +43,21 @@ function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
 }
 
-function resolveReplyToMessageId(params: {
+/** Map framework threadId/replyToId to Feishu message.reply params. */
+function resolveFeishuThreadParams(params: {
   replyToId?: string | null;
   threadId?: string | number | null;
-}): string | undefined {
+}): { replyToMessageId?: string; replyInThread?: boolean } {
   const replyToId = params.replyToId?.trim();
   if (replyToId) {
-    return replyToId;
+    return { replyToMessageId: replyToId };
   }
-  if (params.threadId == null) {
-    return undefined;
+  // threadId is the Feishu root_id (topic root message). Use message.reply +
+  // reply_in_thread to route into the topic thread.
+  if (params.threadId != null && String(params.threadId).trim()) {
+    return { replyToMessageId: String(params.threadId), replyInThread: true };
   }
-  const trimmed = String(params.threadId).trim();
-  return trimmed || undefined;
+  return {};
 }
 
 async function sendOutboundText(params: {
@@ -63,17 +65,18 @@ async function sendOutboundText(params: {
   to: string;
   text: string;
   replyToMessageId?: string;
+  replyInThread?: boolean;
   accountId?: string;
 }) {
-  const { cfg, to, text, accountId, replyToMessageId } = params;
+  const { cfg, to, text, accountId, replyToMessageId, replyInThread } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const renderMode = account.config?.renderMode ?? "auto";
 
   if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
-    return sendMarkdownCardFeishu({ cfg, to, text, accountId, replyToMessageId });
+    return sendMarkdownCardFeishu({ cfg, to, text, replyToMessageId, replyInThread, accountId });
   }
 
-  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
+  return sendMessageFeishu({ cfg, to, text, replyToMessageId, replyInThread, accountId });
 }
 
 export const feishuOutbound: ChannelOutboundAdapter = {
@@ -82,7 +85,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
-    const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+    const threadParams = resolveFeishuThreadParams({ replyToId, threadId });
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,
     // auto-upload and send as Feishu image message instead of leaking path text.
@@ -94,7 +97,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl: localImagePath,
           accountId: accountId ?? undefined,
-          replyToMessageId,
+          ...threadParams,
         });
         return { channel: "feishu", ...result };
       } catch (err) {
@@ -108,7 +111,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       to,
       text,
       accountId: accountId ?? undefined,
-      replyToMessageId,
+      ...threadParams,
     });
     return { channel: "feishu", ...result };
   },
@@ -122,7 +125,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     replyToId,
     threadId,
   }) => {
-    const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+    const threadParams = resolveFeishuThreadParams({ replyToId, threadId });
     // Send text first if provided
     if (text?.trim()) {
       await sendOutboundText({
@@ -130,7 +133,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         to,
         text,
         accountId: accountId ?? undefined,
-        replyToMessageId,
+        ...threadParams,
       });
     }
 
@@ -143,7 +146,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           mediaUrl,
           accountId: accountId ?? undefined,
           mediaLocalRoots,
-          replyToMessageId,
+          ...threadParams,
         });
         return { channel: "feishu", ...result };
       } catch (err) {
@@ -156,7 +159,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           text: fallbackText,
           accountId: accountId ?? undefined,
-          replyToMessageId,
+          ...threadParams,
         });
         return { channel: "feishu", ...result };
       }
@@ -168,7 +171,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       to,
       text: text ?? "",
       accountId: accountId ?? undefined,
-      replyToMessageId,
+      ...threadParams,
     });
     return { channel: "feishu", ...result };
   },

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -77,6 +77,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   let typingState: TypingIndicatorState | null = null;
   const typingCallbacks = createTypingCallbacks({
+    // Feishu uses emoji reactions as typing indicators (no native typing API).
+    // Unlike Telegram/Discord, reactions are persistent and don't auto-expire,
+    // so keepalive re-sends are unnecessary and cause repeated notifications.
+    keepaliveIntervalMs: 0,
     start: async () => {
       // Check if typing indicator is enabled (default: true)
       if (!(account.config.typingIndicator ?? true)) {
@@ -163,10 +167,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     if (options?.dedupeWithLastPartial) {
       lastPartial = nextText;
+      // Partial replies are cumulative — each payload contains the full text so far.
+      // Directly replace streamText to avoid the merge fallback appending duplicates.
+      streamText = nextText;
+    } else {
+      const mode = options?.mode ?? "snapshot";
+      streamText =
+        mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
     }
-    const mode = options?.mode ?? "snapshot";
-    streamText =
-      mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
     partialUpdateQueue = partialUpdateQueue.then(async () => {
       if (streamingStartPromise) {
         await streamingStartPromise;
@@ -278,14 +286,24 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
           if (streaming?.isActive()) {
             if (info?.kind === "block") {
-              // Some runtimes emit block payloads without onPartial/final callbacks.
-              // Mirror block text into streamText so onIdle close still sends content.
-              queueStreamingUpdate(text, { mode: "delta" });
+              // Narration: replace card content so each step overwrites the previous one.
+              // Users see the latest status, not a growing log of all narration.
+              streamText = text;
+              partialUpdateQueue = partialUpdateQueue.then(async () => {
+                if (streaming?.isActive()) {
+                  await streaming.update(streamText);
+                }
+              });
             }
             if (info?.kind === "final") {
-              streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
-              deliveredFinalTexts.add(text);
+              // Replace card content with final text. Don't close here — there may be
+              // multiple final payloads; let onIdle close with the last one.
+              streamText = text;
+              partialUpdateQueue = partialUpdateQueue.then(async () => {
+                if (streaming?.isActive()) {
+                  await streaming.update(streamText);
+                }
+              });
             }
             // Send media even when streaming handled the text
             if (hasMedia) {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -413,8 +413,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
       disableBlockStreaming: !streamingEnabled,
-      onToolStart: () => {
+      onToolStart: (payload) => {
         hadToolUse = true;
+        if (payload.phase === "start" && payload.name) {
+          const label = payload.meta
+            ? `▶ ${payload.name} ${payload.meta}`.slice(0, 80)
+            : `▶ ${payload.name}`;
+          historyEntries.push(`\`${label}\``);
+        }
       },
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -14,6 +14,7 @@ import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
+import { cacheStreamingText } from "./streaming-text-cache.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -140,13 +141,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "feishu");
   const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
   const renderMode = account.config?.renderMode ?? "auto";
-  // Card streaming may miss thread affinity in topic contexts; use direct replies there.
-  const streamingEnabled =
-    !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
+  const streamingEnabled = account.config?.streaming !== false && renderMode !== "raw";
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
+  let hadBlockReply = false;
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -224,7 +224,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      await streaming.close(text);
+      // Cache full text before closing so the "Show full text" card-action
+      // button can retrieve it later.
+      const messageId = streaming.getMessageId();
+      if (messageId && streamText) {
+        cacheStreamingText(messageId, streamText);
+      }
+      await streaming.close(text, { addShowFullTextButton: hadBlockReply });
     }
     streaming = null;
     streamingStartPromise = null;
@@ -266,6 +272,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
+            hadBlockReply = true;
             // Drop internal block chunks unless we can safely consume them as
             // streaming-card fallback content.
             if (!(streamingEnabled && useCard)) {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -147,7 +147,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamText = "";
   let lastPartial = "";
   let hadBlockReply = false;
-  let dispatcherRef: { getQueuedCounts: () => Record<string, number> } | null = null;
+  let hadToolUse = false;
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -233,9 +233,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       }
       // Show the "full text" button when tool calls or block replies occurred —
       // these intermediate steps may cause incomplete card rendering.
-      const counts = dispatcherRef?.getQueuedCounts();
-      const hadIntermediateSteps =
-        hadBlockReply || (counts?.tool ?? 0) > 0 || (counts?.block ?? 0) > 0;
+      const hadIntermediateSteps = hadBlockReply || hadToolUse;
+      params.runtime.log?.(
+        `feishu[${account.accountId}] closeStreaming: hadBlockReply=${hadBlockReply}, hadToolUse=${hadToolUse}, hadIntermediateSteps=${hadIntermediateSteps}`,
+      );
       await streaming.close(text, { addShowFullTextButton: hadIntermediateSteps });
     }
     streaming = null;
@@ -407,14 +408,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         typingCallbacks.onCleanup?.();
       },
     });
-  dispatcherRef = dispatcher;
-
   return {
     dispatcher,
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
       disableBlockStreaming: true,
+      onToolStart: () => {
+        hadToolUse = true;
+      },
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -147,6 +147,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamText = "";
   let lastPartial = "";
   let hadBlockReply = false;
+  let dispatcherRef: { getQueuedCounts: () => Record<string, number> } | null = null;
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -230,7 +231,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (messageId && streamText) {
         cacheStreamingText(messageId, streamText);
       }
-      await streaming.close(text, { addShowFullTextButton: hadBlockReply });
+      // Show the "full text" button when tool calls or block replies occurred —
+      // these intermediate steps may cause incomplete card rendering.
+      const counts = dispatcherRef?.getQueuedCounts();
+      const hadIntermediateSteps =
+        hadBlockReply || (counts?.tool ?? 0) > 0 || (counts?.block ?? 0) > 0;
+      await streaming.close(text, { addShowFullTextButton: hadIntermediateSteps });
     }
     streaming = null;
     streamingStartPromise = null;
@@ -401,6 +407,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         typingCallbacks.onCleanup?.();
       },
     });
+  dispatcherRef = dispatcher;
 
   return {
     dispatcher,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -14,7 +14,6 @@ import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
-
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -148,6 +147,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let lastPartial = "";
   let hadBlockReply = false;
   let hadToolUse = false;
+  /** Accumulated history of intermediate steps (block narrations) for the collapsible panel. */
+  const historyEntries: string[] = [];
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -225,14 +226,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      // Append a collapsed panel with the full text when tool calls or block
-      // replies occurred — these intermediate steps may cause incomplete card
-      // rendering, and the panel lets users expand to see the complete response.
+      // Append a collapsed history panel when tool calls or block replies
+      // occurred — the panel shows accumulated intermediate steps so users
+      // can expand to see the full process log.
       const hadIntermediateSteps = hadBlockReply || hadToolUse;
       params.runtime.log?.(
-        `feishu[${account.accountId}] closeStreaming: hadBlockReply=${hadBlockReply}, hadToolUse=${hadToolUse}, addPanel=${hadIntermediateSteps}`,
+        `feishu[${account.accountId}] closeStreaming: hadBlockReply=${hadBlockReply}, hadToolUse=${hadToolUse}, addPanel=${hadIntermediateSteps}, historyEntries=${historyEntries.length}`,
       );
-      await streaming.close(text, { addFullTextPanel: hadIntermediateSteps });
+      const historyText =
+        historyEntries.length > 0 ? historyEntries.join("\n\n---\n\n") : undefined;
+      await streaming.close(text, { addFullTextPanel: hadIntermediateSteps, historyText });
     }
     streaming = null;
     streamingStartPromise = null;
@@ -297,6 +300,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "block") {
               // Narration: replace card content so each step overwrites the previous one.
               // Users see the latest status, not a growing log of all narration.
+              historyEntries.push(text);
               streamText = text;
               partialUpdateQueue = partialUpdateQueue.then(async () => {
                 if (streaming?.isActive()) {
@@ -408,7 +412,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
-      disableBlockStreaming: true,
+      disableBlockStreaming: !streamingEnabled,
       onToolStart: () => {
         hadToolUse = true;
       },

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -14,7 +14,7 @@ import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
-import { cacheStreamingText } from "./streaming-text-cache.js";
+
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -225,19 +225,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      // Cache full text before closing so the "Show full text" card-action
-      // button can retrieve it later.
-      const messageId = streaming.getMessageId();
-      if (messageId && streamText) {
-        cacheStreamingText(messageId, streamText);
-      }
-      // Show the "full text" button when tool calls or block replies occurred —
-      // these intermediate steps may cause incomplete card rendering.
+      // Append a collapsed panel with the full text when tool calls or block
+      // replies occurred — these intermediate steps may cause incomplete card
+      // rendering, and the panel lets users expand to see the complete response.
       const hadIntermediateSteps = hadBlockReply || hadToolUse;
       params.runtime.log?.(
-        `feishu[${account.accountId}] closeStreaming: hadBlockReply=${hadBlockReply}, hadToolUse=${hadToolUse}, hadIntermediateSteps=${hadIntermediateSteps}`,
+        `feishu[${account.accountId}] closeStreaming: hadBlockReply=${hadBlockReply}, hadToolUse=${hadToolUse}, addPanel=${hadIntermediateSteps}`,
       );
-      await streaming.close(text, { addShowFullTextButton: hadIntermediateSteps });
+      await streaming.close(text, { addFullTextPanel: hadIntermediateSteps });
     }
     streaming = null;
     streamingStartPromise = null;

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -324,7 +324,7 @@ export class FeishuStreamingSession {
     await this.queue;
   }
 
-  async close(finalText?: string): Promise<void> {
+  async close(finalText?: string, options?: { addShowFullTextButton?: boolean }): Promise<void> {
     if (!this.state || this.closed) {
       return;
     }
@@ -367,10 +367,58 @@ export class FeishuStreamingSession {
       })
       .catch((e) => this.log?.(`Close failed: ${String(e)}`));
 
+    // Append "Show full text" button when the response included intermediate
+    // steps (tool calls / block narration) that may not have rendered fully.
+    if (options?.addShowFullTextButton && this.state) {
+      this.state.sequence += 1;
+      const buttonElement = {
+        tag: "action",
+        actions: [
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D" },
+            type: "default",
+            size: "small",
+            value: {
+              command: "__show_full_text__",
+              message_id: this.state.messageId,
+            },
+          },
+        ],
+        element_id: "show_full_btn",
+      };
+      await fetchWithSsrFGuard({
+        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements`,
+        init: {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${await getToken(this.creds)}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            elements: JSON.stringify(buttonElement),
+            action: "append",
+            sequence: this.state.sequence,
+            uuid: `btn_${this.state.cardId}_${this.state.sequence}`,
+          }),
+        },
+        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+        auditContext: "feishu.streaming-card.add-button",
+      })
+        .then(async ({ release }) => {
+          await release();
+        })
+        .catch((e) => this.log?.(`Add show-full-text button failed: ${String(e)}`));
+    }
+
     this.log?.(`Closed streaming: cardId=${this.state.cardId}`);
   }
 
   isActive(): boolean {
     return this.state !== null && !this.closed;
+  }
+
+  getMessageId(): string | undefined {
+    return this.state?.messageId;
   }
 }

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -389,7 +389,7 @@ export class FeishuStreamingSession {
       };
       const btnBody = {
         elements: JSON.stringify(buttonElement),
-        action: "append",
+        type: "append",
         sequence: this.state.sequence,
         uuid: `btn_${this.state.cardId}_${this.state.sequence}`,
       };

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -387,28 +387,37 @@ export class FeishuStreamingSession {
         ],
         element_id: "show_full_btn",
       };
-      await fetchWithSsrFGuard({
-        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements`,
-        init: {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${await getToken(this.creds)}`,
-            "Content-Type": "application/json",
+      const btnBody = {
+        elements: JSON.stringify(buttonElement),
+        action: "append",
+        sequence: this.state.sequence,
+        uuid: `btn_${this.state.cardId}_${this.state.sequence}`,
+      };
+      this.log?.(
+        `Adding show-full-text button: cardId=${this.state.cardId}, seq=${this.state.sequence}`,
+      );
+      try {
+        const { response, release } = await fetchWithSsrFGuard({
+          url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements`,
+          init: {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${await getToken(this.creds)}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(btnBody),
           },
-          body: JSON.stringify({
-            elements: JSON.stringify(buttonElement),
-            action: "append",
-            sequence: this.state.sequence,
-            uuid: `btn_${this.state.cardId}_${this.state.sequence}`,
-          }),
-        },
-        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-        auditContext: "feishu.streaming-card.add-button",
-      })
-        .then(async ({ release }) => {
-          await release();
-        })
-        .catch((e) => this.log?.(`Add show-full-text button failed: ${String(e)}`));
+          policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+          auditContext: "feishu.streaming-card.add-button",
+        });
+        const respText = await response.text();
+        release();
+        this.log?.(
+          `Add button response: status=${response.status}, body=${respText.slice(0, 500)}`,
+        );
+      } catch (e) {
+        this.log?.(`Add show-full-text button failed: ${String(e)}`);
+      }
     }
 
     this.log?.(`Closed streaming: cardId=${this.state.cardId}`);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -294,15 +294,15 @@ export class FeishuStreamingSession {
     if (!this.state || this.closed) {
       return;
     }
-    const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
-    if (!mergedInput || mergedInput === this.state.currentText) {
+    // Use text as-is — the caller (reply-dispatcher) controls merge/replace semantics.
+    if (!text || text === this.state.currentText) {
       return;
     }
 
     // Throttle: skip if updated recently, but remember pending text
     const now = Date.now();
     if (now - this.lastUpdateTime < this.updateThrottleMs) {
-      this.pendingText = mergedInput;
+      this.pendingText = text;
       return;
     }
     this.pendingText = null;
@@ -312,12 +312,14 @@ export class FeishuStreamingSession {
       if (!this.state || this.closed) {
         return;
       }
-      const mergedText = mergeStreamingText(this.state.currentText, mergedInput);
-      if (!mergedText || mergedText === this.state.currentText) {
+      // Use pendingText if a newer update arrived while queued, otherwise use text.
+      const finalText = this.pendingText ?? text;
+      this.pendingText = null;
+      if (!finalText || finalText === this.state.currentText) {
         return;
       }
-      this.state.currentText = mergedText;
-      await this.updateCardContent(mergedText, (e) => this.log?.(`Update failed: ${String(e)}`));
+      this.state.currentText = finalText;
+      await this.updateCardContent(finalText, (e) => this.log?.(`Update failed: ${String(e)}`));
     });
     await this.queue;
   }

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -341,83 +341,72 @@ export class FeishuStreamingSession {
       this.state.currentText = text;
     }
 
-    // Close streaming mode
+    // Close streaming mode (and optionally append "Show full text" button)
+    // via batch_update API to combine both operations in a single request.
     this.state.sequence += 1;
-    await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
-      init: {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json; charset=utf-8",
-        },
-        body: JSON.stringify({
-          settings: JSON.stringify({
+    const batchActions: Record<string, unknown>[] = [
+      {
+        action: "partial_update_setting",
+        params: {
+          settings: {
             config: { streaming_mode: false, summary: { content: truncateSummary(text) } },
-          }),
-          sequence: this.state.sequence,
-          uuid: `c_${this.state.cardId}_${this.state.sequence}`,
-        }),
+          },
+        },
       },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.close",
-    })
-      .then(async ({ release }) => {
-        await release();
-      })
-      .catch((e) => this.log?.(`Close failed: ${String(e)}`));
+    ];
 
-    // Append "Show full text" button when the response included intermediate
-    // steps (tool calls / block narration) that may not have rendered fully.
-    if (options?.addShowFullTextButton && this.state) {
-      this.state.sequence += 1;
-      const buttonElement = {
-        tag: "action",
-        actions: [
-          {
-            tag: "button",
-            text: { tag: "plain_text", content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D" },
-            type: "default",
-            size: "small",
-            value: {
-              command: "__show_full_text__",
-              message_id: this.state.messageId,
+    if (options?.addShowFullTextButton) {
+      batchActions.push({
+        action: "add_elements",
+        params: {
+          type: "append",
+          elements: [
+            {
+              tag: "action",
+              actions: [
+                {
+                  tag: "button",
+                  text: { tag: "plain_text", content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D" },
+                  type: "default",
+                  size: "small",
+                  value: {
+                    command: "__show_full_text__",
+                    message_id: this.state.messageId,
+                  },
+                },
+              ],
+              element_id: "show_full_btn",
             },
+          ],
+        },
+      });
+    }
+
+    try {
+      const { response, release } = await fetchWithSsrFGuard({
+        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/batch_update`,
+        init: {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${await getToken(this.creds)}`,
+            "Content-Type": "application/json; charset=utf-8",
           },
-        ],
-        element_id: "show_full_btn",
-      };
-      const btnBody = {
-        elements: JSON.stringify([buttonElement]),
-        type: "append",
-        sequence: this.state.sequence,
-        uuid: `btn_${this.state.cardId}_${this.state.sequence}`,
-      };
-      this.log?.(
-        `Adding show-full-text button: cardId=${this.state.cardId}, seq=${this.state.sequence}`,
-      );
-      try {
-        const { response, release } = await fetchWithSsrFGuard({
-          url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements`,
-          init: {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${await getToken(this.creds)}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(btnBody),
-          },
-          policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-          auditContext: "feishu.streaming-card.add-button",
-        });
-        const respText = await response.text();
-        release();
-        this.log?.(
-          `Add button response: status=${response.status}, body=${respText.slice(0, 500)}`,
-        );
-      } catch (e) {
-        this.log?.(`Add show-full-text button failed: ${String(e)}`);
+          body: JSON.stringify({
+            actions: JSON.stringify(batchActions),
+            sequence: this.state.sequence,
+            uuid: `c_${this.state.cardId}_${this.state.sequence}`,
+          }),
+        },
+        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+        auditContext: "feishu.streaming-card.close",
+      });
+      const respText = await response.text();
+      release();
+      if (response.status !== 200 || !respText.includes('"code":0')) {
+        this.log?.(`batch_update failed: status=${response.status}, body=${respText.slice(0, 500)}`);
       }
+    } catch (e) {
+      this.log?.(`Close failed: ${String(e)}`);
     }
 
     this.log?.(`Closed streaming: cardId=${this.state.cardId}`);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -324,7 +324,10 @@ export class FeishuStreamingSession {
     await this.queue;
   }
 
-  async close(finalText?: string, options?: { addFullTextPanel?: boolean }): Promise<void> {
+  async close(
+    finalText?: string,
+    options?: { addFullTextPanel?: boolean; historyText?: string },
+  ): Promise<void> {
     if (!this.state || this.closed) {
       return;
     }
@@ -356,6 +359,8 @@ export class FeishuStreamingSession {
     ];
 
     if (options?.addFullTextPanel && text) {
+      // Use accumulated history entries when available; fall back to final text
+      const panelContent = options.historyText ?? text;
       batchActions.push({
         action: "add_elements",
         params: {
@@ -367,14 +372,25 @@ export class FeishuStreamingSession {
               header: {
                 title: {
                   tag: "plain_text",
-                  content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D",
+                  content: "history",
                 },
+                vertical_align: "center",
+                icon: {
+                  tag: "standard_icon",
+                  token: "down-small-ccm_outlined",
+                  size: "16px 16px",
+                },
+                icon_position: "follow_text",
+                icon_expanded_angle: -180,
               },
+              border: { color: "grey", corner_radius: "5px" },
+              padding: "8px 8px 8px 8px",
               element_id: "full_text_panel",
               elements: [
                 {
                   tag: "markdown",
-                  content: text,
+                  content: panelContent,
+                  text_size: "notation",
                   element_id: "full_text_content",
                 },
               ],
@@ -405,7 +421,9 @@ export class FeishuStreamingSession {
       const respText = await response.text();
       release();
       if (response.status !== 200 || !respText.includes('"code":0')) {
-        this.log?.(`batch_update failed: status=${response.status}, body=${respText.slice(0, 500)}`);
+        this.log?.(
+          `batch_update failed: status=${response.status}, body=${respText.slice(0, 500)}`,
+        );
       }
     } catch (e) {
       this.log?.(`Close failed: ${String(e)}`);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -362,19 +362,14 @@ export class FeishuStreamingSession {
           type: "append",
           elements: [
             {
-              tag: "action",
-              actions: [
-                {
-                  tag: "button",
-                  text: { tag: "plain_text", content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D" },
-                  type: "default",
-                  size: "small",
-                  value: {
-                    command: "__show_full_text__",
-                    message_id: this.state.messageId,
-                  },
-                },
-              ],
+              tag: "button",
+              text: { tag: "plain_text", content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D" },
+              type: "default",
+              size: "small",
+              value: {
+                command: "__show_full_text__",
+                message_id: this.state.messageId,
+              },
               element_id: "show_full_btn",
             },
           ],

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -324,7 +324,7 @@ export class FeishuStreamingSession {
     await this.queue;
   }
 
-  async close(finalText?: string, options?: { addShowFullTextButton?: boolean }): Promise<void> {
+  async close(finalText?: string, options?: { addFullTextPanel?: boolean }): Promise<void> {
     if (!this.state || this.closed) {
       return;
     }
@@ -355,22 +355,29 @@ export class FeishuStreamingSession {
       },
     ];
 
-    if (options?.addShowFullTextButton) {
+    if (options?.addFullTextPanel && text) {
       batchActions.push({
         action: "add_elements",
         params: {
           type: "append",
           elements: [
             {
-              tag: "button",
-              text: { tag: "plain_text", content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D" },
-              type: "default",
-              size: "small",
-              value: {
-                command: "__show_full_text__",
-                message_id: this.state.messageId,
+              tag: "collapsible_panel",
+              expanded: false,
+              header: {
+                title: {
+                  tag: "plain_text",
+                  content: "\u{1F4CB} \u67E5\u770B\u5B8C\u6574\u56DE\u590D",
+                },
               },
-              element_id: "show_full_btn",
+              element_id: "full_text_panel",
+              elements: [
+                {
+                  tag: "markdown",
+                  content: text,
+                  element_id: "full_text_content",
+                },
+              ],
             },
           ],
         },

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -388,7 +388,7 @@ export class FeishuStreamingSession {
         element_id: "show_full_btn",
       };
       const btnBody = {
-        elements: JSON.stringify(buttonElement),
+        elements: JSON.stringify([buttonElement]),
         type: "append",
         sequence: this.state.sequence,
         uuid: `btn_${this.state.cardId}_${this.state.sequence}`,

--- a/extensions/feishu/src/streaming-text-cache.ts
+++ b/extensions/feishu/src/streaming-text-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * In-memory cache for streaming card full text.
+ *
+ * When a streaming card closes, the complete text is stored here keyed by the
+ * Feishu message ID.  The "Show full text" card-action button reads from this
+ * cache to re-send the content as a plain message when the card rendering was
+ * incomplete.
+ *
+ * The cache is intentionally volatile — gateway restarts clear it.  A future
+ * iteration may read from session JSONL files for persistent access.
+ */
+
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+interface CacheEntry {
+  text: string;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export function cacheStreamingText(messageId: string, text: string): void {
+  cleanExpired();
+  cache.set(messageId, { text, timestamp: Date.now() });
+}
+
+export function getStreamingText(messageId: string): string | undefined {
+  const entry = cache.get(messageId);
+  if (!entry) return undefined;
+  if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+    cache.delete(messageId);
+    return undefined;
+  }
+  return entry.text;
+}
+
+function cleanExpired(): void {
+  const now = Date.now();
+  for (const [key, val] of cache) {
+    if (now - val.timestamp > CACHE_TTL_MS) cache.delete(key);
+  }
+}

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -233,7 +233,7 @@ export async function handleToolExecutionStart(
   // Best-effort typing signal; do not block tool summaries on slow emitters.
   void ctx.params.onAgentEvent?.({
     stream: "tool",
-    data: { phase: "start", name: toolName, toolCallId },
+    data: { phase: "start", name: toolName, toolCallId, meta },
   });
 
   if (

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -385,9 +385,10 @@ export async function runAgentTurnWithFallback(params: {
                 if (evt.stream === "tool") {
                   const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
                   const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
+                  const meta = typeof evt.data.meta === "string" ? evt.data.meta : undefined;
                   if (phase === "start" || phase === "update") {
                     await params.typingSignals.signalToolStart();
-                    await params.opts?.onToolStart?.({ name, phase });
+                    await params.opts?.onToolStart?.({ name, phase, meta });
                   }
                 }
                 // Track auto-compaction completion

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -53,7 +53,7 @@ export type GetReplyOptions = {
   onBlockReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a tool phase starts/updates, before summary payloads are emitted. */
-  onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+  onToolStart?: (payload: { name?: string; phase?: string; meta?: string }) => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;


### PR DESCRIPTION
## Summary

- **P2P topic session isolation**: Messages in Feishu DM topics now route to separate sessions (`direct:ou_xxx:topic:om_xxx`), matching group topic behavior
- **Enable streaming card for topic sessions**: Removed `!threadReplyMode` guard — streaming cards already support `reply_in_thread`, so topic contexts now get streaming rendering
- **History panel**: Collapsible panel appended to streaming cards when tool calls or block narrations occur. Shows accumulated intermediate steps (tool starts with meta, block narrations) so users can expand to see the full process log
- **Tool meta in onToolStart**: Extended `onToolStart` payload with `meta` field to provide tool context (e.g. "with fetch https://...") in history entries

## Files

| File | Change |
|------|--------|
| `extensions/feishu/src/bot.ts` | P2P topic scope calculation, peerId/parentPeer/threadReply routing |
| `extensions/feishu/src/outbound.ts` | Thread-aware outbound routing for topic sessions |
| `extensions/feishu/src/reply-dispatcher.ts` | Block streaming toggle, historyEntries accumulation, tool meta in onToolStart |
| `extensions/feishu/src/streaming-card.ts` | CardKit batch_update API for close + collapsible panel |
| `extensions/feishu/src/streaming-text-cache.ts` | In-memory cache (kept for future card action fallback) |
| `extensions/feishu/src/card-action.ts` | `__show_full_text__` handler (kept for future) |
| `src/auto-reply/types.ts` | Add `meta` to `onToolStart` payload type |
| `src/agents/pi-embedded-subscribe.handlers.tools.ts` | Pass tool `meta` through `onAgentEvent` |
| `src/auto-reply/reply/agent-runner-execution.ts` | Forward `meta` to `onToolStart` callback |

## Test plan

- [x] P2P topic isolation: send message in DM topic → verify separate session created
- [x] Streaming card in topic: send message in group topic → verify streaming card renders
- [x] History panel: trigger tool call → verify collapsible "history" panel with tool starts and narrations
- [x] Tool meta: verify tool start entries with meta in history panel
- [x] Deploy to dev and test via Lark bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)