### PR TITLE
fix(failover): recognize Poe "used up your points" as billing error

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -111,6 +111,15 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
     }
   });
+  it("matches Poe API exhaustion error (#42236)", () => {
+    const samples = [
+      "402 You've used up your points! Visit https://poe.com/api/keys to get more.",
+      "You've used up your points!",
+    ];
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample)).toBe(true);
+    }
+  });
   it("does not false-positive on issue IDs or text containing 402", () => {
     const falsePositives = [
       "Fixed issue CHE-402 in the latest release",
@@ -740,6 +749,13 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("LLM error: weekly/monthly limit reached")).toBe("rate_limit");
     expect(classifyFailoverReason("LLM error: monthly limit reached")).toBe("rate_limit");
     expect(classifyFailoverReason("LLM error: daily limit exceeded")).toBe("rate_limit");
+  });
+  it("classifies Poe API exhaustion as billing (#42236)", () => {
+    expect(
+      classifyFailoverReason(
+        "402 You've used up your points! Visit https://poe.com/api/keys to get more.",
+      ),
+    ).toBe("billing");
   });
   it("classifies permanent auth errors as auth_permanent", () => {
     expect(classifyFailoverReason("invalid_api_key")).toBe("auth_permanent");

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -52,6 +52,7 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    "used up your points",
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,


### PR DESCRIPTION
## Summary
- Add `"used up your points"` to billing error patterns so Poe API exhaustion messages trigger model fallback

## Problem
When Poe API returns HTTP 402 with `You've used up your points\! Visit https://poe.com/api/keys to get more.`, OpenClaw does not classify it as a billing error. The `RAW_402_MARKER_RE` only matches `402 payment required`, and none of the existing billing patterns match "used up your points".

Result: model fallback never triggers and users see the raw error instead of switching to fallback models.

## Fix
Add `"used up your points"` to `ERROR_PATTERNS.billing` in `failover-matches.ts`. This ensures `isBillingErrorMessage()` recognizes the Poe exhaustion message, which then causes `classifyFailoverReason()` to return `"billing"` and trigger fallback.

## Test plan
- [x] `isBillingErrorMessage` test: Poe error message matches as billing
- [x] `classifyFailoverReason` test: full Poe 402 message classified as `"billing"`
- [x] Existing false-positive tests still pass ("402 items found", etc.)

Closes #42236