### PR TITLE
fix: keep tools.profile="minimal" from implicitly exposing fs/exec tools

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -315,6 +315,58 @@ describe("Agent-specific tool filtering", () => {
     expect(toolNames).toEqual(["session_status"]);
   });
 
+  it("minimal profile with tools.fs configured should not expose fs tools", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "pixel",
+            workspace: "/home/test/.openclaw/workspace-pixel",
+            tools: {
+              profile: "minimal",
+              exec: { host: "gateway", security: "allowlist", ask: "always" },
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:pixel:discord:channel:123",
+      workspaceDir: "/tmp/test-minimal-fs",
+      agentDir: "/tmp/agent-minimal-fs",
+    });
+
+    const toolNames = tools.map((t) => t.name);
+    expect(toolNames).toEqual(["session_status"]);
+  });
+
+  it("minimal profile without any tool sections should only expose session_status", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "restricted",
+            workspace: "~/openclaw-restricted",
+            tools: { profile: "minimal" },
+          },
+        ],
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:restricted:main",
+      workspaceDir: "/tmp/test-minimal-bare",
+      agentDir: "/tmp/agent-minimal-bare",
+    });
+
+    const toolNames = tools.map((t) => t.name);
+    expect(toolNames).toEqual(["session_status"]);
+  });
+
   it("should allow different tool policies for different agents", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -271,4 +271,57 @@ describe("resolveEffectiveToolPolicy", () => {
     const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
     expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });
+
+  it("does not implicitly expose fs tools when profile is minimal", () => {
+    const cfg = {
+      tools: {
+        profile: "minimal",
+        fs: { workspaceOnly: true },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toBeUndefined();
+  });
+
+  it("does not implicitly expose exec tools when profile is minimal", () => {
+    const cfg = {
+      tools: {
+        profile: "minimal",
+        exec: { host: "sandbox" },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toBeUndefined();
+  });
+
+  it("does not implicitly expose tools when agent profile is minimal", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "pixel",
+            tools: {
+              profile: "minimal",
+              fs: { workspaceOnly: true },
+              exec: { host: "gateway" },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "pixel" });
+    expect(result.profileAlsoAllow).toBeUndefined();
+  });
+
+  it("still honors explicit alsoAllow even with minimal profile", () => {
+    const cfg = {
+      tools: {
+        profile: "minimal",
+        alsoAllow: ["web_search"],
+        fs: { workspaceOnly: true },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["web_search"]);
+  });
 });

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -245,7 +245,13 @@ function hasExplicitToolSection(section: unknown): boolean {
 function resolveImplicitProfileAlsoAllow(params: {
   globalTools?: OpenClawConfig["tools"];
   agentTools?: AgentToolsConfig;
+  profile?: string;
 }): string[] | undefined {
+  const normalizedProfile = params.profile?.trim().toLowerCase();
+  if (normalizedProfile === "minimal") {
+    return undefined;
+  }
+
   const implicit = new Set<string>();
   if (
     hasExplicitToolSection(params.agentTools?.exec) ||
@@ -297,7 +303,11 @@ export function resolveEffectiveToolPolicy(params: {
   });
   const explicitProfileAlsoAllow =
     resolveExplicitProfileAlsoAllow(agentTools) ?? resolveExplicitProfileAlsoAllow(globalTools);
-  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({ globalTools, agentTools });
+  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({
+    globalTools,
+    agentTools,
+    profile,
+  });
   const profileAlsoAllow =
     explicitProfileAlsoAllow || implicitProfileAlsoAllow
       ? Array.from(


### PR DESCRIPTION
## Summary
`tools.profile: "minimal"` should expose only `session_status`, but implicit tool-section expansion was re-adding filesystem and exec tools whenever `tools.fs` / `tools.exec` config blocks were present.

This patch makes `minimal` fail-closed again by skipping implicit `alsoAllow` expansion for `minimal` profiles.

## Root cause
`resolveImplicitProfileAlsoAllow()` inferred grants from config section presence:
- `tools.exec` → `exec`, `process`
- `tools.fs` → `read`, `write`, `edit`

That inference was also applied to `profile: "minimal"`, which bypassed the intended minimal boundary.

## Changes
- `src/agents/pi-tools.policy.ts`
  - Skip implicit profile-based exposure when effective profile is `minimal`.
  - Preserve explicit `alsoAllow` behavior.
- `src/agents/pi-tools.policy.test.ts`
  - Added regression coverage for global + agent `minimal` profiles.
  - Added coverage that explicit `alsoAllow` still works.
- `src/agents/pi-tools-agent-config.test.ts`
  - Added end-to-end agent config regression tests confirming only `session_status` is exposed under `minimal`.

## Validation
- `pnpm vitest src/agents/pi-tools.policy.test.ts src/agents/pi-tools-agent-config.test.ts --run`
- Result: 54 passing

Fixes #42165
