### PR TITLE
refactor(doctor): extract dm alias migration helpers

### DIFF
--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -9,6 +9,7 @@ import {
   resolveTelegramPreviewStreamMode,
 } from "../config/discord-preview-streaming.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+import { normalizeDmAliases } from "./doctor-legacy-dm-aliases.js";
 
 export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   config: OpenClawConfig;
@@ -19,87 +20,6 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
 
   const isRecord = (value: unknown): value is Record<string, unknown> =>
     Boolean(value) && typeof value === "object" && !Array.isArray(value);
-
-  const normalizeDmAliases = (params: {
-    provider: "slack" | "discord";
-    entry: Record<string, unknown>;
-    pathPrefix: string;
-  }): { entry: Record<string, unknown>; changed: boolean } => {
-    let changed = false;
-    let updated: Record<string, unknown> = params.entry;
-    const rawDm = updated.dm;
-    const dm = isRecord(rawDm) ? structuredClone(rawDm) : null;
-    let dmChanged = false;
-
-    const allowFromEqual = (a: unknown, b: unknown): boolean => {
-      if (!Array.isArray(a) || !Array.isArray(b)) {
-        return false;
-      }
-      const na = a.map((v) => String(v).trim()).filter(Boolean);
-      const nb = b.map((v) => String(v).trim()).filter(Boolean);
-      if (na.length !== nb.length) {
-        return false;
-      }
-      return na.every((v, i) => v === nb[i]);
-    };
-
-    const topDmPolicy = updated.dmPolicy;
-    const legacyDmPolicy = dm?.policy;
-    if (topDmPolicy === undefined && legacyDmPolicy !== undefined) {
-      updated = { ...updated, dmPolicy: legacyDmPolicy };
-      changed = true;
-      if (dm) {
-        delete dm.policy;
-        dmChanged = true;
-      }
-      changes.push(`Moved ${params.pathPrefix}.dm.policy → ${params.pathPrefix}.dmPolicy.`);
-    } else if (topDmPolicy !== undefined && legacyDmPolicy !== undefined) {
-      if (topDmPolicy === legacyDmPolicy) {
-        if (dm) {
-          delete dm.policy;
-          dmChanged = true;
-          changes.push(`Removed ${params.pathPrefix}.dm.policy (dmPolicy already set).`);
-        }
-      }
-    }
-
-    const topAllowFrom = updated.allowFrom;
-    const legacyAllowFrom = dm?.allowFrom;
-    if (topAllowFrom === undefined && legacyAllowFrom !== undefined) {
-      updated = { ...updated, allowFrom: legacyAllowFrom };
-      changed = true;
-      if (dm) {
-        delete dm.allowFrom;
-        dmChanged = true;
-      }
-      changes.push(`Moved ${params.pathPrefix}.dm.allowFrom → ${params.pathPrefix}.allowFrom.`);
-    } else if (topAllowFrom !== undefined && legacyAllowFrom !== undefined) {
-      if (allowFromEqual(topAllowFrom, legacyAllowFrom)) {
-        if (dm) {
-          delete dm.allowFrom;
-          dmChanged = true;
-          changes.push(`Removed ${params.pathPrefix}.dm.allowFrom (allowFrom already set).`);
-        }
-      }
-    }
-
-    if (dm && isRecord(rawDm) && dmChanged) {
-      const keys = Object.keys(dm);
-      if (keys.length === 0) {
-        if (updated.dm !== undefined) {
-          const { dm: _ignored, ...rest } = updated;
-          updated = rest;
-          changed = true;
-          changes.push(`Removed empty ${params.pathPrefix}.dm after migration.`);
-        }
-      } else {
-        updated = { ...updated, dm };
-        changed = true;
-      }
-    }
-
-    return { entry: updated, changed };
-  };
 
   const normalizePreviewStreamingAliases = (params: {
     entry: Record<string, unknown>;
@@ -228,12 +148,12 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
     let changed = false;
     if (provider !== "telegram") {
       const base = normalizeDmAliases({
-        provider,
         entry: rawEntry,
         pathPrefix: `channels.${provider}`,
       });
       updated = base.entry;
       changed = base.changed;
+      changes.push(...base.changes);
     }
     const providerStreaming = normalizeStreamingAliasesForProvider({
       provider,
@@ -255,12 +175,12 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
         let accountChanged = false;
         if (provider !== "telegram") {
           const res = normalizeDmAliases({
-            provider,
             entry: rawAccount,
             pathPrefix: `channels.${provider}.accounts.${accountId}`,
           });
           accountEntry = res.entry;
           accountChanged = res.changed;
+          changes.push(...res.changes);
         }
         const accountStreaming = normalizeStreamingAliasesForProvider({
           provider,

--- a/src/commands/doctor-legacy-dm-aliases.test.ts
+++ b/src/commands/doctor-legacy-dm-aliases.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDmAliases } from "./doctor-legacy-dm-aliases.js";
+
+describe("normalizeDmAliases", () => {
+  it("moves legacy dm aliases to top-level keys and preserves unrelated dm config", () => {
+    const result = normalizeDmAliases({
+      entry: {
+        dm: {
+          enabled: true,
+          policy: "open",
+          allowFrom: ["*"],
+        },
+      },
+      pathPrefix: "channels.slack",
+    });
+
+    expect(result.entry).toEqual({
+      dm: { enabled: true },
+      dmPolicy: "open",
+      allowFrom: ["*"],
+    });
+    expect(result.changed).toBe(true);
+    expect(result.changes).toEqual([
+      "Moved channels.slack.dm.policy → channels.slack.dmPolicy.",
+      "Moved channels.slack.dm.allowFrom → channels.slack.allowFrom.",
+    ]);
+  });
+
+  it("removes duplicate legacy aliases when top-level values already exist", () => {
+    const result = normalizeDmAliases({
+      entry: {
+        dmPolicy: "allowlist",
+        allowFrom: ["123"],
+        dm: {
+          policy: "allowlist",
+          allowFrom: ["123"],
+        },
+      },
+      pathPrefix: "channels.discord.accounts.work",
+    });
+
+    expect(result.entry).toEqual({
+      dmPolicy: "allowlist",
+      allowFrom: ["123"],
+    });
+    expect(result.changed).toBe(true);
+    expect(result.changes).toEqual([
+      "Removed channels.discord.accounts.work.dm.policy (dmPolicy already set).",
+      "Removed channels.discord.accounts.work.dm.allowFrom (allowFrom already set).",
+      "Removed empty channels.discord.accounts.work.dm after migration.",
+    ]);
+  });
+
+  it("keeps differing legacy aliases in dm when top-level values do not match", () => {
+    const entry = {
+      dmPolicy: "open",
+      allowFrom: ["123"],
+      dm: {
+        policy: "allowlist",
+        allowFrom: ["456"],
+        groupEnabled: true,
+      },
+    };
+
+    const result = normalizeDmAliases({
+      entry,
+      pathPrefix: "channels.discord",
+    });
+
+    expect(result.entry).toBe(entry);
+    expect(result.changed).toBe(false);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/src/commands/doctor-legacy-dm-aliases.ts
+++ b/src/commands/doctor-legacy-dm-aliases.ts
@@ -1,0 +1,86 @@
+import { isRecord } from "../utils.js";
+
+function allowFromEqual(a: unknown, b: unknown): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return false;
+  }
+  const na = a.map((v) => String(v).trim()).filter(Boolean);
+  const nb = b.map((v) => String(v).trim()).filter(Boolean);
+  if (na.length !== nb.length) {
+    return false;
+  }
+  return na.every((v, i) => v === nb[i]);
+}
+
+export function normalizeDmAliases(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+}): {
+  entry: Record<string, unknown>;
+  changed: boolean;
+  changes: string[];
+} {
+  const changes: string[] = [];
+  let changed = false;
+  let updated: Record<string, unknown> = params.entry;
+  const rawDm = updated.dm;
+  const dm = isRecord(rawDm) ? structuredClone(rawDm) : null;
+  let dmChanged = false;
+
+  const topDmPolicy = updated.dmPolicy;
+  const legacyDmPolicy = dm?.policy;
+  if (topDmPolicy === undefined && legacyDmPolicy !== undefined) {
+    updated = { ...updated, dmPolicy: legacyDmPolicy };
+    changed = true;
+    if (dm) {
+      delete dm.policy;
+      dmChanged = true;
+    }
+    changes.push(`Moved ${params.pathPrefix}.dm.policy → ${params.pathPrefix}.dmPolicy.`);
+  } else if (topDmPolicy !== undefined && legacyDmPolicy !== undefined) {
+    if (topDmPolicy === legacyDmPolicy) {
+      if (dm) {
+        delete dm.policy;
+        dmChanged = true;
+        changes.push(`Removed ${params.pathPrefix}.dm.policy (dmPolicy already set).`);
+      }
+    }
+  }
+
+  const topAllowFrom = updated.allowFrom;
+  const legacyAllowFrom = dm?.allowFrom;
+  if (topAllowFrom === undefined && legacyAllowFrom !== undefined) {
+    updated = { ...updated, allowFrom: legacyAllowFrom };
+    changed = true;
+    if (dm) {
+      delete dm.allowFrom;
+      dmChanged = true;
+    }
+    changes.push(`Moved ${params.pathPrefix}.dm.allowFrom → ${params.pathPrefix}.allowFrom.`);
+  } else if (topAllowFrom !== undefined && legacyAllowFrom !== undefined) {
+    if (allowFromEqual(topAllowFrom, legacyAllowFrom)) {
+      if (dm) {
+        delete dm.allowFrom;
+        dmChanged = true;
+        changes.push(`Removed ${params.pathPrefix}.dm.allowFrom (allowFrom already set).`);
+      }
+    }
+  }
+
+  if (dm && isRecord(rawDm) && dmChanged) {
+    const keys = Object.keys(dm);
+    if (keys.length === 0) {
+      if (updated.dm !== undefined) {
+        const { dm: _ignored, ...rest } = updated;
+        updated = rest;
+        changed = true;
+        changes.push(`Removed empty ${params.pathPrefix}.dm after migration.`);
+      }
+    } else {
+      updated = { ...updated, dm };
+      changed = true;
+    }
+  }
+
+  return { entry: updated, changed, changes };
+}


### PR DESCRIPTION
## Summary

- Problem: `src/commands/doctor-legacy-config.ts` still contained inline DM alias migration logic for `dm.policy` and `dm.allowFrom`.
- Why it matters: this mixes a small, self-contained compatibility migration helper into the larger legacy config normalization flow.
- What changed: extracted the DM alias migration into `src/commands/doctor-legacy-dm-aliases.ts` and added focused helper tests.
- What did NOT change (scope boundary): no migration rules, change messages, or config semantics changed.

## Change Type (select all)

- [x] Refactor

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related #42036

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): doctor config compatibility migration
- Relevant config (redacted): synthetic legacy Slack/Discord config fixtures

### Steps

1. Run `normalizeCompatibilityConfigValues()` on config using legacy `dm.policy` / `dm.allowFrom` keys.
2. Verify top-level aliases are migrated or removed when already duplicated.
3. Verify mismatched top-level vs nested values remain unchanged.

### Expected

- Legacy DM alias migration keeps the same behavior while the main legacy config module gets smaller.

### Actual

- Migration behavior stayed the same; focused helper tests and existing migration tests passed.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: alias move, duplicate alias cleanup, mismatched values no-op.
- Edge cases checked: nested `dm` object preserved when unrelated keys remain, empty `dm` removed after migration.
- What you did **not** verify: any interactive doctor CLI flow beyond existing compatibility migration tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / commit.
- Files/config to restore: `src/commands/doctor-legacy-config.ts`
- Known bad symptoms reviewers should watch for: doctor stops moving `dm.policy` / `dm.allowFrom` correctly or changes migration note text.

## Risks and Mitigations

- Risk: extraction could accidentally change migration messages or nested `dm` cleanup behavior.
- Mitigation: focused helper tests cover move, cleanup, and no-op cases, and the existing migration suite still passes.

AI-assisted: Yes (Codex). Locally tested.
