### PR TITLE
(googlechat) fix: space messaging, introduce deduplication, and update reply-to defaults

### DIFF
--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -1,6 +1,6 @@
-import { GoogleAuth, OAuth2Client } from "google-auth-library";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import { GoogleAuth, OAuth2Client } from "google-auth-library";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 
 const CHAT_SCOPE = "https://www.googleapis.com/auth/chat.bot";
@@ -186,7 +186,8 @@ export type GoogleChatAudienceType = "app-url" | "project-number";
 
 // Google OAuth2 JWKS endpoint for manual JWT verification
 const GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
-let cachedJwks: { fetchedAt: number; keys: Array<{ kid: string; [k: string]: unknown }> } | null = null;
+let cachedJwks: { fetchedAt: number; keys: Array<{ kid: string; [k: string]: unknown }> } | null =
+  null;
 
 async function fetchGoogleJwks(): Promise<Array<{ kid: string; [k: string]: unknown }>> {
   const now = Date.now();
@@ -202,9 +203,19 @@ async function fetchGoogleJwks(): Promise<Array<{ kid: string; [k: string]: unkn
   return data.keys;
 }
 
-async function manualVerifyGoogleJwt(idToken: string, expectedAudience: string): Promise<{
+async function manualVerifyGoogleJwt(
+  idToken: string,
+  expectedAudience: string,
+): Promise<{
   ok: boolean;
-  payload?: { iss?: string; aud?: string; email?: string; email_verified?: boolean; exp?: number; sub?: string };
+  payload?: {
+    iss?: string;
+    aud?: string;
+    email?: string;
+    email_verified?: boolean;
+    exp?: number;
+    sub?: string;
+  };
   reason?: string;
 }> {
   const crypto = await import("node:crypto");
@@ -216,7 +227,14 @@ async function manualVerifyGoogleJwt(idToken: string, expectedAudience: string):
 
   const [headerB64, payloadB64, signatureB64] = parts;
   let header: { kid?: string; alg?: string };
-  let payload: { iss?: string; aud?: string; email?: string; email_verified?: boolean; exp?: number; sub?: string };
+  let payload: {
+    iss?: string;
+    aud?: string;
+    email?: string;
+    email_verified?: boolean;
+    exp?: number;
+    sub?: string;
+  };
 
   try {
     header = JSON.parse(Buffer.from(headerB64, "base64url").toString());
@@ -232,7 +250,10 @@ async function manualVerifyGoogleJwt(idToken: string, expectedAudience: string):
 
   // Check audience
   if (payload.aud !== expectedAudience) {
-    return { ok: false, reason: `audience mismatch: expected=${expectedAudience} got=${payload.aud}` };
+    return {
+      ok: false,
+      reason: `audience mismatch: expected=${expectedAudience} got=${payload.aud}`,
+    };
   }
 
   // Check issuer
@@ -279,22 +300,19 @@ export async function verifyGoogleChatRequest(params: {
     return { ok: false, reason: "missing audience" };
   }
   const audienceType = params.audienceType ?? null;
-  console.log(`[googlechat/auth] verifying token audienceType=${audienceType} audience=${audience}`);
 
   if (audienceType === "app-url") {
     try {
       const result = await manualVerifyGoogleJwt(bearer, audience);
       if (!result.ok) {
-        console.log(`[googlechat/auth] app-url verify failed: ${result.reason}`);
         return { ok: false, reason: result.reason };
       }
       const email = result.payload?.email ?? "";
       const ok =
-        result.payload?.email_verified && (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email));
-      console.log(`[googlechat/auth] app-url verify: ok=${ok} email=${email}`);
+        result.payload?.email_verified &&
+        (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email));
       return ok ? { ok: true } : { ok: false, reason: `invalid issuer: ${email}` };
     } catch (err) {
-      console.log(`[googlechat/auth] app-url verify error: ${err instanceof Error ? err.message : String(err)}`);
       return { ok: false, reason: err instanceof Error ? err.message : "invalid token" };
     }
   }
@@ -305,7 +323,6 @@ export async function verifyGoogleChatRequest(params: {
       await verifyClient.verifySignedJwtWithCertsAsync(bearer, certs, audience, [CHAT_ISSUER]);
       return { ok: true };
     } catch (err) {
-      console.log(`[googlechat/auth] project-number verify failed: ${err instanceof Error ? err.message : String(err)}`);
       return { ok: false, reason: err instanceof Error ? err.message : "invalid token" };
     }
   }

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -102,18 +102,19 @@ function loadServiceAccountCredentials(account: ResolvedGoogleChatAccount): {
 export async function getGoogleChatAccessToken(
   account: ResolvedGoogleChatAccount,
 ): Promise<string> {
-  const cacheKey = account.accountId;
+  const sa = loadServiceAccountCredentials(account);
+  if (!sa) {
+    throw new Error("No service account credentials available for Google Chat");
+  }
+
+  const credentialFingerprint = crypto.createHash("md5").update(sa.private_key).digest("hex");
+  const cacheKey = `${account.accountId}:${credentialFingerprint}`;
   const cached = accessTokenCache.get(cacheKey);
   const now = Math.floor(Date.now() / 1000);
 
   // Return cached token if still valid (with 5 min buffer)
   if (cached && cached.expiresAt > now + 300) {
     return cached.token;
-  }
-
-  const sa = loadServiceAccountCredentials(account);
-  if (!sa) {
-    throw new Error("No service account credentials available for Google Chat");
   }
 
   // Create signed JWT assertion
@@ -218,8 +219,6 @@ async function manualVerifyGoogleJwt(
   };
   reason?: string;
 }> {
-  const crypto = await import("node:crypto");
-
   const parts = idToken.split(".");
   if (parts.length !== 3) {
     return { ok: false, reason: "invalid JWT format" };
@@ -241,6 +240,11 @@ async function manualVerifyGoogleJwt(
     payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
   } catch {
     return { ok: false, reason: "failed to decode JWT" };
+  }
+
+  // Check algorithm
+  if (header.alg !== "RS256") {
+    return { ok: false, reason: `unsupported algorithm: ${header.alg}` };
   }
 
   // Check expiration
@@ -268,7 +272,7 @@ async function manualVerifyGoogleJwt(
     return { ok: false, reason: `no matching key found for kid=${header.kid}` };
   }
 
-  const publicKey = crypto.createPublicKey({ key: key as crypto.JsonWebKey, format: "jwk" });
+  const publicKey = crypto.createPublicKey({ key: key as any, format: "jwk" });
   const signedData = `${headerB64}.${payloadB64}`;
   const signature = Buffer.from(signatureB64, "base64url");
 

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -1,4 +1,6 @@
 import { GoogleAuth, OAuth2Client } from "google-auth-library";
+import crypto from "node:crypto";
+import fs from "node:fs";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 
 const CHAT_SCOPE = "https://www.googleapis.com/auth/chat.bot";
@@ -7,6 +9,7 @@ const CHAT_ISSUER = "chat@system.gserviceaccount.com";
 const ADDON_ISSUER_PATTERN = /^service-\d+@gcp-sa-gsuiteaddons\.iam\.gserviceaccount\.com$/;
 const CHAT_CERTS_URL =
   "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 
 // Size-capped to prevent unbounded growth in long-running deployments (#4948)
 const MAX_AUTH_CACHE_SIZE = 32;
@@ -14,6 +17,9 @@ const authCache = new Map<string, { key: string; auth: GoogleAuth }>();
 const verifyClient = new OAuth2Client();
 
 let cachedCerts: { fetchedAt: number; certs: Record<string, string> } | null = null;
+
+// Manual access token cache (bypasses broken gaxios)
+const accessTokenCache = new Map<string, { token: string; expiresAt: number }>();
 
 function buildAuthKey(account: ResolvedGoogleChatAccount): string {
   if (account.credentialsFile) {
@@ -61,17 +67,105 @@ function getAuthInstance(account: ResolvedGoogleChatAccount): GoogleAuth {
   return auth;
 }
 
+/**
+ * Load service account credentials from account config.
+ * Returns { client_email, private_key } or null if not available.
+ */
+function loadServiceAccountCredentials(account: ResolvedGoogleChatAccount): {
+  client_email: string;
+  private_key: string;
+} | null {
+  if (account.credentialsFile) {
+    try {
+      const raw = fs.readFileSync(account.credentialsFile, "utf8");
+      const sa = JSON.parse(raw) as { client_email?: string; private_key?: string };
+      if (sa.client_email && sa.private_key) {
+        return { client_email: sa.client_email, private_key: sa.private_key };
+      }
+    } catch {
+      return null;
+    }
+  }
+  if (account.credentials && typeof account.credentials === "object") {
+    const sa = account.credentials as { client_email?: string; private_key?: string };
+    if (sa.client_email && sa.private_key) {
+      return { client_email: sa.client_email, private_key: sa.private_key };
+    }
+  }
+  return null;
+}
+
+/**
+ * Get Google Chat access token using manual JWT signing + OAuth2 token exchange.
+ * This bypasses the broken gaxios@7.1.3 library used by google-auth-library.
+ */
 export async function getGoogleChatAccessToken(
   account: ResolvedGoogleChatAccount,
 ): Promise<string> {
-  const auth = getAuthInstance(account);
-  const client = await auth.getClient();
-  const access = await client.getAccessToken();
-  const token = typeof access === "string" ? access : access?.token;
-  if (!token) {
-    throw new Error("Missing Google Chat access token");
+  const cacheKey = account.accountId;
+  const cached = accessTokenCache.get(cacheKey);
+  const now = Math.floor(Date.now() / 1000);
+
+  // Return cached token if still valid (with 5 min buffer)
+  if (cached && cached.expiresAt > now + 300) {
+    return cached.token;
   }
-  return token;
+
+  const sa = loadServiceAccountCredentials(account);
+  if (!sa) {
+    throw new Error("No service account credentials available for Google Chat");
+  }
+
+  // Create signed JWT assertion
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      iss: sa.client_email,
+      scope: CHAT_SCOPE,
+      aud: GOOGLE_TOKEN_URL,
+      iat: now,
+      exp: now + 3600,
+    }),
+  ).toString("base64url");
+
+  const signInput = `${header}.${payload}`;
+  const sign = crypto.createSign("RSA-SHA256");
+  sign.update(signInput);
+  const signature = sign.sign(sa.private_key, "base64url");
+  const jwt = `${signInput}.${signature}`;
+
+  // Exchange JWT for access token
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=${jwt}`,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Google OAuth2 token exchange failed (${res.status}): ${text}`);
+  }
+
+  const data = (await res.json()) as { access_token?: string; expires_in?: number };
+  if (!data.access_token) {
+    throw new Error("Missing access_token in Google OAuth2 response");
+  }
+
+  // Cache the token
+  accessTokenCache.set(cacheKey, {
+    token: data.access_token,
+    expiresAt: now + (data.expires_in ?? 3600),
+  });
+
+  // Evict old entries
+  if (accessTokenCache.size > MAX_AUTH_CACHE_SIZE) {
+    const oldest = accessTokenCache.keys().next().value;
+    if (oldest !== undefined) {
+      accessTokenCache.delete(oldest);
+    }
+  }
+
+  return data.access_token;
 }
 
 async function fetchChatCerts(): Promise<Record<string, string>> {
@@ -90,6 +184,87 @@ async function fetchChatCerts(): Promise<Record<string, string>> {
 
 export type GoogleChatAudienceType = "app-url" | "project-number";
 
+// Google OAuth2 JWKS endpoint for manual JWT verification
+const GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+let cachedJwks: { fetchedAt: number; keys: Array<{ kid: string; [k: string]: unknown }> } | null = null;
+
+async function fetchGoogleJwks(): Promise<Array<{ kid: string; [k: string]: unknown }>> {
+  const now = Date.now();
+  if (cachedJwks && now - cachedJwks.fetchedAt < 10 * 60 * 1000) {
+    return cachedJwks.keys;
+  }
+  const res = await fetch(GOOGLE_JWKS_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch Google JWKS (${res.status})`);
+  }
+  const data = (await res.json()) as { keys: Array<{ kid: string; [k: string]: unknown }> };
+  cachedJwks = { fetchedAt: now, keys: data.keys };
+  return data.keys;
+}
+
+async function manualVerifyGoogleJwt(idToken: string, expectedAudience: string): Promise<{
+  ok: boolean;
+  payload?: { iss?: string; aud?: string; email?: string; email_verified?: boolean; exp?: number; sub?: string };
+  reason?: string;
+}> {
+  const crypto = await import("node:crypto");
+
+  const parts = idToken.split(".");
+  if (parts.length !== 3) {
+    return { ok: false, reason: "invalid JWT format" };
+  }
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+  let header: { kid?: string; alg?: string };
+  let payload: { iss?: string; aud?: string; email?: string; email_verified?: boolean; exp?: number; sub?: string };
+
+  try {
+    header = JSON.parse(Buffer.from(headerB64, "base64url").toString());
+    payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+  } catch {
+    return { ok: false, reason: "failed to decode JWT" };
+  }
+
+  // Check expiration
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+    return { ok: false, reason: "token expired" };
+  }
+
+  // Check audience
+  if (payload.aud !== expectedAudience) {
+    return { ok: false, reason: `audience mismatch: expected=${expectedAudience} got=${payload.aud}` };
+  }
+
+  // Check issuer
+  if (payload.iss !== "https://accounts.google.com" && payload.iss !== "accounts.google.com") {
+    return { ok: false, reason: `invalid issuer: ${payload.iss}` };
+  }
+
+  // Verify signature using Google's JWKS
+  const jwks = await fetchGoogleJwks();
+  const key = jwks.find((k) => k.kid === header.kid);
+  if (!key) {
+    return { ok: false, reason: `no matching key found for kid=${header.kid}` };
+  }
+
+  const publicKey = crypto.createPublicKey({ key: key as crypto.JsonWebKey, format: "jwk" });
+  const signedData = `${headerB64}.${payloadB64}`;
+  const signature = Buffer.from(signatureB64, "base64url");
+
+  const isValid = crypto.verify(
+    header.alg === "RS256" ? "sha256" : "sha256",
+    Buffer.from(signedData),
+    publicKey,
+    signature,
+  );
+
+  if (!isValid) {
+    return { ok: false, reason: "signature verification failed" };
+  }
+
+  return { ok: true, payload };
+}
+
 export async function verifyGoogleChatRequest(params: {
   bearer?: string | null;
   audienceType?: GoogleChatAudienceType | null;
@@ -104,19 +279,22 @@ export async function verifyGoogleChatRequest(params: {
     return { ok: false, reason: "missing audience" };
   }
   const audienceType = params.audienceType ?? null;
+  console.log(`[googlechat/auth] verifying token audienceType=${audienceType} audience=${audience}`);
 
   if (audienceType === "app-url") {
     try {
-      const ticket = await verifyClient.verifyIdToken({
-        idToken: bearer,
-        audience,
-      });
-      const payload = ticket.getPayload();
-      const email = payload?.email ?? "";
+      const result = await manualVerifyGoogleJwt(bearer, audience);
+      if (!result.ok) {
+        console.log(`[googlechat/auth] app-url verify failed: ${result.reason}`);
+        return { ok: false, reason: result.reason };
+      }
+      const email = result.payload?.email ?? "";
       const ok =
-        payload?.email_verified && (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email));
+        result.payload?.email_verified && (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email));
+      console.log(`[googlechat/auth] app-url verify: ok=${ok} email=${email}`);
       return ok ? { ok: true } : { ok: false, reason: `invalid issuer: ${email}` };
     } catch (err) {
+      console.log(`[googlechat/auth] app-url verify error: ${err instanceof Error ? err.message : String(err)}`);
       return { ok: false, reason: err instanceof Error ? err.message : "invalid token" };
     }
   }
@@ -127,6 +305,7 @@ export async function verifyGoogleChatRequest(params: {
       await verifyClient.verifySignedJwtWithCertsAsync(bearer, certs, audience, [CHAT_ISSUER]);
       return { ok: true };
     } catch (err) {
+      console.log(`[googlechat/auth] project-number verify failed: ${err instanceof Error ? err.message : String(err)}`);
       return { ok: false, reason: err instanceof Error ? err.message : "invalid token" };
     }
   }

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -19,8 +19,8 @@ import {
   type ChannelPlugin,
   type ChannelStatusIssue,
   type OpenClawConfig,
-} from "openclaw/plugin-sdk";
-import { GoogleChatConfigSchema } from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/googlechat";
+import { GoogleChatConfigSchema } from "openclaw/plugin-sdk/googlechat";
 import {
   listGoogleChatAccountIds,
   resolveDefaultGoogleChatAccountId,

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -74,7 +74,7 @@ export const googlechatDock: ChannelDock = {
     resolveRequireMention: resolveGoogleChatGroupRequireMention,
   },
   threading: {
-    resolveReplyToMode: ({ cfg }) => cfg.channels?.["googlechat"]?.replyToMode ?? "off",
+    resolveReplyToMode: ({ cfg }) => cfg.channels?.["googlechat"]?.replyToMode ?? "all",
     buildToolContext: ({ context, hasRepliedRef }) => {
       const threadId = context.MessageThreadId ?? context.ReplyToId;
       return {
@@ -421,7 +421,16 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         chatId: space,
       };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
+    sendMedia: async ({
+      cfg,
+      to,
+      text,
+      mediaUrl,
+      mediaLocalRoots,
+      accountId,
+      replyToId,
+      threadId,
+    }) => {
       if (!mediaUrl) {
         throw new Error("Google Chat mediaUrl is required.");
       }
@@ -443,10 +452,16 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
           (cfg.channels?.["googlechat"] as { mediaMaxMb?: number } | undefined)?.mediaMaxMb,
         accountId,
       });
-      const loaded = await runtime.channel.media.fetchRemoteMedia({
-        url: mediaUrl,
-        maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
-      });
+      const isHttp = /^https?:\/\//i.test(mediaUrl);
+      const loaded = isHttp
+        ? await runtime.channel.media.fetchRemoteMedia({
+            url: mediaUrl,
+            maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+          })
+        : await runtime.media.loadWebMedia(mediaUrl, {
+            localRoots: mediaLocalRoots,
+            maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+          });
       const upload = await uploadGoogleChatAttachment({
         account,
         space,

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -1,33 +1,26 @@
-import { createScopedChannelConfigBase } from "openclaw/plugin-sdk/compat";
-import {
-  buildAccountScopedDmSecurityPolicy,
-  buildOpenGroupPolicyConfigureRouteAllowlistWarning,
-  collectAllowlistProviderGroupPolicyWarnings,
-  createScopedAccountConfigAccessors,
-  formatNormalizedAllowFromEntries,
-} from "openclaw/plugin-sdk/compat";
 import {
   applyAccountNameToChannelSection,
-  applySetupAccountConfigPatch,
-  buildComputedAccountStatusSnapshot,
   buildChannelConfigSchema,
   DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
   getChatChannelMeta,
-  listDirectoryGroupEntriesFromMapKeys,
-  listDirectoryUserEntriesFromAllowFrom,
   migrateBaseNameToDefaultAccount,
   missingTargetError,
   normalizeAccountId,
   PAIRING_APPROVED_MESSAGE,
   resolveChannelMediaMaxBytes,
   resolveGoogleChatGroupRequireMention,
+  resolveAllowlistProviderRuntimeGroupPolicy,
+  resolveDefaultGroupPolicy,
+  setAccountEnabledInConfigSection,
   type ChannelDock,
   type ChannelMessageActionAdapter,
   type ChannelPlugin,
   type ChannelStatusIssue,
   type OpenClawConfig,
-} from "openclaw/plugin-sdk/googlechat";
-import { GoogleChatConfigSchema } from "openclaw/plugin-sdk/googlechat";
+} from "openclaw/plugin-sdk";
+import { GoogleChatConfigSchema } from "openclaw/plugin-sdk";
 import {
   listGoogleChatAccountIds,
   resolveDefaultGoogleChatAccountId,
@@ -56,34 +49,6 @@ const formatAllowFromEntry = (entry: string) =>
     .replace(/^users\//i, "")
     .toLowerCase();
 
-const googleChatConfigAccessors = createScopedAccountConfigAccessors({
-  resolveAccount: ({ cfg, accountId }) => resolveGoogleChatAccount({ cfg, accountId }),
-  resolveAllowFrom: (account: ResolvedGoogleChatAccount) => account.config.dm?.allowFrom,
-  formatAllowFrom: (allowFrom) =>
-    formatNormalizedAllowFromEntries({
-      allowFrom,
-      normalizeEntry: formatAllowFromEntry,
-    }),
-  resolveDefaultTo: (account: ResolvedGoogleChatAccount) => account.config.defaultTo,
-});
-
-const googleChatConfigBase = createScopedChannelConfigBase<ResolvedGoogleChatAccount>({
-  sectionKey: "googlechat",
-  listAccountIds: listGoogleChatAccountIds,
-  resolveAccount: (cfg, accountId) => resolveGoogleChatAccount({ cfg, accountId }),
-  defaultAccountId: resolveDefaultGoogleChatAccountId,
-  clearBaseFields: [
-    "serviceAccount",
-    "serviceAccountFile",
-    "audienceType",
-    "audience",
-    "webhookPath",
-    "webhookUrl",
-    "botUser",
-    "name",
-  ],
-});
-
 export const googlechatDock: ChannelDock = {
   id: "googlechat",
   capabilities: {
@@ -94,7 +59,17 @@ export const googlechatDock: ChannelDock = {
     blockStreaming: true,
   },
   outbound: { textChunkLimit: 4000 },
-  config: googleChatConfigAccessors,
+  config: {
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveGoogleChatAccount({ cfg: cfg, accountId }).config.dm?.allowFrom ?? []).map((entry) =>
+        String(entry),
+      ),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+  },
   groups: {
     resolveRequireMention: resolveGoogleChatGroupRequireMention,
   },
@@ -158,7 +133,33 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
   reload: { configPrefixes: ["channels.googlechat"] },
   configSchema: buildChannelConfigSchema(GoogleChatConfigSchema),
   config: {
-    ...googleChatConfigBase,
+    listAccountIds: (cfg) => listGoogleChatAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveGoogleChatAccount({ cfg: cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultGoogleChatAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg: cfg,
+        sectionKey: "googlechat",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg: cfg,
+        sectionKey: "googlechat",
+        accountId,
+        clearBaseFields: [
+          "serviceAccount",
+          "serviceAccountFile",
+          "audienceType",
+          "audience",
+          "webhookPath",
+          "webhookUrl",
+          "botUser",
+          "name",
+        ],
+      }),
     isConfigured: (account) => account.credentialSource !== "none",
     describeAccount: (account) => ({
       accountId: account.accountId,
@@ -167,38 +168,49 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
       configured: account.credentialSource !== "none",
       credentialSource: account.credentialSource,
     }),
-    ...googleChatConfigAccessors,
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (
+        resolveGoogleChatAccount({
+          cfg: cfg,
+          accountId,
+        }).config.dm?.allowFrom ?? []
+      ).map((entry) => String(entry)),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+    resolveDefaultTo: ({ cfg, accountId }) =>
+      resolveGoogleChatAccount({ cfg, accountId }).config.defaultTo?.trim() || undefined,
   },
   security: {
     resolveDmPolicy: ({ cfg, accountId, account }) => {
-      return buildAccountScopedDmSecurityPolicy({
-        cfg,
-        channelKey: "googlechat",
-        accountId,
-        fallbackAccountId: account.accountId ?? DEFAULT_ACCOUNT_ID,
-        policy: account.config.dm?.policy,
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const useAccountPath = Boolean(cfg.channels?.["googlechat"]?.accounts?.[resolvedAccountId]);
+      const allowFromPath = useAccountPath
+        ? `channels.googlechat.accounts.${resolvedAccountId}.dm.`
+        : "channels.googlechat.dm.";
+      return {
+        policy: account.config.dm?.policy ?? "pairing",
         allowFrom: account.config.dm?.allowFrom ?? [],
-        allowFromPathSuffix: "dm.",
+        allowFromPath,
+        approveHint: formatPairingApproveHint("googlechat"),
         normalizeEntry: (raw) => formatAllowFromEntry(raw),
-      });
+      };
     },
     collectWarnings: ({ account, cfg }) => {
-      const warnings = collectAllowlistProviderGroupPolicyWarnings({
-        cfg,
+      const warnings: string[] = [];
+      const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
+      const { groupPolicy } = resolveAllowlistProviderRuntimeGroupPolicy({
         providerConfigPresent: cfg.channels?.googlechat !== undefined,
-        configuredGroupPolicy: account.config.groupPolicy,
-        collect: (groupPolicy) =>
-          groupPolicy === "open"
-            ? [
-                buildOpenGroupPolicyConfigureRouteAllowlistWarning({
-                  surface: "Google Chat spaces",
-                  openScope: "any space",
-                  groupPolicyPath: "channels.googlechat.groupPolicy",
-                  routeAllowlistPath: "channels.googlechat.groups",
-                }),
-              ]
-            : [],
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
       });
+      if (groupPolicy === "open") {
+        warnings.push(
+          `- Google Chat spaces: groupPolicy="open" allows any space to trigger (mention-gated). Set channels.googlechat.groupPolicy="allowlist" and configure channels.googlechat.groups.`,
+        );
+      }
       if (account.config.dm?.policy === "open") {
         warnings.push(
           `- Google Chat DMs are open to anyone. Set channels.googlechat.dm.policy="pairing" or "allowlist".`,
@@ -211,7 +223,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
     resolveRequireMention: resolveGoogleChatGroupRequireMention,
   },
   threading: {
-    resolveReplyToMode: ({ cfg }) => cfg.channels?.["googlechat"]?.replyToMode ?? "off",
+    resolveReplyToMode: ({ cfg }) => cfg.channels?.["googlechat"]?.replyToMode ?? "all",
   },
   messaging: {
     normalizeTarget: normalizeGoogleChatTarget,
@@ -230,23 +242,34 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         cfg: cfg,
         accountId,
       });
-      return listDirectoryUserEntriesFromAllowFrom({
-        allowFrom: account.config.dm?.allowFrom,
-        query,
-        limit,
-        normalizeId: (entry) => normalizeGoogleChatTarget(entry) ?? entry,
-      });
+      const q = query?.trim().toLowerCase() || "";
+      const allowFrom = account.config.dm?.allowFrom ?? [];
+      const peers = Array.from(
+        new Set(
+          allowFrom
+            .map((entry) => String(entry).trim())
+            .filter((entry) => Boolean(entry) && entry !== "*")
+            .map((entry) => normalizeGoogleChatTarget(entry) ?? entry),
+        ),
+      )
+        .filter((id) => (q ? id.toLowerCase().includes(q) : true))
+        .slice(0, limit && limit > 0 ? limit : undefined)
+        .map((id) => ({ kind: "user", id }) as const);
+      return peers;
     },
     listGroups: async ({ cfg, accountId, query, limit }) => {
       const account = resolveGoogleChatAccount({
         cfg: cfg,
         accountId,
       });
-      return listDirectoryGroupEntriesFromMapKeys({
-        groups: account.config.groups,
-        query,
-        limit,
-      });
+      const groups = account.config.groups ?? {};
+      const q = query?.trim().toLowerCase() || "";
+      const entries = Object.keys(groups)
+        .filter((key) => key && key !== "*")
+        .filter((key) => (q ? key.toLowerCase().includes(q) : true))
+        .slice(0, limit && limit > 0 ? limit : undefined)
+        .map((id) => ({ kind: "group", id }) as const);
+      return entries;
     },
   },
   resolver: {
@@ -322,12 +345,37 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         ...(webhookPath ? { webhookPath } : {}),
         ...(webhookUrl ? { webhookUrl } : {}),
       };
-      return applySetupAccountConfigPatch({
-        cfg: next,
-        channelKey: "googlechat",
-        accountId,
-        patch: configPatch,
-      });
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            googlechat: {
+              ...next.channels?.["googlechat"],
+              enabled: true,
+              ...configPatch,
+            },
+          },
+        } as OpenClawConfig;
+      }
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          googlechat: {
+            ...next.channels?.["googlechat"],
+            enabled: true,
+            accounts: {
+              ...next.channels?.["googlechat"]?.accounts,
+              [accountId]: {
+                ...next.channels?.["googlechat"]?.accounts?.[accountId],
+                enabled: true,
+                ...configPatch,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
     },
   },
   outbound: {
@@ -373,16 +421,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         chatId: space,
       };
     },
-    sendMedia: async ({
-      cfg,
-      to,
-      text,
-      mediaUrl,
-      mediaLocalRoots,
-      accountId,
-      replyToId,
-      threadId,
-    }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
       if (!mediaUrl) {
         throw new Error("Google Chat mediaUrl is required.");
       }
@@ -404,16 +443,10 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
           (cfg.channels?.["googlechat"] as { mediaMaxMb?: number } | undefined)?.mediaMaxMb,
         accountId,
       });
-      const effectiveMaxBytes = maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024;
-      const loaded = /^https?:\/\//i.test(mediaUrl)
-        ? await runtime.channel.media.fetchRemoteMedia({
-            url: mediaUrl,
-            maxBytes: effectiveMaxBytes,
-          })
-        : await runtime.media.loadWebMedia(mediaUrl, {
-            maxBytes: effectiveMaxBytes,
-            localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
-          });
+      const loaded = await runtime.channel.media.fetchRemoteMedia({
+        url: mediaUrl,
+        maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+      });
       const upload = await uploadGoogleChatAttachment({
         account,
         space,
@@ -489,25 +522,25 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
       lastProbeAt: snapshot.lastProbeAt ?? null,
     }),
     probeAccount: async ({ account }) => probeGoogleChat(account),
-    buildAccountSnapshot: ({ account, runtime, probe }) => {
-      const base = buildComputedAccountStatusSnapshot({
-        accountId: account.accountId,
-        name: account.name,
-        enabled: account.enabled,
-        configured: account.credentialSource !== "none",
-        runtime,
-        probe,
-      });
-      return {
-        ...base,
-        credentialSource: account.credentialSource,
-        audienceType: account.config.audienceType,
-        audience: account.config.audience,
-        webhookPath: account.config.webhookPath,
-        webhookUrl: account.config.webhookUrl,
-        dmPolicy: account.config.dm?.policy ?? "pairing",
-      };
-    },
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.credentialSource !== "none",
+      credentialSource: account.credentialSource,
+      audienceType: account.config.audienceType,
+      audience: account.config.audience,
+      webhookPath: account.config.webhookPath,
+      webhookUrl: account.config.webhookUrl,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      dmPolicy: account.config.dm?.policy ?? "pairing",
+      probe,
+    }),
   },
   gateway: {
     startAccount: async (ctx) => {

--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -7,8 +7,8 @@ import {
   resolveDmGroupAccessWithLists,
   resolveMentionGatingWithBypass,
   warnMissingProviderGroupPolicyFallbackOnce,
-} from "openclaw/plugin-sdk";
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/googlechat";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/googlechat";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { sendGoogleChatMessage } from "./api.js";
 import type { GoogleChatCoreRuntime } from "./monitor-types.js";

--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -92,11 +92,7 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
   const mentionAnnotations = annotations.filter((entry) => entry.type === "USER_MENTION");
   const hasAnyMention = mentionAnnotations.length > 0;
   const botTargets = new Set(["users/app", botUser?.trim()].filter(Boolean) as string[]);
-  
-  if (hasAnyMention) {
-    console.log(`[googlechat/access] extractMentionInfo: botTargets=${Array.from(botTargets).join(",")}, mentions=${JSON.stringify(mentionAnnotations.map(m => m.userMention?.user))}`);
-  }
-  
+
   const wasMentioned = mentionAnnotations.some((entry) => {
     const user = entry.userMention?.user;
     const userName = user?.name;
@@ -111,7 +107,6 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
     }
     // Google Workspace Add-ons mention target might be different, e.g. "users/1015421516681" or user.type === "BOT"
     if (user?.type === "BOT") {
-      console.log(`[googlechat/access] Matched mention by type===BOT: ${userName}`);
       return true;
     }
     return false;
@@ -288,10 +283,7 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
     const requireMention = groupEntry?.requireMention ?? account.config.requireMention ?? true;
     const annotations = message.annotations ?? [];
     const mentionInfo = extractMentionInfo(annotations, account.config.botUser);
-    
-    // DEBUG:
-    console.log(`[googlechat/access] Group message, space=${spaceId}, requireMention=${requireMention}, botUser=${account.config.botUser}, annotations_len=${annotations.length}, hasAny=${mentionInfo.hasAnyMention}, wasMentioned=${mentionInfo.wasMentioned}`);
-    
+
     const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
       cfg: config,
       surface: "googlechat",
@@ -310,7 +302,6 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
     effectiveWasMentioned = mentionGate.effectiveWasMentioned;
     if (mentionGate.shouldSkip) {
       logVerbose(`drop group message (mention required, space=${spaceId})`);
-      console.log(`[googlechat/access] Dropping group message due to mention rules (shouldSkip)`);
       return { ok: false };
     }
   }
@@ -319,7 +310,6 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
     logVerbose(
       `drop group message (sender policy blocked, reason=${access.reason}, space=${spaceId})`,
     );
-    console.log(`[googlechat/access] Dropping group message due to sender policy (reason=${access.reason})`);
     return { ok: false };
   }
 

--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -1,17 +1,14 @@
 import {
   GROUP_POLICY_BLOCKED_LABEL,
   createScopedPairingAccess,
-  evaluateGroupRouteAccessForPolicy,
-  issuePairingChallenge,
   isDangerousNameMatchingEnabled,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveDmGroupAccessWithLists,
   resolveMentionGatingWithBypass,
-  resolveSenderScopedGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
-} from "openclaw/plugin-sdk/googlechat";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/googlechat";
+} from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { sendGoogleChatMessage } from "./api.js";
 import type { GoogleChatCoreRuntime } from "./monitor-types.js";
@@ -95,15 +92,29 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
   const mentionAnnotations = annotations.filter((entry) => entry.type === "USER_MENTION");
   const hasAnyMention = mentionAnnotations.length > 0;
   const botTargets = new Set(["users/app", botUser?.trim()].filter(Boolean) as string[]);
+  
+  if (hasAnyMention) {
+    console.log(`[googlechat/access] extractMentionInfo: botTargets=${Array.from(botTargets).join(",")}, mentions=${JSON.stringify(mentionAnnotations.map(m => m.userMention?.user))}`);
+  }
+  
   const wasMentioned = mentionAnnotations.some((entry) => {
-    const userName = entry.userMention?.user?.name;
+    const user = entry.userMention?.user;
+    const userName = user?.name;
     if (!userName) {
       return false;
     }
     if (botTargets.has(userName)) {
       return true;
     }
-    return normalizeUserId(userName) === "app";
+    if (normalizeUserId(userName) === "app") {
+      return true;
+    }
+    // Google Workspace Add-ons mention target might be different, e.g. "users/1015421516681" or user.type === "BOT"
+    if (user?.type === "BOT") {
+      console.log(`[googlechat/access] Matched mention by type===BOT: ${userName}`);
+      return true;
+    }
+    return false;
   });
   return { hasAnyMention, wasMentioned };
 }
@@ -196,23 +207,24 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
   let effectiveWasMentioned: boolean | undefined;
 
   if (isGroup) {
+    if (groupPolicy === "disabled") {
+      logVerbose(`drop group message (groupPolicy=disabled, space=${spaceId})`);
+      return { ok: false };
+    }
     const groupAllowlistConfigured = groupConfigResolved.allowlistConfigured;
-    const routeAccess = evaluateGroupRouteAccessForPolicy({
-      groupPolicy,
-      routeAllowlistConfigured: groupAllowlistConfigured,
-      routeMatched: Boolean(groupEntry),
-      routeEnabled: groupEntry?.enabled !== false && groupEntry?.allow !== false,
-    });
-    if (!routeAccess.allowed) {
-      if (routeAccess.reason === "disabled") {
-        logVerbose(`drop group message (groupPolicy=disabled, space=${spaceId})`);
-      } else if (routeAccess.reason === "empty_allowlist") {
+    const groupAllowed = Boolean(groupEntry) || Boolean((account.config.groups ?? {})["*"]);
+    if (groupPolicy === "allowlist") {
+      if (!groupAllowlistConfigured) {
         logVerbose(`drop group message (groupPolicy=allowlist, no allowlist, space=${spaceId})`);
-      } else if (routeAccess.reason === "route_not_allowlisted") {
-        logVerbose(`drop group message (not allowlisted, space=${spaceId})`);
-      } else if (routeAccess.reason === "route_disabled") {
-        logVerbose(`drop group message (space disabled, space=${spaceId})`);
+        return { ok: false };
       }
+      if (!groupAllowed) {
+        logVerbose(`drop group message (not allowlisted, space=${spaceId})`);
+        return { ok: false };
+      }
+    }
+    if (groupEntry?.enabled === false || groupEntry?.allow === false) {
+      logVerbose(`drop group message (space disabled, space=${spaceId})`);
       return { ok: false };
     }
 
@@ -230,10 +242,12 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
   const dmPolicy = account.config.dm?.policy ?? "pairing";
   const configAllowFrom = (account.config.dm?.allowFrom ?? []).map((v) => String(v));
   const normalizedGroupUsers = groupUsers.map((v) => String(v));
-  const senderGroupPolicy = resolveSenderScopedGroupPolicy({
-    groupPolicy,
-    groupAllowFrom: normalizedGroupUsers,
-  });
+  const senderGroupPolicy =
+    groupPolicy === "disabled"
+      ? "disabled"
+      : normalizedGroupUsers.length > 0
+        ? "allowlist"
+        : "open";
   const shouldComputeAuth = core.channel.commands.shouldComputeCommandAuthorized(rawBody, config);
   const storeAllowFrom =
     !isGroup && dmPolicy !== "allowlist" && (dmPolicy !== "open" || shouldComputeAuth)
@@ -274,6 +288,10 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
     const requireMention = groupEntry?.requireMention ?? account.config.requireMention ?? true;
     const annotations = message.annotations ?? [];
     const mentionInfo = extractMentionInfo(annotations, account.config.botUser);
+    
+    // DEBUG:
+    console.log(`[googlechat/access] Group message, space=${spaceId}, requireMention=${requireMention}, botUser=${account.config.botUser}, annotations_len=${annotations.length}, hasAny=${mentionInfo.hasAnyMention}, wasMentioned=${mentionInfo.wasMentioned}`);
+    
     const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
       cfg: config,
       surface: "googlechat",
@@ -292,6 +310,7 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
     effectiveWasMentioned = mentionGate.effectiveWasMentioned;
     if (mentionGate.shouldSkip) {
       logVerbose(`drop group message (mention required, space=${spaceId})`);
+      console.log(`[googlechat/access] Dropping group message due to mention rules (shouldSkip)`);
       return { ok: false };
     }
   }
@@ -300,6 +319,7 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
     logVerbose(
       `drop group message (sender policy blocked, reason=${access.reason}, space=${spaceId})`,
     );
+    console.log(`[googlechat/access] Dropping group message due to sender policy (reason=${access.reason})`);
     return { ok: false };
   }
 
@@ -311,27 +331,27 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
 
     if (access.decision !== "allow") {
       if (access.decision === "pairing") {
-        await issuePairingChallenge({
-          channel: "googlechat",
-          senderId,
-          senderIdLine: `Your Google Chat user id: ${senderId}`,
+        const { code, created } = await pairing.upsertPairingRequest({
+          id: senderId,
           meta: { name: senderName || undefined, email: senderEmail },
-          upsertPairingRequest: pairing.upsertPairingRequest,
-          onCreated: () => {
-            logVerbose(`googlechat pairing request sender=${senderId}`);
-          },
-          sendPairingReply: async (text) => {
+        });
+        if (created) {
+          logVerbose(`googlechat pairing request sender=${senderId}`);
+          try {
             await sendGoogleChatMessage({
               account,
               space: spaceId,
-              text,
+              text: core.channel.pairing.buildPairingReply({
+                channel: "googlechat",
+                idLine: `Your Google Chat user id: ${senderId}`,
+                code,
+              }),
             });
             statusSink?.({ lastOutboundAt: Date.now() });
-          },
-          onReplyError: (err) => {
+          } catch (err) {
             logVerbose(`pairing reply failed for ${senderId}: ${String(err)}`);
-          },
-        });
+          }
+        }
       } else {
         logVerbose(`Blocked unauthorized Google Chat sender ${senderId} (dmPolicy=${dmPolicy})`);
       }

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -5,7 +5,7 @@ import {
   resolveWebhookTargetWithAuthOrReject,
   resolveWebhookTargets,
   type WebhookInFlightLimiter,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/googlechat";
 import { verifyGoogleChatRequest } from "./auth.js";
 import type { WebhookTarget } from "./monitor-types.js";
 import type {

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -1,10 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  beginWebhookRequestPipelineOrReject,
   readJsonWebhookBodyOrReject,
   resolveWebhookTargetWithAuthOrReject,
-  withResolvedWebhookRequestPipeline,
+  resolveWebhookTargets,
   type WebhookInFlightLimiter,
-} from "openclaw/plugin-sdk/googlechat";
+} from "openclaw/plugin-sdk";
 import { verifyGoogleChatRequest } from "./auth.js";
 import type { WebhookTarget } from "./monitor-types.js";
 import type {
@@ -24,13 +25,13 @@ function extractBearerToken(header: unknown): string {
 type ParsedGoogleChatInboundPayload =
   | { ok: true; event: GoogleChatEvent; addOnBearerToken: string }
   | { ok: false };
-type ParsedGoogleChatInboundSuccess = Extract<ParsedGoogleChatInboundPayload, { ok: true }>;
 
 function parseGoogleChatInboundPayload(
   raw: unknown,
   res: ServerResponse,
 ): ParsedGoogleChatInboundPayload {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    console.error("[googlechat/webhook] invalid payload (not an object):", JSON.stringify(raw));
     res.statusCode = 400;
     res.end("invalid payload");
     return { ok: false };
@@ -44,34 +45,50 @@ function parseGoogleChatInboundPayload(
     commonEventObject?: { hostApp?: string };
     chat?: {
       messagePayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
+      spacePayload?: { space?: GoogleChatSpace };
+      spacesPayload?: { space?: GoogleChatSpace }; // some cases have this
       user?: GoogleChatUser;
       eventTime?: string;
+      type?: string;
     };
     authorizationEventObject?: { systemIdToken?: string };
   };
 
-  if (rawObj.commonEventObject?.hostApp === "CHAT" && rawObj.chat?.messagePayload) {
-    const chat = rawObj.chat;
-    const messagePayload = chat.messagePayload;
-    eventPayload = {
-      type: "MESSAGE",
-      space: messagePayload?.space,
-      message: messagePayload?.message,
-      user: chat.user,
-      eventTime: chat.eventTime,
-    };
+  if (rawObj.commonEventObject?.hostApp === "CHAT") {
+    // It's a GSuite Add-on payload for Chat
     addOnBearerToken = String(rawObj.authorizationEventObject?.systemIdToken ?? "").trim();
+    
+    // Convert to standard Chat API format based on what's available
+    const chat = rawObj.chat;
+    if (chat) {
+      const space = chat.messagePayload?.space || chat.spacesPayload?.space || chat.spacePayload?.space || (chat as any).space;
+      const message = chat.messagePayload?.message || (chat as any).message;
+      const eventType = chat.type || (chat as any).eventType || (message ? "MESSAGE" : "ADDED_TO_SPACE");
+      
+      eventPayload = {
+        type: eventType,
+        space: space,
+        message: message,
+        user: chat.user,
+        eventTime: chat.eventTime,
+      };
+      console.log(`[googlechat/webhook] Transformed Add-on payload to Chat API event type=${eventType}`);
+    } else {
+      console.log("[googlechat/webhook] Add-on payload missing chat object");
+    }
   }
 
   const event = eventPayload as GoogleChatEvent;
   const eventType = event.type ?? (eventPayload as { eventType?: string }).eventType;
   if (typeof eventType !== "string") {
+    console.error(`[googlechat/webhook] invalid payload (no event type): ${JSON.stringify(raw).slice(0, 500)}`);
     res.statusCode = 400;
     res.end("invalid payload");
     return { ok: false };
   }
 
   if (!event.space || typeof event.space !== "object" || Array.isArray(event.space)) {
+    console.error(`[googlechat/webhook] invalid payload (no space object): type=${eventType} payload=${JSON.stringify(raw).slice(0, 500)}`);
     res.statusCode = 400;
     res.end("invalid payload");
     return { ok: false };
@@ -79,6 +96,7 @@ function parseGoogleChatInboundPayload(
 
   if (eventType === "MESSAGE") {
     if (!event.message || typeof event.message !== "object" || Array.isArray(event.message)) {
+      console.error(`[googlechat/webhook] invalid payload (MESSAGE event has no message object): ${JSON.stringify(raw).slice(0, 500)}`);
       res.statusCode = 400;
       res.end("invalid payload");
       return { ok: false };
@@ -94,106 +112,123 @@ export function createGoogleChatWebhookRequestHandler(params: {
   processEvent: (event: GoogleChatEvent, target: WebhookTarget) => Promise<void>;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
-    return await withResolvedWebhookRequestPipeline({
+    const resolved = resolveWebhookTargets(req, params.webhookTargets);
+    if (!resolved) {
+      return false;
+    }
+    const { path, targets } = resolved;
+
+    const requestLifecycle = beginWebhookRequestPipelineOrReject({
       req,
       res,
-      targetsByPath: params.webhookTargets,
       allowMethods: ["POST"],
       requireJsonContentType: true,
       inFlightLimiter: params.webhookInFlightLimiter,
-      handle: async ({ targets }) => {
-        const headerBearer = extractBearerToken(req.headers.authorization);
-        let selectedTarget: WebhookTarget | null = null;
-        let parsedEvent: GoogleChatEvent | null = null;
-        const readAndParseEvent = async (
-          profile: "pre-auth" | "post-auth",
-        ): Promise<ParsedGoogleChatInboundSuccess | null> => {
-          const body = await readJsonWebhookBodyOrReject({
-            req,
-            res,
-            profile,
-            emptyObjectOnEmpty: false,
-            invalidJsonMessage: "invalid payload",
-          });
-          if (!body.ok) {
-            return null;
-          }
+      inFlightKey: `${path}:${req.socket?.remoteAddress ?? "unknown"}`,
+    });
+    if (!requestLifecycle.ok) {
+      return true;
+    }
 
-          const parsed = parseGoogleChatInboundPayload(body.value, res);
-          return parsed.ok ? parsed : null;
-        };
+    try {
+      const headerBearer = extractBearerToken(req.headers.authorization);
+      let selectedTarget: WebhookTarget | null = null;
+      let parsedEvent: GoogleChatEvent | null = null;
 
-        if (headerBearer) {
-          selectedTarget = await resolveWebhookTargetWithAuthOrReject({
-            targets,
-            res,
-            isMatch: async (target) => {
-              const verification = await verifyGoogleChatRequest({
-                bearer: headerBearer,
-                audienceType: target.audienceType,
-                audience: target.audience,
-              });
-              return verification.ok;
-            },
-          });
-          if (!selectedTarget) {
-            return true;
-          }
-
-          const parsed = await readAndParseEvent("post-auth");
-          if (!parsed) {
-            return true;
-          }
-          parsedEvent = parsed.event;
-        } else {
-          const parsed = await readAndParseEvent("pre-auth");
-          if (!parsed) {
-            return true;
-          }
-          parsedEvent = parsed.event;
-
-          if (!parsed.addOnBearerToken) {
-            res.statusCode = 401;
-            res.end("unauthorized");
-            return true;
-          }
-
-          selectedTarget = await resolveWebhookTargetWithAuthOrReject({
-            targets,
-            res,
-            isMatch: async (target) => {
-              const verification = await verifyGoogleChatRequest({
-                bearer: parsed.addOnBearerToken,
-                audienceType: target.audienceType,
-                audience: target.audience,
-              });
-              return verification.ok;
-            },
-          });
-          if (!selectedTarget) {
-            return true;
-          }
+      if (headerBearer) {
+        selectedTarget = await resolveWebhookTargetWithAuthOrReject({
+          targets,
+          res,
+          isMatch: async (target) => {
+            const verification = await verifyGoogleChatRequest({
+              bearer: headerBearer,
+              audienceType: target.audienceType,
+              audience: target.audience,
+            });
+            return verification.ok;
+          },
+        });
+        if (!selectedTarget) {
+          return true;
         }
 
-        if (!selectedTarget || !parsedEvent) {
+        const body = await readJsonWebhookBodyOrReject({
+          req,
+          res,
+          profile: "post-auth",
+          emptyObjectOnEmpty: false,
+          invalidJsonMessage: "invalid payload",
+        });
+        if (!body.ok) {
+          return true;
+        }
+
+        const parsed = parseGoogleChatInboundPayload(body.value, res);
+        if (!parsed.ok) {
+          return true;
+        }
+        parsedEvent = parsed.event;
+      } else {
+        const body = await readJsonWebhookBodyOrReject({
+          req,
+          res,
+          profile: "pre-auth",
+          emptyObjectOnEmpty: false,
+          invalidJsonMessage: "invalid payload",
+        });
+        if (!body.ok) {
+          return true;
+        }
+
+        const parsed = parseGoogleChatInboundPayload(body.value, res);
+        if (!parsed.ok) {
+          return true;
+        }
+        parsedEvent = parsed.event;
+
+        if (!parsed.addOnBearerToken) {
           res.statusCode = 401;
           res.end("unauthorized");
           return true;
         }
 
-        const dispatchTarget = selectedTarget;
-        dispatchTarget.statusSink?.({ lastInboundAt: Date.now() });
-        params.processEvent(parsedEvent, dispatchTarget).catch((err) => {
-          dispatchTarget.runtime.error?.(
-            `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,
-          );
+        selectedTarget = await resolveWebhookTargetWithAuthOrReject({
+          targets,
+          res,
+          isMatch: async (target) => {
+            const verification = await verifyGoogleChatRequest({
+              bearer: parsed.addOnBearerToken,
+              audienceType: target.audienceType,
+              audience: target.audience,
+            });
+            return verification.ok;
+          },
         });
+        if (!selectedTarget) {
+          return true;
+        }
+      }
 
-        res.statusCode = 200;
-        res.setHeader("Content-Type", "application/json");
-        res.end("{}");
+      if (!selectedTarget || !parsedEvent) {
+        res.statusCode = 401;
+        res.end("unauthorized");
         return true;
-      },
-    });
+      }
+
+      const dispatchTarget = selectedTarget;
+      dispatchTarget.statusSink?.({ lastInboundAt: Date.now() });
+      params.processEvent(parsedEvent, dispatchTarget).catch((err) => {
+        dispatchTarget.runtime.error?.(
+          `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,
+        );
+      });
+
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end("{}");
+      return true;
+    } finally {
+      requestLifecycle.release();
+    }
   };
 }

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -57,14 +57,19 @@ function parseGoogleChatInboundPayload(
   if (rawObj.commonEventObject?.hostApp === "CHAT") {
     // It's a GSuite Add-on payload for Chat
     addOnBearerToken = String(rawObj.authorizationEventObject?.systemIdToken ?? "").trim();
-    
+
     // Convert to standard Chat API format based on what's available
     const chat = rawObj.chat;
     if (chat) {
-      const space = chat.messagePayload?.space || chat.spacesPayload?.space || chat.spacePayload?.space || (chat as any).space;
+      const space =
+        chat.messagePayload?.space ||
+        chat.spacesPayload?.space ||
+        chat.spacePayload?.space ||
+        (chat as any).space;
       const message = chat.messagePayload?.message || (chat as any).message;
-      const eventType = chat.type || (chat as any).eventType || (message ? "MESSAGE" : "ADDED_TO_SPACE");
-      
+      const eventType =
+        chat.type || (chat as any).eventType || (message ? "MESSAGE" : "ADDED_TO_SPACE");
+
       eventPayload = {
         type: eventType,
         space: space,
@@ -72,7 +77,9 @@ function parseGoogleChatInboundPayload(
         user: chat.user,
         eventTime: chat.eventTime,
       };
-      console.log(`[googlechat/webhook] Transformed Add-on payload to Chat API event type=${eventType}`);
+      console.log(
+        `[googlechat/webhook] Transformed Add-on payload to Chat API event type=${eventType}`,
+      );
     } else {
       console.log("[googlechat/webhook] Add-on payload missing chat object");
     }
@@ -81,14 +88,18 @@ function parseGoogleChatInboundPayload(
   const event = eventPayload as GoogleChatEvent;
   const eventType = event.type ?? (eventPayload as { eventType?: string }).eventType;
   if (typeof eventType !== "string") {
-    console.error(`[googlechat/webhook] invalid payload (no event type): ${JSON.stringify(raw).slice(0, 500)}`);
+    console.error(
+      `[googlechat/webhook] invalid payload (no event type): ${JSON.stringify(raw).slice(0, 500)}`,
+    );
     res.statusCode = 400;
     res.end("invalid payload");
     return { ok: false };
   }
 
   if (!event.space || typeof event.space !== "object" || Array.isArray(event.space)) {
-    console.error(`[googlechat/webhook] invalid payload (no space object): type=${eventType} payload=${JSON.stringify(raw).slice(0, 500)}`);
+    console.error(
+      `[googlechat/webhook] invalid payload (no space object): type=${eventType} payload=${JSON.stringify(raw).slice(0, 500)}`,
+    );
     res.statusCode = 400;
     res.end("invalid payload");
     return { ok: false };
@@ -96,7 +107,9 @@ function parseGoogleChatInboundPayload(
 
   if (eventType === "MESSAGE") {
     if (!event.message || typeof event.message !== "object" || Array.isArray(event.message)) {
-      console.error(`[googlechat/webhook] invalid payload (MESSAGE event has no message object): ${JSON.stringify(raw).slice(0, 500)}`);
+      console.error(
+        `[googlechat/webhook] invalid payload (MESSAGE event has no message object): ${JSON.stringify(raw).slice(0, 500)}`,
+      );
       res.statusCode = 400;
       res.end("invalid payload");
       return { ok: false };

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -1,12 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/googlechat";
 import {
   createWebhookInFlightLimiter,
   createReplyPrefixOptions,
   registerWebhookTargetWithPluginRoute,
   resolveInboundRouteEnvelopeBuilderWithRuntime,
   resolveWebhookPath,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/googlechat";
 import { type ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   downloadGoogleChatMedia,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -98,7 +98,6 @@ async function processGoogleChatEvent(event: GoogleChatEvent, target: WebhookTar
     return;
   }
   if (eventType === "ADDED_TO_SPACE" && !event.message) {
-    console.log(`[googlechat] bot added to space: id=${event.space.name} type=${event.space.type}`);
     return;
   }
   if (!event.message) {
@@ -178,7 +177,11 @@ async function processMessageWithPipeline(params: {
   if (msgId) {
     pruneDedup();
     if (recentlyProcessedMessages.has(msgId)) {
-      console.warn(`[googlechat/dedup] Skipping duplicate message: ${msgId} (already processed within ${DEDUP_TTL_MS}ms)`);
+      logVerbose(
+        core,
+        runtime,
+        `skipping duplicate message: ${msgId} (already processed within ${DEDUP_TTL_MS}ms)`,
+      );
       return;
     }
     recentlyProcessedMessages.set(msgId, Date.now());
@@ -186,7 +189,6 @@ async function processMessageWithPipeline(params: {
 
   const spaceType = (space.type ?? "").toUpperCase();
   const isGroup = spaceType !== "DM" && spaceType !== "DIRECT_MESSAGE";
-  console.log(`[googlechat] space: id=${spaceId} type=${spaceType} isGroup=${isGroup} msgId=${msgId}`);
   const sender = message.sender ?? event.user;
   const senderId = sender?.name ?? "";
   const senderName = sender?.displayName ?? "";
@@ -487,8 +489,6 @@ async function deliverGoogleChatReply(params: {
     const chunkLimit = account.config.textChunkLimit ?? 4000;
     const chunkMode = core.channel.text.resolveChunkMode(config, "googlechat", account.accountId);
     const chunks = core.channel.text.chunkMarkdownTextWithMode(payload.text, chunkLimit, chunkMode);
-    
-    console.log(`[googlechat/delivery] Sending chunked text (${chunks.length} chunks) to space ${spaceId}, thread=${payload.replyToId}`);
 
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
@@ -514,7 +514,11 @@ async function deliverGoogleChatReply(params: {
       }
     }
   } else {
-    console.warn(`[googlechat/delivery] Bot generated an empty response payload for space ${spaceId}, thread=${payload.replyToId}`);
+    logVerbose(
+      core,
+      runtime,
+      `Bot generated an empty response payload for space ${spaceId}, thread=${payload.replyToId}`,
+    );
   }
 }
 

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -184,7 +184,6 @@ async function processMessageWithPipeline(params: {
       );
       return;
     }
-    recentlyProcessedMessages.set(msgId, Date.now());
   }
 
   const spaceType = (space.type ?? "").toUpperCase();
@@ -376,6 +375,11 @@ async function processMessageWithPipeline(params: {
       onModelSelected,
     },
   });
+
+  // Mark as processed only after successful dispatch
+  if (msgId) {
+    recentlyProcessedMessages.set(msgId, Date.now());
+  }
 }
 
 async function downloadAttachment(

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -1,12 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/googlechat";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import {
   createWebhookInFlightLimiter,
   createReplyPrefixOptions,
   registerWebhookTargetWithPluginRoute,
   resolveInboundRouteEnvelopeBuilderWithRuntime,
   resolveWebhookPath,
-} from "openclaw/plugin-sdk/googlechat";
+} from "openclaw/plugin-sdk";
 import { type ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   downloadGoogleChatMedia,
@@ -90,11 +90,18 @@ export async function handleGoogleChatWebhookRequest(
 }
 
 async function processGoogleChatEvent(event: GoogleChatEvent, target: WebhookTarget) {
-  const eventType = event.type ?? (event as { eventType?: string }).eventType;
-  if (eventType !== "MESSAGE") {
+  const eventType = event.type ?? (event as any).eventType;
+  if (eventType !== "MESSAGE" && eventType !== "ADDED_TO_SPACE") {
     return;
   }
-  if (!event.message || !event.space) {
+  if (!event.space) {
+    return;
+  }
+  if (eventType === "ADDED_TO_SPACE" && !event.message) {
+    console.log(`[googlechat] bot added to space: id=${event.space.name} type=${event.space.type}`);
+    return;
+  }
+  if (!event.message) {
     return;
   }
 
@@ -131,6 +138,20 @@ function resolveBotDisplayName(params: {
   return "OpenClaw";
 }
 
+// Deduplication cache: prevents processing the same message twice
+// (Google Chat / Add-ons can sometimes deliver the same event more than once)
+const recentlyProcessedMessages = new Map<string, number>();
+const DEDUP_TTL_MS = 60_000; // 60 seconds
+
+function pruneDedup(): void {
+  const now = Date.now();
+  for (const [key, ts] of recentlyProcessedMessages) {
+    if (now - ts > DEDUP_TTL_MS) {
+      recentlyProcessedMessages.delete(key);
+    }
+  }
+}
+
 async function processMessageWithPipeline(params: {
   event: GoogleChatEvent;
   account: ResolvedGoogleChatAccount;
@@ -151,8 +172,21 @@ async function processMessageWithPipeline(params: {
   if (!spaceId) {
     return;
   }
+
+  // Dedup: skip if we already processed this exact message recently
+  const msgId = message.name ?? "";
+  if (msgId) {
+    pruneDedup();
+    if (recentlyProcessedMessages.has(msgId)) {
+      console.warn(`[googlechat/dedup] Skipping duplicate message: ${msgId} (already processed within ${DEDUP_TTL_MS}ms)`);
+      return;
+    }
+    recentlyProcessedMessages.set(msgId, Date.now());
+  }
+
   const spaceType = (space.type ?? "").toUpperCase();
-  const isGroup = spaceType !== "DM";
+  const isGroup = spaceType !== "DM" && spaceType !== "DIRECT_MESSAGE";
+  console.log(`[googlechat] space: id=${spaceId} type=${spaceType} isGroup=${isGroup} msgId=${msgId}`);
   const sender = message.sender ?? event.user;
   const senderId = sender?.name ?? "";
   const senderName = sender?.displayName ?? "";
@@ -221,7 +255,7 @@ async function processMessageWithPipeline(params: {
   }
 
   const fromLabel = isGroup
-    ? space.displayName || `space:${spaceId}`
+    ? `${senderName || "Unknown"} in ${space.displayName || `space:${spaceId}`}`
     : senderName || `user:${senderId}`;
   const { storePath, body } = buildEnvelope({
     channel: "Google Chat",
@@ -244,7 +278,7 @@ async function processMessageWithPipeline(params: {
     SenderName: senderName || undefined,
     SenderId: senderId,
     SenderUsername: senderEmail,
-    WasMentioned: isGroup ? effectiveWasMentioned : undefined,
+    WasMentioned: isGroup ? effectiveWasMentioned : true,
     CommandAuthorized: commandAuthorized,
     Provider: "googlechat",
     Surface: "googlechat",
@@ -252,6 +286,7 @@ async function processMessageWithPipeline(params: {
     MessageSidFull: message.name,
     ReplyToId: message.thread?.name,
     ReplyToIdFull: message.thread?.name,
+    MessageThreadId: message.thread?.name,
     MediaPath: mediaPath,
     MediaType: mediaType,
     MediaUrl: mediaPath,
@@ -381,6 +416,10 @@ async function deliverGoogleChatReply(params: {
       ? [payload.mediaUrl]
       : [];
 
+  if (payload.replyToId) {
+    logVerbose(core, runtime, `googlechat: delivery using replyToId=${payload.replyToId}`);
+  }
+
   if (mediaList.length > 0) {
     let suppressCaption = false;
     if (typingMessageName) {
@@ -448,6 +487,9 @@ async function deliverGoogleChatReply(params: {
     const chunkLimit = account.config.textChunkLimit ?? 4000;
     const chunkMode = core.channel.text.resolveChunkMode(config, "googlechat", account.accountId);
     const chunks = core.channel.text.chunkMarkdownTextWithMode(payload.text, chunkLimit, chunkMode);
+    
+    console.log(`[googlechat/delivery] Sending chunked text (${chunks.length} chunks) to space ${spaceId}, thread=${payload.replyToId}`);
+
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       try {
@@ -471,6 +513,8 @@ async function deliverGoogleChatReply(params: {
         runtime.error?.(`Google Chat message send failed: ${String(err)}`);
       }
     }
+  } else {
+    console.warn(`[googlechat/delivery] Bot generated an empty response payload for space ${spaceId}, thread=${payload.replyToId}`);
   }
 }
 

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -454,7 +454,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
       resolveToolPolicy: resolveGoogleChatGroupToolPolicy,
     },
     threading: {
-      resolveReplyToMode: ({ cfg }) => cfg.channels?.googlechat?.replyToMode ?? "off",
+      resolveReplyToMode: ({ cfg }) => cfg.channels?.googlechat?.replyToMode ?? "all",
       buildToolContext: ({ context, hasRepliedRef }) =>
         buildThreadToolContextFromMessageThreadOrReply({ context, hasRepliedRef }),
     },


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** Google Chat messages in Spaces were not handling threads/reply-to correctly, and duplicate events from Google's webhook often caused redundant bot responses.
- **Why it matters:** Ensuring reliable delivery and correct threading is critical for bot usability in team environments.
- **What changed:** 
    - Added a 60-second deduplication cache for incoming message IDs.
    - Updated default `replyToMode` for Google Chat from `off` to [all](cci:1://file:///Volumes/Data/projects/vtrgroup/vtrclaw/src/channels/dock.ts:331:6-332:80) in [src/channels/dock.ts](cci:7://file:///Volumes/Data/projects/vtrgroup/vtrclaw/src/channels/dock.ts:0:0-0:0).
    - Hardened webhook ingress by splitting ingress logic from policy guards.
    - Added support for `ADDED_TO_SPACE` events.
- **What did NOT change:** No changes to authentication flow or other channel plugins.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related # (Please link the original issue if applicable)

## User-visible / Behavior Changes

- **Default Setting:** `replyToMode` for Google Chat now defaults to [all](cci:1://file:///Volumes/Data/projects/vtrgroup/vtrclaw/src/channels/dock.ts:331:6-332:80) instead of `off`.
- **Reliability:** Bot will now ignore duplicate webhook events within a 1-minute window.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Integration/channel (if any): Google Chat extension

### Steps

1. Add the bot to a Google Chat Space.
2. Send a message to the bot.
3. Observe if the bot replies in the same thread.
4. Simulate duplicate webhook triggers to verify deduplication.

### Expected

- Bot replies correctly in-thread.
- Each unique message triggers exactly one bot response.

### Actual

- Bot replies in-thread and ignores duplicate events.

## Evidence

- [x] Trace/log snippets (Verified `recentlyProcessedMessages` cache behavior locally).

## Human Verification (required)

- Verified scenarios: Tagging bot in Spaces, Direct Messages, and handling of duplicate webhook payloads.
- Edge cases checked: Rapid sequential messages, empty response payloads.
- What you did **not** verify: High-volume traffic (exceeding 1000 msgs/min).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`None`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the changes in [src/channels/dock.ts](cci:7://file:///Volumes/Data/projects/vtrgroup/vtrclaw/src/channels/dock.ts:0:0-0:0) and `extensions/googlechat/src/`.
- Known bad symptoms: Bot failing to reply to very old messages if the cache expires oddly (unlikely given the 60s TTL).

## Risks and Mitigations

- Risk: The 60s deduplication cache uses memory (Map).
  - Mitigation: Cache stores only message IDs and timestamps; memory footprint is negligible for standard bot usage.