### PR TITLE
fix(backup): treat non-existent output paths as directories

### DIFF
--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -105,11 +105,23 @@ async function resolveOutputPath(params: {
     if (stat.isDirectory()) {
       return path.join(resolved, basename);
     }
-  } catch {
-    // Treat as a file path when the target does not exist yet.
+    // If it's a file, use it directly as the archive path
+    return resolved;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    // Path doesn't exist — check if it looks like an explicit archive filename
+    if (code === "ENOENT") {
+      const ext = path.extname(resolved).toLowerCase();
+      const isArchiveExtension = ext === ".gz" || ext === ".zip" || ext === ".tgz";
+      if (!isArchiveExtension) {
+        // No archive extension — treat as a directory
+        return path.join(resolved, basename);
+      }
+      // Has archive extension — treat as explicit filename
+      return resolved;
+    }
+    throw err;
   }
-
-  return resolved;
 }
 
 async function assertOutputPathReady(outputPath: string): Promise<void> {

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -112,12 +112,17 @@ async function resolveOutputPath(params: {
     // Path doesn't exist — check if it looks like an explicit archive filename
     if (code === "ENOENT") {
       const ext = path.extname(resolved).toLowerCase();
-      const isArchiveExtension = ext === ".gz" || ext === ".zip" || ext === ".tgz";
-      if (!isArchiveExtension) {
-        // No archive extension — treat as a directory
+      // Valid compressed archive extensions (backup always creates gzip-compressed archives)
+      const isValidCompressedExtension = ext === ".gz" || ext === ".zip" || ext === ".tgz";
+      // .tar is not a compressed format - it's misleading since backup always uses gzip
+      // But treat it as an explicit archive filename if specified
+      const isExplicitArchive = isValidCompressedExtension || ext === ".tar";
+      // Any non-empty custom suffix (like .bak) should be treated as explicit file output
+      if (!isExplicitArchive && ext === "") {
+        // No extension — treat as a directory
         return path.join(resolved, basename);
       }
-      // Has archive extension — treat as explicit filename
+      // Has archive extension or custom suffix — treat as explicit filename
       return resolved;
     }
     throw err;


### PR DESCRIPTION
When the user specifies an output directory that doesn't exist yet (without a trailing slash), the backup command was incorrectly treating it as a file path instead of a directory. This caused the archive to be created without the .tar.gz extension.

Fix: Default to treating non-existent paths as directories by checking for archive extensions (.tar.gz, .zip, .tgz). If no extension, treat as directory.

Fixes openclaw/openclaw#41830