### PR TITLE
fix(slack): normalize route binding peer ids

### DIFF
--- a/src/config/config.slack-binding-peer-id-warning.test.ts
+++ b/src/config/config.slack-binding-peer-id-warning.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectWithPlugins } from "./config.js";
+
+describe("Slack binding peer id warnings", () => {
+  it("warns but accepts target-style Slack channel peer ids", () => {
+    const result = validateConfigObjectWithPlugins({
+      bindings: [
+        {
+          agentId: "gemini",
+          match: {
+            channel: "slack",
+            peer: { kind: "channel", id: "channel:C123456" },
+          },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "bindings.0.match.peer.id",
+          message: expect.stringContaining('normalize "channel:C123456" to "C123456"'),
+        }),
+      ]),
+    );
+  });
+
+  it("does not warn for raw Slack peer ids", () => {
+    const result = validateConfigObjectWithPlugins({
+      bindings: [
+        {
+          agentId: "gemini",
+          match: {
+            channel: "slack",
+            peer: { kind: "channel", id: "C123456" },
+          },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -457,7 +457,7 @@ export const FIELD_HELP: Record<string, string> = {
   "bindings[].match.peer.kind":
     'Peer conversation type: "direct", "group", "channel", or legacy "dm" (deprecated alias for direct). Prefer "direct" for new configs and keep kind aligned with channel semantics.',
   "bindings[].match.peer.id":
-    "Conversation identifier used with peer matching, such as a chat ID, channel ID, or group ID from the provider. Keep this exact to avoid silent non-matches.",
+    "Conversation identifier used with peer matching, such as a chat ID, channel ID, or group ID from the provider. Use the raw provider id, not messaging target syntax (for Slack use C123/U123, not channel:C123/user:U123), to avoid silent non-matches.",
   "bindings[].match.guildId":
     "Optional Discord-style guild/server ID constraint for binding evaluation in multi-server deployments. Use this when the same peer identifiers can appear across different guilds.",
   "bindings[].match.teamId":

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { normalizeChatType } from "../channels/chat-type.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
 import {
   normalizePluginsConfig,
@@ -16,6 +17,7 @@ import {
   isWindowsAbsolutePath,
 } from "../shared/avatar-policy.js";
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
+import { canonicalizeSlackRoutePeerId } from "../slack/targets.js";
 import { isRecord } from "../utils.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
@@ -220,6 +222,50 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
         '(use gateway.bind="loopback" or gateway.bind="custom" with gateway.customBindHost="127.0.0.1")',
     },
   ];
+}
+
+function collectSlackBindingPeerWarnings(config: OpenClawConfig): ConfigValidationIssue[] {
+  const bindings = Array.isArray(config.bindings) ? config.bindings : [];
+  const warnings: ConfigValidationIssue[] = [];
+  for (const [index, binding] of bindings.entries()) {
+    const match = binding?.match;
+    if (!match || typeof match !== "object") {
+      continue;
+    }
+    if (normalizeChatChannelId(match.channel) !== "slack") {
+      continue;
+    }
+    const peer = match.peer;
+    if (!peer || typeof peer !== "object") {
+      continue;
+    }
+    const kind = normalizeChatType(peer.kind);
+    if (kind !== "direct" && kind !== "group" && kind !== "channel") {
+      continue;
+    }
+    const rawPeerId =
+      typeof peer.id === "string"
+        ? peer.id.trim()
+        : typeof peer.id === "number" || typeof peer.id === "bigint"
+          ? String(peer.id).trim()
+          : "";
+    if (!rawPeerId) {
+      continue;
+    }
+    const canonical = canonicalizeSlackRoutePeerId({ kind, raw: rawPeerId });
+    if (!canonical.usedTargetSyntax || canonical.id === rawPeerId) {
+      continue;
+    }
+    const preferredExample = kind === "direct" ? "U123ABC" : "C123ABC";
+    warnings.push({
+      path: `bindings.${index}.match.peer.id`,
+      message:
+        `Slack binding peer ids should use raw Slack ids like "${preferredExample}", ` +
+        `not messaging target syntax. OpenClaw will normalize "${rawPeerId}" ` +
+        `to "${canonical.id}" for compatibility.`,
+    });
+  }
+  return warnings;
 }
 
 /**
@@ -453,6 +499,8 @@ function validateConfigObjectWithPluginsBase(
       validateHeartbeatTarget(entry?.heartbeat?.target, `agents.list.${index}.heartbeat.target`);
     }
   }
+
+  warnings.push(...collectSlackBindingPeerWarnings(config));
 
   if (!hasExplicitPluginsConfig) {
     if (issues.length > 0) {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -256,7 +256,8 @@ function collectSlackBindingPeerWarnings(config: OpenClawConfig): ConfigValidati
     if (!canonical.usedTargetSyntax || canonical.id === rawPeerId) {
       continue;
     }
-    const preferredExample = kind === "direct" ? "U123ABC" : "C123ABC";
+    const preferredExample =
+      kind === "direct" ? "U123ABC" : kind === "group" ? "G123ABC" : "C123ABC";
     warnings.push({
       path: `bindings.${index}.match.peer.id`,
       message:

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -656,6 +656,52 @@ describe("backward compatibility: peer.kind group ↔ channel", () => {
   });
 });
 
+describe("Slack peer id normalization for bindings", () => {
+  test("target-style channel ids match runtime raw channel ids", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "gemini",
+          match: {
+            channel: "slack",
+            peer: { kind: "channel", id: "channel:c123456" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: null,
+      peer: { kind: "channel", id: "C123456" },
+    });
+    expect(route.agentId).toBe("gemini");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("target-style user ids match runtime raw direct peer ids", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "ops",
+          match: {
+            channel: "slack",
+            peer: { kind: "direct", id: "user:u123456" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: null,
+      peer: { kind: "direct", id: "U123456" },
+    });
+    expect(route.agentId).toBe("ops");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+});
+
 describe("role-based agent routing", () => {
   type DiscordBinding = NonNullable<OpenClawConfig["bindings"]>[number];
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -4,6 +4,7 @@ import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
 import { logDebug } from "../logger.js";
+import { canonicalizeSlackRoutePeerId } from "../slack/targets.js";
 import { listBindings } from "./bindings.js";
 import {
   buildAgentMainSessionKey,
@@ -86,6 +87,21 @@ function normalizeId(value: unknown): string {
     return String(value).trim();
   }
   return "";
+}
+
+function normalizePeerIdForRoute(params: {
+  channel: string;
+  kind: string | undefined;
+  value: unknown;
+}): string {
+  const normalized = normalizeId(params.value);
+  if (!normalized || params.channel !== "slack") {
+    return normalized;
+  }
+  if (params.kind !== "direct" && params.kind !== "group" && params.kind !== "channel") {
+    return normalized;
+  }
+  return canonicalizeSlackRoutePeerId({ kind: params.kind, raw: normalized }).id;
 }
 
 export function buildAgentSessionKey(params: {
@@ -245,7 +261,7 @@ function buildEvaluatedBindingsByChannel(
     if (!channel) {
       continue;
     }
-    const match = normalizeBindingMatch(binding.match);
+    const match = normalizeBindingMatch(binding.match, channel);
     const evaluated: EvaluatedBinding = {
       binding,
       match,
@@ -472,12 +488,13 @@ function getEvaluatedBindingIndexForChannelAccount(
 
 function normalizePeerConstraint(
   peer: { kind?: string; id?: string } | undefined,
+  channel: string,
 ): NormalizedPeerConstraint {
   if (!peer) {
     return { state: "none" };
   }
   const kind = normalizeChatType(peer.kind);
-  const id = normalizeId(peer.id);
+  const id = normalizePeerIdForRoute({ channel, kind, value: peer.id });
   if (!kind || !id) {
     return { state: "invalid" };
   }
@@ -494,11 +511,12 @@ function normalizeBindingMatch(
         roles?: string[] | undefined;
       }
     | undefined,
+  channel: string,
 ): NormalizedBindingMatch {
   const rawRoles = match?.roles;
   return {
     accountPattern: (match?.accountId ?? "").trim(),
-    peer: normalizePeerConstraint(match?.peer),
+    peer: normalizePeerConstraint(match?.peer, channel),
     guildId: normalizeId(match?.guildId) || null,
     teamId: normalizeId(match?.teamId) || null,
     roles: Array.isArray(rawRoles) && rawRoles.length > 0 ? rawRoles : null,
@@ -617,7 +635,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const peer = input.peer
     ? {
         kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
-        id: normalizeId(input.peer.id),
+        id: normalizePeerIdForRoute({
+          channel,
+          kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
+          value: input.peer.id,
+        }),
       }
     : null;
   const guildId = normalizeId(input.guildId);
@@ -630,7 +652,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const parentPeer = input.parentPeer
     ? {
         kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
-        id: normalizeId(input.parentPeer.id),
+        id: normalizePeerIdForRoute({
+          channel,
+          kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
+          value: input.parentPeer.id,
+        }),
       }
     : null;
 

--- a/src/slack/targets.test.ts
+++ b/src/slack/targets.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { normalizeSlackMessagingTarget } from "../channels/plugins/normalize/slack.js";
-import { parseSlackTarget, resolveSlackChannelId } from "./targets.js";
+import {
+  canonicalizeSlackRoutePeerId,
+  parseSlackTarget,
+  resolveSlackChannelId,
+} from "./targets.js";
 
 describe("parseSlackTarget", () => {
   it("parses user mentions and prefixes", () => {
@@ -59,5 +63,33 @@ describe("resolveSlackChannelId", () => {
 describe("normalizeSlackMessagingTarget", () => {
   it("defaults raw ids to channels", () => {
     expect(normalizeSlackMessagingTarget("C123")).toBe("channel:c123");
+  });
+});
+
+describe("canonicalizeSlackRoutePeerId", () => {
+  it("normalizes Slack target syntax for channel bindings", () => {
+    expect(canonicalizeSlackRoutePeerId({ kind: "channel", raw: "channel:c123abc" })).toEqual({
+      id: "C123ABC",
+      didNormalize: true,
+      usedTargetSyntax: true,
+    });
+    expect(canonicalizeSlackRoutePeerId({ kind: "group", raw: "<#C123ABC|general>" })).toEqual({
+      id: "C123ABC",
+      didNormalize: true,
+      usedTargetSyntax: true,
+    });
+  });
+
+  it("normalizes Slack target syntax for direct bindings", () => {
+    expect(canonicalizeSlackRoutePeerId({ kind: "direct", raw: "user:u123abc" })).toEqual({
+      id: "U123ABC",
+      didNormalize: true,
+      usedTargetSyntax: true,
+    });
+    expect(canonicalizeSlackRoutePeerId({ kind: "direct", raw: "<@U123ABC>" })).toEqual({
+      id: "U123ABC",
+      didNormalize: true,
+      usedTargetSyntax: true,
+    });
   });
 });

--- a/src/slack/targets.ts
+++ b/src/slack/targets.ts
@@ -11,8 +11,17 @@ import {
 export type SlackTargetKind = MessagingTargetKind;
 
 export type SlackTarget = MessagingTarget;
+export type SlackRoutePeerKind = "direct" | "group" | "channel";
 
 type SlackTargetParseOptions = MessagingTargetParseOptions;
+
+function looksLikeSlackChannelId(value: string): boolean {
+  return /^[CG][A-Z0-9]+$/i.test(value);
+}
+
+function looksLikeSlackUserId(value: string): boolean {
+  return /^[UW][A-Z0-9]+$/i.test(value);
+}
 
 export function parseSlackTarget(
   raw: string,
@@ -54,4 +63,61 @@ export function parseSlackTarget(
 export function resolveSlackChannelId(raw: string): string {
   const target = parseSlackTarget(raw, { defaultKind: "channel" });
   return requireTargetKind({ platform: "Slack", target, kind: "channel" });
+}
+
+export function canonicalizeSlackRoutePeerId(params: { kind: SlackRoutePeerKind; raw: string }): {
+  id: string;
+  didNormalize: boolean;
+  usedTargetSyntax: boolean;
+} {
+  const trimmed = params.raw.trim();
+  if (!trimmed) {
+    return { id: "", didNormalize: false, usedTargetSyntax: false };
+  }
+
+  if (params.kind === "direct") {
+    const mention = trimmed.match(/^<@([A-Z0-9]+)>$/i);
+    if (mention?.[1]) {
+      const id = mention[1].toUpperCase();
+      return { id, didNormalize: id !== trimmed, usedTargetSyntax: true };
+    }
+
+    const prefixed = trimmed.match(/^(?:slack:|user:)([A-Z0-9]+)$/i);
+    if (prefixed?.[1] && looksLikeSlackUserId(prefixed[1])) {
+      const id = prefixed[1].toUpperCase();
+      return { id, didNormalize: id !== trimmed, usedTargetSyntax: true };
+    }
+
+    if (looksLikeSlackUserId(trimmed)) {
+      const id = trimmed.toUpperCase();
+      return { id, didNormalize: id !== trimmed, usedTargetSyntax: false };
+    }
+
+    return { id: trimmed, didNormalize: false, usedTargetSyntax: false };
+  }
+
+  const channelMention = trimmed.match(/^<#([A-Z0-9]+)(?:\|[^>]+)?>$/i);
+  if (channelMention?.[1]) {
+    const id = channelMention[1].toUpperCase();
+    return { id, didNormalize: id !== trimmed, usedTargetSyntax: true };
+  }
+
+  const channelPrefixed = trimmed.match(/^channel:([A-Z0-9]+)$/i);
+  if (channelPrefixed?.[1] && looksLikeSlackChannelId(channelPrefixed[1])) {
+    const id = channelPrefixed[1].toUpperCase();
+    return { id, didNormalize: id !== trimmed, usedTargetSyntax: true };
+  }
+
+  const hashPrefixed = trimmed.match(/^#([A-Z0-9]+)$/i);
+  if (hashPrefixed?.[1] && looksLikeSlackChannelId(hashPrefixed[1])) {
+    const id = hashPrefixed[1].toUpperCase();
+    return { id, didNormalize: id !== trimmed, usedTargetSyntax: true };
+  }
+
+  if (looksLikeSlackChannelId(trimmed)) {
+    const id = trimmed.toUpperCase();
+    return { id, didNormalize: id !== trimmed, usedTargetSyntax: false };
+  }
+
+  return { id: trimmed, didNormalize: false, usedTargetSyntax: false };
 }


### PR DESCRIPTION
Fixes #41608

## Summary
- normalize Slack route binding peer ids before matching so target-style forms like `channel:C123` and `user:U123` resolve to the same canonical ids as inbound Slack events
- add a non-fatal config warning plus schema help text so existing configs keep working while operators are nudged toward raw Slack ids in bindings
- cover the regression with route-matching, config-warning, and Slack target normalization tests

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
- [x] `pnpm test`

AI-assisted: yes (Cursor)
Testing: fully tested locally

Made with [Cursor](https://cursor.com)