### PR TITLE
fix: recognize Poe 402 'used up your points' as billing for fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback cooldown probing: cap cooldown-bypass probing to one attempt per provider per fallback run so multi-model same-provider cooldown chains can continue to cross-provider fallbacks instead of repeatedly stalling on duplicate cooldown probes. (#41711) Thanks @cgdusek.
 - Telegram/direct delivery: bridge direct delivery sends to internal `message:sent` hooks so internal hook listeners observe successful Telegram deliveries. (#40185) Thanks @vincentkoc.
 - Plugins/global hook runner: harden singleton state handling so shared global hook runner reuse does not leak or corrupt runner state across executions. (#40184) Thanks @vincentkoc.
+- Agents/fallback: recognize Poe `402 You've used up your points!` billing errors so configured model fallbacks trigger instead of surfacing the raw provider error. (#42278) Thanks @CryUshio.
 
 ## 2026.3.8
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -646,6 +646,12 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("402 Payment Required: Weekly/Monthly Limit Exhausted")).toBe(
       "billing",
     );
+    // Poe returns 402 without "payment required"; must be recognized for fallback
+    expect(
+      classifyFailoverReason(
+        "402 You've used up your points! Visit https://poe.com/api/keys to get more.",
+      ),
+    ).toBe("billing");
     expect(classifyFailoverReason(INSUFFICIENT_QUOTA_PAYLOAD)).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
     expect(classifyFailoverReason("request ended without sending any chunks")).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -237,7 +237,7 @@ const RETRYABLE_402_SCOPED_RESULT_HINTS = [
   "exhausted",
 ] as const;
 const RAW_402_MARKER_RE =
-  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b/i;
+  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b|^\s*402\s+.*used up your points\b/i;
 const LEADING_402_WRAPPER_RE =
   /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
 


### PR DESCRIPTION
Poe API returns '402 You've used up your points! Visit https://poe.com/api/keys to get more.' which was not matched by RAW_402_MARKER_RE (requires 'payment required'). Add Poe-specific pattern to RAW_402_MARKER_RE so fallback triggers.

Ref: https://poe.com/api/keys
Made-with: Cursor

## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** Poe API returns `402 You've used up your points! Visit https://poe.com/api/keys to get more.` when credits are exhausted. `RAW_402_MARKER_RE` only matches `402 payment required` and similar patterns, so this error is not recognized as billing.
- **Why it matters:** Without recognition, `classifyFailoverReason` returns `null`, fallback is not triggered, and the user sees a generic failure instead of automatic failover to another model.
- **What changed:** Added `|^\s*402\s+.*used up your points\b` to `RAW_402_MARKER_RE` so Poe's 402 message is treated as billing and triggers fallback.
- **What did NOT change (scope boundary):** Other 402 formats, `classifyFailoverReasonFromHttpStatus`, and non-Poe providers are unchanged. Only Poe's specific "used up your points" text is matched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42236
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- When Poe returns `402 You've used up your points!`, model fallback now triggers instead of failing with an unclassified error.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node ≥22
- Model/provider: Poe (poe.com)
- Integration/channel (if any): Any channel using Poe as LLM provider
- Relevant config (redacted): `agents.defaults.models` with Poe + fallback model (e.g. OpenRouter)

### Steps

1. Configure Poe as primary model and another provider (e.g. OpenRouter) as fallback.
2. Exhaust Poe API points (or simulate 402 response).
3. Send a message that triggers an LLM call.

### Expected

- Error is classified as billing; fallback to secondary model is triggered.

### Actual

- Before fix: `classifyFailoverReason` returns `null`, no fallback, generic error shown.
- After fix: Error classified as `billing`, fallback triggers.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added `pi-embedded-helpers.isbillingerrormessage.test.ts` case for Poe 402 message; regex logic verified via standalone Node script.

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:** Regex matches `402 You've used up your points! Visit https://poe.com/api/keys to get more.`; existing 402 patterns (e.g. `402 Payment Required`) still match.
- **Edge cases checked:** Pattern is narrow (`used up your points`); does not match arbitrary `402 xxx` text.

<img width="915" height="367" alt="1" src="https://github.com/user-attachments/assets/7ebe6492-a971-4303-9f54-93f405eaf71a" />

<img width="902" height="216" alt="截屏2026-03-10 23 16 11" src="https://github.com/user-attachments/assets/57606704-13d6-425d-873b-2db1d0515551" />



## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- Known bad symptoms reviewers should watch for: Poe 402 no longer triggering fallback; false positives on other 402 messages containing "used up your points".

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- **Risk:** Another provider returns a 402 message containing "used up your points" with different semantics.
  - **Mitigation:** Pattern is specific to Poe's known wording; `classify402Message` still distinguishes billing vs rate_limit via existing hints.