### PR TITLE
fix(telegram): chunk long html outbound messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/direct delivery: bridge direct delivery sends to internal `message:sent` hooks so internal hook listeners observe successful Telegram deliveries. (#40185) Thanks @vincentkoc.
 - Plugins/global hook runner: harden singleton state handling so shared global hook runner reuse does not leak or corrupt runner state across executions. (#40184) Thanks @vincentkoc.
 - Agents/fallback: recognize Poe `402 You've used up your points!` billing errors so configured model fallbacks trigger instead of surfacing the raw provider error. (#42278) Thanks @CryUshio.
+- Telegram/outbound HTML sends: chunk long HTML-mode messages, preserve plain-text fallback and silent-delivery params across retries, and cut over to plain text when HTML chunk planning cannot safely preserve the full message. (#42240) thanks @obviyus.
 
 ## 2026.3.8
 

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramHtml } from "./format.js";
+import { markdownToTelegramHtml, splitTelegramHtmlChunks } from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {
@@ -111,5 +111,13 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("||secret|| trailing ||");
     expect(res).toContain("<tg-spoiler>secret</tg-spoiler>");
     expect(res).toContain("trailing ||");
+  });
+
+  it("splits long html text without breaking balanced tags", () => {
+    const chunks = splitTelegramHtmlChunks(`<b>${"A".repeat(5000)}</b>`, 4000);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
+    expect(chunks[0]).toMatch(/^<b>.*<\/b>$/);
+    expect(chunks[1]).toMatch(/^<b>.*<\/b>$/);
   });
 });

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -113,11 +113,19 @@ describe("markdownToTelegramHtml", () => {
     expect(res).toContain("trailing ||");
   });
 
-  it("splits long html text without breaking balanced tags", () => {
-    const chunks = splitTelegramHtmlChunks(`<b>${"A".repeat(5000)}</b>`, 4000);
+  it("splits long multiline html text without breaking balanced tags", () => {
+    const chunks = splitTelegramHtmlChunks(`<b>${"A\n".repeat(2500)}</b>`, 4000);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
-    expect(chunks[0]).toMatch(/^<b>.*<\/b>$/);
-    expect(chunks[1]).toMatch(/^<b>.*<\/b>$/);
+    expect(chunks[0]).toMatch(/^<b>[\s\S]*<\/b>$/);
+    expect(chunks[1]).toMatch(/^<b>[\s\S]*<\/b>$/);
+  });
+
+  it("fails loudly when a leading entity cannot fit inside a chunk", () => {
+    expect(() => splitTelegramHtmlChunks(`A&amp;${"B".repeat(20)}`, 4)).toThrow(/leading entity/i);
+  });
+
+  it("fails loudly when tag overhead leaves no room for text", () => {
+    expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
   });
 });

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -125,6 +125,12 @@ describe("markdownToTelegramHtml", () => {
     expect(() => splitTelegramHtmlChunks(`A&amp;${"B".repeat(20)}`, 4)).toThrow(/leading entity/i);
   });
 
+  it("treats malformed leading ampersands as plain text when chunking html", () => {
+    const chunks = splitTelegramHtmlChunks(`&${"A".repeat(5000)}`, 4000);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
+  });
+
   it("fails loudly when tag overhead leaves no room for text", () => {
     expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
   });

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -241,6 +241,158 @@ export function renderTelegramHtmlText(
   return markdownToTelegramHtml(text, { tableMode: options.tableMode });
 }
 
+type TelegramHtmlTag = {
+  name: string;
+  openTag: string;
+  closeTag: string;
+};
+
+const TELEGRAM_SELF_CLOSING_HTML_TAGS = new Set(["br"]);
+
+function buildTelegramHtmlOpenPrefix(tags: TelegramHtmlTag[]): string {
+  return tags.map((tag) => tag.openTag).join("");
+}
+
+function buildTelegramHtmlCloseSuffix(tags: TelegramHtmlTag[]): string {
+  return tags
+    .slice()
+    .toReversed()
+    .map((tag) => tag.closeTag)
+    .join("");
+}
+
+function buildTelegramHtmlCloseSuffixLength(tags: TelegramHtmlTag[]): number {
+  return tags.reduce((total, tag) => total + tag.closeTag.length, 0);
+}
+
+function findTelegramHtmlSafeSplitIndex(text: string, maxLength: number): number {
+  if (text.length <= maxLength) {
+    return text.length;
+  }
+  const normalizedMaxLength = Math.max(1, Math.floor(maxLength));
+  let splitAt = normalizedMaxLength;
+  const lastAmpersand = text.lastIndexOf("&", normalizedMaxLength - 1);
+  const lastSemicolon = text.lastIndexOf(";", normalizedMaxLength - 1);
+  if (lastAmpersand > lastSemicolon) {
+    splitAt = lastAmpersand;
+  }
+  return splitAt > 0 ? splitAt : normalizedMaxLength;
+}
+
+function popTelegramHtmlTag(tags: TelegramHtmlTag[], name: string): void {
+  for (let index = tags.length - 1; index >= 0; index -= 1) {
+    if (tags[index]?.name === name) {
+      tags.splice(index, 1);
+      return;
+    }
+  }
+}
+
+export function splitTelegramHtmlChunks(html: string, limit: number): string[] {
+  if (!html) {
+    return [];
+  }
+  const normalizedLimit = Math.max(1, Math.floor(limit));
+  if (html.length <= normalizedLimit) {
+    return [html];
+  }
+
+  const chunks: string[] = [];
+  const openTags: TelegramHtmlTag[] = [];
+  let current = "";
+  let chunkHasContent = false;
+
+  const resetCurrent = () => {
+    current = buildTelegramHtmlOpenPrefix(openTags);
+    chunkHasContent = false;
+  };
+
+  const flushCurrent = () => {
+    if (!chunkHasContent) {
+      return;
+    }
+    chunks.push(`${current}${buildTelegramHtmlCloseSuffix(openTags)}`);
+    resetCurrent();
+  };
+
+  const appendText = (segment: string) => {
+    let remaining = segment;
+    while (remaining.length > 0) {
+      const available =
+        normalizedLimit - current.length - buildTelegramHtmlCloseSuffixLength(openTags);
+      if (available <= 0) {
+        const prefix = buildTelegramHtmlOpenPrefix(openTags);
+        if (!chunkHasContent && current === prefix) {
+          current += remaining;
+          chunkHasContent = true;
+          remaining = "";
+          break;
+        }
+        flushCurrent();
+        continue;
+      }
+      if (remaining.length <= available) {
+        current += remaining;
+        chunkHasContent = true;
+        break;
+      }
+      const splitAt = findTelegramHtmlSafeSplitIndex(remaining, available);
+      current += remaining.slice(0, splitAt);
+      chunkHasContent = true;
+      remaining = remaining.slice(splitAt);
+      flushCurrent();
+    }
+  };
+
+  resetCurrent();
+  HTML_TAG_PATTERN.lastIndex = 0;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_PATTERN.exec(html)) !== null) {
+    const tagStart = match.index;
+    const tagEnd = HTML_TAG_PATTERN.lastIndex;
+    appendText(html.slice(lastIndex, tagStart));
+
+    const rawTag = match[0];
+    const isClosing = match[1] === "</";
+    const tagName = match[2].toLowerCase();
+    const isSelfClosing =
+      !isClosing &&
+      (TELEGRAM_SELF_CLOSING_HTML_TAGS.has(tagName) || rawTag.trimEnd().endsWith("/>"));
+
+    if (!isClosing) {
+      const nextCloseLength = isSelfClosing ? 0 : `</${tagName}>`.length;
+      if (
+        chunkHasContent &&
+        current.length +
+          rawTag.length +
+          buildTelegramHtmlCloseSuffixLength(openTags) +
+          nextCloseLength >
+          normalizedLimit
+      ) {
+        flushCurrent();
+      }
+    }
+
+    current += rawTag;
+    chunkHasContent = true;
+    if (isClosing) {
+      popTelegramHtmlTag(openTags, tagName);
+    } else if (!isSelfClosing) {
+      openTags.push({
+        name: tagName,
+        openTag: rawTag,
+        closeTag: `</${tagName}>`,
+      });
+    }
+    lastIndex = tagEnd;
+  }
+
+  appendText(html.slice(lastIndex));
+  flushCurrent();
+  return chunks.length > 0 ? chunks : [html];
+}
+
 function splitTelegramChunkByHtmlLimit(
   chunk: MarkdownIR,
   htmlLimit: number,

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -265,6 +265,50 @@ function buildTelegramHtmlCloseSuffixLength(tags: TelegramHtmlTag[]): number {
   return tags.reduce((total, tag) => total + tag.closeTag.length, 0);
 }
 
+function findTelegramHtmlEntityEnd(text: string, start: number): number {
+  if (text[start] !== "&") {
+    return -1;
+  }
+  let index = start + 1;
+  if (index >= text.length) {
+    return -1;
+  }
+  if (text[index] === "#") {
+    index += 1;
+    if (index >= text.length) {
+      return -1;
+    }
+    const isHex = text[index] === "x" || text[index] === "X";
+    if (isHex) {
+      index += 1;
+      const hexStart = index;
+      while (/[0-9A-Fa-f]/.test(text[index] ?? "")) {
+        index += 1;
+      }
+      if (index === hexStart) {
+        return -1;
+      }
+    } else {
+      const digitStart = index;
+      while (/[0-9]/.test(text[index] ?? "")) {
+        index += 1;
+      }
+      if (index === digitStart) {
+        return -1;
+      }
+    }
+  } else {
+    const nameStart = index;
+    while (/[A-Za-z0-9]/.test(text[index] ?? "")) {
+      index += 1;
+    }
+    if (index === nameStart) {
+      return -1;
+    }
+  }
+  return text[index] === ";" ? index : -1;
+}
+
 function findTelegramHtmlSafeSplitIndex(text: string, maxLength: number): number {
   if (text.length <= maxLength) {
     return text.length;
@@ -276,6 +320,10 @@ function findTelegramHtmlSafeSplitIndex(text: string, maxLength: number): number
   }
   const lastSemicolon = text.lastIndexOf(";", normalizedMaxLength - 1);
   if (lastAmpersand < lastSemicolon) {
+    return normalizedMaxLength;
+  }
+  const entityEnd = findTelegramHtmlEntityEnd(text, lastAmpersand);
+  if (entityEnd === -1 || entityEnd < normalizedMaxLength) {
     return normalizedMaxLength;
   }
   return lastAmpersand;

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -270,13 +270,15 @@ function findTelegramHtmlSafeSplitIndex(text: string, maxLength: number): number
     return text.length;
   }
   const normalizedMaxLength = Math.max(1, Math.floor(maxLength));
-  let splitAt = normalizedMaxLength;
   const lastAmpersand = text.lastIndexOf("&", normalizedMaxLength - 1);
-  const lastSemicolon = text.lastIndexOf(";", normalizedMaxLength - 1);
-  if (lastAmpersand > lastSemicolon) {
-    splitAt = lastAmpersand;
+  if (lastAmpersand === -1) {
+    return normalizedMaxLength;
   }
-  return splitAt > 0 ? splitAt : normalizedMaxLength;
+  const lastSemicolon = text.lastIndexOf(";", normalizedMaxLength - 1);
+  if (lastAmpersand < lastSemicolon) {
+    return normalizedMaxLength;
+  }
+  return lastAmpersand;
 }
 
 function popTelegramHtmlTag(tags: TelegramHtmlTag[], name: string): void {
@@ -300,15 +302,15 @@ export function splitTelegramHtmlChunks(html: string, limit: number): string[] {
   const chunks: string[] = [];
   const openTags: TelegramHtmlTag[] = [];
   let current = "";
-  let chunkHasContent = false;
+  let chunkHasPayload = false;
 
   const resetCurrent = () => {
     current = buildTelegramHtmlOpenPrefix(openTags);
-    chunkHasContent = false;
+    chunkHasPayload = false;
   };
 
   const flushCurrent = () => {
-    if (!chunkHasContent) {
+    if (!chunkHasPayload) {
       return;
     }
     chunks.push(`${current}${buildTelegramHtmlCloseSuffix(openTags)}`);
@@ -321,24 +323,31 @@ export function splitTelegramHtmlChunks(html: string, limit: number): string[] {
       const available =
         normalizedLimit - current.length - buildTelegramHtmlCloseSuffixLength(openTags);
       if (available <= 0) {
-        const prefix = buildTelegramHtmlOpenPrefix(openTags);
-        if (!chunkHasContent && current === prefix) {
-          current += remaining;
-          chunkHasContent = true;
-          remaining = "";
-          break;
+        if (!chunkHasPayload) {
+          throw new Error(
+            `Telegram HTML chunk limit exceeded by tag overhead (limit=${normalizedLimit})`,
+          );
         }
         flushCurrent();
         continue;
       }
       if (remaining.length <= available) {
         current += remaining;
-        chunkHasContent = true;
+        chunkHasPayload = true;
         break;
       }
       const splitAt = findTelegramHtmlSafeSplitIndex(remaining, available);
+      if (splitAt <= 0) {
+        if (!chunkHasPayload) {
+          throw new Error(
+            `Telegram HTML chunk limit exceeded by leading entity (limit=${normalizedLimit})`,
+          );
+        }
+        flushCurrent();
+        continue;
+      }
       current += remaining.slice(0, splitAt);
-      chunkHasContent = true;
+      chunkHasPayload = true;
       remaining = remaining.slice(splitAt);
       flushCurrent();
     }
@@ -363,7 +372,7 @@ export function splitTelegramHtmlChunks(html: string, limit: number): string[] {
     if (!isClosing) {
       const nextCloseLength = isSelfClosing ? 0 : `</${tagName}>`.length;
       if (
-        chunkHasContent &&
+        chunkHasPayload &&
         current.length +
           rawTag.length +
           buildTelegramHtmlCloseSuffixLength(openTags) +
@@ -375,7 +384,9 @@ export function splitTelegramHtmlChunks(html: string, limit: number): string[] {
     }
 
     current += rawTag;
-    chunkHasContent = true;
+    if (isSelfClosing) {
+      chunkHasPayload = true;
+    }
     if (isClosing) {
       popTelegramHtmlTag(openTags, tagName);
     } else if (!isSelfClosing) {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1257,6 +1257,37 @@ describe("sendMessageTelegram", () => {
       expect.objectContaining({ maxBytes: 42 * 1024 * 1024 }),
     );
   });
+
+  it("chunks long html-mode text and keeps buttons on the last chunk only", async () => {
+    const chatId = "123";
+    const htmlText = `<b>${"A".repeat(5000)}</b>`;
+
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 90, chat: { id: chatId } })
+      .mockResolvedValueOnce({ message_id: 91, chat: { id: chatId } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    const res = await sendMessageTelegram(chatId, htmlText, {
+      token: "tok",
+      api,
+      textMode: "html",
+      buttons: [[{ text: "OK", callback_data: "ok" }]],
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    const firstCall = sendMessage.mock.calls[0];
+    const secondCall = sendMessage.mock.calls[1];
+    expect(firstCall).toBeDefined();
+    expect(secondCall).toBeDefined();
+    expect((firstCall[1] as string).length).toBeLessThanOrEqual(4000);
+    expect((secondCall[1] as string).length).toBeLessThanOrEqual(4000);
+    expect(firstCall[2]?.reply_markup).toBeUndefined();
+    expect(secondCall[2]?.reply_markup).toEqual({
+      inline_keyboard: [[{ text: "OK", callback_data: "ok" }]],
+    });
+    expect(res.messageId).toBe("91");
+  });
 });
 
 describe("reactMessageTelegram", () => {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1347,6 +1347,30 @@ describe("sendMessageTelegram", () => {
     expect(plainFallbackCalls.every((call) => String(call?.[1] ?? "").length > 0)).toBe(true);
     expect(res.messageId).toBe("93");
   });
+
+  it("cuts over to plain text when fallback text needs more chunks than html", async () => {
+    const chatId = "123";
+    const htmlText = `<b>${"A".repeat(5000)}</b>`;
+    const plainText = "P".repeat(9000);
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 94, chat: { id: chatId } })
+      .mockResolvedValueOnce({ message_id: 95, chat: { id: chatId } })
+      .mockResolvedValueOnce({ message_id: 96, chat: { id: chatId } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    const res = await sendMessageTelegram(chatId, htmlText, {
+      token: "tok",
+      api,
+      textMode: "html",
+      plainText,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(sendMessage.mock.calls.every((call) => call[2]?.parse_mode === undefined)).toBe(true);
+    expect(sendMessage.mock.calls.map((call) => String(call[1] ?? "")).join("")).toBe(plainText);
+    expect(res.messageId).toBe("96");
+  });
 });
 
 describe("reactMessageTelegram", () => {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1135,6 +1135,31 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("keeps disable_notification on plain-text fallback when silent is true", async () => {
+    const chatId = "123";
+    const parseErr = new Error(
+      "400: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 9",
+    );
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(parseErr)
+      .mockResolvedValueOnce({ message_id: 2, chat: { id: chatId } });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "_oops_", {
+      token: "tok",
+      api,
+      silent: true,
+    });
+
+    expect(sendMessage.mock.calls).toEqual([
+      [chatId, "<i>oops</i>", { parse_mode: "HTML", disable_notification: true }],
+      [chatId, "_oops_", { disable_notification: true }],
+    ]);
+  });
+
   it("parses message_thread_id from recipient string (telegram:group:...:topic:...)", async () => {
     const chatId = "-1001234567890";
     const sendMessage = vi.fn().mockResolvedValue({

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1288,6 +1288,35 @@ describe("sendMessageTelegram", () => {
     });
     expect(res.messageId).toBe("91");
   });
+
+  it("preserves caller plain-text fallback across chunked html parse retries", async () => {
+    const chatId = "123";
+    const htmlText = `<b>${"A".repeat(5000)}</b>`;
+    const plainText = `${"P".repeat(2500)}${"Q".repeat(2500)}`;
+    const parseErr = new Error(
+      "400: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 9",
+    );
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(parseErr)
+      .mockResolvedValueOnce({ message_id: 90, chat: { id: chatId } })
+      .mockRejectedValueOnce(parseErr)
+      .mockResolvedValueOnce({ message_id: 91, chat: { id: chatId } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    const res = await sendMessageTelegram(chatId, htmlText, {
+      token: "tok",
+      api,
+      textMode: "html",
+      plainText,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(4);
+    const plainFallbackCalls = [sendMessage.mock.calls[1], sendMessage.mock.calls[3]];
+    expect(plainFallbackCalls.map((call) => String(call?.[1] ?? "")).join("")).toBe(plainText);
+    expect(plainFallbackCalls.every((call) => !String(call?.[1] ?? "").includes("<"))).toBe(true);
+    expect(res.messageId).toBe("91");
+  });
 });
 
 describe("reactMessageTelegram", () => {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1317,6 +1317,36 @@ describe("sendMessageTelegram", () => {
     expect(plainFallbackCalls.every((call) => !String(call?.[1] ?? "").includes("<"))).toBe(true);
     expect(res.messageId).toBe("91");
   });
+
+  it("keeps malformed leading ampersands on the chunked plain-text fallback path", async () => {
+    const chatId = "123";
+    const htmlText = `&${"A".repeat(5000)}`;
+    const plainText = "fallback!!";
+    const parseErr = new Error(
+      "400: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 0",
+    );
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(parseErr)
+      .mockResolvedValueOnce({ message_id: 92, chat: { id: chatId } })
+      .mockRejectedValueOnce(parseErr)
+      .mockResolvedValueOnce({ message_id: 93, chat: { id: chatId } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    const res = await sendMessageTelegram(chatId, htmlText, {
+      token: "tok",
+      api,
+      textMode: "html",
+      plainText,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(4);
+    expect(String(sendMessage.mock.calls[0]?.[1] ?? "")).toMatch(/^&/);
+    const plainFallbackCalls = [sendMessage.mock.calls[1], sendMessage.mock.calls[3]];
+    expect(plainFallbackCalls.map((call) => String(call?.[1] ?? "")).join("")).toBe(plainText);
+    expect(plainFallbackCalls.every((call) => String(call?.[1] ?? "").length > 0)).toBe(true);
+    expect(res.messageId).toBe("93");
+  });
 });
 
 describe("reactMessageTelegram", () => {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -108,24 +108,30 @@ function resolveTelegramMessageIdOrThrow(
   throw new Error(`Telegram ${context} returned no message_id`);
 }
 
+function splitTelegramPlainTextChunks(text: string, limit: number): string[] {
+  if (!text) {
+    return [];
+  }
+  const normalizedLimit = Math.max(1, Math.floor(limit));
+  const chunks: string[] = [];
+  for (let start = 0; start < text.length; start += normalizedLimit) {
+    chunks.push(text.slice(start, start + normalizedLimit));
+  }
+  return chunks;
+}
+
 function splitTelegramPlainTextFallback(text: string, chunkCount: number, limit: number): string[] {
   if (!text) {
     return [];
   }
   const normalizedLimit = Math.max(1, Math.floor(limit));
-  if (chunkCount <= 1 || text.length <= normalizedLimit) {
-    return [text];
-  }
-  if (text.length > chunkCount * normalizedLimit) {
-    const chunks: string[] = [];
-    for (let start = 0; start < text.length; start += normalizedLimit) {
-      chunks.push(text.slice(start, start + normalizedLimit));
-    }
-    return chunks;
+  const fixedChunks = splitTelegramPlainTextChunks(text, normalizedLimit);
+  if (chunkCount <= 1 || fixedChunks.length >= chunkCount) {
+    return fixedChunks;
   }
   const chunks: string[] = [];
   let offset = 0;
-  for (let index = 0; index < chunkCount && offset < text.length; index += 1) {
+  for (let index = 0; index < chunkCount; index += 1) {
     const remainingChars = text.length - offset;
     const remainingChunks = chunkCount - index;
     const nextChunkLength =
@@ -686,14 +692,65 @@ export async function sendMessageTelegram(
         }
       : undefined;
 
+  const sendPlainChunkedText = async (
+    plainText: string,
+    context: string,
+  ): Promise<{ messageId: string; chatId: string }> => {
+    const chunks = splitTelegramPlainTextChunks(plainText, 4000);
+    let lastMessageId = "";
+    let lastChatId = chatId;
+    for (let index = 0; index < chunks.length; index += 1) {
+      const chunk = chunks[index];
+      if (!chunk) {
+        continue;
+      }
+      const res = await withTelegramThreadFallback(
+        buildTextParams(index === chunks.length - 1),
+        "message",
+        opts.verbose,
+        async (effectiveParams, label) => {
+          const params = effectiveParams ? { ...effectiveParams } : {};
+          if (linkPreviewOptions) {
+            params.link_preview_options = linkPreviewOptions;
+          }
+          const hasParams = Object.keys(params).length > 0;
+          return await requestWithChatNotFound(
+            () =>
+              hasParams
+                ? api.sendMessage(chatId, chunk, params as Parameters<typeof api.sendMessage>[2])
+                : api.sendMessage(chatId, chunk),
+            label,
+          );
+        },
+      );
+      const messageId = resolveTelegramMessageIdOrThrow(res, context);
+      recordSentMessage(chatId, messageId);
+      lastMessageId = String(messageId);
+      lastChatId = String(res?.chat?.id ?? chatId);
+    }
+    return { messageId: lastMessageId, chatId: lastChatId };
+  };
+
   const sendChunkedText = async (
     rawText: string,
     context: string,
   ): Promise<{ messageId: string; chatId: string }> => {
-    const htmlChunks = splitTelegramHtmlChunks(rawText, 4000);
-    const plainTextChunks = opts.plainText
-      ? splitTelegramPlainTextFallback(opts.plainText, htmlChunks.length, 4000)
-      : [];
+    let htmlChunks: string[];
+    try {
+      htmlChunks = splitTelegramHtmlChunks(rawText, 4000);
+    } catch (error) {
+      logVerbose(
+        `telegram ${context} failed HTML chunk planning, retrying as plain text: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+      return await sendPlainChunkedText(opts.plainText ?? rawText, context);
+    }
+    const plainTextChunks = splitTelegramPlainTextFallback(
+      opts.plainText ?? rawText,
+      htmlChunks.length,
+      4000,
+    );
     const chunks = htmlChunks.map((chunk, index) => ({
       rawText: chunk,
       htmlText: chunk,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -632,27 +632,48 @@ export async function sendMessageTelegram(
   const linkPreviewEnabled = account.config.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
 
-  const sendTelegramText = async (
-    rawText: string,
+  type TelegramTextChunk = {
+    plainText: string;
+    htmlText?: string;
+  };
+
+  const sendTelegramTextChunk = async (
+    chunk: TelegramTextChunk,
     params?: Record<string, unknown>,
-    fallbackText?: string,
-    preRenderedHtml?: string,
   ) => {
     return await withTelegramThreadFallback(
       params,
       "message",
       opts.verbose,
       async (effectiveParams, label) => {
-        const htmlText = preRenderedHtml ?? renderHtmlText(rawText);
         const baseParams = effectiveParams ? { ...effectiveParams } : {};
         if (linkPreviewOptions) {
           baseParams.link_preview_options = linkPreviewOptions;
         }
-        const hasBaseParams = Object.keys(baseParams).length > 0;
-        const sendParams = {
-          parse_mode: "HTML" as const,
+        const plainParams = {
           ...baseParams,
           ...(opts.silent === true ? { disable_notification: true } : {}),
+        };
+        const hasPlainParams = Object.keys(plainParams).length > 0;
+        const requestPlain = (retryLabel: string) =>
+          requestWithChatNotFound(
+            () =>
+              hasPlainParams
+                ? api.sendMessage(
+                    chatId,
+                    chunk.plainText,
+                    plainParams as Parameters<typeof api.sendMessage>[2],
+                  )
+                : api.sendMessage(chatId, chunk.plainText),
+            retryLabel,
+          );
+        if (!chunk.htmlText) {
+          return await requestPlain(label);
+        }
+        const htmlText = chunk.htmlText;
+        const htmlParams = {
+          parse_mode: "HTML" as const,
+          ...plainParams,
         };
         return await withTelegramHtmlParseFallback({
           label,
@@ -663,22 +684,11 @@ export async function sendMessageTelegram(
                 api.sendMessage(
                   chatId,
                   htmlText,
-                  sendParams as Parameters<typeof api.sendMessage>[2],
+                  htmlParams as Parameters<typeof api.sendMessage>[2],
                 ),
               retryLabel,
             ),
-          requestPlain: (retryLabel) => {
-            const plainParams = hasBaseParams
-              ? (baseParams as Parameters<typeof api.sendMessage>[2])
-              : undefined;
-            return requestWithChatNotFound(
-              () =>
-                plainParams
-                  ? api.sendMessage(chatId, fallbackText ?? rawText, plainParams)
-                  : api.sendMessage(chatId, fallbackText ?? rawText),
-              retryLabel,
-            );
-          },
+          requestPlain,
         });
       },
     );
@@ -692,11 +702,10 @@ export async function sendMessageTelegram(
         }
       : undefined;
 
-  const sendPlainChunkedText = async (
-    plainText: string,
+  const sendTelegramTextChunks = async (
+    chunks: TelegramTextChunk[],
     context: string,
   ): Promise<{ messageId: string; chatId: string }> => {
-    const chunks = splitTelegramPlainTextChunks(plainText, 4000);
     let lastMessageId = "";
     let lastChatId = chatId;
     for (let index = 0; index < chunks.length; index += 1) {
@@ -704,25 +713,7 @@ export async function sendMessageTelegram(
       if (!chunk) {
         continue;
       }
-      const res = await withTelegramThreadFallback(
-        buildTextParams(index === chunks.length - 1),
-        "message",
-        opts.verbose,
-        async (effectiveParams, label) => {
-          const params = effectiveParams ? { ...effectiveParams } : {};
-          if (linkPreviewOptions) {
-            params.link_preview_options = linkPreviewOptions;
-          }
-          const hasParams = Object.keys(params).length > 0;
-          return await requestWithChatNotFound(
-            () =>
-              hasParams
-                ? api.sendMessage(chatId, chunk, params as Parameters<typeof api.sendMessage>[2])
-                : api.sendMessage(chatId, chunk),
-            label,
-          );
-        },
-      );
+      const res = await sendTelegramTextChunk(chunk, buildTextParams(index === chunks.length - 1));
       const messageId = resolveTelegramMessageIdOrThrow(res, context);
       recordSentMessage(chatId, messageId);
       lastMessageId = String(messageId);
@@ -731,10 +722,7 @@ export async function sendMessageTelegram(
     return { messageId: lastMessageId, chatId: lastChatId };
   };
 
-  const sendChunkedText = async (
-    rawText: string,
-    context: string,
-  ): Promise<{ messageId: string; chatId: string }> => {
+  const buildChunkedTextPlan = (rawText: string, context: string): TelegramTextChunk[] => {
     const fallbackText = opts.plainText ?? rawText;
     let htmlChunks: string[];
     try {
@@ -745,44 +733,24 @@ export async function sendMessageTelegram(
           error,
         )}`,
       );
-      return await sendPlainChunkedText(fallbackText, context);
+      return splitTelegramPlainTextChunks(fallbackText, 4000).map((plainText) => ({ plainText }));
     }
     const fixedPlainTextChunks = splitTelegramPlainTextChunks(fallbackText, 4000);
     if (fixedPlainTextChunks.length > htmlChunks.length) {
       logVerbose(
         `telegram ${context} plain-text fallback needs more chunks than HTML; sending plain text`,
       );
-      return await sendPlainChunkedText(fallbackText, context);
+      return fixedPlainTextChunks.map((plainText) => ({ plainText }));
     }
     const plainTextChunks = splitTelegramPlainTextFallback(fallbackText, htmlChunks.length, 4000);
-    const chunks = htmlChunks.map((chunk, index) => ({
-      rawText: chunk,
-      htmlText: chunk,
-      plainText: plainTextChunks[index],
+    return htmlChunks.map((htmlText, index) => ({
+      htmlText,
+      plainText: plainTextChunks[index] ?? htmlText,
     }));
-
-    let lastMessageId = "";
-    let lastChatId = chatId;
-    for (let index = 0; index < chunks.length; index += 1) {
-      const chunk = chunks[index];
-      if (!chunk) {
-        continue;
-      }
-      const isLastChunk = index === chunks.length - 1;
-      const res = await sendTelegramText(
-        chunk.rawText,
-        buildTextParams(isLastChunk),
-        chunk.plainText,
-        chunk.htmlText,
-      );
-      const messageId = resolveTelegramMessageIdOrThrow(res, context);
-      recordSentMessage(chatId, messageId);
-      lastMessageId = String(messageId);
-      lastChatId = String(res?.chat?.id ?? chatId);
-    }
-
-    return { messageId: lastMessageId, chatId: lastChatId };
   };
+
+  const sendChunkedText = async (rawText: string, context: string) =>
+    await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
 
   if (mediaUrl) {
     const media = await loadWebMedia(
@@ -942,11 +910,11 @@ export async function sendMessageTelegram(
         const textResult = await sendChunkedText(followUpText, "text follow-up send");
         return { messageId: textResult.messageId, chatId: resolvedChatId };
       }
-      const textParams = buildTextParams(true);
-      const textRes = await sendTelegramText(followUpText, textParams);
-      const textMessageId = resolveTelegramMessageIdOrThrow(textRes, "text follow-up send");
-      recordSentMessage(chatId, textMessageId);
-      return { messageId: String(textMessageId), chatId: resolvedChatId };
+      const textResult = await sendTelegramTextChunks(
+        [{ plainText: followUpText, htmlText: renderHtmlText(followUpText) }],
+        "text follow-up send",
+      );
+      return { messageId: textResult.messageId, chatId: resolvedChatId };
     }
 
     return { messageId: String(mediaMessageId), chatId: resolvedChatId };
@@ -959,11 +927,10 @@ export async function sendMessageTelegram(
   if (textMode === "html") {
     textResult = await sendChunkedText(text, "text send");
   } else {
-    const textParams = buildTextParams(true);
-    const res = await sendTelegramText(text, textParams, opts.plainText);
-    const messageId = resolveTelegramMessageIdOrThrow(res, "text send");
-    recordSentMessage(chatId, messageId);
-    textResult = { messageId: String(messageId), chatId: String(res?.chat?.id ?? chatId) };
+    textResult = await sendTelegramTextChunks(
+      [{ plainText: opts.plainText ?? text, htmlText: renderHtmlText(text) }],
+      "text send",
+    );
   }
   recordChannelActivity({
     channel: "telegram",

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -108,6 +108,36 @@ function resolveTelegramMessageIdOrThrow(
   throw new Error(`Telegram ${context} returned no message_id`);
 }
 
+function splitTelegramPlainTextFallback(text: string, chunkCount: number, limit: number): string[] {
+  if (!text) {
+    return [];
+  }
+  const normalizedLimit = Math.max(1, Math.floor(limit));
+  if (chunkCount <= 1 || text.length <= normalizedLimit) {
+    return [text];
+  }
+  if (text.length > chunkCount * normalizedLimit) {
+    const chunks: string[] = [];
+    for (let start = 0; start < text.length; start += normalizedLimit) {
+      chunks.push(text.slice(start, start + normalizedLimit));
+    }
+    return chunks;
+  }
+  const chunks: string[] = [];
+  let offset = 0;
+  for (let index = 0; index < chunkCount && offset < text.length; index += 1) {
+    const remainingChars = text.length - offset;
+    const remainingChunks = chunkCount - index;
+    const nextChunkLength =
+      remainingChunks === 1
+        ? remainingChars
+        : Math.min(normalizedLimit, Math.ceil(remainingChars / remainingChunks));
+    chunks.push(text.slice(offset, offset + nextChunkLength));
+    offset += nextChunkLength;
+  }
+  return chunks;
+}
+
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 const MESSAGE_NOT_MODIFIED_RE =
@@ -660,10 +690,14 @@ export async function sendMessageTelegram(
     rawText: string,
     context: string,
   ): Promise<{ messageId: string; chatId: string }> => {
-    const chunks = splitTelegramHtmlChunks(rawText, 4000).map((chunk) => ({
+    const htmlChunks = splitTelegramHtmlChunks(rawText, 4000);
+    const plainTextChunks = opts.plainText
+      ? splitTelegramPlainTextFallback(opts.plainText, htmlChunks.length, 4000)
+      : [];
+    const chunks = htmlChunks.map((chunk, index) => ({
       rawText: chunk,
       htmlText: chunk,
-      plainText: chunk,
+      plainText: plainTextChunks[index],
     }));
 
     let lastMessageId = "";

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -735,6 +735,7 @@ export async function sendMessageTelegram(
     rawText: string,
     context: string,
   ): Promise<{ messageId: string; chatId: string }> => {
+    const fallbackText = opts.plainText ?? rawText;
     let htmlChunks: string[];
     try {
       htmlChunks = splitTelegramHtmlChunks(rawText, 4000);
@@ -744,13 +745,16 @@ export async function sendMessageTelegram(
           error,
         )}`,
       );
-      return await sendPlainChunkedText(opts.plainText ?? rawText, context);
+      return await sendPlainChunkedText(fallbackText, context);
     }
-    const plainTextChunks = splitTelegramPlainTextFallback(
-      opts.plainText ?? rawText,
-      htmlChunks.length,
-      4000,
-    );
+    const fixedPlainTextChunks = splitTelegramPlainTextChunks(fallbackText, 4000);
+    if (fixedPlainTextChunks.length > htmlChunks.length) {
+      logVerbose(
+        `telegram ${context} plain-text fallback needs more chunks than HTML; sending plain text`,
+      );
+      return await sendPlainChunkedText(fallbackText, context);
+    }
+    const plainTextChunks = splitTelegramPlainTextFallback(fallbackText, htmlChunks.length, 4000);
     const chunks = htmlChunks.map((chunk, index) => ({
       rawText: chunk,
       htmlText: chunk,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -26,7 +26,7 @@ import { buildTelegramThreadParams, buildTypingThreadParams } from "./bot/helper
 import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
-import { renderTelegramHtmlText } from "./format.js";
+import { renderTelegramHtmlText, splitTelegramHtmlChunks } from "./format.js";
 import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
@@ -600,13 +600,14 @@ export async function sendMessageTelegram(
     rawText: string,
     params?: Record<string, unknown>,
     fallbackText?: string,
+    preRenderedHtml?: string,
   ) => {
     return await withTelegramThreadFallback(
       params,
       "message",
       opts.verbose,
       async (effectiveParams, label) => {
-        const htmlText = renderHtmlText(rawText);
+        const htmlText = preRenderedHtml ?? renderHtmlText(rawText);
         const baseParams = effectiveParams ? { ...effectiveParams } : {};
         if (linkPreviewOptions) {
           baseParams.link_preview_options = linkPreviewOptions;
@@ -645,6 +646,47 @@ export async function sendMessageTelegram(
         });
       },
     );
+  };
+
+  const buildTextParams = (isLastChunk: boolean) =>
+    hasThreadParams || (isLastChunk && replyMarkup)
+      ? {
+          ...threadParams,
+          ...(isLastChunk && replyMarkup ? { reply_markup: replyMarkup } : {}),
+        }
+      : undefined;
+
+  const sendChunkedText = async (
+    rawText: string,
+    context: string,
+  ): Promise<{ messageId: string; chatId: string }> => {
+    const chunks = splitTelegramHtmlChunks(rawText, 4000).map((chunk) => ({
+      rawText: chunk,
+      htmlText: chunk,
+      plainText: chunk,
+    }));
+
+    let lastMessageId = "";
+    let lastChatId = chatId;
+    for (let index = 0; index < chunks.length; index += 1) {
+      const chunk = chunks[index];
+      if (!chunk) {
+        continue;
+      }
+      const isLastChunk = index === chunks.length - 1;
+      const res = await sendTelegramText(
+        chunk.rawText,
+        buildTextParams(isLastChunk),
+        chunk.plainText,
+        chunk.htmlText,
+      );
+      const messageId = resolveTelegramMessageIdOrThrow(res, context);
+      recordSentMessage(chatId, messageId);
+      lastMessageId = String(messageId);
+      lastChatId = String(res?.chat?.id ?? chatId);
+    }
+
+    return { messageId: lastMessageId, chatId: lastChatId };
   };
 
   if (mediaUrl) {
@@ -801,21 +843,15 @@ export async function sendMessageTelegram(
     // If text was too long for a caption, send it as a separate follow-up message.
     // Use HTML conversion so markdown renders like captions.
     if (needsSeparateText && followUpText) {
-      const textParams =
-        hasThreadParams || replyMarkup
-          ? {
-              ...threadParams,
-              ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
-            }
-          : undefined;
+      if (textMode === "html") {
+        const textResult = await sendChunkedText(followUpText, "text follow-up send");
+        return { messageId: textResult.messageId, chatId: resolvedChatId };
+      }
+      const textParams = buildTextParams(true);
       const textRes = await sendTelegramText(followUpText, textParams);
-      // Return the text message ID as the "main" message (it's the actual content).
       const textMessageId = resolveTelegramMessageIdOrThrow(textRes, "text follow-up send");
       recordSentMessage(chatId, textMessageId);
-      return {
-        messageId: String(textMessageId),
-        chatId: resolvedChatId,
-      };
+      return { messageId: String(textMessageId), chatId: resolvedChatId };
     }
 
     return { messageId: String(mediaMessageId), chatId: resolvedChatId };
@@ -824,22 +860,22 @@ export async function sendMessageTelegram(
   if (!text || !text.trim()) {
     throw new Error("Message must be non-empty for Telegram sends");
   }
-  const textParams =
-    hasThreadParams || replyMarkup
-      ? {
-          ...threadParams,
-          ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
-        }
-      : undefined;
-  const res = await sendTelegramText(text, textParams, opts.plainText);
-  const messageId = resolveTelegramMessageIdOrThrow(res, "text send");
-  recordSentMessage(chatId, messageId);
+  let textResult: { messageId: string; chatId: string };
+  if (textMode === "html") {
+    textResult = await sendChunkedText(text, "text send");
+  } else {
+    const textParams = buildTextParams(true);
+    const res = await sendTelegramText(text, textParams, opts.plainText);
+    const messageId = resolveTelegramMessageIdOrThrow(res, "text send");
+    recordSentMessage(chatId, messageId);
+    textResult = { messageId: String(messageId), chatId: String(res?.chat?.id ?? chatId) };
+  }
   recordChannelActivity({
     channel: "telegram",
     accountId: account.accountId,
     direction: "outbound",
   });
-  return { messageId: String(messageId), chatId: String(res?.chat?.id ?? chatId) };
+  return textResult;
 }
 
 export async function sendTypingTelegram(


### PR DESCRIPTION
## Summary

- Problem: Telegram sends that go through the HTML-mode outbound path (`channelData` / inline buttons) bypass chunking and hit Telegram's 4096-char limit.
- Why it matters: long replies and subagent completion announces can fail with `400: Bad Request: message is too long`, silently dropping user-visible output.
- What changed: added an HTML-aware chunker, routed HTML-mode text sends through it, and kept Telegram inline buttons on the last chunk only.
- What did NOT change (scope boundary): markdown-mode plain-text fallback/retry behavior, non-Telegram channels, and normal short-message delivery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #28851
- Fixes #25110
- Supersedes #42183

## User-visible / Behavior Changes

Long Telegram HTML-mode replies now arrive as multiple messages instead of failing once they exceed Telegram's message limit. Inline buttons remain attached to the final chunk.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Bun test harness
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default Telegram send path with inline buttons

### Steps

1. Call `telegramOutbound.sendPayload` with `payload.text` longer than 4096 chars and `channelData.telegram.buttons` present.
2. Let that route into `sendMessageTelegram`.
3. Observe the Bot API calls.

### Expected

- Multiple `sendMessage` calls, each within Telegram's limit.
- `reply_markup` only on the last chunk.

### Actual

- Before fix: one oversized `sendMessage` call, then `400: Bad Request: message is too long`.
- After fix: two sends in local repro (`4000` and `1001` chars) with buttons only on the last chunk.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the old failure locally, added a regression test for long HTML-mode sends with buttons, confirmed the same repro now emits two Telegram sends with buttons only on the last chunk.
- Edge cases checked: long HTML-mode send, HTML tag balancing across chunks, long follow-up text after caption split, existing HTML parse fallback behavior.
- What you did **not** verify: live Telegram delivery against a real bot token; full `src/telegram/send.test.ts` still has two pre-existing retry-test failures unrelated to this path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/telegram/send.ts`, `src/telegram/format.ts`
- Known bad symptoms reviewers should watch for: malformed HTML in chunked Telegram replies, buttons appearing on every chunk, or long HTML-mode sends still failing with `message is too long`.

## Risks and Mitigations

- Risk: HTML chunking could split malformed caller-provided HTML awkwardly.
  - Mitigation: chunker preserves open-tag context and closes/reopens balanced tags per chunk; coverage added for long tagged input.
