### PR TITLE
feat(gateway): make health monitor stale threshold and max restarts configurable

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12314,14 +12314,14 @@
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 653
+        "line_number": 657
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 686
+        "line_number": 690
       }
     ],
     "src/config/schema.irc.ts": [
@@ -12360,14 +12360,14 @@
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "e73c9fcad85cd4eecc74181ec4bdb31064d68439",
         "is_verified": false,
-        "line_number": 217
+        "line_number": 219
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "2eda7cd978f39eebec3bf03e4410a40e14167fff",
         "is_verified": false,
-        "line_number": 326
+        "line_number": 328
       }
     ],
     "src/config/slack-http-config.test.ts": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Refactor/channels: remove the legacy channel shim directories and point channel-specific imports directly at the extension-owned implementations. (#45967) thanks @scoootscooob.
 - Feishu/streaming: add `onReasoningStream` and `onReasoningEnd` support to streaming cards, so `/reasoning stream` renders thinking tokens as markdown blockquotes in the same card — matching the Telegram channel's reasoning lane behavior.
 - Feishu/cards: add identity-aware structured card headers and note footers for Feishu replies and direct sends, while keeping that presentation wired through the shared outbound identity path. (#29938) Thanks @nszhsl.
+- Gateway/health monitor: add configurable stale-event thresholds and restart limits, plus per-channel and per-account `healthMonitor.enabled` overrides, while keeping the existing global disable path on `gateway.channelHealthCheckMinutes=0`. (#42107) Thanks @rstar327.
 
 ### Fixes
 

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -57,6 +57,10 @@ export type BlueBubblesAccountConfig = {
   allowPrivateNetwork?: boolean;
   /** Per-group configuration keyed by chat GUID or identifier. */
   groups?: Record<string, BlueBubblesGroupConfig>;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: {
+    enabled?: boolean;
+  };
 };
 
 export type BlueBubblesActionConfig = {

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
+const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
@@ -14,6 +15,7 @@ vi.mock("./media.js", () => ({
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
+  sendStructuredCardFeishu: sendStructuredCardFeishuMock,
 }));
 
 vi.mock("./runtime.js", () => ({
@@ -33,6 +35,7 @@ function resetOutboundMocks() {
   vi.clearAllMocks();
   sendMessageFeishuMock.mockResolvedValue({ messageId: "text_msg" });
   sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
+  sendStructuredCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
   sendMediaFeishuMock.mockResolvedValue({ messageId: "media_msg" });
 }
 
@@ -132,7 +135,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
       accountId: "main",
     });
 
-    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         to: "chat_1",
         text: "| a | b |\n| - | - |",
@@ -207,7 +210,7 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
     );
   });
 
-  it("forwards replyToId to sendMarkdownCardFeishu when renderMode=card", async () => {
+  it("forwards replyToId to sendStructuredCardFeishu when renderMode=card", async () => {
     await sendText({
       cfg: {
         channels: {
@@ -222,7 +225,7 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
       accountId: "main",
     });
 
-    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_reply_target",
       }),

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -212,6 +212,37 @@ describe("gateway.channelHealthCheckMinutes", () => {
       expect(res.issues[0]?.path).toBe("gateway.channelHealthCheckMinutes");
     }
   });
+
+  it("rejects stale thresholds shorter than the health check interval", () => {
+    const res = validateConfigObject({
+      gateway: {
+        channelHealthCheckMinutes: 5,
+        channelStaleEventThresholdMinutes: 4,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.channelStaleEventThresholdMinutes");
+    }
+  });
+
+  it("accepts stale thresholds that match or exceed the health check interval", () => {
+    const equal = validateConfigObject({
+      gateway: {
+        channelHealthCheckMinutes: 5,
+        channelStaleEventThresholdMinutes: 5,
+      },
+    });
+    expect(equal.ok).toBe(true);
+
+    const greater = validateConfigObject({
+      gateway: {
+        channelHealthCheckMinutes: 5,
+        channelStaleEventThresholdMinutes: 6,
+      },
+    });
+    expect(greater.ok).toBe(true);
+  });
 });
 
 describe("cron webhook schema", () => {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -243,6 +243,18 @@ describe("gateway.channelHealthCheckMinutes", () => {
     });
     expect(greater.ok).toBe(true);
   });
+
+  it("rejects stale thresholds shorter than the default health check interval", () => {
+    const res = validateConfigObject({
+      gateway: {
+        channelStaleEventThresholdMinutes: 4,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.channelStaleEventThresholdMinutes");
+    }
+  });
 });
 
 describe("cron webhook schema", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -102,6 +102,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
   "gateway.channelHealthCheckMinutes":
     "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
+  "gateway.channelHealthMonitorEnabled":
+    "Global enable switch for the gateway channel health monitor. Set false to disable all health-monitor-initiated channel restarts; per-channel healthMonitor.enabled overrides can further disable individual channels or accounts when the global monitor stays on.",
   "gateway.channelStaleEventThresholdMinutes":
     "How many minutes a connected channel can go without receiving any event before the health monitor treats it as a stale socket and triggers a restart. Default: 30.",
   "gateway.channelMaxRestartsPerHour":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -102,8 +102,6 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
   "gateway.channelHealthCheckMinutes":
     "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
-  "gateway.channelHealthMonitorEnabled":
-    "Global enable switch for the gateway channel health monitor. Set false to disable all health-monitor-initiated channel restarts; per-channel healthMonitor.enabled overrides can further disable individual channels or accounts when the global monitor stays on.",
   "gateway.channelStaleEventThresholdMinutes":
     "How many minutes a connected channel can go without receiving any event before the health monitor treats it as a stale socket and triggers a restart. Default: 30.",
   "gateway.channelMaxRestartsPerHour":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -102,6 +102,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
   "gateway.channelHealthCheckMinutes":
     "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
+  "gateway.channelStaleEventThresholdMinutes":
+    "How many minutes a connected channel can go without receiving any event before the health monitor treats it as a stale socket and triggers a restart. Default: 30.",
+  "gateway.channelMaxRestartsPerHour":
+    "Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.",
   "gateway.tailscale":
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -83,6 +83,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools": "Gateway Tool Exposure Policy",
   "gateway.tools.allow": "Gateway Tool Allowlist",
   "gateway.tools.deny": "Gateway Tool Denylist",
+  "gateway.channelHealthMonitorEnabled": "Gateway Channel Health Monitor Enabled",
   "gateway.channelHealthCheckMinutes": "Gateway Channel Health Check Interval (min)",
   "gateway.channelStaleEventThresholdMinutes": "Gateway Channel Stale Event Threshold (min)",
   "gateway.channelMaxRestartsPerHour": "Gateway Channel Max Restarts Per Hour",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -83,7 +83,6 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools": "Gateway Tool Exposure Policy",
   "gateway.tools.allow": "Gateway Tool Allowlist",
   "gateway.tools.deny": "Gateway Tool Denylist",
-  "gateway.channelHealthMonitorEnabled": "Gateway Channel Health Monitor Enabled",
   "gateway.channelHealthCheckMinutes": "Gateway Channel Health Check Interval (min)",
   "gateway.channelStaleEventThresholdMinutes": "Gateway Channel Stale Event Threshold (min)",
   "gateway.channelMaxRestartsPerHour": "Gateway Channel Max Restarts Per Hour",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -84,6 +84,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools.allow": "Gateway Tool Allowlist",
   "gateway.tools.deny": "Gateway Tool Denylist",
   "gateway.channelHealthCheckMinutes": "Gateway Channel Health Check Interval (min)",
+  "gateway.channelStaleEventThresholdMinutes": "Gateway Channel Stale Event Threshold (min)",
+  "gateway.channelMaxRestartsPerHour": "Gateway Channel Max Restarts Per Hour",
   "gateway.tailscale": "Gateway Tailscale",
   "gateway.tailscale.mode": "Gateway Tailscale Mode",
   "gateway.tailscale.resetOnExit": "Gateway Tailscale Reset on Exit",

--- a/src/config/types.channel-messaging-common.ts
+++ b/src/config/types.channel-messaging-common.ts
@@ -4,7 +4,10 @@ import type {
   GroupPolicy,
   MarkdownConfig,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type {
+  ChannelHealthMonitorConfig,
+  ChannelHeartbeatVisibilityConfig,
+} from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 
 export type CommonChannelMessagingConfig = {
@@ -43,6 +46,8 @@ export type CommonChannelMessagingConfig = {
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: ChannelHealthMonitorConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
   /** Max outbound media size in MB. */

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -18,6 +18,14 @@ export type ChannelHeartbeatVisibilityConfig = {
   useIndicator?: boolean;
 };
 
+export type ChannelHealthMonitorConfig = {
+  /**
+   * Enable channel-health-monitor restarts for this channel or account.
+   * Inherits the global gateway setting when omitted.
+   */
+  enabled?: boolean;
+};
+
 export type ChannelDefaultsConfig = {
   groupPolicy?: GroupPolicy;
   /** Default heartbeat visibility for all channels. */
@@ -39,6 +47,7 @@ export type ExtensionChannelConfig = {
   defaultAccount?: string;
   dmPolicy?: string;
   groupPolicy?: GroupPolicy;
+  healthMonitor?: ChannelHealthMonitorConfig;
   accounts?: Record<string, unknown>;
   [key: string]: unknown;
 };

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -8,7 +8,10 @@ import type {
   OutboundRetryConfig,
   ReplyToMode,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type {
+  ChannelHealthMonitorConfig,
+  ChannelHeartbeatVisibilityConfig,
+} from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { SecretInput } from "./types.secrets.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
@@ -297,6 +300,8 @@ export type DiscordAccountConfig = {
   guilds?: Record<string, DiscordGuildEntry>;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: ChannelHealthMonitorConfig;
   /** Exec approval forwarding configuration. */
   execApprovals?: DiscordExecApprovalConfig;
   /** Agent-controlled interactive components (buttons, select menus). */

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -426,12 +426,6 @@ export type GatewayConfig = {
   /** Tool access restrictions for HTTP /tools/invoke endpoint. */
   tools?: GatewayToolsConfig;
   /**
-   * Global enable switch for the channel health monitor.
-   * Set to false to disable health-monitor-driven channel restarts entirely.
-   * Default: true.
-   */
-  channelHealthMonitorEnabled?: boolean;
-  /**
    * Channel health monitor interval in minutes.
    * Periodically checks channel health and restarts unhealthy channels.
    * Set to 0 to disable. Default: 5.

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -431,4 +431,16 @@ export type GatewayConfig = {
    * Set to 0 to disable. Default: 5.
    */
   channelHealthCheckMinutes?: number;
+  /**
+   * Stale event threshold in minutes for the channel health monitor.
+   * A connected channel that receives no events for this duration is treated
+   * as a stale socket and restarted. Default: 30.
+   */
+  channelStaleEventThresholdMinutes?: number;
+  /**
+   * Maximum number of health-monitor-initiated channel restarts per hour.
+   * Once this limit is reached, the monitor skips further restarts until
+   * the rolling window expires. Default: 10.
+   */
+  channelMaxRestartsPerHour?: number;
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -426,6 +426,12 @@ export type GatewayConfig = {
   /** Tool access restrictions for HTTP /tools/invoke endpoint. */
   tools?: GatewayToolsConfig;
   /**
+   * Global enable switch for the channel health monitor.
+   * Set to false to disable health-monitor-driven channel restarts entirely.
+   * Default: true.
+   */
+  channelHealthMonitorEnabled?: boolean;
+  /**
    * Channel health monitor interval in minutes.
    * Periodically checks channel health and restarts unhealthy channels.
    * Set to 0 to disable. Default: 5.

--- a/src/config/types.googlechat.ts
+++ b/src/config/types.googlechat.ts
@@ -4,6 +4,7 @@ import type {
   GroupPolicy,
   ReplyToMode,
 } from "./types.base.js";
+import type { ChannelHealthMonitorConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 import type { SecretRef } from "./types.secrets.js";
 
@@ -99,6 +100,8 @@ export type GoogleChatAccountConfig = {
   /** Per-action tool gating (default: true for all). */
   actions?: GoogleChatActionConfig;
   dm?: GoogleChatDmConfig;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: ChannelHealthMonitorConfig;
   /**
    * Typing indicator mode (default: "message").
    * - "none": No indicator

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -4,7 +4,10 @@ import type {
   GroupPolicy,
   MarkdownConfig,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type {
+  ChannelHealthMonitorConfig,
+  ChannelHeartbeatVisibilityConfig,
+} from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
@@ -77,6 +80,8 @@ export type IMessageAccountConfig = {
   >;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: ChannelHealthMonitorConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
 };

--- a/src/config/types.msteams.ts
+++ b/src/config/types.msteams.ts
@@ -4,7 +4,10 @@ import type {
   GroupPolicy,
   MarkdownConfig,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type {
+  ChannelHealthMonitorConfig,
+  ChannelHeartbeatVisibilityConfig,
+} from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 import type { SecretInput } from "./types.secrets.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
@@ -114,6 +117,8 @@ export type MSTeamsConfig = {
   sharePointSiteId?: string;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Channel health monitor overrides for this channel. */
+  healthMonitor?: ChannelHealthMonitorConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
 };

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -5,7 +5,10 @@ import type {
   MarkdownConfig,
   ReplyToMode,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type {
+  ChannelHealthMonitorConfig,
+  ChannelHeartbeatVisibilityConfig,
+} from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
@@ -185,6 +188,8 @@ export type SlackAccountConfig = {
   channels?: Record<string, SlackChannelConfig>;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: ChannelHealthMonitorConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
   /**

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -8,7 +8,10 @@ import type {
   ReplyToMode,
   SessionThreadBindingsConfig,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type {
+  ChannelHealthMonitorConfig,
+  ChannelHeartbeatVisibilityConfig,
+} from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
@@ -179,6 +182,8 @@ export type TelegramAccountConfig = {
   reactionLevel?: "off" | "ack" | "minimal" | "extensive";
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: ChannelHealthMonitorConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
   /**

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -4,7 +4,10 @@ import type {
   GroupPolicy,
   MarkdownConfig,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type {
+  ChannelHealthMonitorConfig,
+  ChannelHeartbeatVisibilityConfig,
+} from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
@@ -78,6 +81,8 @@ type WhatsAppSharedConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Channel health monitor overrides for this channel/account. */
+  healthMonitor?: ChannelHealthMonitorConfig;
 };
 
 type WhatsAppConfigCore = {

--- a/src/config/zod-schema.channels.ts
+++ b/src/config/zod-schema.channels.ts
@@ -8,3 +8,10 @@ export const ChannelHeartbeatVisibilitySchema = z
   })
   .strict()
   .optional();
+
+export const ChannelHealthMonitorSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -13,7 +13,10 @@ import {
   resolveTelegramCustomCommands,
 } from "./telegram-custom-commands.js";
 import { ToolPolicySchema } from "./zod-schema.agent-runtime.js";
-import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
+import {
+  ChannelHealthMonitorSchema,
+  ChannelHeartbeatVisibilitySchema,
+} from "./zod-schema.channels.js";
 import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,
@@ -271,6 +274,7 @@ export const TelegramAccountSchemaBase = z
     reactionNotifications: z.enum(["off", "own", "all"]).optional(),
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     linkPreview: z.boolean().optional(),
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
@@ -511,6 +515,7 @@ export const DiscordAccountSchema = z
     dm: DiscordDmSchema.optional(),
     guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     execApprovals: z
       .object({
         enabled: z.boolean().optional(),
@@ -782,6 +787,7 @@ export const GoogleChatAccountSchema = z
       .strict()
       .optional(),
     dm: GoogleChatDmSchema.optional(),
+    healthMonitor: ChannelHealthMonitorSchema,
     typingIndicator: z.enum(["none", "message", "reaction"]).optional(),
     responsePrefix: z.string().optional(),
   })
@@ -898,6 +904,7 @@ export const SlackAccountSchema = z
     dm: SlackDmSchema.optional(),
     channels: z.record(z.string(), SlackChannelSchema.optional()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
     typingReaction: z.string().optional(),
@@ -1032,6 +1039,7 @@ export const SignalAccountSchemaBase = z
       .optional(),
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
   })
   .strict();
@@ -1145,6 +1153,7 @@ export const IrcAccountSchemaBase = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     mediaMaxMb: z.number().positive().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
   })
   .strict();
@@ -1272,6 +1281,7 @@ export const IMessageAccountSchemaBase = z
       )
       .optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
   })
   .strict();
@@ -1383,6 +1393,7 @@ export const BlueBubblesAccountSchemaBase = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     groups: z.record(z.string(), BlueBubblesGroupConfigSchema.optional()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
   })
   .strict();
@@ -1499,6 +1510,7 @@ export const MSTeamsConfigSchema = z
     /** SharePoint site ID for file uploads in group chats/channels (e.g., "contoso.sharepoint.com,guid1,guid2") */
     sharePointSiteId: z.string().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
   })
   .strict()

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { ToolPolicySchema } from "./zod-schema.agent-runtime.js";
-import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
+import {
+  ChannelHealthMonitorSchema,
+  ChannelHeartbeatVisibilitySchema,
+} from "./zod-schema.channels.js";
 import {
   BlockStreamingCoalesceSchema,
   DmConfigSchema,
@@ -56,6 +59,7 @@ const WhatsAppSharedSchema = z.object({
   ackReaction: WhatsAppAckReactionSchema,
   debounceMs: z.number().int().nonnegative().optional().default(0),
   heartbeat: ChannelHeartbeatVisibilitySchema,
+  healthMonitor: ChannelHealthMonitorSchema,
 });
 
 function enforceOpenDmPolicyAllowFromStar(params: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -695,7 +695,6 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
-        channelHealthMonitorEnabled: z.boolean().optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -835,6 +835,21 @@ export const OpenClawSchema = z
           .optional(),
       })
       .strict()
+      .superRefine((gateway, ctx) => {
+        if (
+          gateway.channelStaleEventThresholdMinutes != null &&
+          gateway.channelHealthCheckMinutes != null &&
+          gateway.channelHealthCheckMinutes !== 0 &&
+          gateway.channelStaleEventThresholdMinutes < gateway.channelHealthCheckMinutes
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["channelStaleEventThresholdMinutes"],
+            message:
+              "channelStaleEventThresholdMinutes should be >= channelHealthCheckMinutes to avoid delayed stale detection",
+          });
+        }
+      })
       .optional(),
     memory: MemorySchema,
     skills: z

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -695,6 +695,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        channelHealthMonitorEnabled: z.boolean().optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -696,6 +696,8 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
+        channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
+        channelMaxRestartsPerHour: z.number().int().min(1).optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -836,11 +836,11 @@ export const OpenClawSchema = z
       })
       .strict()
       .superRefine((gateway, ctx) => {
+        const effectiveHealthCheckMinutes = gateway.channelHealthCheckMinutes ?? 5;
         if (
           gateway.channelStaleEventThresholdMinutes != null &&
-          gateway.channelHealthCheckMinutes != null &&
-          gateway.channelHealthCheckMinutes !== 0 &&
-          gateway.channelStaleEventThresholdMinutes < gateway.channelHealthCheckMinutes
+          effectiveHealthCheckMinutes !== 0 &&
+          gateway.channelStaleEventThresholdMinutes < effectiveHealthCheckMinutes
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -11,6 +11,7 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
     markChannelLoggedOut: vi.fn(),
+    isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),
     ...overrides,
@@ -224,6 +225,53 @@ describe("channel-health-monitor", () => {
       { isManuallyStopped: vi.fn(() => true) },
     );
     await expectNoStart(manager);
+  });
+
+  it("skips channels with health monitor disabled globally for that account", async () => {
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: { running: false, enabled: true, configured: true },
+        },
+      },
+      { isHealthMonitorEnabled: vi.fn(() => false) },
+    );
+    await expectNoStart(manager);
+  });
+
+  it("still restarts enabled accounts when another account on the same channel is disabled", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: {
+            running: true,
+            connected: false,
+            enabled: true,
+            configured: true,
+            lastStartAt: now - 300_000,
+          },
+          quiet: {
+            running: true,
+            connected: false,
+            enabled: true,
+            configured: true,
+            lastStartAt: now - 300_000,
+          },
+        },
+      },
+      {
+        isHealthMonitorEnabled: vi.fn((channelId: ChannelId, accountId: string) => {
+          return !(channelId === "discord" && accountId === "quiet");
+        }),
+      },
+    );
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.stopChannel).toHaveBeenCalledWith("discord", "default");
+    expect(manager.startChannel).toHaveBeenCalledWith("discord", "default");
+    expect(manager.stopChannel).not.toHaveBeenCalledWith("discord", "quiet");
+    expect(manager.startChannel).not.toHaveBeenCalledWith("discord", "quiet");
+    monitor.stop();
   });
 
   it("restarts a stuck channel (running but not connected)", async () => {

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -118,6 +118,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (!status) {
             continue;
           }
+          if (!channelManager.isHealthMonitorEnabled(channelId as ChannelId, accountId)) {
+            continue;
+          }
           if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
             continue;
           }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -41,6 +41,16 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-health-monitor"],
   },
+  {
+    prefix: "gateway.channelStaleEventThresholdMinutes",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
+  {
+    prefix: "gateway.channelMaxRestartsPerHour",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
   // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -37,6 +37,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
   {
+    prefix: "gateway.channelHealthMonitorEnabled",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
+  {
     prefix: "gateway.channelHealthCheckMinutes",
     kind: "hot",
     actions: ["restart-health-monitor"],

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -37,11 +37,6 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
   {
-    prefix: "gateway.channelHealthMonitorEnabled",
-    kind: "hot",
-    actions: ["restart-health-monitor"],
-  },
-  {
     prefix: "gateway.channelHealthCheckMinutes",
     kind: "hot",
     actions: ["restart-health-monitor"],

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -235,4 +235,27 @@ describe("server-channels auto restart", () => {
 
     expect(manager.isHealthMonitorEnabled("discord", "router-d")).toBe(false);
   });
+
+  it("falls back to channel-level health monitor overrides when account resolution omits them", () => {
+    installTestRegistry(
+      createTestPlugin({
+        resolveAccount: () => ({
+          enabled: true,
+          configured: true,
+        }),
+      }),
+    );
+
+    const manager = createManager({
+      loadConfig: () => ({
+        channels: {
+          discord: {
+            healthMonitor: { enabled: false },
+          },
+        },
+      }),
+    });
+
+    expect(manager.isHealthMonitorEnabled("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
+  });
 });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -44,12 +44,13 @@ function createTestPlugin(params?: {
   account?: TestAccount;
   startAccount?: NonNullable<ChannelPlugin<TestAccount>["gateway"]>["startAccount"];
   includeDescribeAccount?: boolean;
+  resolveAccount?: ChannelPlugin<TestAccount>["config"]["resolveAccount"];
 }): ChannelPlugin<TestAccount> {
   const account = params?.account ?? { enabled: true, configured: true };
   const includeDescribeAccount = params?.includeDescribeAccount !== false;
   const config: ChannelPlugin<TestAccount>["config"] = {
     listAccountIds: () => [DEFAULT_ACCOUNT_ID],
-    resolveAccount: () => account,
+    resolveAccount: params?.resolveAccount ?? (() => account),
     isEnabled: (resolved) => resolved.enabled !== false,
   };
   if (includeDescribeAccount) {
@@ -88,13 +89,16 @@ function installTestRegistry(plugin: ChannelPlugin<TestAccount>) {
   setActivePluginRegistry(registry);
 }
 
-function createManager(options?: { channelRuntime?: PluginRuntime["channel"] }) {
+function createManager(options?: {
+  channelRuntime?: PluginRuntime["channel"];
+  loadConfig?: () => Record<string, unknown>;
+}) {
   const log = createSubsystemLogger("gateway/server-channels-test");
   const channelLogs = { discord: log } as Record<ChannelId, SubsystemLogger>;
   const runtime = runtimeForLogger(log);
   const channelRuntimeEnvs = { discord: runtime } as Record<ChannelId, RuntimeEnv>;
   return createChannelManager({
-    loadConfig: () => ({}),
+    loadConfig: () => options?.loadConfig?.() ?? {},
     channelLogs,
     channelRuntimeEnvs,
     ...(options?.channelRuntime ? { channelRuntime: options.channelRuntime } : {}),
@@ -179,5 +183,56 @@ describe("server-channels auto restart", () => {
 
     await manager.startChannels();
     expect(startAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses plugin account resolution for health monitor overrides", () => {
+    installTestRegistry(
+      createTestPlugin({
+        resolveAccount: (cfg, accountId) => {
+          const accounts = (
+            cfg as {
+              channels?: {
+                discord?: {
+                  accounts?: Record<
+                    string,
+                    TestAccount & { healthMonitor?: { enabled?: boolean } }
+                  >;
+                };
+              };
+            }
+          ).channels?.discord?.accounts;
+          if (!accounts) {
+            return { enabled: true, configured: true };
+          }
+          const direct = accounts[accountId ?? DEFAULT_ACCOUNT_ID];
+          if (direct) {
+            return direct;
+          }
+          const normalized = (accountId ?? DEFAULT_ACCOUNT_ID).toLowerCase().replaceAll(" ", "-");
+          const matchKey = Object.keys(accounts).find(
+            (key) => key.toLowerCase().replaceAll(" ", "-") === normalized,
+          );
+          return matchKey ? (accounts[matchKey] ?? { enabled: true, configured: true }) : {};
+        },
+      }),
+    );
+
+    const manager = createManager({
+      loadConfig: () => ({
+        channels: {
+          discord: {
+            accounts: {
+              "Router D": {
+                enabled: true,
+                configured: true,
+                healthMonitor: { enabled: false },
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    expect(manager.isHealthMonitorEnabled("discord", "router-d")).toBe(false);
   });
 });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -258,4 +258,30 @@ describe("server-channels auto restart", () => {
 
     expect(manager.isHealthMonitorEnabled("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
   });
+
+  it("uses wrapped account config health monitor overrides", () => {
+    installTestRegistry(
+      createTestPlugin({
+        resolveAccount: () => ({
+          enabled: true,
+          configured: true,
+          config: {
+            healthMonitor: { enabled: false },
+          },
+        }),
+      }),
+    );
+
+    const manager = createManager({
+      loadConfig: () => ({
+        channels: {
+          discord: {
+            healthMonitor: { enabled: true },
+          },
+        },
+      }),
+    });
+
+    expect(manager.isHealthMonitorEnabled("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
+  });
 });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -132,10 +132,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
   const isHealthMonitorEnabled = (channelId: ChannelId, accountId: string): boolean => {
     const cfg = loadConfig();
-    if (cfg.gateway?.channelHealthMonitorEnabled === false) {
-      return false;
-    }
-
     const channelConfig = cfg.channels?.[channelId] as RawChannelConfig | undefined;
     const accountOverride = channelConfig?.accounts?.[accountId]?.healthMonitor?.enabled;
     if (typeof accountOverride === "boolean") {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -31,6 +31,16 @@ type ChannelRuntimeStore = {
   runtimes: Map<string, ChannelAccountSnapshot>;
 };
 
+type RawHealthMonitorEntry = {
+  healthMonitor?: {
+    enabled?: boolean;
+  };
+};
+
+type RawChannelConfig = RawHealthMonitorEntry & {
+  accounts?: Record<string, RawHealthMonitorEntry | undefined>;
+};
+
 function createRuntimeStore(): ChannelRuntimeStore {
   return {
     aborts: new Map(),
@@ -105,6 +115,7 @@ export type ChannelManager = {
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
+  isHealthMonitorEnabled: (channelId: ChannelId, accountId: string) => boolean;
 };
 
 // Channel docking: lifecycle hooks (`plugin.gateway`) flow through this manager.
@@ -118,6 +129,26 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   const manuallyStopped = new Set<string>();
 
   const restartKey = (channelId: ChannelId, accountId: string) => `${channelId}:${accountId}`;
+
+  const isHealthMonitorEnabled = (channelId: ChannelId, accountId: string): boolean => {
+    const cfg = loadConfig();
+    if (cfg.gateway?.channelHealthMonitorEnabled === false) {
+      return false;
+    }
+
+    const channelConfig = cfg.channels?.[channelId] as RawChannelConfig | undefined;
+    const accountOverride = channelConfig?.accounts?.[accountId]?.healthMonitor?.enabled;
+    if (typeof accountOverride === "boolean") {
+      return accountOverride;
+    }
+
+    const channelOverride = channelConfig?.healthMonitor?.enabled;
+    if (typeof channelOverride === "boolean") {
+      return channelOverride;
+    }
+
+    return true;
+  };
 
   const getStore = (channelId: ChannelId): ChannelRuntimeStore => {
     const existing = channelStores.get(channelId);
@@ -453,5 +484,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     markChannelLoggedOut,
     isManuallyStopped: isManuallyStopped_,
     resetRestartAttempts: resetRestartAttempts_,
+    isHealthMonitorEnabled,
   };
 }

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -131,9 +131,22 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         }
       | undefined;
     const accountOverride = resolvedAccount?.healthMonitor?.enabled;
+    const channelOverride = (
+      cfg.channels?.[channelId] as
+        | {
+            healthMonitor?: {
+              enabled?: boolean;
+            };
+          }
+        | undefined
+    )?.healthMonitor?.enabled;
 
     if (typeof accountOverride === "boolean") {
       return accountOverride;
+    }
+
+    if (typeof channelOverride === "boolean") {
+      return channelOverride;
     }
 
     return true;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -31,16 +31,6 @@ type ChannelRuntimeStore = {
   runtimes: Map<string, ChannelAccountSnapshot>;
 };
 
-type RawHealthMonitorEntry = {
-  healthMonitor?: {
-    enabled?: boolean;
-  };
-};
-
-type RawChannelConfig = RawHealthMonitorEntry & {
-  accounts?: Record<string, RawHealthMonitorEntry | undefined>;
-};
-
 function createRuntimeStore(): ChannelRuntimeStore {
   return {
     aborts: new Map(),
@@ -132,15 +122,18 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
   const isHealthMonitorEnabled = (channelId: ChannelId, accountId: string): boolean => {
     const cfg = loadConfig();
-    const channelConfig = cfg.channels?.[channelId] as RawChannelConfig | undefined;
-    const accountOverride = channelConfig?.accounts?.[accountId]?.healthMonitor?.enabled;
+    const plugin = getChannelPlugin(channelId);
+    const resolvedAccount = plugin?.config.resolveAccount(cfg, accountId) as
+      | {
+          healthMonitor?: {
+            enabled?: boolean;
+          };
+        }
+      | undefined;
+    const accountOverride = resolvedAccount?.healthMonitor?.enabled;
+
     if (typeof accountOverride === "boolean") {
       return accountOverride;
-    }
-
-    const channelOverride = channelConfig?.healthMonitor?.enabled;
-    if (typeof channelOverride === "boolean") {
-      return channelOverride;
     }
 
     return true;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -128,9 +128,15 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           healthMonitor?: {
             enabled?: boolean;
           };
+          config?: {
+            healthMonitor?: {
+              enabled?: boolean;
+            };
+          };
         }
       | undefined;
     const accountOverride = resolvedAccount?.healthMonitor?.enabled;
+    const wrappedAccountOverride = resolvedAccount?.config?.healthMonitor?.enabled;
     const channelOverride = (
       cfg.channels?.[channelId] as
         | {
@@ -143,6 +149,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
     if (typeof accountOverride === "boolean") {
       return accountOverride;
+    }
+
+    if (typeof wrappedAccountOverride === "boolean") {
+      return wrappedAccountOverride;
     }
 
     if (typeof channelOverride === "boolean") {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -104,10 +104,11 @@ export function createGatewayReloadHandlers(params: {
 
     if (plan.restartHealthMonitor) {
       state.channelHealthMonitor?.stop();
+      const enabled = nextConfig.gateway?.channelHealthMonitorEnabled !== false;
       const minutes = nextConfig.gateway?.channelHealthCheckMinutes;
       const staleMinutes = nextConfig.gateway?.channelStaleEventThresholdMinutes;
       nextState.channelHealthMonitor =
-        minutes === 0
+        !enabled || minutes === 0
           ? null
           : params.createHealthMonitor({
               checkIntervalMs: (minutes ?? 5) * 60_000,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -104,11 +104,10 @@ export function createGatewayReloadHandlers(params: {
 
     if (plan.restartHealthMonitor) {
       state.channelHealthMonitor?.stop();
-      const enabled = nextConfig.gateway?.channelHealthMonitorEnabled !== false;
       const minutes = nextConfig.gateway?.channelHealthCheckMinutes;
       const staleMinutes = nextConfig.gateway?.channelStaleEventThresholdMinutes;
       nextState.channelHealthMonitor =
-        !enabled || minutes === 0
+        minutes === 0
           ? null
           : params.createHealthMonitor({
               checkIntervalMs: (minutes ?? 5) * 60_000,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -50,7 +50,11 @@ export function createGatewayReloadHandlers(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logCron: { error: (msg: string) => void };
   logReload: { info: (msg: string) => void; warn: (msg: string) => void };
-  createHealthMonitor: (checkIntervalMs: number) => ChannelHealthMonitor;
+  createHealthMonitor: (opts: {
+    checkIntervalMs: number;
+    staleEventThresholdMs?: number;
+    maxRestartsPerHour?: number;
+  }) => ChannelHealthMonitor;
 }) {
   const applyHotReload = async (
     plan: GatewayReloadPlan,
@@ -101,8 +105,17 @@ export function createGatewayReloadHandlers(params: {
     if (plan.restartHealthMonitor) {
       state.channelHealthMonitor?.stop();
       const minutes = nextConfig.gateway?.channelHealthCheckMinutes;
+      const staleMinutes = nextConfig.gateway?.channelStaleEventThresholdMinutes;
       nextState.channelHealthMonitor =
-        minutes === 0 ? null : params.createHealthMonitor((minutes ?? 5) * 60_000);
+        minutes === 0
+          ? null
+          : params.createHealthMonitor({
+              checkIntervalMs: (minutes ?? 5) * 60_000,
+              ...(staleMinutes != null && { staleEventThresholdMs: staleMinutes * 60_000 }),
+              ...(nextConfig.gateway?.channelMaxRestartsPerHour != null && {
+                maxRestartsPerHour: nextConfig.gateway.channelMaxRestartsPerHour,
+              }),
+            });
     }
 
     if (plan.restartGmailWatcher) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -757,11 +757,17 @@ export async function startGatewayServer(
 
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
   const healthCheckDisabled = healthCheckMinutes === 0;
+  const staleEventThresholdMinutes = cfgAtStart.gateway?.channelStaleEventThresholdMinutes;
+  const maxRestartsPerHour = cfgAtStart.gateway?.channelMaxRestartsPerHour;
   let channelHealthMonitor = healthCheckDisabled
     ? null
     : startChannelHealthMonitor({
         channelManager,
         checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
+        ...(staleEventThresholdMinutes != null && {
+          staleEventThresholdMs: staleEventThresholdMinutes * 60_000,
+        }),
+        ...(maxRestartsPerHour != null && { maxRestartsPerHour }),
       });
 
   if (!minimalTestGateway) {
@@ -980,8 +986,21 @@ export async function startGatewayServer(
           logChannels,
           logCron,
           logReload,
-          createHealthMonitor: (checkIntervalMs: number) =>
-            startChannelHealthMonitor({ channelManager, checkIntervalMs }),
+          createHealthMonitor: (opts: {
+            checkIntervalMs: number;
+            staleEventThresholdMs?: number;
+            maxRestartsPerHour?: number;
+          }) =>
+            startChannelHealthMonitor({
+              channelManager,
+              checkIntervalMs: opts.checkIntervalMs,
+              ...(opts.staleEventThresholdMs != null && {
+                staleEventThresholdMs: opts.staleEventThresholdMs,
+              }),
+              ...(opts.maxRestartsPerHour != null && {
+                maxRestartsPerHour: opts.maxRestartsPerHour,
+              }),
+            }),
         });
 
         return startGatewayConfigReloader({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -755,8 +755,9 @@ export async function startGatewayServer(
       }
     : startHeartbeatRunner({ cfg: cfgAtStart });
 
+  const healthMonitorEnabled = cfgAtStart.gateway?.channelHealthMonitorEnabled !== false;
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
-  const healthCheckDisabled = healthCheckMinutes === 0;
+  const healthCheckDisabled = !healthMonitorEnabled || healthCheckMinutes === 0;
   const staleEventThresholdMinutes = cfgAtStart.gateway?.channelStaleEventThresholdMinutes;
   const maxRestartsPerHour = cfgAtStart.gateway?.channelMaxRestartsPerHour;
   let channelHealthMonitor = healthCheckDisabled

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -755,9 +755,8 @@ export async function startGatewayServer(
       }
     : startHeartbeatRunner({ cfg: cfgAtStart });
 
-  const healthMonitorEnabled = cfgAtStart.gateway?.channelHealthMonitorEnabled !== false;
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
-  const healthCheckDisabled = !healthMonitorEnabled || healthCheckMinutes === 0;
+  const healthCheckDisabled = healthCheckMinutes === 0;
   const staleEventThresholdMinutes = cfgAtStart.gateway?.channelStaleEventThresholdMinutes;
   const maxRestartsPerHour = cfgAtStart.gateway?.channelMaxRestartsPerHour;
   let channelHealthMonitor = healthCheckDisabled

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -109,6 +109,9 @@ const hoisted = vi.hoisted(() => {
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
     markChannelLoggedOut: vi.fn(),
+    isHealthMonitorEnabled: vi.fn(() => true),
+    isManuallyStopped: vi.fn(() => false),
+    resetRestartAttempts: vi.fn(),
   };
 
   const createChannelManager = vi.fn(() => providerManager);

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -26,6 +26,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     startChannel: vi.fn(),
     stopChannel: vi.fn(),
     markChannelLoggedOut: vi.fn(),
+    isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),
   };


### PR DESCRIPTION
## Summary

- Problem: Health monitor `staleEventThresholdMs` and `maxRestartsPerHour` are hardcoded, preventing tuning for different usage patterns.
- Why it matters: Quiet channels trigger unnecessary restarts; no way to adjust thresholds per deployment.
- What changed: Added `channelStaleEventThresholdMinutes` and `channelMaxRestartsPerHour` to gateway config, wired through the health monitor startup and hot-reload paths.
- What did NOT change (scope boundary): Default values unchanged. Health evaluation logic itself untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41471

## User-visible / Behavior Changes

New optional gateway config keys:
- `channelStaleEventThresholdMinutes` — how long before a channel is considered stale (default: 30 min)
- `channelMaxRestartsPerHour` — max restart attempts per hour (default: 10)

Both support hot-reload.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` - new optional gateway config keys
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove new config keys; defaults are preserved.
- Known bad symptoms: Channels not being restarted when stale if threshold set too high.

## Risks and Mitigations

None