### PR TITLE
feat(android): add inline Adaptive Card rendering in chat

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/AdaptiveCardParser.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/AdaptiveCardParser.kt
@@ -1,0 +1,61 @@
+package ai.openclaw.app.chat
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class ParsedAdaptiveCard(
+  val card: Map<String, Any>,
+  val fallbackText: String,
+  val templateData: Map<String, Any>? = null,
+)
+
+private val cardMarkerRegex =
+  Regex("<!--adaptive-card-->(.*?)<!--/adaptive-card-->", RegexOption.DOT_MATCHES_ALL)
+
+/**
+ * Extract the first adaptive card JSON from marker-delimited text.
+ * Returns null when no markers are present.
+ */
+fun parseAdaptiveCardMarkers(text: String): ParsedAdaptiveCard? {
+  val match = cardMarkerRegex.find(text) ?: return null
+  val jsonStr = match.groupValues[1].trim()
+  val fallback = text.substring(0, match.range.first).trim()
+
+  return try {
+    val json = JSONObject(jsonStr)
+    val card = jsonObjectToMap(json)
+    val templateData = (card["templateData"] as? Map<*, *>)
+      ?.let { @Suppress("UNCHECKED_CAST") (it as Map<String, Any>) }
+    ParsedAdaptiveCard(card = card, fallbackText = fallback, templateData = templateData)
+  } catch (_: Exception) {
+    null
+  }
+}
+
+/** Remove adaptive card marker blocks, leaving only surrounding text. */
+fun stripCardMarkers(text: String): String {
+  return cardMarkerRegex.replace(text, "").trim()
+}
+
+// -- JSON-to-Map helpers using Android built-in org.json --
+
+private fun jsonObjectToMap(obj: JSONObject): Map<String, Any> {
+  val map = mutableMapOf<String, Any>()
+  for (key in obj.keys()) {
+    map[key] = unwrapJsonValue(obj.get(key))
+  }
+  return map
+}
+
+private fun jsonArrayToList(arr: JSONArray): List<Any> {
+  return (0 until arr.length()).map { unwrapJsonValue(arr.get(it)) }
+}
+
+private fun unwrapJsonValue(value: Any): Any {
+  return when (value) {
+    is JSONObject -> jsonObjectToMap(value)
+    is JSONArray -> jsonArrayToList(value)
+    JSONObject.NULL -> ""
+    else -> value
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/AdaptiveCardParser.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/AdaptiveCardParser.kt
@@ -12,20 +12,35 @@ data class ParsedAdaptiveCard(
 private val cardMarkerRegex =
   Regex("<!--adaptive-card-->(.*?)<!--/adaptive-card-->", RegexOption.DOT_MATCHES_ALL)
 
+private val dataMarkerRegex =
+  Regex("<!--adaptive-card-data-->(.*?)<!--/adaptive-card-data-->", RegexOption.DOT_MATCHES_ALL)
+
 /**
  * Extract the first adaptive card JSON from marker-delimited text.
- * Returns null when no markers are present.
+ * Template data is extracted from separate `<!--adaptive-card-data-->` markers.
+ * Returns null when no card markers are present.
  */
 fun parseAdaptiveCardMarkers(text: String): ParsedAdaptiveCard? {
   val match = cardMarkerRegex.find(text) ?: return null
   val jsonStr = match.groupValues[1].trim()
-  val fallback = text.substring(0, match.range.first).trim()
+
+  // Extract template data from separate data markers
+  val dataMatch = dataMarkerRegex.find(text)
+  val templateData = dataMatch?.let {
+    try {
+      val dataJson = JSONObject(it.groupValues[1].trim())
+      jsonObjectToMap(dataJson)
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  // Strip both card and data markers to get fallback text
+  val fallback = stripCardMarkers(stripDataMarkers(text))
 
   return try {
     val json = JSONObject(jsonStr)
     val card = jsonObjectToMap(json)
-    val templateData = (card["templateData"] as? Map<*, *>)
-      ?.let { @Suppress("UNCHECKED_CAST") (it as Map<String, Any>) }
     ParsedAdaptiveCard(card = card, fallbackText = fallback, templateData = templateData)
   } catch (_: Exception) {
     null
@@ -35,6 +50,11 @@ fun parseAdaptiveCardMarkers(text: String): ParsedAdaptiveCard? {
 /** Remove adaptive card marker blocks, leaving only surrounding text. */
 fun stripCardMarkers(text: String): String {
   return cardMarkerRegex.replace(text, "").trim()
+}
+
+/** Remove adaptive card data marker blocks, leaving only surrounding text. */
+fun stripDataMarkers(text: String): String {
+  return dataMarkerRegex.replace(text, "").trim()
 }
 
 // -- JSON-to-Map helpers using Android built-in org.json --

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/AdaptiveCardComposable.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/AdaptiveCardComposable.kt
@@ -37,14 +37,26 @@ import ai.openclaw.app.ui.mobileCodeBorder
 import ai.openclaw.app.ui.mobileCodeText
 import ai.openclaw.app.ui.mobileText
 import ai.openclaw.app.ui.mobileTextSecondary
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
 
 private const val TAG = "AdaptiveCard"
 
 /**
  * Renders an Adaptive Card from a parsed JSON map inline in a chat bubble.
  * Supports TextBlock, FactSet, ColumnSet, Container, Image (placeholder),
- * Table, RichTextBlock, CodeBlock, ActionSet, ImageSet, Rating, ProgressBar,
- * Action.Submit, Action.Execute, and Action.OpenUrl.
+ * Table, RichTextBlock, CodeBlock, ActionSet, Icon, List, ImageSet, Rating,
+ * ProgressBar, Action.Submit, Action.Execute, and Action.OpenUrl.
  * Unknown element types are silently skipped.
  */
 @Composable
@@ -96,6 +108,8 @@ private fun RenderElement(element: Map<String, Any>) {
     "RichTextBlock" -> RenderRichTextBlock(element)
     "CodeBlock" -> RenderCodeBlock(element)
     "ActionSet" -> RenderActionSet(element)
+    "Icon" -> RenderIcon(element)
+    "List" -> RenderList(element)
     "ImageSet" -> RenderImageSet(element)
     "Rating" -> RenderRating(element)
     "ProgressBar" -> RenderProgressBar(element)
@@ -346,6 +360,85 @@ private fun RenderActionSet(element: Map<String, Any>) {
   }
 }
 
+@Composable
+private fun RenderIcon(element: Map<String, Any>) {
+  val name = element["name"] as? String ?: return
+  val size = element["size"] as? String
+  val color = element["color"] as? String
+  val style = element["style"] as? String // "regular" or "filled"
+
+  val iconSize = when (size?.lowercase()) {
+    "small" -> 16.dp
+    "large" -> 32.dp
+    else -> 20.dp // medium / default
+  }
+
+  val iconColor = when (color?.lowercase()) {
+    "accent" -> mobileAccent
+    "good", "green" -> Color(0xFF4CAF50)
+    "warning", "yellow" -> Color(0xFFFFC107)
+    "attention", "red" -> Color(0xFFF44336)
+    else -> mobileText
+  }
+
+  // Map well-known icon names to Material icons; fall back to text label
+  val isFilled = style?.lowercase() == "filled"
+  val imageVector = when (name.lowercase()) {
+    "info", "information" -> if (isFilled) Icons.Filled.Info else Icons.Outlined.Info
+    "warning", "alert" -> if (isFilled) Icons.Filled.Warning else Icons.Outlined.Warning
+    "checkmark", "check", "success" -> if (isFilled) Icons.Filled.CheckCircle else Icons.Outlined.CheckCircle
+    else -> null
+  }
+
+  if (imageVector != null) {
+    Icon(
+      imageVector = imageVector,
+      contentDescription = name,
+      tint = iconColor,
+      modifier = Modifier.size(iconSize),
+    )
+  } else {
+    // Fallback: render icon name as a small styled label
+    Text(
+      text = "[$name]",
+      style = mobileCaption1,
+      color = iconColor,
+    )
+  }
+}
+
+@Composable
+private fun RenderList(element: Map<String, Any>) {
+  val items = element.typedList("items")
+  if (items.isEmpty()) return
+
+  val style = element["style"] as? String // "ordered" or "unordered"
+  val isOrdered = style?.lowercase() == "ordered"
+
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    for ((index, item) in items.withIndex()) {
+      val text = item["text"] as? String ?: continue
+      val icon = item.typedMap("icon")
+      val prefix = if (isOrdered) "${index + 1}. " else "\u2022 "
+
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        if (icon != null) {
+          // Render inline icon before the list item text
+          RenderIcon(icon)
+        }
+        Text(
+          text = "$prefix$text",
+          style = mobileCallout,
+          color = mobileText,
+        )
+      }
+    }
+  }
+}
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun RenderImageSet(element: Map<String, Any>) {
@@ -470,4 +563,10 @@ private fun Map<String, Any>.typedList(key: String): List<Map<String, Any>> {
     ?.filterIsInstance<Map<*, *>>()
     ?.map { it as Map<String, Any> }
     ?: emptyList()
+}
+
+/** Safely cast a nested map value from a loosely-typed map to Map<String, Any>?. */
+@Suppress("UNCHECKED_CAST")
+private fun Map<String, Any>.typedMap(key: String): Map<String, Any>? {
+  return this[key] as? Map<String, Any>
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/AdaptiveCardComposable.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/AdaptiveCardComposable.kt
@@ -1,0 +1,243 @@
+package ai.openclaw.app.ui.chat
+
+import android.util.Log
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import ai.openclaw.app.ui.mobileAccent
+import ai.openclaw.app.ui.mobileBorder
+import ai.openclaw.app.ui.mobileCallout
+import ai.openclaw.app.ui.mobileCaption1
+import ai.openclaw.app.ui.mobileText
+import ai.openclaw.app.ui.mobileTextSecondary
+
+private const val TAG = "AdaptiveCard"
+
+/**
+ * Renders an Adaptive Card from a parsed JSON map inline in a chat bubble.
+ * Supports TextBlock, FactSet, ColumnSet, Container, Image (placeholder),
+ * Action.Submit, and Action.OpenUrl. Unknown element types are silently skipped.
+ */
+@Composable
+fun AdaptiveCardView(card: Map<String, Any>, modifier: Modifier = Modifier) {
+  Surface(
+    shape = RoundedCornerShape(12.dp),
+    border = BorderStroke(1.dp, mobileBorder),
+    color = MaterialTheme.colorScheme.surface,
+    modifier = modifier.fillMaxWidth(),
+  ) {
+    Column(
+      modifier = Modifier.padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      // Render body elements
+      val body = card.typedList("body")
+      for (element in body) {
+        RenderElement(element)
+      }
+
+      // Render actions
+      val actions = card.typedList("actions")
+      if (actions.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          for (action in actions) {
+            RenderAction(action, modifier = Modifier.weight(1f))
+          }
+        }
+      }
+    }
+  }
+}
+
+// -- Element rendering --
+
+@Composable
+private fun RenderElement(element: Map<String, Any>) {
+  when (element["type"] as? String) {
+    "TextBlock" -> RenderTextBlock(element)
+    "FactSet" -> RenderFactSet(element)
+    "ColumnSet" -> RenderColumnSet(element)
+    "Container" -> RenderContainer(element)
+    "Image" -> RenderImagePlaceholder(element)
+    else -> {
+      // Skip unknown element types gracefully
+      Log.d(TAG, "Skipping unknown element type: ${element["type"]}")
+    }
+  }
+}
+
+@Composable
+private fun RenderTextBlock(element: Map<String, Any>) {
+  val text = element["text"] as? String ?: return
+  val size = element["size"] as? String
+  val weight = element["weight"] as? String
+  val isSubtle = element["isSubtle"] == true
+
+  val style = when (size?.lowercase()) {
+    "large" -> MaterialTheme.typography.titleMedium
+    "small" -> mobileCaption1
+    else -> mobileCallout
+  }
+
+  val fontWeight = when (weight?.lowercase()) {
+    "bolder" -> FontWeight.Bold
+    "lighter" -> FontWeight.Light
+    else -> style.fontWeight
+  }
+
+  val color = if (isSubtle) mobileTextSecondary else mobileText
+
+  Text(
+    text = text,
+    style = style.copy(fontWeight = fontWeight),
+    color = color,
+  )
+}
+
+@Composable
+private fun RenderFactSet(element: Map<String, Any>) {
+  val facts = element.typedList("facts")
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    for (fact in facts) {
+      val title = fact["title"] as? String ?: continue
+      val value = fact["value"] as? String ?: ""
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Text(
+          text = title,
+          style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
+          color = mobileText,
+          modifier = Modifier.weight(0.4f),
+        )
+        Text(
+          text = value,
+          style = mobileCallout,
+          color = mobileTextSecondary,
+          modifier = Modifier.weight(0.6f),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun RenderColumnSet(element: Map<String, Any>) {
+  val columns = element.typedList("columns")
+  if (columns.isEmpty()) return
+
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    for (column in columns) {
+      val items = column.typedList("items")
+      // Use width property for weight; default to equal distribution
+      val widthStr = column["width"] as? String
+      val weight = widthStr?.removeSuffix("px")?.toFloatOrNull()
+        ?: if (widthStr == "stretch" || widthStr == "auto" || widthStr == null) 1f else 1f
+
+      Column(
+        modifier = Modifier.weight(weight),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+      ) {
+        for (item in items) {
+          RenderElement(item)
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun RenderContainer(element: Map<String, Any>) {
+  val items = element.typedList("items")
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    for (item in items) {
+      RenderElement(item)
+    }
+  }
+}
+
+@Composable
+private fun RenderImagePlaceholder(element: Map<String, Any>) {
+  // No HTTP image loading library available; show alt text or URL as placeholder
+  val altText = element["altText"] as? String
+  val url = element["url"] as? String ?: ""
+  Text(
+    text = altText ?: "[Image: $url]",
+    style = mobileCaption1,
+    color = mobileTextSecondary,
+  )
+}
+
+// -- Action rendering --
+
+@Composable
+private fun RenderAction(action: Map<String, Any>, modifier: Modifier = Modifier) {
+  val title = action["title"] as? String ?: return
+  val type = action["type"] as? String
+
+  when (type) {
+    "Action.OpenUrl" -> {
+      val uriHandler = LocalUriHandler.current
+      val url = action["url"] as? String
+      OutlinedButton(
+        onClick = {
+          url?.let {
+            try {
+              uriHandler.openUri(it)
+            } catch (e: Exception) {
+              Log.w(TAG, "Failed to open URL: $it", e)
+            }
+          }
+        },
+        modifier = modifier,
+      ) {
+        Text(text = title, style = mobileCallout, color = mobileAccent)
+      }
+    }
+    "Action.Submit" -> {
+      OutlinedButton(
+        onClick = { Log.d(TAG, "Action.Submit tapped: $title, data=${action["data"]}") },
+        modifier = modifier,
+      ) {
+        Text(text = title, style = mobileCallout, color = mobileAccent)
+      }
+    }
+    else -> {
+      Log.d(TAG, "Skipping unknown action type: $type")
+    }
+  }
+}
+
+// -- Helpers --
+
+/** Safely cast a list value from a loosely-typed map to List<Map<String, Any>>. */
+@Suppress("UNCHECKED_CAST")
+private fun Map<String, Any>.typedList(key: String): List<Map<String, Any>> {
+  return (this[key] as? List<*>)
+    ?.filterIsInstance<Map<*, *>>()
+    ?.map { it as Map<String, Any> }
+    ?: emptyList()
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/AdaptiveCardComposable.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/AdaptiveCardComposable.kt
@@ -4,12 +4,15 @@ import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
@@ -17,12 +20,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import ai.openclaw.app.ui.mobileAccent
 import ai.openclaw.app.ui.mobileBorder
 import ai.openclaw.app.ui.mobileCallout
 import ai.openclaw.app.ui.mobileCaption1
+import ai.openclaw.app.ui.mobileCodeBg
+import ai.openclaw.app.ui.mobileCodeBorder
+import ai.openclaw.app.ui.mobileCodeText
 import ai.openclaw.app.ui.mobileText
 import ai.openclaw.app.ui.mobileTextSecondary
 
@@ -31,7 +43,9 @@ private const val TAG = "AdaptiveCard"
 /**
  * Renders an Adaptive Card from a parsed JSON map inline in a chat bubble.
  * Supports TextBlock, FactSet, ColumnSet, Container, Image (placeholder),
- * Action.Submit, and Action.OpenUrl. Unknown element types are silently skipped.
+ * Table, RichTextBlock, CodeBlock, ActionSet, ImageSet, Rating, ProgressBar,
+ * Action.Submit, Action.Execute, and Action.OpenUrl.
+ * Unknown element types are silently skipped.
  */
 @Composable
 fun AdaptiveCardView(card: Map<String, Any>, modifier: Modifier = Modifier) {
@@ -78,6 +92,13 @@ private fun RenderElement(element: Map<String, Any>) {
     "ColumnSet" -> RenderColumnSet(element)
     "Container" -> RenderContainer(element)
     "Image" -> RenderImagePlaceholder(element)
+    "Table" -> RenderTable(element)
+    "RichTextBlock" -> RenderRichTextBlock(element)
+    "CodeBlock" -> RenderCodeBlock(element)
+    "ActionSet" -> RenderActionSet(element)
+    "ImageSet" -> RenderImageSet(element)
+    "Rating" -> RenderRating(element)
+    "ProgressBar" -> RenderProgressBar(element)
     else -> {
       // Skip unknown element types gracefully
       Log.d(TAG, "Skipping unknown element type: ${element["type"]}")
@@ -181,7 +202,8 @@ private fun RenderContainer(element: Map<String, Any>) {
 
 @Composable
 private fun RenderImagePlaceholder(element: Map<String, Any>) {
-  // No HTTP image loading library available; show alt text or URL as placeholder
+  // TODO: Use Coil or Glide for actual image loading when available as a dependency.
+  // For now, show alt text or URL as a placeholder.
   val altText = element["altText"] as? String
   val url = element["url"] as? String ?: ""
   Text(
@@ -189,6 +211,214 @@ private fun RenderImagePlaceholder(element: Map<String, Any>) {
     style = mobileCaption1,
     color = mobileTextSecondary,
   )
+}
+
+@Composable
+private fun RenderTable(element: Map<String, Any>) {
+  val columns = element.typedList("columns")
+  val rows = element.typedList("rows")
+
+  Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+    // Header row from column definitions
+    if (columns.isNotEmpty()) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        for (col in columns) {
+          val header = col["header"] as? String ?: ""
+          Text(
+            text = header,
+            style = mobileCallout.copy(fontWeight = FontWeight.Bold),
+            color = mobileText,
+            modifier = Modifier.weight(1f),
+          )
+        }
+      }
+    }
+
+    // Data rows
+    for (row in rows) {
+      val cells = row.typedList("cells")
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        for (cell in cells) {
+          // Each cell may contain items or a simple text value
+          val items = cell.typedList("items")
+          if (items.isNotEmpty()) {
+            Column(modifier = Modifier.weight(1f)) {
+              for (item in items) {
+                RenderElement(item)
+              }
+            }
+          } else {
+            val value = cell["value"] as? String ?: cell["text"] as? String ?: ""
+            Text(
+              text = value,
+              style = mobileCallout,
+              color = mobileTextSecondary,
+              modifier = Modifier.weight(1f),
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun RenderRichTextBlock(element: Map<String, Any>) {
+  val inlines = element.typedList("inlines")
+  if (inlines.isEmpty()) return
+
+  val annotated = buildAnnotatedString {
+    for (inline in inlines) {
+      val text = inline["text"] as? String ?: continue
+      val isBold = inline["weight"] as? String == "Bolder" || inline["fontWeight"] as? String == "Bold"
+      val isItalic = inline["italic"] == true
+      val isStrikethrough = inline["strikethrough"] == true
+      val isSubtle = inline["isSubtle"] == true
+
+      val spanStyle = SpanStyle(
+        fontWeight = if (isBold) FontWeight.Bold else null,
+        fontStyle = if (isItalic) FontStyle.Italic else null,
+        textDecoration = if (isStrikethrough) TextDecoration.LineThrough else null,
+        color = if (isSubtle) mobileTextSecondary else mobileText,
+      )
+      withStyle(spanStyle) {
+        append(text)
+      }
+    }
+  }
+
+  Text(text = annotated, style = mobileCallout)
+}
+
+@Composable
+private fun RenderCodeBlock(element: Map<String, Any>) {
+  val code = element["codeSnippet"] as? String
+    ?: element["code"] as? String
+    ?: element["text"] as? String
+    ?: return
+  val language = element["language"] as? String
+
+  Surface(
+    shape = RoundedCornerShape(8.dp),
+    color = mobileCodeBg,
+    border = BorderStroke(1.dp, mobileCodeBorder),
+    modifier = Modifier.fillMaxWidth(),
+  ) {
+    Column(
+      modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      if (!language.isNullOrBlank()) {
+        Text(
+          text = language.uppercase(),
+          style = mobileCaption1,
+          color = mobileTextSecondary,
+        )
+      }
+      Text(
+        text = code.trimEnd(),
+        fontFamily = FontFamily.Monospace,
+        style = mobileCallout,
+        color = mobileCodeText,
+      )
+    }
+  }
+}
+
+@Composable
+private fun RenderActionSet(element: Map<String, Any>) {
+  val actions = element.typedList("actions")
+  if (actions.isEmpty()) return
+
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    modifier = Modifier.fillMaxWidth(),
+  ) {
+    for (action in actions) {
+      RenderAction(action, modifier = Modifier.weight(1f))
+    }
+  }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun RenderImageSet(element: Map<String, Any>) {
+  val images = element.typedList("images")
+  if (images.isEmpty()) return
+
+  // TODO: Use Coil or Glide for actual image loading when available.
+  FlowRow(
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    for (image in images) {
+      val altText = image["altText"] as? String
+      val url = image["url"] as? String ?: ""
+      Text(
+        text = altText ?: "[Image: $url]",
+        style = mobileCaption1,
+        color = mobileTextSecondary,
+      )
+    }
+  }
+}
+
+@Composable
+private fun RenderRating(element: Map<String, Any>) {
+  // value can arrive as Int or Double from JSON parsing
+  val rawValue = element["value"]
+  val value = when (rawValue) {
+    is Number -> rawValue.toDouble()
+    is String -> rawValue.toDoubleOrNull() ?: 0.0
+    else -> 0.0
+  }
+  val max = when (val rawMax = element["max"]) {
+    is Number -> rawMax.toInt()
+    is String -> rawMax.toIntOrNull() ?: 5
+    else -> 5
+  }
+
+  val fullStars = value.toInt().coerceIn(0, max)
+  val emptyStars = (max - fullStars).coerceAtLeast(0)
+  val stars = "\u2605".repeat(fullStars) + "\u2606".repeat(emptyStars)
+
+  Text(
+    text = stars,
+    style = mobileCallout,
+    color = mobileAccent,
+  )
+}
+
+@Composable
+private fun RenderProgressBar(element: Map<String, Any>) {
+  val rawValue = element["value"]
+  val value = when (rawValue) {
+    is Number -> rawValue.toFloat()
+    is String -> rawValue.toFloatOrNull() ?: 0f
+    else -> 0f
+  }
+  // Normalize: if value > 1 treat as percentage (0-100), otherwise as fraction (0-1)
+  val progress = if (value > 1f) (value / 100f).coerceIn(0f, 1f) else value.coerceIn(0f, 1f)
+
+  val label = element["label"] as? String
+
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    if (!label.isNullOrBlank()) {
+      Text(text = label, style = mobileCaption1, color = mobileTextSecondary)
+    }
+    LinearProgressIndicator(
+      progress = { progress },
+      modifier = Modifier.fillMaxWidth().height(6.dp),
+      color = mobileAccent,
+      trackColor = mobileBorder,
+    )
+  }
 }
 
 // -- Action rendering --
@@ -217,9 +447,9 @@ private fun RenderAction(action: Map<String, Any>, modifier: Modifier = Modifier
         Text(text = title, style = mobileCallout, color = mobileAccent)
       }
     }
-    "Action.Submit" -> {
+    "Action.Submit", "Action.Execute" -> {
       OutlinedButton(
-        onClick = { Log.d(TAG, "Action.Submit tapped: $title, data=${action["data"]}") },
+        onClick = { Log.d(TAG, "$type tapped: $title, data=${action["data"]}") },
         modifier = modifier,
       ) {
         Text(text = title, style = mobileCallout, color = mobileAccent)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.unit.sp
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.chat.parseAdaptiveCardMarkers
+import ai.openclaw.app.chat.stripCardMarkers
 import ai.openclaw.app.tools.ToolDisplayRegistry
 import ai.openclaw.app.ui.mobileAccent
 import ai.openclaw.app.ui.mobileAccentSoft
@@ -116,7 +118,17 @@ private fun ChatMessageBody(content: List<ChatMessageContent>, textColor: Color)
       when (part.type) {
         "text" -> {
           val text = part.text ?: continue
-          ChatMarkdown(text = text, textColor = textColor)
+          // Check for adaptive card markers before falling back to markdown
+          val parsed = remember(text) { parseAdaptiveCardMarkers(text) }
+          if (parsed != null) {
+            // Render fallback text (if any) as markdown above the card
+            if (parsed.fallbackText.isNotBlank()) {
+              ChatMarkdown(text = parsed.fallbackText, textColor = textColor)
+            }
+            AdaptiveCardView(card = parsed.card)
+          } else {
+            ChatMarkdown(text = text, textColor = textColor)
+          }
         }
         else -> {
           val b64 = part.base64 ?: continue


### PR DESCRIPTION
## Summary

Adds native Adaptive Card rendering to the Android app. When a chat message contains `<!--adaptive-card-->` markers, the card is parsed and rendered inline in the chat bubble using Jetpack Compose.

### New files
- `AdaptiveCardParser.kt` — marker extraction + JSON parsing
- `AdaptiveCardComposable.kt` — Compose renderer for AC v1.6 elements

### Modified files
- `ChatMessageViews.kt` — card detection in `ChatMessageBody` before markdown render

### Element support
TextBlock, FactSet, ColumnSet, Container, Image, Action.Submit, Action.OpenUrl

### Performance target
<50ms first render, <2MB memory per card.

### Ecosystem Context

This PR is part of the Adaptive Cards feature set powered by:

| Package | Version | Role |
|---------|---------|------|
| [adaptive-cards-mcp](https://github.com/AiCodingBattle/adaptive-cards-mcp) | v2.3.0 | Shared core — v1.6 JSON Schema validation, 7 host profiles, WCAG a11y scoring (0-100), 21 layout patterns, 924 tests |
| [openclaw-adaptive-cards](https://github.com/VikrantSingh01/openclaw-adaptive-cards) | v4.0.0 | OpenClaw plugin — `adaptive_card` tool, MCP bridge, channel-aware prompt guidance, fallback text generation, action routing |

The plugin emits `<!--adaptive-card-->` markers in tool result text. This PR adds the Android client-side parser and Jetpack Compose renderer that consumes those markers.

### Related PRs

- #41908 — Concept documentation
- #41735 — Community plugins listing
- #41565 — Shared channel rendering strategies
- #42350 — iOS native rendering
- #42307 — Web UI rendering
