### PR TITLE
fix(cli): accept positional id for cron runs

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -219,6 +219,28 @@ describe("cron cli", () => {
     expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
   });
 
+  it("accepts cron runs job id as a positional argument", async () => {
+    await runCronCommand(["cron", "runs", "job-123"]);
+
+    expect(getGatewayCallParams<{ id?: string; limit?: number }>("cron.runs")).toEqual({
+      id: "job-123",
+      limit: 50,
+    });
+  });
+
+  it("still accepts cron runs --id without a positional argument", async () => {
+    await runCronCommand(["cron", "runs", "--id", "job-123", "--limit", "7"]);
+
+    expect(getGatewayCallParams<{ id?: string; limit?: number }>("cron.runs")).toEqual({
+      id: "job-123",
+      limit: 7,
+    });
+  });
+
+  it("rejects conflicting cron runs ids between positional arg and --id", async () => {
+    await expectCronCommandExit(["cron", "runs", "job-123", "--id", "job-456"]);
+  });
+
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
     await runCronCommand([
       "cron",

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -65,13 +65,29 @@ export function registerCronSimpleCommands(cron: Command) {
     cron
       .command("runs")
       .description("Show cron run history (JSONL-backed)")
-      .requiredOption("--id <id>", "Job id")
+      .argument("[id]", "Job id")
+      .option("--id <id>", "Job id")
       .option("--limit <n>", "Max entries (default 50)", "50")
-      .action(async (opts) => {
+      .action(async (idArg, opts, command) => {
         try {
           const limitRaw = Number.parseInt(String(opts.limit ?? "50"), 10);
           const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
-          const id = String(opts.id);
+          const positionalId = typeof idArg === "string" ? idArg.trim() : "";
+          const optionId = typeof opts.id === "string" ? opts.id.trim() : "";
+
+          if (positionalId && optionId && positionalId !== optionId) {
+            command.error(
+              `conflicting job ids: positional \`${positionalId}\` vs --id \`${optionId}\``,
+            );
+            return;
+          }
+
+          const id = optionId || positionalId;
+          if (!id) {
+            command.error("missing required job id (pass <id> or --id <id>)");
+            return;
+          }
+
           const res = await callGatewayFromCli("cron.runs", opts, {
             id,
             limit,


### PR DESCRIPTION
## Summary
- accept `openclaw cron runs <jobId>` as a positional alias for `--id`
- keep `--id` support intact
- fail loudly when positional `<id>` and `--id` disagree instead of silently ignoring one

## Testing
- `./node_modules/.bin/vitest run src/cli/cron-cli.test.ts --config vitest.unit.config.ts`

Fixes #42300.
