### PR TITLE
docs: add Tengji (George) Zhang to maintainer table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,9 @@ Welcome to the lobster tank! 🦞
 - **Robin Waslander** - Security, PR triage, bug fixes
   - GitHub: [@hydro13](https://github.com/hydro13) · X: [@Robin_waslander](https://x.com/Robin_waslander)
 
+- **Tengji (George) Zhang** - Chinese model APIs, cloud, pi
+  - GitHub: [@odysseus0](https://github.com/odysseus0) · X: [@odysseus0z](https://x.com/odysseus0z)
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!


### PR DESCRIPTION
Add myself to the maintainer list in CONTRIBUTING.md.

Focus: Chinese model providers, cloud & community; pi harness, esp. context/caching.