### PR TITLE
fix(voice-call): add configurable responseAgentId

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -105,6 +105,7 @@ const voiceCallConfigSchema = {
     },
     store: { label: "Call Log Store Path", advanced: true },
     responseModel: { label: "Response Model", advanced: true },
+    responseAgentId: { label: "Response Agent ID", advanced: true },
     responseSystemPrompt: { label: "Response System Prompt", advanced: true },
     responseTimeoutMs: { label: "Response Timeout (ms)", advanced: true },
   },

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -342,6 +342,9 @@ export const VoiceCallConfigSchema = z
     /** Model for generating voice responses (e.g., "anthropic/claude-sonnet-4", "openai/gpt-4o") */
     responseModel: z.string().default("openai/gpt-4o-mini"),
 
+    /** Agent ID for voice response generation (defaults to "main") */
+    responseAgentId: z.string().optional(),
+
     /** System prompt for voice responses */
     responseSystemPrompt: z.string().optional(),
 

--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -42,6 +42,7 @@ type CoreAgentDeps = {
     lane?: string;
     extraSystemPrompt?: string;
     agentDir?: string;
+    agentId?: string;
   }) => Promise<{
     payloads?: Array<{ text?: string; isError?: boolean }>;
     meta?: { aborted?: boolean };

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -59,7 +59,7 @@ export async function generateVoiceResponse(
   // Build voice-specific session key based on phone number
   const normalizedPhone = from.replace(/\D/g, "");
   const sessionKey = `voice:${normalizedPhone}`;
-  const agentId = "main";
+  const agentId = voiceConfig.responseAgentId || "main";
 
   // Resolve paths
   const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -136,6 +136,7 @@ export async function generateVoiceResponse(
       lane: "voice",
       extraSystemPrompt,
       agentDir,
+      agentId,
     });
 
     // Extract text from payloads


### PR DESCRIPTION
### Problem
Voice call responses always use `agentId = "main"`, so the response generator reads the main agent's workspace (memory, system prompt) regardless of which agent should handle voice. Multi-agent setups where voice is routed to a dedicated agent get the wrong context.

### Root Cause
`response-generator.ts:62` hardcodes `const agentId = "main"` -- there is no config path to override it.

### Fix
Added `responseAgentId` (optional string) to `VoiceCallConfigSchema` and the UI config schema. `response-generator.ts` now reads `voiceConfig.responseAgentId || "main"`, so the default behavior is unchanged but operators can point voice responses at any agent.

### What did NOT change
No changes to call flow, TTS, STT, telephony, or session management.

## Validation
- `pnpm build` -- clean
- `pnpm check` -- clean
- `pnpm test extensions/voice-call/src/config.test.ts` -- passed

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Resubmission of #42129 (closed for clean commit history).
Closes #42155