### PR TITLE
fix: stream backup tar archive to prevent stalls on large installations (#42282)

### DIFF
--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import * as tar from "tar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
@@ -429,6 +430,53 @@ describe("backup commands", () => {
       expect(result.assets[0]?.kind).toBe("config");
     } finally {
       delete process.env.OPENCLAW_CONFIG_PATH;
+    }
+  });
+
+  it("rejects with the underlying error and cleans up the .tmp file when the tar stream errors", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-tar-error-"));
+
+    const tarSpy = vi.spyOn(tar.c, "asyncNoFile").mockImplementation((..._args: unknown[]) => {
+      const stream = new Readable({ read() {} });
+      setImmediate(() => stream.emit("error", new Error("simulated tar write failure")));
+      return stream as ReturnType<(typeof tar.c)["asyncNoFile"]>;
+    });
+
+    try {
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      await expect(backupCreateCommand(runtime, { output: backupDir })).rejects.toThrow(
+        "simulated tar write failure",
+      );
+      // Cleanup must remove any .tmp files created by the streaming write.
+      const files = await fs.readdir(backupDir);
+      expect(files.filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+    } finally {
+      tarSpy.mockRestore();
+      await fs.rm(backupDir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces an actionable OOM hint when archive creation fails with ENOMEM", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-oom-"));
+
+    const tarSpy = vi.spyOn(tar.c, "asyncNoFile").mockImplementation((..._args: unknown[]) => {
+      const stream = new Readable({ read() {} });
+      setImmediate(() => stream.emit("error", new Error("ENOMEM: not enough memory")));
+      return stream as ReturnType<(typeof tar.c)["asyncNoFile"]>;
+    });
+
+    try {
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      await expect(backupCreateCommand(runtime, { output: backupDir })).rejects.toThrow(
+        /--exclude-logs or --exclude-media/i,
+      );
+    } finally {
+      tarSpy.mockRestore();
+      await fs.rm(backupDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -342,22 +342,81 @@ export async function backupCreateCommand(
       });
       await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
-      await tar.c(
-        {
-          file: tempArchivePath,
-          gzip: true,
-          portable: true,
-          preservePaths: true,
-          onWriteEntry: (entry) => {
-            entry.path = remapArchiveEntryPath({
-              entryPath: entry.path,
-              manifestPath,
-              archiveRoot,
-            });
+      // Use the streaming API (no `file:` option) so tar never buffers the
+      // entire archive in memory — critical for 4 GB+ installations.
+      const PROGRESS_INTERVAL = 100 * 1024 * 1024; // 100 MB
+      let bytesWritten = 0;
+      let nextProgressAt = PROGRESS_INTERVAL;
+
+      await new Promise<void>((resolve, reject) => {
+        const destStream = createWriteStream(tempArchivePath);
+        let settled = false;
+
+        const fail = (err: Error) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          try {
+            destStream.destroy();
+          } catch {
+            /* ignore */
+          }
+          const msg = err.message ?? "";
+          if (msg.includes("ENOMEM") || /heap out of memory|allocation failed/i.test(msg)) {
+            reject(
+              new Error(
+                `Backup failed: out of memory. Try --exclude-logs or --exclude-media to reduce archive size. (${msg})`,
+                { cause: err },
+              ),
+            );
+          } else {
+            reject(err);
+          }
+        };
+
+        // asyncNoFile is typed to return Pack (the readable stream class) directly,
+        // avoiding overload-resolution ambiguity when `file` is absent.
+        const tarStream = tar.c.asyncNoFile(
+          {
+            gzip: true,
+            portable: true,
+            preservePaths: true,
+            onWriteEntry: (entry) => {
+              entry.path = remapArchiveEntryPath({
+                entryPath: entry.path,
+                manifestPath,
+                archiveRoot,
+              });
+            },
           },
-        },
-        [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
-      );
+          [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
+        );
+
+        tarStream.on("error", fail);
+        destStream.on("error", fail);
+        destStream.on("finish", () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          resolve();
+        });
+
+        // Track bytes written for progress reporting on large archives.
+        tarStream.on("data", (chunk: unknown) => {
+          bytesWritten += Buffer.isBuffer(chunk) ? chunk.length : 0;
+          if (!opts.json && bytesWritten >= nextProgressAt) {
+            runtime.log(
+              `Backup progress: ${Math.floor(bytesWritten / (1024 * 1024))}MB written...`,
+            );
+            nextProgressAt = bytesWritten + PROGRESS_INTERVAL;
+          }
+        });
+
+        tarStream.pipe(destStream);
+      });
+
       await publishTempArchive({ tempArchivePath, outputPath });
     } finally {
       await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);


### PR DESCRIPTION
## Summary

Fixes #42282 — `openclaw backup create` silently stalls on large installations because the tar archive isn't properly streaming to disk. This replaces the file-mode tar call with an explicit streaming pipeline with error propagation.

## Changes

- **`src/commands/backup.ts`**:
  - Replaced `tar.c({ file: ... })` with `tar.c.asyncNoFile()` piped to `createWriteStream()` — true streaming, no memory buffering
  - Proper error handling: stream errors reject the promise, `settled` flag prevents double-rejection
  - `destStream.destroy()` releases file handles on error before cleanup
  - Progress logging every 100MB (skipped in `--json` mode)
  - ENOMEM/heap OOM errors surface an actionable hint: `--exclude-logs or --exclude-media`

- **`src/commands/backup.test.ts`**:
  - Test: tar stream error rejects properly + cleans up .tmp files
  - Test: ENOMEM error includes actionable hint in message

## How It Works

Before (broken):
```
tar.c({ file: tmpPath, gzip: true }, paths)  // buffers or silently fails on large payloads
```

After (streaming):
```
tar.c({ gzip: true }, paths)  // readable stream
  .pipe(createWriteStream(tmpPath))  // direct to disk
  // with error listeners on both streams
```

## Testing

```
pnpm vitest run src/commands/backup.test.ts
✓ 15 tests passed
```

## Relationship to Other PRs

- **#42281** adds `--exclude-logs` / `--exclude-media` flags (complementary — reduces archive size)
- **This PR** fixes the root cause: streaming pipeline so any size archive works