### PR TITLE
feat: add OPENCLAW_ADDITIONAL_PORTS to docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
 # Optional alternative auth mode (use token OR password).
 # OPENCLAW_GATEWAY_PASSWORD=change-me-to-a-strong-password
 
+# Optional additional port mappings (e.g., for range 8000-8100 on all interfaces).
+# Format: [HOST_IP:]START-END:START-END OR [HOST_IP:]PORT:PORT
+# OPENCLAW_ADDITIONAL_PORTS=0.0.0.0:8000-8100:8000-8100
+
 # Optional path overrides (defaults shown for reference).
 # OPENCLAW_STATE_DIR=~/.openclaw
 # OPENCLAW_CONFIG_PATH=~/.openclaw/openclaw.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
-      - "${OPENCLAW_ADDITIONAL_PORTS:-127.0.0.1:18789:18789}"
+      - "${OPENCLAW_ADDITIONAL_PORTS}"
     init: true
     restart: unless-stopped
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+      - "${OPENCLAW_ADDITIONAL_PORTS:-127.0.0.1:18789:18789}"
     init: true
     restart: unless-stopped
     command:


### PR DESCRIPTION
This PR adds support for mapping an entire range of ports (or specific ports) from the container to the host interface via the `OPENCLAW_ADDITIONAL_PORTS` environment variable.

### Motivation
Users may need to expose ranges of ports (e.g., 8000-8100) for various integrations or tools running within the OpenClaw container.

### Changes
- Updated `docker-compose.yml` to include an optional third port mapping entry using `OPENCLAW_ADDITIONAL_PORTS`.
- Added documentation and an example in `.env.example`.

### Testing
- Verified `docker-compose.yml` syntax with `docker compose config`.
- Lightly tested by setting the variable in a local `.env` and confirming the mapping appears in the generated config.

AI-assisted: Yes