### PR TITLE
fix(discord): require explicit mentions for plain text guild messages

### DIFF
--- a/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts
+++ b/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts
@@ -282,7 +282,7 @@ function captureThreadDispatchCtx() {
 
 describe("discord tool result dispatch", () => {
   it(
-    "accepts guild messages when mentionPatterns match",
+    "does not accept guild messages when only mentionPatterns match plain text",
     async () => {
       const cfg = createMentionRequiredGuildConfig({
         messages: {
@@ -299,9 +299,9 @@ describe("discord tool result dispatch", () => {
         client,
       );
 
-      await vi.waitFor(() => expect(dispatchMock).toHaveBeenCalledTimes(1));
-      expect(dispatchMock).toHaveBeenCalledTimes(1);
-      expect(sendMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(dispatchMock).toHaveBeenCalledTimes(0));
+      expect(dispatchMock).toHaveBeenCalledTimes(0);
+      expect(sendMock).toHaveBeenCalledTimes(0);
     },
     MENTION_PATTERNS_TEST_TIMEOUT_MS,
   );

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -598,6 +598,82 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.wasMentioned).toBe(true);
   });
+
+  it("does not treat plain-text bot names as mentions when bot user id is known", async () => {
+    const channelId = "channel-text-mention-1";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+
+    const message = {
+      id: "m-text-mention-1",
+      content: "openclaw please review this",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+        messages: {
+          groupChat: {
+            mentionPatterns: ["openclaw"],
+          },
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      data: {
+        channel_id: channelId,
+        guild_id: "guild-1",
+        guild: {
+          id: "guild-1",
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).toBeNull();
+  });
 });
 
 describe("shouldIgnoreBoundThreadWebhookMessage", () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -11,6 +11,7 @@ import {
 } from "../../auto-reply/reply/history.js";
 import {
   buildMentionRegexes,
+  matchesMentionPatterns,
   matchesMentionWithExplicit,
 } from "../../auto-reply/reply/mentions.js";
 import { formatAllowlistMatchMeta } from "../../channels/allowlist-match.js";
@@ -596,18 +597,24 @@ export async function preflightDiscordMessage(
   }
 
   const mentionText = hasTypedText ? baseText : "";
+  const transcriptMentioned =
+    !hasTypedText && preflightTranscript
+      ? matchesMentionPatterns(preflightTranscript, mentionRegexes)
+      : false;
   const wasMentioned =
     !isDirectMessage &&
-    matchesMentionWithExplicit({
-      text: mentionText,
-      mentionRegexes,
-      explicit: {
-        hasAnyMention,
-        isExplicitlyMentioned: explicitlyMentioned,
-        canResolveExplicit: Boolean(botId),
-      },
-      transcript: preflightTranscript,
-    });
+    (botId
+      ? explicitlyMentioned || transcriptMentioned
+      : matchesMentionWithExplicit({
+          text: mentionText,
+          mentionRegexes,
+          explicit: {
+            hasAnyMention,
+            isExplicitlyMentioned: explicitlyMentioned,
+            canResolveExplicit: false,
+          },
+          transcript: preflightTranscript,
+        }));
   const implicitMention = Boolean(
     !isDirectMessage &&
     botId &&


### PR DESCRIPTION
## Summary
- stop treating plain-text bot names as Discord guild mentions when the bot user id is known
- keep explicit `@mentions` and reply-to-bot implicit mentions working as before
- keep audio transcript fallback for voice-only guild messages

## Why
Discord already provides explicit mention entities. Falling back to plain-text name matching in guild channels causes false positives when users or bots discuss another bot by name without actually mentioning it. In multi-bot coordination channels, that can cascade into unwanted replies.

## Testing
- `pnpm --dir /Users/lizeyu/Projects/openclaw exec vitest run src/discord/monitor/message-handler.preflight.test.ts`
- `pnpm --dir /Users/lizeyu/Projects/openclaw exec vitest run --config vitest.e2e.config.ts src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts`
- `pnpm --dir /Users/lizeyu/Projects/openclaw build`
- `pnpm --dir /Users/lizeyu/Projects/openclaw check`

## AI-assisted
- AI-assisted: Codex
- Testing degree: targeted tests + full build/check
