### PR TITLE
fix(telegram): answer callbacks before sequentialize

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1050,16 +1050,8 @@ export const registerTelegramHandlers = ({
     if (shouldSkipUpdate(ctx)) {
       return;
     }
-    const answerCallbackQuery =
-      typeof (ctx as { answerCallbackQuery?: unknown }).answerCallbackQuery === "function"
-        ? () => ctx.answerCallbackQuery()
-        : () => bot.api.answerCallbackQuery(callback.id);
-    // Answer immediately to prevent Telegram from retrying while we process
-    await withTelegramApiErrorLogging({
-      operation: "answerCallbackQuery",
-      runtime,
-      fn: answerCallbackQuery,
-    }).catch(() => {});
+    // answerCallbackQuery is handled by the pre-sequentialize middleware in bot.ts
+    // to avoid Telegram's ~15s server-side timeout when updates are queued.
     try {
       const data = (callback.data ?? "").trim();
       const callbackMessage = callback.message;

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -116,6 +116,38 @@ describe("createTelegramBot", () => {
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(sequentializeKey).toBe(getTelegramSequentialKey);
   });
+  it("answers callback queries in pre-sequentialize middleware", async () => {
+    createTelegramBot({ token: "tok" });
+    // The pre-sequentialize middleware is registered via bot.use before sequentialize.
+    // Find it: it's the middleware registered right before the sequentialize middleware.
+    const seqMiddleware = sequentializeSpy.mock.results[0]?.value;
+    const allMiddlewares = middlewareUseSpy.mock.calls.map((call) => call[0]);
+    const seqIdx = allMiddlewares.indexOf(seqMiddleware);
+    expect(seqIdx).toBeGreaterThan(0);
+    const preSeqMiddleware = allMiddlewares[seqIdx - 1] as (
+      ctx: Record<string, unknown>,
+      next: () => Promise<void>,
+    ) => Promise<void>;
+    expect(typeof preSeqMiddleware).toBe("function");
+
+    const nextSpy = vi.fn(async () => {});
+
+    // With callbackQuery present: should answer
+    await preSeqMiddleware(
+      { callbackQuery: { id: "cbq-test" }, answerCallbackQuery: answerCallbackQuerySpy },
+      nextSpy,
+    );
+    expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+    expect(nextSpy).toHaveBeenCalledTimes(1);
+
+    answerCallbackQuerySpy.mockClear();
+    nextSpy.mockClear();
+
+    // Without callbackQuery: should not answer, still call next
+    await preSeqMiddleware({}, nextSpy);
+    expect(answerCallbackQuerySpy).not.toHaveBeenCalled();
+    expect(nextSpy).toHaveBeenCalledTimes(1);
+  });
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
@@ -141,7 +173,6 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = replySpy.mock.calls[0][0];
     expect(payload.Body).toContain("cmd:option_a");
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
   });
   it("wraps inbound message with Telegram envelope", async () => {
     await withEnvAsync({ TZ: "Europe/Vienna" }, async () => {

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -7,7 +7,6 @@ import {
 } from "../auto-reply/commands-registry.js";
 import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
 import {
-  answerCallbackQuerySpy,
   commandSpy,
   editMessageTextSpy,
   enqueueSystemEventSpy,
@@ -206,7 +205,6 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).not.toHaveBeenCalled();
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-2");
   });
 
   it("allows callback_query in groups when group policy authorizes the sender", async () => {
@@ -250,7 +248,6 @@ describe("createTelegramBot", () => {
 
     // The callback should be processed (not silently blocked)
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-group-1");
   });
 
   it("edits commands list for pagination callbacks", async () => {
@@ -363,7 +360,6 @@ describe("createTelegramBot", () => {
     });
 
     expect(editMessageTextSpy).not.toHaveBeenCalled();
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-4");
   });
 
   it("routes compact model callbacks by inferring provider", async () => {
@@ -411,7 +407,6 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = replySpy.mock.calls[0]?.[0];
     expect(payload?.Body).toContain(`/model amazon-bedrock/${modelId}`);
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-compact-1");
   });
 
   it("rejects ambiguous compact model callbacks and returns provider list", async () => {
@@ -464,7 +459,6 @@ describe("createTelegramBot", () => {
     expect(editMessageTextSpy.mock.calls[0]?.[2]).toContain(
       'Could not resolve model "shared-model".',
     );
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-compact-2");
   });
 
   it("includes sender identity in group envelope headers", async () => {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -236,6 +236,22 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     }
   });
 
+  // Answer callback queries BEFORE sequentialize to avoid Telegram's ~15s timeout.
+  // When an agent turn is running, sequentialize queues updates for the same topic.
+  // By the time the queued callback is processed, the answer window is dead.
+  // Note: this also answers queries for updates that shouldSkipUpdate would later reject,
+  // but answerCallbackQuery is idempotent and Telegram ignores redundant answers.
+  bot.use(async (ctx, next) => {
+    if (ctx.callbackQuery) {
+      void ctx.answerCallbackQuery().catch((err: unknown) => {
+        logVerbose(
+          `answerCallbackQuery failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }
+    await next();
+  });
+
   bot.use(sequentialize(getTelegramSequentialKey));
 
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");


### PR DESCRIPTION
### Problem
Telegram inline-button callbacks show a stuck loading spinner when another update for the same chat is already being processed. Telegram's server-side timeout for `answerCallbackQuery` is ~15 seconds, but the sequentialize middleware queues same-chat updates behind the active agent turn, which can run for minutes. By the time the handler runs, the answer window is dead.

### Root Cause
`answerCallbackQuery` is called inside `bot-handlers.ts` callback_query handler, which runs AFTER the sequentialize middleware. When an agent turn is active for the same sequentialize key (chat/topic), the callback update sits in the queue until the turn completes -- well past Telegram's answer deadline.

### Fix
Moved `answerCallbackQuery` into a pre-sequentialize middleware in `bot.ts` that fires for every update containing a `callbackQuery`. This answers the query immediately on arrival, before sequentialize can queue it. The call is fire-and-forget (`void ... .catch()`) so it never blocks the pipeline. Removed the now-redundant `answerCallbackQuery` from `bot-handlers.ts`. `answerCallbackQuery` is idempotent -- answering queries for updates that are later skipped by `shouldSkipUpdate` is harmless.

### What did NOT change
No changes to callback data routing, command parsing, or sequentialize key logic.

## Validation
- `pnpm build` -- clean
- `pnpm check` -- clean
- `pnpm test src/telegram/bot.create-telegram-bot.test.ts src/telegram/bot.test.ts` -- 87 tests passed

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Resubmission of #42125 (closed for clean commit history).
Closes #42156