### PR TITLE
feat: auto-inject shared bootstrap files

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { clearAllBootstrapSnapshots } from "./bootstrap-cache.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -20,8 +21,21 @@ function registerExtraBootstrapFileHook() {
         path: path.join(context.workspaceDir, "EXTRA.md"),
         content: "extra",
         missing: false,
-      } as unknown as WorkspaceBootstrapFile,
+      },
     ];
+  });
+}
+
+function registerMutatingPushHook() {
+  registerInternalHook("agent:bootstrap", (event) => {
+    const context = event.context as AgentBootstrapHookContext;
+    // Mimics shared-bootstrap hook: mutates via .push() instead of spread
+    context.bootstrapFiles.push({
+      name: "SHARED_TEST.md",
+      path: path.join(context.workspaceDir, "SHARED_TEST.md"),
+      content: "shared",
+      missing: false,
+    });
   });
 }
 
@@ -63,6 +77,30 @@ describe("resolveBootstrapFilesForRun", () => {
     const files = await resolveBootstrapFilesForRun({ workspaceDir });
 
     expect(files.some((file) => file.path === path.join(workspaceDir, "EXTRA.md"))).toBe(true);
+  });
+
+  it("does not accumulate hook-pushed files across cached calls", async () => {
+    registerMutatingPushHook();
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const sessionKey = "test-session-cache-mutation";
+
+    try {
+      const first = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountFirst = first.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountFirst).toBe(1);
+
+      const second = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountSecond = second.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountSecond).toBe(1);
+
+      // Third call to be thorough — would be 3 copies without the fix
+      const third = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountThird = third.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountThird).toBe(1);
+    } finally {
+      clearAllBootstrapSnapshots();
+    }
   });
 
   it("drops malformed hook files with missing/invalid paths", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -78,11 +78,13 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey: params.sessionKey,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
-    contextMode: params.contextMode,
-    runKind: params.runKind,
-  });
+  const bootstrapFiles = [
+    ...applyContextModeFilter({
+      files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+      contextMode: params.contextMode,
+      runKind: params.runKind,
+    }),
+  ];
 
   const updated = await applyBootstrapHookOverrides({
     files: bootstrapFiles,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -141,7 +141,7 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_MEMORY_ALT_FILENAME;
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  name: WorkspaceBootstrapFileName | (string & {});
   path: string;
   content?: string;
   missing: boolean;

--- a/src/hooks/bundled/shared-bootstrap/HOOK.md
+++ b/src/hooks/bundled/shared-bootstrap/HOOK.md
@@ -1,0 +1,37 @@
+---
+name: shared-bootstrap
+description: "Inject shared SHARED_*.md bootstrap files from the state directory into all agents"
+homepage: https://docs.openclaw.ai/automation/hooks#shared-bootstrap
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔗",
+        "events": ["agent:bootstrap"],
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Shared Bootstrap Hook
+
+Auto-discovers `SHARED_*.md` files in `<stateDir>/shared/` (default `~/.openclaw/shared/`)
+and injects them into every agent's `Project Context` during `agent:bootstrap`.
+
+No configuration required. Drop files in the directory, restart, every agent gets them.
+
+## Setup
+
+```bash
+mkdir -p ~/.openclaw/shared
+echo "# Shared Rules" > ~/.openclaw/shared/SHARED_RULES.md
+```
+
+## Behavior
+
+- Only files matching `SHARED_*.md` are loaded (e.g. `SHARED_RULES.md`, `SHARED_SOUL.md`).
+- Files are sorted alphabetically and appended after workspace bootstrap files.
+- If the directory does not exist or contains no matching files, the hook does nothing.
+- If the directory exists but is unreadable, bootstrap fails with an error.
+- If a matching file exists but cannot be read, bootstrap fails with an error.
+- No subagent filtering — shared files appear in every session type.

--- a/src/hooks/bundled/shared-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/shared-bootstrap/handler.test.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentBootstrapHookContext } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+
+const mockStateDir = vi.hoisted(() => ({ value: "" }));
+vi.mock("../../../config/paths.js", () => ({
+  get STATE_DIR() {
+    return mockStateDir.value;
+  },
+}));
+
+// Import after mock setup — STATE_DIR is read at call time (not module load)
+import handler from "./handler.js";
+
+function createBootstrapContext(params: {
+  workspaceDir: string;
+  sessionKey: string;
+}): AgentBootstrapHookContext {
+  return {
+    workspaceDir: params.workspaceDir,
+    bootstrapFiles: [],
+    sessionKey: params.sessionKey,
+  };
+}
+
+describe("shared-bootstrap hook", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-shared-bootstrap-"));
+    mockStateDir.value = tempDir;
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does nothing when shared directory does not exist", async () => {
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("does nothing when shared directory is empty", async () => {
+    await fs.mkdir(path.join(tempDir, "shared"), { recursive: true });
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("does nothing when no SHARED_*.md files exist", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "RULES.md"), "no prefix", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "notes.txt"), "not md", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("injects SHARED_*.md files from shared directory", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared rules", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_SOUL.md"), "shared soul", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(2);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+    expect(context.bootstrapFiles[0].content).toBe("shared rules");
+    expect(context.bootstrapFiles[1].name).toBe("SHARED_SOUL.md");
+    expect(context.bootstrapFiles[1].content).toBe("shared soul");
+  });
+
+  it("sorts files alphabetically", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_C.md"), "c", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_A.md"), "a", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_B.md"), "b", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles.map((f) => f.name)).toEqual([
+      "SHARED_A.md",
+      "SHARED_B.md",
+      "SHARED_C.md",
+    ]);
+  });
+
+  it("ignores files without SHARED_ prefix", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SOUL.md"), "not shared", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "config.json"), "{}", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+  });
+
+  it("throws when shared directory exists but is unreadable", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.chmod(sharedDir, 0o000);
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+
+    try {
+      await expect(handler(event)).rejects.toThrow();
+    } finally {
+      await fs.chmod(sharedDir, 0o755);
+    }
+  });
+
+  it("throws when a matching file cannot be read", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    const filePath = path.join(sharedDir, "SHARED_BROKEN.md");
+    await fs.writeFile(filePath, "content", "utf-8");
+    await fs.chmod(filePath, 0o000);
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+
+    try {
+      await expect(handler(event)).rejects.toThrow();
+    } finally {
+      await fs.chmod(filePath, 0o644);
+    }
+  });
+
+  it("shared files survive in subagent sessions", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared rules", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:subagent:abc",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+  });
+});

--- a/src/hooks/bundled/shared-bootstrap/handler.ts
+++ b/src/hooks/bundled/shared-bootstrap/handler.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { STATE_DIR } from "../../../config/paths.js";
+import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
+
+const sharedBootstrapHook: HookHandler = async (event) => {
+  if (!isAgentBootstrapEvent(event)) {
+    return;
+  }
+
+  const sharedDir = path.join(STATE_DIR, "shared");
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sharedDir);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  const sharedFiles = entries
+    .filter((f) => f.startsWith("SHARED_") && f.endsWith(".md"))
+    .toSorted();
+  if (sharedFiles.length === 0) {
+    return;
+  }
+
+  for (const file of sharedFiles) {
+    const filePath = path.join(sharedDir, file);
+    const content = await fs.readFile(filePath, "utf-8");
+    event.context.bootstrapFiles.push({
+      name: file,
+      path: filePath,
+      content,
+      missing: false,
+    });
+  }
+};
+
+export default sharedBootstrapHook;


### PR DESCRIPTION
## Summary

- Problem: Multi-agent setups need shared context (rules, personality guidelines, operational procedures) injected into every agent's bootstrap. Currently each agent's workspace must contain its own copy of shared files, or symlinks must be manually maintained. There is no built-in mechanism to auto-inject shared files across all agents.
- Why it matters: Operators running multiple agents (5, 10, 20+) must manually sync shared context to every workspace. A missed update means agents diverge on rules or personality.
- What changed: (1) New bundled `shared-bootstrap` hook that auto-discovers `SHARED_*.md` files from `<stateDir>/shared/` (default `~/.openclaw/shared/`) and pushes them into every agent's bootstrap context during `agent:bootstrap`. Files are sorted alphabetically. Missing directory is silently skipped; unreadable directory or file throws. (2) `WorkspaceBootstrapFile.name` type widened from the fixed union to also accept arbitrary strings (for `SHARED_*.md` names). (3) `resolveBootstrapFilesForRun` now spreads the filtered array into a fresh copy before passing to hooks, preventing mutation-based hooks (like this one using `.push()`) from accumulating entries across cached calls.
- What did NOT change (scope boundary): No changes to compaction, session management, agent resolution, or existing bootstrap file loading. The hook is additive - it appends to the bootstrap file list without modifying existing entries.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19620
- Related #19621 (previous PR, closed for clean commit history)

## User-visible / Behavior Changes

Drop `SHARED_*.md` files into `~/.openclaw/shared/` and every agent automatically receives them in their bootstrap context. No configuration needed. Files appear in alphabetical order after workspace-specific bootstrap files.

## Security Impact (required)

- New permissions/capabilities? No (reads from the existing state directory the gateway already owns)
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No (reads only from `<stateDir>/shared/`, same trust boundary as other state directory content)

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): Any
- Relevant config (redacted): Default state directory

### Steps

1. Create `~/.openclaw/shared/SHARED_RULES.md` with some content
2. Start or restart the gateway
3. Send a message to any agent
4. Check the agent's bootstrap context (system prompt) for the shared content

### Expected

- Shared file content appears in the agent's system prompt under Project Context

### Actual

- Before: shared content not injected; manual workspace copies required
- After: shared content auto-injected for all agents

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

8 new hook tests: no-op on missing directory, no-op on empty directory, no-op without SHARED_ prefix files, injection of SHARED_*.md files, alphabetical sorting, non-matching file filtering, unreadable directory throws, unreadable file throws, subagent sessions. 1 new bootstrap-files test: mutation-based hooks do not accumulate entries across cached calls.

## Human Verification (required)

- Verified scenarios: All new and existing bootstrap-files tests pass. Hook handler tests cover all documented behaviors from HOOK.md. Traced the hook registration path and confirmed the hook fires during agent:bootstrap.
- Edge cases checked: Missing shared directory (silent no-op), empty directory, mixed file types (only SHARED_*.md matched), unreadable directory/file (throws), subagent sessions (shared files included), repeated cached calls with mutating hooks (no accumulation).
- What you did **not** verify: Live gateway test with actual agents (requires running gateway restart).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (no shared directory = no behavior change)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `shared-bootstrap` hook directory or revert the commit. Without the hook, no shared files are injected.
- Files/config to restore: `src/hooks/bundled/shared-bootstrap/`, `src/agents/bootstrap-files.ts`, `src/agents/workspace.ts`
- Known bad symptoms reviewers should watch for: Duplicate shared entries in bootstrap (would indicate the array spread fix in bootstrap-files.ts regressed), or bootstrap failures on startup (would indicate file permission issues in the shared directory).

## Risks and Mitigations

- Risk: Large shared files could inflate context for all agents unnecessarily.
  - Mitigation: Operator controls what goes into `~/.openclaw/shared/`. Only explicitly named `SHARED_*.md` files are loaded. No recursive directory scanning.
- Risk: Type widening of `WorkspaceBootstrapFile.name` could accept invalid names in other contexts.
  - Mitigation: The `(string & {})` intersection preserves autocomplete for the existing union members while allowing arbitrary strings. Existing code checking for specific names continues to work via type narrowing.

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Resubmission of #19621 (closed for clean commit history).