### PR TITLE
Speed up install smoke Docker builds

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            OPENCLAW_SKIP_UI_BUILD=1
           tags: openclaw-dockerfile-smoke:local
           load: true
           push: false
@@ -69,6 +71,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             OPENCLAW_EXTENSIONS=diagnostics-otel
+            OPENCLAW_SKIP_UI_BUILD=1
           tags: openclaw-ext-smoke:local
           load: true
           push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN mkdir -p /out && \
 
 # ── Stage 2: Build ──────────────────────────────────────────────
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS build
+ARG OPENCLAW_SKIP_UI_BUILD
 
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@
 #   Slim (bookworm-slim):    docker build --build-arg OPENCLAW_VARIANT=slim .
 ARG OPENCLAW_EXTENSIONS=""
 ARG OPENCLAW_VARIANT=default
+ARG OPENCLAW_SKIP_UI_BUILD=""
 ARG OPENCLAW_NODE_BOOKWORM_IMAGE="node:22-bookworm@sha256:b501c082306a4f528bc4038cbf2fbb58095d583d0419a259b2114b5ac53d12e9"
 ARG OPENCLAW_NODE_BOOKWORM_DIGEST="sha256:b501c082306a4f528bc4038cbf2fbb58095d583d0419a259b2114b5ac53d12e9"
 ARG OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE="node:22-bookworm-slim@sha256:9c2c405e3ff9b9afb2873232d24bb06367d649aa3e6259cbe314da59578e81e9"
@@ -79,9 +80,16 @@ RUN pnpm canvas:a2ui:bundle || \
      echo "stub" > src/canvas-host/a2ui/.bundle.hash && \
      rm -rf vendor/a2ui apps/shared/OpenClawKit/Tools/CanvasA2UI)
 RUN pnpm build:docker
-# Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
+# Force pnpm for UI build (Bun may fail on ARM/Synology architectures).
+# Install Smoke can skip the full UI build and use a minimal placeholder asset
+# because that workflow only validates image build + basic CLI startup.
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:build
+RUN if [ -n "$OPENCLAW_SKIP_UI_BUILD" ]; then \
+      mkdir -p dist/control-ui && \
+      printf '%s\n' '<!doctype html><title>OpenClaw Control UI</title><p>Smoke build placeholder.</p>' > dist/control-ui/index.html; \
+    else \
+      pnpm ui:build; \
+    fi
 
 # Prune dev dependencies and strip build-only metadata before copying
 # runtime assets into the final image.


### PR DESCRIPTION
## Summary

Speed up the `Install Smoke / install-smoke` workflow by skipping the full control UI build only for the smoke Docker image builds.

## What changed

- add `OPENCLAW_SKIP_UI_BUILD` in `Dockerfile`
- when that flag is set, generate a minimal `dist/control-ui/index.html` placeholder instead of running `pnpm ui:build`
- pass `OPENCLAW_SKIP_UI_BUILD=1` only from `.github/workflows/install-smoke.yml` for the root/ext smoke image builds

## Why

The smoke workflow only validates that the Dockerfile still builds and that the CLI starts. It does not exercise the full control UI bundle, so paying the full `pnpm ui:build` cost there is unnecessary.

Release and normal Docker builds are unchanged because the new path is opt-in and only enabled by the smoke workflow.

## Testing

- `./node_modules/.bin/oxfmt --check Dockerfile .github/workflows/install-smoke.yml`
