### PR TITLE
fix(cron): expose missedJobStaggerMs and maxMissedJobsPerRestart in config

### DIFF
--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -57,4 +57,16 @@ export type CronConfig = {
   failureAlert?: CronFailureAlertConfig;
   /** Default destination for failure notifications across all cron jobs. */
   failureDestination?: CronFailureDestinationConfig;
+  /**
+   * Delay in ms between missed job executions on startup.
+   * Prevents overwhelming the gateway when many jobs are overdue.
+   * Default: 5000.
+   */
+  missedJobStaggerMs?: number;
+  /**
+   * Maximum number of missed jobs to run immediately on startup.
+   * Additional missed jobs will be rescheduled to fire gradually.
+   * Default: 5.
+   */
+  maxMissedJobsPerRestart?: number;
 };

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -235,6 +235,8 @@ export function buildGatewayCronService(params: {
     defaultAgentId,
     resolveSessionStorePath,
     sessionStorePath,
+    missedJobStaggerMs: params.cfg.cron?.missedJobStaggerMs,
+    maxMissedJobsPerRestart: params.cfg.cron?.maxMissedJobsPerRestart,
     enqueueSystemEvent: (text, opts) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(opts?.agentId);
       const sessionKey = resolveCronSessionKey({


### PR DESCRIPTION
## Summary

Fixes #42039 - Expose `missedJobStaggerMs` and `maxMissedJobsPerRestart` configuration options to allow users to control cron job catchup behavior on gateway restart.

## Details

Previously, `missedJobStaggerMs` and `maxMissedJobsPerRestart` were hardcoded defaults in the cron service:
- `missedJobStaggerMs`: 5000ms (delay between missed job executions)
- `maxMissedJobsPerRestart`: 5 (max missed jobs to run immediately on startup)

This change adds these options to the `CronConfig` type so users can configure them via `openclaw.yaml`:

```yaml
cron:
  missedJobStaggerMs: 3000   # Optional: custom delay between missed jobs
  maxMissedJobsPerRestart: 10 # Optional: run up to 10 jobs immediately
```

## Changes

- `src/config/types.cron.ts`: Added `missedJobStaggerMs` and `maxMissedJobsPerRestart` fields to `CronConfig`
- `src/gateway/server-cron.ts`: Pass config values to `CronService` constructor

## Test plan

- [x] Type check passes
- [x] Format check passes
- [ ] Manual testing with custom config values