### PR TITLE
Fix: Add null check for model.input in model-scan.ts

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -326,12 +326,12 @@ async function probeImage(
 }
 
 function ensureImageInput(model: OpenAIModel): OpenAIModel {
-  if (model.input.includes("image")) {
+  if (model.input?.includes("image")) {
     return model;
   }
   return {
     ...model,
-    input: Array.from(new Set([...model.input, "image"])),
+    input: Array.from(new Set([...(model.input ?? []), "image"])),
   };
 }
 
@@ -472,7 +472,7 @@ export async function scanOpenRouterModels(
       };
 
       const toolResult = await probeTool(model, apiKey, timeoutMs);
-      const imageResult = model.input.includes("image")
+      const imageResult = model.input?.includes("image")
         ? await probeImage(ensureImageInput(model), apiKey, timeoutMs)
         : { ok: false, latencyMs: null, skipped: true };
 


### PR DESCRIPTION
## Summary
- Added optional chaining (`?.`) to `model.input.includes` calls in model-scan.ts
- Added fallback to empty array when `model.input` is undefined

## Problem
Custom OpenAI-compatible providers (e.g., MiniMax) without an `input` field on the model object cause crashes when code calls `model.input.includes("image")` without null-checking.

```
TypeError: Cannot read properties of undefined (reading 'includes')
```

## Solution
Use optional chaining to safely check for image support:
- `model.input.includes` → `model.input?.includes`
- `[...model.input, "image"]` → `[...(model.input ?? []), "image"]`

Fixes #42068