### PR TITLE
docs: sync zh-CN translation with latest en-US index and tts

### DIFF
--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -38,7 +38,7 @@ x-i18n:
 
 <Columns>
   <Card title="入门指南" href="/start/getting-started" icon="rocket">
-    安装 OpenClaw 并在几分钟内启动 Gateway 网关。
+    安装 OpenClaw，并在几分钟内启动 Gateway 网关。
   </Card>
   <Card title="运行向导" href="/start/wizard" icon="sparkles">
     通过 `openclaw onboard` 和配对流程进行引导式设置。
@@ -48,7 +48,20 @@ x-i18n:
   </Card>
 </Columns>
 
-OpenClaw 通过单个 Gateway 网关进程将聊天应用连接到 Pi 等编程智能体。它为 OpenClaw 助手提供支持，并支持本地或远程部署。
+## 什么是 OpenClaw？
+
+OpenClaw 是一个**自托管的 Gateway 网关**，它将你最喜爱的聊天应用（WhatsApp、Telegram、Discord、iMessage 等）连接到像 Pi 这样的 AI 编程智能体。你只需在自己的机器（或服务器）上运行一个 Gateway 网关进程，它就会成为消息应用与全天候在线 AI 助手之间的桥梁。
+
+**它是为谁准备的？** 想要一个可以随时随地发消息，且无需交出数据控制权或依赖托管服务的个人 AI 助手的开发者和高级用户。
+
+**它有什么独特之处？**
+
+- **自托管**：运行在你的硬件上，由你制定规则。
+- **多渠道**：一个 Gateway 网关进程同时服务于 WhatsApp、Telegram、Discord 等多个平台。
+- **智能体原生**：专为支持工具调用、会话、记忆和多智能体路由的编程智能体而设计。
+- **开源**：采用 MIT 许可证，由社区驱动。
+
+**你需要什么？** Node 22+、所选提供商的 API 密钥，以及 5 分钟时间。为了获得最佳质量和安全性，请使用现有的最强大的最新一代模型。
 
 ## 工作原理
 
@@ -83,7 +96,7 @@ Gateway 网关是会话、路由和渠道连接的唯一事实来源。
     浏览器仪表板，用于聊天、配置、会话和节点管理。
   </Card>
   <Card title="移动节点" icon="smartphone">
-    配对 iOS 和 Android 节点，支持 Canvas。
+    配对 iOS 和 Android 节点，支持 Canvas、摄像头、语音及设备操作等工作流。
   </Card>
 </Columns>
 
@@ -95,7 +108,7 @@ Gateway 网关是会话、路由和渠道连接的唯一事实来源。
     npm install -g openclaw@latest
     ```
   </Step>
-  <Step title="新手引导并安装服务">
+  <Step title="运行向导并安装服务">
     ```bash
     openclaw onboard --install-daemon
     ```

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -7,7 +7,7 @@ x-i18n:
   generated_at: "2026-02-04T17:53:40Z"
   model: claude-opus-4-5
   provider: pi
-  source_hash: fc8babf7885ef91d526795051376d928599c4cf8aff75400138a0d7d9fa3b75f
+  source_hash: 0d167684402482da3162add3aeb4e184bb867a2578cc858a5ca27a918a985155
   source_path: index.md
   workflow: 15
 ---
@@ -96,7 +96,7 @@ Gateway 网关是会话、路由和渠道连接的唯一事实来源。
     浏览器仪表板，用于聊天、配置、会话和节点管理。
   </Card>
   <Card title="移动节点" icon="smartphone">
-    配对 iOS 和 Android 节点，支持 Canvas、摄像头、语音及设备操作等工作流。
+    配对 iOS 和 Android 节点，支持 Canvas、摄像头和语音等工作流。
   </Card>
 </Columns>
 

--- a/docs/zh-CN/tts.md
+++ b/docs/zh-CN/tts.md
@@ -87,6 +87,7 @@ TTS 配置位于 `openclaw.json` 中的 `messages.tts` 下。完整 schema 在 [
       },
       openai: {
         apiKey: "openai_api_key",
+        baseUrl: "https://api.openai.com/v1",
         model: "gpt-4o-mini-tts",
         voice: "alloy",
       },
@@ -208,6 +209,9 @@ TTS 配置位于 `openclaw.json` 中的 `messages.tts` 下。完整 schema 在 [
 - `prefsPath`：覆盖本地偏好 JSON 路径（提供商/限制/摘要）。
 - `apiKey` 值回退到环境变量（`ELEVENLABS_API_KEY`/`XI_API_KEY`、`OPENAI_API_KEY`）。
 - `elevenlabs.baseUrl`：覆盖 ElevenLabs API 基础 URL。
+- `openai.baseUrl`：覆盖 OpenAI TTS 端点。
+  - 解析顺序：`messages.tts.openai.baseUrl` -> `OPENAI_TTS_BASE_URL` -> `https://api.openai.com/v1`
+  - 非默认值被视为 OpenAI 兼容的 TTS 端点，因此可以接受自定义模型和语音名称。
 - `elevenlabs.voiceSettings`：
   - `stability`、`similarityBoost`、`style`：`0..1`
   - `useSpeakerBoost`：`true|false`

--- a/docs/zh-CN/tts.md
+++ b/docs/zh-CN/tts.md
@@ -9,7 +9,7 @@ x-i18n:
   generated_at: "2026-02-03T10:13:55Z"
   model: claude-opus-4-5
   provider: pi
-  source_hash: 070ff0cc8592f64c6c9e4ddaddc7e8fba82f0692ceded6fe833ec9ba5b61e6fb
+  source_hash: 02dbaf88bae62e0815c19121ee0469deb6ddb620f5c58b0a09bf17133837c7b5
   source_path: tts.md
   workflow: 15
 ---


### PR DESCRIPTION
This PR updates the Chinese documentation to sync with the latest English version:
  
   1. index.md : Added the missing "What is OpenClaw?" section, updated the "Mobile nodes" card with camera/voice features, and fixed untranslated text in cards.
   2. tts.md : Synchronized `baseUrl` configuration for OpenAI and added documentation for the `OPENAI_TTS_BASE_URL` environment variable.
These changes improve the onboarding experience for Chinese-speaking users and ensure technical parity between documentation versions.