### PR TITLE
refactor(doctor): extract streaming alias migration helpers

### DIFF
--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -1,14 +1,7 @@
 import { shouldMoveSingleAccountChannelKey } from "../channels/plugins/setup-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  formatSlackStreamingBooleanMigrationMessage,
-  formatSlackStreamModeMigrationMessage,
-  resolveDiscordPreviewStreamMode,
-  resolveSlackNativeStreaming,
-  resolveSlackStreamingMode,
-  resolveTelegramPreviewStreamMode,
-} from "../config/discord-preview-streaming.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+import { normalizeStreamingAliasesForProvider } from "./doctor-legacy-streaming-aliases.js";
 
 export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   config: OpenClawConfig;
@@ -101,122 +94,6 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
     return { entry: updated, changed };
   };
 
-  const normalizePreviewStreamingAliases = (params: {
-    entry: Record<string, unknown>;
-    pathPrefix: string;
-    resolveStreaming: (entry: Record<string, unknown>) => string;
-  }): { entry: Record<string, unknown>; changed: boolean } => {
-    let updated = params.entry;
-    const hadLegacyStreamMode = updated.streamMode !== undefined;
-    const beforeStreaming = updated.streaming;
-    const resolved = params.resolveStreaming(updated);
-    const shouldNormalize =
-      hadLegacyStreamMode ||
-      typeof beforeStreaming === "boolean" ||
-      (typeof beforeStreaming === "string" && beforeStreaming !== resolved);
-    if (!shouldNormalize) {
-      return { entry: updated, changed: false };
-    }
-
-    let changed = false;
-    if (beforeStreaming !== resolved) {
-      updated = { ...updated, streaming: resolved };
-      changed = true;
-    }
-    if (hadLegacyStreamMode) {
-      const { streamMode: _ignored, ...rest } = updated;
-      updated = rest;
-      changed = true;
-      changes.push(
-        `Moved ${params.pathPrefix}.streamMode → ${params.pathPrefix}.streaming (${resolved}).`,
-      );
-    }
-    if (typeof beforeStreaming === "boolean") {
-      changes.push(`Normalized ${params.pathPrefix}.streaming boolean → enum (${resolved}).`);
-    } else if (typeof beforeStreaming === "string" && beforeStreaming !== resolved) {
-      changes.push(
-        `Normalized ${params.pathPrefix}.streaming (${beforeStreaming}) → (${resolved}).`,
-      );
-    }
-
-    return { entry: updated, changed };
-  };
-
-  const normalizeSlackStreamingAliases = (params: {
-    entry: Record<string, unknown>;
-    pathPrefix: string;
-  }): { entry: Record<string, unknown>; changed: boolean } => {
-    let updated = params.entry;
-    const hadLegacyStreamMode = updated.streamMode !== undefined;
-    const legacyStreaming = updated.streaming;
-    const beforeStreaming = updated.streaming;
-    const beforeNativeStreaming = updated.nativeStreaming;
-    const resolvedStreaming = resolveSlackStreamingMode(updated);
-    const resolvedNativeStreaming = resolveSlackNativeStreaming(updated);
-    const shouldNormalize =
-      hadLegacyStreamMode ||
-      typeof legacyStreaming === "boolean" ||
-      (typeof legacyStreaming === "string" && legacyStreaming !== resolvedStreaming);
-    if (!shouldNormalize) {
-      return { entry: updated, changed: false };
-    }
-
-    let changed = false;
-    if (beforeStreaming !== resolvedStreaming) {
-      updated = { ...updated, streaming: resolvedStreaming };
-      changed = true;
-    }
-    if (
-      typeof beforeNativeStreaming !== "boolean" ||
-      beforeNativeStreaming !== resolvedNativeStreaming
-    ) {
-      updated = { ...updated, nativeStreaming: resolvedNativeStreaming };
-      changed = true;
-    }
-    if (hadLegacyStreamMode) {
-      const { streamMode: _ignored, ...rest } = updated;
-      updated = rest;
-      changed = true;
-      changes.push(formatSlackStreamModeMigrationMessage(params.pathPrefix, resolvedStreaming));
-    }
-    if (typeof legacyStreaming === "boolean") {
-      changes.push(
-        formatSlackStreamingBooleanMigrationMessage(params.pathPrefix, resolvedNativeStreaming),
-      );
-    } else if (typeof legacyStreaming === "string" && legacyStreaming !== resolvedStreaming) {
-      changes.push(
-        `Normalized ${params.pathPrefix}.streaming (${legacyStreaming}) → (${resolvedStreaming}).`,
-      );
-    }
-
-    return { entry: updated, changed };
-  };
-
-  const normalizeStreamingAliasesForProvider = (params: {
-    provider: "telegram" | "slack" | "discord";
-    entry: Record<string, unknown>;
-    pathPrefix: string;
-  }): { entry: Record<string, unknown>; changed: boolean } => {
-    if (params.provider === "telegram") {
-      return normalizePreviewStreamingAliases({
-        entry: params.entry,
-        pathPrefix: params.pathPrefix,
-        resolveStreaming: resolveTelegramPreviewStreamMode,
-      });
-    }
-    if (params.provider === "discord") {
-      return normalizePreviewStreamingAliases({
-        entry: params.entry,
-        pathPrefix: params.pathPrefix,
-        resolveStreaming: resolveDiscordPreviewStreamMode,
-      });
-    }
-    return normalizeSlackStreamingAliases({
-      entry: params.entry,
-      pathPrefix: params.pathPrefix,
-    });
-  };
-
   const normalizeProvider = (provider: "telegram" | "slack" | "discord") => {
     const channels = next.channels as Record<string, unknown> | undefined;
     const rawEntry = channels?.[provider];
@@ -242,6 +119,7 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
     });
     updated = providerStreaming.entry;
     changed = changed || providerStreaming.changed;
+    changes.push(...providerStreaming.changes);
 
     const rawAccounts = updated.accounts;
     if (isRecord(rawAccounts)) {
@@ -269,6 +147,7 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
         });
         accountEntry = accountStreaming.entry;
         accountChanged = accountChanged || accountStreaming.changed;
+        changes.push(...accountStreaming.changes);
         if (accountChanged) {
           accounts[accountId] = accountEntry;
           accountsChanged = true;

--- a/src/commands/doctor-legacy-streaming-aliases.test.ts
+++ b/src/commands/doctor-legacy-streaming-aliases.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { normalizeStreamingAliasesForProvider } from "./doctor-legacy-streaming-aliases.js";
+
+describe("normalizeStreamingAliasesForProvider", () => {
+  it("normalizes discord boolean streaming aliases to enum values", () => {
+    const result = normalizeStreamingAliasesForProvider({
+      provider: "discord",
+      entry: { streaming: true },
+      pathPrefix: "channels.discord",
+    });
+
+    expect(result.entry).toEqual({ streaming: "partial" });
+    expect(result.changed).toBe(true);
+    expect(result.changes).toEqual([
+      "Normalized channels.discord.streaming boolean → enum (partial).",
+    ]);
+  });
+
+  it("moves telegram streamMode into streaming", () => {
+    const result = normalizeStreamingAliasesForProvider({
+      provider: "telegram",
+      entry: { streamMode: "block" },
+      pathPrefix: "channels.telegram",
+    });
+
+    expect(result.entry).toEqual({ streaming: "block" });
+    expect(result.changed).toBe(true);
+    expect(result.changes).toEqual([
+      "Moved channels.telegram.streamMode → channels.telegram.streaming (block).",
+    ]);
+  });
+
+  it("normalizes slack legacy streaming keys to streaming and nativeStreaming", () => {
+    const result = normalizeStreamingAliasesForProvider({
+      provider: "slack",
+      entry: { streaming: false, streamMode: "status_final" },
+      pathPrefix: "channels.slack",
+    });
+
+    expect(result.entry).toEqual({
+      streaming: "progress",
+      nativeStreaming: false,
+    });
+    expect(result.changed).toBe(true);
+    expect(result.changes).toEqual([
+      "Moved channels.slack.streamMode → channels.slack.streaming (progress).",
+      "Moved channels.slack.streaming (boolean) → channels.slack.nativeStreaming (false).",
+    ]);
+  });
+});

--- a/src/commands/doctor-legacy-streaming-aliases.ts
+++ b/src/commands/doctor-legacy-streaming-aliases.ts
@@ -1,0 +1,124 @@
+import {
+  formatSlackStreamingBooleanMigrationMessage,
+  formatSlackStreamModeMigrationMessage,
+  resolveDiscordPreviewStreamMode,
+  resolveSlackNativeStreaming,
+  resolveSlackStreamingMode,
+  resolveTelegramPreviewStreamMode,
+} from "../config/discord-preview-streaming.js";
+
+function normalizePreviewStreamingAliases(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  resolveStreaming: (entry: Record<string, unknown>) => string;
+}): { entry: Record<string, unknown>; changed: boolean; changes: string[] } {
+  const changes: string[] = [];
+  let updated = params.entry;
+  const hadLegacyStreamMode = updated.streamMode !== undefined;
+  const beforeStreaming = updated.streaming;
+  const resolved = params.resolveStreaming(updated);
+  const shouldNormalize =
+    hadLegacyStreamMode ||
+    typeof beforeStreaming === "boolean" ||
+    (typeof beforeStreaming === "string" && beforeStreaming !== resolved);
+  if (!shouldNormalize) {
+    return { entry: updated, changed: false, changes };
+  }
+
+  let changed = false;
+  if (beforeStreaming !== resolved) {
+    updated = { ...updated, streaming: resolved };
+    changed = true;
+  }
+  if (hadLegacyStreamMode) {
+    const { streamMode: _ignored, ...rest } = updated;
+    updated = rest;
+    changed = true;
+    changes.push(
+      `Moved ${params.pathPrefix}.streamMode → ${params.pathPrefix}.streaming (${resolved}).`,
+    );
+  }
+  if (typeof beforeStreaming === "boolean") {
+    changes.push(`Normalized ${params.pathPrefix}.streaming boolean → enum (${resolved}).`);
+  } else if (typeof beforeStreaming === "string" && beforeStreaming !== resolved) {
+    changes.push(`Normalized ${params.pathPrefix}.streaming (${beforeStreaming}) → (${resolved}).`);
+  }
+
+  return { entry: updated, changed, changes };
+}
+
+function normalizeSlackStreamingAliases(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+}): { entry: Record<string, unknown>; changed: boolean; changes: string[] } {
+  const changes: string[] = [];
+  let updated = params.entry;
+  const hadLegacyStreamMode = updated.streamMode !== undefined;
+  const legacyStreaming = updated.streaming;
+  const beforeStreaming = updated.streaming;
+  const beforeNativeStreaming = updated.nativeStreaming;
+  const resolvedStreaming = resolveSlackStreamingMode(updated);
+  const resolvedNativeStreaming = resolveSlackNativeStreaming(updated);
+  const shouldNormalize =
+    hadLegacyStreamMode ||
+    typeof legacyStreaming === "boolean" ||
+    (typeof legacyStreaming === "string" && legacyStreaming !== resolvedStreaming);
+  if (!shouldNormalize) {
+    return { entry: updated, changed: false, changes };
+  }
+
+  let changed = false;
+  if (beforeStreaming !== resolvedStreaming) {
+    updated = { ...updated, streaming: resolvedStreaming };
+    changed = true;
+  }
+  if (
+    typeof beforeNativeStreaming !== "boolean" ||
+    beforeNativeStreaming !== resolvedNativeStreaming
+  ) {
+    updated = { ...updated, nativeStreaming: resolvedNativeStreaming };
+    changed = true;
+  }
+  if (hadLegacyStreamMode) {
+    const { streamMode: _ignored, ...rest } = updated;
+    updated = rest;
+    changed = true;
+    changes.push(formatSlackStreamModeMigrationMessage(params.pathPrefix, resolvedStreaming));
+  }
+  if (typeof legacyStreaming === "boolean") {
+    changes.push(
+      formatSlackStreamingBooleanMigrationMessage(params.pathPrefix, resolvedNativeStreaming),
+    );
+  } else if (typeof legacyStreaming === "string" && legacyStreaming !== resolvedStreaming) {
+    changes.push(
+      `Normalized ${params.pathPrefix}.streaming (${legacyStreaming}) → (${resolvedStreaming}).`,
+    );
+  }
+
+  return { entry: updated, changed, changes };
+}
+
+export function normalizeStreamingAliasesForProvider(params: {
+  provider: "telegram" | "slack" | "discord";
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+}): { entry: Record<string, unknown>; changed: boolean; changes: string[] } {
+  if (params.provider === "telegram") {
+    return normalizePreviewStreamingAliases({
+      entry: params.entry,
+      pathPrefix: params.pathPrefix,
+      resolveStreaming: resolveTelegramPreviewStreamMode,
+    });
+  }
+  if (params.provider === "discord") {
+    return normalizePreviewStreamingAliases({
+      entry: params.entry,
+      pathPrefix: params.pathPrefix,
+      resolveStreaming: resolveDiscordPreviewStreamMode,
+    });
+  }
+  return normalizeSlackStreamingAliases({
+    entry: params.entry,
+    pathPrefix: params.pathPrefix,
+  });
+}


### PR DESCRIPTION
## Summary

- Problem: `src/commands/doctor-legacy-config.ts` still contained inline streaming alias migration helpers for Telegram, Discord, and Slack.
- Why it matters: this mixes a self-contained compatibility migration subsystem into the larger legacy config normalization flow.
- What changed: extracted provider streaming alias migration into `src/commands/doctor-legacy-streaming-aliases.ts` and added focused helper tests.
- What did NOT change (scope boundary): no migration rules, migration messages, or config semantics changed.

## Change Type (select all)

- [x] Refactor

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related #42040

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): doctor config compatibility migration
- Relevant config (redacted): synthetic Telegram/Discord/Slack legacy streaming fixtures

### Steps

1. Run `normalizeCompatibilityConfigValues()` on config using legacy streaming aliases.
2. Verify Telegram and Discord preview aliases normalize to canonical `streaming` values.
3. Verify Slack legacy `streaming` / `streamMode` normalize to `streaming` plus `nativeStreaming`.

### Expected

- Streaming alias migration keeps the same behavior while the main legacy config module gets smaller.

### Actual

- Migration behavior stayed the same; focused helper tests and existing migration tests passed.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Discord boolean alias normalization, Telegram `streamMode` migration, Slack legacy streaming migration.
- Edge cases checked: unchanged entries remain untouched, migration note text stays the same.
- What you did **not** verify: any interactive doctor CLI flow beyond existing compatibility migration tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / commit.
- Files/config to restore: `src/commands/doctor-legacy-config.ts`
- Known bad symptoms reviewers should watch for: doctor stops normalizing legacy streaming aliases correctly or changes migration note text.

## Risks and Mitigations

- Risk: extraction could accidentally change provider-specific streaming normalization or migration messages.
- Mitigation: focused helper tests cover Telegram, Discord, and Slack paths, and the existing migration suite still passes.

AI-assisted: Yes (Codex). Locally tested.
