### PR TITLE
feat(feishu): add replyToMode config for reply behavior control

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1356,6 +1356,12 @@ export async function handleFeishuMessage(params: {
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
     const replyTargetMessageId =
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
+
+    // Apply replyToMode: "all" (default) = always reply, "off" = never reply,
+    // "first" = reply only to the first message (handled downstream by outbound)
+    const replyToMode = groupConfig?.replyToMode ?? feishuCfg?.replyToMode ?? "all";
+    const effectiveReplyTargetMessageId =
+      replyToMode === "off" ? undefined : replyTargetMessageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {
@@ -1406,7 +1412,7 @@ export async function handleFeishuMessage(params: {
             agentId,
             runtime: runtime as RuntimeEnv,
             chatId: ctx.chatId,
-            replyToMessageId: replyTargetMessageId,
+            replyToMessageId: effectiveReplyTargetMessageId,
             skipReplyToInMessages: !isGroup,
             replyInThread,
             rootId: ctx.rootId,
@@ -1504,7 +1510,7 @@ export async function handleFeishuMessage(params: {
         agentId: route.agentId,
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
-        replyToMessageId: replyTargetMessageId,
+        replyToMessageId: effectiveReplyTargetMessageId,
         skipReplyToInMessages: !isGroup,
         replyInThread,
         rootId: ctx.rootId,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1358,10 +1358,9 @@ export async function handleFeishuMessage(params: {
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
 
     // Apply replyToMode: "all" (default) = always reply, "off" = never reply,
-    // "first" = reply only to the first message (handled downstream by outbound)
+    // "first" = reply only to the first outbound message per inbound trigger
     const replyToMode = groupConfig?.replyToMode ?? feishuCfg?.replyToMode ?? "all";
-    const effectiveReplyTargetMessageId =
-      replyToMode === "off" ? undefined : replyTargetMessageId;
+    const effectiveReplyTargetMessageId = replyToMode === "off" ? undefined : replyTargetMessageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {
@@ -1420,6 +1419,7 @@ export async function handleFeishuMessage(params: {
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             messageCreateTimeMs,
+            replyToMode,
           });
 
           log(
@@ -1518,6 +1518,7 @@ export async function handleFeishuMessage(params: {
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         messageCreateTimeMs,
+        replyToMode,
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -131,6 +131,14 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
+/**
+ * Reply-to mode for group chats.
+ * - "all" (default): Bot replies to every triggering message (current behavior)
+ * - "first": Bot replies only to the first message in a session
+ * - "off": Bot never uses reply-to (sends as standalone messages)
+ */
+const ReplyToModeSchema = z.enum(["off", "first", "all"]).optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -142,6 +150,7 @@ export const FeishuGroupSchema = z
     groupSessionScope: GroupSessionScopeSchema,
     topicSessionMode: TopicSessionModeSchema,
     replyInThread: ReplyInThreadSchema,
+    replyToMode: ReplyToModeSchema,
   })
   .strict();
 
@@ -172,6 +181,7 @@ const FeishuSharedConfigShape = {
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
   reactionNotifications: ReactionNotificationModeSchema,
+  replyToMode: ReplyToModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
 };

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -53,6 +53,9 @@ export type CreateFeishuReplyDispatcherParams = {
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
+  /** Controls reply-to behaviour: "all" (default) = every message replies,
+   *  "first" = only the first outbound message replies, "off" = never reply. */
+  replyToMode?: "all" | "first" | "off";
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
@@ -68,8 +71,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     rootId,
     mentionTargets,
     accountId,
+    replyToMode,
   } = params;
-  const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
+  let sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
+  // Track whether the first reply has been sent for "first" mode
+  let firstReplySent = false;
+  /** Return the current reply-to ID and, when replyToMode is "first", clear it
+   *  after the first outbound message so subsequent messages are standalone. */
+  const consumeReplyToMessageId = (): string | undefined => {
+    const id = sendReplyToMessageId;
+    if (replyToMode === "first" && !firstReplySent) {
+      firstReplySent = true;
+      // Clear so subsequent sends in this dispatch don't reply-to
+      sendReplyToMessageId = undefined;
+    }
+    return id;
+  };
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuAccount({ cfg, accountId });
@@ -294,7 +311,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   cfg,
                   to: chatId,
                   mediaUrl,
-                  replyToMessageId: sendReplyToMessageId,
+                  replyToMessageId: consumeReplyToMessageId(),
                   replyInThread: effectiveReplyInThread,
                   accountId,
                 });
@@ -314,7 +331,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId: sendReplyToMessageId,
+                replyToMessageId: consumeReplyToMessageId(),
                 replyInThread: effectiveReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
@@ -335,7 +352,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId: sendReplyToMessageId,
+                replyToMessageId: consumeReplyToMessageId(),
                 replyInThread: effectiveReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
@@ -354,7 +371,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               cfg,
               to: chatId,
               mediaUrl,
-              replyToMessageId: sendReplyToMessageId,
+              replyToMessageId: consumeReplyToMessageId(),
               replyInThread: effectiveReplyInThread,
               accountId,
             });


### PR DESCRIPTION
## Summary

Add `replyToMode` configuration to the Feishu channel plugin, bringing it in line with Discord, Telegram, and Slack which already support this setting.

## Problem

The Feishu bot always replies to the triggering message (via Feishu reply API). In long-running sessions, this causes replies to attach to old messages instead of appearing as standalone messages, which is confusing for users.

There is currently no way to control this behavior — Discord/Telegram/Slack all have `replyToMode` (`"off"` | `"first"` | `"all"`), but Feishu does not.

## Solution

Add `replyToMode` to the Feishu config schema with three modes:

- `"all"` (default) — always reply to the triggering message (current behavior, backward compatible)
- `"first"` — reply only to the first message in a session
- `"off"` — never use reply-to, send as standalone messages

The setting is available at three levels:
- Top-level: `channels.feishu.replyToMode`
- Per-account: `channels.feishu.accounts.<id>.replyToMode`
- Per-group: `channels.feishu.groups.<id>.replyToMode`

## Changes

- `extensions/feishu/src/config-schema.ts`: Add `ReplyToModeSchema` to `FeishuSharedConfigShape` and `FeishuGroupSchema`
- `extensions/feishu/src/bot.ts`: Read `replyToMode` from group config > feishu config (default `"all"`), set `effectiveReplyTargetMessageId` to `undefined` when mode is `"off"`

## Usage

```json
{
  "channels": {
    "feishu": {
      "replyToMode": "off"
    }
  }
}
```

Or per-group:

```json
{
  "channels": {
    "feishu": {
      "groups": {
        "oc_xxx": {
          "replyToMode": "off"
        }
      }
    }
  }
}
```

## Testing

All 62 existing Feishu extension tests pass. No behavioral change for existing users (default is `"all"`).