### PR TITLE
fix(openai-codex): normalize legacy override transport to codex responses

### DIFF
--- a/src/agents/pi-embedded-runner/model.provider-normalization.ts
+++ b/src/agents/pi-embedded-runner/model.provider-normalization.ts
@@ -20,6 +20,14 @@ function isOpenAICodexBaseUrl(baseUrl?: string): boolean {
   return /^https?:\/\/chatgpt\.com\/backend-api\/?$/i.test(trimmed);
 }
 
+function isLegacyCodexCompatBaseUrl(baseUrl?: string): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return /^https?:\/\/api\.githubcopilot\.com\/?$/i.test(trimmed);
+}
+
 function normalizeOpenAICodexTransport(params: {
   provider: string;
   model: Model<Api>;
@@ -31,15 +39,19 @@ function normalizeOpenAICodexTransport(params: {
   const useCodexTransport =
     !params.model.baseUrl ||
     isOpenAIApiBaseUrl(params.model.baseUrl) ||
-    isOpenAICodexBaseUrl(params.model.baseUrl);
+    isOpenAICodexBaseUrl(params.model.baseUrl) ||
+    isLegacyCodexCompatBaseUrl(params.model.baseUrl);
 
   const nextApi =
-    useCodexTransport && params.model.api === "openai-responses"
+    useCodexTransport &&
+    (params.model.api === "openai-responses" || params.model.api === "openai-completions")
       ? ("openai-codex-responses" as const)
       : params.model.api;
   const nextBaseUrl =
     nextApi === "openai-codex-responses" &&
-    (!params.model.baseUrl || isOpenAIApiBaseUrl(params.model.baseUrl))
+    (!params.model.baseUrl ||
+      isOpenAIApiBaseUrl(params.model.baseUrl) ||
+      isLegacyCodexCompatBaseUrl(params.model.baseUrl))
       ? OPENAI_CODEX_BASE_URL
       : params.model.baseUrl;
 

--- a/src/agents/pi-embedded-runner/model.provider-normalization.ts
+++ b/src/agents/pi-embedded-runner/model.provider-normalization.ts
@@ -25,7 +25,7 @@ function isLegacyCodexCompatBaseUrl(baseUrl?: string): boolean {
   if (!trimmed) {
     return false;
   }
-  return /^https?:\/\/api\.githubcopilot\.com\/?$/i.test(trimmed);
+  return /^https?:\/\/api\.githubcopilot\.com(?:\/v1)?\/?$/i.test(trimmed);
 }
 
 function normalizeOpenAICodexTransport(params: {
@@ -42,9 +42,12 @@ function normalizeOpenAICodexTransport(params: {
     isOpenAICodexBaseUrl(params.model.baseUrl) ||
     isLegacyCodexCompatBaseUrl(params.model.baseUrl);
 
+  const shouldPromoteResponses = useCodexTransport && params.model.api === "openai-responses";
+  const shouldPromoteLegacyCompletions =
+    isLegacyCodexCompatBaseUrl(params.model.baseUrl) && params.model.api === "openai-completions";
+
   const nextApi =
-    useCodexTransport &&
-    (params.model.api === "openai-responses" || params.model.api === "openai-completions")
+    shouldPromoteResponses || shouldPromoteLegacyCompletions
       ? ("openai-codex-responses" as const)
       : params.model.api;
   const nextBaseUrl =

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -718,6 +718,60 @@ describe("resolveModel", () => {
     });
   });
 
+  it("normalizes legacy githubcopilot openai-completions override to codex transport", () => {
+    mockOpenAICodexTemplateModel();
+
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://api.githubcopilot.com",
+            api: "openai-completions",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expectResolvedForwardCompatFallback({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      cfg,
+      expectedModel: {
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+        id: "gpt-5.4",
+        provider: "openai-codex",
+      },
+    });
+  });
+
+  it("normalizes legacy githubcopilot /v1 openai-completions override to codex transport", () => {
+    mockOpenAICodexTemplateModel();
+
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://api.githubcopilot.com/v1",
+            api: "openai-completions",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expectResolvedForwardCompatFallback({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      cfg,
+      expectedModel: {
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+        id: "gpt-5.4",
+        provider: "openai-codex",
+      },
+    });
+  });
+
   it("includes auth hint for unknown ollama models (#17328)", () => {
     // resetMockDiscoverModels() in beforeEach already sets find → null
     const result = resolveModel("ollama", "gemma3:4b", "/tmp/agent");


### PR DESCRIPTION
# PR Draft: fix(openai-codex): normalize legacy provider overrides to Codex transport

## Summary
Fixes a regression where explicit `openai-codex` provider overrides using legacy OpenAI-compatible settings (notably `api: openai-completions` + `baseUrl: https://api.githubcopilot.com`) fail at runtime with:

- `Authorization header is badly formatted`

The patch normalizes those legacy override shapes back to Codex-native transport (`openai-codex-responses` + `https://chatgpt.com/backend-api`) for `openai-codex` provider resolution.

---

## User impact
Users with existing/legacy explicit `models.providers.openai-codex` blocks can hit hard failures after upgrading, even though implicit Codex provider behavior still works.

### Immediate workaround (no code change)
Remove the entire `models.providers.openai-codex` override block from `openclaw.json`.

- Do **not** remove only `baseUrl` while keeping the provider block; schema validation rejects that shape.
- After removing the full override block and restarting, OpenClaw uses implicit Codex defaults and the regression path is avoided.

---

## Repro (sanitized)
Using latest image, this fails pre-fix:

1. Configure provider override:
   - `provider: openai-codex`
   - `api: openai-completions`
   - `baseUrl: https://api.githubcopilot.com`
   - model id `gpt-5.3-codex`
2. Run Codex gateway smoke (`openai-codex/gpt-5.3-codex`)
3. Observe: `Authorization header is badly formatted`

Control cases pre-fix:
- No provider override: PASS
- Explicit codex-native override (`openai-codex-responses` + `chatgpt backend`): PASS

---

## Root cause hypothesis
`openai-codex` provider resolution accepts explicit provider overrides and can preserve legacy transport/api shape (`openai-completions`) for Codex models. That bypasses codex-native expectations and leads to malformed auth behavior against Codex endpoint assumptions.

Relevant change window for investigation: `v2026.3.2 -> v2026.3.7` (model/provider resolution refactors + codex/gpt-5.4 support wave).

---

## Patch
File:
- `src/agents/pi-embedded-runner/model.provider-normalization.ts`

Changes:
1. Add `isLegacyCodexCompatBaseUrl()` for `https://api.githubcopilot.com`
2. For provider `openai-codex`, when codex transport applies:
   - normalize `openai-responses` **or** `openai-completions` -> `openai-codex-responses`
3. Normalize base URL to `https://chatgpt.com/backend-api` when source is OpenAI API base or legacy Codex compat base

Patch file attached separately:
- `pr-openai-codex-regression.patch`

---

## Validation performed (test Docker only)
Image used:
- `openclaw:test-latest-2026-3-8-patched`

Matrix after patch:
1. No `openai-codex` override: PASS
2. Legacy override (`api.githubcopilot.com` + `openai-completions`): PASS
3. Explicit codex-native override (`chatgpt backend` + `openai-codex-responses`): PASS

Workaround verification on unpatched latest image:
1. Legacy override (`api.githubcopilot.com` + `openai-completions`): FAIL (`Authorization header is badly formatted`)
2. Remove entire `models.providers.openai-codex` block and restart: PASS

Full smoke suite after patch:
- baseline sync: PASS
- gateway codex oauth smoke: PASS
- codex-usage skill smoke: PASS
- overall: PASS

WHAM probe (sanitized) from test Docker:
- profile A: HTTP 200, allowed=true, limit_reached=false, 5h+weekly windows present
- profile B: HTTP 200, allowed=true, limit_reached=false, 5h+weekly windows present

No tokens or account identifiers included.

---

## Backward compatibility
Safe/compatible:
- Only affects `openai-codex` provider normalization path
- Leaves non-codex providers untouched
- Preserves codex-native explicit configs
- Adds compatibility for legacy codex override configs

---

## Suggested tests to add upstream
1. Unit test: `openai-codex` + `api=openai-completions` + `baseUrl=api.githubcopilot.com` resolves to codex transport/base URL.
2. Unit test: legacy override no longer produces malformed auth header path.
3. Keep existing tests ensuring codex-native explicit override stays codex-native.

---

## Security and privacy
- Report contains no secrets.
- Access/refresh tokens and account IDs omitted/redacted.