### PR TITLE
fix(acp): isolate spawn env from skill-injected process.env mutations

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -65,6 +65,27 @@ describe("resolveAcpClientSpawnEnv", () => {
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
   });
 
+  it("preserves runtime PATH updates when preserveRuntimeKeys is provided", () => {
+    const baseEnv: NodeJS.ProcessEnv = {
+      PATH: "/snapshot/bin",
+      USER: "openclaw",
+    };
+    const runtimeEnv: NodeJS.ProcessEnv = {
+      PATH: "/runtime/bin",
+      PATHEXT: ".CMD;.EXE",
+    };
+
+    const env = resolveAcpClientSpawnEnv(baseEnv, {
+      preserveRuntimeKeys: ["PATH", "PATHEXT"],
+      runtimeEnv,
+    });
+
+    expect(env.PATH).toBe("/runtime/bin");
+    expect(env.PATHEXT).toBe(".CMD;.EXE");
+    expect(env.USER).toBe("openclaw");
+    expect(baseEnv.PATH).toBe("/snapshot/bin");
+  });
+
   it("strips skill-injected env keys when stripKeys is provided", () => {
     const openAiApiKeyEnv = envVar("OPENAI", "API", "KEY");
     const elevenLabsApiKeyEnv = envVar("ELEVENLABS", "API", "KEY");

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -352,6 +352,8 @@ function buildServerArgs(opts: AcpClientOptions): string[] {
 
 type AcpClientSpawnEnvOptions = {
   stripKeys?: Iterable<string>;
+  preserveRuntimeKeys?: readonly string[];
+  runtimeEnv?: NodeJS.ProcessEnv;
 };
 
 export function resolveAcpClientSpawnEnv(
@@ -359,6 +361,17 @@ export function resolveAcpClientSpawnEnv(
   options: AcpClientSpawnEnvOptions = {},
 ): NodeJS.ProcessEnv {
   const env = omitEnvKeysCaseInsensitive(baseEnv, options.stripKeys ?? []);
+
+  if (options.preserveRuntimeKeys && options.preserveRuntimeKeys.length > 0) {
+    const runtimeEnv = options.runtimeEnv ?? process.env;
+    for (const key of options.preserveRuntimeKeys) {
+      const value = runtimeEnv[key];
+      if (typeof value === "string") {
+        env[key] = value;
+      }
+    }
+  }
+
   env.OPENCLAW_SHELL = "acp-client";
   return env;
 }
@@ -512,7 +525,11 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
     stripProviderAuthEnvVars,
     activeSkillEnvKeys: getActiveSkillEnvKeys(),
   });
-  const spawnEnv = resolveAcpClientSpawnEnv(getBaselineProcessEnv(), { stripKeys });
+  const spawnEnv = resolveAcpClientSpawnEnv(getBaselineProcessEnv(), {
+    stripKeys,
+    preserveRuntimeKeys: ["PATH", "Path", "PATHEXT"],
+    runtimeEnv: process.env,
+  });
   const spawnInvocation = resolveAcpClientSpawnInvocation(
     { serverCommand, serverArgs: effectiveArgs },
     {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -500,7 +500,8 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const defaultServerArgs = entryPath ? [entryPath, ...serverArgs] : serverArgs;
   const serverCommand = opts.serverCommand ?? defaultServerCommand;
   const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : defaultServerArgs;
-  const { getActiveSkillEnvKeys } = await import("../agents/skills/env-overrides.runtime.js");
+  const { getActiveSkillEnvKeys, getBaselineProcessEnv } =
+    await import("../agents/skills/env-overrides.runtime.js");
   const stripProviderAuthEnvVars = shouldStripProviderAuthEnvVarsForAcpServer({
     serverCommand,
     serverArgs: effectiveArgs,
@@ -511,7 +512,7 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
     stripProviderAuthEnvVars,
     activeSkillEnvKeys: getActiveSkillEnvKeys(),
   });
-  const spawnEnv = resolveAcpClientSpawnEnv(process.env, { stripKeys });
+  const spawnEnv = resolveAcpClientSpawnEnv(getBaselineProcessEnv(), { stripKeys });
   const spawnInvocation = resolveAcpClientSpawnInvocation(
     { serverCommand, serverArgs: effectiveArgs },
     {

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createFixtureSuite } from "../test-utils/fixture-suite.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 import { writeSkill } from "./skills.e2e-test-helpers.js";
@@ -12,7 +12,11 @@ import {
   buildWorkspaceSkillSnapshot,
   loadWorkspaceSkillEntries,
 } from "./skills.js";
-import { getActiveSkillEnvKeys, getBaselineProcessEnv } from "./skills/env-overrides.js";
+import {
+  _resetBaselineEnvForTesting,
+  getActiveSkillEnvKeys,
+  getBaselineProcessEnv,
+} from "./skills/env-overrides.js";
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-suite-");
 let tempHome: TempHomeEnv | null = null;
@@ -238,6 +242,10 @@ describe("buildWorkspaceSkillsPrompt", () => {
 });
 
 describe("applySkillEnvOverrides", () => {
+  beforeEach(() => {
+    _resetBaselineEnvForTesting();
+  });
+
   it("sets and restores env vars", async () => {
     const workspaceDir = await makeWorkspace();
     const skillDir = path.join(workspaceDir, "skills", "env-skill");

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -12,7 +12,7 @@ import {
   buildWorkspaceSkillSnapshot,
   loadWorkspaceSkillEntries,
 } from "./skills.js";
-import { getActiveSkillEnvKeys } from "./skills/env-overrides.js";
+import { getActiveSkillEnvKeys, getBaselineProcessEnv } from "./skills/env-overrides.js";
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-suite-");
 let tempHome: TempHomeEnv | null = null;
@@ -447,6 +447,44 @@ describe("applySkillEnvOverrides", () => {
       } finally {
         restore();
         expect(process.env.OPENAI_API_KEY).toBeUndefined();
+      }
+    });
+  });
+
+  it("getBaselineProcessEnv does not include skill-injected keys", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "baseline-env-skill");
+    await writeSkill({
+      dir: skillDir,
+      name: "baseline-env-skill",
+      description: "Needs env",
+      metadata:
+        '{"openclaw":{"requires":{"env":["BASELINE_TEST_KEY"]},"primaryEnv":"BASELINE_TEST_KEY"}}',
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    withClearedEnv(["BASELINE_TEST_KEY"], () => {
+      const restore = applySkillEnvOverrides({
+        skills: entries,
+        config: {
+          skills: {
+            entries: {
+              "baseline-env-skill": { apiKey: "agent-a-token" }, // pragma: allowlist secret
+            },
+          },
+        },
+      });
+
+      try {
+        // process.env is polluted with the skill key
+        expect(process.env.BASELINE_TEST_KEY).toBe("agent-a-token");
+
+        // baseline snapshot should NOT contain the injected key
+        const baseline = getBaselineProcessEnv();
+        expect(baseline.BASELINE_TEST_KEY).toBeUndefined();
+      } finally {
+        restore();
       }
     });
   });

--- a/src/agents/skills/env-overrides.runtime.ts
+++ b/src/agents/skills/env-overrides.runtime.ts
@@ -1,1 +1,1 @@
-export { getActiveSkillEnvKeys } from "./env-overrides.js";
+export { getActiveSkillEnvKeys, getBaselineProcessEnv } from "./env-overrides.js";

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -59,6 +59,16 @@ export function getBaselineProcessEnv(): NodeJS.ProcessEnv {
   return { ...(baselineProcessEnv ?? process.env) };
 }
 
+/**
+ * Test-only helper to reset the lazily captured baseline environment snapshot.
+ */
+export function _resetBaselineEnvForTesting(): void {
+  if (process.env.NODE_ENV !== "test") {
+    return;
+  }
+  baselineProcessEnv = undefined;
+}
+
 function acquireActiveSkillEnvKey(key: string, value: string): boolean {
   const active = activeSkillEnvEntries.get(key);
   if (active) {

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -30,6 +30,35 @@ export function getActiveSkillEnvKeys(): ReadonlySet<string> {
   return new Set(activeSkillEnvEntries.keys());
 }
 
+/**
+ * Frozen snapshot of `process.env` captured before any skill overrides
+ * are applied. ACP spawn uses this instead of the live `process.env` so
+ * that agent-specific API keys injected by skill config never leak into
+ * child processes belonging to other agents.
+ *
+ * Captured lazily on the first `applySkillEnvOverrides` /
+ * `applySkillEnvOverridesFromSnapshot` call.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/42189
+ */
+let baselineProcessEnv: Readonly<NodeJS.ProcessEnv> | undefined;
+
+function captureBaselineEnvOnce(): void {
+  if (baselineProcessEnv) {
+    return;
+  }
+  baselineProcessEnv = Object.freeze({ ...process.env });
+}
+
+/**
+ * Returns a shallow copy of the `process.env` snapshot taken before any
+ * skill-config env overrides were applied.  Falls back to a copy of the
+ * current `process.env` when no overrides have been applied yet.
+ */
+export function getBaselineProcessEnv(): NodeJS.ProcessEnv {
+  return { ...(baselineProcessEnv ?? process.env) };
+}
+
 function acquireActiveSkillEnvKey(key: string, value: string): boolean {
   const active = activeSkillEnvEntries.get(key);
   if (active) {
@@ -211,6 +240,7 @@ function createEnvReverter(updates: EnvUpdate[]) {
 }
 
 export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
+  captureBaselineEnvOnce();
   const { skills, config } = params;
   const updates: EnvUpdate[] = [];
 
@@ -237,6 +267,7 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   snapshot?: SkillSnapshot;
   config?: OpenClawConfig;
 }) {
+  captureBaselineEnvOnce();
   const { snapshot, config } = params;
   if (!snapshot) {
     return () => {};


### PR DESCRIPTION
## Summary
ACP spawn env construction was inheriting the live `process.env`, which can contain agent-specific skill-injected API keys.

This patch isolates ACP spawn env from those mutations by using a baseline process env snapshot captured before skill env overrides are applied.

## Root cause
- Skill env overrides intentionally mutate global `process.env` during run setup.
- `createAcpClient()` used `resolveAcpClientSpawnEnv(process.env, ...)`.
- Persistent ACP flows could therefore inherit env state from a different agent context.

## Changes
- `src/agents/skills/env-overrides.ts`
  - Added one-time baseline env capture (`captureBaselineEnvOnce`).
  - Added `getBaselineProcessEnv()` helper that returns a copy of the pre-override environment.
- `src/agents/skills/env-overrides.runtime.ts`
  - Re-exported `getBaselineProcessEnv` for runtime consumers.
- `src/acp/client.ts`
  - Switched ACP spawn env source from live `process.env` to `getBaselineProcessEnv()`.
  - Kept existing `stripKeys` filtering (`getActiveSkillEnvKeys`) as defense in depth.
- `src/agents/skills.test.ts`
  - Added regression test showing baseline env excludes skill-injected keys.

## Validation
- `pnpm vitest src/agents/skills.test.ts src/acp/client.test.ts --run`
- Result: 48 passing

Fixes #42189
