### PR TITLE
feat(tts): add Volcengine (ByteDance) TTS V3 provider integration

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,13 +9,14 @@ title: "Text-to-Speech"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, or Edge TTS.
+OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, Volcengine, or Edge TTS.
 It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubble.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
 - **OpenAI** (primary or fallback provider; also used for summaries)
+- **Volcengine** (primary or fallback provider; ByteDance TTS V3 API)
 - **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
 
 ### Edge TTS notes
@@ -32,10 +33,11 @@ does not publish limits, so assume similar or lower limits. citeturn0searc
 
 ## Optional keys
 
-If you want OpenAI or ElevenLabs:
+If you want OpenAI, ElevenLabs, or Volcengine:
 
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `OPENAI_API_KEY`
+- `VOLCENGINE_ACCESS_KEY` (also requires `volcengine.appId` in config or `VOLCENGINE_APP_ID`)
 
 Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
 to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
@@ -50,6 +52,7 @@ so that provider must also be authenticated if you enable summaries.
 - [OpenAI Audio API reference](https://platform.openai.com/docs/api-reference/audio)
 - [ElevenLabs Text to Speech](https://elevenlabs.io/docs/api-reference/text-to-speech)
 - [ElevenLabs Authentication](https://elevenlabs.io/docs/api-reference/authentication)
+- [Volcengine TTS (ByteDance)](https://www.volcengine.com/docs/6561/1598757)
 - [node-edge-tts](https://github.com/SchneeHertz/node-edge-tts)
 - [Microsoft Speech output formats](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech#audio-outputs)
 
@@ -59,7 +62,7 @@ No. Auto‑TTS is **off** by default. Enable it in config with
 `messages.tts.auto` or per session with `/tts always` (alias: `/tts on`).
 
 Edge TTS **is** enabled by default once TTS is on, and is used automatically
-when no OpenAI or ElevenLabs API keys are available.
+when no OpenAI, ElevenLabs, or Volcengine API keys are available.
 
 ## Config
 
@@ -139,6 +142,25 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 }
 ```
 
+### Volcengine TTS (ByteDance)
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "volcengine",
+      volcengine: {
+        appId: "your-app-id",
+        accessKey: "your-access-key",
+        resourceId: "seed-tts-2.0",
+        speaker: "zh_female_vv_uranus_bigtts",
+      },
+    },
+  },
+}
+```
+
 ### Disable Edge TTS
 
 ```json5
@@ -205,9 +227,9 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
+- `provider`: `"elevenlabs"`, `"openai"`, `"volcengine"`, or `"edge"` (fallback is automatic).
 - If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
-  otherwise `edge`.
+  then `volcengine` (if key), otherwise `edge`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
@@ -215,7 +237,7 @@ Then run:
 - `maxTextLength`: hard cap for TTS input (chars). `/tts audio` fails if exceeded.
 - `timeoutMs`: request timeout (ms).
 - `prefsPath`: override the local prefs JSON path (provider/limit/summary).
-- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `OPENAI_API_KEY`).
+- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `OPENAI_API_KEY`, `VOLCENGINE_ACCESS_KEY`).
 - `elevenlabs.baseUrl`: override ElevenLabs API base URL.
 - `openai.baseUrl`: override the OpenAI TTS endpoint.
   - Resolution order: `messages.tts.openai.baseUrl` -> `OPENAI_TTS_BASE_URL` -> `https://api.openai.com/v1`
@@ -236,6 +258,14 @@ Then run:
 - `edge.saveSubtitles`: write JSON subtitles alongside the audio file.
 - `edge.proxy`: proxy URL for Edge TTS requests.
 - `edge.timeoutMs`: request timeout override (ms).
+- `volcengine.appId`: Volcengine application ID.
+- `volcengine.accessKey`: Volcengine access key (falls back to `VOLCENGINE_ACCESS_KEY` env var).
+- `volcengine.resourceId`: TTS resource ID (default `seed-tts-2.0`).
+- `volcengine.speaker`: voice speaker (default `zh_female_vv_uranus_bigtts`).
+- `volcengine.format`: audio format (default `mp3`).
+- `volcengine.sampleRate`: sample rate in Hz (default `24000`).
+- `volcengine.speechRate`: speech rate, `-50` (0.5x) to `100` (2x), `0` = normal.
+- `volcengine.baseUrl`: override Volcengine TTS API base URL (default `https://openspeech.bytedance.com`).
 
 ## Model-driven overrides (default on)
 
@@ -260,7 +290,7 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (`openai` | `elevenlabs` | `edge`, requires `allowProvider: true`)
+- `provider` (`openai` | `elevenlabs` | `edge` | `volcengine`, requires `allowProvider: true`)
 - `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
 - `model` (OpenAI TTS model or ElevenLabs model id)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -134,6 +134,23 @@
       "label": "ElevenLabs Base URL",
       "advanced": true
     },
+    "tts.volcengine.appId": {
+      "label": "Volcengine App ID",
+      "advanced": true
+    },
+    "tts.volcengine.accessKey": {
+      "label": "Volcengine Access Key",
+      "sensitive": true,
+      "advanced": true
+    },
+    "tts.volcengine.resourceId": {
+      "label": "Volcengine Resource ID",
+      "advanced": true
+    },
+    "tts.volcengine.speaker": {
+      "label": "Volcengine Speaker",
+      "advanced": true
+    },
     "publicUrl": {
       "label": "Public Webhook URL",
       "advanced": true
@@ -421,7 +438,7 @@
           },
           "provider": {
             "type": "string",
-            "enum": ["openai", "elevenlabs", "edge"]
+            "enum": ["openai", "elevenlabs", "edge", "volcengine"]
           },
           "summaryModel": {
             "type": "string"
@@ -565,6 +582,39 @@
                 "type": "integer",
                 "minimum": 1000,
                 "maximum": 120000
+              }
+            }
+          },
+          "volcengine": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "appId": {
+                "type": "string"
+              },
+              "accessKey": {
+                "type": "string"
+              },
+              "resourceId": {
+                "type": "string"
+              },
+              "speaker": {
+                "type": "string"
+              },
+              "format": {
+                "type": "string"
+              },
+              "sampleRate": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "speechRate": {
+                "type": "integer",
+                "minimum": -50,
+                "maximum": 100
+              },
+              "baseUrl": {
+                "type": "string"
               }
             }
           },

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -56,7 +56,8 @@ function ttsUsage(): ReplyPayload {
       `**Providers:**\n` +
       `• edge — Free, fast (default)\n` +
       `• openai — High quality (requires API key)\n` +
-      `• elevenlabs — Premium voices (requires API key)\n\n` +
+      `• elevenlabs — Premium voices (requires API key)\n` +
+      `• volcengine — ByteDance TTS (requires App ID + Access Key)\n\n` +
       `**Text Limit (default: 1500, max: 4096):**\n` +
       `When text exceeds the limit:\n` +
       `• Summary ON: AI summarizes, then generates audio\n` +
@@ -161,6 +162,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     if (!args.trim()) {
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
+      const hasVolcengine = Boolean(resolveTtsApiKey(config, "volcengine"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
       return {
         shouldContinue: false,
@@ -170,14 +172,20 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `Primary: ${currentProvider}\n` +
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
+            `Volcengine key: ${hasVolcengine ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Usage: /tts provider openai | elevenlabs | volcengine | edge`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "edge" &&
+      requested !== "volcengine"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,6 +1,6 @@
 import type { SecretInput } from "./types.secrets.js";
 
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "volcengine";
 
 export type TtsMode = "final" | "all";
 
@@ -75,6 +75,17 @@ export type TtsConfig = {
     saveSubtitles?: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  /** Volcengine (ByteDance) TTS V3 configuration. */
+  volcengine?: {
+    appId?: string;
+    accessKey?: SecretInput;
+    resourceId?: string;
+    speaker?: string;
+    format?: string;
+    sampleRate?: number;
+    speechRate?: number;
+    baseUrl?: string;
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -355,7 +355,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "volcengine"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -421,6 +421,19 @@ export const TtsConfigSchema = z
         saveSubtitles: z.boolean().optional(),
         proxy: z.string().optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
+      })
+      .strict()
+      .optional(),
+    volcengine: z
+      .object({
+        appId: z.string().optional(),
+        accessKey: SecretInputSchema.optional().register(sensitive),
+        resourceId: z.string().optional(),
+        speaker: z.string().optional(),
+        format: z.string().optional(),
+        sampleRate: z.number().int().positive().optional(),
+        speechRate: z.number().int().min(-50).max(100).optional(),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -38,6 +38,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         prefsPath,
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
+        hasVolcengineKey: Boolean(resolveTtsApiKey(config, "volcengine")),
         edgeEnabled: isTtsProviderConfigured(config, "edge"),
       });
     } catch (err) {
@@ -100,13 +101,18 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (
+      provider !== "openai" &&
+      provider !== "elevenlabs" &&
+      provider !== "edge" &&
+      provider !== "volcengine"
+    ) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          "Invalid provider. Use openai, elevenlabs, volcengine, or edge.",
         ),
       );
       return;
@@ -140,6 +146,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
             name: "ElevenLabs",
             configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
             models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
+          },
+          {
+            id: "volcengine",
+            name: "Volcengine TTS",
+            configured: Boolean(resolveTtsApiKey(config, "volcengine")),
+            models: [],
           },
           {
             id: "edge",

--- a/src/secrets/runtime-config-collectors-tts.ts
+++ b/src/secrets/runtime-config-collectors-tts.ts
@@ -43,4 +43,19 @@ export function collectTtsApiKeyAssignments(params: {
       },
     });
   }
+  const volcengine = params.tts.volcengine;
+  if (isRecord(volcengine)) {
+    collectSecretInputAssignment({
+      value: volcengine.accessKey,
+      path: `${params.pathPrefix}.volcengine.accessKey`,
+      expected: "string",
+      defaults: params.defaults,
+      context: params.context,
+      active: params.active,
+      inactiveReason: params.inactiveReason,
+      apply: (value) => {
+        volcengine.accessKey = value;
+      },
+    });
+  }
 }

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -151,7 +151,12 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "edge" ||
+              rawValue === "volcengine"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);
@@ -655,6 +660,131 @@ export async function openaiTTS(params: {
     }
 
     return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export const DEFAULT_VOLCENGINE_BASE_URL = "https://openspeech.bytedance.com";
+
+function normalizeVolcengineBaseUrl(baseUrl?: string): string {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return DEFAULT_VOLCENGINE_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+type VolcengineV3Chunk = {
+  code: number;
+  data?: string;
+  message?: string;
+};
+
+const VOLCENGINE_AUDIO_CHUNK_CODE = 0;
+const VOLCENGINE_STREAM_COMPLETE_CODE = 20000000;
+
+export async function volcengineTTS(params: {
+  text: string;
+  appId: string;
+  accessKey: string;
+  resourceId: string;
+  speaker: string;
+  format: string;
+  sampleRate: number;
+  speechRate: number;
+  baseUrl: string;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const {
+    text,
+    appId,
+    accessKey,
+    resourceId,
+    speaker,
+    format,
+    sampleRate,
+    speechRate,
+    baseUrl,
+    timeoutMs,
+  } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const url = `${normalizeVolcengineBaseUrl(baseUrl)}/api/v3/tts/unidirectional`;
+
+    const body = {
+      user: { uid: "openclaw" },
+      req_params: {
+        text,
+        speaker,
+        audio_params: {
+          format,
+          sample_rate: sampleRate,
+          speech_rate: speechRate,
+        },
+      },
+    };
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Api-App-Id": appId,
+        "X-Api-Access-Key": accessKey,
+        "X-Api-Resource-Id": resourceId,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => "");
+      throw new Error(`Volcengine TTS V3 API error (${response.status}): ${errText}`);
+    }
+
+    const responseText = await response.text();
+    if (!responseText.trim()) {
+      throw new Error("Volcengine TTS returned empty response");
+    }
+
+    const audioChunks: Buffer[] = [];
+    const lines = responseText.split("\n");
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      let chunk: VolcengineV3Chunk;
+      try {
+        chunk = JSON.parse(trimmed) as VolcengineV3Chunk;
+      } catch {
+        throw new Error("Volcengine TTS: invalid JSON in stream response");
+      }
+
+      if (chunk.code === VOLCENGINE_AUDIO_CHUNK_CODE) {
+        if (chunk.data) {
+          const decoded = Buffer.from(chunk.data, "base64");
+          if (decoded.length > 0) {
+            audioChunks.push(decoded);
+          }
+        }
+      } else if (chunk.code === VOLCENGINE_STREAM_COMPLETE_CODE) {
+        break;
+      } else {
+        throw new Error(`Volcengine TTS error: ${chunk.message ?? "unknown"} (code ${chunk.code})`);
+      }
+    }
+
+    if (audioChunks.length === 0) {
+      throw new Error("Volcengine TTS returned no audio data");
+    }
+
+    return Buffer.concat(audioChunks);
   } finally {
     clearTimeout(timeout);
   }

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -464,6 +464,11 @@ describe("tts", () => {
       messages: { tts: {} },
     };
 
+    const volcengineCfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: { tts: { volcengine: { appId: "test-app-id" } } },
+    };
+
     it("selects provider based on available API keys", () => {
       const cases = [
         {
@@ -472,6 +477,7 @@ describe("tts", () => {
             ELEVENLABS_API_KEY: undefined,
             XI_API_KEY: undefined,
           },
+          cfg: baseCfg,
           prefsPath: "/tmp/tts-prefs-openai.json",
           expected: "openai",
         },
@@ -481,6 +487,7 @@ describe("tts", () => {
             ELEVENLABS_API_KEY: "test-elevenlabs-key",
             XI_API_KEY: undefined,
           },
+          cfg: baseCfg,
           prefsPath: "/tmp/tts-prefs-elevenlabs.json",
           expected: "elevenlabs",
         },
@@ -491,6 +498,7 @@ describe("tts", () => {
             XI_API_KEY: undefined,
             VOLCENGINE_ACCESS_KEY: "test-volcengine-key",
           },
+          cfg: volcengineCfg,
           prefsPath: "/tmp/tts-prefs-volcengine.json",
           expected: "volcengine",
         },
@@ -501,6 +509,7 @@ describe("tts", () => {
             XI_API_KEY: undefined,
             VOLCENGINE_ACCESS_KEY: undefined,
           },
+          cfg: baseCfg,
           prefsPath: "/tmp/tts-prefs-edge.json",
           expected: "edge",
         },
@@ -508,11 +517,28 @@ describe("tts", () => {
 
       for (const testCase of cases) {
         withEnv(testCase.env, () => {
-          const config = resolveTtsConfig(baseCfg);
+          const config = resolveTtsConfig(testCase.cfg);
           const provider = getTtsProvider(config, testCase.prefsPath);
           expect(provider).toBe(testCase.expected);
         });
       }
+    });
+
+    it("falls back to edge when volcengine has accessKey but no appId", () => {
+      withEnv(
+        {
+          OPENAI_API_KEY: undefined,
+          ELEVENLABS_API_KEY: undefined,
+          XI_API_KEY: undefined,
+          VOLCENGINE_ACCESS_KEY: "test-volcengine-key",
+          VOLCENGINE_APP_ID: undefined,
+        },
+        () => {
+          const config = resolveTtsConfig(baseCfg);
+          const provider = getTtsProvider(config, "/tmp/tts-prefs-no-appid.json");
+          expect(provider).toBe("edge");
+        },
+      );
     });
   });
 

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -489,6 +489,17 @@ describe("tts", () => {
             OPENAI_API_KEY: undefined,
             ELEVENLABS_API_KEY: undefined,
             XI_API_KEY: undefined,
+            VOLCENGINE_ACCESS_KEY: "test-volcengine-key",
+          },
+          prefsPath: "/tmp/tts-prefs-volcengine.json",
+          expected: "volcengine",
+        },
+        {
+          env: {
+            OPENAI_API_KEY: undefined,
+            ELEVENLABS_API_KEY: undefined,
+            XI_API_KEY: undefined,
+            VOLCENGINE_ACCESS_KEY: undefined,
           },
           prefsPath: "/tmp/tts-prefs-edge.json",
           expected: "edge",
@@ -553,6 +564,58 @@ describe("tts", () => {
       withEnv({ OPENAI_TTS_BASE_URL: "http://localhost:8880/v1/" }, () => {
         const config = resolveTtsConfig(baseCfg);
         expect(config.openai.baseUrl).toBe("http://localhost:8880/v1");
+      });
+    });
+  });
+
+  describe("resolveTtsConfig – volcengine", () => {
+    const baseCfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: { tts: {} },
+    };
+
+    it("uses volcengine defaults when no config is provided", () => {
+      const config = resolveTtsConfig(baseCfg);
+      expect(config.volcengine.resourceId).toBe("seed-tts-2.0");
+      expect(config.volcengine.speaker).toBe("zh_female_vv_uranus_bigtts");
+      expect(config.volcengine.format).toBe("mp3");
+      expect(config.volcengine.sampleRate).toBe(24000);
+      expect(config.volcengine.speechRate).toBe(0);
+      expect(config.volcengine.baseUrl).toBe("https://openspeech.bytedance.com");
+    });
+
+    it("resolves volcengine config from explicit values", () => {
+      const cfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: {
+            volcengine: {
+              appId: "my-app",
+              resourceId: "seed-tts-1.0",
+              speaker: "zh_male_test",
+              format: "wav",
+              sampleRate: 16000,
+              speechRate: 10,
+              baseUrl: "https://custom.example.com",
+            },
+          },
+        },
+      };
+      const config = resolveTtsConfig(cfg);
+      expect(config.volcengine.appId).toBe("my-app");
+      expect(config.volcengine.resourceId).toBe("seed-tts-1.0");
+      expect(config.volcengine.speaker).toBe("zh_male_test");
+      expect(config.volcengine.format).toBe("wav");
+      expect(config.volcengine.sampleRate).toBe(16000);
+      expect(config.volcengine.speechRate).toBe(10);
+      expect(config.volcengine.baseUrl).toBe("https://custom.example.com");
+    });
+
+    it("resolves Volcengine access key from env var", () => {
+      const key = "volc-key-from-env";
+      withEnv({ VOLCENGINE_ACCESS_KEY: key }, () => {
+        const config = resolveTtsConfig(baseCfg);
+        expect(tts.resolveTtsApiKey(config, "volcengine")).toBe(key);
       });
     });
   });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -29,6 +29,7 @@ import { isVoiceCompatibleAudio } from "../media/audio.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
+  DEFAULT_VOLCENGINE_BASE_URL,
   edgeTTS,
   elevenLabsTTS,
   inferEdgeExtension,
@@ -41,6 +42,7 @@ import {
   parseTtsDirectives,
   scheduleCleanup,
   summarizeText,
+  volcengineTTS,
 } from "./tts-core.js";
 export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
 
@@ -57,6 +59,12 @@ const DEFAULT_OPENAI_VOICE = "alloy";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+
+const DEFAULT_VOLCENGINE_RESOURCE_ID = "seed-tts-2.0";
+const DEFAULT_VOLCENGINE_SPEAKER = "zh_female_vv_uranus_bigtts";
+const DEFAULT_VOLCENGINE_FORMAT = "mp3";
+const DEFAULT_VOLCENGINE_SAMPLE_RATE = 24000;
+const DEFAULT_VOLCENGINE_SPEECH_RATE = 0;
 
 const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   stability: 0.5,
@@ -85,6 +93,7 @@ const DEFAULT_OUTPUT = {
 const TELEPHONY_OUTPUT = {
   openai: { format: "pcm" as const, sampleRate: 24000 },
   elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
+  volcengine: { format: "pcm" as const, sampleRate: 24000 },
 };
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);
@@ -130,6 +139,16 @@ export type ResolvedTtsConfig = {
     saveSubtitles: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  volcengine: {
+    appId?: string;
+    accessKey?: string;
+    resourceId: string;
+    speaker: string;
+    format: string;
+    sampleRate: number;
+    speechRate: number;
+    baseUrl: string;
   };
   prefsPath?: string;
   maxTextLength: number;
@@ -318,6 +337,19 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       proxy: raw.edge?.proxy?.trim() || undefined,
       timeoutMs: raw.edge?.timeoutMs,
     },
+    volcengine: {
+      appId: raw.volcengine?.appId?.trim() || undefined,
+      accessKey: normalizeResolvedSecretInputString({
+        value: raw.volcengine?.accessKey,
+        path: "messages.tts.volcengine.accessKey",
+      }),
+      resourceId: raw.volcengine?.resourceId?.trim() || DEFAULT_VOLCENGINE_RESOURCE_ID,
+      speaker: raw.volcengine?.speaker?.trim() || DEFAULT_VOLCENGINE_SPEAKER,
+      format: raw.volcengine?.format?.trim() || DEFAULT_VOLCENGINE_FORMAT,
+      sampleRate: raw.volcengine?.sampleRate ?? DEFAULT_VOLCENGINE_SAMPLE_RATE,
+      speechRate: raw.volcengine?.speechRate ?? DEFAULT_VOLCENGINE_SPEECH_RATE,
+      baseUrl: raw.volcengine?.baseUrl?.trim() || DEFAULT_VOLCENGINE_BASE_URL,
+    },
     prefsPath: raw.prefsPath,
     maxTextLength: raw.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
     timeoutMs: raw.timeoutMs ?? DEFAULT_TIMEOUT_MS,
@@ -456,6 +488,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "volcengine")) {
+    return "volcengine";
+  }
   return "edge";
 }
 
@@ -523,10 +558,13 @@ export function resolveTtsApiKey(
   if (provider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (provider === "volcengine") {
+    return config.volcengine.accessKey || process.env.VOLCENGINE_ACCESS_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "volcengine", "edge"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -660,6 +698,7 @@ export async function textToSpeech(params: {
       }
 
       let audioBuffer: Buffer;
+      let providerOutputFormat: string;
       if (provider === "elevenlabs") {
         const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
         const modelIdOverride = params.overrides?.elevenlabs?.modelId;
@@ -683,6 +722,22 @@ export async function textToSpeech(params: {
           voiceSettings,
           timeoutMs: config.timeoutMs,
         });
+        providerOutputFormat = output.elevenlabs;
+      } else if (provider === "volcengine") {
+        const appId = config.volcengine.appId || process.env.VOLCENGINE_APP_ID || "";
+        audioBuffer = await volcengineTTS({
+          text: params.text,
+          appId,
+          accessKey: apiKey,
+          resourceId: config.volcengine.resourceId,
+          speaker: config.volcengine.speaker,
+          format: config.volcengine.format,
+          sampleRate: config.volcengine.sampleRate,
+          speechRate: config.volcengine.speechRate,
+          baseUrl: config.volcengine.baseUrl,
+          timeoutMs: config.timeoutMs,
+        });
+        providerOutputFormat = config.volcengine.format;
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
@@ -695,6 +750,7 @@ export async function textToSpeech(params: {
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
         });
+        providerOutputFormat = output.openai;
       }
 
       const latencyMs = Date.now() - providerStart;
@@ -702,7 +758,8 @@ export async function textToSpeech(params: {
       const tempRoot = resolvePreferredOpenClawTmpDir();
       mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
       const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-      const audioPath = path.join(tempDir, `voice-${Date.now()}${output.extension}`);
+      const ext = provider === "volcengine" ? `.${config.volcengine.format}` : output.extension;
+      const audioPath = path.join(tempDir, `voice-${Date.now()}${ext}`);
       writeFileSync(audioPath, audioBuffer);
       scheduleCleanup(tempDir);
 
@@ -711,8 +768,8 @@ export async function textToSpeech(params: {
         audioPath,
         latencyMs,
         provider,
-        outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
-        voiceCompatible: output.voiceCompatible,
+        outputFormat: providerOutputFormat,
+        voiceCompatible: provider === "volcengine" ? false : output.voiceCompatible,
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));
@@ -769,6 +826,32 @@ export async function textToSpeechTelephony(params: {
           applyTextNormalization: config.elevenlabs.applyTextNormalization,
           languageCode: config.elevenlabs.languageCode,
           voiceSettings: config.elevenlabs.voiceSettings,
+          timeoutMs: config.timeoutMs,
+        });
+
+        return {
+          success: true,
+          audioBuffer,
+          latencyMs: Date.now() - providerStart,
+          provider,
+          outputFormat: output.format,
+          sampleRate: output.sampleRate,
+        };
+      }
+
+      if (provider === "volcengine") {
+        const output = TELEPHONY_OUTPUT.volcengine;
+        const appId = config.volcengine.appId || process.env.VOLCENGINE_APP_ID || "";
+        const audioBuffer = await volcengineTTS({
+          text: params.text,
+          appId,
+          accessKey: apiKey,
+          resourceId: config.volcengine.resourceId,
+          speaker: config.volcengine.speaker,
+          format: output.format,
+          sampleRate: output.sampleRate,
+          speechRate: config.volcengine.speechRate,
+          baseUrl: config.volcengine.baseUrl,
           timeoutMs: config.timeoutMs,
         });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -488,7 +488,7 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
-  if (resolveTtsApiKey(config, "volcengine")) {
+  if (isTtsProviderConfigured(config, "volcengine")) {
     return "volcengine";
   }
   return "edge";
@@ -564,6 +564,10 @@ export function resolveTtsApiKey(
   return undefined;
 }
 
+export function resolveVolcengineAppId(config: ResolvedTtsConfig): string | undefined {
+  return config.volcengine.appId || process.env.VOLCENGINE_APP_ID || undefined;
+}
+
 export const TTS_PROVIDERS = ["openai", "elevenlabs", "volcengine", "edge"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
@@ -573,6 +577,9 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
 export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
   if (provider === "edge") {
     return config.edge.enabled;
+  }
+  if (provider === "volcengine") {
+    return Boolean(resolveTtsApiKey(config, provider)) && Boolean(resolveVolcengineAppId(config));
   }
   return Boolean(resolveTtsApiKey(config, provider));
 }
@@ -724,7 +731,12 @@ export async function textToSpeech(params: {
         });
         providerOutputFormat = output.elevenlabs;
       } else if (provider === "volcengine") {
-        const appId = config.volcengine.appId || process.env.VOLCENGINE_APP_ID || "";
+        const appId = resolveVolcengineAppId(config);
+        if (!appId) {
+          throw new Error(
+            "volcengine: missing appId (set messages.tts.volcengine.appId or VOLCENGINE_APP_ID)",
+          );
+        }
         audioBuffer = await volcengineTTS({
           text: params.text,
           appId,
@@ -769,7 +781,10 @@ export async function textToSpeech(params: {
         latencyMs,
         provider,
         outputFormat: providerOutputFormat,
-        voiceCompatible: provider === "volcengine" ? false : output.voiceCompatible,
+        voiceCompatible:
+          provider === "volcengine"
+            ? isVoiceCompatibleAudio({ fileName: audioPath })
+            : output.voiceCompatible,
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));
@@ -841,7 +856,12 @@ export async function textToSpeechTelephony(params: {
 
       if (provider === "volcengine") {
         const output = TELEPHONY_OUTPUT.volcengine;
-        const appId = config.volcengine.appId || process.env.VOLCENGINE_APP_ID || "";
+        const appId = resolveVolcengineAppId(config);
+        if (!appId) {
+          throw new Error(
+            "volcengine: missing appId (set messages.tts.volcengine.appId or VOLCENGINE_APP_ID)",
+          );
+        }
         const audioBuffer = await volcengineTTS({
           text: params.text,
           appId,


### PR DESCRIPTION
## Summary

- Add Volcengine TTS provider (ByteDance TTS V3 HTTP JSON Lines API) as a new speech synthesis backend alongside OpenAI, ElevenLabs, and Edge TTS
- Implement `volcengineTTS()` core function with streaming JSON Lines parsing, config resolution, Zod schema validation, and plugin UI hints
- Wire up provider selection, `/tts` command support, Gateway RPC methods, API key handling (`VOLCENGINE_ACCESS_KEY`), and telephony output support
- Add unit tests for config resolution, provider selection, and Volcengine-specific defaults
- Update documentation with Volcengine configuration examples and parameter reference

## Test plan

- [ ] Verify `volcengineTTS()` synthesizes audio correctly with valid Volcengine credentials
- [ ] Confirm `/tts provider volcengine` command switches provider and `/tts status` shows Volcengine key status
- [ ] Validate fallback chain: openai → elevenlabs → volcengine → edge
- [ ] Run existing TTS unit tests (`src/tts/tts.test.ts`) to ensure no regressions
- [ ] Verify telephony output path works for Volcengine provider