### PR TITLE
feat(voice-call): configurable responseAgentId

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -105,6 +105,7 @@ const voiceCallConfigSchema = {
     },
     store: { label: "Call Log Store Path", advanced: true },
     responseModel: { label: "Response Model", advanced: true },
+    responseAgentId: { label: "Response Agent ID", advanced: true },
     responseSystemPrompt: { label: "Response System Prompt", advanced: true },
     responseTimeoutMs: { label: "Response Timeout (ms)", advanced: true },
   },

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -342,6 +342,9 @@ export const VoiceCallConfigSchema = z
     /** Model for generating voice responses (e.g., "anthropic/claude-sonnet-4", "openai/gpt-4o") */
     responseModel: z.string().default("openai/gpt-4o-mini"),
 
+    /** Agent ID for voice response generation (defaults to "main") */
+    responseAgentId: z.string().optional(),
+
     /** System prompt for voice responses */
     responseSystemPrompt: z.string().optional(),
 

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -59,7 +59,7 @@ export async function generateVoiceResponse(
   // Build voice-specific session key based on phone number
   const normalizedPhone = from.replace(/\D/g, "");
   const sessionKey = `voice:${normalizedPhone}`;
-  const agentId = "main";
+  const agentId = voiceConfig.responseAgentId || "main";
 
   // Resolve paths
   const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });


### PR DESCRIPTION
### Problem

The voice-call plugin always generates responses using the `main` agent's workspace context. In multi-agent setups, voice calls should be able to use a different agent's workspace (with its own memory, skills, and personality).

### Fix

Add `responseAgentId` to the voice-call plugin config schema. When set, voice response generation uses that agent's workspace instead of `main`. Falls back to `main` when unset.

### Details

- Config field added to `VoiceCallConfigSchema` (Zod `.strict()`) as `z.string().optional()`
- `responseAgentId` flows through `normalizeAgentId()` which validates against `/^[a-z0-9][a-z0-9_-]{0,63}$/i` -- no path traversal risk
- UI config form updated with the new field (marked `advanced: true`)

## Validation
- `pnpm build` -- clean
- `pnpm check` -- clean
- `pnpm test` -- passed

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Closes #42155