### PR TITLE
Fix sidebar tree collapse not hiding child items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/mobile: allow paired iOS and Android clients to refresh same-family OS metadata on authenticated reconnect instead of requiring a new approval. (#83490) Thanks @ngutman.
 - WhatsApp: treat `upload-file` as a supported media send intent by lowering path/URL uploads through the channel's normal send-media transport. (#81883) Thanks @ngutman.
 - iOS: end Live Activities when OpenClaw is connected, idle, or disconnected, and show compact attention states for approval-required reconnects. (#83597) Thanks @ngutman.
+- Control UI: hide child nav items when collapsing the active sidebar group. Fixes #42167. (#42223) Thanks @Aroool.
 
 ## 2026.5.17
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -276,9 +276,8 @@ export function renderApp(state: AppViewState) {
       <aside class="nav ${state.settings.navCollapsed ? "nav--collapsed" : ""}">
         ${TAB_GROUPS.map((group) => {
           const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-          const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
           return html`
-            <div class="nav-group ${isGroupCollapsed && !hasActiveTab ? "nav-group--collapsed" : ""}">
+            <div class="nav-group ${isGroupCollapsed ? "nav-group--collapsed" : ""}">
               <button
                 class="nav-label"
                 @click=${() => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -136,7 +136,6 @@ import { icons } from "./icons.ts";
 import { createLazyView, renderLazyView } from "./lazy-view.ts";
 import {
   iconForTab,
-  isTabInGroup,
   isSettingsTab,
   normalizeBasePath,
   pathForTab,
@@ -1763,8 +1762,7 @@ export function renderApp(state: AppViewState) {
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-                  const hasActiveTab = isTabInGroup(group, state.tab);
-                  const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
+                  const showItems = navCollapsed || !isGroupCollapsed;
 
                   return html`
                     <section class="nav-section ${!showItems ? "nav-section--collapsed" : ""}">

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -447,6 +447,29 @@ describe("control UI routing", () => {
     expectElement(header, ".nav-collapse-toggle", HTMLElement);
   });
 
+  it("hides child nav items when the active group is collapsed", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    app.applySettings({
+      ...app.settings,
+      navGroupsCollapsed: { ...app.settings.navGroupsCollapsed, chat: true },
+    });
+    await app.updateComplete;
+
+    const chatLink = expectElement(app, 'a.nav-item[href="/chat"]', HTMLAnchorElement);
+    const section = chatLink.closest(".nav-section");
+    expect(section).toBeInstanceOf(HTMLElement);
+    if (!(section instanceof HTMLElement)) {
+      throw new Error("Expected chat link to be inside a nav section");
+    }
+
+    expect([...section.classList]).toContain("nav-section--collapsed");
+    expect(
+      section.querySelector<HTMLButtonElement>(".nav-section__label")?.getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
   it("shows recent sessions in the sidebar and switches through them", async () => {
     const app = mountApp("/overview");
     app.sessionKey = "agent:main:second";


### PR DESCRIPTION
Fixes #42167

The sidebar collapse state (`isGroupCollapsed`) was updating correctly, but the `nav-group--collapsed` class was only applied when the group did not contain the active tab.

Because of this, the collapse indicator updated while the child items remained visible.

This change removes that condition so collapsing a group consistently hides its child items.

Verified locally in Control UI that collapsing a sidebar group now hides its child items correctly, including when the active tab belongs to that group.

## Real behavior proof

- **Behavior or issue addressed:** Collapsing the active Control UI sidebar group should hide its child nav items instead of only rotating the chevron. This verifies the fix for #42167 on rebased head `fab6230a7cc795665627fc4ca0a9c18e03b18707`.
- **Real environment tested:** Blacksmith Testbox through Crabbox, remote OpenClaw checkout on Linux, Testbox `tbx_01krw54we9rnygkdxyx4xaq2vw`, Actions run https://github.com/openclaw/openclaw/actions/runs/26006156907.
- **Exact steps or command run after this patch:** Ran the remote Testbox command `pnpm check:changed && pnpm test ui/src/ui/navigation.browser.test.ts -- --reporter=verbose`.
- **Evidence after fix:** Terminal output excerpt from the remote Testbox run:

```text
[check:changed] ui/src/ui/app-render.ts: core production
[check:changed] ui/src/ui/navigation.browser.test.ts: core test
Found 0 warnings and 0 errors.
✓ ui/src/ui/navigation.browser.test.ts > control UI routing > hides child nav items when the active group is collapsed
Test Files 1 passed (1)
Tests 14 passed (14)
blacksmith run summary provider=blacksmith-testbox leaseId=tbx_01krw54we9rnygkdxyx4xaq2vw exitCode=0
```

- **Observed result after fix:** The active `chat` sidebar group receives `nav-section--collapsed` when `navGroupsCollapsed.chat` is true, and the section label reports `aria-expanded="false"`; the full navigation browser test file passed remotely.
- **What was not tested:** No additional gaps. This proof used the remote browser test harness rather than a manual screenshot.
