### PR TITLE
fix: emergency fallback when compaction summarization fails

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1547,6 +1547,242 @@ describe("compaction-safeguard double-compaction guard", () => {
   });
 });
 
+describe("compaction-safeguard emergency fallback", () => {
+  it("includes split-turn note when isSplitTurn and turnPrefixMessages present", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const spy = vi
+      .spyOn(compactionModule, "summarizeInStages")
+      .mockRejectedValue(new Error("split turn failure"));
+
+    const compactionHandler = createCompactionHandler();
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [
+          { role: "user", content: "prefix msg 1", timestamp: Date.now() - 9000 },
+          { role: "assistant", content: "prefix reply 1", timestamp: Date.now() - 8500 },
+        ] as AgentMessage[],
+        firstKeptEntryId: "entry-split",
+        tokensBefore: 999_999,
+        isSplitTurn: true,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: undefined,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      const result = (await compactionHandler(mockEvent, mockContext)) as {
+        cancel?: boolean;
+        compaction?: { summary: string };
+      };
+
+      expect(result.cancel).toBeUndefined();
+      expect(result.compaction).toBeDefined();
+      expect(result.compaction!.summary).toContain("Split-turn context lost");
+      expect(result.compaction!.summary).toContain("2 turn-prefix message(s)");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns emergency compaction instead of cancelling when summarization throws", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    // Mock summarizeInStages to throw deterministically so the test
+    // exercises the catch path regardless of token estimation internals.
+    const spy = vi
+      .spyOn(compactionModule, "summarizeInStages")
+      .mockRejectedValue(new Error("injected summarization failure"));
+
+    const compactionHandler = createCompactionHandler();
+
+    // Provide enough messages (>3 turns) so splitPreservedRecentTurns
+    // still leaves some for summarization (default preserves 3 recent turns).
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-emergency",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: ["a.ts"], edited: ["b.ts"], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: "Prior conversation context about the project.",
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      const result = (await compactionHandler(mockEvent, mockContext)) as {
+        cancel?: boolean;
+        compaction?: {
+          summary: string;
+          firstKeptEntryId: string;
+          tokensBefore: number;
+          details: { readFiles: string[]; modifiedFiles: string[] };
+        };
+      };
+
+      // Must NOT cancel — that creates the stuck-session loop.
+      expect(result.cancel).toBeUndefined();
+      expect(result.compaction).toBeDefined();
+      expect(result.compaction!.summary).toContain("Emergency compaction");
+      expect(result.compaction!.summary).toContain("injected summarization failure");
+      // Prior summary must be preserved in emergency fallback
+      expect(result.compaction!.summary).toContain("Prior conversation context about the project.");
+      expect(result.compaction!.firstKeptEntryId).toBe("entry-emergency");
+      expect(result.compaction!.tokensBefore).toBe(999_999);
+      expect(result.compaction!.details.readFiles).toEqual(["a.ts"]);
+      expect(result.compaction!.details.modifiedFiles).toEqual(["b.ts"]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("re-throws AbortError instead of triggering emergency fallback", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const abortError = new DOMException("The operation was aborted", "AbortError");
+    const spy = vi.spyOn(compactionModule, "summarizeInStages").mockRejectedValue(abortError);
+
+    const compactionHandler = createCompactionHandler();
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-abort",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: undefined,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      await expect(compactionHandler(mockEvent, mockContext)).rejects.toThrow("AbortError");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("truncates long prior summary to prevent unbounded nesting", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const spy = vi
+      .spyOn(compactionModule, "summarizeInStages")
+      .mockRejectedValue(new Error("nesting failure"));
+
+    const compactionHandler = createCompactionHandler();
+
+    const longPrior = "x".repeat(10_000);
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-nesting",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: longPrior,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      const result = (await compactionHandler(mockEvent, mockContext)) as {
+        compaction?: { summary: string };
+      };
+
+      expect(result.compaction).toBeDefined();
+      expect(result.compaction!.summary).toContain("[…truncated]");
+      // The full 10k prior should NOT appear verbatim
+      expect(result.compaction!.summary).not.toContain(longPrior);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 async function expectWorkspaceSummaryEmptyForAgentsAlias(
   createAlias: (outsidePath: string, agentsPath: string) => void,
 ) {

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1720,7 +1720,58 @@ describe("compaction-safeguard emergency fallback", () => {
     });
 
     try {
-      await expect(compactionHandler(mockEvent, mockContext)).rejects.toThrow("AbortError");
+      await expect(compactionHandler(mockEvent, mockContext)).rejects.toThrow(abortError);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("re-throws non-AbortError when signal is aborted (e.g. TimeoutError)", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const timeoutError = new Error("request timed out");
+    timeoutError.name = "TimeoutError";
+    const spy = vi.spyOn(compactionModule, "summarizeInStages").mockRejectedValue(timeoutError);
+
+    const compactionHandler = createCompactionHandler();
+
+    const abortController = new AbortController();
+    abortController.abort(timeoutError);
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-timeout-abort",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: undefined,
+      },
+      customInstructions: "",
+      signal: abortController.signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      await expect(compactionHandler(mockEvent, mockContext)).rejects.toThrow("request timed out");
     } finally {
       spy.mockRestore();
     }

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -970,8 +970,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       };
     } catch (error) {
       // Re-throw abort errors so signal cancellation doesn't trigger emergency fallback.
-      // Check both DOMException (native AbortSignal) and plain Error (polyfills/manual) variants.
-      if (error instanceof Error && error.name === "AbortError") {
+      // Check signal state first (covers all abort reasons including TimeoutError),
+      // then fall back to name check for cases where signal is unavailable.
+      if (signal?.aborted || (error instanceof Error && error.name === "AbortError")) {
         throw error;
       }
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -711,6 +711,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       ...preparation.turnPrefixMessages,
     ]);
     const toolFailureSection = formatToolFailuresSection(toolFailures);
+    let preservedTurnsSection = "";
+    let droppedSummary: string | undefined;
 
     // Model resolution: ctx.model is undefined in compact.ts workflow (extensionRunner.initialize() is never called).
     // Fall back to runtime.model which is explicitly passed when building extension paths.
@@ -762,8 +764,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         typeof preparation.tokensBefore === "number" && Number.isFinite(preparation.tokensBefore)
           ? preparation.tokensBefore
           : undefined;
-
-      let droppedSummary: string | undefined;
 
       if (tokensBefore !== undefined) {
         const summarizableTokens =
@@ -833,7 +833,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         recentTurnsPreserve,
       });
       messagesToSummarize = summaryTargetMessages;
-      const preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);
+      preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);
       const latestUserAsk = extractLatestUserAsk([...messagesToSummarize, ...turnPrefixMessages]);
       const identifierSeedText = [...messagesToSummarize, ...turnPrefixMessages]
         .slice(-10)
@@ -969,12 +969,56 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         },
       };
     } catch (error) {
+      // Re-throw abort errors so signal cancellation doesn't trigger emergency fallback.
+      // Check both DOMException (native AbortSignal) and plain Error (polyfills/manual) variants.
+      if (error instanceof Error && error.name === "AbortError") {
+        throw error;
+      }
+      const errorMessage = error instanceof Error ? error.message : String(error);
       log.warn(
-        `Compaction summarization failed; cancelling compaction to preserve history: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Compaction summarization failed; using emergency fallback to avoid stuck session: ${errorMessage}`,
       );
-      return { cancel: true };
+      // Emergency fallback: return a static summary instead of cancelling.
+      // Cancelling leaves the session at its current (oversized) context,
+      // causing a compaction-fail-retry loop on every subsequent message.
+      const effectivePrior = droppedSummary ?? preparation.previousSummary;
+      // Truncate carried-forward summary to prevent unbounded nesting across repeated failures.
+      const MAX_PRIOR_SUMMARY_CHARS = 4000;
+      const clampedPrior =
+        effectivePrior && effectivePrior.length > MAX_PRIOR_SUMMARY_CHARS
+          ? effectivePrior.slice(0, MAX_PRIOR_SUMMARY_CHARS) + "\n[…truncated]"
+          : effectivePrior;
+      const priorContext = clampedPrior
+        ? `\n\nPrior summary (carried forward):\n${clampedPrior}`
+        : "";
+      const splitTurnNote =
+        preparation.isSplitTurn && preparation.turnPrefixMessages?.length
+          ? `\n\n**Split-turn context lost:** ${preparation.turnPrefixMessages.length} turn-prefix message(s) could not be summarized due to the failure above.`
+          : "";
+      // Best-effort: include workspace critical rules (AGENTS.md Session Startup / Red Lines).
+      let workspaceCtx = "";
+      try {
+        workspaceCtx = await readWorkspaceContextForSummary();
+      } catch {
+        // best-effort; don't let this block the emergency return
+      }
+      const emergencySummary =
+        `Emergency compaction: summarization failed (${errorMessage}). ` +
+        `History was cut at the SDK-computed boundary; content before that point is not summarized.` +
+        priorContext +
+        splitTurnNote +
+        preservedTurnsSection +
+        toolFailureSection +
+        fileOpsSummary +
+        workspaceCtx;
+      return {
+        compaction: {
+          summary: emergencySummary,
+          firstKeptEntryId: preparation.firstKeptEntryId,
+          tokensBefore: preparation.tokensBefore,
+          details: { readFiles, modifiedFiles },
+        },
+      };
     }
   });
 }


### PR DESCRIPTION
## Summary

- Problem: When compaction summarization fails (API error, timeout, malformed response), the catch block returns `{ cancel: true }`, leaving the session at its oversized context. Every subsequent message re-triggers compaction, which fails again, creating a stuck-session loop the user cannot escape without manual intervention.
- Why it matters: A single transient API failure permanently wedges a session. The user sees repeated "compaction failed" warnings with no way to continue the conversation.
- What changed: The catch block now returns an emergency static summary instead of cancelling. The summary preserves the prior summary (truncated to 4000 chars to prevent nesting), file ops, tool failures, preserved recent turns, workspace context, and a split-turn note when applicable. AbortError is re-thrown so signal cancellation still works correctly.
- What did NOT change (scope boundary): The happy path (successful summarization) is untouched. No changes to chunking, token estimation, model resolution, or the summarizeInStages pipeline. The emergency fallback only fires when summarizeInStages throws a non-abort error.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42158
- Related #40055 (previous PR, closed for clean commit history)

## User-visible / Behavior Changes

Sessions that previously got stuck in a compaction-fail-retry loop now recover automatically. The session loses detailed history (replaced by a terse emergency note) but remains usable. Users see a warning log instead of a silent loop.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: Any Anthropic model
- Integration/channel (if any): Any
- Relevant config (redacted): Default compaction settings

### Steps

1. Fill a session to context window capacity (many large tool results)
2. Trigger compaction (send another message)
3. Have the summarization API call fail (network error, malformed response, rate limit)

### Expected

- Session recovers with an emergency summary and remains usable

### Actual

- Before fix: `{ cancel: true }` returned, session stays oversized, next message triggers compaction again in a loop
- After fix: emergency summary returned, session continues

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

4 new tests covering: emergency fallback on summarization failure, AbortError re-throw, prior summary truncation for unbounded nesting prevention, split-turn note inclusion.

## Human Verification (required)

- Verified scenarios: All 4 new tests pass. Existing compaction-safeguard tests pass (236 existing + 4 new). Manually traced the catch block logic to confirm AbortError discrimination, prior summary clamping, and emergency summary assembly.
- Edge cases checked: AbortError not caught by fallback, prior summary exceeding 4000 chars truncated with marker, split-turn with turnPrefixMessages generates note, empty fileOps/toolFailures produce clean output.
- What you did **not** verify: Live gateway testing with a real oversized session (requires filling 200K context).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit. The old `{ cancel: true }` behavior returns.
- Files/config to restore: `src/agents/pi-extensions/compaction-safeguard.ts`
- Known bad symptoms reviewers should watch for: Emergency summaries appearing when normal compaction should succeed (would indicate the try block is throwing unexpectedly on the happy path).

## Risks and Mitigations

- Risk: Emergency summary is less informative than a real LLM-generated summary, so repeated failures degrade context quality.
  - Mitigation: The fallback preserves prior summary, file ops, tool failures, and recent turns - enough for the agent to continue. A successful compaction on the next cycle restores full quality.
- Risk: Prior summary truncation at 4000 chars could lose important context.
  - Mitigation: 4000 chars is generous for a summary. Truncation only applies to carried-forward summaries from previous emergency fallbacks (nesting scenario). Normal summaries are well under this limit.

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Resubmission of #40055 (closed for clean commit history).