### PR TITLE
fix(discord): fail fast when bot identity cannot be resolved

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -436,6 +436,51 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
   });
 
+  it("drops unmentioned guild messages when mention regexes are available even without botUserId", async () => {
+    const channelId = "channel-require-mention-no-bot-id";
+    const guildId = "guild-require-mention-no-bot-id";
+    const client = createGuildTextClient(channelId);
+    const message = createMessage({
+      id: "m-require-mention-no-bot-id",
+      channelId,
+      content: "hello there",
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: {
+          ...DEFAULT_CFG,
+          messages: {
+            groupChat: {
+              mentionPatterns: ["openclaw"],
+            },
+          },
+        } as import("../../config/config.js").OpenClawConfig,
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client,
+      }),
+      botUserId: undefined,
+      guildEntries: {
+        [guildId]: {
+          requireMention: true,
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("drops guild messages that mention another user when ignoreOtherMentions=true", async () => {
     const channelId = "channel-other-mention-1";
     const guildId = "guild-other-mention-1";

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -683,9 +683,9 @@ export async function preflightDiscordMessage(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} baseRequireMention=${shouldRequireMentionByConfig} boundThreadSession=${isBoundThreadSession} mentionGate.shouldSkip=${mentionGate.shouldSkip} wasMentioned=${wasMentioned}`,
   );
   if (isGuildMessage && shouldRequireMention) {
-    if (botId && mentionGate.shouldSkip) {
+    if (mentionGate.shouldSkip) {
       logDebug(`[discord-preflight] drop: no-mention`);
-      logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
+      logVerbose(`discord: drop guild message (mention required, botId=${botId ?? "unknown"})`);
       logger.info(
         {
           channelId: messageChannelId,

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -410,6 +410,50 @@ describe("monitorDiscordProvider", () => {
     expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects startup when fetching the bot identity fails", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const runtime = baseRuntime();
+    clientFetchUserMock.mockRejectedValue(new Error("whoami boom"));
+
+    await expect(
+      monitorDiscordProvider({
+        config: baseConfig(),
+        runtime,
+      }),
+    ).rejects.toThrow("whoami boom");
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("discord: failed to fetch bot identity for account default"),
+    );
+    expect(createDiscordMessageHandlerMock).not.toHaveBeenCalled();
+    expect(monitorLifecycleMock).not.toHaveBeenCalled();
+    expect(createdBindingManagers).toHaveLength(1);
+    expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects startup when the bot identity is missing an id", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const runtime = baseRuntime();
+    clientFetchUserMock.mockResolvedValue({ username: "OpenClaw" });
+
+    await expect(
+      monitorDiscordProvider({
+        config: baseConfig(),
+        runtime,
+      }),
+    ).rejects.toThrow('fetchUser("@me") returned no bot user id');
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'discord: failed to resolve bot identity for account default: fetchUser("@me") returned no bot user id',
+      ),
+    );
+    expect(createDiscordMessageHandlerMock).not.toHaveBeenCalled();
+    expect(monitorLifecycleMock).not.toHaveBeenCalled();
+    expect(createdBindingManagers).toHaveLength(1);
+    expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
   it("does not double-stop thread bindings when lifecycle performs cleanup", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -653,12 +653,26 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       });
     }
 
+    let botUser: Awaited<ReturnType<Client["fetchUser"]>>;
     try {
-      const botUser = await client.fetchUser("@me");
-      botUserId = botUser?.id;
-      botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
+      botUser = await client.fetchUser("@me");
     } catch (err) {
-      runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
+      runtime.error?.(
+        danger(
+          `discord: failed to fetch bot identity for account ${account.accountId}: ${formatErrorMessage(err)}`,
+        ),
+      );
+      throw err;
+    }
+
+    botUserId = typeof botUser?.id === "string" ? botUser.id.trim() || undefined : undefined;
+    botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
+    if (!botUserId) {
+      const error = new Error(
+        `discord: failed to resolve bot identity for account ${account.accountId}: fetchUser("@me") returned no bot user id`,
+      );
+      runtime.error?.(danger(error.message));
+      throw error;
     }
 
     if (voiceEnabled) {


### PR DESCRIPTION
## Summary
- fail Discord monitor startup fast when `fetchUser("@me")` fails or returns no bot user id
- keep guild mention gating active even if `botUserId` is unexpectedly missing
- add regression tests for startup rejection and defense-in-depth mention gating

## Testing
- env -i PATH=/Users/rnrnstar/.nvm/versions/node/v22.20.0/bin:/usr/bin:/bin:/opt/homebrew/bin HOME=/Users/rnrnstar TERM=xterm-256color node ./node_modules/vitest/vitest.mjs run --config vitest.config.ts src/discord/monitor/provider.test.ts src/discord/monitor/message-handler.preflight.test.ts