### PR TITLE
fix(outbound): skip unconfigured channel providers during contact name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Docs: https://docs.openclaw.ai
 - Security/system.run: fail closed for approval-backed interpreter/runtime commands when OpenClaw cannot bind exactly one concrete local file operand, while extending best-effort direct-file binding to additional runtime forms. Thanks @tdjackey for reporting.
 - Gateway/session reset auth: split conversation `/new` and `/reset` handling away from the admin-only `sessions.reset` control-plane RPC so write-scoped gateway callers can no longer reach the privileged reset path through `agent`. Thanks @tdjackey for reporting.
 - Telegram/final preview delivery followup: keep ambiguous missing-`message_id` finals only when a preview was already visible, while first-preview/no-id cases still fall back so Telegram users do not lose the final reply. (#41932) thanks @hougangdev.
-- Outbound/channel selection: skip unconfigured channel providers during contact name resolution so known-but-absent channels no longer produce confusing errors or inflate the configured-channel list. Fixes #42080. Thanks @ademczuk.
+- Outbound/channel selection: skip unconfigured channel providers during contact name resolution so known-but-absent channels no longer produce confusing errors or inflate the configured-channel list. Fixes #42080. Thanks @njwoodard.
 
 ## 2026.3.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 - Security/system.run: fail closed for approval-backed interpreter/runtime commands when OpenClaw cannot bind exactly one concrete local file operand, while extending best-effort direct-file binding to additional runtime forms. Thanks @tdjackey for reporting.
 - Gateway/session reset auth: split conversation `/new` and `/reset` handling away from the admin-only `sessions.reset` control-plane RPC so write-scoped gateway callers can no longer reach the privileged reset path through `agent`. Thanks @tdjackey for reporting.
 - Telegram/final preview delivery followup: keep ambiguous missing-`message_id` finals only when a preview was already visible, while first-preview/no-id cases still fall back so Telegram users do not lose the final reply. (#41932) thanks @hougangdev.
+- Outbound/channel selection: skip unconfigured channel providers during contact name resolution so known-but-absent channels no longer produce confusing errors or inflate the configured-channel list. Fixes #42080. Thanks @ademczuk.
 
 ## 2026.3.8
 

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -10,6 +10,17 @@ vi.mock("../../channels/plugins/index.js", () => ({
 
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 
+function makePlugin(id: string, opts?: { isConfigured?: boolean }) {
+  return {
+    id,
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({}),
+      isConfigured: async () => opts?.isConfigured ?? true,
+    },
+  };
+}
+
 describe("resolveMessageChannelSelection", () => {
   beforeEach(() => {
     mocks.listChannelPlugins.mockReset();
@@ -17,16 +28,43 @@ describe("resolveMessageChannelSelection", () => {
   });
 
   it("keeps explicit known channels and marks source explicit", async () => {
+    mocks.listChannelPlugins.mockReturnValue([makePlugin("telegram")]);
+
     const selection = await resolveMessageChannelSelection({
-      cfg: {} as never,
+      cfg: { channels: { telegram: { accounts: { default: {} } } } } as never,
       channel: "telegram",
     });
 
     expect(selection).toEqual({
       channel: "telegram",
-      configured: [],
+      configured: ["telegram"],
       source: "explicit",
     });
+  });
+
+  it("throws for known-but-unconfigured explicit channel even when fallback exists", async () => {
+    mocks.listChannelPlugins.mockReturnValue([makePlugin("telegram")]);
+
+    // Explicit channel must not silently reroute — the agent should see the
+    // error and retry with a valid channel to avoid misdelivery.
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: { channels: { telegram: { accounts: { default: {} } } } } as never,
+        channel: "whatsapp",
+        fallbackChannel: "telegram",
+      }),
+    ).rejects.toThrow("Channel whatsapp is not configured. Configured channels: telegram");
+  });
+
+  it("throws for known-but-unconfigured channel when no channels configured at all", async () => {
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).rejects.toThrow(
+      "Channel whatsapp is not configured (no message channels are configured).",
+    );
   });
 
   it("falls back to tool context channel when explicit channel is unknown", async () => {
@@ -57,19 +95,29 @@ describe("resolveMessageChannelSelection", () => {
   });
 
   it("selects single configured channel when no explicit/fallback channel exists", async () => {
-    mocks.listChannelPlugins.mockReturnValue([
-      {
-        id: "discord",
-        config: {
-          listAccountIds: () => ["default"],
-          resolveAccount: () => ({}),
-          isConfigured: async () => true,
-        },
-      },
-    ]);
+    mocks.listChannelPlugins.mockReturnValue([makePlugin("discord")]);
 
     const selection = await resolveMessageChannelSelection({
-      cfg: {} as never,
+      cfg: { channels: { discord: { accounts: { default: {} } } } } as never,
+    });
+
+    expect(selection).toEqual({
+      channel: "discord",
+      configured: ["discord"],
+      source: "single-configured",
+    });
+  });
+
+  it("excludes unconfigured channels from configured list", async () => {
+    mocks.listChannelPlugins.mockReturnValue([
+      makePlugin("discord"),
+      makePlugin("whatsapp", { isConfigured: true }),
+    ]);
+
+    // Only discord has a config block; whatsapp has no config entry
+    // so isPluginConfigured skips it despite isConfigured returning true.
+    const selection = await resolveMessageChannelSelection({
+      cfg: { channels: { discord: { accounts: { default: {} } } } } as never,
     });
 
     expect(selection).toEqual({

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -62,9 +62,7 @@ describe("resolveMessageChannelSelection", () => {
         cfg: {} as never,
         channel: "whatsapp",
       }),
-    ).rejects.toThrow(
-      "Channel whatsapp is not configured (no message channels are configured).",
-    );
+    ).rejects.toThrow("Channel whatsapp is not configured (no message channels are configured).");
   });
 
   it("falls back to tool context channel when explicit channel is unknown", async () => {

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -112,11 +112,11 @@ export async function resolveMessageChannelSelection(params: {
       throw new Error(`Unknown channel: ${String(normalized)}`);
     }
 
-    // Known channel — verify it's actually configured before accepting (#42080).
-    // Throw on mismatch so the agent/caller sees a clear error and can retry
-    // with a valid channel instead of silently rerouting to a different one.
-    const configured = await listConfiguredMessageChannels(params.cfg);
-    if (!configured.includes(normalized as MessageChannelId)) {
+    // Known channel — verify it has a config entry before accepting (#42080).
+    // Check config presence, not full plugin auth (isConfigured), so channels
+    // with valid config but pending auth (e.g. WhatsApp web linking) still work.
+    if (params.cfg.channels?.[normalized] === undefined) {
+      const configured = await listConfiguredMessageChannels(params.cfg);
       throw new Error(
         configured.length > 0
           ? `Channel ${String(normalized)} is not configured. Configured channels: ${configured.join(", ")}`
@@ -125,7 +125,7 @@ export async function resolveMessageChannelSelection(params: {
     }
     return {
       channel: normalized as MessageChannelId,
-      configured,
+      configured: await listConfiguredMessageChannels(params.cfg),
       source: "explicit",
     };
   }

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -43,6 +43,12 @@ function isAccountEnabled(account: unknown): boolean {
 }
 
 async function isPluginConfigured(plugin: ChannelPlugin, cfg: OpenClawConfig): Promise<boolean> {
+  // Skip channels absent from config — prevents phantom "default" accounts
+  // from stale auth files inflating the configured-channel count (#42080).
+  if (cfg.channels?.[plugin.id] === undefined) {
+    return false;
+  }
+
   const accountIds = plugin.config.listAccountIds(cfg);
   if (accountIds.length === 0) {
     return false;
@@ -105,9 +111,21 @@ export async function resolveMessageChannelSelection(params: {
       }
       throw new Error(`Unknown channel: ${String(normalized)}`);
     }
+
+    // Known channel — verify it's actually configured before accepting (#42080).
+    // Throw on mismatch so the agent/caller sees a clear error and can retry
+    // with a valid channel instead of silently rerouting to a different one.
+    const configured = await listConfiguredMessageChannels(params.cfg);
+    if (!configured.includes(normalized as MessageChannelId)) {
+      throw new Error(
+        configured.length > 0
+          ? `Channel ${String(normalized)} is not configured. Configured channels: ${configured.join(", ")}`
+          : `Channel ${String(normalized)} is not configured (no message channels are configured).`,
+      );
+    }
     return {
       channel: normalized as MessageChannelId,
-      configured: await listConfiguredMessageChannels(params.cfg),
+      configured,
       source: "explicit",
     };
   }

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -37,6 +37,7 @@ const whatsappConfig = {
     whatsapp: {
       allowFrom: ["*"],
     },
+    imessage: {},
   },
 } as OpenClawConfig;
 
@@ -447,9 +448,16 @@ describe("runMessageAction context isolation", () => {
   });
 
   it("blocks cross-provider sends by default", async () => {
+    const crossProviderCfg = {
+      channels: {
+        slack: { botToken: "xoxb-test", appToken: "xapp-test" },
+        telegram: {},
+      },
+    } as OpenClawConfig;
+
     await expect(
       runDrySend({
-        cfg: slackConfig,
+        cfg: crossProviderCfg,
         actionParams: {
           channel: "telegram",
           target: "@opsbot",
@@ -1126,7 +1134,7 @@ describe("runMessageAction components parsing", () => {
       buttons: [{ label: "A", customId: "a" }],
     };
     const result = await runMessageAction({
-      cfg: {} as OpenClawConfig,
+      cfg: { channels: { discord: {} } } as OpenClawConfig,
       action: "send",
       params: {
         channel: "discord",
@@ -1145,7 +1153,7 @@ describe("runMessageAction components parsing", () => {
   it("throws on invalid components JSON strings", async () => {
     await expect(
       runMessageAction({
-        cfg: {} as OpenClawConfig,
+        cfg: { channels: { discord: {} } } as OpenClawConfig,
         action: "send",
         params: {
           channel: "discord",
@@ -1203,7 +1211,7 @@ describe("runMessageAction accountId defaults", () => {
 
   it("propagates defaultAccountId into params", async () => {
     await runMessageAction({
-      cfg: {} as OpenClawConfig,
+      cfg: { channels: { discord: {} } } as OpenClawConfig,
       action: "send",
       params: {
         channel: "discord",
@@ -1230,6 +1238,7 @@ describe("runMessageAction accountId defaults", () => {
   it("falls back to the agent's bound account when accountId is omitted", async () => {
     await runMessageAction({
       cfg: {
+        channels: { discord: {} },
         bindings: [{ agentId: "agent-b", match: { channel: "discord", accountId: "account-b" } }],
       } as OpenClawConfig,
       action: "send",

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -30,7 +30,7 @@ describe("sendMessage channel normalization", () => {
   it("threads resolved cfg through alias + target normalization in outbound dispatch", async () => {
     const resolvedCfg = {
       __resolvedCfgMarker: "cfg-from-secret-resolution",
-      channels: {},
+      channels: { imessage: {} },
     } as Record<string, unknown>;
     const seen: {
       resolveCfg?: unknown;
@@ -115,7 +115,7 @@ describe("sendMessage channel normalization", () => {
       ]),
     );
     const result = await sendMessage({
-      cfg: {},
+      cfg: { channels: { msteams: {} } },
       to: "conversation:19:abc@thread.tacv2",
       content: "hi",
       channel: "teams",
@@ -138,7 +138,7 @@ describe("sendMessage channel normalization", () => {
       ]),
     );
     const result = await sendMessage({
-      cfg: {},
+      cfg: { channels: { imessage: {} } },
       to: "someone@example.com",
       content: "hi",
       channel: "imsg",
@@ -166,7 +166,7 @@ describe("sendMessage replyToId threading", () => {
     const capturedCtx = setupMattermostCapture();
 
     await sendMessage({
-      cfg: {},
+      cfg: { channels: { mattermost: {} } },
       to: "channel:town-square",
       content: "thread reply",
       channel: "mattermost",
@@ -181,7 +181,7 @@ describe("sendMessage replyToId threading", () => {
     const capturedCtx = setupMattermostCapture();
 
     await sendMessage({
-      cfg: {},
+      cfg: { channels: { mattermost: {} } },
       to: "channel:town-square",
       content: "topic reply",
       channel: "mattermost",
@@ -210,7 +210,7 @@ describe("sendPoll channel normalization", () => {
     );
 
     const result = await sendPoll({
-      cfg: {},
+      cfg: { channels: { msteams: {} } },
       to: "conversation:19:abc@thread.tacv2",
       question: "Lunch?",
       options: ["Pizza", "Sushi"],
@@ -246,7 +246,7 @@ describe("gateway url override hardening", () => {
 
     callGatewayMock.mockResolvedValueOnce({ messageId: "m1" });
     await sendMessage({
-      cfg: {},
+      cfg: { channels: { mattermost: {} } },
       to: "channel:town-square",
       content: "hi",
       channel: "mattermost",
@@ -274,7 +274,7 @@ describe("gateway url override hardening", () => {
 
     callGatewayMock.mockResolvedValueOnce({ messageId: "m-agent" });
     await sendMessage({
-      cfg: {},
+      cfg: { channels: { mattermost: {} } },
       to: "channel:town-square",
       content: "hi",
       channel: "mattermost",

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -55,7 +55,7 @@ describe("sendMessage", () => {
 
   it("passes explicit agentId to outbound delivery for scoped media roots", async () => {
     await sendMessage({
-      cfg: {},
+      cfg: { channels: { telegram: {} } },
       channel: "telegram",
       to: "123456",
       content: "hi",


### PR DESCRIPTION
## Summary

Fixes #42080 - when an agent prompt says "message Nick" without specifying a channel, the gateway's contact-name resolution fans out to ALL registered channel providers, including providers absent from `openclaw.json`. WhatsApp (entirely absent from config) gets queried, producing `Unknown target "Nick" for whatsapp` errors and listing whatsapp in the "multiple channels configured" error message.

**Root cause** - two defects combine:

1. `resolveMessageChannelSelection` accepted any explicitly-specified channel that passed `isKnownChannel()` without checking if the channel was actually configured in `openclaw.json`.
2. `isPluginConfigured` evaluated channels absent from config because `listAccountIds()` falls back to `["default"]`, and stale auth files on disk (e.g. `~/.openclaw/credentials/whatsapp/default/creds.json`) caused `isConfigured` to return true for phantom accounts.

**Fix** - defence in depth at two layers:

- **`isPluginConfigured` config-presence guard**: if `cfg.channels?.[plugin.id]` is undefined, return false immediately. Prevents phantom "default" accounts from stale auth files inflating the configured-channel count. Fixes broadcast fan-out and auto-select paths.
- **Explicit path validation**: if the LLM picks a known channel that has no config entry, throw a clear "Channel X is not configured. Configured channels: Y" error instead of silently proceeding. Uses a light config-presence check (not full `isConfigured` which does disk I/O) so channels with valid config but pending auth (e.g. WhatsApp web linking) still work.

Related prior art: #31765 by @alexey-pelykh (closed by barnacle bot) addressed the same class of bug but at a different layer (`agent.ts` handler vs `channel-selection.ts`). This PR fixes the channel-selection layer specifically.

## Changes

| File | Change |
|------|--------|
| `src/infra/outbound/channel-selection.ts` | Config-presence guard in `isPluginConfigured` + explicit channel validation |
| `src/infra/outbound/channel-selection.test.ts` | 3 new tests + 2 updated tests (8 total) |
| `src/infra/outbound/message-action-runner.test.ts` | 6 tests updated to include channel config entries |
| `CHANGELOG.md` | Entry under Fixes |

## Test plan

- [x] `pnpm vitest run src/infra/outbound/channel-selection.test.ts` - 8 pass
- [x] `pnpm vitest run src/infra/outbound/message-action-runner.test.ts` - 40 pass
- [x] `pnpm vitest run src/gateway/server-methods/send.test.ts` - 19 pass
- [x] `pnpm vitest run src/cron/isolated-agent/delivery-target.test.ts` - 16 pass
- [x] `pnpm vitest run src/cron/isolated-agent.delivery-target-thread-session.test.ts` - 6 pass
- [x] `pnpm vitest run src/cli/channel-auth.test.ts` - 7 pass
- [ ] Manual: configure only telegram in `openclaw.json`, send "message Nick" - should NOT query whatsapp
- [ ] Manual: explicitly specify `channel: "whatsapp"` when whatsapp absent from config - should get clear "not configured" error