### PR TITLE
fix: add --exclude-logs and --exclude-media flags to backup create (#42273)

### DIFF
--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -26,6 +26,8 @@ export function registerBackupCommand(program: Command) {
     .option("--verify", "Verify the archive after writing it", false)
     .option("--only-config", "Back up only the active JSON config file", false)
     .option("--no-include-workspace", "Exclude workspace directories from the backup")
+    .option("--exclude-logs", "Exclude logs/ subdirectory from the archive", false)
+    .option("--exclude-media", "Exclude media/inbound/ subdirectory from the archive", false)
     .addHelpText(
       "after",
       () =>
@@ -48,6 +50,10 @@ export function registerBackupCommand(program: Command) {
             "Back up state/config without agent workspace files.",
           ],
           ["openclaw backup create --only-config", "Back up only the active JSON config file."],
+          [
+            "openclaw backup create --exclude-logs --exclude-media",
+            "Skip logs/ and media/inbound/ to reduce archive size on large installations.",
+          ],
         ])}`,
     )
     .action(async (opts) => {
@@ -59,6 +65,8 @@ export function registerBackupCommand(program: Command) {
           verify: Boolean(opts.verify),
           onlyConfig: Boolean(opts.onlyConfig),
           includeWorkspace: opts.includeWorkspace as boolean,
+          excludeLogs: Boolean(opts.excludeLogs),
+          excludeMedia: Boolean(opts.excludeMedia),
         });
       });
     });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -408,6 +408,144 @@ describe("backup commands", () => {
     expect(result.assets[0]?.kind).toBe("config");
   });
 
+  it("excludes logs/ subtree when --exclude-logs is set", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const logsDir = path.join(stateDir, "logs");
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-excl-logs-"));
+    try {
+      await fs.mkdir(logsDir, { recursive: true });
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(logsDir, "gateway.log"), "log data\n", "utf8");
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const nowMs = Date.UTC(2026, 2, 9, 2, 0, 0);
+      const result = await backupCreateCommand(runtime, {
+        output: backupDir,
+        excludeLogs: true,
+        nowMs,
+      });
+
+      expect(result.excludeLogs).toBe(true);
+      expect(result.excludeMedia).toBe(false);
+
+      const extractDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-backup-excl-logs-extract-"),
+      );
+      try {
+        await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = path.join(extractDir, buildBackupArchiveRoot(nowMs));
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(archiveRoot, "manifest.json"), "utf8"),
+        ) as { options: { excludeLogs?: boolean } };
+        expect(manifest.options.excludeLogs).toBe(true);
+
+        // logs/gateway.log must not be present in the archive
+        const stateAsset = result.assets.find((a) => a.kind === "state");
+        expect(stateAsset).toBeDefined();
+        const encodedLogPath = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
+          "logs",
+          "gateway.log",
+        );
+        await expect(fs.access(encodedLogPath)).rejects.toThrow();
+
+        // state.txt outside logs/ must still be present
+        const encodedStatePath = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
+          "state.txt",
+        );
+        expect(await fs.readFile(encodedStatePath, "utf8")).toBe("state\n");
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(backupDir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes media/inbound/ subtree when --exclude-media is set", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const mediaDir = path.join(stateDir, "media");
+    const inboundDir = path.join(mediaDir, "inbound");
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-excl-media-"));
+    try {
+      await fs.mkdir(inboundDir, { recursive: true });
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+      await fs.writeFile(path.join(inboundDir, "video.mp4"), "fake video\n", "utf8");
+      await fs.writeFile(path.join(mediaDir, "thumb.png"), "fake img\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const nowMs = Date.UTC(2026, 2, 9, 3, 0, 0);
+      const result = await backupCreateCommand(runtime, {
+        output: backupDir,
+        excludeMedia: true,
+        nowMs,
+      });
+
+      expect(result.excludeLogs).toBe(false);
+      expect(result.excludeMedia).toBe(true);
+
+      const extractDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-backup-excl-media-extract-"),
+      );
+      try {
+        await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = path.join(extractDir, buildBackupArchiveRoot(nowMs));
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(archiveRoot, "manifest.json"), "utf8"),
+        ) as { options: { excludeMedia?: boolean } };
+        expect(manifest.options.excludeMedia).toBe(true);
+
+        const stateAsset = result.assets.find((a) => a.kind === "state");
+        expect(stateAsset).toBeDefined();
+        const encodedPayload = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
+        );
+
+        // media/inbound/video.mp4 must be absent
+        await expect(
+          fs.access(path.join(encodedPayload, "media", "inbound", "video.mp4")),
+        ).rejects.toThrow();
+
+        // media/thumb.png outside inbound/ must be present
+        expect(await fs.readFile(path.join(encodedPayload, "media", "thumb.png"), "utf8")).toBe(
+          "fake img\n",
+        );
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(backupDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run summary lists excluded subdirectories when exclude flags are set", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const result = await backupCreateCommand(runtime, {
+      dryRun: true,
+      excludeLogs: true,
+      excludeMedia: true,
+    });
+
+    expect(result.excludeLogs).toBe(true);
+    expect(result.excludeMedia).toBe(true);
+    const logOutput = (runtime.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => String(c[0]))
+      .join("\n");
+    expect(logOutput).toMatch(/logs\//);
+    expect(logOutput).toMatch(/media\/inbound\//);
+  });
+
   it("allows config-only backups even when the config file is invalid", async () => {
     const configPath = path.join(tempHome.home, "custom-config.json");
     process.env.OPENCLAW_CONFIG_PATH = configPath;

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -22,6 +22,8 @@ export type BackupCreateOptions = {
   dryRun?: boolean;
   includeWorkspace?: boolean;
   onlyConfig?: boolean;
+  excludeLogs?: boolean;
+  excludeMedia?: boolean;
   verify?: boolean;
   json?: boolean;
   nowMs?: number;
@@ -43,6 +45,8 @@ type BackupManifest = {
   options: {
     includeWorkspace: boolean;
     onlyConfig?: boolean;
+    excludeLogs?: boolean;
+    excludeMedia?: boolean;
   };
   paths: {
     stateDir: string;
@@ -66,6 +70,8 @@ export type BackupCreateResult = {
   dryRun: boolean;
   includeWorkspace: boolean;
   onlyConfig: boolean;
+  excludeLogs: boolean;
+  excludeMedia: boolean;
   verified: boolean;
   assets: BackupAsset[];
   skipped: Array<{
@@ -194,6 +200,8 @@ function buildManifest(params: {
   archiveRoot: string;
   includeWorkspace: boolean;
   onlyConfig: boolean;
+  excludeLogs: boolean;
+  excludeMedia: boolean;
   assets: BackupAsset[];
   skipped: BackupCreateResult["skipped"];
   stateDir: string;
@@ -211,6 +219,8 @@ function buildManifest(params: {
     options: {
       includeWorkspace: params.includeWorkspace,
       onlyConfig: params.onlyConfig,
+      excludeLogs: params.excludeLogs || undefined,
+      excludeMedia: params.excludeMedia || undefined,
     },
     paths: {
       stateDir: params.stateDir,
@@ -238,6 +248,16 @@ function formatTextSummary(result: BackupCreateResult): string[] {
   for (const asset of result.assets) {
     lines.push(`- ${asset.kind}: ${asset.displayPath}`);
   }
+  const excludedSubdirs: string[] = [];
+  if (result.excludeLogs) {
+    excludedSubdirs.push("logs/");
+  }
+  if (result.excludeMedia) {
+    excludedSubdirs.push("media/inbound/");
+  }
+  if (excludedSubdirs.length > 0) {
+    lines.push(`Excluded subdirectories: ${excludedSubdirs.join(", ")}`);
+  }
   if (result.skipped.length > 0) {
     lines.push(`Skipped ${result.skipped.length} path${result.skipped.length === 1 ? "" : "s"}:`);
     for (const entry of result.skipped) {
@@ -257,6 +277,38 @@ function formatTextSummary(result: BackupCreateResult): string[] {
     }
   }
   return lines;
+}
+
+/**
+ * Returns a tar filter that skips logs/ and/or media/inbound/ subtrees within
+ * any of the given asset source paths. Returns undefined when no exclusions apply.
+ */
+function buildTarFilter(params: {
+  excludeLogs: boolean;
+  excludeMedia: boolean;
+  assetSourcePaths: string[];
+}): ((entryPath: string) => boolean) | undefined {
+  if (!params.excludeLogs && !params.excludeMedia) {
+    return undefined;
+  }
+  return (entryPath: string) => {
+    const normalizedEntry = path.resolve(entryPath);
+    for (const assetPath of params.assetSourcePaths) {
+      const rel = path.relative(assetPath, normalizedEntry);
+      // Skip if outside this asset or is the asset root itself
+      if (rel === "" || rel.startsWith("..")) {
+        continue;
+      }
+      const parts = rel.split(path.sep);
+      if (params.excludeLogs && parts[0] === "logs") {
+        return false;
+      }
+      if (params.excludeMedia && parts[0] === "media" && parts[1] === "inbound") {
+        return false;
+      }
+    }
+    return true;
+  };
 }
 
 function remapArchiveEntryPath(params: {
@@ -279,6 +331,8 @@ export async function backupCreateCommand(
   const archiveRoot = buildBackupArchiveRoot(nowMs);
   const onlyConfig = Boolean(opts.onlyConfig);
   const includeWorkspace = onlyConfig ? false : (opts.includeWorkspace ?? true);
+  const excludeLogs = Boolean(opts.excludeLogs);
+  const excludeMedia = Boolean(opts.excludeMedia);
   const plan = await resolveBackupPlanFromDisk({ includeWorkspace, onlyConfig, nowMs });
   const outputPath = await resolveOutputPath({
     output: opts.output,
@@ -317,6 +371,8 @@ export async function backupCreateCommand(
     dryRun: Boolean(opts.dryRun),
     includeWorkspace,
     onlyConfig,
+    excludeLogs,
+    excludeMedia,
     verified: false,
     assets: plan.included,
     skipped: plan.skipped,
@@ -333,6 +389,8 @@ export async function backupCreateCommand(
         archiveRoot,
         includeWorkspace,
         onlyConfig,
+        excludeLogs,
+        excludeMedia,
         assets: result.assets,
         skipped: result.skipped,
         stateDir: plan.stateDir,
@@ -342,12 +400,18 @@ export async function backupCreateCommand(
       });
       await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
+      const tarFilter = buildTarFilter({
+        excludeLogs,
+        excludeMedia,
+        assetSourcePaths: result.assets.map((asset) => asset.sourcePath),
+      });
       await tar.c(
         {
           file: tempArchivePath,
           gzip: true,
           portable: true,
           preservePaths: true,
+          filter: tarFilter,
           onWriteEntry: (entry) => {
             entry.path = remapArchiveEntryPath({
               entryPath: entry.path,


### PR DESCRIPTION
## Summary

Fixes #42273 — `openclaw backup create` stalls on large installations (4GB+) because it tries to archive everything including logs (2.6GB) and inbound media with no way to skip them.

## Changes

- **`src/commands/backup.ts`**: Added `excludeLogs` and `excludeMedia` options with a `buildTarFilter()` that skips `logs/` and `media/inbound/` subdirectories within source paths during tar creation. Updated manifest and summary output to reflect exclusions.
- **`src/cli/program/register.backup.ts`**: Wired `--exclude-logs` and `--exclude-media` CLI flags.
- **`src/commands/backup.test.ts`**: 3 new tests covering exclude-logs, exclude-media (preserves other media like thumbnails), and dry-run summary text.

## Usage

```bash
# Skip logs (saves ~2.6GB on typical installs)
openclaw backup create --exclude-logs

# Skip inbound media 
openclaw backup create --exclude-media

# Both
openclaw backup create --exclude-logs --exclude-media
```

## Testing

All 16 backup tests pass:
```
pnpm vitest run src/commands/backup.test.ts
✓ 16 tests passed
```

## Context

Real-world installation with 4.1GB `.openclaw` dir:
- `logs/`: 2.6GB (63% of total)
- `browser/`: 488MB
- `session-index/`: 225MB  
- `media/`: 142MB
- `agents/`: 126MB

With `--exclude-logs`, the backup drops from 4.1GB → ~1.5GB and should complete in seconds instead of stalling.