### PR TITLE
fix(tts): propagate audio_as_voice from tool results

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -119,6 +119,31 @@ describe("handleToolExecutionEnd media emission", () => {
     });
   });
 
+  it("propagates audioAsVoice when tool output includes [[audio_as_voice]]", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          {
+            type: "text",
+            text: "[[audio_as_voice]]\nMEDIA:/tmp/tts-output.opus",
+          },
+        ],
+      },
+    });
+
+    expect(onToolResult).toHaveBeenCalledWith({
+      mediaUrls: ["/tmp/tts-output.opus"],
+      audioAsVoice: true,
+    });
+  });
+
   it("does NOT emit local media for untrusted tools", async () => {
     const onToolResult = vi.fn();
     const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -15,7 +15,7 @@ import type {
 import {
   extractMessagingToolSend,
   extractToolErrorMessage,
-  extractToolResultMediaPaths,
+  extractToolResultMedia,
   extractToolResultText,
   filterToolResultMediaUrls,
   isToolResultError,
@@ -284,12 +284,16 @@ async function emitToolResultOutput(params: {
 
   // emitToolOutput() already handles MEDIA: directives when enabled; this path
   // only sends raw media URLs for non-verbose delivery mode.
-  const mediaPaths = filterToolResultMediaUrls(toolName, extractToolResultMediaPaths(result));
+  const extracted = extractToolResultMedia(result);
+  const mediaPaths = filterToolResultMediaUrls(toolName, extracted.mediaUrls);
   if (mediaPaths.length === 0) {
     return;
   }
   try {
-    void ctx.params.onToolResult({ mediaUrls: mediaPaths });
+    void ctx.params.onToolResult({
+      mediaUrls: mediaPaths,
+      ...(extracted.audioAsVoice ? { audioAsVoice: true } : {}),
+    });
   } catch {
     // ignore delivery failures
   }

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { extractToolResultMediaPaths } from "./pi-embedded-subscribe.tools.js";
+import {
+  extractToolResultMedia,
+  extractToolResultMediaPaths,
+} from "./pi-embedded-subscribe.tools.js";
 
 describe("extractToolResultMediaPaths", () => {
   it("returns empty array for null/undefined", () => {
@@ -29,6 +32,10 @@ describe("extractToolResultMediaPaths", () => {
       details: { path: "/tmp/screenshot.png" },
     };
     expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/screenshot.png"]);
+    expect(extractToolResultMedia(result)).toEqual({
+      mediaUrls: ["/tmp/screenshot.png"],
+      audioAsVoice: false,
+    });
   });
 
   it("extracts MEDIA: path with extra text in the block", () => {
@@ -206,16 +213,20 @@ describe("extractToolResultMediaPaths", () => {
     expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/indented.png"]);
   });
 
-  it("extracts valid MEDIA: line while ignoring <media:audio> on another line", () => {
+  it("extracts audio MEDIA: lines and preserves audioAsVoice directives", () => {
     const result = {
       content: [
         {
           type: "text",
-          text: "<media:audio> was transcribed\nMEDIA:/tmp/tts-output.opus\nDone",
+          text: "[[audio_as_voice]]\n<media:audio> was transcribed\nMEDIA:/tmp/tts-output.opus\nDone",
         },
       ],
     };
     expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/tts-output.opus"]);
+    expect(extractToolResultMedia(result)).toEqual({
+      mediaUrls: ["/tmp/tts-output.opus"],
+      audioAsVoice: true,
+    });
   });
 
   it("extracts multiple MEDIA: lines from a single text block", () => {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -193,19 +193,23 @@ export function filterToolResultMediaUrls(
  * returns base64 image data but no file path; those need a different delivery
  * path like saving to a temp file).
  */
-export function extractToolResultMediaPaths(result: unknown): string[] {
+export function extractToolResultMedia(result: unknown): {
+  mediaUrls: string[];
+  audioAsVoice: boolean;
+} {
   if (!result || typeof result !== "object") {
-    return [];
+    return { mediaUrls: [], audioAsVoice: false };
   }
   const record = result as Record<string, unknown>;
   const content = Array.isArray(record.content) ? record.content : null;
   if (!content) {
-    return [];
+    return { mediaUrls: [], audioAsVoice: false };
   }
 
   // Extract MEDIA: paths from text content blocks using the shared parser so
   // directive matching and validation stay in sync with outbound reply parsing.
   const paths: string[] = [];
+  let audioAsVoice = false;
   let hasImageContent = false;
   for (const item of content) {
     if (!item || typeof item !== "object") {
@@ -218,6 +222,9 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     }
     if (entry.type === "text" && typeof entry.text === "string") {
       const parsed = splitMediaFromOutput(entry.text);
+      if (parsed.audioAsVoice) {
+        audioAsVoice = true;
+      }
       if (parsed.mediaUrls?.length) {
         paths.push(...parsed.mediaUrls);
       }
@@ -225,7 +232,7 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
   }
 
   if (paths.length > 0) {
-    return paths;
+    return { mediaUrls: paths, audioAsVoice };
   }
 
   // Fall back to details.path when image content exists but no MEDIA: text.
@@ -233,11 +240,16 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     const details = record.details as Record<string, unknown> | undefined;
     const p = typeof details?.path === "string" ? details.path.trim() : "";
     if (p) {
-      return [p];
+      return { mediaUrls: [p], audioAsVoice: false };
     }
   }
 
-  return [];
+  return { mediaUrls: [], audioAsVoice: false };
+}
+
+// Backward-compatible helper for callers that only care about media paths.
+export function extractToolResultMediaPaths(result: unknown): string[] {
+  return extractToolResultMedia(result).mediaUrls;
 }
 
 export function isToolResultError(result: unknown): boolean {


### PR DESCRIPTION
Propagate   from tool results so Telegram can send voice notes (sendVoice) instead of audio file attachments.

Summary

• Problem: The TTS tool emits   alongside MEDIA:/path, but the tool-result media extraction path only forwarded mediaUrls and dropped the audioAsVoice directive. Telegram therefore sent audio as a regular file instead of a voice note.
• Why it matters: Users expect TTS output to appear as a native Telegram voice message (waveform bubble). Losing the directive breaks the intended UX.
• What changed: Preserve and propagate the audioAsVoice flag when parsing tool result text blocks (via the shared splitMediaFromOutput() parser), and include it in the emitted tool-result payload.
• What did NOT change (scope boundary): No changes to TTS generation, audio encoding, Telegram voice compatibility rules, or outbound media loading.

Change Type (select all)

• [x] Bug fix
• [ ] Feature
• [ ] Refactor
• [ ] Docs
• [ ] Security hardening
• [ ] Chore/infra

Scope (select all touched areas)

• [ ] Gateway / orchestration
• [ ] Skills / tool execution
• [ ] Auth / tokens
• [ ] Memory / storage
• [x] Integrations
• [ ] API / contracts
• [ ] UI / DX
• [ ] CI/CD / infra

Linked Issue/PR

• Closes #42060
• Related #

User-visible / Behavior Changes

• Telegram: TTS outputs tagged with   are delivered as voice notes when the media is voice-compatible.

Security Impact (required)

• New permissions/capabilities? No
• Secrets/tokens handling changed? No
• New/changed network calls? No
• Command/tool execution surface changed? No
• Data access scope changed? No
• If any Yes, explain risk + mitigation: N/A

Repro + Verification

Environment

• OS: macOS (Darwin arm64)
• Runtime/container: Node.js + pnpm (local dev)
• Model/provider: N/A
• Integration/channel (if any): Telegram
• Relevant config (redacted): N/A

Steps

1. Run the tts tool (or simulate a tool result) that returns text containing:

•  
• MEDIA:/tmp/tts-output.opus

2. Ensure tool-result handling extracts both the media path and the voice directive.
3. Verify Telegram delivery path receives audioAsVoice: true so it can route through sendVoice.

Expected

• audioAsVoice survives parsing/normalization and is available to Telegram delivery.

Actual

• Previously the directive was dropped; audio was delivered as a regular file attachment.

Evidence

• [x] Failing test/log before + passing after
• Updated/added coverage in src/agents/pi-embedded-subscribe.tools.media.test.ts
• Verified locally: pnpm vitest src/agents/pi-embedded-subscribe.tools.media.test.ts

Human Verification (required)

• Verified scenarios:
• MEDIA extraction preserves audioAsVoice when present.
• Edge cases checked:
• Tool text containing other tags/lines still extracts media correctly.
• What you did not verify:
• Live Telegram API end-to-end (unit tests cover directive propagation).

Review Conversations

• [x] I replied to or resolved every bot review conversation I addressed in this PR.
• [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Compatibility / Migration

• Backward compatible? Yes
• Config/env changes? No
• Migration needed? No

Failure Recovery (if this breaks)

• How to disable/revert this change quickly: revert this PR/commit.
• Files/config to restore:
• src/agents/pi-embedded-subscribe.tools.ts
• src/agents/pi-embedded-subscribe.handlers.tools.ts
• src/agents/pi-embedded-subscribe.tools.media.test.ts
• Known bad symptoms reviewers should watch for:
• TTS audio still delivered as file attachment despite  .

Risks and Mitigations

• Risk: Minimal; change only propagates an existing directive flag.
• Mitigation: Unit test coverage for tool-result parsing + unchanged Telegram voice-compatibility rules.
