### PR TITLE
fix(tui): hide <relevant-memories> scaffolding in rendered output

### DIFF
--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -32,6 +32,13 @@ function stripRelevantMemoriesTags(text: string): string {
     }
 
     lastIndex = idx + match[0].length;
+    if (!inMemoryBlock) {
+      if (result.endsWith("\r\n") && text.slice(lastIndex, lastIndex + 2) === "\r\n") {
+        lastIndex += 2;
+      } else if (result.endsWith("\n") && text[lastIndex] === "\n") {
+        lastIndex += 1;
+      }
+    }
   }
 
   if (!inMemoryBlock) {

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -134,6 +134,21 @@ Assistant body`,
     expect(text).toContain("Assistant body");
   });
 
+  it("strips relevant-memories scaffolding from assistant string content", () => {
+    const text = extractTextFromMessage({
+      role: "assistant",
+      content: [
+        "Visible",
+        "<relevant-memories>",
+        "internal-only",
+        "</relevant-memories>",
+        "Still visible",
+      ].join("\n"),
+    });
+
+    expect(text).toBe("Visible\nStill visible");
+  });
+
   it("does not strip metadata-like blocks that are not a leading prefix", () => {
     const text = extractTextFromMessage({
       role: "user",
@@ -191,6 +206,23 @@ describe("extractContentFromMessage", () => {
     });
 
     expect(text).toBe("hello");
+  });
+
+  it("strips relevant-memories scaffolding from assistant text blocks", () => {
+    const text = extractContentFromMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: ["Visible", "<relevant-memories>", "internal-only", "</relevant-memories>"].join(
+            "\n",
+          ),
+        },
+        { type: "text", text: "Still visible" },
+      ],
+    });
+
+    expect(text).toBe("Visible\nStill visible");
   });
 
   it("renders error text when stopReason is error and content is not an array", () => {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,5 +1,6 @@
 import { formatRawAssistantErrorForUi } from "../agents/pi-embedded-helpers.js";
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { stripAssistantInternalScaffolding } from "../shared/text/assistant-visible-text.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
@@ -153,6 +154,10 @@ export function sanitizeRenderableText(text: string): string {
   return applyRtlIsolation(tokenSafe);
 }
 
+function sanitizeAssistantRenderableText(text: string): string {
+  return sanitizeRenderableText(stripAssistantInternalScaffolding(text)).trimEnd();
+}
+
 export function resolveFinalAssistantText(params: {
   finalText?: string | null;
   streamedText?: string | null;
@@ -222,6 +227,7 @@ function collectSanitizedBlockStrings(params: {
   content: unknown;
   blockType: "text" | "thinking";
   valueKey: "text" | "thinking";
+  isAssistant?: boolean;
 }): string[] {
   if (!Array.isArray(params.content)) {
     return [];
@@ -233,7 +239,10 @@ function collectSanitizedBlockStrings(params: {
     }
     const rec = block as Record<string, unknown>;
     if (rec.type === params.blockType && typeof rec[params.valueKey] === "string") {
-      parts.push(sanitizeRenderableText(rec[params.valueKey] as string));
+      const text = rec[params.valueKey] as string;
+      parts.push(
+        params.isAssistant ? sanitizeAssistantRenderableText(text) : sanitizeRenderableText(text),
+      );
     }
   }
   return parts;
@@ -256,6 +265,7 @@ export function extractThinkingFromMessage(message: unknown): string {
     content,
     blockType: "thinking",
     valueKey: "thinking",
+    isAssistant: resolved.record.role === "assistant",
   });
   return parts.join("\n").trim();
 }
@@ -272,13 +282,18 @@ export function extractContentFromMessage(message: unknown): string {
   const { record, content } = resolved;
 
   if (typeof content === "string") {
-    return sanitizeRenderableText(content).trim();
+    const sanitized =
+      record.role === "assistant"
+        ? sanitizeAssistantRenderableText(content)
+        : sanitizeRenderableText(content);
+    return sanitized.trim();
   }
 
   const parts = collectSanitizedBlockStrings({
     content,
     blockType: "text",
     valueKey: "text",
+    isAssistant: record.role === "assistant",
   });
   if (parts.length > 0) {
     return parts.join("\n").trim();
@@ -286,9 +301,16 @@ export function extractContentFromMessage(message: unknown): string {
   return formatAssistantErrorFromRecord(record);
 }
 
-function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean }): string {
+function extractTextBlocks(
+  content: unknown,
+  opts?: { includeThinking?: boolean; isAssistant?: boolean },
+): string {
   if (typeof content === "string") {
-    return sanitizeRenderableText(content).trim();
+    const sanitized =
+      opts?.isAssistant === true
+        ? sanitizeAssistantRenderableText(content)
+        : sanitizeRenderableText(content);
+    return sanitized.trim();
   }
   if (!Array.isArray(content)) {
     return "";
@@ -298,6 +320,7 @@ function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean 
     content,
     blockType: "text",
     valueKey: "text",
+    isAssistant: opts?.isAssistant,
   });
   const thinkingParts =
     opts?.includeThinking === true
@@ -305,6 +328,7 @@ function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean 
           content,
           blockType: "thinking",
           valueKey: "thinking",
+          isAssistant: opts?.isAssistant,
         })
       : [];
 
@@ -323,7 +347,10 @@ export function extractTextFromMessage(
   if (!record) {
     return "";
   }
-  const text = extractTextBlocks(record.content, opts);
+  const text = extractTextBlocks(record.content, {
+    ...opts,
+    isAssistant: record.role === "assistant",
+  });
   if (text) {
     if (record.role === "user") {
       return stripLeadingInboundMetadata(text);


### PR DESCRIPTION
## Summary
- hide `<relevant-memories>` scaffolding from assistant text shown in the TUI
- strip the extra newline left behind when that internal block is removed
- add regressions for both string content and text-block content paths

## Root cause
The TUI formatter only sanitized ANSI/control characters. It did not strip assistant-only scaffolding, so `<relevant-memories>` blocks leaked straight into rendered output. When the block was removed, line-oriented content could also keep an extra blank line.

## Fix
- route assistant text through `stripAssistantInternalScaffolding()` before rendering
- trim the leftover block-boundary newline so adjacent visible text joins cleanly
- cover both `extractTextFromMessage()` and `extractContentFromMessage()` with regressions

## Testing
- `corepack pnpm exec vitest run src/tui/tui-formatters.test.ts`

Closes #42203