### PR TITLE
fix: prevent raw provider server_error JSON from leaking into chat

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -90,6 +90,12 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("does not rewrite *_error JSON payloads without errorContext unless stream-marked", () => {
+    const text =
+      '{"type":"error","error":{"type":"server_error","code":"server_error","message":"Example payload for docs"}}';
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
   it("does not rewrite regular assistant JSON that only contains error-shaped fields", () => {
     const text =
       '{"request_id":"example-123","error":{"code":"example_code","message":"Example payload for docs"}}';

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -82,6 +82,12 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("does not rewrite regular assistant JSON that only contains error-shaped fields", () => {
+    const text =
+      '{"request_id":"example-123","error":{"code":"example_code","message":"Example payload for docs"}}';
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
   it("returns a friendly message for rate limit errors in Error: prefixed payloads", () => {
     expect(sanitizeUserFacingText("Error: 429 Rate limit exceeded", { errorContext: true })).toBe(
       "⚠️ API rate limit reached. Please try again later.",

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -96,6 +96,20 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
 
+  it("does not rewrite HTTP-prefixed raw API JSON payloads without errorContext", () => {
+    const text =
+      '400 {"type":"error","error":{"type":"server_error","code":"server_error","message":"Example payload for docs"}}';
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("still rewrites HTTP-prefixed raw API payloads in errorContext", () => {
+    const text =
+      '400 {"type":"error","error":{"type":"server_error","code":"server_error","message":"Provider failed"}}';
+    expect(sanitizeUserFacingText(text, { errorContext: true })).toBe(
+      "HTTP 400 server_error: Provider failed",
+    );
+  });
+
   it("does not rewrite regular assistant JSON that only contains error-shaped fields", () => {
     const text =
       '{"request_id":"example-123","error":{"code":"example_code","message":"Example payload for docs"}}';

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -90,6 +90,14 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("keeps context-overflow rewrites in errorContext for stream-marked *_error payloads", () => {
+    const raw =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"Request exceeds model context window"},"sequence_number":2}';
+    expect(sanitizeUserFacingText(raw, { errorContext: true })).toContain(
+      "Context overflow: prompt too large for the model.",
+    );
+  });
+
   it("does not rewrite *_error JSON payloads without errorContext unless stream-marked", () => {
     const text =
       '{"type":"error","error":{"type":"server_error","code":"server_error","message":"Example payload for docs"}}';

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -74,6 +74,14 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("sanitizes non-_error raw API payloads when errorContext is true", () => {
+    const raw =
+      '{"error":{"code":503,"message":"The model is overloaded. Please try later","status":"UNAVAILABLE"}}';
+    expect(sanitizeUserFacingText(raw, { errorContext: true })).toBe(
+      "LLM error: The model is overloaded. Please try later",
+    );
+  });
+
   it("sanitizes raw API error payloads even without explicit errorContext", () => {
     const raw =
       '{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -74,6 +74,14 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("sanitizes raw API error payloads even without explicit errorContext", () => {
+    const raw =
+      '{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';
+    expect(sanitizeUserFacingText(raw)).toBe(
+      "LLM error server_error: An error occurred while processing your request.",
+    );
+  });
+
   it("returns a friendly message for rate limit errors in Error: prefixed payloads", () => {
     expect(sanitizeUserFacingText("Error: 429 Rate limit exceeded", { errorContext: true })).toBe(
       "⚠️ API rate limit reached. Please try again later.",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -605,21 +605,32 @@ function isLikelyProviderErrorType(type?: string): boolean {
   return normalized.endsWith("_error");
 }
 
+function hasProviderStreamSequenceMarker(payload: ErrorPayload): boolean {
+  return typeof payload.sequence_number === "number" && Number.isFinite(payload.sequence_number);
+}
+
 function shouldRewriteRawPayloadWithoutErrorContext(raw: string): boolean {
   const info = parseApiErrorInfo(raw);
   if (!info) {
     return false;
   }
-  if (isLikelyProviderErrorType(info.type)) {
-    return true;
-  }
+
   if (info.httpCode) {
     const parsedCode = Number(info.httpCode);
     if (Number.isFinite(parsedCode) && parsedCode >= 400) {
       return true;
     }
   }
-  return false;
+
+  // Outside explicit errorContext, only rewrite payloads that strongly look like
+  // streamed provider error events (sequence marker + provider *_error type).
+  // This avoids clobbering legitimate assistant JSON examples.
+  const payload = parseApiErrorPayload(raw);
+  if (!payload || !hasProviderStreamSequenceMarker(payload)) {
+    return false;
+  }
+
+  return isLikelyProviderErrorType(info.type);
 }
 
 export function formatRawAssistantErrorForUi(raw?: string): string {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -597,6 +597,31 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
   };
 }
 
+function isLikelyProviderErrorType(type?: string): boolean {
+  const normalized = type?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return normalized.endsWith("_error");
+}
+
+function shouldRewriteRawPayloadWithoutErrorContext(raw: string): boolean {
+  const info = parseApiErrorInfo(raw);
+  if (!info) {
+    return false;
+  }
+  if (isLikelyProviderErrorType(info.type)) {
+    return true;
+  }
+  if (info.httpCode) {
+    const parsedCode = Number(info.httpCode);
+    if (Number.isFinite(parsedCode) && parsedCode >= 400) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function formatRawAssistantErrorForUi(raw?: string): string {
   const trimmed = (raw ?? "").trim();
   if (!trimmed) {
@@ -728,11 +753,11 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return "";
   }
 
-  // Raw JSON API error payloads should never reach the user, regardless of
-  // whether the caller flagged this as an error context.  Providers sometimes
-  // stream server_error events as regular assistant text (not isError), and
-  // without this guard the raw JSON leaks into chat.  (#42132)
-  if (isRawApiErrorPayload(trimmed)) {
+  // Raw JSON API error payloads with strong provider-error signals should not
+  // reach the user even when the stream chunk was not flagged as `isError`.
+  // Keep this narrow to avoid clobbering legitimate assistant JSON output.
+  // (#42132)
+  if (shouldRewriteRawPayloadWithoutErrorContext(trimmed)) {
     return formatRawAssistantErrorForUi(trimmed);
   }
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -728,6 +728,14 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return "";
   }
 
+  // Raw JSON API error payloads should never reach the user, regardless of
+  // whether the caller flagged this as an error context.  Providers sometimes
+  // stream server_error events as regular assistant text (not isError), and
+  // without this guard the raw JSON leaks into chat.  (#42132)
+  if (isRawApiErrorPayload(trimmed)) {
+    return formatRawAssistantErrorForUi(trimmed);
+  }
+
   // Only apply error-pattern rewrites when the caller knows this text is an error payload.
   // Otherwise we risk swallowing legitimate assistant text that merely *mentions* these errors.
   if (errorContext) {
@@ -749,7 +757,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       return BILLING_ERROR_USER_MESSAGE;
     }
 
-    if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
+    if (isLikelyHttpErrorText(trimmed)) {
       return formatRawAssistantErrorForUi(trimmed);
     }
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -762,7 +762,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
   // reach the user even when the stream chunk was not flagged as `isError`.
   // Keep this narrow to avoid clobbering legitimate assistant JSON output.
   // (#42132)
-  if (shouldRewriteRawPayloadWithoutErrorContext(trimmed)) {
+  if (!errorContext && shouldRewriteRawPayloadWithoutErrorContext(trimmed)) {
     return formatRawAssistantErrorForUi(trimmed);
   }
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -615,16 +615,10 @@ function shouldRewriteRawPayloadWithoutErrorContext(raw: string): boolean {
     return false;
   }
 
-  if (info.httpCode) {
-    const parsedCode = Number(info.httpCode);
-    if (Number.isFinite(parsedCode) && parsedCode >= 400) {
-      return true;
-    }
-  }
-
   // Outside explicit errorContext, only rewrite payloads that strongly look like
   // streamed provider error events (sequence marker + provider *_error type).
-  // This avoids clobbering legitimate assistant JSON examples.
+  // Do not rewrite solely based on HTTP-prefixed JSON here to avoid clobbering
+  // assistant-authored docs/examples outside explicit error handling paths.
   const payload = parseApiErrorPayload(raw);
   if (!payload || !hasProviderStreamSequenceMarker(payload)) {
     return false;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -782,7 +782,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       return BILLING_ERROR_USER_MESSAGE;
     }
 
-    if (isLikelyHttpErrorText(trimmed)) {
+    if (isLikelyHttpErrorText(trimmed) || isRawApiErrorPayload(trimmed)) {
       return formatRawAssistantErrorForUi(trimmed);
     }
 


### PR DESCRIPTION
## Summary
Raw provider JSON error payloads can leak into user chat when streamed as plain assistant text (without `isError` metadata).

This patch ensures those payloads are always sanitized before user delivery.

## Root cause
`sanitizeUserFacingText()` only rewrote raw API error payloads inside `errorContext=true` branches.
If provider streaming mislabeled a `server_error` JSON block as normal assistant text, the raw payload passed through unchanged.

## Changes
- `src/agents/pi-embedded-helpers/errors.ts`
  - Added an unconditional early guard in `sanitizeUserFacingText()`:
    - If text matches a raw API error payload shape, rewrite with `formatRawAssistantErrorForUi()` regardless of `errorContext`.
  - Kept other broader rewrites (role/conflict/context-overflow/etc.) gated behind `errorContext` to avoid clobbering normal content.
- `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
  - Added regression test for raw `server_error` JSON with no `errorContext` flag.

## Validation
- `pnpm vitest src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts --run`
- `pnpm vitest src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts --run`
- Result: all passing

Fixes #42132
