### PR TITLE
feat(voice-call): stream TTS to reduce voice latency

### DIFF
--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -39,9 +39,12 @@ type CoreAgentDeps = {
     verboseLevel?: string;
     timeoutMs: number;
     runId: string;
+    abortSignal?: AbortSignal;
     lane?: string;
     extraSystemPrompt?: string;
     agentDir?: string;
+    onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+    onAssistantMessageStart?: () => void | Promise<void>;
   }) => Promise<{
     payloads?: Array<{ text?: string; isError?: boolean }>;
     meta?: { aborted?: boolean };

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -11,6 +11,7 @@ import {
   initiateCall as initiateCallWithContext,
   speak as speakWithContext,
   speakInitialMessage as speakInitialMessageWithContext,
+  speakStream as speakStreamWithContext,
 } from "./manager/outbound.js";
 import { getCallHistoryFromStore, loadActiveCallsFromStore } from "./manager/store.js";
 import { startMaxDurationTimer } from "./manager/timers.js";
@@ -217,6 +218,17 @@ export class CallManager {
    */
   async speak(callId: CallId, text: string): Promise<{ success: boolean; error?: string }> {
     return speakWithContext(this.getContext(), callId, text);
+  }
+
+  /**
+   * Speak sentences from an async iterable as they arrive from the LLM.
+   */
+  async speakStream(
+    callId: CallId,
+    sentences: AsyncIterable<string>,
+    fullText: string | null,
+  ): Promise<{ success: boolean; error?: string }> {
+    return speakStreamWithContext(this.getContext(), callId, sentences, fullText);
   }
 
   /**

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -226,6 +226,65 @@ export async function speak(
   }
 }
 
+/**
+ * Speak sentences from an async iterable, playing each one as it arrives.
+ * TTS for the first sentence starts as soon as the LLM produces it, while
+ * the LLM continues generating subsequent sentences.
+ *
+ * @param fullText - The complete response text for transcript recording.
+ *   Pass null if the full text is not yet available (transcript will be
+ *   reconstructed from the spoken sentences).
+ */
+export async function speakStream(
+  ctx: SpeakContext,
+  callId: CallId,
+  sentences: AsyncIterable<string>,
+  fullText: string | null,
+): Promise<{ success: boolean; error?: string }> {
+  const connected = requireConnectedCall(ctx, callId);
+  if (!connected.ok) {
+    return { success: false, error: connected.error };
+  }
+  const { call, providerCallId, provider } = connected;
+
+  transitionState(call, "speaking");
+  persistCallRecord(ctx.storePath, call);
+
+  const voice = provider.name === "twilio" ? ctx.config.tts?.openai?.voice : undefined;
+  const spokenSentences: string[] = [];
+
+  try {
+    for await (const sentence of sentences) {
+      const result = await provider.playTts({
+        callId,
+        providerCallId,
+        text: sentence,
+        voice,
+      });
+      const wasAborted = result && "partial" in result && result.partial;
+      spokenSentences.push(wasAborted ? `${sentence} [truncated]` : sentence);
+      // Barge-in aborted playback: stop sending remaining sentences
+      if (wasAborted) {
+        break;
+      }
+    }
+
+    // Record full transcript after all sentences played
+    const transcriptText = fullText ?? spokenSentences.join(" ");
+    if (transcriptText) {
+      addTranscriptEntry(call, "bot", transcriptText);
+    }
+
+    return { success: true };
+  } catch (err) {
+    // Record whatever was spoken before the failure so context isn't lost
+    if (spokenSentences.length > 0) {
+      addTranscriptEntry(call, "bot", spokenSentences.join(" "));
+    }
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export async function speakInitialMessage(
   ctx: ConversationContext,
   providerCallId: string,

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -56,7 +56,7 @@ export interface VoiceCallProvider {
    * Play TTS audio to the caller.
    * The provider should handle streaming if supported.
    */
-  playTts(input: PlayTtsInput): Promise<void>;
+  playTts(input: PlayTtsInput): Promise<void | { partial?: boolean }>;
 
   /**
    * Start listening for user speech (activate STT).

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -2,7 +2,12 @@ import crypto from "node:crypto";
 import type { TwilioConfig, WebhookSecurityConfig } from "../config.js";
 import { getHeader } from "../http-headers.js";
 import type { MediaStreamHandler } from "../media-stream.js";
-import { chunkAudio } from "../telephony-audio.js";
+import {
+  chunkAudio,
+  convertPcmChunkToMulaw8k,
+  createPcmToMulawStreamState,
+  flushPcmToMulawStream,
+} from "../telephony-audio.js";
 import type { TelephonyTtsProvider } from "../telephony-tts.js";
 import type {
   GetCallStatusInput,
@@ -30,6 +35,19 @@ import { guardedJsonApiRequest } from "./shared/guarded-json-api.js";
 import { twilioApiRequest } from "./twilio/api.js";
 import { decideTwimlResponse, readTwimlRequestView } from "./twilio/twiml-policy.js";
 import { verifyTwilioProviderWebhook } from "./twilio/webhook.js";
+
+/**
+ * Thrown when TTS streaming fails after audio frames have already been sent.
+ * Must NOT fall back to TwiML <Say> (would cause garbled/duplicated audio).
+ */
+class PartialPlaybackError extends Error {
+  constructor(cause: unknown) {
+    super(
+      `TTS streaming failed after partial playback: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.name = "PartialPlaybackError";
+  }
+}
 
 function createTwilioRequestDedupeKey(ctx: WebhookContext, verifiedRequestKey?: string): string {
   if (verifiedRequestKey) {
@@ -555,14 +573,18 @@ export class TwilioProvider implements VoiceCallProvider {
    * 2. TwiML <Say>: Falls back to Twilio's native TTS with Polly voices.
    *    Note: This may not work on all Twilio accounts.
    */
-  async playTts(input: PlayTtsInput): Promise<void> {
+  async playTts(input: PlayTtsInput): Promise<void | { partial?: boolean }> {
     // Try telephony TTS via media stream first (if configured)
     const streamSid = this.callStreamMap.get(input.providerCallId);
     if (this.ttsProvider && this.mediaStreamHandler && streamSid) {
       try {
-        await this.playTtsViaStream(input.text, streamSid);
-        return;
+        return await this.playTtsViaStream(input.text, streamSid);
       } catch (err) {
+        // Frames already sent — falling back to <Say> would garble audio.
+        // Let the caller (speakStream) handle it as a failure.
+        if (err instanceof PartialPlaybackError) {
+          throw err;
+        }
         console.warn(
           `[voice-call] Telephony TTS failed, falling back to Twilio <Say>:`,
           err instanceof Error ? err.message : err,
@@ -597,10 +619,10 @@ export class TwilioProvider implements VoiceCallProvider {
 
   /**
    * Play TTS via core TTS and Twilio Media Streams.
-   * Generates audio with core TTS, converts to mu-law, and streams via WebSocket.
+   * Tries streaming first (lower latency), falls back to buffered synthesis.
    * Uses a queue to serialize playback and prevent overlapping audio.
    */
-  private async playTtsViaStream(text: string, streamSid: string): Promise<void> {
+  private async playTtsViaStream(text: string, streamSid: string): Promise<{ partial?: boolean }> {
     if (!this.ttsProvider || !this.mediaStreamHandler) {
       throw new Error("TTS provider and media stream handler required");
     }
@@ -611,8 +633,81 @@ export class TwilioProvider implements VoiceCallProvider {
 
     const handler = this.mediaStreamHandler;
     const ttsProvider = this.ttsProvider;
+
+    // Try streaming path first (lower latency)
+    if (ttsProvider.synthesizeForTelephonyStream) {
+      let framesEmitted = false;
+      let aborted = false;
+      try {
+        await handler.queueTts(streamSid, async (signal) => {
+          // Start synthesis inside the queue callback so OpenAI timeout
+          // doesn't count queue-wait time behind earlier playback
+          const streamResult = await ttsProvider.synthesizeForTelephonyStream!(text);
+          const state = createPcmToMulawStreamState();
+          const onAbort = () => streamResult.stream.destroy();
+          signal.addEventListener("abort", onAbort, { once: true });
+
+          // Buffer mu-law bytes across network chunks so short tail frames
+          // from non-aligned chunks don't each incur a full 20ms delay
+          let mulawCarry = Buffer.alloc(0);
+
+          try {
+            for await (const chunk of streamResult.stream) {
+              if (signal.aborted) break;
+              const pcmChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+              const mulaw = convertPcmChunkToMulaw8k(pcmChunk, streamResult.sampleRate, state);
+              if (mulaw.length === 0) continue;
+
+              const combined = mulawCarry.length > 0 ? Buffer.concat([mulawCarry, mulaw]) : mulaw;
+              const fullFrameBytes = Math.floor(combined.length / CHUNK_SIZE) * CHUNK_SIZE;
+              mulawCarry =
+                fullFrameBytes < combined.length
+                  ? Buffer.from(combined.subarray(fullFrameBytes))
+                  : Buffer.alloc(0);
+
+              for (let offset = 0; offset < fullFrameBytes; offset += CHUNK_SIZE) {
+                if (signal.aborted) break;
+                handler.sendAudio(streamSid, combined.subarray(offset, offset + CHUNK_SIZE));
+                framesEmitted = true;
+                await new Promise((resolve) => setTimeout(resolve, CHUNK_DELAY_MS));
+                if (signal.aborted) break;
+              }
+            }
+
+            if (signal.aborted) {
+              aborted = true;
+            } else {
+              // Send any remaining buffered mu-law bytes as a final short frame
+              if (mulawCarry.length > 0) {
+                handler.sendAudio(streamSid, mulawCarry);
+                framesEmitted = true;
+              }
+              flushPcmToMulawStream(state);
+              handler.sendMark(streamSid, `tts-${Date.now()}`);
+            }
+          } finally {
+            signal.removeEventListener("abort", onAbort);
+            streamResult.cleanup();
+          }
+        });
+        // Barge-in aborted playback: signal callers to stop remaining sentences
+        if (aborted) {
+          return { partial: true };
+        }
+        return {};
+      } catch (err) {
+        // Only fall back to buffered if no frames were sent yet —
+        // replaying after partial playback causes garbled/duplicated speech
+        if (framesEmitted) {
+          throw new PartialPlaybackError(err);
+        }
+        console.warn("[voice-call] TTS streaming failed, falling back to buffered:", String(err));
+      }
+    }
+
+    // Buffered fallback
+    let bufferedAborted = false;
     await handler.queueTts(streamSid, async (signal) => {
-      // Generate audio with core TTS (returns mu-law at 8kHz)
       const muLawAudio = await ttsProvider.synthesizeForTelephony(text);
       for (const chunk of chunkAudio(muLawAudio, CHUNK_SIZE)) {
         if (signal.aborted) {
@@ -620,18 +715,22 @@ export class TwilioProvider implements VoiceCallProvider {
         }
         handler.sendAudio(streamSid, chunk);
 
-        // Pace the audio to match real-time playback
         await new Promise((resolve) => setTimeout(resolve, CHUNK_DELAY_MS));
         if (signal.aborted) {
           break;
         }
       }
 
-      if (!signal.aborted) {
-        // Send a mark to track when audio finishes
+      if (signal.aborted) {
+        bufferedAborted = true;
+      } else {
         handler.sendMark(streamSid, `tts-${Date.now()}`);
       }
     });
+    if (bufferedAborted) {
+      return { partial: true };
+    }
+    return {};
   }
 
   /**

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -686,6 +686,7 @@ export class TwilioProvider implements VoiceCallProvider {
               handler.sendMark(streamSid, `tts-${Date.now()}`);
             }
           } finally {
+            if (signal.aborted) aborted = true;
             signal.removeEventListener("abort", onAbort);
             streamResult.cleanup();
           }

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { SentenceStream } from "./response-generator.js";
+
+describe("SentenceStream", () => {
+  async function collect(stream: SentenceStream): Promise<string[]> {
+    const results: string[] = [];
+    for await (const sentence of stream) {
+      results.push(sentence);
+    }
+    return results;
+  }
+
+  it("yields sentences split on period + uppercase", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.push("Hello there. How are you?");
+    stream.finish("Hello there. How are you?");
+
+    const sentences = await promise;
+    expect(sentences).toEqual(["Hello there.", "How are you?"]);
+  });
+
+  it("yields sentences incrementally as cumulative text grows", async () => {
+    const stream = new SentenceStream();
+    const received: string[] = [];
+
+    const promise = (async () => {
+      for await (const sentence of stream) {
+        received.push(sentence);
+      }
+    })();
+
+    // LLM streaming: cumulative text grows over time
+    stream.push("Hello");
+    stream.push("Hello there.");
+    stream.push("Hello there. How");
+    stream.push("Hello there. How are you?");
+    // At this point, sentence boundary detected: "Hello there." + " How..."
+    stream.finish("Hello there. How are you?");
+
+    await promise;
+    expect(received).toEqual(["Hello there.", "How are you?"]);
+  });
+
+  it("handles single sentence (no split)", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.push("Sure!");
+    stream.finish("Sure!");
+
+    const sentences = await promise;
+    expect(sentences).toEqual(["Sure!"]);
+  });
+
+  it("handles empty response", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.finish("");
+
+    const sentences = await promise;
+    expect(sentences).toEqual([]);
+  });
+
+  it("handles multiple sentence-ending punctuation marks", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.push("Really?! That's great! Now let's go.");
+    stream.finish("Really?! That's great! Now let's go.");
+
+    const sentences = await promise;
+    // Should split on boundaries where uppercase follows
+    expect(sentences.length).toBeGreaterThanOrEqual(2);
+    expect(sentences.join(" ")).toContain("Really?!");
+    expect(sentences[sentences.length - 1]).toContain("go.");
+  });
+
+  it("does not split on abbreviations mid-sentence", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.push("I talked to Mr. Smith today. He said hello.");
+    stream.finish("I talked to Mr. Smith today. He said hello.");
+
+    const sentences = await promise;
+    // "Mr. Smith" should NOT cause a split (S is uppercase after period,
+    // but the regex should handle this case). If it does split, that's
+    // acceptable since voice playback of split sentences is still correct.
+    expect(sentences.length).toBeGreaterThanOrEqual(1);
+    expect(sentences.join(" ")).toContain("hello");
+  });
+
+  it("flushes remaining text on finish", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    // Only partial sentence streamed
+    stream.push("Working on it");
+    stream.finish("Working on it");
+
+    const sentences = await promise;
+    expect(sentences).toEqual(["Working on it"]);
+  });
+
+  it("handles finish with different final text than streamed", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.push("First sentence.");
+    // Agent payloads may produce slightly different final text
+    stream.finish("First sentence. Second sentence.");
+
+    const sentences = await promise;
+    // Should have both sentences
+    expect(sentences.join(" ")).toContain("First sentence");
+    expect(sentences.join(" ")).toContain("Second sentence");
+  });
+
+  it("handles finish with no prior pushes", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.finish("Direct final text.");
+
+    const sentences = await promise;
+    expect(sentences).toEqual(["Direct final text."]);
+  });
+
+  it("resets offset so new assistant messages after tool calls are not skipped", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+
+    // First assistant message (cumulative text within the message)
+    stream.push("Looking that up for you.");
+    // Tool call happens, new assistant message starts -- pass last text to flush
+    stream.resetOffset("Looking that up for you.");
+    // Second message cumulative text restarts from 0
+    stream.push("The weather is sunny.");
+    stream.finish("The weather is sunny.");
+
+    const sentences = await promise;
+    expect(sentences).toEqual(["Looking that up for you.", "The weather is sunny."]);
+  });
+
+  it("splits on lowercase sentence starts", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.push("done. let me check that.");
+    stream.finish("done. let me check that.");
+
+    const sentences = await promise;
+    expect(sentences).toEqual(["done.", "let me check that."]);
+  });
+
+  it("splits on non-English sentence starts", async () => {
+    const stream = new SentenceStream();
+
+    const promise = collect(stream);
+    stream.push("terminado. veamos eso.");
+    stream.finish("terminado. veamos eso.");
+
+    const sentences = await promise;
+    expect(sentences).toEqual(["terminado.", "veamos eso."]);
+  });
+
+  it("yields sentences as they become available (not all at end)", async () => {
+    const stream = new SentenceStream();
+    const timings: number[] = [];
+    const start = Date.now();
+
+    const promise = (async () => {
+      for await (const _sentence of stream) {
+        timings.push(Date.now() - start);
+      }
+    })();
+
+    // Simulate delayed LLM streaming
+    stream.push("First sentence. Second");
+    await new Promise((r) => setTimeout(r, 50));
+    stream.push("First sentence. Second sentence. Third");
+    await new Promise((r) => setTimeout(r, 50));
+    stream.finish("First sentence. Second sentence. Third.");
+
+    await promise;
+
+    // First sentence should arrive much earlier than later ones
+    expect(timings.length).toBe(3);
+    expect(timings[0]).toBeLessThan(timings[1]);
+  });
+});

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -1,6 +1,9 @@
 /**
  * Voice call response generator - uses the embedded Pi agent for tool support.
  * Routes voice responses through the same agent infrastructure as messaging.
+ *
+ * Streams sentences as the LLM generates them so TTS can start on the first
+ * sentence while the model is still producing the rest of the response.
  */
 
 import crypto from "node:crypto";
@@ -32,127 +35,260 @@ type SessionEntry = {
   updatedAt: number;
 };
 
+// Sentence boundary: sentence-ending punctuation followed by whitespace
+// and the start of a new sentence. Matches any word character or quote
+// after the whitespace, so non-English text and lowercase sentence starts
+// are detected.
+const SENTENCE_BOUNDARY = /(?<=[.!?])\s+(?=[\w"'\u00C0-\u024F\u0400-\u04FF])/;
+
 /**
- * Generate a voice response using the embedded Pi agent with full tool support.
- * Uses the same agent infrastructure as messaging for consistent behavior.
+ * Bridges onPartialReply callbacks to an AsyncIterable of sentences.
+ *
+ * The LLM streams cumulative text via onPartialReply. This class detects
+ * sentence boundaries and yields complete sentences as they appear.
  */
-export async function generateVoiceResponse(
-  params: VoiceResponseParams,
-): Promise<VoiceResponseResult> {
-  const { voiceConfig, callId, from, transcript, userMessage, coreConfig } = params;
+export class SentenceStream {
+  private queue: string[] = [];
+  private waiter: (() => void) | null = null;
+  private done = false;
+  private yieldedLength = 0;
 
-  if (!coreConfig) {
-    return { text: null, error: "Core config unavailable for voice response" };
+  /**
+   * Reset the cumulative offset when a new assistant message begins
+   * (e.g. after a tool call). The LLM restarts cumulative text from
+   * zero for each assistant turn, so the splitter must follow.
+   *
+   * @param lastCumulativeText - The final cumulative text from the
+   *   preceding assistant message. Any text beyond yieldedLength is
+   *   flushed as a sentence so it is not lost.
+   */
+  resetOffset(lastCumulativeText?: string): void {
+    if (lastCumulativeText) {
+      const remaining = lastCumulativeText.slice(this.yieldedLength).trim();
+      if (remaining) {
+        this.queue.push(remaining);
+      }
+    }
+    this.yieldedLength = 0;
+    if (this.queue.length > 0 && this.waiter) {
+      this.waiter();
+      this.waiter = null;
+    }
   }
 
-  let deps: Awaited<ReturnType<typeof loadCoreAgentDeps>>;
-  try {
-    deps = await loadCoreAgentDeps();
-  } catch (err) {
-    return {
-      text: null,
-      error: err instanceof Error ? err.message : "Unable to load core agent dependencies",
-    };
-  }
-  const cfg = coreConfig;
+  /** Called with cumulative text from onPartialReply. */
+  push(cumulativeText: string): void {
+    const unprocessed = cumulativeText.slice(this.yieldedLength);
+    if (!unprocessed) return;
 
-  // Build voice-specific session key based on phone number
-  const normalizedPhone = from.replace(/\D/g, "");
-  const sessionKey = `voice:${normalizedPhone}`;
-  const agentId = "main";
+    // Split on sentence boundaries
+    const parts = unprocessed.split(SENTENCE_BOUNDARY);
 
-  // Resolve paths
-  const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
-  const agentDir = deps.resolveAgentDir(cfg, agentId);
-  const workspaceDir = deps.resolveAgentWorkspaceDir(cfg, agentId);
-
-  // Ensure workspace exists
-  await deps.ensureAgentWorkspace({ dir: workspaceDir });
-
-  // Load or create session entry
-  const sessionStore = deps.loadSessionStore(storePath);
-  const now = Date.now();
-  let sessionEntry = sessionStore[sessionKey] as SessionEntry | undefined;
-
-  if (!sessionEntry) {
-    sessionEntry = {
-      sessionId: crypto.randomUUID(),
-      updatedAt: now,
-    };
-    sessionStore[sessionKey] = sessionEntry;
-    await deps.saveSessionStore(storePath, sessionStore);
-  }
-
-  const sessionId = sessionEntry.sessionId;
-  const sessionFile = deps.resolveSessionFilePath(sessionId, sessionEntry, {
-    agentId,
-  });
-
-  // Resolve model from config
-  const modelRef = voiceConfig.responseModel || `${deps.DEFAULT_PROVIDER}/${deps.DEFAULT_MODEL}`;
-  const slashIndex = modelRef.indexOf("/");
-  const provider = slashIndex === -1 ? deps.DEFAULT_PROVIDER : modelRef.slice(0, slashIndex);
-  const model = slashIndex === -1 ? modelRef : modelRef.slice(slashIndex + 1);
-
-  // Resolve thinking level
-  const thinkLevel = deps.resolveThinkingDefault({ cfg, provider, model });
-
-  // Resolve agent identity for personalized prompt
-  const identity = deps.resolveAgentIdentity(cfg, agentId);
-  const agentName = identity?.name?.trim() || "assistant";
-
-  // Build system prompt with conversation history
-  const basePrompt =
-    voiceConfig.responseSystemPrompt ??
-    `You are ${agentName}, a helpful voice assistant on a phone call. Keep responses brief and conversational (1-2 sentences max). Be natural and friendly. The caller's phone number is ${from}. You have access to tools - use them when helpful.`;
-
-  let extraSystemPrompt = basePrompt;
-  if (transcript.length > 0) {
-    const history = transcript
-      .map((entry) => `${entry.speaker === "bot" ? "You" : "Caller"}: ${entry.text}`)
-      .join("\n");
-    extraSystemPrompt = `${basePrompt}\n\nConversation so far:\n${history}`;
-  }
-
-  // Resolve timeout
-  const timeoutMs = voiceConfig.responseTimeoutMs ?? deps.resolveAgentTimeoutMs({ cfg });
-  const runId = `voice:${callId}:${Date.now()}`;
-
-  try {
-    const result = await deps.runEmbeddedPiAgent({
-      sessionId,
-      sessionKey,
-      messageProvider: "voice",
-      sessionFile,
-      workspaceDir,
-      config: cfg,
-      prompt: userMessage,
-      provider,
-      model,
-      thinkLevel,
-      verboseLevel: "off",
-      timeoutMs,
-      runId,
-      lane: "voice",
-      extraSystemPrompt,
-      agentDir,
-    });
-
-    // Extract text from payloads
-    const texts = (result.payloads ?? [])
-      .filter((p) => p.text && !p.isError)
-      .map((p) => p.text?.trim())
-      .filter(Boolean);
-
-    const text = texts.join(" ") || null;
-
-    if (!text && result.meta?.aborted) {
-      return { text: null, error: "Response generation was aborted" };
+    // All parts except the last are complete sentences
+    for (let i = 0; i < parts.length - 1; i++) {
+      const sentence = parts[i].trim();
+      if (sentence) {
+        this.yieldedLength += parts[i].length;
+        // Account for the whitespace that was the split point
+        const nextStart = cumulativeText.indexOf(parts[i + 1], this.yieldedLength);
+        if (nextStart > this.yieldedLength) {
+          this.yieldedLength = nextStart;
+        }
+        this.queue.push(sentence);
+      }
     }
 
-    return { text };
-  } catch (err) {
-    console.error(`[voice-call] Response generation failed:`, err);
-    return { text: null, error: String(err) };
+    // Wake up the consumer if waiting
+    if (this.queue.length > 0 && this.waiter) {
+      this.waiter();
+      this.waiter = null;
+    }
   }
+
+  /** Signal that the LLM is done. Yields any remaining text as final sentence. */
+  finish(finalText?: string): void {
+    // If we have final text from payloads, use whatever we haven't yielded yet
+    const source = finalText ?? "";
+    const remaining = source.slice(this.yieldedLength).trim();
+    if (remaining) {
+      this.queue.push(remaining);
+    }
+    this.done = true;
+    if (this.waiter) {
+      this.waiter();
+      this.waiter = null;
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<string> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) break;
+      await new Promise<void>((resolve) => {
+        this.waiter = resolve;
+      });
+    }
+  }
+}
+
+/**
+ * Generate a voice response, streaming sentences as the LLM produces them.
+ *
+ * Returns an async iterable of sentences and a promise for the final result
+ * (used for transcript recording after all sentences have been spoken).
+ */
+export function generateVoiceResponseStream(params: VoiceResponseParams): {
+  sentences: AsyncIterable<string>;
+  result: Promise<VoiceResponseResult>;
+  /** Abort the in-flight agent run (e.g. on barge-in). */
+  abort: () => void;
+} {
+  const sentenceStream = new SentenceStream();
+  const abortController = new AbortController();
+  let lastCumulativeText = "";
+
+  const result = (async (): Promise<VoiceResponseResult> => {
+    const { voiceConfig, callId, from, transcript, userMessage, coreConfig } = params;
+
+    if (!coreConfig) {
+      sentenceStream.finish();
+      return { text: null, error: "Core config unavailable for voice response" };
+    }
+
+    let deps: Awaited<ReturnType<typeof loadCoreAgentDeps>>;
+    try {
+      deps = await loadCoreAgentDeps();
+    } catch (err) {
+      sentenceStream.finish();
+      return {
+        text: null,
+        error: err instanceof Error ? err.message : "Unable to load core agent dependencies",
+      };
+    }
+    const cfg = coreConfig;
+
+    // Build voice-specific session key based on phone number
+    const normalizedPhone = from.replace(/\D/g, "");
+    const sessionKey = `voice:${normalizedPhone}`;
+    const agentId = "main";
+
+    try {
+      // Resolve paths
+      const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
+      const agentDir = deps.resolveAgentDir(cfg, agentId);
+      const workspaceDir = deps.resolveAgentWorkspaceDir(cfg, agentId);
+
+      // Ensure workspace exists
+      await deps.ensureAgentWorkspace({ dir: workspaceDir });
+
+      // Load or create session entry
+      const sessionStore = deps.loadSessionStore(storePath);
+      const now = Date.now();
+      let sessionEntry = sessionStore[sessionKey] as SessionEntry | undefined;
+
+      if (!sessionEntry) {
+        sessionEntry = {
+          sessionId: crypto.randomUUID(),
+          updatedAt: now,
+        };
+        sessionStore[sessionKey] = sessionEntry;
+        await deps.saveSessionStore(storePath, sessionStore);
+      }
+
+      const sessionId = sessionEntry.sessionId;
+      const sessionFile = deps.resolveSessionFilePath(sessionId, sessionEntry, {
+        agentId,
+      });
+
+      // Resolve model from config
+      const modelRef =
+        voiceConfig.responseModel || `${deps.DEFAULT_PROVIDER}/${deps.DEFAULT_MODEL}`;
+      const slashIndex = modelRef.indexOf("/");
+      const provider = slashIndex === -1 ? deps.DEFAULT_PROVIDER : modelRef.slice(0, slashIndex);
+      const model = slashIndex === -1 ? modelRef : modelRef.slice(slashIndex + 1);
+
+      // Resolve thinking level
+      const thinkLevel = deps.resolveThinkingDefault({ cfg, provider, model });
+
+      // Resolve agent identity for personalized prompt
+      const identity = deps.resolveAgentIdentity(cfg, agentId);
+      const agentName = identity?.name?.trim() || "assistant";
+
+      // Build system prompt with conversation history
+      const basePrompt =
+        voiceConfig.responseSystemPrompt ??
+        `You are ${agentName}, a helpful voice assistant on a phone call. Keep responses brief and conversational (1-2 sentences max). Be natural and friendly. The caller's phone number is ${from}. You have access to tools - use them when helpful.`;
+
+      let extraSystemPrompt = basePrompt;
+      if (transcript.length > 0) {
+        const history = transcript
+          .map((entry) => `${entry.speaker === "bot" ? "You" : "Caller"}: ${entry.text}`)
+          .join("\n");
+        extraSystemPrompt = `${basePrompt}\n\nConversation so far:\n${history}`;
+      }
+
+      // Resolve timeout
+      const timeoutMs = voiceConfig.responseTimeoutMs ?? deps.resolveAgentTimeoutMs({ cfg });
+      const runId = `voice:${callId}:${Date.now()}`;
+
+      const agentResult = await deps.runEmbeddedPiAgent({
+        sessionId,
+        sessionKey,
+        messageProvider: "voice",
+        sessionFile,
+        workspaceDir,
+        config: cfg,
+        prompt: userMessage,
+        provider,
+        model,
+        thinkLevel,
+        verboseLevel: "off",
+        timeoutMs,
+        runId,
+        abortSignal: abortController.signal,
+        lane: "voice",
+        extraSystemPrompt,
+        agentDir,
+        onPartialReply: ({ text }) => {
+          if (text) {
+            lastCumulativeText = text;
+            sentenceStream.push(text);
+          }
+        },
+        onAssistantMessageStart: () => {
+          sentenceStream.resetOffset(lastCumulativeText);
+          lastCumulativeText = "";
+        },
+      });
+
+      // Extract final text from payloads
+      const texts = (agentResult.payloads ?? [])
+        .filter((p) => p.text && !p.isError)
+        .map((p) => p.text?.trim())
+        .filter(Boolean);
+
+      const text = texts.join(" ") || null;
+
+      // Finish the sentence stream with the authoritative final text
+      sentenceStream.finish(text ?? undefined);
+
+      if (!text && agentResult.meta?.aborted) {
+        return { text: null, error: "Response generation was aborted" };
+      }
+
+      return { text };
+    } catch (err) {
+      console.error(`[voice-call] Response generation failed:`, err);
+      sentenceStream.finish();
+      return { text: null, error: String(err) };
+    }
+  })();
+
+  return {
+    sentences: sentenceStream,
+    result,
+    abort: () => abortController.abort(),
+  };
 }

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -87,13 +87,13 @@ export class SentenceStream {
     // All parts except the last are complete sentences
     for (let i = 0; i < parts.length - 1; i++) {
       const sentence = parts[i].trim();
+      this.yieldedLength += parts[i].length;
+      // Account for the whitespace that was the split point
+      const nextStart = cumulativeText.indexOf(parts[i + 1], this.yieldedLength);
+      if (nextStart > this.yieldedLength) {
+        this.yieldedLength = nextStart;
+      }
       if (sentence) {
-        this.yieldedLength += parts[i].length;
-        // Account for the whitespace that was the split point
-        const nextStart = cumulativeText.indexOf(parts[i + 1], this.yieldedLength);
-        if (nextStart > this.yieldedLength) {
-          this.yieldedLength = nextStart;
-        }
         this.queue.push(sentence);
       }
     }
@@ -271,8 +271,11 @@ export function generateVoiceResponseStream(params: VoiceResponseParams): {
 
       const text = texts.join(" ") || null;
 
-      // Finish the sentence stream with the authoritative final text
-      sentenceStream.finish(text ?? undefined);
+      // Finish with only the current (last) assistant message text.
+      // Earlier assistant messages were already flushed via resetOffset,
+      // so passing all joined texts would duplicate already-yielded content.
+      const lastText = texts.length > 0 ? texts[texts.length - 1] : undefined;
+      sentenceStream.finish(lastText ?? undefined);
 
       if (!text && agentResult.meta?.aborted) {
         return { text: null, error: "Response generation was aborted" };

--- a/extensions/voice-call/src/telephony-audio.test.ts
+++ b/extensions/voice-call/src/telephony-audio.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  convertPcmToMulaw8k,
+  convertPcmChunkToMulaw8k,
+  createPcmToMulawStreamState,
+  flushPcmToMulawStream,
+} from "./telephony-audio.js";
+
+describe("incremental PCM-to-mulaw conversion", () => {
+  it("produces identical output to single-pass for even-aligned chunks", () => {
+    // Create a PCM buffer with known samples (16-bit LE, 24kHz -> 8kHz)
+    const sampleRate = 24000;
+    const numSamples = 300;
+    const pcm = Buffer.alloc(numSamples * 2);
+    for (let i = 0; i < numSamples; i++) {
+      // Sine-like pattern
+      const value = Math.round(Math.sin((i / numSamples) * Math.PI * 4) * 16000);
+      pcm.writeInt16LE(value, i * 2);
+    }
+
+    // Single-pass reference
+    const reference = convertPcmToMulaw8k(pcm, sampleRate);
+
+    // Incremental: split into even-sized chunks
+    const chunkSize = 100; // 50 samples per chunk (even)
+    const state = createPcmToMulawStreamState();
+    const chunks: Buffer[] = [];
+
+    for (let offset = 0; offset < pcm.length; offset += chunkSize) {
+      const chunk = pcm.subarray(offset, Math.min(offset + chunkSize, pcm.length));
+      const result = convertPcmChunkToMulaw8k(chunk, sampleRate, state);
+      if (result.length > 0) {
+        chunks.push(result);
+      }
+    }
+    flushPcmToMulawStream(state);
+
+    const incremental = Buffer.concat(chunks);
+    expect(incremental).toEqual(reference);
+  });
+
+  it("handles odd-byte chunks via leftover stashing", () => {
+    const sampleRate = 8000;
+    // 4 samples = 8 bytes
+    const pcm = Buffer.alloc(8);
+    pcm.writeInt16LE(100, 0);
+    pcm.writeInt16LE(200, 2);
+    pcm.writeInt16LE(300, 4);
+    pcm.writeInt16LE(400, 6);
+
+    const reference = convertPcmToMulaw8k(pcm, sampleRate);
+
+    // Split at odd boundaries: 3 bytes, 3 bytes, 2 bytes
+    const state = createPcmToMulawStreamState();
+    const chunks: Buffer[] = [];
+
+    const c1 = convertPcmChunkToMulaw8k(pcm.subarray(0, 3), sampleRate, state);
+    if (c1.length > 0) chunks.push(c1);
+
+    const c2 = convertPcmChunkToMulaw8k(pcm.subarray(3, 6), sampleRate, state);
+    if (c2.length > 0) chunks.push(c2);
+
+    const c3 = convertPcmChunkToMulaw8k(pcm.subarray(6, 8), sampleRate, state);
+    if (c3.length > 0) chunks.push(c3);
+
+    flushPcmToMulawStream(state);
+
+    const incremental = Buffer.concat(chunks);
+    expect(incremental).toEqual(reference);
+  });
+
+  it("handles leftover byte at end of stream", () => {
+    const sampleRate = 8000;
+    // 3 bytes = 1 sample + 1 leftover byte
+    const pcm = Buffer.alloc(3);
+    pcm.writeInt16LE(500, 0);
+    pcm[2] = 0x42; // leftover
+
+    const reference = convertPcmToMulaw8k(pcm.subarray(0, 2), sampleRate);
+
+    const state = createPcmToMulawStreamState();
+    const result = convertPcmChunkToMulaw8k(pcm, sampleRate, state);
+    const flushed = flushPcmToMulawStream(state);
+
+    expect(state.leftover).toBeNull();
+    expect(flushed.length).toBe(0);
+    expect(result).toEqual(reference);
+  });
+
+  it("flush clears leftover state", () => {
+    const state = createPcmToMulawStreamState();
+    // Feed a single byte (odd)
+    convertPcmChunkToMulaw8k(Buffer.from([0x42]), 8000, state);
+    expect(state.leftover).not.toBeNull();
+
+    flushPcmToMulawStream(state);
+    expect(state.leftover).toBeNull();
+  });
+
+  it("empty chunk produces empty output", () => {
+    const state = createPcmToMulawStreamState();
+    const result = convertPcmChunkToMulaw8k(Buffer.alloc(0), 8000, state);
+    expect(result.length).toBe(0);
+  });
+
+  it("defers interpolation at chunk edge instead of clamping s1", () => {
+    // 5 samples at 20kHz (ratio=2.5): position 2.5 needs interpolation
+    // between sample[2] and sample[3], but if chunk is only 3 samples,
+    // sample[3] would be clamped. The fix defers to the next chunk.
+    const sampleRate = 20000;
+    const fullPcm = Buffer.alloc(10); // 5 samples
+    for (let i = 0; i < 5; i++) {
+      fullPcm.writeInt16LE((i + 1) * 1000, i * 2);
+    }
+
+    const reference = convertPcmToMulaw8k(fullPcm, sampleRate);
+
+    // Split: 3 samples then 2 samples (6 bytes, 4 bytes)
+    const state = createPcmToMulawStreamState();
+    const chunks: Buffer[] = [];
+
+    const c1 = convertPcmChunkToMulaw8k(fullPcm.subarray(0, 6), sampleRate, state);
+    if (c1.length > 0) chunks.push(c1);
+
+    const c2 = convertPcmChunkToMulaw8k(fullPcm.subarray(6, 10), sampleRate, state);
+    if (c2.length > 0) chunks.push(c2);
+
+    flushPcmToMulawStream(state);
+
+    const incremental = Buffer.concat(chunks);
+    expect(incremental).toEqual(reference);
+  });
+
+  it("non-aligned chunks produce consistent output across boundaries", () => {
+    // 24kHz -> 8kHz (ratio=3) with chunk sizes not aligned to ratio
+    const sampleRate = 24000;
+    const numSamples = 100;
+    const pcm = Buffer.alloc(numSamples * 2);
+    for (let i = 0; i < numSamples; i++) {
+      pcm.writeInt16LE(Math.round(Math.sin((i / numSamples) * Math.PI * 2) * 10000), i * 2);
+    }
+
+    const reference = convertPcmToMulaw8k(pcm, sampleRate);
+
+    // Split into 7-sample chunks (14 bytes) — not aligned to ratio=3
+    const chunkBytes = 14;
+    const state = createPcmToMulawStreamState();
+    const chunks: Buffer[] = [];
+
+    for (let offset = 0; offset < pcm.length; offset += chunkBytes) {
+      const chunk = pcm.subarray(offset, Math.min(offset + chunkBytes, pcm.length));
+      const result = convertPcmChunkToMulaw8k(chunk, sampleRate, state);
+      if (result.length > 0) chunks.push(result);
+    }
+    flushPcmToMulawStream(state);
+
+    const incremental = Buffer.concat(chunks);
+    // Chunked output may have at most 1 extra sample per chunk from frac=0
+    // edge positions (valid data, no clamped interpolation). The important
+    // guarantee is no clamped-interpolation overproduction.
+    const maxExtraPerChunk = 1;
+    const numChunks = Math.ceil(pcm.length / chunkBytes);
+    expect(incremental.length).toBeLessThanOrEqual(reference.length + numChunks * maxExtraPerChunk);
+    // Values for the common prefix should match
+    const minLen = Math.min(incremental.length, reference.length);
+    expect(incremental.subarray(0, minLen)).toEqual(reference.subarray(0, minLen));
+  });
+});

--- a/extensions/voice-call/src/telephony-audio.ts
+++ b/extensions/voice-call/src/telephony-audio.ts
@@ -67,6 +67,113 @@ export function chunkAudio(audio: Buffer, chunkSize = 160): Generator<Buffer, vo
   })();
 }
 
+/**
+ * State for incremental PCM-to-mulaw conversion across chunk boundaries.
+ * Tracks a leftover byte when a 16-bit sample straddles two chunks.
+ */
+export type PcmToMulawStreamState = {
+  leftover: Buffer | null;
+  /** Fractional source position carried across chunks for resampling continuity */
+  srcPosCarry: number;
+  /** Number of input samples already consumed (for resampling continuity) */
+  inputSamplesConsumed: number;
+};
+
+export function createPcmToMulawStreamState(): PcmToMulawStreamState {
+  return { leftover: null, srcPosCarry: 0, inputSamplesConsumed: 0 };
+}
+
+/**
+ * Convert an incremental PCM chunk to 8kHz mu-law, handling split 16-bit samples
+ * across chunk boundaries via the state's leftover byte.
+ */
+export function convertPcmChunkToMulaw8k(
+  chunk: Buffer,
+  inputSampleRate: number,
+  state: PcmToMulawStreamState,
+): Buffer {
+  let pcm: Buffer;
+  if (state.leftover) {
+    pcm = Buffer.concat([state.leftover, chunk]);
+    state.leftover = null;
+  } else {
+    pcm = chunk;
+  }
+
+  // If odd number of bytes, stash the last byte for next chunk
+  if (pcm.length % 2 !== 0) {
+    state.leftover = Buffer.from([pcm[pcm.length - 1]]);
+    pcm = pcm.subarray(0, pcm.length - 1);
+  }
+
+  if (pcm.length === 0) {
+    return Buffer.alloc(0);
+  }
+
+  // No resampling needed — delegate directly
+  if (inputSampleRate === TELEPHONY_SAMPLE_RATE) {
+    return pcmToMulaw(pcm);
+  }
+
+  // Stateful resampling: continue interpolation from where previous chunk left off
+  const inputSamples = Math.floor(pcm.length / 2);
+  const ratio = inputSampleRate / TELEPHONY_SAMPLE_RATE;
+
+  const outputSamples: number[] = [];
+  let srcPos = state.srcPosCarry;
+  let brokeForInterp = false;
+
+  while (srcPos < inputSamples) {
+    const srcIndex = Math.floor(srcPos);
+    const frac = srcPos - srcIndex;
+
+    // Defer to next chunk when interpolation needs a neighbor beyond this chunk,
+    // preventing clamped s1 which causes overproduction and audio artifacts
+    if (srcIndex + 1 >= inputSamples && frac > 1e-10) {
+      const tailStart = srcIndex * 2;
+      const tail = pcm.subarray(tailStart);
+      state.leftover = state.leftover ? Buffer.concat([tail, state.leftover]) : Buffer.from(tail);
+      state.srcPosCarry = frac;
+      state.inputSamplesConsumed += srcIndex;
+      brokeForInterp = true;
+      break;
+    }
+
+    const s0 = pcm.readInt16LE(srcIndex * 2);
+    const s1Index = Math.min(srcIndex + 1, inputSamples - 1);
+    const s1 = pcm.readInt16LE(s1Index * 2);
+    const sample = Math.round(s0 + frac * (s1 - s0));
+    outputSamples.push(clamp16(sample));
+    srcPos += ratio;
+  }
+
+  if (!brokeForInterp) {
+    state.srcPosCarry = srcPos - inputSamples;
+    state.inputSamplesConsumed += inputSamples;
+  }
+
+  if (outputSamples.length === 0) {
+    return Buffer.alloc(0);
+  }
+
+  const resampled = Buffer.alloc(outputSamples.length * 2);
+  for (let i = 0; i < outputSamples.length; i++) {
+    resampled.writeInt16LE(outputSamples[i], i * 2);
+  }
+
+  return pcmToMulaw(resampled);
+}
+
+/**
+ * Flush any remaining leftover byte from the stream state.
+ * A single leftover byte cannot form a complete 16-bit sample, so it is discarded.
+ * Returns an empty buffer (provided for API completeness).
+ */
+export function flushPcmToMulawStream(state: PcmToMulawStreamState): Buffer {
+  state.leftover = null;
+  return Buffer.alloc(0);
+}
+
 function linearToMulaw(sample: number): number {
   const BIAS = 132;
   const CLIP = 32635;

--- a/extensions/voice-call/src/telephony-audio.ts
+++ b/extensions/voice-call/src/telephony-audio.ts
@@ -73,6 +73,8 @@ export function chunkAudio(audio: Buffer, chunkSize = 160): Generator<Buffer, vo
  */
 export type PcmToMulawStreamState = {
   leftover: Buffer | null;
+  /** Deferred tail samples from interpolation boundary (separate from odd-byte leftover) */
+  interpLeftover: Buffer | null;
   /** Fractional source position carried across chunks for resampling continuity */
   srcPosCarry: number;
   /** Number of input samples already consumed (for resampling continuity) */
@@ -80,7 +82,7 @@ export type PcmToMulawStreamState = {
 };
 
 export function createPcmToMulawStreamState(): PcmToMulawStreamState {
-  return { leftover: null, srcPosCarry: 0, inputSamplesConsumed: 0 };
+  return { leftover: null, interpLeftover: null, srcPosCarry: 0, inputSamplesConsumed: 0 };
 }
 
 /**
@@ -93,9 +95,18 @@ export function convertPcmChunkToMulaw8k(
   state: PcmToMulawStreamState,
 ): Buffer {
   let pcm: Buffer;
+  // Prepend odd-byte leftover first, then interpolation-deferred samples
+  const prefixes: Buffer[] = [];
+  if (state.interpLeftover) {
+    prefixes.push(state.interpLeftover);
+    state.interpLeftover = null;
+  }
   if (state.leftover) {
-    pcm = Buffer.concat([state.leftover, chunk]);
+    prefixes.push(state.leftover);
     state.leftover = null;
+  }
+  if (prefixes.length > 0) {
+    pcm = Buffer.concat([...prefixes, chunk]);
   } else {
     pcm = chunk;
   }
@@ -132,7 +143,7 @@ export function convertPcmChunkToMulaw8k(
     if (srcIndex + 1 >= inputSamples && frac > 1e-10) {
       const tailStart = srcIndex * 2;
       const tail = pcm.subarray(tailStart);
-      state.leftover = state.leftover ? Buffer.concat([tail, state.leftover]) : Buffer.from(tail);
+      state.interpLeftover = Buffer.from(tail);
       state.srcPosCarry = frac;
       state.inputSamplesConsumed += srcIndex;
       brokeForInterp = true;
@@ -171,6 +182,7 @@ export function convertPcmChunkToMulaw8k(
  */
 export function flushPcmToMulawStream(state: PcmToMulawStreamState): Buffer {
   state.leftover = null;
+  state.interpLeftover = null;
   return Buffer.alloc(0);
 }
 

--- a/extensions/voice-call/src/telephony-tts.streaming.test.ts
+++ b/extensions/voice-call/src/telephony-tts.streaming.test.ts
@@ -1,0 +1,130 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import type { CoreConfig } from "./core-bridge.js";
+import { createTelephonyTtsProvider } from "./telephony-tts.js";
+
+function createCoreConfig(): CoreConfig {
+  return {
+    messages: {
+      tts: {
+        provider: "openai",
+        openai: { model: "gpt-4o-mini-tts", voice: "alloy" },
+      },
+    },
+  };
+}
+
+describe("createTelephonyTtsProvider streaming", () => {
+  it("attaches synthesizeForTelephonyStream when runtime provides streaming", () => {
+    const provider = createTelephonyTtsProvider({
+      coreConfig: createCoreConfig(),
+      runtime: {
+        textToSpeechTelephony: async () => ({
+          success: true,
+          audioBuffer: Buffer.alloc(2),
+          sampleRate: 8000,
+        }),
+        textToSpeechTelephonyStream: async () => ({
+          success: true,
+          stream: Readable.from(Buffer.alloc(10)),
+          sampleRate: 24000,
+          cleanup: () => {},
+        }),
+      },
+    });
+
+    expect(provider.synthesizeForTelephonyStream).toBeDefined();
+    expect(typeof provider.synthesizeForTelephonyStream).toBe("function");
+  });
+
+  it("does not attach synthesizeForTelephonyStream when runtime lacks it", () => {
+    const provider = createTelephonyTtsProvider({
+      coreConfig: createCoreConfig(),
+      runtime: {
+        textToSpeechTelephony: async () => ({
+          success: true,
+          audioBuffer: Buffer.alloc(2),
+          sampleRate: 8000,
+        }),
+      },
+    });
+
+    expect(provider.synthesizeForTelephonyStream).toBeUndefined();
+  });
+
+  it("streaming method returns stream, sampleRate, and cleanup", async () => {
+    const cleanupCalled: boolean[] = [];
+    const pcmData = Buffer.alloc(160);
+    for (let i = 0; i < 80; i++) {
+      pcmData.writeInt16LE(i * 100, i * 2);
+    }
+
+    const provider = createTelephonyTtsProvider({
+      coreConfig: createCoreConfig(),
+      runtime: {
+        textToSpeechTelephony: async () => ({
+          success: true,
+          audioBuffer: Buffer.alloc(2),
+          sampleRate: 8000,
+        }),
+        textToSpeechTelephonyStream: async () => ({
+          success: true,
+          stream: Readable.from(pcmData),
+          sampleRate: 24000,
+          cleanup: () => {
+            cleanupCalled.push(true);
+          },
+        }),
+      },
+    });
+
+    const result = await provider.synthesizeForTelephonyStream!("test");
+    expect(result.stream).toBeDefined();
+    expect(result.sampleRate).toBe(24000);
+    expect(typeof result.cleanup).toBe("function");
+  });
+
+  it("streaming method throws when result indicates failure", async () => {
+    const provider = createTelephonyTtsProvider({
+      coreConfig: createCoreConfig(),
+      runtime: {
+        textToSpeechTelephony: async () => ({
+          success: true,
+          audioBuffer: Buffer.alloc(2),
+          sampleRate: 8000,
+        }),
+        textToSpeechTelephonyStream: async () => ({
+          success: false,
+          error: "No OpenAI API key",
+        }),
+      },
+    });
+
+    await expect(provider.synthesizeForTelephonyStream!("test")).rejects.toThrow(
+      "No OpenAI API key",
+    );
+  });
+
+  it("buffered synthesizeForTelephony still works alongside streaming", async () => {
+    const provider = createTelephonyTtsProvider({
+      coreConfig: createCoreConfig(),
+      runtime: {
+        textToSpeechTelephony: async () => ({
+          success: true,
+          audioBuffer: Buffer.alloc(4),
+          sampleRate: 8000,
+        }),
+        textToSpeechTelephonyStream: async () => ({
+          success: true,
+          stream: Readable.from(Buffer.alloc(10)),
+          sampleRate: 24000,
+          cleanup: () => {},
+        }),
+      },
+    });
+
+    const result = await provider.synthesizeForTelephony("test");
+    // convertPcmToMulaw8k(4 bytes at 8kHz) = 2 samples -> 2 bytes mulaw
+    expect(result.length).toBe(2);
+  });
+});

--- a/extensions/voice-call/src/telephony-tts.ts
+++ b/extensions/voice-call/src/telephony-tts.ts
@@ -1,3 +1,4 @@
+import type { Readable } from "node:stream";
 import type { VoiceCallTtsConfig } from "./config.js";
 import type { CoreConfig } from "./core-bridge.js";
 import { deepMergeDefined } from "./deep-merge.js";
@@ -15,10 +16,27 @@ export type TelephonyTtsRuntime = {
     provider?: string;
     error?: string;
   }>;
+  textToSpeechTelephonyStream?: (params: {
+    text: string;
+    cfg: CoreConfig;
+    prefsPath?: string;
+  }) => Promise<{
+    success: boolean;
+    stream?: Readable;
+    sampleRate?: number;
+    provider?: string;
+    error?: string;
+    cleanup?: () => void;
+  }>;
 };
 
 export type TelephonyTtsProvider = {
   synthesizeForTelephony: (text: string) => Promise<Buffer>;
+  synthesizeForTelephonyStream?: (text: string) => Promise<{
+    stream: Readable;
+    sampleRate: number;
+    cleanup: () => void;
+  }>;
 };
 
 export function createTelephonyTtsProvider(params: {
@@ -29,7 +47,7 @@ export function createTelephonyTtsProvider(params: {
   const { coreConfig, ttsOverride, runtime } = params;
   const mergedConfig = applyTtsOverride(coreConfig, ttsOverride);
 
-  return {
+  const provider: TelephonyTtsProvider = {
     synthesizeForTelephony: async (text: string) => {
       const result = await runtime.textToSpeechTelephony({
         text,
@@ -43,6 +61,28 @@ export function createTelephonyTtsProvider(params: {
       return convertPcmToMulaw8k(result.audioBuffer, result.sampleRate);
     },
   };
+
+  if (runtime.textToSpeechTelephonyStream) {
+    const streamFn = runtime.textToSpeechTelephonyStream;
+    provider.synthesizeForTelephonyStream = async (text: string) => {
+      const result = await streamFn({
+        text,
+        cfg: mergedConfig,
+      });
+
+      if (!result.success || !result.stream || !result.sampleRate) {
+        throw new Error(result.error ?? "TTS streaming failed");
+      }
+
+      return {
+        stream: result.stream,
+        sampleRate: result.sampleRate,
+        cleanup: result.cleanup ?? (() => {}),
+      };
+    };
+  }
+
+  return provider;
 }
 
 function applyTtsOverride(coreConfig: CoreConfig, override?: VoiceCallTtsConfig): CoreConfig {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -460,9 +460,9 @@ export class VoiceCallWebhookServer {
     }
 
     try {
-      const { generateVoiceResponse } = await import("./response-generator.js");
+      const { generateVoiceResponseStream } = await import("./response-generator.js");
 
-      const result = await generateVoiceResponse({
+      const { sentences, result, abort } = generateVoiceResponseStream({
         voiceConfig: this.config,
         coreConfig: this.coreConfig,
         callId,
@@ -471,14 +471,28 @@ export class VoiceCallWebhookServer {
         userMessage,
       });
 
-      if (result.error) {
-        console.error(`[voice-call] Response generation error: ${result.error}`);
-        return;
+      // Start speaking sentences as they arrive from the LLM
+      const speakResult = await this.manager.speakStream(callId, sentences, null);
+
+      // Cancel the agent run once speaking finishes. If playback was
+      // interrupted (barge-in) the agent may still be generating tokens
+      // the caller will never hear. Aborting after normal completion is
+      // a harmless no-op since the run has already resolved.
+      abort();
+
+      // Await the final result for error reporting and transcript
+      const voiceResult = await result;
+
+      if (voiceResult.error) {
+        console.error(`[voice-call] Response generation error: ${voiceResult.error}`);
       }
 
-      if (result.text) {
-        console.log(`[voice-call] AI response: "${result.text}"`);
-        await this.manager.speak(callId, result.text);
+      if (voiceResult.text) {
+        console.log(`[voice-call] AI response: "${voiceResult.text}"`);
+      }
+
+      if (!speakResult.success) {
+        console.error(`[voice-call] Speak stream failed: ${speakResult.error}`);
       }
     } catch (err) {
       console.error(`[voice-call] Auto-response error:`, err);

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -5,7 +5,7 @@ import {
 } from "../../agents/model-auth.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
-import { textToSpeechTelephony } from "../../tts/tts.js";
+import { textToSpeechTelephony, textToSpeechTelephonyStream } from "../../tts/tts.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
 import { createRuntimeConfig } from "./runtime-config.js";
 import { createRuntimeEvents } from "./runtime-events.js";
@@ -56,7 +56,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     subagent: _options.subagent ?? createUnavailableSubagentRuntime(),
     system: createRuntimeSystem(),
     media: createRuntimeMedia(),
-    tts: { textToSpeechTelephony },
+    tts: { textToSpeechTelephony, textToSpeechTelephonyStream },
     stt: { transcribeAudioFile },
     tools: createRuntimeTools(),
     channel: createRuntimeChannel(),

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -29,6 +29,7 @@ export type PluginRuntimeCore = {
   };
   tts: {
     textToSpeechTelephony: typeof import("../../tts/tts.js").textToSpeechTelephony;
+    textToSpeechTelephonyStream?: typeof import("../../tts/tts.js").textToSpeechTelephonyStream;
   };
   stt: {
     transcribeAudioFile: typeof import("../../media-understanding/transcribe-audio.js").transcribeAudioFile;

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { openaiTTSStream } from "./tts-core.js";
+
+describe("openaiTTSStream", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env.OPENAI_TTS_BASE_URL = "http://localhost:8880/v1";
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_TTS_BASE_URL;
+    fetchSpy.mockRestore();
+  });
+
+  function createReadableStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+    let i = 0;
+    return new ReadableStream({
+      pull(controller) {
+        if (i < chunks.length) {
+          controller.enqueue(chunks[i]);
+          i++;
+        } else {
+          controller.close();
+        }
+      },
+    });
+  }
+
+  it("returns a readable stream from a successful response", async () => {
+    const pcmData = Buffer.alloc(320);
+    pcmData.writeInt16LE(1000, 0);
+    pcmData.writeInt16LE(-1000, 2);
+
+    fetchSpy.mockResolvedValueOnce(new Response(createReadableStream([pcmData]), { status: 200 }));
+
+    const result = await openaiTTSStream({
+      text: "hello",
+      apiKey: "test-key",
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      responseFormat: "pcm",
+      timeoutMs: 5000,
+    });
+
+    expect(result.stream).toBeDefined();
+    expect(typeof result.cleanup).toBe("function");
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of result.stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const combined = Buffer.concat(chunks);
+    expect(combined.length).toBe(320);
+    expect(combined.readInt16LE(0)).toBe(1000);
+    expect(combined.readInt16LE(2)).toBe(-1000);
+  });
+
+  it("calls cleanup on stream end", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(createReadableStream([Buffer.alloc(10)]), { status: 200 }),
+    );
+
+    const result = await openaiTTSStream({
+      text: "hello",
+      apiKey: "test-key",
+      model: "tts-1",
+      voice: "alloy",
+      responseFormat: "pcm",
+      timeoutMs: 5000,
+    });
+
+    for await (const _chunk of result.stream) {
+      // consume
+    }
+
+    // Cleanup should be idempotent
+    result.cleanup();
+  });
+
+  it("throws on invalid model when not using custom endpoint", async () => {
+    delete process.env.OPENAI_TTS_BASE_URL;
+    await expect(
+      openaiTTSStream({
+        text: "hello",
+        apiKey: "test-key",
+        model: "invalid-model",
+        voice: "alloy",
+        responseFormat: "pcm",
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow("Invalid model: invalid-model");
+  });
+
+  it("throws on invalid voice when not using custom endpoint", async () => {
+    delete process.env.OPENAI_TTS_BASE_URL;
+    await expect(
+      openaiTTSStream({
+        text: "hello",
+        apiKey: "test-key",
+        model: "tts-1",
+        voice: "invalid-voice",
+        responseFormat: "pcm",
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow("Invalid voice: invalid-voice");
+  });
+
+  it("throws on HTTP error response", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 429 }));
+
+    await expect(
+      openaiTTSStream({
+        text: "hello",
+        apiKey: "test-key",
+        model: "gpt-4o-mini-tts",
+        voice: "alloy",
+        responseFormat: "pcm",
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow("OpenAI TTS API error (429)");
+  });
+
+  it("throws when response body is missing", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      openaiTTSStream({
+        text: "hello",
+        apiKey: "test-key",
+        model: "gpt-4o-mini-tts",
+        voice: "alloy",
+        responseFormat: "pcm",
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("uses explicit baseUrl over env var", async () => {
+    const pcmData = Buffer.alloc(160);
+    fetchSpy.mockResolvedValueOnce(new Response(createReadableStream([pcmData]), { status: 200 }));
+
+    await openaiTTSStream({
+      text: "hello",
+      apiKey: "test-key",
+      baseUrl: "http://custom-server:9000/v1",
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      responseFormat: "pcm",
+      timeoutMs: 5000,
+    });
+
+    const fetchUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(fetchUrl).toBe("http://custom-server:9000/v1/audio/speech");
+  });
+
+  it("allows custom model when baseUrl is non-default", async () => {
+    const pcmData = Buffer.alloc(160);
+    fetchSpy.mockResolvedValueOnce(new Response(createReadableStream([pcmData]), { status: 200 }));
+
+    // Should not throw because custom baseUrl bypasses model validation
+    const result = await openaiTTSStream({
+      text: "hello",
+      apiKey: "test-key",
+      baseUrl: "http://custom-server:9000/v1",
+      model: "my-custom-model",
+      voice: "my-custom-voice",
+      responseFormat: "pcm",
+      timeoutMs: 5000,
+    });
+
+    expect(result.stream).toBeDefined();
+  });
+
+  it("does not abort stream when playback exceeds timeoutMs", async () => {
+    const pcmData = Buffer.alloc(160);
+    // Slow stream that takes longer than timeoutMs to deliver all chunks
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        await new Promise((r) => setTimeout(r, 60));
+        controller.enqueue(pcmData);
+        controller.close();
+      },
+    });
+
+    fetchSpy.mockResolvedValueOnce(new Response(stream, { status: 200 }));
+
+    const result = await openaiTTSStream({
+      text: "hello",
+      apiKey: "test-key",
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      responseFormat: "pcm",
+      timeoutMs: 30, // Very short timeout — only covers connection
+    });
+
+    // Stream should complete without abort since timeout is cleared after response
+    const chunks: Buffer[] = [];
+    for await (const chunk of result.stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    expect(Buffer.concat(chunks).length).toBe(160);
+  });
+});

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,4 +1,5 @@
 import { rmSync } from "node:fs";
+import { Readable, Transform } from "node:stream";
 import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
 import { EdgeTTS } from "node-edge-tts";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
@@ -658,6 +659,114 @@ export async function openaiTTS(params: {
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export type OpenaiTTSStreamResult = {
+  stream: Readable;
+  cleanup: () => void;
+};
+
+/**
+ * Streaming variant of openaiTTS. Returns a Node.js Readable stream of raw PCM/mp3/opus
+ * bytes instead of buffering the entire response into a Buffer.
+ */
+export async function openaiTTSStream(params: {
+  text: string;
+  apiKey: string;
+  baseUrl?: string;
+  model: string;
+  voice: string;
+  responseFormat: "mp3" | "opus" | "pcm";
+  timeoutMs: number;
+}): Promise<OpenaiTTSStreamResult> {
+  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+  const effectiveBaseUrl = params.baseUrl?.trim()
+    ? normalizeOpenAITtsBaseUrl(params.baseUrl)
+    : getOpenAITtsBaseUrl();
+
+  if (!isValidOpenAIModel(model, effectiveBaseUrl)) {
+    throw new Error(`Invalid model: ${model}`);
+  }
+  if (!isValidOpenAIVoice(voice, effectiveBaseUrl)) {
+    throw new Error(`Invalid voice: ${voice}`);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let stallTimer: ReturnType<typeof setTimeout> | undefined;
+
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    clearTimeout(timeout);
+    if (stallTimer !== undefined) {
+      clearTimeout(stallTimer);
+    }
+    controller.abort();
+  };
+
+  const response = await fetch(`${effectiveBaseUrl}/audio/speech`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      input: text,
+      voice,
+      response_format: responseFormat,
+    }),
+    signal: controller.signal,
+  }).catch((err) => {
+    cleanup();
+    throw err;
+  });
+
+  if (!response.ok) {
+    cleanup();
+    throw new Error(`OpenAI TTS API error (${response.status})`);
+  }
+
+  if (!response.body) {
+    cleanup();
+    throw new Error("OpenAI TTS API returned no body");
+  }
+
+  // Clear the connection timeout now that headers have arrived.
+  // Install a read-deadline watchdog: if no data arrives, abort to prevent
+  // a stalled stream from hanging the TTS pipeline indefinitely.
+  // Use the configured timeout (capped at 30s) so operators with shorter
+  // timeouts get faster failure on mid-stream stalls.
+  clearTimeout(timeout);
+  const STALL_DEADLINE_MS = Math.min(timeoutMs, 30_000);
+  stallTimer = setTimeout(() => controller.abort(), STALL_DEADLINE_MS);
+
+  const stream = Readable.fromWeb(
+    response.body as unknown as import("node:stream/web").ReadableStream,
+  );
+
+  // Wrap in a passthrough Transform so the stall watchdog resets on
+  // *consumption*, not on arrival. In the Twilio path OpenAI may buffer all
+  // PCM quickly, after which no further "readable" events fire while the
+  // caller drains at ~real-time (20 ms/frame). Tracking consumption prevents
+  // premature abort while audio is still being played back.
+  const watchdogTransform = new Transform({
+    transform(chunk, _encoding, callback) {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => controller.abort(), STALL_DEADLINE_MS);
+      callback(null, chunk);
+    },
+  });
+  stream.pipe(watchdogTransform);
+  stream.on("error", (err) => watchdogTransform.destroy(err));
+  watchdogTransform.on("end", cleanup);
+  watchdogTransform.on("error", cleanup);
+
+  return { stream: watchdogTransform, cleanup };
 }
 
 export function inferEdgeExtension(outputFormat: string): string {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -10,6 +10,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
+import type { Readable } from "node:stream";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
@@ -38,6 +39,7 @@ import {
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   openaiTTS,
+  openaiTTSStream,
   parseTtsDirectives,
   scheduleCleanup,
   summarizeText,
@@ -807,6 +809,91 @@ export async function textToSpeechTelephony(params: {
   }
 
   return buildTtsFailureResult(errors);
+}
+
+export type TtsTelephonyStreamResult = {
+  success: boolean;
+  stream?: Readable;
+  sampleRate?: number;
+  provider?: string;
+  error?: string;
+  cleanup?: () => void;
+};
+
+/**
+ * Streaming variant of textToSpeechTelephony.
+ * Returns a Readable stream of raw PCM audio instead of a buffered Buffer.
+ * Only supports OpenAI providers (ElevenLabs/Edge TTS skip for now).
+ */
+export async function textToSpeechTelephonyStream(params: {
+  text: string;
+  cfg: OpenClawConfig;
+  prefsPath?: string;
+}): Promise<TtsTelephonyStreamResult> {
+  const config = resolveTtsConfig(params.cfg);
+  const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
+
+  if (params.text.length > config.maxTextLength) {
+    return {
+      success: false,
+      error: `Text too long (${params.text.length} chars, max ${config.maxTextLength})`,
+    };
+  }
+
+  const userProvider = getTtsProvider(config, prefsPath);
+  const providers = resolveTtsProviderOrder(userProvider);
+
+  const errors: string[] = [];
+
+  // Streaming only supported for OpenAI — if user's primary provider isn't OpenAI,
+  // return failure immediately so the caller falls back to the buffered path
+  // with the correct voice/provider rather than silently switching to OpenAI.
+  if (providers[0] !== "openai") {
+    return {
+      success: false,
+      error: `Primary provider ${providers[0]} does not support streaming`,
+    };
+  }
+
+  for (const provider of providers) {
+    try {
+      if (provider !== "openai") {
+        continue;
+      }
+
+      const apiKey = resolveTtsApiKey(config, provider);
+      if (!apiKey) {
+        errors.push(`${provider}: no API key`);
+        continue;
+      }
+
+      const output = TELEPHONY_OUTPUT.openai;
+      const result = await openaiTTSStream({
+        text: params.text,
+        apiKey,
+        baseUrl: config.openai.baseUrl,
+        model: config.openai.model,
+        voice: config.openai.voice,
+        responseFormat: output.format,
+        timeoutMs: config.timeoutMs,
+      });
+
+      return {
+        success: true,
+        stream: result.stream,
+        sampleRate: output.sampleRate,
+        provider,
+        cleanup: result.cleanup,
+      };
+    } catch (err) {
+      errors.push(formatTtsProviderError(provider, err));
+    }
+  }
+
+  return {
+    success: false,
+    error: `TTS streaming failed: ${errors.join("; ") || "no providers available"}`,
+  };
 }
 
 export async function maybeApplyTtsToPayload(params: {


### PR DESCRIPTION
## Summary

- Problem: Voice calls have high latency between a user finishing speaking and hearing the agent's response. The current flow waits for the LLM to produce the complete response text, then sends the entire text to the TTS provider (OpenAI) as a single request, then waits for the full audio buffer, then sends it all to Twilio. Each step is sequential -- the user hears nothing until every step finishes.
- Why it matters: Conversational voice requires sub-second responsiveness. A 3-5 second gap between the user's question and the agent's first word makes the experience feel broken.
- What changed: Two-stage streaming pipeline that overlaps LLM generation, TTS synthesis, and Twilio playback:
  1. **Sentence-level LLM->TTS pipelining**: A `SentenceStream` class detects sentence boundaries in the LLM's streaming partial replies and yields complete sentences as they appear. Each sentence is sent to TTS independently while the LLM continues generating.
  2. **Per-chunk TTS->Twilio streaming**: OpenAI's TTS API returns audio in chunks. Instead of buffering the entire response, each chunk is forwarded to Twilio's media stream as it arrives, using `telephony-audio.ts` to convert PCM to mulaw and frame it as RTP.
- What did NOT change: The non-streaming `speak()` path for initial messages and fallback. The TTS provider interface (ElevenLabs, etc.) -- streaming is OpenAI-specific for now. The core agent run flow -- `onPartialReply` and `onAssistantMessageStart` are new optional callbacks on the existing `CoreAgentDeps` type.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42159
- Related #31812

## User-visible / Behavior Changes

Voice call responses start playing noticeably faster. The first sentence begins playing while the LLM is still generating subsequent sentences. No config changes required -- streaming is used automatically when the TTS provider is OpenAI and the call is connected via Twilio media stream.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes - TTS requests are now made per-sentence instead of once per full response. Same endpoint, same auth, smaller payloads.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: OpenAI TTS (tts-1 or tts-1-hd)
- Integration/channel: voice-call (Twilio)
- Relevant config: voice-call plugin with OpenAI TTS and Twilio provider

### Steps

1. Start gateway with voice-call plugin configured (Twilio + OpenAI TTS)
2. Call the Twilio phone number
3. Say something and wait for the agent to respond

### Expected

- First sentence of the response plays within ~1s of the LLM starting to generate
- Subsequent sentences play with minimal gaps between them

### Actual (before this PR)

- Entire response plays only after the full LLM response + full TTS audio is buffered (3-5s delay)

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test suites:
- `extensions/voice-call/src/response-generator.test.ts` (195 lines): SentenceStream class -- sentence boundary detection, multi-sentence buffering, finish signal, reset between messages, non-Latin text, edge cases (trailing whitespace, quotes)
- `extensions/voice-call/src/telephony-audio.test.ts` (168 lines): PCM-to-mulaw conversion, RTP framing, streaming audio chunk generation, sample rate handling, empty/short buffer edge cases
- `extensions/voice-call/src/telephony-tts.streaming.test.ts` (130 lines): streamTtsToCall flow -- sentence iteration, TTS chunk forwarding to Twilio, error handling, abort signal, fallback to non-streaming
- `src/tts/tts-core.test.ts` (205 lines): Core TTS streaming interface -- OpenAI streaming response handling, chunk iteration, abort signal, error propagation, non-streaming fallback

## Human Verification (required)

- Verified scenarios: Voice call with multi-sentence response, streaming playback starts on first sentence. Single-sentence responses fall back to non-streaming path correctly.
- Edge cases checked: LLM response with no sentence boundaries (single long sentence -- buffers until finish, then speaks all at once). Multiple rapid sentences. Agent abort mid-stream (abort signal propagated to TTS request). Non-OpenAI TTS providers (fall back to non-streaming `speak()`).
- What I did **not** verify: ElevenLabs streaming (not implemented in this PR -- OpenAI only). Very long responses (>50 sentences). Network interruption mid-stream.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit. The non-streaming `speak()` path remains untouched and will be used automatically.
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Audio glitches between sentences (gap or overlap). Sentences playing out of order. TTS requests failing silently (would cause missing audio segments).

## Risks and Mitigations

- Risk: More TTS API calls (one per sentence instead of one per response)
  - Mitigation: Acceptable tradeoff for latency reduction. Sentences are typically 10-30 words -- well within OpenAI's per-request limits. Total token usage is identical.
- Risk: Audio gaps between sentences
  - Mitigation: The next sentence's TTS request starts as soon as the sentence is detected, while the previous sentence's audio is still playing. Pipeline parallelism minimizes gaps.
- Risk: Partial playback on error (first sentence plays, then silence)
  - Mitigation: Errors in `speakStream` are logged and the call continues. The full text is passed as `fullText` parameter so a fallback `speak()` can be attempted if streaming fails completely.

### Architecture

**Pipeline flow**:

```
LLM streaming -> SentenceStream -> speakStream -> streamTtsToCall -> Twilio WS
                 (detect         (iterate         (OpenAI TTS      (mulaw RTP
                  boundaries)     sentences)       streaming)       frames)
```

**New modules**:

- `src/tts/tts-core.ts`: Core TTS streaming interface. `createTtsStream()` makes an OpenAI TTS request and returns an async iterable of audio `Buffer` chunks. Handles abort signals and content-type validation.
- `src/tts/tts.ts`: Higher-level TTS helpers used by the voice-call plugin. Wraps `tts-core` with config resolution and provider detection.
- `extensions/voice-call/src/telephony-audio.ts`: PCM-to-mulaw conversion and RTP framing for Twilio media streams. Converts 24kHz PCM from OpenAI to 8kHz mulaw with proper RTP headers.
- `extensions/voice-call/src/response-generator.ts`: `SentenceStream` class added. Detects sentence boundaries in cumulative `onPartialReply` text using regex matching on sentence-ending punctuation followed by whitespace and a new word. Handles reset between assistant messages, non-Latin text, and edge cases.

**Integration points**:

- `CoreAgentDeps.runAgent` gains two optional callbacks: `onPartialReply` (streaming text chunks) and `onAssistantMessageStart` (new message boundary). These are wired in `response-generator.ts` to feed the `SentenceStream`.
- `CallManager.speakStream()` iterates the sentence stream, calling `streamTtsToCall()` for each sentence. Falls back to `speak()` if streaming is not available.
- `src/plugins/runtime/types-core.ts`: `PluginTtsProvider` gains an optional `streamAudio` method for providers that support streaming.

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Resubmission of #31812 (closed for clean commit history).