### PR TITLE
docs(acp): document resumeSessionId for session resume

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -269,6 +269,7 @@ Common use cases:
 Notes:
 
 - `resumeSessionId` requires `runtime: "acp"` — returns an error if used with the sub-agent runtime.
+- `resumeSessionId` restores the upstream ACP conversation history; `thread` and `mode` still apply normally to the new OpenClaw session you are creating, so `mode: "session"` still requires `thread: true`.
 - The target agent must support `session/load` (Codex and Claude Code do).
 - If the session ID isn't found, the spawn fails with a clear error — no silent fallback to a new session.
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -243,8 +243,34 @@ Interface details:
   - `mode: "session"` requires `thread: true`
 - `cwd` (optional): requested runtime working directory (validated by backend/runtime policy).
 - `label` (optional): operator-facing label used in session/banner text.
+- `resumeSessionId` (optional): resume an existing ACP session instead of creating a new one. The agent replays its conversation history via `session/load`. Requires `runtime: "acp"`.
 - `streamTo` (optional): `"parent"` streams initial ACP run progress summaries back to the requester session as system events.
   - When available, accepted responses include `streamLogPath` pointing to a session-scoped JSONL log (`<sessionId>.acp-stream.jsonl`) you can tail for full relay history.
+
+### Resume an existing session
+
+Use `resumeSessionId` to continue a previous ACP session instead of starting fresh. The agent replays its conversation history via `session/load`, so it picks up with full context of what came before.
+
+```json
+{
+  "task": "Continue where we left off — fix the remaining test failures",
+  "runtime": "acp",
+  "agentId": "codex",
+  "resumeSessionId": "<previous-session-id>"
+}
+```
+
+Common use cases:
+
+- Hand off a Codex session from your laptop to your phone — tell your agent to pick up where you left off
+- Continue a coding session you started interactively in the CLI, now headlessly through your agent
+- Pick up work that was interrupted by a gateway restart or idle timeout
+
+Notes:
+
+- `resumeSessionId` requires `runtime: "acp"` — returns an error if used with the sub-agent runtime.
+- The target agent must support `session/load` (Codex and Claude Code do).
+- If the session ID isn't found, the spawn fails with a clear error — no silent fallback to a new session.
 
 ### Operator smoke test
 


### PR DESCRIPTION
## Summary

- **Problem:** The new `resumeSessionId` parameter (landed in #41847) has no documentation, so users may not discover it.
- **Why it matters:** Session resume is a key UX improvement — hand off sessions between devices, continue interrupted work, bridge interactive and headless workflows.
- **What changed:** Added `resumeSessionId` to the `sessions_spawn` interface details list and a new "Resume an existing session" subsection with example, use cases, and notes.
- **What did NOT change (scope boundary):** No changes to troubleshooting, command cookbook, or comparison tables — this is purely a `sessions_spawn` parameter addition.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #41847

## User-visible / Behavior Changes

None — docs only.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Docs change only — verified markdown renders correctly.

### Steps

1. Visit https://docs.openclaw.ai/tools/acp-agents#acp-agents
2. Note `resumeSessionId` is not documented.
3. After this PR, the parameter appears in interface details and has its own subsection.

### Expected

- Users can discover and understand session resume from the docs.

### Actual

- Parameter is undocumented.

## Evidence

- [x] Screenshot/recording

Diff is 26 lines of markdown — visual review in the PR files tab.

## Human Verification (required)

- Verified scenarios: Read the rendered diff for accuracy against the implementation in #41847.
- Edge cases checked: Confirmed parameter name, error behavior, and runtime requirement match the merged code.
- What I did **not** verify: Live Mintlify rendering (no local docs preview setup).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit.

## Risks and Mitigations

None — docs-only change.

🤖 AI-assisted (Ada drafted the docs section, Pej reviewed and iterated on content before opening)
- [x] Lightly tested (markdown review, no live preview)
- [x] I understand what the code does