### PR TITLE
fix(sandbox): sanitize Docker env before marking OPENCLAW_CLI

### DIFF
--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
+import { OPENCLAW_CLI_ENV_VALUE, markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import { buildSandboxCreateArgs } from "./sandbox/docker.js";
+import { sanitizeEnvVars } from "./sandbox/sanitize-env-vars.js";
 import type { SandboxDockerConfig } from "./sandbox/types.js";
 
 describe("buildSandboxCreateArgs", () => {
@@ -134,6 +135,42 @@ describe("buildSandboxCreateArgs", () => {
     }
     expect(ulimitValues).toEqual(
       expect.arrayContaining(["nofile=1024:2048", "nproc=128", "core=0"]),
+    );
+  });
+
+  it("adds the OpenClaw exec marker after env sanitization", () => {
+    const envSanitization = sanitizeEnvVars(
+      {
+        NODE_ENV: "test",
+      },
+      { strictMode: true },
+    );
+
+    expect(markOpenClawExecEnv(envSanitization.allowed)).toEqual({
+      NODE_ENV: "test",
+      OPENCLAW_CLI: OPENCLAW_CLI_ENV_VALUE,
+    });
+
+    const cfg = createSandboxConfig({
+      env: {
+        NODE_ENV: "test",
+      },
+    });
+
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-marker",
+      cfg,
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+    });
+
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--env",
+        "NODE_ENV=test",
+        "--env",
+        `OPENCLAW_CLI=${OPENCLAW_CLI_ENV_VALUE}`,
+      ]),
     );
   });
 

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { OPENCLAW_CLI_ENV_VALUE, markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
+import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
 import { buildSandboxCreateArgs } from "./sandbox/docker.js";
-import { sanitizeEnvVars } from "./sandbox/sanitize-env-vars.js";
 import type { SandboxDockerConfig } from "./sandbox/types.js";
 
 describe("buildSandboxCreateArgs", () => {
@@ -138,19 +137,7 @@ describe("buildSandboxCreateArgs", () => {
     );
   });
 
-  it("adds the OpenClaw exec marker after env sanitization", () => {
-    const envSanitization = sanitizeEnvVars(
-      {
-        NODE_ENV: "test",
-      },
-      { strictMode: true },
-    );
-
-    expect(markOpenClawExecEnv(envSanitization.allowed)).toEqual({
-      NODE_ENV: "test",
-      OPENCLAW_CLI: OPENCLAW_CLI_ENV_VALUE,
-    });
-
+  it("preserves the OpenClaw exec marker when strict env sanitization is enabled", () => {
     const cfg = createSandboxConfig({
       env: {
         NODE_ENV: "test",
@@ -162,6 +149,9 @@ describe("buildSandboxCreateArgs", () => {
       cfg,
       scopeKey: "main",
       createdAtMs: 1700000000000,
+      envSanitizationOptions: {
+        strictMode: true,
+      },
     });
 
     expect(args).toEqual(

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -5,6 +5,7 @@ import {
   resolveWindowsSpawnProgram,
 } from "../../plugin-sdk/windows-spawn.js";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
+import type { EnvSanitizationOptions } from "./sanitize-env-vars.js";
 
 type ExecDockerRawOptions = {
   allowFailure?: boolean;
@@ -52,7 +53,7 @@ export function resolveDockerSpawnInvocation(
     env: runtime.env,
     execPath: runtime.execPath,
     packageName: "docker",
-    allowShellFallback: true,
+    allowShellFallback: false,
   });
   const resolved = materializeWindowsSpawnProgram(program, args);
   return {
@@ -325,6 +326,7 @@ export function buildSandboxCreateArgs(params: {
   allowSourcesOutsideAllowedRoots?: boolean;
   allowReservedContainerTargets?: boolean;
   allowContainerNamespaceJoin?: boolean;
+  envSanitizationOptions?: EnvSanitizationOptions;
 }) {
   // Runtime security validation: blocks dangerous bind mounts, network modes, and profiles.
   validateSandboxSecurity({
@@ -366,7 +368,7 @@ export function buildSandboxCreateArgs(params: {
   if (params.cfg.user) {
     args.push("--user", params.cfg.user);
   }
-  const envSanitization = sanitizeEnvVars(params.cfg.env ?? {});
+  const envSanitization = sanitizeEnvVars(params.cfg.env ?? {}, params.envSanitizationOptions);
   if (envSanitization.blocked.length > 0) {
     log.warn(`Blocked sensitive environment variables: ${envSanitization.blocked.join(", ")}`);
   }

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -366,14 +366,14 @@ export function buildSandboxCreateArgs(params: {
   if (params.cfg.user) {
     args.push("--user", params.cfg.user);
   }
-  const envSanitization = sanitizeEnvVars(markOpenClawExecEnv(params.cfg.env ?? {}));
+  const envSanitization = sanitizeEnvVars(params.cfg.env ?? {});
   if (envSanitization.blocked.length > 0) {
     log.warn(`Blocked sensitive environment variables: ${envSanitization.blocked.join(", ")}`);
   }
   if (envSanitization.warnings.length > 0) {
     log.warn(`Suspicious environment variables: ${envSanitization.warnings.join(", ")}`);
   }
-  for (const [key, value] of Object.entries(envSanitization.allowed)) {
+  for (const [key, value] of Object.entries(markOpenClawExecEnv(envSanitization.allowed))) {
     args.push("--env", `${key}=${value}`);
   }
   for (const cap of params.cfg.capDrop) {

--- a/src/agents/sandbox/docker.windows.test.ts
+++ b/src/agents/sandbox/docker.windows.test.ts
@@ -47,22 +47,20 @@ describe("resolveDockerSpawnInvocation", () => {
     });
   });
 
-  it("falls back to shell mode when only unresolved docker.cmd wrapper exists", async () => {
+  it("rejects unresolved docker.cmd wrappers instead of shelling out", async () => {
     const dir = await createTempDir();
     const cmdPath = path.join(dir, "docker.cmd");
     await mkdir(path.dirname(cmdPath), { recursive: true });
     await writeFile(cmdPath, "@ECHO off\r\necho docker\r\n", "utf8");
 
-    const resolved = resolveDockerSpawnInvocation(["ps"], {
-      platform: "win32",
-      env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
-      execPath: "C:\\node\\node.exe",
-    });
-    expect(path.normalize(resolved.command).toLowerCase()).toBe(
-      path.normalize(cmdPath).toLowerCase(),
+    expect(() =>
+      resolveDockerSpawnInvocation(["ps"], {
+        platform: "win32",
+        env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
+        execPath: "C:\\node\\node.exe",
+      }),
+    ).toThrow(
+      /wrapper resolved, but no executable\/Node entrypoint could be resolved without shell execution\./i,
     );
-    expect(resolved.args).toEqual(["ps"]);
-    expect(resolved.shell).toBe(true);
-    expect(resolved.windowsHide).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Problem: the Docker sandbox path injected `OPENCLAW_CLI` before env sanitization, unlike the other execution paths from #41411.
- Why it matters: if this call site ever enables `strictMode`, the sanitizer would block the marker and log it as a blocked variable; on Windows, Docker also allowed a `shell: true` fallback for unresolved wrapper shims.
- What changed: Docker env sanitization now runs on user-provided env first, then `markOpenClawExecEnv` is applied immediately before emitting `--env` args; Docker Windows resolution now refuses shell fallback and requires a direct executable or resolvable Node entrypoint; the regression tests now cover the strict-mode integration path and unresolved Windows wrapper rejection.
- What did NOT change (scope boundary): no allowlist changes, no new env vars, and no behavior changes outside Docker sandbox arg construction/spawn resolution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #41411

## User-visible / Behavior Changes

- On Windows, Docker sandbox startup now fails fast instead of shelling out through an unresolved `docker.cmd`/`.bat` wrapper.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Docker no longer permits Windows shell fallback, which removes a shell-execution path for user-influenced Docker args. The compatibility tradeoff is limited to unresolved wrapper setups, which now fail with an explicit error instead of invoking `cmd.exe`.

## Repro + Verification

### Environment

- OS: macOS (tests cover Windows resolution path)
- Runtime/container: Node 22, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Docker sandbox
- Relevant config (redacted): default sandbox config with `env.NODE_ENV=test`

### Steps

1. Build Docker create args with `envSanitizationOptions.strictMode=true` and `env.NODE_ENV=test`.
2. Verify the resulting `--env` args still include `OPENCLAW_CLI` after sanitization.
3. On a simulated Windows PATH containing only an unresolved `docker.cmd`, resolve the Docker spawn invocation.

### Expected

- User env is sanitized first.
- `OPENCLAW_CLI` is appended after sanitization and survives strict-mode filtering.
- Windows Docker resolution does not allow `shell: true` fallback.

### Actual

- After this patch, the Docker path matches the other injection points from #41411, preserves `OPENCLAW_CLI` after strict sanitization, and rejects unresolved Windows wrappers instead of shelling out.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/agents/sandbox-create-args.test.ts src/agents/sandbox/docker.windows.test.ts`; `pnpm exec oxfmt --check src/agents/sandbox/docker.ts src/agents/sandbox/docker.windows.test.ts src/agents/sandbox-create-args.test.ts`; `pnpm exec oxlint src/agents/sandbox/docker.ts src/agents/sandbox/docker.windows.test.ts src/agents/sandbox-create-args.test.ts`
- Edge cases checked: strict-mode sanitization still permits the injected marker once it is applied after sanitization; unresolved Windows `docker.cmd` wrappers are rejected instead of enabling `shell: true`.
- What you did **not** verify: full `pnpm check` is currently failing on unrelated `main` branch TypeScript errors in other agent/OAuth files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Mostly`)
- Config/env changes? (`No`)
- Migration needed? (`Maybe`)
- If yes, exact upgrade steps: Windows environments that rely on an unresolved `docker.cmd`/`.bat` shim need Docker installed in a form that resolves to a direct executable or a resolvable Node entrypoint.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/agents/sandbox/docker.ts`, `src/agents/sandbox/docker.windows.test.ts`, `src/agents/sandbox-create-args.test.ts`
- Known bad symptoms reviewers should watch for: Docker sandbox create args missing `OPENCLAW_CLI` under strict sanitization, or Windows Docker startup failing because only an unresolved wrapper is available.

## Risks and Mitigations

- Risk: Windows environments that previously relied on shell fallback may now fail to launch Docker sandboxes.
  - Mitigation: the new behavior is explicit and tested; it avoids executing user-influenced Docker args through `cmd.exe` and surfaces a direct remediation path.
- Risk: Docker env arg ordering diverges from the other execution paths again in a future refactor.
  - Mitigation: regression test asserts marker injection survives the strict-mode integration path.
