### PR TITLE
fix(discord): clarify allowBots bot-message drops

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -2,10 +2,26 @@ import { ChannelType } from "@buape/carbon";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
+const logDebugMock = vi.hoisted(() => vi.fn());
+const logVerboseMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../media-understanding/audio-preflight.js", () => ({
   transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
 }));
+vi.mock("../../globals.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../globals.js")>();
+  return {
+    ...actual,
+    logVerbose: (...args: unknown[]) => logVerboseMock(...args),
+  };
+});
+vi.mock("../../logger.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logger.js")>();
+  return {
+    ...actual,
+    logDebug: (...args: unknown[]) => logDebugMock(...args),
+  };
+});
 import {
   __testing as sessionBindingTesting,
   registerSessionBindingAdapter,
@@ -270,6 +286,8 @@ describe("preflightDiscordMessage", () => {
   beforeEach(() => {
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
     transcribeFirstAudioMock.mockReset();
+    logDebugMock.mockReset();
+    logVerboseMock.mockReset();
   });
 
   it("drops bound-thread bot system messages to prevent ACP self-loop", async () => {
@@ -407,6 +425,36 @@ describe("preflightDiscordMessage", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it("logs a diagnostic hint when bot messages are blocked by allowBots=false", async () => {
+    const channelId = "channel-bot-default-off";
+    const guildId = "guild-bot-default-off";
+    const message = createMessage({
+      id: "m-bot-default-off",
+      channelId,
+      content: "relay chatter",
+      author: {
+        id: "relay-bot-1",
+        bot: true,
+        username: "Relay",
+      },
+    });
+
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {} as DiscordConfig,
+    });
+
+    expect(result).toBeNull();
+    expect(logDebugMock).toHaveBeenCalledWith(
+      "[discord-preflight] drop: bot message blocked (allowBots=false, sender=relay-bot-1)",
+    );
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      'discord: drop bot message (allowBots=false; set channels.discord.allowBots=true or "mentions" to allow bot senders)',
+    );
   });
 
   it("allows bot messages with explicit mention when allowBots=mentions", async () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -187,7 +187,12 @@ export async function preflightDiscordMessage(
 
   if (author.bot) {
     if (allowBotsMode === "off" && !sender.isPluralKit) {
-      logVerbose("discord: drop bot message (allowBots=false)");
+      logDebug(
+        `[discord-preflight] drop: bot message blocked (allowBots=false, sender=${sender.id})`,
+      );
+      logVerbose(
+        'discord: drop bot message (allowBots=false; set channels.discord.allowBots=true or "mentions" to allow bot senders)',
+      );
       return null;
     }
   }


### PR DESCRIPTION
## Summary

- Problem: when `channels.discord.allowBots` is left at its default `false`, bot-authored messages are dropped with only a verbose-only hint, which makes the drop hard to diagnose in normal file-log workflows.
- Why it matters: operators setting up bot-to-bot Discord flows can lose time debugging a silent-looking filter because the runtime behavior is correct but the diagnostic signal is too weak.
- What changed: add a file-logger `debug` line for the `allowBots=false` bot-drop path and upgrade the verbose message so it points directly at `channels.discord.allowBots=true` or `"mentions"`.
- What did NOT change (scope boundary): default `allowBots` behavior is unchanged; bot messages are still blocked unless explicitly allowed.
- AI-assisted: Yes (Codex). I reviewed the code and verification steps before submission.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40267
- Related #

## User-visible / Behavior Changes

- Discord bot-authored messages blocked by the default `channels.discord.allowBots=false` path now emit a `debug` diagnostic entry in file logs.
- The verbose drop message now points directly to `channels.discord.allowBots=true` or `"mentions"` as the configuration fix.
- Runtime filtering behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): default `channels.discord.allowBots=false`

### Steps

1. Receive a bot-authored Discord guild message while `channels.discord.allowBots` is unset / `false`.
2. Observe the preflight result and emitted diagnostics.
3. Compare against adjacent `allowBots=true` / `allowBots="mentions"` behavior.

### Expected

- Bot-authored messages remain blocked by default.
- Operators get a durable diagnostic in file logs and an actionable verbose hint pointing at the relevant config.

### Actual

- The message is still dropped, and the new diagnostics now explain that `allowBots=false` caused the drop and how to allow bot senders.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence summary:
- Added a regression test covering the `allowBots=false` bot-drop diagnostic path in `src/discord/monitor/message-handler.preflight.test.ts`.
- Verified adjacent Discord preflight coverage still passes, including ACP/bound-thread preflight tests.
- New emitted strings under test:
  - `[discord-preflight] drop: bot message blocked (allowBots=false, sender=relay-bot-1)`
  - `discord: drop bot message (allowBots=false; set channels.discord.allowBots=true or "mentions" to allow bot senders)`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: default `allowBots=false` still drops bot-authored guild messages and now emits both the new debug diagnostic and the updated verbose hint.
- Edge cases checked: nearby `allowBots="mentions"` and ACP preflight behavior still pass in targeted tests.
- What you did **not** verify: live Discord gateway behavior against a real bot-to-bot channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / commit.
- Files/config to restore: `src/discord/monitor/message-handler.preflight.ts`, `src/discord/monitor/message-handler.preflight.test.ts`
- Known bad symptoms reviewers should watch for: Discord bot-message drops stop logging the new debug hint or `allowBots=true` / `"mentions"` behavior regresses.

## Risks and Mitigations

- Risk: the extra debug line could add minor file-log noise for operators intentionally blocking bot senders.
  - Mitigation: it only fires on the existing drop path and does not change runtime behavior or message delivery.

