### PR TITLE
fix(feishu): auto-read block content in color_text when content is omitted

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,15 +181,6 @@
         "line_number": 15
       }
     ],
-    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
-        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
-        "is_verified": false,
-        "line_number": 58
-      }
-    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
@@ -206,22 +197,6 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1859
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -9896,35 +9871,35 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 1503
+        "line_number": 1510
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 1780
+        "line_number": 1787
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 1781
+        "line_number": 1788
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2209
+        "line_number": 2216
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2490
+        "line_number": 2497
       }
     ],
     "docs/install/macos-vm.md": [
@@ -10177,21 +10152,21 @@
         "filename": "docs/tools/web.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 157
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 251
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "674397e2c0c2faaa85961c708d2a96a7cc7af217",
         "is_verified": false,
-        "line_number": 332
+        "line_number": 356
       }
     ],
     "docs/tts.md": [
@@ -10990,15 +10965,6 @@
         "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
-        "is_verified": false,
-        "line_number": 14
-      }
-    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11367,84 +11333,6 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "src/agents/memory-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
-        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    "src/agents/model-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 228
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 275
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
-        "is_verified": false,
-        "line_number": 374
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
-        "is_verified": false,
-        "line_number": 395
-      }
-    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11463,31 +11351,6 @@
         "line_number": 157
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
-        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
-        "is_verified": false,
-        "line_number": 20
-      }
-    ],
     "src/agents/models-config.providers.nvidia.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11502,40 +11365,6 @@
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
         "line_number": 23
-      }
-    ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
-        "is_verified": false,
-        "line_number": 113
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11574,15 +11403,6 @@
         "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
-        "is_verified": false,
-        "line_number": 126
-      }
-    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11592,65 +11412,13 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
+    "src/agents/tools/web-fetch.cf-markdown.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
+        "filename": "src/agents/tools/web-fetch.cf-markdown.test.ts",
+        "hashed_secret": "86bc57c4a7bfc76cf9a86d57e9b6daeefecdc056",
         "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
-        "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/tools/web-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
-        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
-        "is_verified": false,
-        "line_number": 129
+        "line_number": 117
       }
     ],
     "src/agents/tools/web-search.ts": [
@@ -11659,64 +11427,16 @@
         "filename": "src/agents/tools/web-search.ts",
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 320
       }
     ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
+    "src/agents/tools/web-tools.enabled-defaults.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "354a920b3d519d11b737695308dab1bfcf77dbb3",
         "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
-        "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 246
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
+        "line_number": 655
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11771,15 +11491,6 @@
         "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
-        "is_verified": false,
-        "line_number": 215
-      }
-    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11787,50 +11498,6 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
-      }
-    ],
-    "src/commands/auth-choice.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
-        "is_verified": false,
-        "line_number": 454
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 584
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
-        "is_verified": false,
-        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11842,31 +11509,6 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 128
-      }
-    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11874,52 +11516,6 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
-        "is_verified": false,
-        "line_number": 127
-      }
-    ],
-    "src/commands/models/list.status.e2e.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11936,96 +11532,6 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
-      }
-    ],
-    "src/commands/onboard-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
-        "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12053,15 +11559,6 @@
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
         "line_number": 60
-      }
-    ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 24
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12388,15 +11885,6 @@
         "line_number": 10
       }
     ],
-    "src/docker-setup.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
-        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
-        "is_verified": false,
-        "line_number": 131
-      }
-    ],
     "src/gateway/auth-rate-limit.ts": [
       {
         "type": "Secret Keyword",
@@ -12480,15 +11968,6 @@
         "line_number": 704
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
-      {
-        "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12523,40 +12002,6 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
-      }
-    ],
-    "src/gateway/server.auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
-      }
-    ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
-        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
-        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
-        "is_verified": false,
-        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12771,15 +12216,6 @@
         "line_number": 88
       }
     ],
-    "src/media-understanding/apply.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
       {
         "type": "Secret Keyword",
@@ -12887,6 +12323,38 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 357
+      }
+    ],
+    "src/secrets/runtime-web-tools.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime-web-tools.test.ts",
+        "hashed_secret": "2a2e0606a243ecec6a676d214897ad9d930a2dd8",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime-web-tools.test.ts",
+        "hashed_secret": "5de8028632e69ea765cf8bfaf0e32a441103de12",
+        "is_verified": false,
+        "line_number": 228
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime-web-tools.test.ts",
+        "hashed_secret": "4a9927de9f7d1779bc0ed9ac46bfbb033b5cd837",
+        "is_verified": false,
+        "line_number": 400
+      }
+    ],
+    "src/secrets/runtime-web-tools.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime-web-tools.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 21
       }
     ],
     "src/security/audit.test.ts": [
@@ -13013,5 +12481,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T03:11:06Z"
+  "generated_at": "2026-03-10T12:35:24Z"
 }

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -171,11 +171,29 @@ export const FeishuDocSchema = Type.Union([
   Type.Object({
     action: Type.Literal("color_text"),
     doc_token: Type.String({ description: "Document token" }),
-    block_id: Type.String({ description: "Text block ID to update" }),
-    content: Type.String({
-      description:
-        'Text with color markup. Tags: [red], [green], [blue], [orange], [yellow], [purple], [grey], [bold], [bg:yellow]. Example: "Revenue [green]+15%[/green] YoY"',
-    }),
+    block_id: Type.String({ description: "Text or heading block ID to update" }),
+    content: Type.Optional(
+      Type.String({
+        description:
+          'Text with color markup. Tags: [red], [green], [blue], [orange], [yellow], [purple], [grey], [bold], [bg:yellow]. Example: "Revenue [green]+15%[/green] YoY". If omitted, the existing block text is preserved.',
+      }),
+    ),
+    text_color: Type.Optional(
+      Type.Integer({
+        description:
+          "Apply a uniform text color to the entire block (1=red, 2=orange, 3=yellow, 4=green, 5=blue, 6=purple, 7=grey). Only used when content is omitted.",
+        minimum: 1,
+        maximum: 7,
+      }),
+    ),
+    background_color: Type.Optional(
+      Type.Integer({
+        description:
+          "Apply a uniform background color to the entire block (1=red, 2=orange, 3=yellow, 4=green, 5=blue, 6=purple, 7=grey). Only used when content is omitted.",
+        minimum: 1,
+        maximum: 7,
+      }),
+    ),
   }),
 ]);
 

--- a/extensions/feishu/src/docx-color-text.test.ts
+++ b/extensions/feishu/src/docx-color-text.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { parseColorMarkup, updateColorText } from "./docx-color-text.js";
+
+describe("parseColorMarkup", () => {
+  it("returns plain text segment when no markup", () => {
+    expect(parseColorMarkup("hello world")).toEqual([{ text: "hello world" }]);
+  });
+
+  it("parses color tags", () => {
+    const result = parseColorMarkup("[red]error[/red]");
+    expect(result).toEqual([{ text: "error", textColor: 1 }]);
+  });
+
+  it("mixes plain text and colored segments", () => {
+    const result = parseColorMarkup("Revenue [green]+15%[/green] YoY");
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ text: "Revenue " });
+    expect(result[1]).toEqual({ text: "+15%", textColor: 4 });
+    expect(result[2]).toEqual({ text: " YoY" });
+  });
+});
+
+// 模拟飞书 client
+function mockClient(block?: Record<string, unknown>) {
+  return {
+    docx: {
+      documentBlock: {
+        get: vi.fn().mockResolvedValue({
+          code: 0,
+          data: { block },
+        }),
+        patch: vi.fn().mockResolvedValue({
+          code: 0,
+          data: { block: {} },
+        }),
+      },
+    },
+  } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+describe("updateColorText", () => {
+  it("uses provided content with markup", async () => {
+    const client = mockClient();
+    const result = await updateColorText(client, "doc1", "blk1", "[red]hello[/red]");
+    expect(result.success).toBe(true);
+    expect(result.segments).toBe(1);
+    expect(client.docx.documentBlock.get).not.toHaveBeenCalled();
+    expect(client.docx.documentBlock.patch).toHaveBeenCalledWith({
+      path: { document_id: "doc1", block_id: "blk1" },
+      data: {
+        update_text_elements: {
+          elements: [
+            {
+              text_run: {
+                content: "hello",
+                text_element_style: { text_color: 1 },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("reads existing text block content when content is omitted", async () => {
+    const block = {
+      block_type: 2,
+      text: {
+        elements: [{ text_run: { content: "existing text" } }],
+      },
+    };
+    const client = mockClient(block);
+    const result = await updateColorText(client, "doc1", "blk1");
+    expect(result.success).toBe(true);
+    expect(client.docx.documentBlock.get).toHaveBeenCalledWith({
+      path: { document_id: "doc1", block_id: "blk1" },
+    });
+    // 使用现有文本作为纯文本 segment
+    expect(result.segments).toBe(1);
+  });
+
+  it("reads heading2 block content when content is omitted", async () => {
+    const block = {
+      block_type: 4,
+      heading2: {
+        elements: [{ text_run: { content: "Chapter Title" } }],
+      },
+    };
+    const client = mockClient(block);
+    const result = await updateColorText(client, "doc1", "blk1", undefined, 5);
+    expect(result.success).toBe(true);
+    // 使用 uniform color 路径
+    expect(client.docx.documentBlock.patch).toHaveBeenCalledWith({
+      path: { document_id: "doc1", block_id: "blk1" },
+      data: {
+        update_text_elements: {
+          elements: [
+            {
+              text_run: {
+                content: "Chapter Title",
+                text_element_style: { text_color: 5 },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("applies uniform text_color and background_color", async () => {
+    const block = {
+      block_type: 5,
+      heading3: {
+        elements: [{ text_run: { content: "Section " } }, { text_run: { content: "Title" } }],
+      },
+    };
+    const client = mockClient(block);
+    const result = await updateColorText(client, "doc1", "blk1", undefined, 1, 3);
+    expect(result.success).toBe(true);
+    expect(result.segments).toBe(1);
+    expect(client.docx.documentBlock.patch).toHaveBeenCalledWith({
+      path: { document_id: "doc1", block_id: "blk1" },
+      data: {
+        update_text_elements: {
+          elements: [
+            {
+              text_run: {
+                content: "Section Title",
+                text_element_style: { text_color: 1, background_color: 3 },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("throws when block has no text and content is omitted", async () => {
+    const block = { block_type: 99 }; // 不支持的 block 类型
+    const client = mockClient(block);
+    await expect(updateColorText(client, "doc1", "blk1")).rejects.toThrow(
+      "Block has no text content to color",
+    );
+  });
+});

--- a/extensions/feishu/src/docx-color-text.test.ts
+++ b/extensions/feishu/src/docx-color-text.test.ts
@@ -62,7 +62,7 @@ describe("updateColorText", () => {
     });
   });
 
-  it("reads existing text block content when content is omitted", async () => {
+  it("returns early without patch when content and colors are all omitted", async () => {
     const block = {
       block_type: 2,
       text: {
@@ -72,11 +72,12 @@ describe("updateColorText", () => {
     const client = mockClient(block);
     const result = await updateColorText(client, "doc1", "blk1");
     expect(result.success).toBe(true);
+    expect(result.segments).toBe(0);
     expect(client.docx.documentBlock.get).toHaveBeenCalledWith({
       path: { document_id: "doc1", block_id: "blk1" },
     });
-    // 使用现有文本作为纯文本 segment
-    expect(result.segments).toBe(1);
+    // No-op: patch must NOT be called to preserve existing rich formatting
+    expect(client.docx.documentBlock.patch).not.toHaveBeenCalled();
   });
 
   it("reads heading2 block content when content is omitted", async () => {

--- a/extensions/feishu/src/docx-color-text.ts
+++ b/extensions/feishu/src/docx-color-text.ts
@@ -109,16 +109,116 @@ export function parseColorMarkup(content: string): Segment[] {
   return segments;
 }
 
+// Block type → property name mapping for text/heading blocks
+const BLOCK_TYPE_KEY: Record<number, string> = {
+  2: "text",
+  3: "heading1",
+  4: "heading2",
+  5: "heading3",
+  6: "heading4",
+  7: "heading5",
+  8: "heading6",
+  9: "heading7",
+  10: "heading8",
+  11: "heading9",
+};
+
 /**
- * Update a text block with colored segments.
+ * Extract plain text from a block's elements array.
+ * Handles text blocks (type 2) and heading blocks (types 3-11).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block shape is loosely typed
+function extractBlockText(block: any): string {
+  const blockType: number | undefined = block?.block_type;
+  if (blockType == null) return "";
+  const key = BLOCK_TYPE_KEY[blockType];
+  if (!key) return "";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK elements array
+  const elements: any[] | undefined = block[key]?.elements;
+  if (!elements) return "";
+  return elements.map((el) => el?.text_run?.content ?? "").join("");
+}
+
+/**
+ * Fetch existing block content from Feishu API.
+ */
+async function fetchBlockText(
+  client: Lark.Client,
+  docToken: string,
+  blockId: string,
+): Promise<string> {
+  const res = await client.docx.documentBlock.get({
+    path: { document_id: docToken, block_id: blockId },
+  });
+  if (res.code !== 0) {
+    throw new Error(`Failed to fetch block: ${res.msg}`);
+  }
+  return extractBlockText(res.data?.block);
+}
+
+/**
+ * Update a text or heading block with colored segments.
+ *
+ * When `content` is omitted, the existing block text is read from the API.
+ * `textColor` / `bgColor` apply a uniform color to the entire block text
+ * (only used when `content` is omitted).
  */
 export async function updateColorText(
   client: Lark.Client,
   docToken: string,
   blockId: string,
-  content: string,
+  content?: string,
+  textColor?: number,
+  bgColor?: number,
 ) {
-  const segments = parseColorMarkup(content);
+  let markup: string;
+
+  if (content != null && content !== "") {
+    // Caller provided explicit content with color markup
+    markup = content;
+  } else {
+    // No content provided — read existing block text
+    const existingText = await fetchBlockText(client, docToken, blockId);
+    if (!existingText) {
+      throw new Error("Block has no text content to color");
+    }
+
+    if (textColor || bgColor) {
+      // Apply uniform color to existing text (no markup parsing needed)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK type
+      const elements: any[] = [
+        {
+          text_run: {
+            content: existingText,
+            text_element_style: {
+              ...(textColor && { text_color: textColor }),
+              ...(bgColor && { background_color: bgColor }),
+            },
+          },
+        },
+      ];
+
+      const res = await client.docx.documentBlock.patch({
+        path: { document_id: docToken, block_id: blockId },
+        data: { update_text_elements: { elements } },
+      });
+
+      if (res.code !== 0) {
+        throw new Error(res.msg);
+      }
+
+      return {
+        success: true,
+        segments: 1,
+        block: res.data?.block,
+      };
+    }
+
+    // No color params either — preserve existing text as-is
+    markup = existingText;
+  }
+
+  const segments = parseColorMarkup(markup);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK type
   const elements: any[] = segments.map((seg) => ({

--- a/extensions/feishu/src/docx-color-text.ts
+++ b/extensions/feishu/src/docx-color-text.ts
@@ -214,8 +214,8 @@ export async function updateColorText(
       };
     }
 
-    // No color params either — preserve existing text as-is
-    markup = existingText;
+    // No color params either — nothing to apply; bail out without touching the block
+    return { success: true, segments: 0, block: undefined };
   }
 
   const segments = parseColorMarkup(markup);

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1377,7 +1377,16 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                     ),
                   );
                 case "color_text":
-                  return json(await updateColorText(client, p.doc_token, p.block_id, p.content));
+                  return json(
+                    await updateColorText(
+                      client,
+                      p.doc_token,
+                      p.block_id,
+                      p.content,
+                      p.text_color,
+                      p.background_color,
+                    ),
+                  );
                 case "insert_table_row":
                   return json(await insertTableRow(client, p.doc_token, p.block_id, p.row_index));
                 case "insert_table_column":


### PR DESCRIPTION
## Problem

The `color_text` action in `feishu_doc` tool destroys heading block content when `content` parameter is omitted. When an AI agent calls `color_text(block_id=xxx)` without providing `content`, the value `undefined` is stringified and written into the block, replacing the original text with the literal string "undefined".

This is particularly destructive for heading blocks (H2/H3), as users lose their section titles with no way to recover.

## Root Cause

`updateColorText()` passes `content` directly to `parseColorMarkup()` without checking for `undefined`. JavaScript's string coercion turns `undefined` into `"undefined"`, which then replaces the block's actual text via `update_text_elements`.

## Solution

1. **Auto-read existing content**: When `content` is omitted, fetch the block's current text via `documentBlock.get()` API before proceeding
2. **New `text_color` / `background_color` params**: Allow applying uniform colors to existing block text without rewriting content — e.g. `color_text(block_id=xxx, text_color=5)` to make a heading blue
3. **Support all heading types**: New `extractBlockText()` helper handles `text` (type 2) and `heading1`–`heading9` (types 3–11)
4. **Schema update**: `content` is now optional; new integer params `text_color` (1-7) and `background_color` (1-7) added

## Changes

- `extensions/feishu/src/docx-color-text.ts` — Core fix: auto-read block content, uniform color support, heading block extraction
- `extensions/feishu/src/doc-schema.ts` — Schema: `content` optional, new `text_color`/`background_color` params  
- `extensions/feishu/src/docx.ts` — Pass new params to `updateColorText()`
- `extensions/feishu/src/docx-color-text.test.ts` — 8 new tests covering all scenarios

## Testing

- 8 vitest cases pass (parseColorMarkup + updateColorText with text/heading blocks, uniform color, missing content)
- Manually verified: heading blocks retain content when `content` is omitted
- Backward compatible: existing `color_text` calls with explicit `content` work unchanged

Closes #26222 (partially — adds heading block support to color_text)