### PR TITLE
fix: recover stuck Control UI chat runs

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -5,6 +5,7 @@ import { resetToolStream } from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
 import { abortChatRun, loadChatHistory, sendChatMessage } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
+import type { GatewayBrowserClient } from "./gateway.ts";
 import type { GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
@@ -25,9 +26,109 @@ export type ChatHost = {
 };
 
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
+const CHAT_RUN_WATCHDOG_IDLE_MS = 15_000;
+const CHAT_RUN_WATCHDOG_RETRY_MS = 5_000;
+const CHAT_RUN_WATCHDOG_WAIT_TIMEOUT_MS = 50;
 
 export function isChatBusy(host: ChatHost) {
   return host.chatSending || Boolean(host.chatRunId);
+}
+
+type ChatRunWatchdogHost = ChatHost & {
+  client: GatewayBrowserClient | null;
+  chatLoading: boolean;
+  chatMessages: unknown[];
+  chatThinkingLevel: string | null;
+  chatRunLastActivityAt: number | null;
+  chatRunWatchdogTimer: number | null;
+  chatRunWatchdogProbeInFlight: boolean;
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+  lastError: string | null;
+};
+
+function clearChatRunWatchdogTimer(host: ChatRunWatchdogHost) {
+  if (host.chatRunWatchdogTimer !== null) {
+    globalThis.clearTimeout(host.chatRunWatchdogTimer);
+    host.chatRunWatchdogTimer = null;
+  }
+}
+
+export function resetChatRunWatchdog(host: ChatRunWatchdogHost) {
+  clearChatRunWatchdogTimer(host);
+  host.chatRunWatchdogProbeInFlight = false;
+  if (!host.chatRunId) {
+    host.chatRunLastActivityAt = null;
+  }
+}
+
+async function runChatRunWatchdog(host: ChatRunWatchdogHost, runId: string) {
+  if (!host.connected || !host.client || !host.chatRunId || host.chatRunId !== runId) {
+    resetChatRunWatchdog(host);
+    return;
+  }
+  if (host.chatRunWatchdogProbeInFlight) {
+    scheduleChatRunWatchdog(host, CHAT_RUN_WATCHDOG_RETRY_MS);
+    return;
+  }
+
+  host.chatRunWatchdogProbeInFlight = true;
+  try {
+    const result = await host.client.request<{ status?: string }>("agent.wait", {
+      runId,
+      timeoutMs: CHAT_RUN_WATCHDOG_WAIT_TIMEOUT_MS,
+    });
+    if (host.chatRunId !== runId) {
+      return;
+    }
+    if (result?.status === "ok" || result?.status === "error") {
+      host.chatRunId = null;
+      host.chatStream = null;
+      host.chatStreamStartedAt = null;
+      host.chatRunLastActivityAt = null;
+      resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
+      try {
+        await loadChatHistory(host as unknown as OpenClawApp);
+      } finally {
+        await flushChatQueue(host);
+      }
+      return;
+    }
+  } catch (err) {
+    host.lastError = String(err);
+  } finally {
+    host.chatRunWatchdogProbeInFlight = false;
+  }
+
+  if (host.chatRunId === runId) {
+    scheduleChatRunWatchdog(host, CHAT_RUN_WATCHDOG_RETRY_MS);
+  }
+}
+
+export function scheduleChatRunWatchdog(host: ChatRunWatchdogHost, delayMs?: number) {
+  clearChatRunWatchdogTimer(host);
+  if (!host.connected || !host.client || !host.chatRunId) {
+    resetChatRunWatchdog(host);
+    return;
+  }
+
+  const now = Date.now();
+  const lastActivityAt = host.chatRunLastActivityAt ?? now;
+  const delay =
+    delayMs ?? Math.max(0, CHAT_RUN_WATCHDOG_IDLE_MS - Math.max(0, now - lastActivityAt));
+  const runId = host.chatRunId;
+  host.chatRunWatchdogTimer = globalThis.setTimeout(() => {
+    host.chatRunWatchdogTimer = null;
+    void runChatRunWatchdog(host, runId);
+  }, delay);
+}
+
+export function noteChatRunActivity(host: ChatRunWatchdogHost, now = Date.now()) {
+  if (!host.chatRunId) {
+    return;
+  }
+  host.chatRunLastActivityAt = now;
+  scheduleChatRunWatchdog(host);
 }
 
 export function isChatStopCommand(text: string) {
@@ -65,7 +166,10 @@ export async function handleAbortChat(host: ChatHost) {
     return;
   }
   host.chatMessage = "";
-  await abortChatRun(host as unknown as OpenClawApp);
+  const ok = await abortChatRun(host as unknown as OpenClawApp);
+  if (ok && host.chatRunId) {
+    noteChatRunActivity(host as unknown as ChatRunWatchdogHost);
+  }
 }
 
 function enqueueChatMessage(

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -3,7 +3,13 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "../../../src/gateway/events.js";
 import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
-import { CHAT_SESSIONS_ACTIVE_MINUTES, flushChatQueueForEvent } from "./app-chat.ts";
+import {
+  CHAT_SESSIONS_ACTIVE_MINUTES,
+  flushChatQueueForEvent,
+  noteChatRunActivity,
+  resetChatRunWatchdog,
+  scheduleChatRunWatchdog,
+} from "./app-chat.ts";
 import type { EventLogEntry } from "./app-events.ts";
 import {
   applySettings,
@@ -91,6 +97,11 @@ type GatewayHost = {
   serverVersion: string | null;
   sessionKey: string;
   chatRunId: string | null;
+  chatRunLastActivityAt: number | null;
+  chatRunWatchdogTimer: number | null;
+  chatRunWatchdogProbeInFlight: boolean;
+  chatStreamStartedAt: number | null;
+  chatStream: string | null;
   refreshSessionsAfterChat: Set<string>;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
@@ -218,6 +229,8 @@ export function connectGateway(host: GatewayHost) {
       host.chatRunId = null;
       (host as unknown as { chatStream: string | null }).chatStream = null;
       (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
+      host.chatRunLastActivityAt = null;
+      resetChatRunWatchdog(host);
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
       void loadAssistantIdentity(host as unknown as OpenClawApp);
       void loadAgents(host as unknown as OpenClawApp);
@@ -248,6 +261,7 @@ export function connectGateway(host: GatewayHost) {
         host.lastError = null;
         host.lastErrorCode = null;
       }
+      resetChatRunWatchdog(host);
     },
     onEvent: (evt) => {
       if (host.client !== client) {
@@ -315,6 +329,13 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     );
   }
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
+  if (state === "delta") {
+    noteChatRunActivity(host);
+  } else if (host.chatRunId) {
+    scheduleChatRunWatchdog(host);
+  } else {
+    resetChatRunWatchdog(host);
+  }
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
   if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {
     void loadChatHistory(host as unknown as OpenClawApp);

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -1,3 +1,4 @@
+import { resetChatRunWatchdog, scheduleChatRunWatchdog } from "./app-chat.ts";
 import { connectGateway } from "./app-gateway.ts";
 import {
   startLogsPolling,
@@ -35,6 +36,10 @@ type LifecycleHost = {
   chatMessages: unknown[];
   chatToolMessages: unknown[];
   chatStream: string;
+  chatRunId: string | null;
+  chatRunLastActivityAt: number | null;
+  chatRunWatchdogTimer: number | null;
+  chatRunWatchdogProbeInFlight: boolean;
   logsAutoFollow: boolean;
   logsAtBottom: boolean;
   logsEntries: unknown[];
@@ -76,6 +81,7 @@ export function handleDisconnected(host: LifecycleHost) {
   stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);
   stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
   stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);
+  resetChatRunWatchdog(host as unknown as Parameters<typeof resetChatRunWatchdog>[0]);
   host.client?.stop();
   host.client = null;
   host.connected = false;
@@ -85,6 +91,13 @@ export function handleDisconnected(host: LifecycleHost) {
 }
 
 export function handleUpdated(host: LifecycleHost, changed: Map<PropertyKey, unknown>) {
+  if (changed.has("chatRunId")) {
+    if (host.chatRunId) {
+      scheduleChatRunWatchdog(host as unknown as Parameters<typeof scheduleChatRunWatchdog>[0]);
+    } else {
+      resetChatRunWatchdog(host as unknown as Parameters<typeof resetChatRunWatchdog>[0]);
+    }
+  }
   if (host.tab === "chat" && host.chatManualRefreshInFlight) {
     return;
   }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -383,6 +383,9 @@ export class OpenClawApp extends LitElement {
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
+  chatRunLastActivityAt: number | null = null;
+  chatRunWatchdogTimer: number | null = null;
+  chatRunWatchdogProbeInFlight = false;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
   private logsPollInterval: number | null = null;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it, vi } from "vitest";
 import { handleChatEvent, loadChatHistory, type ChatEventPayload, type ChatState } from "./chat.ts";
 
+vi.stubGlobal("localStorage", {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+});
+
+vi.mock("../app-settings.ts", () => ({
+  setLastActiveSessionKey: vi.fn(),
+}));
+
+vi.mock("../app-scroll.ts", () => ({
+  scheduleChatScroll: vi.fn(),
+}));
+
+vi.mock("../app-tool-stream.ts", () => ({
+  resetToolStream: vi.fn(),
+}));
+
+vi.mock("../../i18n/index.ts", () => ({
+  isSupportedLocale: vi.fn(() => false),
+}));
+
 function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
     chatAttachments: [],
@@ -533,6 +555,142 @@ describe("loadChatHistory", () => {
 
     // text takes precedence — "real reply" is NOT silent, so message is kept.
     expect(state.chatMessages).toHaveLength(1);
+  });
+});
+
+describe("chat run watchdog", () => {
+  it("recovers a stale run and flushes a queued message", async () => {
+    vi.useFakeTimers();
+    try {
+      const { scheduleChatRunWatchdog } = await import("../app-chat.ts");
+      const request = vi.fn(async (method: string) => {
+        if (method === "agent.wait") {
+          return { status: "ok" };
+        }
+        if (method === "chat.history") {
+          return { messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }] };
+        }
+        if (method === "chat.send") {
+          return {};
+        }
+        throw new Error(`unexpected method: ${method}`);
+      });
+      const state = createState({
+        client: { request } as unknown as ChatState["client"],
+        connected: true,
+      }) as ChatState & {
+        chatQueue: Array<{ id: string; text: string; createdAt: number }>;
+        chatRunLastActivityAt: number | null;
+        chatRunWatchdogTimer: number | null;
+        chatRunWatchdogProbeInFlight: boolean;
+        refreshSessionsAfterChat: Set<string>;
+      };
+      state.chatRunId = "run-1";
+      state.chatStreamStartedAt = Date.now();
+      state.chatRunLastActivityAt = Date.now();
+      state.chatRunWatchdogTimer = null;
+      state.chatRunWatchdogProbeInFlight = false;
+      state.chatQueue = [{ id: "q-1", text: "continue", createdAt: Date.now() }];
+      state.refreshSessionsAfterChat = new Set();
+
+      scheduleChatRunWatchdog(state as never);
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(request).toHaveBeenCalledWith("agent.wait", {
+        runId: "run-1",
+        timeoutMs: 50,
+      });
+      expect(request).toHaveBeenCalledWith("chat.history", {
+        sessionKey: "main",
+        limit: 200,
+      });
+      expect(request).toHaveBeenCalledWith(
+        "chat.send",
+        expect.objectContaining({
+          sessionKey: "main",
+          message: "continue",
+          deliver: false,
+        }),
+      );
+      expect(state.chatQueue).toEqual([]);
+      expect(state.chatRunId).not.toBe("run-1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps waiting when the run is still active", async () => {
+    vi.useFakeTimers();
+    try {
+      const { scheduleChatRunWatchdog } = await import("../app-chat.ts");
+      const request = vi.fn(async (method: string) => {
+        if (method === "agent.wait") {
+          return { status: "timeout" };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      });
+      const state = createState({
+        client: { request } as unknown as ChatState["client"],
+        connected: true,
+      }) as ChatState & {
+        chatQueue: Array<{ id: string; text: string; createdAt: number }>;
+        chatRunLastActivityAt: number | null;
+        chatRunWatchdogTimer: number | null;
+        chatRunWatchdogProbeInFlight: boolean;
+        refreshSessionsAfterChat: Set<string>;
+      };
+      state.chatRunId = "run-1";
+      state.chatStreamStartedAt = Date.now();
+      state.chatRunLastActivityAt = Date.now();
+      state.chatRunWatchdogTimer = null;
+      state.chatRunWatchdogProbeInFlight = false;
+      state.chatQueue = [{ id: "q-1", text: "continue", createdAt: Date.now() }];
+      state.refreshSessionsAfterChat = new Set();
+
+      scheduleChatRunWatchdog(state as never);
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(state.chatRunId).toBe("run-1");
+      expect(state.chatQueue).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels the watchdog when reset before it fires", async () => {
+    vi.useFakeTimers();
+    try {
+      const { resetChatRunWatchdog, scheduleChatRunWatchdog } = await import("../app-chat.ts");
+      const request = vi.fn();
+      const state = createState({
+        client: { request } as unknown as ChatState["client"],
+        connected: true,
+      }) as ChatState & {
+        chatQueue: Array<{ id: string; text: string; createdAt: number }>;
+        chatRunLastActivityAt: number | null;
+        chatRunWatchdogTimer: number | null;
+        chatRunWatchdogProbeInFlight: boolean;
+        refreshSessionsAfterChat: Set<string>;
+      };
+      state.chatRunId = "run-1";
+      state.chatStreamStartedAt = Date.now();
+      state.chatRunLastActivityAt = Date.now();
+      state.chatRunWatchdogTimer = null;
+      state.chatRunWatchdogProbeInFlight = false;
+      state.chatQueue = [];
+      state.refreshSessionsAfterChat = new Set();
+
+      scheduleChatRunWatchdog(state as never);
+      resetChatRunWatchdog(state as never);
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(request).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -38,6 +38,7 @@ export type ChatState = {
   chatMessage: string;
   chatAttachments: ChatAttachment[];
   chatRunId: string | null;
+  chatRunLastActivityAt?: number | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   lastError: string | null;
@@ -193,6 +194,7 @@ export async function sendChatMessage(
   state.lastError = null;
   const runId = generateUUID();
   state.chatRunId = runId;
+  state.chatRunLastActivityAt = now;
   state.chatStream = "";
   state.chatStreamStartedAt = now;
 
@@ -279,6 +281,10 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       return "final";
     }
     return null;
+  }
+
+  if (payload.runId && state.chatRunId && payload.runId === state.chatRunId) {
+    state.chatRunLastActivityAt = Date.now();
   }
 
   if (payload.state === "delta") {


### PR DESCRIPTION
## Summary

- Problem: the Control UI chat can stay stuck in a busy state after a long-running run if the terminal chat event is missed.
- Why it matters: the next user message gets queued in the UI and does not flush automatically, so the session looks stalled until the user pokes it again.
- What changed: added a small client-side watchdog that probes `agent.wait` after chat inactivity and recovers the UI when the gateway already considers the run finished.
- What did NOT change (scope boundary): this PR does not change backend chat protocol, queue semantics, or model rate-limit retry behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42213

## User-visible / Behavior Changes

- Stale Control UI chat runs can recover automatically instead of blocking the next queued message forever.
- If `agent.wait` still reports the run as active, the UI keeps waiting and does not flush the queue early.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local macOS dev environment
- Runtime/container: Node.js dev environment
- Model/provider: not required for the regression tests
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): not required

### Steps

1. Start a long-running Control UI chat run.
2. Let the UI miss the terminal chat event and keep `chatRunId` active.
3. Queue another user message behind that stale run.

### Expected

- The UI should probe `agent.wait` after inactivity.
- If the run is already finished, the busy state should clear and the queued message should flush.

### Actual

- Before this change, the queued message could remain blocked behind a stale UI run until the user sent another prompt.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run ui/src/ui/controllers/chat.test.ts`, `pnpm exec oxlint ui/src/ui/app-chat.ts ui/src/ui/app-lifecycle.ts ui/src/ui/app-gateway.ts ui/src/ui/app.ts ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts`, `pnpm build`
- Edge cases checked: stale finished run recovery, still-active run timeout path, watchdog reset before firing
- What you did **not** verify: a live end-to-end reproduction against a real gateway/browser session after this patch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the chat watchdog helpers in `ui/src/ui/app-chat.ts`
- Files/config to restore: `ui/src/ui/app-chat.ts`, `ui/src/ui/app-gateway.ts`, `ui/src/ui/app-lifecycle.ts`, `ui/src/ui/controllers/chat.ts`
- Known bad symptoms reviewers should watch for: queued messages flushing while a run is still genuinely active

## Risks and Mitigations

- Risk: the UI now probes `agent.wait` after inactivity and could recover too aggressively if the inactivity threshold is wrong
  - Mitigation: the watchdog only recovers when `agent.wait` reports terminal status, and keeps waiting when the run still reports `timeout`
