### PR TITLE
fix(telegram): handle buffer/filename in message send action

### DIFF
--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -802,3 +802,37 @@ describe("handleTelegramAction per-account gating", () => {
     );
   });
 });
+
+describe("handleTelegramAction buffer forwarding", () => {
+  beforeEach(() => {
+    sendMessageTelegram.mockClear();
+  });
+
+  it("forwards inline attachment buffers", async () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok" } },
+    } as OpenClawConfig;
+
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        buffer: "QUJD",
+        filename: "note.txt",
+        contentType: "text/plain",
+      },
+      cfg,
+    );
+
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "123456",
+      "",
+      expect.objectContaining({
+        token: "tok",
+        buffer: "QUJD",
+        filename: "note.txt",
+        contentType: "text/plain",
+      }),
+    );
+  });
+});

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -188,10 +188,15 @@ export async function handleTelegramAction(
     }
     const to = readStringParam(params, "to", { required: true });
     const mediaUrl = readStringParam(params, "mediaUrl");
+    const buffer = readStringParam(params, "buffer", { trim: false });
+    const filename = readStringParam(params, "filename");
+    const contentType =
+      readStringParam(params, "contentType") ?? readStringParam(params, "mimeType");
+    const hasAttachment = Boolean(mediaUrl || buffer);
     // Allow content to be omitted when sending media-only (e.g., voice notes)
     const content =
       readStringParam(params, "content", {
-        required: !mediaUrl,
+        required: !hasAttachment,
         allowEmpty: true,
       }) ?? "";
     const buttons = readTelegramButtons(params);
@@ -240,6 +245,9 @@ export async function handleTelegramAction(
       token,
       accountId: accountId ?? undefined,
       mediaUrl: mediaUrl || undefined,
+      buffer: buffer || undefined,
+      filename: filename || undefined,
+      contentType: contentType || undefined,
       mediaLocalRoots: options?.mediaLocalRoots,
       buttons,
       replyToMessageId: replyToMessageId ?? undefined,

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -1123,6 +1123,35 @@ describe("signalMessageActions", () => {
       cfg,
     );
   });
+
+  it("forwards inline attachment buffers for send actions", async () => {
+    const cfg = telegramCfg();
+
+    await telegramMessageActions.handleAction?.({
+      channel: "telegram",
+      action: "send",
+      params: {
+        to: "123",
+        buffer: "QUJD",
+        filename: "note.txt",
+        contentType: "text/plain",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "123",
+        content: "",
+        buffer: "QUJD",
+        filename: "note.txt",
+        contentType: "text/plain",
+      }),
+      cfg,
+    );
+  });
 });
 
 describe("slack actions adapter", () => {

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -24,7 +24,14 @@ const providerId = "telegram";
 function readTelegramSendParams(params: Record<string, unknown>) {
   const to = readStringParam(params, "to", { required: true });
   const mediaUrl = readStringParam(params, "media", { trim: false });
-  const message = readStringParam(params, "message", { required: !mediaUrl, allowEmpty: true });
+  const buffer = readStringParam(params, "buffer", { trim: false });
+  const filename = readStringParam(params, "filename");
+  const contentType = readStringParam(params, "contentType") ?? readStringParam(params, "mimeType");
+  const hasAttachment = Boolean(mediaUrl || buffer);
+  const message = readStringParam(params, "message", {
+    required: !hasAttachment,
+    allowEmpty: true,
+  });
   const caption = readStringParam(params, "caption", { allowEmpty: true });
   const content = message || caption || "";
   const replyTo = readStringParam(params, "replyTo");
@@ -37,6 +44,9 @@ function readTelegramSendParams(params: Record<string, unknown>) {
     to,
     content,
     mediaUrl: mediaUrl ?? undefined,
+    buffer: buffer ?? undefined,
+    filename: filename ?? undefined,
+    contentType: contentType ?? undefined,
     replyToMessageId: replyTo ?? undefined,
     messageThreadId: threadId ?? undefined,
     buttons,

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -55,3 +55,24 @@ describe("message action sandbox media hydration", () => {
     }
   });
 });
+
+describe("hydrateAttachmentParamsForAction — send action", () => {
+  it("normalizes inline data-URL buffers for send actions", async () => {
+    const args: Record<string, unknown> = {
+      buffer: "data:image/png;base64,QUJD",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg: {} as OpenClawConfig,
+      channel: "telegram",
+      args,
+      action: "send",
+      mediaPolicy: { allow: true },
+    });
+
+    expect(args).toMatchObject({
+      buffer: "QUJD",
+      contentType: "image/png",
+    });
+  });
+});

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -358,7 +358,11 @@ export async function hydrateAttachmentParamsForAction(params: {
   dryRun?: boolean;
   mediaPolicy: AttachmentMediaPolicy;
 }): Promise<void> {
-  if (params.action !== "sendAttachment" && params.action !== "setGroupIcon") {
+  if (
+    params.action !== "send" &&
+    params.action !== "sendAttachment" &&
+    params.action !== "setGroupIcon"
+  ) {
     return;
   }
   await hydrateAttachmentActionPayload({

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -500,6 +500,32 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("sends inline buffers without loading media URLs", async () => {
+    const chatId = "123";
+    const sendDocument = vi.fn().mockResolvedValue({
+      message_id: 73,
+      chat: { id: chatId },
+    });
+    const api = { sendDocument } as unknown as {
+      sendDocument: typeof sendDocument;
+    };
+
+    const res = await sendMessageTelegram(chatId, "caption", {
+      token: "tok",
+      api,
+      buffer: Buffer.from("hello world").toString("base64"),
+      filename: "note.txt",
+      contentType: "text/plain",
+    });
+
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    expect(sendDocument).toHaveBeenCalledWith(chatId, expect.anything(), {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
+    expect(res.messageId).toBe("73");
+  });
+
   it("splits long captions into media + text messages when text exceeds 1024 chars", async () => {
     const chatId = "123";
     const longText = "A".repeat(1100);

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -47,6 +47,9 @@ type TelegramSendOpts = {
   accountId?: string;
   verbose?: boolean;
   mediaUrl?: string;
+  buffer?: string;
+  filename?: string;
+  contentType?: string;
   mediaLocalRoots?: readonly string[];
   maxBytes?: number;
   api?: TelegramApiOverride;
@@ -559,6 +562,9 @@ export async function sendMessageTelegram(
     verbose: opts.verbose,
   });
   const mediaUrl = opts.mediaUrl?.trim();
+  const bufferBase64 = opts.buffer?.trim();
+  const inlineFileName = opts.filename?.trim();
+  const inlineContentType = opts.contentType?.trim();
   const mediaMaxBytes =
     opts.maxBytes ??
     (typeof account.config.mediaMaxMb === "number" ? account.config.mediaMaxMb : 100) * 1024 * 1024;
@@ -647,14 +653,20 @@ export async function sendMessageTelegram(
     );
   };
 
-  if (mediaUrl) {
-    const media = await loadWebMedia(
-      mediaUrl,
-      buildOutboundMediaLoadOptions({
-        maxBytes: mediaMaxBytes,
-        mediaLocalRoots: opts.mediaLocalRoots,
-      }),
-    );
+  if (bufferBase64 || mediaUrl) {
+    const media = bufferBase64
+      ? {
+          buffer: Buffer.from(bufferBase64, "base64"),
+          contentType: inlineContentType,
+          fileName: inlineFileName,
+        }
+      : await loadWebMedia(
+          mediaUrl!,
+          buildOutboundMediaLoadOptions({
+            maxBytes: mediaMaxBytes,
+            mediaLocalRoots: opts.mediaLocalRoots,
+          }),
+        );
     const kind = kindFromMime(media.contentType ?? undefined);
     const isGif = isGifMedia({
       contentType: media.contentType,


### PR DESCRIPTION
The message tool send action accepted buffer and filename parameters
but silently ignored them for Telegram, returning ok=true without
sending the attachment.

Fix across three layers:
- **hydrateAttachmentParamsForAction**: process buffer for `send` action (extends existing function rather than adding a separate one)
- **readTelegramSendParams**: extract buffer/filename from params
- **sendMessageTelegram**: support direct buffer sending via InputFile, integrated into the shared media path with `splitTelegramCaption`, `withTelegramThreadFallback`, and `recordSentMessage`

Rebased on latest main to resolve conflicts.

Closes #41779
Supersedes #41894