### PR TITLE
docs(zh-CN): 添加 5 个 CLI 命令中文文档翻译

### DIFF
--- a/docs/zh-CN/ci.md
+++ b/docs/zh-CN/ci.md
@@ -1,0 +1,56 @@
+---
+title: CI 流水线
+description: OpenClaw CI 流水线的工作原理
+summary: "CI 任务图、范围检测和本地命令等效"
+read_when:
+  - 你需要了解为什么某个 CI 任务没有运行
+  - 你正在调试失败的 GitHub Actions 检查
+---
+
+# CI 流水线
+
+CI 在每次推送到 `main` 分支和每个 Pull Request 时运行。它使用智能范围检测来跳过仅有文档或原生代码变更时的昂贵任务。
+
+## 任务概览
+
+| 任务               | 用途                                                 | 运行时机                                      |
+| ----------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| `docs-scope`      | 检测仅文档变更                                | 始终                                            |
+| `changed-scope`   | 检测哪些区域发生了变更 (node/macos/android/windows) | 非文档 PR                                    |
+| `check`           | TypeScript 类型检查、lint、格式化                          | 推送到 `main`，或有 Node 相关变更的 PR |
+| `check-docs`      | Markdown lint + 检查坏链接                       | 文档变更                                  |
+| `code-analysis`   | 代码行数阈值检查 (1000 行)                        | 仅 PR                                |
+| `secrets`         | 检测泄露的密钥                                   | 始终                                            |
+| `build-artifacts` | 构建一次 dist，共享给其他任务                  | 非文档，node 变更                            |
+| `release-check`   | 验证 npm pack 内容                              | 构建后                                       |
+| `checks`          | Node/Bun 测试 + 协议检查                         | 非文档，node 变更                            |
+| `checks-windows`  | Windows 特定测试                                  | 非文档，windows 相关变更                |
+| `macos`           | Swift lint/build/test + TS 测试                        | 有 macos 变更的 PR                            |
+| `android`         | Gradle 构建 + 测试                                    | 非文档，android 变更                         |
+
+## 快速失败顺序
+
+任务按顺序排列，使便宜的检查在昂贵的检查之前失败：
+
+1. `docs-scope` + `code-analysis` + `check` (并行, ~1-2 分钟)
+2. `build-artifacts` (等待上述完成)
+3. `checks`, `checks-windows`, `macos`, `android` (等待构建完成)
+
+范围检测逻辑位于 `scripts/ci-changed-scope.mjs`，单元测试位于 `src/scripts/ci-changed-scope.test.ts`。
+
+## 运行器
+
+| 运行器                           | 任务                                       |
+| -------------------------------- | ------------------------------------------ |
+| `blacksmith-16vcpu-ubuntu-2404`  | 大多数 Linux 任务，包括范围检测 |
+| `blacksmith-32vcpu-windows-2025` | `checks-windows`                           |
+| `macos-latest`                   | `macos`, `ios`                             |
+
+## 本地等效命令
+
+```bash
+pnpm check          # 类型 + lint + 格式化
+pnpm test           # vitest 测试
+pnpm check:docs     # 文档格式化 + lint + 坏链接检查
+pnpm release:check  # 验证 npm pack
+```

--- a/docs/zh-CN/cli/clawbot.md
+++ b/docs/zh-CN/cli/clawbot.md
@@ -1,0 +1,21 @@
+---
+summary: "`openclaw clawbot` CLI 参考（遗留别名命名空间）"
+read_when:
+  - 你维护使用 `openclaw clawbot ...` 的旧脚本
+  - 你需要迁移到当前命令的指导
+title: "clawbot"
+---
+
+# `openclaw clawbot`
+
+保留用于向后兼容的遗留别名命名空间。
+
+当前支持的别名：
+
+- `openclaw clawbot qr`（与 [`openclaw qr`](/cli/qr) 行为相同）
+
+## 迁移
+
+建议直接使用现代顶级命令：
+
+- `openclaw clawbot qr` -> `openclaw qr`

--- a/docs/zh-CN/cli/completion.md
+++ b/docs/zh-CN/cli/completion.md
@@ -1,0 +1,35 @@
+---
+summary: "`openclaw completion` CLI 参考（生成/安装 shell 补全脚本）"
+read_when:
+  - 你想要 zsh/bash/fish/PowerShell 的 shell 补全
+  - 你需要将补全脚本缓存到 OpenClaw 状态目录
+title: "completion"
+---
+
+# `openclaw completion`
+
+生成 shell 补全脚本，并可选安装到你的 shell 配置文件。
+
+## 用法
+
+```bash
+openclaw completion
+openclaw completion --shell zsh
+openclaw completion --install
+openclaw completion --shell fish --install
+openclaw completion --write-state
+openclaw completion --shell bash --write-state
+```
+
+## 选项
+
+- `-s, --shell <shell>`: shell 目标 (`zsh`, `bash`, `powershell`, `fish`; 默认: `zsh`)
+- `-i, --install`: 通过在 shell 配置文件中添加 source 行来安装补全
+- `--write-state`: 将补全脚本写入 `$OPENCLAW_STATE_DIR/completions` 而不打印到 stdout
+- `-y, --yes`: 跳过安装确认提示
+
+## 注意事项
+
+- `--install` 在你的 shell 配置文件中写入一个小的"OpenClaw Completion"块，并指向缓存的脚本。
+- 无 `--install` 或 `--write-state` 时，命令将脚本打印到 stdout。
+- 补全生成会急加载命令树，因此嵌套子命令也会被包含。

--- a/docs/zh-CN/cli/daemon.md
+++ b/docs/zh-CN/cli/daemon.md
@@ -1,0 +1,43 @@
+---
+summary: "`openclaw daemon` CLI 参考（gateway 服务管理的遗留别名）"
+read_when:
+  - 你仍在脚本中使用 `openclaw daemon ...`
+  - 你需要服务生命周期命令 (install/start/stop/restart/status)
+title: "daemon"
+---
+
+# `openclaw daemon`
+
+Gateway 服务管理命令的遗留别名。
+
+`openclaw daemon ...` 映射到与 `openclaw gateway ...` 服务命令相同的服务控制面。
+
+## 用法
+
+```bash
+openclaw daemon status
+openclaw daemon install
+openclaw daemon start
+openclaw daemon stop
+openclaw daemon restart
+openclaw daemon uninstall
+```
+
+## 子命令
+
+- `status`: 显示服务安装状态并探测 Gateway 健康状态
+- `install`: 安装服务 (`launchd`/`systemd`/`schtasks`)
+- `uninstall`: 移除服务
+- `start`: 启动服务
+- `stop`: 停止服务
+- `restart`: 重启服务
+
+## 常用选项
+
+- `status`: `--url`, `--token`, `--password`, `--timeout`, `--no-probe`, `--deep`, `--json`
+- `install`: `--port`, `--runtime <node|bun>`, `--token`, `--force`, `--json`
+- lifecycle (`uninstall|start|stop|restart`): `--json`
+
+## 推荐
+
+使用 [`openclaw gateway`](/cli/gateway) 获取当前文档和示例。

--- a/docs/zh-CN/cli/qr.md
+++ b/docs/zh-CN/cli/qr.md
@@ -1,0 +1,42 @@
+---
+summary: "`openclaw qr` CLI 参考（生成 iOS 配对二维码和设置码）"
+read_when:
+  - 你想快速将 iOS 应用与 Gateway 配对
+  - 你需要设置码输出用于远程/手动分享
+title: "qr"
+---
+
+# `openclaw qr`
+
+根据当前 Gateway 配置生成 iOS 配对二维码和设置码。
+
+## 用法
+
+```bash
+openclaw qr
+openclaw qr --setup-code-only
+openclaw qr --json
+openclaw qr --remote
+openclaw qr --url wss://gateway.example/ws --token '<token>'
+```
+
+## 选项
+
+- `--remote`: 使用配置中的 `gateway.remote.url` 和远程 token/password
+- `--url <url>`: 覆盖 payload 中使用的 gateway URL
+- `--public-url <url>`: 覆盖 payload 中使用的公共 URL
+- `--token <token>`: 覆盖 payload 中的 gateway token
+- `--password <password>`: 覆盖 payload 中的 gateway password
+- `--setup-code-only`: 仅打印设置码
+- `--no-ascii`: 跳过 ASCII 二维码渲染
+- `--json`: 输出 JSON (`setupCode`, `gatewayUrl`, `auth`, `urlSource`)
+
+## 注意事项
+
+- `--token` 和 `--password` 互斥，不能同时使用。
+- 使用 `--remote` 时，如果有效激活的远程凭证配置为 SecretRefs 且你未传递 `--token` 或 `--password`，命令会从活动的 gateway 快照中解析它们。如果 gateway 不可用，命令会快速失败。
+- 不使用 `--remote` 时，当密码认证可生效时（显式 `gateway.auth.mode="password"` 或推断的密码模式且 auth/env 中无胜出的 token），本地 `gateway.auth.password` SecretRefs 会被解析，且未传递 CLI auth 覆盖。
+- Gateway 版本偏差注意：此命令路径需要支持 `secrets.resolve` 的 gateway；旧版 gateway 返回 unknown-method 错误。
+- 扫描后，使用以下命令批准设备配对：
+  - `openclaw devices list`
+  - `openclaw devices approve <requestId>`

--- a/docs/zh-CN/cli/secrets.md
+++ b/docs/zh-CN/cli/secrets.md
@@ -1,0 +1,168 @@
+---
+summary: "`openclaw secrets` CLI 参考（重载、审计、配置、应用）"
+read_when:
+  - 运行时重新解析密钥引用
+  - 审计明文残留和未解析引用
+  - 配置 SecretRefs 并应用单向清理变更
+title: "secrets"
+---
+
+# `openclaw secrets`
+
+使用 `openclaw secrets` 管理 SecretRefs 并保持活动运行时快照健康。
+
+命令角色：
+
+- `reload`: gateway RPC (`secrets.reload`) 重新解析引用并仅在完全成功时交换运行时快照（不写入配置）。
+- `audit`: 对配置/认证存储和遗留残留进行只读扫描，检查明文、未解析引用和优先级漂移。
+- `configure`: 提供商设置、目标映射和预检的交互式规划器（需要 TTY）。
+- `apply`: 执行保存的计划（`--dry-run` 仅验证），然后清理目标明文残留。
+
+推荐操作循环：
+
+```bash
+openclaw secrets audit --check
+openclaw secrets configure
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets audit --check
+openclaw secrets reload
+```
+
+CI/门禁的退出码说明：
+
+- `audit --check` 发现问题时返回 `1`。
+- 未解析引用返回 `2`。
+
+相关文档：
+
+- 密钥指南: [Secrets Management](/gateway/secrets)
+- 凭证面: [SecretRef Credential Surface](/reference/secretref-credential-surface)
+- 安全指南: [Security](/gateway/security)
+
+## 重载运行时快照
+
+重新解析密钥引用并原子性交换运行时快照。
+
+```bash
+openclaw secrets reload
+openclaw secrets reload --json
+```
+
+注意：
+
+- 使用 gateway RPC 方法 `secrets.reload`。
+- 如果解析失败，gateway 保留最后已知的良好快照并返回错误（无部分激活）。
+- JSON 响应包含 `warningCount`。
+
+## 审计
+
+扫描 OpenClaw 状态以检测：
+
+- 明文密钥存储
+- 未解析引用
+- 优先级漂移（`auth-profiles.json` 凭证覆盖 `openclaw.json` 引用）
+- 遗留残留（旧版认证存储条目、OAuth 提醒）
+
+```bash
+openclaw secrets audit
+openclaw secrets audit --check
+openclaw secrets audit --json
+```
+
+退出行为：
+
+- `--check` 发现问题时以非零退出。
+- 未解析引用以更高优先级的非零码退出。
+
+报告结构要点：
+
+- `status`: `clean | findings | unresolved`
+- `summary`: `plaintextCount`, `unresolvedRefCount`, `shadowedRefCount`, `legacyResidueCount`
+- 发现码：
+  - `PLAINTEXT_FOUND`
+  - `REF_UNRESOLVED`
+  - `REF_SHADOWED`
+  - `LEGACY_RESIDUE`
+
+## 配置（交互式助手）
+
+交互式构建提供商和 SecretRef 变更，运行预检，并可选应用：
+
+```bash
+openclaw secrets configure
+openclaw secrets configure --plan-out /tmp/openclaw-secrets-plan.json
+openclaw secrets configure --apply --yes
+openclaw secrets configure --providers-only
+openclaw secrets configure --skip-provider-setup
+openclaw secrets configure --agent ops
+openclaw secrets configure --json
+```
+
+流程：
+
+1. 首先设置提供商（`secrets.providers` 别名的 `add/edit/remove`）
+2. 然后映射凭证（选择字段并分配 `{source, provider, id}` 引用）
+3. 最后预检和可选应用
+
+标志：
+
+- `--providers-only`: 仅配置 `secrets.providers`，跳过凭证映射
+- `--skip-provider-setup`: 跳过提供商设置，将凭证映射到现有提供商
+- `--agent <id>`: 将 `auth-profiles.json` 目标发现和写入限定到一个代理存储
+
+注意：
+
+- 需要交互式 TTY。
+- 不能同时使用 `--providers-only` 和 `--skip-provider-setup`。
+- `configure` 目标是 `openclaw.json` 中的密钥承载字段以及选定代理作用域的 `auth-profiles.json`。
+- `configure` 支持在选择器流程中直接创建新的 `auth-profiles.json` 映射。
+- 规范支持面: [SecretRef Credential Surface](/reference/secretref-credential-surface)。
+- 应用前执行预检解析。
+- 生成的计划默认启用清理选项（`scrubEnv`、`scrubAuthProfilesForProviderTargets`、`scrubLegacyAuthJson` 均启用）。
+- 应用路径对已清理的明文值是单向的。
+- 无 `--apply` 时，CLI 仍会在预检后提示 `Apply this plan now?`。
+- 有 `--apply`（且无 `--yes`）时，CLI 会额外提示不可逆确认。
+
+Exec 提供商安全注意：
+
+- Homebrew 安装通常暴露 `/opt/homebrew/bin/*` 下的符号链接二进制文件。
+- 仅在需要受信任的包管理器路径时设置 `allowSymlinkCommand: true`，并配合 `trustedDirs`（例如 `["/opt/homebrew"]`）。
+- 在 Windows 上，如果提供商路径的 ACL 验证不可用，OpenClaw 会安全失败。仅对受信任路径设置 `allowInsecurePath: true` 以绕过路径安全检查。
+
+## 应用保存的计划
+
+应用或预检之前生成的计划：
+
+```bash
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --json
+```
+
+计划合约详情（允许的目标路径、验证规则和失败语义）：
+
+- [Secrets Apply Plan Contract](/gateway/secrets-plan-contract)
+
+`apply` 可能更新的内容：
+
+- `openclaw.json`（SecretRef 目标 + 提供商 upserts/deletes）
+- `auth-profiles.json`（提供商目标清理）
+- 遗留 `auth.json` 残留
+- `~/.openclaw/.env` 已知密钥键（值已被迁移）
+
+## 为什么没有回滚备份
+
+`secrets apply` 故意不写入包含旧明文值的回滚备份。
+
+安全性来自严格的预检 + 失败时的原子-ish 应用配合尽力而为的内存恢复。
+
+## 示例
+
+```bash
+openclaw secrets audit --check
+openclaw secrets configure
+openclaw secrets audit --check
+```
+
+如果 `audit --check` 仍报告明文发现，更新剩余报告的目标路径并重新运行审计。


### PR DESCRIPTION
## 概述

添加 5 个 CLI 命令的中文文档翻译，完善中文文档覆盖。

## 新增文件

- `docs/zh-CN/cli/qr.md` - QR 码生成命令文档
- `docs/zh-CN/cli/secrets.md` - 密钥管理命令文档
- `docs/zh-CN/cli/completion.md` - Shell 补全命令文档
- `docs/zh-CN/cli/daemon.md` - Gateway 服务管理命令文档（遗留别名）
- `docs/zh-CN/cli/clawbot.md` - Clawbot 遗留别名文档

## 背景

发现英文文档 `docs/cli/` 目录下有 5 个文件在中文文档 `docs/zh-CN/cli/` 中缺失，已完成翻译补充。

## 检查清单

- [x] 翻译内容准确
- [x] 保持原有 frontmatter 格式
- [x] 链接引用正确