### PR TITLE
tui: expose reasoning stream in slash command help/completion

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -15,10 +15,14 @@ describe("getSlashCommands", () => {
   it("provides level completions for built-in toggles", () => {
     const commands = getSlashCommands();
     const verbose = commands.find((command) => command.name === "verbose");
+    const reasoning = commands.find((command) => command.name === "reasoning");
     const activation = commands.find((command) => command.name === "activation");
     expect(verbose?.getArgumentCompletions?.("o")).toEqual([
       { value: "on", label: "on" },
       { value: "off", label: "off" },
+    ]);
+    expect(reasoning?.getArgumentCompletions?.("s")).toEqual([
+      { value: "stream", label: "stream" },
     ]);
     expect(activation?.getArgumentCompletions?.("a")).toEqual([
       { value: "always", label: "always" },

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -4,7 +4,7 @@ import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thi
 import type { OpenClawConfig } from "../config/types.js";
 
 const VERBOSE_LEVELS = ["on", "off"];
-const REASONING_LEVELS = ["on", "off"];
+const REASONING_LEVELS = ["on", "off", "stream"];
 const ELEVATED_LEVELS = ["on", "off", "ask", "full"];
 const ACTIVATION_LEVELS = ["mention", "always"];
 const USAGE_FOOTER_LEVELS = ["off", "tokens", "full"];
@@ -83,7 +83,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "reasoning",
-      description: "Set reasoning on/off",
+      description: "Set reasoning on/off/stream",
       getArgumentCompletions: reasoningCompletions,
     },
     {
@@ -143,7 +143,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/model <provider/model> (or /models)",
     `/think <${thinkLevels}>`,
     "/verbose <on|off>",
-    "/reasoning <on|off>",
+    "/reasoning <on|off|stream>",
     "/usage <off|tokens|full>",
     "/elevated <on|off|ask|full>",
     "/elev <on|off|ask|full>",

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -347,7 +347,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "reasoning":
         if (!args) {
-          chatLog.addSystem("usage: /reasoning <on|off>");
+          chatLog.addSystem("usage: /reasoning <on|off|stream>");
           break;
         }
         try {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -166,6 +166,45 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
+  it("renders thinking stream updates for active runs when reasoning level is stream", () => {
+    const { chatLog, tui, handleAgentEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-think",
+        sessionInfo: { verboseLevel: "on", reasoningLevel: "stream" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-think",
+      stream: "thinking",
+      data: { text: "Reasoning:\n_checking now_" },
+    });
+
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith(
+      "Reasoning:\n_checking now_",
+      "run-think:thinking",
+    );
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores thinking stream updates when reasoning level is not stream", () => {
+    const { chatLog, tui, handleAgentEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-think",
+        sessionInfo: { verboseLevel: "on", reasoningLevel: "off" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-think",
+      stream: "thinking",
+      data: { text: "Reasoning:\n_hidden_" },
+    });
+
+    expect(chatLog.updateAssistant).not.toHaveBeenCalled();
+    expect(tui.requestRender).not.toHaveBeenCalled();
+  });
+
   it("captures runId from chat events when activeChatRunId is unset", () => {
     const { state, chatLog, handleChatEvent, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
@@ -277,6 +316,31 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     expect(chatLog.startTool).toHaveBeenCalledWith("tc-final", "session_status", undefined);
     expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("clears active thinking stream when the run reaches final", () => {
+    const { state, chatLog, handleAgentEvent, handleChatEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-think-final",
+        sessionInfo: { verboseLevel: "on", reasoningLevel: "stream" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-think-final",
+      stream: "thinking",
+      data: { text: "Reasoning:\n_working_" },
+    });
+    chatLog.dropAssistant.mockClear();
+
+    handleChatEvent({
+      runId: "run-think-final",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-think-final:thinking");
   });
 
   it("ignores lifecycle updates for non-active runs in the same session", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -46,8 +46,18 @@ export function createEventHandlers(context: EventHandlerContext) {
   } = context;
   const finalizedRuns = new Map<string, number>();
   const sessionRuns = new Map<string, number>();
+  const thinkingRuns = new Set<string>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
+
+  const thinkingRunId = (runId: string) => `${runId}:thinking`;
+
+  const clearThinkingRun = (runId: string) => {
+    if (!thinkingRuns.delete(runId)) {
+      return;
+    }
+    chatLog.dropAssistant(thinkingRunId(runId));
+  };
 
   const pruneRunMap = (runs: Map<string, number>) => {
     if (runs.size <= 200) {
@@ -79,6 +89,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     lastSessionKey = state.currentSessionKey;
     finalizedRuns.clear();
     sessionRuns.clear();
+    thinkingRuns.clear();
     streamAssembler = new TuiStreamAssembler();
     clearLocalRunIds?.();
   };
@@ -91,6 +102,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const noteFinalizedRun = (runId: string) => {
     finalizedRuns.set(runId, Date.now());
     sessionRuns.delete(runId);
+    clearThinkingRun(runId);
     streamAssembler.drop(runId);
     pruneRunMap(finalizedRuns);
   };
@@ -119,6 +131,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     wasActiveRun: boolean;
     status: "aborted" | "error";
   }) => {
+    clearThinkingRun(params.runId);
     streamAssembler.drop(params.runId);
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
@@ -314,6 +327,19 @@ export function createEventHandlers(context: EventHandlerContext) {
           chatLog.updateToolResult(toolCallId, { content: [] }, { isError: Boolean(data.isError) });
         }
       }
+      tui.requestRender();
+      return;
+    }
+    if (evt.stream === "thinking") {
+      if (!isActiveRun || state.sessionInfo.reasoningLevel !== "stream") {
+        return;
+      }
+      const text = asString(evt.data?.text, "");
+      if (!text.trim()) {
+        return;
+      }
+      thinkingRuns.add(evt.runId);
+      chatLog.updateAssistant(text, thinkingRunId(evt.runId));
       tui.requestRender();
       return;
     }


### PR DESCRIPTION
## Summary
- Include `stream` in TUI `/reasoning` argument completion.
- Update TUI `/reasoning` help/usage text from `on|off` to `on|off|stream`.

## Why
`ReasoningLevel` already supports `stream`, but TUI command metadata and usage hints only advertised `on|off`. This makes users think stream mode is unsupported in TUI.

## Scope
- TUI command metadata/help only.
- No behavior change to gateway/session logic.

## Files
- `src/tui/commands.ts`
- `src/tui/tui-command-handlers.ts`

Refs: #42276
