### PR TITLE
refactor(doctor): extract legacy config file migration helper

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs/promises";
-import path from "node:path";
 import { normalizeChatChannelId } from "../channels/registry.js";
 import {
   isNumericTelegramUserId,
@@ -48,7 +46,6 @@ import {
 import { inspectTelegramAccount } from "../telegram/account-inspect.js";
 import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/accounts.js";
 import { note } from "../terminal/note.js";
-import { resolveHomeDir } from "../utils.js";
 import {
   formatConfigPath,
   noteIncludeConfinementWarning,
@@ -56,6 +53,7 @@ import {
   resolveConfigPathTarget,
   stripUnknownConfigKeys,
 } from "./doctor-config-analysis.js";
+import { maybeMigrateLegacyConfigFile } from "./doctor-legacy-config-file.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
@@ -1602,53 +1600,6 @@ function maybeRepairLegacyToolsBySenderKeys(cfg: OpenClawConfig): {
   return { config: next, changes };
 }
 
-async function maybeMigrateLegacyConfig(): Promise<string[]> {
-  const changes: string[] = [];
-  const home = resolveHomeDir();
-  if (!home) {
-    return changes;
-  }
-
-  const targetDir = path.join(home, ".openclaw");
-  const targetPath = path.join(targetDir, "openclaw.json");
-  try {
-    await fs.access(targetPath);
-    return changes;
-  } catch {
-    // missing config
-  }
-
-  const legacyCandidates = [
-    path.join(home, ".clawdbot", "clawdbot.json"),
-    path.join(home, ".moldbot", "moldbot.json"),
-    path.join(home, ".moltbot", "moltbot.json"),
-  ];
-
-  let legacyPath: string | null = null;
-  for (const candidate of legacyCandidates) {
-    try {
-      await fs.access(candidate);
-      legacyPath = candidate;
-      break;
-    } catch {
-      // continue
-    }
-  }
-  if (!legacyPath) {
-    return changes;
-  }
-
-  await fs.mkdir(targetDir, { recursive: true });
-  try {
-    await fs.copyFile(legacyPath, targetPath, fs.constants.COPYFILE_EXCL);
-    changes.push(`Migrated legacy config: ${legacyPath} -> ${targetPath}`);
-  } catch {
-    // If it already exists, skip silently.
-  }
-
-  return changes;
-}
-
 export async function loadAndMaybeMigrateDoctorConfig(params: {
   options: DoctorOptions;
   confirm: (p: { message: string; initialValue: boolean }) => Promise<boolean>;
@@ -1662,7 +1613,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note(stateDirResult.warnings.map((entry) => `- ${entry}`).join("\n"), "Doctor warnings");
   }
 
-  const legacyConfigChanges = await maybeMigrateLegacyConfig();
+  const legacyConfigChanges = await maybeMigrateLegacyConfigFile();
   if (legacyConfigChanges.length > 0) {
     note(legacyConfigChanges.map((entry) => `- ${entry}`).join("\n"), "Doctor changes");
   }

--- a/src/commands/doctor-legacy-config-file.test.ts
+++ b/src/commands/doctor-legacy-config-file.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import { maybeMigrateLegacyConfigFile } from "./doctor-legacy-config-file.js";
+
+describe("maybeMigrateLegacyConfigFile", () => {
+  it("copies a legacy config file into the canonical config path", async () => {
+    await withTempHome(async (home) => {
+      const legacyPath = path.join(home, ".clawdbot", "clawdbot.json");
+      const legacyContent = JSON.stringify({ model: "claude-sonnet-4-5" }, null, 2);
+      await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+      await fs.writeFile(legacyPath, legacyContent, "utf8");
+
+      const changes = await maybeMigrateLegacyConfigFile();
+      const targetPath = path.join(home, ".openclaw", "openclaw.json");
+
+      expect(changes).toEqual([`Migrated legacy config: ${legacyPath} -> ${targetPath}`]);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(legacyContent);
+    });
+  });
+
+  it("skips migration when the canonical config already exists", async () => {
+    await withTempHome(async (home) => {
+      const targetPath = path.join(home, ".openclaw", "openclaw.json");
+      const legacyPath = path.join(home, ".clawdbot", "clawdbot.json");
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+      await fs.writeFile(targetPath, JSON.stringify({ model: "existing" }, null, 2), "utf8");
+      await fs.writeFile(legacyPath, JSON.stringify({ model: "legacy" }, null, 2), "utf8");
+
+      const changes = await maybeMigrateLegacyConfigFile();
+
+      expect(changes).toEqual([]);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toContain('"existing"');
+    });
+  });
+
+  it("returns no changes when no legacy config file exists", async () => {
+    await withTempHome(async () => {
+      await expect(maybeMigrateLegacyConfigFile()).resolves.toEqual([]);
+    });
+  });
+});

--- a/src/commands/doctor-legacy-config-file.ts
+++ b/src/commands/doctor-legacy-config-file.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveHomeDir } from "../utils.js";
+
+export async function maybeMigrateLegacyConfigFile(): Promise<string[]> {
+  const changes: string[] = [];
+  const home = resolveHomeDir();
+  if (!home) {
+    return changes;
+  }
+
+  const targetDir = path.join(home, ".openclaw");
+  const targetPath = path.join(targetDir, "openclaw.json");
+  try {
+    await fs.access(targetPath);
+    return changes;
+  } catch {
+    // missing config
+  }
+
+  const legacyCandidates = [
+    path.join(home, ".clawdbot", "clawdbot.json"),
+    path.join(home, ".moldbot", "moldbot.json"),
+    path.join(home, ".moltbot", "moltbot.json"),
+  ];
+
+  let legacyPath: string | null = null;
+  for (const candidate of legacyCandidates) {
+    try {
+      await fs.access(candidate);
+      legacyPath = candidate;
+      break;
+    } catch {
+      // continue
+    }
+  }
+  if (!legacyPath) {
+    return changes;
+  }
+
+  await fs.mkdir(targetDir, { recursive: true });
+  try {
+    await fs.copyFile(legacyPath, targetPath, fs.constants.COPYFILE_EXCL);
+    changes.push(`Migrated legacy config: ${legacyPath} -> ${targetPath}`);
+  } catch {
+    // If it already exists, skip silently.
+  }
+
+  return changes;
+}


### PR DESCRIPTION
## Summary

- Problem: `src/commands/doctor-config-flow.ts` still contained inline filesystem logic for migrating legacy config files into the canonical `~/.openclaw/openclaw.json` location.
- Why it matters: this makes the doctor entrypoint harder to read and leaves a small, self-contained migration helper mixed into the main orchestration flow.
- What changed: extracted the legacy config file copy logic into `src/commands/doctor-legacy-config-file.ts` and added focused tests for copy, skip, and no-op cases.
- What did NOT change (scope boundary): no migration behavior, config semantics, or doctor output format changed.

## Change Type (select all)

- [x] Refactor

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related #41777

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): doctor CLI
- Relevant config (redacted): temporary home dirs with synthetic legacy config fixtures

### Steps

1. Create a legacy config file under `~/.clawdbot/clawdbot.json`.
2. Run the extracted helper and verify it copies into `~/.openclaw/openclaw.json`.
3. Repeat with an existing canonical config and with no legacy file present.

### Expected

- Doctor keeps the same legacy file migration behavior while the orchestration file gets smaller.

### Actual

- Behavior stayed the same; focused helper tests and existing doctor flow tests passed.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: legacy config copy, existing target skip, no-op when no legacy config exists.
- Edge cases checked: canonical config pre-exists, no legacy candidates exist.
- What you did **not** verify: end-to-end interactive doctor prompts beyond the existing `doctor-config-flow` tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / commit.
- Files/config to restore: `src/commands/doctor-config-flow.ts`
- Known bad symptoms reviewers should watch for: doctor stops copying legacy config files into the canonical path.

## Risks and Mitigations

- Risk: helper extraction could accidentally change the copy/skip behavior.
- Mitigation: focused tests cover copy, skip, and no-op paths, and `doctor-config-flow` tests still pass.

AI-assisted: Yes (Codex). Locally tested.
