### PR TITLE
fix(agents): show fuzzy match suggestions when edit oldText not found

### DIFF
--- a/src/agents/pi-tools.host-edit.fuzzy-suggestions.test.ts
+++ b/src/agents/pi-tools.host-edit.fuzzy-suggestions.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for edit tool fuzzy match suggestions: when oldText is not found in the file,
+ * the wrapper enriches the error with the closest matching regions (line numbers +
+ * similarity scores) so the model can self-correct in one shot.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  lcsLength,
+  lcsRatio,
+  scoreWindows,
+  wrapEditToolWithFuzzyMatchSuggestions,
+} from "./pi-tools.host-edit.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+// ─── Helpers ───
+
+function makeMockTool(behavior: "success" | "not-found" | "other-error"): AnyAgentTool {
+  return {
+    name: "edit",
+    description: "mock edit tool",
+    schema: { type: "object" as const, properties: {} },
+    execute: async (_toolCallId: string, params: unknown) => {
+      if (behavior === "success") {
+        return { content: [{ type: "text", text: "OK" }], details: {} };
+      }
+      const record = params as Record<string, unknown>;
+      if (behavior === "not-found") {
+        throw new Error(
+          `Could not find the exact text in ${String(record.path)}. The old text must match exactly.`,
+        );
+      }
+      throw new Error("File not found: /no/such/file");
+    },
+  } as unknown as AnyAgentTool;
+}
+
+// ─── lcsLength tests ───
+
+describe("lcsLength", () => {
+  it("returns 0 for empty strings", () => {
+    expect(lcsLength("", "")).toBe(0);
+    expect(lcsLength("abc", "")).toBe(0);
+    expect(lcsLength("", "abc")).toBe(0);
+  });
+
+  it("returns full length for identical strings", () => {
+    expect(lcsLength("hello", "hello")).toBe(5);
+  });
+
+  it("finds common subsequence for different strings", () => {
+    // LCS of "abc" and "axbxc" is "abc" = 3
+    expect(lcsLength("abc", "axbxc")).toBe(3);
+  });
+
+  it("returns 0 for completely different strings", () => {
+    expect(lcsLength("abc", "xyz")).toBe(0);
+  });
+});
+
+// ─── lcsRatio tests ───
+
+describe("lcsRatio", () => {
+  it("returns 1.0 for identical strings", () => {
+    expect(lcsRatio("hello world", "hello world")).toBe(1.0);
+  });
+
+  it("returns 1.0 for two empty strings", () => {
+    expect(lcsRatio("", "")).toBe(1.0);
+  });
+
+  it("returns 0.0 when one string is empty", () => {
+    expect(lcsRatio("abc", "")).toBe(0.0);
+    expect(lcsRatio("", "abc")).toBe(0.0);
+  });
+
+  it("returns 0.0 for completely different strings", () => {
+    expect(lcsRatio("abc", "xyz")).toBe(0.0);
+  });
+
+  it("returns value between 0 and 1 for partially similar strings", () => {
+    const ratio = lcsRatio("function handleClick(event)", "function handleTouch(event)");
+    expect(ratio).toBeGreaterThan(0.5);
+    expect(ratio).toBeLessThan(1.0);
+  });
+});
+
+// ─── scoreWindows tests ───
+
+describe("scoreWindows", () => {
+  it("returns empty array for empty inputs", () => {
+    expect(scoreWindows([], ["hello"])).toEqual([]);
+    expect(scoreWindows(["hello"], [])).toEqual([]);
+    expect(scoreWindows([], [])).toEqual([]);
+  });
+
+  it("finds exact match with score ~1.0", () => {
+    const fileLines = ["line 1", "function foo() {", "  return 42;", "}", "line 5"];
+    const oldTextLines = ["function foo() {", "  return 42;", "}"];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].score).toBeGreaterThan(0.95);
+    expect(results[0].startLine).toBe(2);
+    expect(results[0].endLine).toBe(4);
+  });
+
+  it("finds near-match with minor differences", () => {
+    const fileLines = [
+      "function handleClick(event: MouseEvent) {",
+      "  const target = event.target as HTMLElement;",
+      '  if (target.classList.contains("selected")) {',
+      "    target.remove();",
+      "  }",
+      "}",
+    ];
+    const oldTextLines = [
+      "function handleClick(event: MouseEvent) {",
+      "  const target = event.target as HTMLElement;",
+      '  if (target.classList.contains("active")) {', // different
+      "    target.remove();",
+      "  }",
+      "}",
+    ];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].score).toBeGreaterThan(0.8);
+    expect(results[0].startLine).toBe(1);
+  });
+
+  it("keeps multi-line near-matches when only the line prefixes changed", () => {
+    const fileLines = [
+      "let primaryValue = computeResult(input);",
+      "let fallbackValue = sanitize(primaryValue);",
+    ];
+    const oldTextLines = [
+      "const primaryValue = computeResult(input);",
+      "const fallbackValue = sanitize(primaryValue);",
+    ];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].startLine).toBe(1);
+    expect(results[0].score).toBeGreaterThan(0.7);
+  });
+
+  it("returns empty when content is completely different", () => {
+    const fileLines = ["alpha", "bravo", "charlie", "delta"];
+    const oldTextLines = ["xylophone", "yesterday", "zebra"];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results).toEqual([]);
+  });
+
+  it("returns at most 3 suggestions", () => {
+    // Create a file with 5 similar functions
+    const fileLines: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      fileLines.push(`function handler${i}(event) {`, `  console.log(event);`, `}`, "");
+    }
+    const oldTextLines = ["function handlerX(event) {", "  console.log(event);", "}"];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it("handles single-line oldText", () => {
+    const fileLines = ["const foo = 1;", "const bar = 2;", "const baz = 3;"];
+    const oldTextLines = ["const bar = 22;"];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeGreaterThan(0);
+    // Best match should be the line "const bar = 2;" (line 2)
+    expect(results[0].startLine).toBe(2);
+  });
+
+  it("skips the pre-filter for single-line oldText with renamed prefixes", () => {
+    const fileLines = ["let renderedOutput = formatResult(payload);", "const somethingElse = 1;"];
+    const oldTextLines = ["const renderedOutput = formatResult(payload);"];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].startLine).toBe(1);
+    expect(results[0].score).toBeGreaterThan(0.8);
+  });
+});
+
+// ─── Wrapper integration tests ───
+
+describe("wrapEditToolWithFuzzyMatchSuggestions", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  it("passes through successful results unchanged", async () => {
+    const base = makeMockTool("success");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, "/tmp");
+    const result = await wrapped.execute(
+      "call-1",
+      { path: "test.ts", oldText: "x", newText: "y" },
+      undefined,
+    );
+    const content = (result as { content: Array<{ text?: string }> }).content;
+    expect(content[0]?.text).toBe("OK");
+  });
+
+  it("passes through non-not-found errors unchanged", async () => {
+    const base = makeMockTool("other-error");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, "/tmp");
+    await expect(
+      wrapped.execute("call-1", { path: "test.ts", oldText: "x", newText: "y" }, undefined),
+    ).rejects.toThrow("File not found");
+  });
+
+  it("enriches not-found error with fuzzy suggestions", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "test.ts");
+    await fs.writeFile(
+      filePath,
+      ["function greet(name: string) {", "  return `Hello, ${name}!`;", "}"].join("\n"),
+      "utf-8",
+    );
+
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    try {
+      await wrapped.execute(
+        "call-1",
+        {
+          path: filePath,
+          oldText: "function greet(name: string) {\n  return `Hi, ${name}!`;\n}",
+          newText: "replaced",
+        },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      const msg = (err as Error).message;
+      expect(msg).toContain("most similar region");
+      expect(msg).toContain("similarity:");
+      expect(msg).toMatch(/Lines \d+-\d+/);
+      expect(msg).toContain("Hint:");
+    }
+  });
+
+  it("handles binary files gracefully", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "binary.dat");
+    const buf = Buffer.alloc(100);
+    buf[50] = 0; // null byte
+    buf.write("some text", 0);
+    await fs.writeFile(filePath, buf);
+
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    await expect(
+      wrapped.execute(
+        "call-1",
+        { path: filePath, oldText: "some text", newText: "replaced" },
+        undefined,
+      ),
+    ).rejects.toThrow("appears to be binary");
+  });
+
+  it("handles large files by skipping fuzzy match", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "large.ts");
+    // Create a file > 100KB
+    const largeLine = "x".repeat(200) + "\n";
+    await fs.writeFile(filePath, largeLine.repeat(600), "utf-8");
+
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    await expect(
+      wrapped.execute(
+        "call-1",
+        { path: filePath, oldText: "not here", newText: "replaced" },
+        undefined,
+      ),
+    ).rejects.toThrow(/Fuzzy matching skipped for performance/);
+  });
+
+  it("handles old_string param alias", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "test.ts");
+    await fs.writeFile(filePath, "const x = 1;\n", "utf-8");
+
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    try {
+      await wrapped.execute(
+        "call-1",
+        { path: filePath, old_string: "const x = 2;", new_string: "replaced" },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      // Should have enriched the error (not the raw "not found" from upstream)
+      expect(msg).toContain("most similar region");
+    }
+  });
+
+  it("falls back to no-similar-regions message when file has unrelated content", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "test.ts");
+    await fs.writeFile(filePath, "alpha\nbravo\ncharlie\ndelta\n", "utf-8");
+
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    try {
+      await wrapped.execute(
+        "call-1",
+        { path: filePath, oldText: "xylophone\nyesterday\nzebra", newText: "replaced" },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain("No similar regions found");
+      expect(msg).toContain("re-reading the file");
+    }
+  });
+
+  it("finds multiple similar regions ranked by score", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "handlers.ts");
+    await fs.writeFile(
+      filePath,
+      [
+        "function handleClick(event: MouseEvent) {",
+        "  event.preventDefault();",
+        "}",
+        "",
+        "function handleHover(event: MouseEvent) {",
+        "  event.stopPropagation();",
+        "}",
+        "",
+        "function handleScroll(event: WheelEvent) {",
+        "  event.preventDefault();",
+        "}",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    try {
+      await wrapped.execute(
+        "call-1",
+        {
+          path: filePath,
+          oldText: "function handleClick(event: MouseEvent) {\n  event.preventDefault();\n}",
+          newText: "replaced",
+        },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      // Should find the exact match at lines 1-3 plus similar blocks
+      expect(msg).toContain("Lines 1-3");
+      expect(msg).toContain("similarity:");
+    }
+  });
+
+  it("handles ~ path expansion", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "test.ts");
+    await fs.writeFile(
+      filePath,
+      "const greeting = 'hello world';\nconst farewell = 'goodbye world';\n",
+      "utf-8",
+    );
+
+    // Use absolute path directly (~ expansion tested via resolveHostEditPath internal)
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    try {
+      await wrapped.execute(
+        "call-1",
+        { path: filePath, oldText: "const greeting = 'hello earth';", newText: "replaced" },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain("most similar region");
+    }
+  });
+});

--- a/src/agents/pi-tools.host-edit.fuzzy-suggestions.test.ts
+++ b/src/agents/pi-tools.host-edit.fuzzy-suggestions.test.ts
@@ -162,6 +162,26 @@ describe("scoreWindows", () => {
     expect(results.length).toBeLessThanOrEqual(3);
   });
 
+  it("finds match when only indentation differs (review feedback: pre-filter trims leading whitespace)", () => {
+    // The pre-filter must trim leading whitespace so indentation mismatches
+    // (the most common edit failure) are not rejected by the 8-char prefix check.
+    const fileLines = ["    function indented() {", "        return true;", "    }"];
+    const oldTextLines = ["  function indented() {", "      return true;", "  }"];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].startLine).toBe(1);
+    expect(results[0].score).toBeGreaterThan(0.8);
+  });
+
+  it("keeps short multi-line near-matches for LCS scoring", () => {
+    const fileLines = ["let x", "ok"];
+    const oldTextLines = ["const x", "on"];
+    const results = scoreWindows(fileLines, oldTextLines);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].startLine).toBe(1);
+    expect(results[0].score).toBeGreaterThan(0.4);
+  });
+
   it("handles single-line oldText", () => {
     const fileLines = ["const foo = 1;", "const bar = 2;", "const baz = 3;"];
     const oldTextLines = ["const bar = 22;"];
@@ -178,6 +198,26 @@ describe("scoreWindows", () => {
     expect(results.length).toBeGreaterThan(0);
     expect(results[0].startLine).toBe(1);
     expect(results[0].score).toBeGreaterThan(0.8);
+  });
+
+  it("collects all near-perfect windows before sorting the top matches", () => {
+    const oldTextLines = ["const stableIdentifier = formatResult(payload);"];
+    const fileLines = [
+      "const stableIdentifier = formatResult(payload)",
+      "doSomethingElse();",
+      "const stableIdentifier = formatResult(payload);",
+      "doSomethingElseAgain();",
+      "const stableIdentifier = formatResult(payload)?",
+    ];
+
+    const results = scoreWindows(fileLines, oldTextLines);
+
+    expect(results.map((result) => result.startLine)).toEqual([3, 1, 5]);
+    expect(results.map((result) => result.score)).toEqual(
+      expect.arrayContaining([expect.any(Number), expect.any(Number), expect.any(Number)]),
+    );
+    expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0);
+    expect(results[1]?.score).toBeGreaterThan(results[2]?.score ?? 0);
   });
 });
 
@@ -369,6 +409,53 @@ describe("wrapEditToolWithFuzzyMatchSuggestions", () => {
       // Should find the exact match at lines 1-3 plus similar blocks
       expect(msg).toContain("Lines 1-3");
       expect(msg).toContain("similarity:");
+    }
+  });
+
+  it("rethrows original error when file does not exist (review feedback: FS errors don't mask not-found)", async () => {
+    // When the fallback file read fails (e.g. ENOENT race), the wrapper must
+    // rethrow the original "not found" error, not the FS error.
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, "/nonexistent/path");
+
+    try {
+      await wrapped.execute(
+        "call-1",
+        { path: "missing.ts", oldText: "some text", newText: "replaced" },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      const msg = (err as Error).message;
+      // Must be the original "not found" error, not ENOENT
+      expect(msg).toContain("Could not find the exact text in");
+      expect(msg).not.toContain("ENOENT");
+    }
+  });
+
+  it("uses fs.stat before reading file (review feedback: no full read before size check)", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fuzzy-"));
+    const filePath = path.join(tmpDir, "large.ts");
+    // Create a file > 100KB
+    const largeLine = "x".repeat(200) + "\n";
+    await fs.writeFile(filePath, largeLine.repeat(600), "utf-8");
+
+    const base = makeMockTool("not-found");
+    const wrapped = wrapEditToolWithFuzzyMatchSuggestions(base, tmpDir);
+
+    try {
+      await wrapped.execute(
+        "call-1",
+        { path: filePath, oldText: "not here", newText: "replaced" },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      // Must mention performance skip, proving stat() was checked before read
+      expect(msg).toContain("Fuzzy matching skipped for performance");
+      expect(msg).toContain("File is large");
     }
   });
 

--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -4,6 +4,18 @@ import path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
+// ─── Fuzzy Match Suggestion Constants ───
+
+const FUZZY_MAX_FILE_SIZE_BYTES = 100_000;
+const FUZZY_MAX_SUGGESTIONS = 3;
+const FUZZY_MIN_SIMILARITY = 0.4;
+const FUZZY_NEAR_PERFECT = 0.95;
+const FUZZY_MAX_LINE_LEN = 500;
+const FUZZY_CONTEXT_LINES = 2;
+const FUZZY_MAX_OUTPUT_CHARS = 2000;
+const FUZZY_BINARY_CHECK_BYTES = 8192;
+const FUZZY_PREFILTER_CHUNK_LEN = 8;
+
 /** Resolve path for host edit: expand ~ and resolve relative paths against root. */
 function resolveHostEditPath(root: string, pathParam: string): string {
   const expanded =
@@ -76,6 +88,275 @@ export function wrapHostEditToolWithPostWriteRecovery(
           // File read failed or path invalid; rethrow original error.
         }
         throw err;
+      }
+    },
+  };
+}
+
+// ─── Fuzzy Match Suggestion Helpers ───
+
+/** Space-optimized LCS length between two strings, capped at FUZZY_MAX_LINE_LEN chars each. */
+export function lcsLength(a: string, b: string): number {
+  const m = Math.min(a.length, FUZZY_MAX_LINE_LEN);
+  const n = Math.min(b.length, FUZZY_MAX_LINE_LEN);
+  if (m === 0 || n === 0) {
+    return 0;
+  }
+  const prev = new Uint16Array(n + 1);
+  const curr = new Uint16Array(n + 1);
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      curr[j] = a[i - 1] === b[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], curr[j - 1]);
+    }
+    prev.set(curr);
+    curr.fill(0);
+  }
+  return prev[n];
+}
+
+/** Normalized LCS ratio: 0.0 (no similarity) to 1.0 (identical). */
+export function lcsRatio(a: string, b: string): number {
+  if (a.length === 0 && b.length === 0) {
+    return 1.0;
+  }
+  if (a.length === 0 || b.length === 0) {
+    return 0.0;
+  }
+  const len = lcsLength(a, b);
+  return (
+    (2 * len) / (Math.min(a.length, FUZZY_MAX_LINE_LEN) + Math.min(b.length, FUZZY_MAX_LINE_LEN))
+  );
+}
+
+interface ScoredWindow {
+  startLine: number; // 1-indexed
+  endLine: number; // 1-indexed, inclusive
+  score: number;
+  lines: string[];
+}
+
+function hasSharedPreFilterChunk(fileLine: string, oldLine: string): boolean {
+  // Ignore indentation so leading whitespace-only edits do not block fuzzy suggestions.
+  const fileTrimmed = fileLine.trimStart();
+  const oldTrimmed = oldLine.trimStart();
+  if (
+    oldTrimmed.length < FUZZY_PREFILTER_CHUNK_LEN ||
+    fileTrimmed.length < FUZZY_PREFILTER_CHUNK_LEN
+  ) {
+    return fileTrimmed.includes(oldTrimmed) || oldTrimmed.includes(fileTrimmed);
+  }
+
+  const lastChunkStart = oldTrimmed.length - FUZZY_PREFILTER_CHUNK_LEN;
+  const chunkStarts = new Set([0, Math.floor(lastChunkStart / 2), lastChunkStart]);
+  for (const chunkStart of chunkStarts) {
+    const chunk = oldTrimmed.slice(chunkStart, chunkStart + FUZZY_PREFILTER_CHUNK_LEN);
+    if (fileTrimmed.includes(chunk)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Slide a window of `oldTextLines.length` lines across fileLines and score each window
+ * using per-line LCS ratio. Returns up to FUZZY_MAX_SUGGESTIONS best matches above threshold.
+ */
+export function scoreWindows(fileLines: string[], oldTextLines: string[]): ScoredWindow[] {
+  const windowSize = oldTextLines.length;
+  if (windowSize === 0 || fileLines.length === 0) {
+    return [];
+  }
+
+  const results: ScoredWindow[] = [];
+  const maxStart = fileLines.length - windowSize;
+  const oldTrimmedLower = oldTextLines.map((l) => l.trimEnd().toLowerCase());
+  const shouldPreFilter = windowSize > 1;
+
+  for (let start = 0; start <= maxStart; start++) {
+    if (shouldPreFilter) {
+      // Pre-filter: require >= 30% of lines to share a short substring with oldText.
+      // Sample prefix/middle/suffix chunks so renamed leading tokens still survive.
+      let preFilterHits = 0;
+      for (let i = 0; i < windowSize; i++) {
+        const fileLine = fileLines[start + i].trimEnd().toLowerCase();
+        const oldLine = oldTrimmedLower[i];
+        if (hasSharedPreFilterChunk(fileLine, oldLine)) {
+          preFilterHits++;
+        }
+      }
+      if (preFilterHits < windowSize * 0.3) {
+        continue;
+      }
+    }
+
+    // Full LCS scoring
+    let totalScore = 0;
+    for (let i = 0; i < windowSize; i++) {
+      totalScore += lcsRatio(oldTextLines[i].trimEnd(), fileLines[start + i].trimEnd());
+    }
+    const avgScore = totalScore / windowSize;
+
+    if (avgScore >= FUZZY_MIN_SIMILARITY) {
+      results.push({
+        startLine: start + 1,
+        endLine: start + windowSize,
+        score: avgScore,
+        lines: fileLines.slice(start, start + windowSize),
+      });
+    }
+
+    if (avgScore >= FUZZY_NEAR_PERFECT) {
+      break;
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, FUZZY_MAX_SUGGESTIONS);
+}
+
+/** Format scored windows into a human-readable error message with line numbers. */
+function formatSuggestions(
+  candidates: ScoredWindow[],
+  fileLines: string[],
+  filePath: string,
+): string {
+  const totalLines = fileLines.length;
+  if (candidates.length === 0) {
+    return (
+      `Could not find the exact text in ${filePath}.\n\n` +
+      `The file has ${totalLines} lines. No similar regions found ` +
+      `(similarity < ${Math.round(FUZZY_MIN_SIMILARITY * 100)}%).\n` +
+      `Consider re-reading the file with the read tool to get current content.`
+    );
+  }
+
+  const parts: string[] = [
+    `Could not find the exact text in ${filePath}.\n`,
+    `The ${candidates.length} most similar region${candidates.length > 1 ? "s" : ""} in the file:\n`,
+  ];
+  let totalChars = parts.join("").length;
+
+  for (const candidate of candidates) {
+    const header = `--- Lines ${candidate.startLine}-${candidate.endLine} (similarity: ${Math.round(candidate.score * 100)}%) ---\n`;
+    const ctxStart = Math.max(0, candidate.startLine - 1 - FUZZY_CONTEXT_LINES);
+    const ctxEnd = Math.min(fileLines.length, candidate.endLine + FUZZY_CONTEXT_LINES);
+    const snippet = fileLines
+      .slice(ctxStart, ctxEnd)
+      .map((line, i) => {
+        const lineNum = ctxStart + i + 1;
+        const prefix = lineNum >= candidate.startLine && lineNum <= candidate.endLine ? ">" : " ";
+        return `${prefix} ${String(lineNum).padStart(4)} │ ${line}`;
+      })
+      .join("\n");
+
+    const block = header + snippet + "\n\n";
+    if (totalChars + block.length > FUZZY_MAX_OUTPUT_CHARS) {
+      parts.push("(additional matches truncated)\n");
+      break;
+    }
+    parts.push(block);
+    totalChars += block.length;
+  }
+
+  parts.push(
+    "Hint: Compare the shown regions with your oldText. " +
+      "Check for whitespace differences, renamed variables, or recent file changes.",
+  );
+  return parts.join("");
+}
+
+/** Returns true if content appears to be binary (contains null bytes in the first 8KB). */
+function isBinaryContent(content: string): boolean {
+  const checkLen = Math.min(content.length, FUZZY_BINARY_CHECK_BYTES);
+  for (let i = 0; i < checkLen; i++) {
+    if (content.charCodeAt(i) === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ─── Fuzzy Match Suggestion Wrapper ───
+
+const NOT_FOUND_PATTERN = /Could not find the exact text in /;
+
+/**
+ * Wraps an edit tool to enrich "oldText not found" errors with fuzzy match suggestions.
+ * When the upstream edit fails because oldText doesn't match, this reads the file and returns
+ * the closest matching regions with line numbers and similarity scores, so the model can
+ * self-correct in one shot. Zero overhead on success — only activates on not-found errors.
+ */
+export function wrapEditToolWithFuzzyMatchSuggestions(
+  base: AnyAgentTool,
+  root: string,
+): AnyAgentTool {
+  return {
+    ...base,
+    execute: async (
+      toolCallId: string,
+      params: unknown,
+      signal: AbortSignal | undefined,
+      onUpdate?: AgentToolUpdateCallback<unknown>,
+    ) => {
+      try {
+        return await base.execute(toolCallId, params, signal, onUpdate);
+      } catch (err) {
+        if (!(err instanceof Error) || !NOT_FOUND_PATTERN.test(err.message)) {
+          throw err;
+        }
+
+        const record =
+          params && typeof params === "object" ? (params as Record<string, unknown>) : undefined;
+        const pathParam = record && typeof record.path === "string" ? record.path : undefined;
+        const oldText =
+          record && typeof record.oldText === "string"
+            ? record.oldText
+            : record && typeof record.old_string === "string"
+              ? record.old_string
+              : undefined;
+
+        if (!pathParam || !oldText) {
+          throw err;
+        }
+
+        try {
+          const absolutePath = resolveHostEditPath(root, pathParam);
+
+          // Check file size before reading to avoid loading huge files into memory.
+          const stat = await fs.stat(absolutePath);
+          if (stat.size > FUZZY_MAX_FILE_SIZE_BYTES) {
+            throw new Error(
+              `Could not find the exact text in ${pathParam}.\n\n` +
+                `File is large (${Math.round(stat.size / 1024)}KB). ` +
+                `Fuzzy matching skipped for performance. ` +
+                `Consider re-reading the relevant section with the read tool.`,
+              { cause: err },
+            );
+          }
+
+          const content = await fs.readFile(absolutePath, "utf-8");
+
+          if (isBinaryContent(content)) {
+            throw new Error(
+              `File ${pathParam} appears to be binary. The edit tool only works with text files.`,
+              { cause: err },
+            );
+          }
+
+          const fileLines = content.split("\n");
+          const oldTextLines = oldText.split("\n");
+          const candidates = scoreWindows(fileLines, oldTextLines);
+          throw new Error(formatSuggestions(candidates, fileLines, pathParam), { cause: err });
+        } catch (innerErr) {
+          // Only surface enriched errors (our own throws with { cause: err }).
+          // For unexpected FS errors (ENOENT, EACCES, race conditions), fall back
+          // to the original "not found" error so we don't mask the real issue.
+          if (innerErr instanceof Error && innerErr.cause === err) {
+            throw innerErr;
+          }
+          throw err;
+        }
       }
     },
   };

--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -9,12 +9,22 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 const FUZZY_MAX_FILE_SIZE_BYTES = 100_000;
 const FUZZY_MAX_SUGGESTIONS = 3;
 const FUZZY_MIN_SIMILARITY = 0.4;
-const FUZZY_NEAR_PERFECT = 0.95;
 const FUZZY_MAX_LINE_LEN = 500;
 const FUZZY_CONTEXT_LINES = 2;
 const FUZZY_MAX_OUTPUT_CHARS = 2000;
 const FUZZY_BINARY_CHECK_BYTES = 8192;
 const FUZZY_PREFILTER_CHUNK_LEN = 8;
+
+type FuzzyMatchReadFile = (absolutePath: string, signal?: AbortSignal) => Promise<Buffer | string>;
+
+type FuzzyMatchStat = {
+  size: number;
+};
+
+type FuzzyMatchSuggestionOptions = {
+  readFile?: FuzzyMatchReadFile;
+  stat?: (absolutePath: string, signal?: AbortSignal) => Promise<FuzzyMatchStat | null>;
+};
 
 /** Resolve path for host edit: expand ~ and resolve relative paths against root. */
 function resolveHostEditPath(root: string, pathParam: string): string {
@@ -143,7 +153,8 @@ function hasSharedPreFilterChunk(fileLine: string, oldLine: string): boolean {
     oldTrimmed.length < FUZZY_PREFILTER_CHUNK_LEN ||
     fileTrimmed.length < FUZZY_PREFILTER_CHUNK_LEN
   ) {
-    return fileTrimmed.includes(oldTrimmed) || oldTrimmed.includes(fileTrimmed);
+    // Short lines are cheap to score with LCS, so skip the substring gate entirely.
+    return true;
   }
 
   const lastChunkStart = oldTrimmed.length - FUZZY_PREFILTER_CHUNK_LEN;
@@ -205,13 +216,9 @@ export function scoreWindows(fileLines: string[], oldTextLines: string[]): Score
         lines: fileLines.slice(start, start + windowSize),
       });
     }
-
-    if (avgScore >= FUZZY_NEAR_PERFECT) {
-      break;
-    }
   }
 
-  results.sort((a, b) => b.score - a.score);
+  results.sort((a, b) => b.score - a.score || a.startLine - b.startLine);
   return results.slice(0, FUZZY_MAX_SUGGESTIONS);
 }
 
@@ -290,7 +297,14 @@ const NOT_FOUND_PATTERN = /Could not find the exact text in /;
 export function wrapEditToolWithFuzzyMatchSuggestions(
   base: AnyAgentTool,
   root: string,
+  options?: FuzzyMatchSuggestionOptions,
 ): AnyAgentTool {
+  const readFile: FuzzyMatchReadFile =
+    options?.readFile ??
+    ((absolutePath, signal) => fs.readFile(absolutePath, { encoding: "utf-8", signal }));
+  const statFile =
+    options?.stat ?? ((absolutePath: string) => fs.stat(absolutePath) as Promise<FuzzyMatchStat>);
+
   return {
     ...base,
     execute: async (
@@ -324,7 +338,10 @@ export function wrapEditToolWithFuzzyMatchSuggestions(
           const absolutePath = resolveHostEditPath(root, pathParam);
 
           // Check file size before reading to avoid loading huge files into memory.
-          const stat = await fs.stat(absolutePath);
+          const stat = await statFile(absolutePath, signal);
+          if (!stat) {
+            throw new Error(`File not found: ${absolutePath}`, { cause: err });
+          }
           if (stat.size > FUZZY_MAX_FILE_SIZE_BYTES) {
             throw new Error(
               `Could not find the exact text in ${pathParam}.\n\n` +
@@ -335,7 +352,9 @@ export function wrapEditToolWithFuzzyMatchSuggestions(
             );
           }
 
-          const content = await fs.readFile(absolutePath, "utf-8");
+          const rawContent = await readFile(absolutePath, signal);
+          const content =
+            typeof rawContent === "string" ? rawContent : rawContent.toString("utf-8");
 
           if (isBinaryContent(content)) {
             throw new Error(

--- a/src/agents/pi-tools.read.sandbox-fuzzy-suggestions.test.ts
+++ b/src/agents/pi-tools.read.sandbox-fuzzy-suggestions.test.ts
@@ -1,0 +1,82 @@
+import type { EditToolOptions } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+
+const mocks = vi.hoisted(() => ({
+  operations: undefined as EditToolOptions["operations"] | undefined,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
+  return {
+    ...actual,
+    createEditTool: (_cwd: string, options?: EditToolOptions) => {
+      mocks.operations = options?.operations;
+      return {
+        name: "edit",
+        description: "test sandbox edit tool",
+        parameters: { type: "object", properties: {} },
+        execute: async (_toolCallId: string, params: unknown) => {
+          const record = params as Record<string, unknown>;
+          throw new Error(
+            `Could not find the exact text in ${String(record.path)}. The old text must match exactly.`,
+          );
+        },
+      };
+    },
+  };
+});
+
+const { createSandboxedEditTool } = await import("./pi-tools.read.js");
+
+describe("createSandboxedEditTool fuzzy suggestions", () => {
+  afterEach(() => {
+    mocks.operations = undefined;
+  });
+
+  it("uses the sandbox fs bridge to enrich not-found errors for sandbox-only paths", async () => {
+    const calls: Array<{ kind: "readFile" | "stat"; filePath: string; cwd?: string }> = [];
+    const bridge: SandboxFsBridge = {
+      resolvePath: ({ filePath }) => ({
+        hostPath: `/host${filePath}`,
+        relativePath: filePath.replace(/^\/+/, ""),
+        containerPath: filePath,
+      }),
+      readFile: async ({ filePath, cwd }) => {
+        calls.push({ kind: "readFile", filePath, cwd });
+        return Buffer.from("const sandboxValue = 1;\n", "utf8");
+      },
+      writeFile: async () => {},
+      mkdirp: async () => {},
+      remove: async () => {},
+      rename: async () => {},
+      stat: async ({ filePath, cwd }) => {
+        calls.push({ kind: "stat", filePath, cwd });
+        return {
+          type: "file",
+          size: Buffer.byteLength("const sandboxValue = 1;\n", "utf8"),
+          mtimeMs: 0,
+        };
+      },
+    };
+
+    const tool = createSandboxedEditTool({ root: "/workspace", bridge });
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: "test.ts",
+          oldText: "const sandboxValue = 2;",
+          newText: "const sandboxValue = 3;",
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(/most similar region/);
+
+    expect(calls).toEqual([
+      { kind: "stat", filePath: "/workspace/test.ts", cwd: "/workspace" },
+      { kind: "readFile", filePath: "/workspace/test.ts", cwd: "/workspace" },
+    ]);
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -14,7 +14,10 @@ import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
-import { wrapHostEditToolWithPostWriteRecovery } from "./pi-tools.host-edit.js";
+import {
+  wrapEditToolWithFuzzyMatchSuggestions,
+  wrapHostEditToolWithPostWriteRecovery,
+} from "./pi-tools.host-edit.js";
 import {
   CLAUDE_PARAM_GROUPS,
   assertRequiredParams,
@@ -618,6 +621,8 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
+  // Note: fuzzy match suggestions wrapper is NOT applied to sandbox edits because the
+  // wrapper uses host fs.readFile/fs.stat which cannot access sandbox-only paths.
   return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
 }
 
@@ -633,7 +638,8 @@ export function createHostWorkspaceEditTool(root: string, options?: { workspaceO
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
   const withRecovery = wrapHostEditToolWithPostWriteRecovery(base, root);
-  return wrapToolParamNormalization(withRecovery, CLAUDE_PARAM_GROUPS.edit);
+  const withSuggestions = wrapEditToolWithFuzzyMatchSuggestions(withRecovery, root);
+  return wrapToolParamNormalization(withSuggestions, CLAUDE_PARAM_GROUPS.edit);
 }
 
 export function createOpenClawReadTool(

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -621,9 +621,13 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
-  // Note: fuzzy match suggestions wrapper is NOT applied to sandbox edits because the
-  // wrapper uses host fs.readFile/fs.stat which cannot access sandbox-only paths.
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  const withSuggestions = wrapEditToolWithFuzzyMatchSuggestions(base, params.root, {
+    readFile: (absolutePath, signal) =>
+      params.bridge.readFile({ filePath: absolutePath, cwd: params.root, signal }),
+    stat: (absolutePath, signal) =>
+      params.bridge.stat({ filePath: absolutePath, cwd: params.root, signal }),
+  });
+  return wrapToolParamNormalization(withSuggestions, CLAUDE_PARAM_GROUPS.edit);
 }
 
 export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {


### PR DESCRIPTION
## Problem

When the edit tool fails to find `oldText` in a file, it returns:

> `Could not find the exact text in {path}. The old text must match exactly including all whitespace and newlines.`

This is a dead-end — the model has no information about what's actually in the file. It often retries with the same wrong text, re-reads the entire file (wasting tokens), or gives up after multiple failed attempts.

## Solution

Added a new wrapper `wrapEditToolWithFuzzyMatchSuggestions` that enriches "not found" errors with the closest matching regions from the file. Applied to both `createHostWorkspaceEditTool` and `createSandboxedEditTool`.

**Algorithm:** Sliding window across file lines scored with normalized LCS ratio. A pre-filter (8-char substring check) eliminates 90%+ of windows cheaply before full LCS computation.

**Performance:** Zero overhead on success — the wrapper only activates on failure. File size cap (100KB), binary detection, output cap (2000 chars), and early termination on near-perfect matches (>95%).

## Example: Improved Error Output

```
Could not find the exact text in src/foo.ts.

The 2 most similar regions in the file:

--- Lines 42-47 (similarity: 87%) ---
     40 │ // handler setup
     41 │ const config = {};
>    42 │ function handleClick(event: MouseEvent) {
>    43 │   const target = event.target as HTMLElement;
>    44 │   if (target.classList.contains("selected")) {
>    45 │     target.remove();
>    46 │   }
>    47 │ }
     48 │
     49 │ // next section

--- Lines 128-133 (similarity: 72%) ---
>   128 │ function handleTouch(event: TouchEvent) {
>   129 │   const target = event.target as HTMLElement;
>   130 │   if (target.classList.contains("active")) {
>   131 │     target.remove();
>   132 │   }
>   133 │ }

Hint: Compare the shown regions with your oldText. Check for whitespace
differences, renamed variables, or recent file changes.
```

## Test Coverage (24 tests)

- **Core algorithm:** `lcsLength`, `lcsRatio`, `scoreWindows` — identity, empty, partial, no-match cases
- **Wrapper integration:** success passthrough, non-not-found error passthrough, enriched errors with suggestions, binary file detection, large file handling, `old_string` param alias, no-similar-regions fallback, multiple ranked regions, path resolution
