### PR TITLE
fix(agents): add SSE parse error resilience with auto-retry

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11571,7 +11571,7 @@
         "filename": "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 116
       }
     ],
     "src/agents/pi-tools.safe-bins.e2e.test.ts": [
@@ -13013,5 +13013,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T03:11:06Z"
+  "generated_at": "2026-03-10T12:36:41Z"
 }

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -342,6 +342,7 @@ describe("failover-error", () => {
 
   it("infers timeout from connection/network error messages", () => {
     expect(resolveFailoverReasonFromError({ message: "Connection error." })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ message: "Network connection lost." })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ message: "fetch failed" })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ message: "Network error: ECONNREFUSED" })).toBe(
       "timeout",

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -35,6 +35,7 @@ export {
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,
   isImageSizeError,
+  isLikelySSEParseError,
   isOverloadedErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
@@ -223,8 +223,32 @@ describe("isLikelySSEParseError", () => {
       expect(isLikelySSEParseError("quota exceeded, malformed SSE")).toBe(false);
     });
 
-    it("rejects upstream errors", () => {
-      expect(isLikelySSEParseError("upstream server error, SSE parse error")).toBe(false);
+    it("detects SSE parse errors even when upstream is mentioned", () => {
+      expect(isLikelySSEParseError("upstream server error, SSE parse error")).toBe(true);
+    });
+
+    it("detects SSE parse errors triggered by upstream proxy disconnects", () => {
+      expect(
+        isLikelySSEParseError("Could not parse SSE event: upstream connect error", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("does NOT detect 'failed to parse' without JSON context", () => {
+      expect(
+        isLikelySSEParseError("Failed to parse tool response", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("does NOT detect 'failed to parse configuration'", () => {
+      expect(
+        isLikelySSEParseError("Failed to parse configuration", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
     });
 
     it("rejects context length errors", () => {

--- a/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import { isLikelySSEParseError } from "./errors.js";
+
+describe("isLikelySSEParseError", () => {
+  // -----------------------------------------------------------------------
+  // 基础边界情况
+  // -----------------------------------------------------------------------
+  it("returns false for empty string", () => {
+    expect(isLikelySSEParseError("")).toBe(false);
+  });
+
+  it("returns false for generic error without streaming context", () => {
+    expect(isLikelySSEParseError("something went wrong")).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // SDK 特有 SSE 解析错误模式
+  // -----------------------------------------------------------------------
+  describe("Anthropic/OpenAI SDK patterns", () => {
+    it("detects 'Could not parse SSE event'", () => {
+      expect(isLikelySSEParseError("Could not parse SSE event")).toBe(true);
+    });
+
+    it("detects 'Could not process SSE event'", () => {
+      expect(isLikelySSEParseError("Could not process SSE event")).toBe(true);
+    });
+
+    it("detects 'SSE parse error'", () => {
+      expect(isLikelySSEParseError("SSE parse error: unexpected end of input")).toBe(true);
+    });
+
+    it("detects 'SSE parsing error'", () => {
+      expect(isLikelySSEParseError("SSE parsing error on chunk")).toBe(true);
+    });
+
+    it("detects 'unexpected SSE'", () => {
+      expect(isLikelySSEParseError("unexpected SSE format in response")).toBe(true);
+    });
+
+    it("detects 'malformed SSE'", () => {
+      expect(isLikelySSEParseError("malformed SSE data line")).toBe(true);
+    });
+
+    it("detects 'invalid SSE'", () => {
+      expect(isLikelySSEParseError("invalid SSE event received")).toBe(true);
+    });
+
+    it("detects SDK patterns without streamingContext flag", () => {
+      // SDK 特有模式不需要 streamingContext 标记
+      expect(isLikelySSEParseError("Could not parse SSE event", {})).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // SyntaxError + JSON context + streaming context
+  // -----------------------------------------------------------------------
+  describe("SyntaxError + JSON + streaming context", () => {
+    it("detects SyntaxError with JSON and explicit streaming context", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected token < in JSON at position 0", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("detects syntax error with unexpected end of input in streaming context", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected end of JSON input", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("detects syntax error with unterminated string in streaming context", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unterminated string in JSON", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("does NOT detect SyntaxError + JSON without streaming context", () => {
+      expect(isLikelySSEParseError("SyntaxError: Unexpected token < in JSON at position 0")).toBe(
+        false,
+      );
+    });
+
+    it("detects SyntaxError + JSON with streaming stack trace", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected token < in JSON at position 0", {
+          stack: "at fromSSE (node_modules/openai/streaming.js:123:45)",
+        }),
+      ).toBe(true);
+    });
+
+    it("detects via anthropic/streaming in stack", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected token in JSON", {
+          stack: "at parse (node_modules/@anthropic-ai/sdk/anthropic/streaming.js:50:10)",
+        }),
+      ).toBe(true);
+    });
+
+    it("detects via openai/streaming in stack", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected end of JSON input", {
+          stack: "at processChunk (node_modules/openai/streaming.js:99:5)",
+        }),
+      ).toBe(true);
+    });
+
+    it("detects via /sse/ in stack with JSON context", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected token in JSON", {
+          stack: "at handleEvent (/app/lib/sse/parser.js:10:5)",
+        }),
+      ).toBe(true);
+    });
+
+    it("does NOT detect via /sse/ in stack when streamingContext is explicitly false and no JSON hint", () => {
+      // 注意："Unexpected token" 本身不包含 JSON 关键词，
+      // 但 stack 中有 /sse/ 会被视为 streaming context。
+      // 带有 "SyntaxError" + "unexpected token"（含 JSON 上下文）+ stack 中有 SSE = 检测到
+      // 要排除的是：没有 isSyntaxError/isJsonContext 时不触发
+      expect(
+        isLikelySSEParseError("generic network error", {
+          stack: "at handleEvent (/app/lib/sse/parser.js:10:5)",
+        }),
+      ).toBe(false);
+    });
+
+    it("detects via stream. in stack", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected token in JSON", {
+          stack: "at stream.processLine (index.js:42:3)",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 通用 JSON parse failure + streaming context
+  // -----------------------------------------------------------------------
+  describe("generic JSON parse failure + streaming context", () => {
+    it("detects JSON.parse failure in streaming context", () => {
+      expect(
+        isLikelySSEParseError("JSON.parse: unexpected character at line 1 column 1", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("detects 'json parse error' in streaming context", () => {
+      expect(
+        isLikelySSEParseError("json parse error: invalid data", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("detects 'failed to parse' JSON in streaming context", () => {
+      expect(
+        isLikelySSEParseError("Failed to parse response JSON from SSE stream", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("does NOT detect generic JSON parse failure without streaming context", () => {
+      expect(isLikelySSEParseError("JSON.parse: unexpected character")).toBe(false);
+    });
+
+    it("detects parse error + json via streaming stack", () => {
+      expect(
+        isLikelySSEParseError("parse error: unexpected token in json", {
+          stack: "at _sse.processEvent (lib/index.js:5:5)",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 误报排除
+  // -----------------------------------------------------------------------
+  describe("false positive exclusions", () => {
+    it("rejects context overflow errors", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: context overflow: JSON at position 0", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects context window errors", () => {
+      expect(
+        isLikelySSEParseError("context window exceeded while parsing JSON", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects rate limit errors", () => {
+      expect(
+        isLikelySSEParseError("rate limit exceeded, JSON parse failed", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects billing errors", () => {
+      expect(
+        isLikelySSEParseError("billing: insufficient credit, SSE parse error", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects insufficient balance errors", () => {
+      expect(isLikelySSEParseError("insufficient balance - Could not parse SSE event")).toBe(false);
+    });
+
+    it("rejects quota exceeded errors", () => {
+      expect(isLikelySSEParseError("quota exceeded, malformed SSE")).toBe(false);
+    });
+
+    it("rejects upstream errors", () => {
+      expect(isLikelySSEParseError("upstream server error, SSE parse error")).toBe(false);
+    });
+
+    it("rejects context length errors", () => {
+      expect(
+        isLikelySSEParseError("context length exceeded in JSON stream", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects 'too many requests' errors", () => {
+      expect(isLikelySSEParseError("too many requests, SSE parse error")).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 不相关的错误不触发
+  // -----------------------------------------------------------------------
+  describe("unrelated errors", () => {
+    it("rejects generic network errors", () => {
+      expect(isLikelySSEParseError("ECONNRESET")).toBe(false);
+    });
+
+    it("rejects timeout errors", () => {
+      expect(isLikelySSEParseError("Request timed out")).toBe(false);
+    });
+
+    it("rejects auth errors", () => {
+      expect(isLikelySSEParseError("401 Unauthorized")).toBe(false);
+    });
+
+    it("rejects model not found errors", () => {
+      expect(isLikelySSEParseError("model not found")).toBe(false);
+    });
+
+    it("rejects regular JSON errors without streaming context", () => {
+      expect(isLikelySSEParseError("SyntaxError: Unexpected token in JSON")).toBe(false);
+    });
+  });
+});

--- a/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
@@ -251,6 +251,22 @@ describe("isLikelySSEParseError", () => {
       ).toBe(false);
     });
 
+    it("does NOT detect non-JSON SyntaxError with 'unexpected token' (e.g. eval error)", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected token 'var'", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("detects 'unexpected token' when paired with 'at position' (V8 JSON.parse)", () => {
+      expect(
+        isLikelySSEParseError("SyntaxError: Unexpected token < at position 0", {
+          streamingContext: true,
+        }),
+      ).toBe(true);
+    });
+
     it("does NOT detect 'parse error: unexpected end of stream' (non-JSON)", () => {
       expect(
         isLikelySSEParseError("parse error: unexpected end of stream", {

--- a/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.sse-parse.test.ts
@@ -251,6 +251,14 @@ describe("isLikelySSEParseError", () => {
       ).toBe(false);
     });
 
+    it("does NOT detect 'parse error: unexpected end of stream' (non-JSON)", () => {
+      expect(
+        isLikelySSEParseError("parse error: unexpected end of stream", {
+          streamingContext: true,
+        }),
+      ).toBe(false);
+    });
+
     it("rejects context length errors", () => {
       expect(
         isLikelySSEParseError("context length exceeded in JSON stream", {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -800,7 +800,7 @@ export function isImageSizeError(errorMessage?: string): boolean {
 
 /** 已知与 SSE 上下文无关的误报模式——排除后避免误判。 */
 const SSE_FALSE_POSITIVE_RE =
-  /context.?(?:overflow|window|length)|rate.?limit|billing|insufficient.?(?:credit|balance|quota)|too many requests|quota exceeded|upstream/i;
+  /context.?(?:overflow|window|length)|rate.?limit|billing|insufficient.?(?:credit|balance|quota)|too many requests|quota exceeded/i;
 
 /** Anthropic / OpenAI SDK 抛出的特有 SSE 解析错误消息。 */
 const SSE_SDK_PATTERN_RE =
@@ -851,7 +851,7 @@ export function isLikelySSEParseError(
   const isJsonParseFailure =
     lower.includes("json parse") ||
     lower.includes("json.parse") ||
-    lower.includes("failed to parse") ||
+    (lower.includes("failed to parse") && isJsonContext) ||
     (lower.includes("parse error") && isJsonContext);
 
   if (isJsonParseFailure && inStreamingContext) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -840,7 +840,7 @@ export function isLikelySSEParseError(
   const isJsonContext =
     lower.includes("json") ||
     lower.includes("unexpected token") ||
-    lower.includes("unexpected end of") ||
+    lower.includes("unexpected end of json") ||
     lower.includes("unterminated string");
 
   if (isSyntaxError && isJsonContext && inStreamingContext) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -792,6 +792,75 @@ export function isImageSizeError(errorMessage?: string): boolean {
   return Boolean(parseImageSizeError(errorMessage));
 }
 
+// ---------------------------------------------------------------------------
+// SSE parse error detection
+// ---------------------------------------------------------------------------
+// 反向代理（Azure/CloudFlare/nginx）截断 SSE `data:` 行时，SDK 侧会触发
+// SyntaxError / JSON parse failure。该函数区分此类瞬态错误与其他 JSON 解析错误。
+
+/** 已知与 SSE 上下文无关的误报模式——排除后避免误判。 */
+const SSE_FALSE_POSITIVE_RE =
+  /context.?(?:overflow|window|length)|rate.?limit|billing|insufficient.?(?:credit|balance|quota)|too many requests|quota exceeded|upstream/i;
+
+/** Anthropic / OpenAI SDK 抛出的特有 SSE 解析错误消息。 */
+const SSE_SDK_PATTERN_RE =
+  /could not (?:parse|process) sse|sse (?:parse|parsing) error|unexpected sse|malformed sse|invalid sse/i;
+
+/** 栈追踪中表明正在执行流式解析的关键帧。 */
+const SSE_STACK_STREAMING_RE =
+  /\bstreaming\b|fromsse|from_sse|\/sse[/.]|_sse[/.]|\bstream\.|openai\/streaming|anthropic\/streaming/i;
+
+export function isLikelySSEParseError(
+  errorMessage: string,
+  opts?: { stack?: string; streamingContext?: boolean },
+): boolean {
+  if (!errorMessage) {
+    return false;
+  }
+
+  const lower = errorMessage.toLowerCase();
+
+  // 排除误报：context overflow / rate limit / billing / upstream 等
+  if (SSE_FALSE_POSITIVE_RE.test(errorMessage)) {
+    return false;
+  }
+
+  // 1) Anthropic / OpenAI SDK 特有 SSE 解析错误
+  if (SSE_SDK_PATTERN_RE.test(errorMessage)) {
+    return true;
+  }
+
+  // 判断是否处于流式上下文：显式标记 or 栈追踪中包含流式关键帧
+  const inStreamingContext =
+    opts?.streamingContext === true ||
+    (opts?.stack ? SSE_STACK_STREAMING_RE.test(opts.stack) : false);
+
+  // 2) SyntaxError + JSON 相关 + 流式上下文
+  const isSyntaxError = lower.includes("syntaxerror") || lower.includes("syntax error");
+  const isJsonContext =
+    lower.includes("json") ||
+    lower.includes("unexpected token") ||
+    lower.includes("unexpected end of") ||
+    lower.includes("unterminated string");
+
+  if (isSyntaxError && isJsonContext && inStreamingContext) {
+    return true;
+  }
+
+  // 3) 通用 JSON parse failure + 流式上下文
+  const isJsonParseFailure =
+    lower.includes("json parse") ||
+    lower.includes("json.parse") ||
+    lower.includes("failed to parse") ||
+    (lower.includes("parse error") && isJsonContext);
+
+  if (isJsonParseFailure && inStreamingContext) {
+    return true;
+  }
+
+  return false;
+}
+
 export function isCloudCodeAssistFormatError(raw: string): boolean {
   return !isImageDimensionErrorMessage(raw) && matchesFormatErrorPattern(raw);
 }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -837,10 +837,13 @@ export function isLikelySSEParseError(
 
   // 2) SyntaxError + JSON 相关 + 流式上下文
   const isSyntaxError = lower.includes("syntaxerror") || lower.includes("syntax error");
+  // Narrow JSON context detection: standalone "unexpected token" is too broad
+  // (matches non-JSON SyntaxErrors like `Unexpected token 'var'`). Require
+  // either an explicit "json" mention, V8-style "at position" suffix, or the
+  // JSON-specific "unterminated string" pattern.
   const isJsonContext =
     lower.includes("json") ||
-    lower.includes("unexpected token") ||
-    lower.includes("unexpected end of json") ||
+    (lower.includes("unexpected token") && lower.includes("at position")) ||
     lower.includes("unterminated string");
 
   if (isSyntaxError && isJsonContext && inStreamingContext) {

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -32,6 +32,7 @@ const ERROR_PATTERNS = {
     "deadline exceeded",
     "context deadline exceeded",
     "connection error",
+    "connection lost",
     "network error",
     "network request failed",
     "fetch failed",

--- a/src/agents/pi-embedded-runner/run.sse-parse-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.sse-parse-retry.test.ts
@@ -1,0 +1,109 @@
+import "./run.overflow-compaction.mocks.shared.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isLikelySSEParseError } from "../pi-embedded-helpers.js";
+import { runEmbeddedPiAgent } from "./run.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+} from "./run.overflow-compaction.shared-test.js";
+
+const mockedIsLikelySSEParseError = vi.mocked(isLikelySSEParseError);
+
+describe("runEmbeddedPiAgent SSE parse error retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retries on SSE parse error in assistant response (stopReason=error)", async () => {
+    // 第一次尝试返回 SSE 解析错误
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        lastAssistant: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "Could not parse SSE event",
+          model: "test-model",
+          api: "messages",
+          provider: "anthropic",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          timestamp: Date.now(),
+        },
+      }),
+    );
+    // 第二次尝试成功
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    // mock isLikelySSEParseError 在第一次调用时返回 true
+    mockedIsLikelySSEParseError.mockReturnValueOnce(true).mockReturnValue(false);
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-sse-retry-assistant",
+    });
+
+    // 应该调用了 2 次 attempt（第一次 SSE 错误，第二次成功）
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    // isLikelySSEParseError 被调用时应传递 { streamingContext: true }
+    expect(mockedIsLikelySSEParseError).toHaveBeenCalledWith("Could not parse SSE event", {
+      streamingContext: true,
+    });
+    // 结果不应包含错误
+    expect(result.meta?.error).toBeUndefined();
+  });
+
+  it("retries on SSE parse error in prompt error path", async () => {
+    const sseError = new Error("SyntaxError: Unexpected end of JSON input");
+
+    // 第一次尝试在 prompt 阶段抛出 SSE 解析错误
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: sseError }));
+    // 第二次尝试成功
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedIsLikelySSEParseError.mockReturnValueOnce(true).mockReturnValue(false);
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-sse-retry-prompt",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedIsLikelySSEParseError).toHaveBeenCalledWith(sseError.message, {
+      streamingContext: true,
+    });
+    expect(result.meta?.error).toBeUndefined();
+  });
+
+  it("stops retrying after MAX_SSE_PARSE_RETRIES (3) attempts", async () => {
+    const sseError = new Error("Could not parse SSE event");
+
+    // 连续 4 次返回 SSE 解析错误（3 次重试 + 第 4 次不再重试）
+    for (let i = 0; i < 4; i++) {
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: sseError }));
+    }
+
+    // 前 3 次调用返回 true（触发重试），后续返回 true 但不会被调用因为已达上限
+    mockedIsLikelySSEParseError.mockReturnValue(true);
+
+    // 当超过重试次数后，错误会被 throw 出来
+    // 由于 classifyFailoverReason 返回 null，且 isFailoverErrorMessage 返回 false，
+    // promptError 会被直接 throw
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        runId: "run-sse-retry-exhausted",
+      }),
+    ).rejects.toThrow("Could not parse SSE event");
+
+    // 应该尝试了 4 次（初始 + 3 次重试）
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1099,6 +1099,7 @@ export async function runEmbeddedPiAgent(
               overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
             ) {
               overflowCompactionAttempts++;
+              sseParseRetries = 0;
               log.warn(
                 `context overflow persisted after in-attempt compaction (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); retrying prompt without additional compaction for ${provider}/${modelId}`,
               );
@@ -1266,6 +1267,7 @@ export async function runEmbeddedPiAgent(
                   sessionKey: params.sessionKey,
                 });
                 if (truncResult.truncated) {
+                  sseParseRetries = 0;
                   log.info(
                     `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
                   );
@@ -1337,6 +1339,7 @@ export async function runEmbeddedPiAgent(
             const errorText = promptErrorDetails.message || describeUnknownError(promptError);
             if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
               authRetryPending = true;
+              sseParseRetries = 0;
               continue;
             }
             // Handle role ordering errors with a user-friendly message
@@ -1525,6 +1528,7 @@ export async function runEmbeddedPiAgent(
             ))
           ) {
             authRetryPending = true;
+            sseParseRetries = 0;
             continue;
           }
           if (imageDimensionError && lastProfileId) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1052,9 +1052,11 @@ export async function runEmbeddedPiAgent(
               ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
 
-          // Reset SSE retry budget on successful turns so scattered transient
-          // errors across a long session don't permanently exhaust the budget.
-          if (!promptError && !assistantErrorText) {
+          // Reset SSE retry budget on successful model responses so scattered
+          // transient errors across a long session don't permanently exhaust
+          // the budget. Use stopReason rather than error-text emptiness to
+          // avoid resetting when the response errored with an empty message.
+          if (!promptError && lastAssistant?.stopReason !== "error") {
             sseParseRetries = 0;
           }
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1220,6 +1220,7 @@ export async function runEmbeddedPiAgent(
               }
               if (compactResult.compacted) {
                 autoCompactionCount += 1;
+                sseParseRetries = 0;
                 log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
                 continue;
               }
@@ -1432,6 +1433,7 @@ export async function runEmbeddedPiAgent(
               (await advanceAuthProfile())
             ) {
               logPromptFailoverDecision("rotate_profile");
+              sseParseRetries = 0;
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               continue;
             }
@@ -1444,6 +1446,7 @@ export async function runEmbeddedPiAgent(
                 `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
               );
               thinkLevel = fallbackThinking;
+              sseParseRetries = 0;
               continue;
             }
             // Throw FailoverError for prompt-side failover reasons when fallbacks
@@ -1479,6 +1482,7 @@ export async function runEmbeddedPiAgent(
               `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
             );
             thinkLevel = fallbackThinking;
+            sseParseRetries = 0;
             continue;
           }
 
@@ -1580,6 +1584,7 @@ export async function runEmbeddedPiAgent(
             const rotated = await advanceAuthProfile();
             if (rotated) {
               logAssistantFailoverDecision("rotate_profile");
+              sseParseRetries = 0;
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               continue;
             }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -55,6 +55,7 @@ import {
   isLikelyContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
+  isLikelySSEParseError,
   parseImageSizeError,
   parseImageDimensionError,
   isRateLimitAssistantError,
@@ -828,6 +829,8 @@ export async function runEmbeddedPiAgent(
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
+      const MAX_SSE_PARSE_RETRIES = 3;
+      let sseParseRetries = 0;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
         reason?: AuthProfileFailureReason | null;
@@ -1388,6 +1391,17 @@ export async function runEmbeddedPiAgent(
                 },
               };
             }
+            // SSE parse error retry — 反向代理截断 SSE 行时触发，重试即可恢复
+            if (
+              sseParseRetries < MAX_SSE_PARSE_RETRIES &&
+              isLikelySSEParseError(errorText, { streamingContext: true })
+            ) {
+              sseParseRetries++;
+              log.warn(
+                `SSE parse error detected (attempt ${sseParseRetries}/${MAX_SSE_PARSE_RETRIES}); retrying for ${provider}/${modelId}`,
+              );
+              continue;
+            }
             const promptFailoverReason =
               promptErrorDetails.reason ?? classifyFailoverReason(errorText);
             const promptProfileFailureReason =
@@ -1520,6 +1534,22 @@ export async function runEmbeddedPiAgent(
             log.warn(
               `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
             );
+          }
+
+          // SSE parse error retry — assistant 错误分支
+          if (
+            !aborted &&
+            lastAssistant?.stopReason === "error" &&
+            sseParseRetries < MAX_SSE_PARSE_RETRIES &&
+            isLikelySSEParseError(lastAssistant.errorMessage ?? "", {
+              streamingContext: true,
+            })
+          ) {
+            sseParseRetries++;
+            log.warn(
+              `SSE parse error in assistant response (attempt ${sseParseRetries}/${MAX_SSE_PARSE_RETRIES}); retrying for ${provider}/${modelId}`,
+            );
+            continue;
           }
 
           // Rotate on timeout to try another account/model path in this turn,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -151,6 +151,7 @@ const BASE_RUN_RETRY_ITERATIONS = 24;
 const RUN_RETRY_ITERATIONS_PER_PROFILE = 8;
 const MIN_RUN_RETRY_ITERATIONS = 32;
 const MAX_RUN_RETRY_ITERATIONS = 160;
+const MAX_SSE_PARSE_RETRIES = 3;
 
 function resolveMaxRunRetryIterations(profileCandidateCount: number): number {
   const scaled =
@@ -829,7 +830,6 @@ export async function runEmbeddedPiAgent(
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
-      const MAX_SSE_PARSE_RETRIES = 3;
       let sseParseRetries = 0;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
@@ -1051,6 +1051,12 @@ export async function runEmbeddedPiAgent(
             lastAssistant?.stopReason === "error"
               ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
+
+          // Reset SSE retry budget on successful turns so scattered transient
+          // errors across a long session don't permanently exhaust the budget.
+          if (!promptError && !assistantErrorText) {
+            sseParseRetries = 0;
+          }
 
           const contextOverflowError = !aborted
             ? (() => {


### PR DESCRIPTION
## Summary

Add resilience against malformed SSE parse errors from reverse proxy truncation. Supersedes #29533.

## Changes

### Detection: `isLikelySSEParseError()`
- Detects SyntaxError + JSON context originating from streaming code paths
- Matches Anthropic SDK-specific patterns (`Could not parse SSE event`, etc.)
- Uses stack trace heuristics to distinguish SSE parse errors from unrelated JSON errors
- `failed to parse` and `parse error` arms require JSON context to prevent false positives
- `unexpected end of` narrowed to `unexpected end of json` to exclude non-JSON streaming errors

### Auto-retry in `run.ts`
- `MAX_SSE_PARSE_RETRIES` (3) as module-level constant alongside other caps
- Prompt error branch: retries before failover classification
- Assistant error branch: retries before rotation/fallback logic
- Counter resets on: successful turns, profile rotation, auto-compaction, thinking fallback

### Tests
- `errors.sse-parse.test.ts`: 43 test cases
- `run.sse-parse-retry.test.ts`: 3 integration tests

## All Review Feedback from #42130 Addressed

| Issue | Fix |
|-------|-----|
| `sseParseRetries` never reset | Reset on successful turns + profile rotation + compaction + thinking fallback |
| `"failed to parse"` matches non-JSON errors | Added `isJsonContext` guard |
| `"unexpected end of"` not exclusively JSON | Narrowed to `"unexpected end of json"` |
| `MAX_SSE_PARSE_RETRIES` local to function | Moved to module scope |
| `upstream` blocks legitimate SSE errors | Removed from `SSE_FALSE_POSITIVE_RE` |

## Test Results: 46 passed (43 detection + 3 integration)