### PR TITLE
fix(exec): switch Windows console to UTF-8 codepage for CJK support

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { StringDecoder } from "node:string_decoder";
 import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
@@ -36,7 +37,11 @@ function escapeForCmdExe(arg: string): string {
 }
 
 function buildCmdExeCommandLine(resolvedCommand: string, args: string[]): string {
-  return [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
+  const cmdLine = [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
+  // Switch console codepage to UTF-8 before running the command so that
+  // multi-byte characters (e.g. Chinese) are emitted as UTF-8 instead of the
+  // system's default codepage (often GBK/cp936 on Chinese Windows).
+  return `chcp 65001 >nul && ${cmdLine}`;
 }
 
 /**
@@ -297,13 +302,21 @@ export async function runCommandWithTimeout(
       child.stdin.end();
     }
 
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     child.stdout?.on("data", (d) => {
-      stdout += d.toString();
+      stdout += stdoutDecoder.write(d);
       armNoOutputTimer();
     });
+    child.stdout?.on("end", () => {
+      stdout += stdoutDecoder.end();
+    });
     child.stderr?.on("data", (d) => {
-      stderr += d.toString();
+      stderr += stderrDecoder.write(d);
       armNoOutputTimer();
+    });
+    child.stderr?.on("end", () => {
+      stderr += stderrDecoder.end();
     });
     child.on("error", (err) => {
       if (settled) {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { killProcessTree } from "../../kill-tree.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
@@ -108,14 +109,28 @@ export async function createChildAdapter(params: {
     : undefined;
 
   const onStdout = (listener: (chunk: string) => void) => {
+    const decoder = new StringDecoder("utf8");
     child.stdout.on("data", (chunk) => {
-      listener(chunk.toString());
+      listener(decoder.write(chunk));
+    });
+    child.stdout.on("end", () => {
+      const remaining = decoder.end();
+      if (remaining) {
+        listener(remaining);
+      }
     });
   };
 
   const onStderr = (listener: (chunk: string) => void) => {
+    const decoder = new StringDecoder("utf8");
     child.stderr.on("data", (chunk) => {
-      listener(chunk.toString());
+      listener(decoder.write(chunk));
+    });
+    child.stderr.on("end", () => {
+      const remaining = decoder.end();
+      if (remaining) {
+        listener(remaining);
+      }
     });
   };
 


### PR DESCRIPTION
## Summary

- Prepends `chcp 65001 >/dev/null &&` to cmd.exe command lines on Windows so child processes emit UTF-8 instead of the system's default codepage (GBK/cp936 on Chinese Windows)
- Adds `StringDecoder` as defense-in-depth for UTF-8 multi-byte characters split across buffer chunk boundaries
- Addresses the root cause of mojibake reported in #40625 — the `StringDecoder`-only fix there doesn't resolve the encoding mismatch at the source

## Context

PR #40625 correctly identified the mojibake issue but only addressed chunk boundary splits. As [noted in the comments](https://github.com/openclaw/openclaw/pull/40625#issuecomment-4032446710), the patch doesn't fix `dir` and `powershell` garbled output because the real problem is that Windows commands output in GBK, not UTF-8.

`chcp 65001` switches the cmd.exe console codepage to UTF-8 before running the actual command, which is the standard fix for this class of issues on Windows.

## Changes

| File | Change |
|------|--------|
| `src/process/exec.ts` | `buildCmdExeCommandLine` now prepends `chcp 65001 >/dev/null &&`; `runCommandWithTimeout` uses `StringDecoder` |
| `src/process/supervisor/adapters/child.ts` | `onStdout`/`onStderr` use `StringDecoder` for chunk boundary safety |

## Test plan

- [ ] On Chinese Windows 11: run `dir` and `powershell Get-ChildItem` through openclaw exec — Chinese filenames should display correctly
- [ ] On English Windows: verify `chcp 65001` doesn't break ASCII-only output
- [ ] On macOS/Linux: no behavioral change (cmd.exe wrapper path is Windows-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)