### PR TITLE
fix(acp): strip provider auth env for child ACP processes

### DIFF
--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -5,7 +5,6 @@ import {
   ACPX_PINNED_VERSION,
   createAcpxPluginConfigSchema,
   resolveAcpxPluginConfig,
-  toAcpMcpServers,
 } from "./config.js";
 
 describe("acpx plugin config parsing", () => {
@@ -20,9 +19,9 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.command).toBe(ACPX_BUNDLED_BIN);
     expect(resolved.expectedVersion).toBe(ACPX_PINNED_VERSION);
     expect(resolved.allowPluginLocalInstall).toBe(true);
+    expect(resolved.stripProviderAuthEnvVars).toBe(true);
     expect(resolved.cwd).toBe(path.resolve("/tmp/workspace"));
     expect(resolved.strictWindowsCmdWrapper).toBe(true);
-    expect(resolved.mcpServers).toEqual({});
   });
 
   it("accepts command override and disables plugin-local auto-install", () => {
@@ -37,6 +36,7 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.command).toBe(path.resolve(command));
     expect(resolved.expectedVersion).toBeUndefined();
     expect(resolved.allowPluginLocalInstall).toBe(false);
+    expect(resolved.stripProviderAuthEnvVars).toBe(false);
   });
 
   it("resolves relative command paths against workspace directory", () => {
@@ -50,6 +50,7 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.command).toBe(path.resolve("/home/user/repos/openclaw", "../acpx/dist/cli.js"));
     expect(resolved.expectedVersion).toBeUndefined();
     expect(resolved.allowPluginLocalInstall).toBe(false);
+    expect(resolved.stripProviderAuthEnvVars).toBe(false);
   });
 
   it("keeps bare command names as-is", () => {
@@ -63,6 +64,7 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.command).toBe("acpx");
     expect(resolved.expectedVersion).toBeUndefined();
     expect(resolved.allowPluginLocalInstall).toBe(false);
+    expect(resolved.stripProviderAuthEnvVars).toBe(false);
   });
 
   it("accepts exact expectedVersion override", () => {
@@ -78,6 +80,7 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.command).toBe(path.resolve(command));
     expect(resolved.expectedVersion).toBe("0.1.99");
     expect(resolved.allowPluginLocalInstall).toBe(false);
+    expect(resolved.stripProviderAuthEnvVars).toBe(false);
   });
 
   it("treats expectedVersion=any as no version constraint", () => {
@@ -133,98 +136,5 @@ describe("acpx plugin config parsing", () => {
         workspaceDir: "/tmp/workspace",
       }),
     ).toThrow("strictWindowsCmdWrapper must be a boolean");
-  });
-
-  it("accepts mcp server maps", () => {
-    const resolved = resolveAcpxPluginConfig({
-      rawConfig: {
-        mcpServers: {
-          canva: {
-            command: "npx",
-            args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
-            env: {
-              CANVA_TOKEN: "secret",
-            },
-          },
-        },
-      },
-      workspaceDir: "/tmp/workspace",
-    });
-
-    expect(resolved.mcpServers).toEqual({
-      canva: {
-        command: "npx",
-        args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
-        env: {
-          CANVA_TOKEN: "secret",
-        },
-      },
-    });
-  });
-
-  it("rejects invalid mcp server definitions", () => {
-    expect(() =>
-      resolveAcpxPluginConfig({
-        rawConfig: {
-          mcpServers: {
-            canva: {
-              command: "npx",
-              args: ["-y", 1],
-            },
-          },
-        },
-        workspaceDir: "/tmp/workspace",
-      }),
-    ).toThrow(
-      "mcpServers.canva must have a command string, optional args array, and optional env object",
-    );
-  });
-
-  it("schema accepts mcp server config", () => {
-    const schema = createAcpxPluginConfigSchema();
-    if (!schema.safeParse) {
-      throw new Error("acpx config schema missing safeParse");
-    }
-    const parsed = schema.safeParse({
-      mcpServers: {
-        canva: {
-          command: "npx",
-          args: ["-y", "mcp-remote@latest"],
-          env: {
-            CANVA_TOKEN: "secret",
-          },
-        },
-      },
-    });
-
-    expect(parsed.success).toBe(true);
-  });
-});
-
-describe("toAcpMcpServers", () => {
-  it("converts plugin config maps into ACP stdio MCP entries", () => {
-    expect(
-      toAcpMcpServers({
-        canva: {
-          command: "npx",
-          args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
-          env: {
-            CANVA_TOKEN: "secret",
-          },
-        },
-      }),
-    ).toEqual([
-      {
-        name: "canva",
-        command: "npx",
-        args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
-        env: [
-          {
-            name: "CANVA_TOKEN",
-            value: "secret",
-          },
-        ],
-      },
-    ]);
   });
 });

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -47,6 +47,7 @@ export type ResolvedAcpxPluginConfig = {
   command: string;
   expectedVersion?: string;
   allowPluginLocalInstall: boolean;
+  stripProviderAuthEnvVars: boolean;
   installCommand: string;
   cwd: string;
   permissionMode: AcpxPermissionMode;
@@ -332,6 +333,7 @@ export function resolveAcpxPluginConfig(params: {
     workspaceDir: params.workspaceDir,
   });
   const allowPluginLocalInstall = command === ACPX_BUNDLED_BIN;
+  const stripProviderAuthEnvVars = command === ACPX_BUNDLED_BIN;
   const configuredExpectedVersion = normalized.expectedVersion;
   const expectedVersion =
     configuredExpectedVersion === ACPX_VERSION_ANY
@@ -343,6 +345,7 @@ export function resolveAcpxPluginConfig(params: {
     command,
     expectedVersion,
     allowPluginLocalInstall,
+    stripProviderAuthEnvVars,
     installCommand,
     cwd,
     permissionMode: normalized.permissionMode ?? DEFAULT_PERMISSION_MODE,

--- a/extensions/acpx/src/ensure.test.ts
+++ b/extensions/acpx/src/ensure.test.ts
@@ -77,6 +77,7 @@ describe("acpx ensure", () => {
       command: "/plugin/node_modules/.bin/acpx",
       args: ["--version"],
       cwd: "/plugin",
+      stripProviderAuthEnvVars: undefined,
     });
   });
 
@@ -183,6 +184,54 @@ describe("acpx ensure", () => {
       command: "npm",
       args: ["install", "--omit=dev", "--no-save", `acpx@${ACPX_PINNED_VERSION}`],
       cwd: "/plugin",
+    });
+  });
+
+  it("threads stripProviderAuthEnvVars through version probes and install", async () => {
+    spawnAndCollectMock
+      .mockResolvedValueOnce({
+        stdout: "acpx 0.0.9\n",
+        stderr: "",
+        code: 0,
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        stdout: "added 1 package\n",
+        stderr: "",
+        code: 0,
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        stdout: `acpx ${ACPX_PINNED_VERSION}\n`,
+        stderr: "",
+        code: 0,
+        error: null,
+      });
+
+    await ensureAcpx({
+      command: "/plugin/node_modules/.bin/acpx",
+      pluginRoot: "/plugin",
+      expectedVersion: ACPX_PINNED_VERSION,
+      stripProviderAuthEnvVars: true,
+    });
+
+    expect(spawnAndCollectMock.mock.calls[0]?.[0]).toMatchObject({
+      command: "/plugin/node_modules/.bin/acpx",
+      args: ["--version"],
+      cwd: "/plugin",
+      stripProviderAuthEnvVars: true,
+    });
+    expect(spawnAndCollectMock.mock.calls[1]?.[0]).toMatchObject({
+      command: "npm",
+      args: ["install", "--omit=dev", "--no-save", `acpx@${ACPX_PINNED_VERSION}`],
+      cwd: "/plugin",
+      stripProviderAuthEnvVars: true,
+    });
+    expect(spawnAndCollectMock.mock.calls[2]?.[0]).toMatchObject({
+      command: "/plugin/node_modules/.bin/acpx",
+      args: ["--version"],
+      cwd: "/plugin",
+      stripProviderAuthEnvVars: true,
     });
   });
 

--- a/extensions/acpx/src/ensure.test.ts
+++ b/extensions/acpx/src/ensure.test.ts
@@ -149,6 +149,30 @@ describe("acpx ensure", () => {
       command: "/custom/acpx",
       args: ["--help"],
       cwd: "/custom",
+      stripProviderAuthEnvVars: undefined,
+    });
+  });
+
+  it("forwards stripProviderAuthEnvVars to version checks", async () => {
+    spawnAndCollectMock.mockResolvedValueOnce({
+      stdout: "Usage: acpx [options]\n",
+      stderr: "",
+      code: 0,
+      error: null,
+    });
+
+    await checkAcpxVersion({
+      command: "/plugin/node_modules/.bin/acpx",
+      cwd: "/plugin",
+      expectedVersion: undefined,
+      stripProviderAuthEnvVars: true,
+    });
+
+    expect(spawnAndCollectMock).toHaveBeenCalledWith({
+      command: "/plugin/node_modules/.bin/acpx",
+      args: ["--help"],
+      cwd: "/plugin",
+      stripProviderAuthEnvVars: true,
     });
   });
 

--- a/extensions/acpx/src/ensure.ts
+++ b/extensions/acpx/src/ensure.ts
@@ -102,6 +102,7 @@ export async function checkAcpxVersion(params: {
   command: string;
   cwd?: string;
   expectedVersion?: string;
+  stripProviderAuthEnvVars?: boolean;
   spawnOptions?: SpawnCommandOptions;
 }): Promise<AcpxVersionCheckResult> {
   const expectedVersion = params.expectedVersion?.trim() || undefined;
@@ -113,6 +114,7 @@ export async function checkAcpxVersion(params: {
     command: params.command,
     args: probeArgs,
     cwd,
+    stripProviderAuthEnvVars: params.stripProviderAuthEnvVars,
   };
   let result: Awaited<ReturnType<typeof spawnAndCollect>>;
   try {
@@ -198,6 +200,7 @@ export async function ensureAcpx(params: {
   pluginRoot?: string;
   expectedVersion?: string;
   allowInstall?: boolean;
+  stripProviderAuthEnvVars?: boolean;
   spawnOptions?: SpawnCommandOptions;
 }): Promise<void> {
   if (pendingEnsure) {
@@ -214,6 +217,7 @@ export async function ensureAcpx(params: {
       command: params.command,
       cwd: pluginRoot,
       expectedVersion,
+      stripProviderAuthEnvVars: params.stripProviderAuthEnvVars,
       spawnOptions: params.spawnOptions,
     });
     if (precheck.ok) {
@@ -231,6 +235,7 @@ export async function ensureAcpx(params: {
       command: "npm",
       args: ["install", "--omit=dev", "--no-save", `acpx@${installVersion}`],
       cwd: pluginRoot,
+      stripProviderAuthEnvVars: params.stripProviderAuthEnvVars,
     });
 
     if (install.error) {
@@ -252,6 +257,7 @@ export async function ensureAcpx(params: {
       command: params.command,
       cwd: pluginRoot,
       expectedVersion,
+      stripProviderAuthEnvVars: params.stripProviderAuthEnvVars,
       spawnOptions: params.spawnOptions,
     });
 

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { spawnAndCollectMock } = vi.hoisted(() => ({
+  spawnAndCollectMock: vi.fn(),
+}));
+
+vi.mock("./process.js", () => ({
+  spawnAndCollect: spawnAndCollectMock,
+}));
+
+import { resolveAcpxAgentCommand } from "./mcp-agent-command.js";
+
+describe("resolveAcpxAgentCommand", () => {
+  it("threads stripProviderAuthEnvVars through the config show probe", async () => {
+    spawnAndCollectMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        agents: {
+          codex: {
+            command: "custom-codex",
+          },
+        },
+      }),
+      stderr: "",
+      code: 0,
+      error: null,
+    });
+
+    const command = await resolveAcpxAgentCommand({
+      acpxCommand: "/plugin/node_modules/.bin/acpx",
+      cwd: "/plugin",
+      agent: "codex",
+      stripProviderAuthEnvVars: true,
+    });
+
+    expect(command).toBe("custom-codex");
+    expect(spawnAndCollectMock).toHaveBeenCalledWith(
+      {
+        command: "/plugin/node_modules/.bin/acpx",
+        args: ["--cwd", "/plugin", "config", "show"],
+        cwd: "/plugin",
+        stripProviderAuthEnvVars: true,
+      },
+      undefined,
+    );
+  });
+});

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
@@ -8,7 +8,7 @@ vi.mock("./process.js", () => ({
   spawnAndCollect: spawnAndCollectMock,
 }));
 
-import { resolveAcpxAgentCommand } from "./mcp-agent-command.js";
+import { __testing, resolveAcpxAgentCommand } from "./mcp-agent-command.js";
 
 describe("resolveAcpxAgentCommand", () => {
   it("threads stripProviderAuthEnvVars through the config show probe", async () => {
@@ -42,5 +42,18 @@ describe("resolveAcpxAgentCommand", () => {
       },
       undefined,
     );
+  });
+});
+
+describe("buildMcpProxyAgentCommand", () => {
+  it("escapes Windows-style proxy paths without double-escaping backslashes", () => {
+    const quoted = __testing.quoteCommandPart(
+      "C:\\repo\\extensions\\acpx\\src\\runtime-internals\\mcp-proxy.mjs",
+    );
+
+    expect(quoted).toBe(
+      '"C:\\\\repo\\\\extensions\\\\acpx\\\\src\\\\runtime-internals\\\\mcp-proxy.mjs"',
+    );
+    expect(quoted).not.toContain("\\\\\\");
   });
 });

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
@@ -34,7 +34,7 @@ function quoteCommandPart(value: string): string {
   if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
     return value;
   }
-  return `"${value.replace(/["\\]/g, "\\$&")}"`;
+  return `"${value.replace(/["\\\\]/g, "\\\\$&")}"`;
 }
 
 function toCommandLine(parts: string[]): string {
@@ -62,6 +62,7 @@ function readConfiguredAgentOverrides(value: unknown): Record<string, string> {
 async function loadAgentOverrides(params: {
   acpxCommand: string;
   cwd: string;
+  stripProviderAuthEnvVars?: boolean;
   spawnOptions?: SpawnCommandOptions;
 }): Promise<Record<string, string>> {
   const result = await spawnAndCollect(
@@ -69,6 +70,7 @@ async function loadAgentOverrides(params: {
       command: params.acpxCommand,
       args: ["--cwd", params.cwd, "config", "show"],
       cwd: params.cwd,
+      stripProviderAuthEnvVars: params.stripProviderAuthEnvVars,
     },
     params.spawnOptions,
   );
@@ -87,12 +89,14 @@ export async function resolveAcpxAgentCommand(params: {
   acpxCommand: string;
   cwd: string;
   agent: string;
+  stripProviderAuthEnvVars?: boolean;
   spawnOptions?: SpawnCommandOptions;
 }): Promise<string> {
   const normalizedAgent = normalizeAgentName(params.agent);
   const overrides = await loadAgentOverrides({
     acpxCommand: params.acpxCommand,
     cwd: params.cwd,
+    stripProviderAuthEnvVars: params.stripProviderAuthEnvVars,
     spawnOptions: params.spawnOptions,
   });
   return overrides[normalizedAgent] ?? ACPX_BUILTIN_AGENT_COMMANDS[normalizedAgent] ?? params.agent;

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
@@ -34,8 +34,12 @@ function quoteCommandPart(value: string): string {
   if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
     return value;
   }
-  return `"${value.replace(/["\\\\]/g, "\\\\$&")}"`;
+  return `"${value.replace(/["\\]/g, "\\$&")}"`;
 }
+
+export const __testing = {
+  quoteCommandPart,
+};
 
 function toCommandLine(parts: string[]): string {
   return parts.map(quoteCommandPart).join(" ");

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -304,6 +304,7 @@ describe("spawnAndCollect", () => {
         "process.stdout.write(JSON.stringify({openai:process.env.OPENAI_API_KEY,github:process.env.GITHUB_TOKEN,hf:process.env.HF_TOKEN,openclaw:process.env.OPENCLAW_API_KEY,shell:process.env.OPENCLAW_SHELL}))",
       ],
       cwd: process.cwd(),
+      stripProviderAuthEnvVars: true,
     });
 
     expect(result.code).toBe(0);
@@ -323,7 +324,37 @@ describe("spawnAndCollect", () => {
     expect(parsed.shell).toBe("acp");
   });
 
-  it("preserves provider auth env vars for explicit custom commands", async () => {
+  it("strips provider auth env vars case-insensitively", async () => {
+    vi.stubEnv("OpenAI_Api_Key", "openai-secret");
+    vi.stubEnv("Github_Token", "gh-secret");
+    vi.stubEnv("OPENCLAW_API_KEY", "keep-me");
+
+    const result = await spawnAndCollect({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(JSON.stringify({openai:process.env.OpenAI_Api_Key,github:process.env.Github_Token,openclaw:process.env.OPENCLAW_API_KEY,shell:process.env.OPENCLAW_SHELL}))",
+      ],
+      cwd: process.cwd(),
+      stripProviderAuthEnvVars: true,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.error).toBeNull();
+
+    const parsed = JSON.parse(result.stdout) as {
+      openai?: string;
+      github?: string;
+      openclaw?: string;
+      shell?: string;
+    };
+    expect(parsed.openai).toBeUndefined();
+    expect(parsed.github).toBeUndefined();
+    expect(parsed.openclaw).toBe("keep-me");
+    expect(parsed.shell).toBe("acp");
+  });
+
+  it("preserves provider auth env vars for explicit custom commands by default", async () => {
     vi.stubEnv("OPENAI_API_KEY", "openai-secret");
     vi.stubEnv("GITHUB_TOKEN", "gh-secret");
     vi.stubEnv("HF_TOKEN", "hf-secret");
@@ -336,7 +367,6 @@ describe("spawnAndCollect", () => {
         "process.stdout.write(JSON.stringify({openai:process.env.OPENAI_API_KEY,github:process.env.GITHUB_TOKEN,hf:process.env.HF_TOKEN,openclaw:process.env.OPENCLAW_API_KEY,shell:process.env.OPENCLAW_SHELL}))",
       ],
       cwd: process.cwd(),
-      stripProviderAuthEnvVars: false,
     });
 
     expect(result.code).toBe(0);

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWindowsCmdShimFixture } from "../../../shared/windows-cmd-shim-test-fixtures.js";
 import {
   resolveSpawnCommand,
@@ -28,6 +28,7 @@ async function createTempDir(): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (!dir) {
@@ -288,5 +289,70 @@ describe("spawnAndCollect", () => {
 
     const result = await resultPromise;
     expect(result.error?.name).toBe("AbortError");
+  });
+
+  it("strips shared provider auth env vars from spawned acpx children", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "openai-secret");
+    vi.stubEnv("GITHUB_TOKEN", "gh-secret");
+    vi.stubEnv("HF_TOKEN", "hf-secret");
+    vi.stubEnv("OPENCLAW_API_KEY", "keep-me");
+
+    const result = await spawnAndCollect({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(JSON.stringify({openai:process.env.OPENAI_API_KEY,github:process.env.GITHUB_TOKEN,hf:process.env.HF_TOKEN,openclaw:process.env.OPENCLAW_API_KEY,shell:process.env.OPENCLAW_SHELL}))",
+      ],
+      cwd: process.cwd(),
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.error).toBeNull();
+
+    const parsed = JSON.parse(result.stdout) as {
+      openai?: string;
+      github?: string;
+      hf?: string;
+      openclaw?: string;
+      shell?: string;
+    };
+    expect(parsed.openai).toBeUndefined();
+    expect(parsed.github).toBeUndefined();
+    expect(parsed.hf).toBeUndefined();
+    expect(parsed.openclaw).toBe("keep-me");
+    expect(parsed.shell).toBe("acp");
+  });
+
+  it("preserves provider auth env vars for explicit custom commands", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "openai-secret");
+    vi.stubEnv("GITHUB_TOKEN", "gh-secret");
+    vi.stubEnv("HF_TOKEN", "hf-secret");
+    vi.stubEnv("OPENCLAW_API_KEY", "keep-me");
+
+    const result = await spawnAndCollect({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(JSON.stringify({openai:process.env.OPENAI_API_KEY,github:process.env.GITHUB_TOKEN,hf:process.env.HF_TOKEN,openclaw:process.env.OPENCLAW_API_KEY,shell:process.env.OPENCLAW_SHELL}))",
+      ],
+      cwd: process.cwd(),
+      stripProviderAuthEnvVars: false,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.error).toBeNull();
+
+    const parsed = JSON.parse(result.stdout) as {
+      openai?: string;
+      github?: string;
+      hf?: string;
+      openclaw?: string;
+      shell?: string;
+    };
+    expect(parsed.openai).toBe("openai-secret");
+    expect(parsed.github).toBe("gh-secret");
+    expect(parsed.hf).toBe("hf-secret");
+    expect(parsed.openclaw).toBe("keep-me");
+    expect(parsed.shell).toBe("acp");
   });
 });

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -9,6 +9,7 @@ import {
   applyWindowsSpawnProgramPolicy,
   listKnownProviderAuthEnvVarNames,
   materializeWindowsSpawnProgram,
+  omitEnvKeysCaseInsensitive,
   resolveWindowsSpawnProgramCandidate,
 } from "openclaw/plugin-sdk/acpx";
 
@@ -138,17 +139,11 @@ export function spawnWithResolvedCommand(
     options,
   );
 
-  const childEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    OPENCLAW_SHELL: "acp",
-  };
-  if (params.stripProviderAuthEnvVars !== false) {
-    for (const key of listKnownProviderAuthEnvVarNames()) {
-      if (key !== "OPENCLAW_API_KEY") {
-        delete childEnv[key];
-      }
-    }
-  }
+  const childEnv = omitEnvKeysCaseInsensitive(
+    process.env,
+    params.stripProviderAuthEnvVars ? listKnownProviderAuthEnvVarNames() : [],
+  );
+  childEnv.OPENCLAW_SHELL = "acp";
 
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -7,6 +7,7 @@ import type {
 } from "openclaw/plugin-sdk/acpx";
 import {
   applyWindowsSpawnProgramPolicy,
+  listKnownProviderAuthEnvVarNames,
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgramCandidate,
 } from "openclaw/plugin-sdk/acpx";
@@ -125,6 +126,7 @@ export function spawnWithResolvedCommand(
     command: string;
     args: string[];
     cwd: string;
+    stripProviderAuthEnvVars?: boolean;
   },
   options?: SpawnCommandOptions,
 ): ChildProcessWithoutNullStreams {
@@ -136,9 +138,21 @@ export function spawnWithResolvedCommand(
     options,
   );
 
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCLAW_SHELL: "acp",
+  };
+  if (params.stripProviderAuthEnvVars !== false) {
+    for (const key of listKnownProviderAuthEnvVarNames()) {
+      if (key !== "OPENCLAW_API_KEY") {
+        delete childEnv[key];
+      }
+    }
+  }
+
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,
-    env: { ...process.env, OPENCLAW_SHELL: "acp" },
+    env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
     windowsHide: resolved.windowsHide,
@@ -180,6 +194,7 @@ export async function spawnAndCollect(
     command: string;
     args: string[];
     cwd: string;
+    stripProviderAuthEnvVars?: boolean;
   },
   options?: SpawnCommandOptions,
   runtime?: {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -19,6 +19,7 @@ beforeAll(async () => {
     {
       command: "/definitely/missing/acpx",
       allowPluginLocalInstall: false,
+      stripProviderAuthEnvVars: false,
       installCommand: "n/a",
       cwd: process.cwd(),
       permissionMode: "approve-reads",

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { runAcpRuntimeAdapterContract } from "../../../src/acp/runtime/adapter-contract.testkit.js";
 import { AcpxRuntime, decodeAcpxRuntimeHandleState } from "./runtime.js";
 import {
@@ -21,11 +21,11 @@ beforeAll(async () => {
       allowPluginLocalInstall: false,
       installCommand: "n/a",
       cwd: process.cwd(),
-      mcpServers: {},
       permissionMode: "approve-reads",
       nonInteractivePermissions: "fail",
       strictWindowsCmdWrapper: true,
       queueOwnerTtlSeconds: 0.1,
+      mcpServers: {},
     },
     { logger: NOOP_LOGGER },
   );
@@ -165,7 +165,7 @@ describe("AcpxRuntime", () => {
     for await (const _event of runtime.runTurn({
       handle,
       text: "describe this image",
-      attachments: [{ mediaType: "image/png", data: "aW1hZ2UtYnl0ZXM=" }],
+      attachments: [{ mediaType: "image/png", data: "aW1hZ2UtYnl0ZXM=" }], // pragma: allowlist secret
       mode: "prompt",
       requestId: "req-image",
     })) {
@@ -184,6 +184,40 @@ describe("AcpxRuntime", () => {
       { type: "text", text: "describe this image" },
       { type: "image", mimeType: "image/png", data: "aW1hZ2UtYnl0ZXM=" },
     ]);
+  });
+
+  it("preserves provider auth env vars when runtime uses a custom acpx command", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "openai-secret"); // pragma: allowlist secret
+    vi.stubEnv("GITHUB_TOKEN", "gh-secret"); // pragma: allowlist secret
+
+    try {
+      const { runtime, logPath } = await createMockRuntimeFixture();
+      const handle = await runtime.ensureSession({
+        sessionKey: "agent:codex:acp:custom-env",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      for await (const _event of runtime.runTurn({
+        handle,
+        text: "custom-env",
+        mode: "prompt",
+        requestId: "req-custom-env",
+      })) {
+        // Drain events; assertions inspect the mock runtime log.
+      }
+
+      const logs = await readMockRuntimeLogEntries(logPath);
+      const prompt = logs.find(
+        (entry) =>
+          entry.kind === "prompt" &&
+          String(entry.sessionName ?? "") === "agent:codex:acp:custom-env",
+      );
+      expect(prompt?.openaiApiKey).toBe("openai-secret");
+      expect(prompt?.githubToken).toBe("gh-secret");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("preserves leading spaces across streamed text deltas", async () => {
@@ -395,7 +429,7 @@ describe("AcpxRuntime", () => {
             command: "npx",
             args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
             env: {
-              CANVA_TOKEN: "secret",
+              CANVA_TOKEN: "secret", // pragma: allowlist secret
             },
           },
         },

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -170,6 +170,7 @@ export class AcpxRuntime implements AcpRuntime {
       command: this.config.command,
       cwd: this.config.cwd,
       expectedVersion: this.config.expectedVersion,
+      stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       spawnOptions: this.spawnCommandOptions,
     });
     if (!versionCheck.ok) {
@@ -497,6 +498,7 @@ export class AcpxRuntime implements AcpRuntime {
       command: this.config.command,
       cwd: this.config.cwd,
       expectedVersion: this.config.expectedVersion,
+      stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       spawnOptions: this.spawnCommandOptions,
     });
     if (!versionCheck.ok) {
@@ -686,6 +688,7 @@ export class AcpxRuntime implements AcpRuntime {
       acpxCommand: this.config.command,
       cwd: params.cwd,
       agent: params.agent,
+      stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       spawnOptions: this.spawnCommandOptions,
     });
     const resolved = buildMcpProxyAgentCommand({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -183,7 +183,7 @@ export class AcpxRuntime implements AcpRuntime {
           command: this.config.command,
           args: ["--help"],
           cwd: this.config.cwd,
-          stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
+          stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
         },
         this.spawnCommandOptions,
       );
@@ -310,7 +310,7 @@ export class AcpxRuntime implements AcpRuntime {
         command: this.config.command,
         args,
         cwd: state.cwd,
-        stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
+        stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       },
       this.spawnCommandOptions,
     );
@@ -520,7 +520,7 @@ export class AcpxRuntime implements AcpRuntime {
           command: this.config.command,
           args: ["--help"],
           cwd: this.config.cwd,
-          stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
+          stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
         },
         this.spawnCommandOptions,
       );
@@ -708,7 +708,7 @@ export class AcpxRuntime implements AcpRuntime {
         command: this.config.command,
         args: params.args,
         cwd: params.cwd,
-        stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
+        stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       },
       this.spawnCommandOptions,
       {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -520,6 +520,7 @@ export class AcpxRuntime implements AcpRuntime {
           command: this.config.command,
           args: ["--help"],
           cwd: this.config.cwd,
+          stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
         },
         this.spawnCommandOptions,
       );

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -183,6 +183,7 @@ export class AcpxRuntime implements AcpRuntime {
           command: this.config.command,
           args: ["--help"],
           cwd: this.config.cwd,
+          stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
         },
         this.spawnCommandOptions,
       );
@@ -309,6 +310,7 @@ export class AcpxRuntime implements AcpRuntime {
         command: this.config.command,
         args,
         cwd: state.cwd,
+        stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
       },
       this.spawnCommandOptions,
     );
@@ -705,6 +707,7 @@ export class AcpxRuntime implements AcpRuntime {
         command: this.config.command,
         args: params.args,
         cwd: params.cwd,
+        stripProviderAuthEnvVars: this.config.allowPluginLocalInstall,
       },
       this.spawnCommandOptions,
       {

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -89,6 +89,11 @@ describe("createAcpxRuntimeService", () => {
 
     await vi.waitFor(() => {
       expect(ensureAcpxSpy).toHaveBeenCalledOnce();
+      expect(ensureAcpxSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stripProviderAuthEnvVars: true,
+        }),
+      );
       expect(probeAvailabilitySpy).toHaveBeenCalledOnce();
     });
 

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -59,9 +59,8 @@ export function createAcpxRuntimeService(
       });
       const expectedVersionLabel = pluginConfig.expectedVersion ?? "any";
       const installLabel = pluginConfig.allowPluginLocalInstall ? "enabled" : "disabled";
-      const mcpServerCount = Object.keys(pluginConfig.mcpServers).length;
       ctx.logger.info(
-        `acpx runtime backend registered (command: ${pluginConfig.command}, expectedVersion: ${expectedVersionLabel}, pluginLocalInstall: ${installLabel}${mcpServerCount > 0 ? `, mcpServers: ${mcpServerCount}` : ""})`,
+        `acpx runtime backend registered (command: ${pluginConfig.command}, expectedVersion: ${expectedVersionLabel}, pluginLocalInstall: ${installLabel})`,
       );
 
       lifecycleRevision += 1;
@@ -73,6 +72,7 @@ export function createAcpxRuntimeService(
             logger: ctx.logger,
             expectedVersion: pluginConfig.expectedVersion,
             allowInstall: pluginConfig.allowPluginLocalInstall,
+            stripProviderAuthEnvVars: pluginConfig.stripProviderAuthEnvVars,
             spawnOptions: {
               strictWindowsCmdWrapper: pluginConfig.strictWindowsCmdWrapper,
             },

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -328,6 +328,7 @@ export async function createMockRuntimeFixture(params?: {
   const config: ResolvedAcpxPluginConfig = {
     command: scriptPath,
     allowPluginLocalInstall: false,
+    stripProviderAuthEnvVars: false,
     installCommand: "n/a",
     cwd: dir,
     permissionMode: params?.permissionMode ?? "approve-all",

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -204,6 +204,8 @@ if (command === "prompt") {
     sessionName: sessionFromOption,
     stdinText,
     openclawShell,
+    openaiApiKey: process.env.OPENAI_API_KEY || "",
+    githubToken: process.env.GITHUB_TOKEN || "",
   });
   const requestId = "req-1";
 
@@ -378,6 +380,7 @@ export async function readMockRuntimeLogEntries(
 
 export async function cleanupMockRuntimeFixtures(): Promise<void> {
   delete process.env.MOCK_ACPX_LOG;
+  delete process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS;
   sharedMockCliScriptPath = null;
   logFileSequence = 0;
   while (tempDirs.length > 0) {

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -172,7 +172,9 @@ describe("shouldStripProviderAuthEnvVarsForAcpServer", () => {
     expect(
       shouldStripProviderAuthEnvVarsForAcpServer({
         serverCommand: "openclaw",
+        serverArgs: ["acp"],
         defaultServerCommand: "openclaw",
+        defaultServerArgs: ["acp"],
       }),
     ).toBe(true);
   });
@@ -181,7 +183,20 @@ describe("shouldStripProviderAuthEnvVarsForAcpServer", () => {
     expect(
       shouldStripProviderAuthEnvVarsForAcpServer({
         serverCommand: "custom-acp-server",
+        serverArgs: ["serve"],
         defaultServerCommand: "openclaw",
+        defaultServerArgs: ["acp"],
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves provider auth env vars when an explicit override uses the default executable with different args", () => {
+    expect(
+      shouldStripProviderAuthEnvVarsForAcpServer({
+        serverCommand: process.execPath,
+        serverArgs: ["custom-entry.js"],
+        defaultServerCommand: process.execPath,
+        defaultServerArgs: ["dist/entry.js", "acp"],
       }),
     ).toBe(false);
   });

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -134,6 +134,22 @@ describe("resolveAcpClientSpawnEnv", () => {
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
   });
 
+  it("strips provider auth env vars case-insensitively", () => {
+    const env = resolveAcpClientSpawnEnv(
+      {
+        OpenAI_Api_Key: "openai-secret", // pragma: allowlist secret
+        Github_Token: "gh-secret", // pragma: allowlist secret
+        OPENCLAW_API_KEY: "keep-me",
+      },
+      { stripKeys: new Set(["OPENAI_API_KEY", "GITHUB_TOKEN"]) },
+    );
+
+    expect(env.OpenAI_Api_Key).toBeUndefined();
+    expect(env.Github_Token).toBeUndefined();
+    expect(env.OPENCLAW_API_KEY).toBe("keep-me");
+    expect(env.OPENCLAW_SHELL).toBe("acp-client");
+  });
+
   it("preserves provider auth env vars for explicit custom ACP servers", () => {
     const env = resolveAcpClientSpawnEnv({
       OPENAI_API_KEY: "openai-secret", // pragma: allowlist secret
@@ -153,17 +169,28 @@ describe("resolveAcpClientSpawnEnv", () => {
 describe("shouldStripProviderAuthEnvVarsForAcpServer", () => {
   it("strips provider auth env vars for the default bridge", () => {
     expect(shouldStripProviderAuthEnvVarsForAcpServer()).toBe(true);
+    expect(
+      shouldStripProviderAuthEnvVarsForAcpServer({
+        serverCommand: "openclaw",
+        defaultServerCommand: "openclaw",
+      }),
+    ).toBe(true);
   });
 
   it("preserves provider auth env vars for explicit custom ACP servers", () => {
-    expect(shouldStripProviderAuthEnvVarsForAcpServer("custom-acp-server")).toBe(false);
+    expect(
+      shouldStripProviderAuthEnvVarsForAcpServer({
+        serverCommand: "custom-acp-server",
+        defaultServerCommand: "openclaw",
+      }),
+    ).toBe(false);
   });
 });
 
 describe("buildAcpClientStripKeys", () => {
   it("always includes active skill env keys", () => {
     const stripKeys = buildAcpClientStripKeys({
-      serverCommand: "custom-acp-server",
+      stripProviderAuthEnvVars: false,
       activeSkillEnvKeys: ["SKILL_SECRET", "OPENAI_API_KEY"],
     });
 
@@ -174,6 +201,7 @@ describe("buildAcpClientStripKeys", () => {
 
   it("adds provider auth env vars for the default bridge", () => {
     const stripKeys = buildAcpClientStripKeys({
+      stripProviderAuthEnvVars: true,
       activeSkillEnvKeys: ["SKILL_SECRET"],
     });
 

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -119,7 +119,7 @@ describe("resolveAcpClientSpawnEnv", () => {
       {
         OPENAI_API_KEY: "openai-secret", // pragma: allowlist secret
         GITHUB_TOKEN: "gh-secret", // pragma: allowlist secret
-        HF_TOKEN: "hf-secret",
+        HF_TOKEN: "hf-secret", // pragma: allowlist secret
         OPENCLAW_API_KEY: "keep-me",
         PATH: "/usr/bin",
       },
@@ -138,7 +138,7 @@ describe("resolveAcpClientSpawnEnv", () => {
     const env = resolveAcpClientSpawnEnv({
       OPENAI_API_KEY: "openai-secret", // pragma: allowlist secret
       GITHUB_TOKEN: "gh-secret", // pragma: allowlist secret
-      HF_TOKEN: "hf-secret",
+      HF_TOKEN: "hf-secret", // pragma: allowlist secret
       OPENCLAW_API_KEY: "keep-me",
     });
 

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -4,9 +4,11 @@ import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  buildAcpClientStripKeys,
   resolveAcpClientSpawnEnv,
   resolveAcpClientSpawnInvocation,
   resolvePermissionRequest,
+  shouldStripProviderAuthEnvVarsForAcpServer,
 } from "./client.js";
 import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-mapper.js";
 
@@ -109,6 +111,77 @@ describe("resolveAcpClientSpawnEnv", () => {
 
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
     expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it("strips provider auth env vars for the default OpenClaw bridge", () => {
+    const stripKeys = new Set(["OPENAI_API_KEY", "GITHUB_TOKEN", "HF_TOKEN"]);
+    const env = resolveAcpClientSpawnEnv(
+      {
+        OPENAI_API_KEY: "openai-secret", // pragma: allowlist secret
+        GITHUB_TOKEN: "gh-secret", // pragma: allowlist secret
+        HF_TOKEN: "hf-secret",
+        OPENCLAW_API_KEY: "keep-me",
+        PATH: "/usr/bin",
+      },
+      { stripKeys },
+    );
+
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+    expect(env.HF_TOKEN).toBeUndefined();
+    expect(env.OPENCLAW_API_KEY).toBe("keep-me");
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.OPENCLAW_SHELL).toBe("acp-client");
+  });
+
+  it("preserves provider auth env vars for explicit custom ACP servers", () => {
+    const env = resolveAcpClientSpawnEnv({
+      OPENAI_API_KEY: "openai-secret", // pragma: allowlist secret
+      GITHUB_TOKEN: "gh-secret", // pragma: allowlist secret
+      HF_TOKEN: "hf-secret",
+      OPENCLAW_API_KEY: "keep-me",
+    });
+
+    expect(env.OPENAI_API_KEY).toBe("openai-secret");
+    expect(env.GITHUB_TOKEN).toBe("gh-secret");
+    expect(env.HF_TOKEN).toBe("hf-secret");
+    expect(env.OPENCLAW_API_KEY).toBe("keep-me");
+    expect(env.OPENCLAW_SHELL).toBe("acp-client");
+  });
+});
+
+describe("shouldStripProviderAuthEnvVarsForAcpServer", () => {
+  it("strips provider auth env vars for the default bridge", () => {
+    expect(shouldStripProviderAuthEnvVarsForAcpServer()).toBe(true);
+  });
+
+  it("preserves provider auth env vars for explicit custom ACP servers", () => {
+    expect(shouldStripProviderAuthEnvVarsForAcpServer("custom-acp-server")).toBe(false);
+  });
+});
+
+describe("buildAcpClientStripKeys", () => {
+  it("always includes active skill env keys", () => {
+    const stripKeys = buildAcpClientStripKeys({
+      serverCommand: "custom-acp-server",
+      activeSkillEnvKeys: ["SKILL_SECRET", "OPENAI_API_KEY"],
+    });
+
+    expect(stripKeys.has("SKILL_SECRET")).toBe(true);
+    expect(stripKeys.has("OPENAI_API_KEY")).toBe(true);
+    expect(stripKeys.has("GITHUB_TOKEN")).toBe(false);
+  });
+
+  it("adds provider auth env vars for the default bridge", () => {
+    const stripKeys = buildAcpClientStripKeys({
+      activeSkillEnvKeys: ["SKILL_SECRET"],
+    });
+
+    expect(stripKeys.has("SKILL_SECRET")).toBe(true);
+    expect(stripKeys.has("OPENAI_API_KEY")).toBe(true);
+    expect(stripKeys.has("GITHUB_TOKEN")).toBe(true);
+    expect(stripKeys.has("HF_TOKEN")).toBe(true);
+    expect(stripKeys.has("OPENCLAW_API_KEY")).toBe(false);
   });
 });
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -366,7 +366,9 @@ export function resolveAcpClientSpawnEnv(
 export function shouldStripProviderAuthEnvVarsForAcpServer(
   params: {
     serverCommand?: string;
+    serverArgs?: string[];
     defaultServerCommand?: string;
+    defaultServerArgs?: string[];
   } = {},
 ): boolean {
   const serverCommand = params.serverCommand?.trim();
@@ -374,7 +376,15 @@ export function shouldStripProviderAuthEnvVarsForAcpServer(
     return true;
   }
   const defaultServerCommand = params.defaultServerCommand?.trim();
-  return Boolean(defaultServerCommand) && serverCommand === defaultServerCommand;
+  if (!defaultServerCommand || serverCommand !== defaultServerCommand) {
+    return false;
+  }
+  const serverArgs = params.serverArgs ?? [];
+  const defaultServerArgs = params.defaultServerArgs ?? [];
+  return (
+    serverArgs.length === defaultServerArgs.length &&
+    serverArgs.every((arg, index) => arg === defaultServerArgs[index])
+  );
 }
 
 export function buildAcpClientStripKeys(params: {
@@ -487,12 +497,15 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
 
   const entryPath = resolveSelfEntryPath();
   const defaultServerCommand = entryPath ? process.execPath : "openclaw";
+  const defaultServerArgs = entryPath ? [entryPath, ...serverArgs] : serverArgs;
   const serverCommand = opts.serverCommand ?? defaultServerCommand;
-  const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : [entryPath, ...serverArgs];
+  const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : defaultServerArgs;
   const { getActiveSkillEnvKeys } = await import("../agents/skills/env-overrides.runtime.js");
   const stripProviderAuthEnvVars = shouldStripProviderAuthEnvVarsForAcpServer({
     serverCommand,
+    serverArgs: effectiveArgs,
     defaultServerCommand,
+    defaultServerArgs,
   });
   const stripKeys = buildAcpClientStripKeys({
     stripProviderAuthEnvVars,

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -19,7 +19,10 @@ import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
 } from "../plugin-sdk/windows-spawn.js";
-import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
+import {
+  listKnownProviderAuthEnvVarNames,
+  omitEnvKeysCaseInsensitive,
+} from "../secrets/provider-env-vars.js";
 import { DANGEROUS_ACP_TOOLS } from "../security/dangerous-tools.js";
 
 const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["read", "search", "web_search", "memory_search"]);
@@ -355,28 +358,33 @@ export function resolveAcpClientSpawnEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
   options: AcpClientSpawnEnvOptions = {},
 ): NodeJS.ProcessEnv {
-  const env = { ...baseEnv };
-  for (const key of options.stripKeys ?? []) {
-    delete env[key];
-  }
+  const env = omitEnvKeysCaseInsensitive(baseEnv, options.stripKeys ?? []);
   env.OPENCLAW_SHELL = "acp-client";
   return env;
 }
 
-export function shouldStripProviderAuthEnvVarsForAcpServer(serverCommand?: string): boolean {
-  return !serverCommand;
+export function shouldStripProviderAuthEnvVarsForAcpServer(
+  params: {
+    serverCommand?: string;
+    defaultServerCommand?: string;
+  } = {},
+): boolean {
+  const serverCommand = params.serverCommand?.trim();
+  if (!serverCommand) {
+    return true;
+  }
+  const defaultServerCommand = params.defaultServerCommand?.trim();
+  return Boolean(defaultServerCommand) && serverCommand === defaultServerCommand;
 }
 
 export function buildAcpClientStripKeys(params: {
-  serverCommand?: string;
+  stripProviderAuthEnvVars?: boolean;
   activeSkillEnvKeys?: Iterable<string>;
 }): Set<string> {
   const stripKeys = new Set<string>(params.activeSkillEnvKeys ?? []);
-  if (shouldStripProviderAuthEnvVarsForAcpServer(params.serverCommand)) {
+  if (params.stripProviderAuthEnvVars) {
     for (const key of listKnownProviderAuthEnvVarNames()) {
-      if (key !== "OPENCLAW_API_KEY") {
-        stripKeys.add(key);
-      }
+      stripKeys.add(key);
     }
   }
   return stripKeys;
@@ -478,11 +486,16 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const serverArgs = buildServerArgs(opts);
 
   const entryPath = resolveSelfEntryPath();
-  const serverCommand = opts.serverCommand ?? (entryPath ? process.execPath : "openclaw");
+  const defaultServerCommand = entryPath ? process.execPath : "openclaw";
+  const serverCommand = opts.serverCommand ?? defaultServerCommand;
   const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : [entryPath, ...serverArgs];
   const { getActiveSkillEnvKeys } = await import("../agents/skills/env-overrides.runtime.js");
+  const stripProviderAuthEnvVars = shouldStripProviderAuthEnvVarsForAcpServer({
+    serverCommand,
+    defaultServerCommand,
+  });
   const stripKeys = buildAcpClientStripKeys({
-    serverCommand: opts.serverCommand,
+    stripProviderAuthEnvVars,
     activeSkillEnvKeys: getActiveSkillEnvKeys(),
   });
   const spawnEnv = resolveAcpClientSpawnEnv(process.env, { stripKeys });

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -19,6 +19,7 @@ import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
 } from "../plugin-sdk/windows-spawn.js";
+import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
 import { DANGEROUS_ACP_TOOLS } from "../security/dangerous-tools.js";
 
 const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["read", "search", "web_search", "memory_search"]);
@@ -346,18 +347,39 @@ function buildServerArgs(opts: AcpClientOptions): string[] {
   return args;
 }
 
+type AcpClientSpawnEnvOptions = {
+  stripKeys?: Iterable<string>;
+};
+
 export function resolveAcpClientSpawnEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
-  options?: { stripKeys?: ReadonlySet<string> },
+  options: AcpClientSpawnEnvOptions = {},
 ): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...baseEnv };
-  if (options?.stripKeys) {
-    for (const key of options.stripKeys) {
-      delete env[key];
-    }
+  const env = { ...baseEnv };
+  for (const key of options.stripKeys ?? []) {
+    delete env[key];
   }
   env.OPENCLAW_SHELL = "acp-client";
   return env;
+}
+
+export function shouldStripProviderAuthEnvVarsForAcpServer(serverCommand?: string): boolean {
+  return !serverCommand;
+}
+
+export function buildAcpClientStripKeys(params: {
+  serverCommand?: string;
+  activeSkillEnvKeys?: Iterable<string>;
+}): Set<string> {
+  const stripKeys = new Set<string>(params.activeSkillEnvKeys ?? []);
+  if (shouldStripProviderAuthEnvVarsForAcpServer(params.serverCommand)) {
+    for (const key of listKnownProviderAuthEnvVarNames()) {
+      if (key !== "OPENCLAW_API_KEY") {
+        stripKeys.add(key);
+      }
+    }
+  }
+  return stripKeys;
 }
 
 type AcpSpawnRuntime = {
@@ -459,9 +481,11 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const serverCommand = opts.serverCommand ?? (entryPath ? process.execPath : "openclaw");
   const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : [entryPath, ...serverArgs];
   const { getActiveSkillEnvKeys } = await import("../agents/skills/env-overrides.runtime.js");
-  const spawnEnv = resolveAcpClientSpawnEnv(process.env, {
-    stripKeys: getActiveSkillEnvKeys(),
+  const stripKeys = buildAcpClientStripKeys({
+    serverCommand: opts.serverCommand,
+    activeSkillEnvKeys: getActiveSkillEnvKeys(),
   });
+  const spawnEnv = resolveAcpClientSpawnEnv(process.env, { stripKeys });
   const spawnInvocation = resolveAcpClientSpawnInvocation(
     { serverCommand, serverArgs: effectiveArgs },
     {

--- a/src/plugin-sdk/acpx.ts
+++ b/src/plugin-sdk/acpx.ts
@@ -32,4 +32,7 @@ export {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgramCandidate,
 } from "./windows-spawn.js";
-export { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
+export {
+  listKnownProviderAuthEnvVarNames,
+  omitEnvKeysCaseInsensitive,
+} from "../secrets/provider-env-vars.js";

--- a/src/plugin-sdk/acpx.ts
+++ b/src/plugin-sdk/acpx.ts
@@ -32,3 +32,4 @@ export {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgramCandidate,
 } from "./windows-spawn.js";
+export { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -101,6 +101,7 @@ describe("plugin-sdk subpath exports", () => {
   it("exports acpx helpers", async () => {
     const acpxSdk = await import("openclaw/plugin-sdk/acpx");
     expect(typeof acpxSdk.listKnownProviderAuthEnvVarNames).toBe("function");
+    expect(typeof acpxSdk.omitEnvKeysCaseInsensitive).toBe("function");
   });
 
   it("resolves bundled extension subpaths", async () => {

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -98,6 +98,11 @@ describe("plugin-sdk subpath exports", () => {
     expect(typeof msteamsSdk.loadOutboundMediaFromUrl).toBe("function");
   });
 
+  it("exports acpx helpers", async () => {
+    const acpxSdk = await import("openclaw/plugin-sdk/acpx");
+    expect(typeof acpxSdk.listKnownProviderAuthEnvVarNames).toBe("function");
+  });
+
   it("resolves bundled extension subpaths", async () => {
     for (const { id, load } of bundledExtensionSubpathLoaders) {
       const mod = await load();

--- a/src/secrets/provider-env-vars.test.ts
+++ b/src/secrets/provider-env-vars.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  listKnownProviderAuthEnvVarNames,
+  listKnownSecretEnvVarNames,
+  omitEnvKeysCaseInsensitive,
+} from "./provider-env-vars.js";
+
+describe("provider env vars", () => {
+  it("keeps secret and provider auth env var lists in sync", () => {
+    expect(listKnownSecretEnvVarNames()).toEqual(listKnownProviderAuthEnvVarNames());
+    expect(listKnownSecretEnvVarNames()).toEqual(
+      expect.arrayContaining(["GITHUB_TOKEN", "GH_TOKEN", "ANTHROPIC_OAUTH_TOKEN"]),
+    );
+    expect(listKnownSecretEnvVarNames()).not.toContain("OPENCLAW_API_KEY");
+  });
+
+  it("omits env keys case-insensitively", () => {
+    const env = omitEnvKeysCaseInsensitive(
+      {
+        OpenAI_Api_Key: "openai-secret",
+        Github_Token: "gh-secret",
+        OPENCLAW_API_KEY: "keep-me",
+      },
+      ["OPENAI_API_KEY", "GITHUB_TOKEN"],
+    );
+
+    expect(env.OpenAI_Api_Key).toBeUndefined();
+    expect(env.Github_Token).toBeUndefined();
+    expect(env.OPENCLAW_API_KEY).toBe("keep-me");
+  });
+});

--- a/src/secrets/provider-env-vars.test.ts
+++ b/src/secrets/provider-env-vars.test.ts
@@ -6,9 +6,12 @@ import {
 } from "./provider-env-vars.js";
 
 describe("provider env vars", () => {
-  it("keeps secret and provider auth env var lists in sync", () => {
-    expect(listKnownSecretEnvVarNames()).toEqual(listKnownProviderAuthEnvVarNames());
-    expect(listKnownSecretEnvVarNames()).toEqual(
+  it("keeps the auth scrub list broader than the global secret env list", () => {
+    expect(listKnownProviderAuthEnvVarNames()).toEqual(
+      expect.arrayContaining(["GITHUB_TOKEN", "GH_TOKEN", "ANTHROPIC_OAUTH_TOKEN"]),
+    );
+    expect(listKnownSecretEnvVarNames()).not.toEqual(listKnownProviderAuthEnvVarNames());
+    expect(listKnownSecretEnvVarNames()).not.toEqual(
       expect.arrayContaining(["GITHUB_TOKEN", "GH_TOKEN", "ANTHROPIC_OAUTH_TOKEN"]),
     );
     expect(listKnownSecretEnvVarNames()).not.toContain("OPENCLAW_API_KEY");

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -45,15 +45,42 @@ const EXTRA_PROVIDER_AUTH_ENV_VARS = [
   "VLLM_API_KEY",
 ] as const;
 
+// OPENCLAW_API_KEY authenticates the local OpenClaw bridge itself and must
+// remain available to child bridge/runtime processes.
+const KNOWN_PROVIDER_AUTH_ENV_VARS = [
+  ...new Set([
+    ...Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys),
+    ...EXTRA_PROVIDER_AUTH_ENV_VARS,
+  ]),
+];
+
 export function listKnownProviderAuthEnvVarNames(): string[] {
-  return [
-    ...new Set([
-      ...Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys),
-      ...EXTRA_PROVIDER_AUTH_ENV_VARS,
-    ]),
-  ];
+  return [...KNOWN_PROVIDER_AUTH_ENV_VARS];
 }
 
 export function listKnownSecretEnvVarNames(): string[] {
-  return [...new Set(Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys))];
+  return listKnownProviderAuthEnvVarNames();
+}
+
+export function omitEnvKeysCaseInsensitive(
+  baseEnv: NodeJS.ProcessEnv,
+  keys: Iterable<string>,
+): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  const denied = new Set<string>();
+  for (const key of keys) {
+    const normalizedKey = key.trim();
+    if (normalizedKey) {
+      denied.add(normalizedKey.toUpperCase());
+    }
+  }
+  if (denied.size === 0) {
+    return env;
+  }
+  for (const actualKey of Object.keys(env)) {
+    if (denied.has(actualKey.toUpperCase())) {
+      delete env[actualKey];
+    }
+  }
+  return env;
 }

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -45,13 +45,14 @@ const EXTRA_PROVIDER_AUTH_ENV_VARS = [
   "VLLM_API_KEY",
 ] as const;
 
+const KNOWN_SECRET_ENV_VARS = [
+  ...new Set(Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys)),
+];
+
 // OPENCLAW_API_KEY authenticates the local OpenClaw bridge itself and must
 // remain available to child bridge/runtime processes.
 const KNOWN_PROVIDER_AUTH_ENV_VARS = [
-  ...new Set([
-    ...Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys),
-    ...EXTRA_PROVIDER_AUTH_ENV_VARS,
-  ]),
+  ...new Set([...KNOWN_SECRET_ENV_VARS, ...EXTRA_PROVIDER_AUTH_ENV_VARS]),
 ];
 
 export function listKnownProviderAuthEnvVarNames(): string[] {
@@ -59,7 +60,7 @@ export function listKnownProviderAuthEnvVarNames(): string[] {
 }
 
 export function listKnownSecretEnvVarNames(): string[] {
-  return listKnownProviderAuthEnvVarNames();
+  return [...KNOWN_SECRET_ENV_VARS];
 }
 
 export function omitEnvKeysCaseInsensitive(

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -26,6 +26,34 @@ export const PROVIDER_ENV_VARS: Record<string, readonly string[]> = {
   byteplus: ["BYTEPLUS_API_KEY"],
 };
 
+const EXTRA_PROVIDER_AUTH_ENV_VARS = [
+  "VOYAGE_API_KEY",
+  "GROQ_API_KEY",
+  "DEEPGRAM_API_KEY",
+  "CEREBRAS_API_KEY",
+  "NVIDIA_API_KEY",
+  "COPILOT_GITHUB_TOKEN",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "ANTHROPIC_OAUTH_TOKEN",
+  "CHUTES_OAUTH_TOKEN",
+  "CHUTES_API_KEY",
+  "QWEN_OAUTH_TOKEN",
+  "QWEN_PORTAL_API_KEY",
+  "MINIMAX_OAUTH_TOKEN",
+  "OLLAMA_API_KEY",
+  "VLLM_API_KEY",
+] as const;
+
+export function listKnownProviderAuthEnvVarNames(): string[] {
+  return [
+    ...new Set([
+      ...Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys),
+      ...EXTRA_PROVIDER_AUTH_ENV_VARS,
+    ]),
+  ];
+}
+
 export function listKnownSecretEnvVarNames(): string[] {
   return [...new Set(Object.values(PROVIDER_ENV_VARS).flatMap((keys) => keys))];
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: provider auth env vars such as `OPENAI_API_KEY`, `GITHUB_TOKEN`, and `HF_TOKEN` can leak into ACP child processes.
- Why it matters: downstream ACP agents can detect inherited provider creds and switch auth modes or overwrite their own auth state.
- What changed: the default OpenClaw ACP bridge path and bundled `acpx` spawn path now strip a shared list of provider auth env vars before spawning child ACP processes.
- What did NOT change (scope boundary): explicit custom ACP servers and explicit custom `acpx` commands still inherit their env-based auth contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #41615
- Related #36280

## User-visible / Behavior Changes

- Default `openclaw acp` child processes no longer inherit provider auth env vars from the parent OpenClaw process.
- Bundled `acpx` child processes no longer inherit provider auth env vars from the parent OpenClaw process.
- Explicit custom ACP servers and custom `acpx` commands continue to inherit provider auth env vars.
- `secrets audit` and `secrets apply` now treat additional provider auth env vars such as `GITHUB_TOKEN`, `GH_TOKEN`, `COPILOT_GITHUB_TOKEN`, and `ANTHROPIC_OAUTH_TOKEN` as secrets, so plaintext `.env` entries for those keys are now flagged and scrubbed too.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  Provider auth env vars are now scrubbed before spawning default ACP child processes. This reduces unintended credential propagation. The main compatibility risk is breaking custom servers that rely on inherited creds, so the strip only applies to the default OpenClaw bridge path and bundled `acpx` path, not explicit custom commands. As part of unifying the secret list, `secrets audit` and `secrets apply` now also treat additional provider tokens like `GITHUB_TOKEN` and `GH_TOKEN` as secrets.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): ACP / ACPX
- Relevant config (redacted): default ACP bridge path, bundled `acpx`, explicit custom ACP server command, explicit custom `acpx` command

### Steps

1. Export provider auth env vars like `OPENAI_API_KEY`, `GITHUB_TOKEN`, and `HF_TOKEN` in the parent shell.
2. Start ACP through the default OpenClaw bridge path or bundled `acpx` path.
3. Inspect the spawned child env and then repeat with an explicit custom ACP server or explicit custom `acpx` command.

### Expected

- Default OpenClaw ACP child processes do not receive provider auth env vars.
- `OPENCLAW_API_KEY` remains available.
- Explicit custom ACP servers and explicit custom `acpx` commands still receive inherited provider auth env vars.

### Actual

- Verified locally: behavior matches the expected cases above.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: default ACP bridge strips provider auth vars; bundled `acpx` strips provider auth vars; explicit custom ACP servers preserve provider auth vars; explicit custom `acpx` commands preserve provider auth vars.
- Edge cases checked: `OPENCLAW_API_KEY` is preserved; non-`_API_KEY` auth vars like `GITHUB_TOKEN` and `HF_TOKEN` are stripped where intended; `src/plugin-sdk/subpaths.test.ts` still passes on the clean branch.
- What you did **not** verify: full GitHub Actions run on the new PR branch; behavior on Windows beyond existing spawn-path unit coverage.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or temporarily run ACP through an explicit custom server/custom `acpx` command path.
- Files/config to restore: `src/acp/client.ts`, `extensions/acpx/src/runtime-internals/process.ts`, `extensions/acpx/src/runtime.ts`, `src/secrets/provider-env-vars.ts`
- Known bad symptoms reviewers should watch for: default ACP bridge or bundled `acpx` unexpectedly losing access to required provider creds; explicit custom commands unexpectedly losing inherited creds.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the shared provider-auth env var list misses a provider-specific token name and leaves an unintended credential in child env.
  - Mitigation: centralize the list in `src/secrets/provider-env-vars.ts` and cover non-`_API_KEY` examples in tests.
- Risk: stripping env vars too broadly breaks custom user-managed ACP server setups.
  - Mitigation: only strip on the default OpenClaw bridge path and bundled `acpx` path; explicit custom commands preserve inherited env vars.

