### PR TITLE
fix(auth): honor proxy env for OpenAI Codex OAuth

### DIFF
--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -11,18 +11,39 @@ import {
 } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
 
-const { getOAuthApiKeyMock } = vi.hoisted(() => ({
+const { getOAuthApiKeyMock, withEnvProxyGlobalDispatcherMock } = vi.hoisted(() => ({
   getOAuthApiKeyMock: vi.fn(async () => {
     throw new Error("Failed to extract accountId from token");
   }),
+  withEnvProxyGlobalDispatcherMock: vi.fn(async (run: () => Promise<unknown>) => await run()),
 }));
 
+<<<<<<< HEAD
 vi.mock("@mariozechner/pi-ai/oauth", () => ({
   getOAuthApiKey: getOAuthApiKeyMock,
   getOAuthProviders: () => [
     { id: "openai-codex", envApiKey: "OPENAI_API_KEY", oauthTokenEnv: "OPENAI_OAUTH_TOKEN" }, // pragma: allowlist secret
     { id: "anthropic", envApiKey: "ANTHROPIC_API_KEY", oauthTokenEnv: "ANTHROPIC_OAUTH_TOKEN" }, // pragma: allowlist secret
   ],
+}));
+=======
+vi.mock("@mariozechner/pi-ai/oauth", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai/oauth")>(
+    "@mariozechner/pi-ai/oauth",
+  );
+  return {
+    ...actual,
+    getOAuthApiKey: getOAuthApiKeyMock,
+    getOAuthProviders: () => [
+      { id: "openai-codex", envApiKey: "OPENAI_API_KEY", oauthTokenEnv: "OPENAI_OAUTH_TOKEN" }, // pragma: allowlist secret
+      { id: "anthropic", envApiKey: "ANTHROPIC_API_KEY", oauthTokenEnv: "ANTHROPIC_OAUTH_TOKEN" }, // pragma: allowlist secret
+    ],
+  };
+});
+>>>>>>> 445f5fc (Auth: honor proxy env for OpenAI Codex OAuth)
+
+vi.mock("../../infra/net/env-proxy-global-dispatcher.js", () => ({
+  withEnvProxyGlobalDispatcher: withEnvProxyGlobalDispatcherMock,
 }));
 
 function createExpiredOauthStore(params: {
@@ -55,6 +76,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
 
   beforeEach(async () => {
     getOAuthApiKeyMock.mockClear();
+    withEnvProxyGlobalDispatcherMock.mockClear();
     clearRuntimeAuthProfileStoreSnapshots();
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-refresh-fallback-"));
     agentDir = path.join(tempRoot, "agents", "main", "agent");
@@ -91,6 +113,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
       provider: "openai-codex",
       email: undefined,
     });
+    expect(withEnvProxyGlobalDispatcherMock).toHaveBeenCalledTimes(1);
     expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
   });
 
@@ -111,6 +134,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
         agentDir,
       }),
     ).rejects.toThrow(/OAuth token refresh failed for anthropic/);
+    expect(withEnvProxyGlobalDispatcherMock).not.toHaveBeenCalled();
   });
 
   it("does not use fallback for unrelated openai-codex refresh errors", async () => {

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -18,15 +18,6 @@ const { getOAuthApiKeyMock, withEnvProxyGlobalDispatcherMock } = vi.hoisted(() =
   withEnvProxyGlobalDispatcherMock: vi.fn(async (run: () => Promise<unknown>) => await run()),
 }));
 
-<<<<<<< HEAD
-vi.mock("@mariozechner/pi-ai/oauth", () => ({
-  getOAuthApiKey: getOAuthApiKeyMock,
-  getOAuthProviders: () => [
-    { id: "openai-codex", envApiKey: "OPENAI_API_KEY", oauthTokenEnv: "OPENAI_OAUTH_TOKEN" }, // pragma: allowlist secret
-    { id: "anthropic", envApiKey: "ANTHROPIC_API_KEY", oauthTokenEnv: "ANTHROPIC_OAUTH_TOKEN" }, // pragma: allowlist secret
-  ],
-}));
-=======
 vi.mock("@mariozechner/pi-ai/oauth", async () => {
   const actual = await vi.importActual<typeof import("@mariozechner/pi-ai/oauth")>(
     "@mariozechner/pi-ai/oauth",
@@ -40,7 +31,6 @@ vi.mock("@mariozechner/pi-ai/oauth", async () => {
     ],
   };
 });
->>>>>>> 445f5fc (Auth: honor proxy env for OpenAI Codex OAuth)
 
 vi.mock("../../infra/net/env-proxy-global-dispatcher.js", () => ({
   withEnvProxyGlobalDispatcher: withEnvProxyGlobalDispatcherMock,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,8 +1,9 @@
-import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai";
+import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai/oauth";
 import { getOAuthApiKey, getOAuthProviders } from "@mariozechner/pi-ai/oauth";
 import { loadConfig, type OpenClawConfig } from "../../config/config.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { withFileLock } from "../../infra/file-lock.js";
+import { withEnvProxyGlobalDispatcher } from "../../infra/net/env-proxy-global-dispatcher.js";
 import { refreshQwenPortalCredentials } from "../../providers/qwen-portal-oauth.js";
 import { resolveSecretRefString, type SecretRefResolveCache } from "../../secrets/resolve.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
@@ -194,7 +195,10 @@ async function refreshOAuthTokenWithLock(params: {
               if (!oauthProvider) {
                 return null;
               }
-              return await getOAuthApiKey(oauthProvider, oauthCreds);
+              const resolveApiKey = async () => await getOAuthApiKey(oauthProvider, oauthCreds);
+              return normalizeProviderId(cred.provider) === "openai-codex"
+                ? await withEnvProxyGlobalDispatcher(resolveApiKey)
+                : await resolveApiKey();
             })();
     if (!result) {
       return null;

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -7,10 +7,15 @@ const mocks = vi.hoisted(() => ({
   createVpsAwareOAuthHandlers: vi.fn(),
   runOpenAIOAuthTlsPreflight: vi.fn(),
   formatOpenAIOAuthTlsPreflightFix: vi.fn(),
+  withEnvProxyGlobalDispatcher: vi.fn(async (run: () => Promise<unknown>) => await run()),
 }));
 
 vi.mock("@mariozechner/pi-ai/oauth", () => ({
   loginOpenAICodex: mocks.loginOpenAICodex,
+}));
+
+vi.mock("../infra/net/env-proxy-global-dispatcher.js", () => ({
+  withEnvProxyGlobalDispatcher: mocks.withEnvProxyGlobalDispatcher,
 }));
 
 vi.mock("./oauth-flow.js", () => ({
@@ -79,6 +84,7 @@ describe("loginOpenAICodexOAuth", () => {
     const { result, spin, runtime } = await runCodexOAuth({ isRemote: false });
 
     expect(result).toEqual(creds);
+    expect(mocks.withEnvProxyGlobalDispatcher).toHaveBeenCalledTimes(1);
     expect(mocks.loginOpenAICodex).toHaveBeenCalledOnce();
     expect(spin.stop).toHaveBeenCalledWith("OpenAI OAuth complete");
     expect(runtime.error).not.toHaveBeenCalled();

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,5 +1,6 @@
-import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import type { OAuthCredentials } from "@mariozechner/pi-ai/oauth";
 import { loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
+import { withEnvProxyGlobalDispatcher } from "../infra/net/env-proxy-global-dispatcher.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";
@@ -50,11 +51,14 @@ export async function loginOpenAICodexOAuth(params: {
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser…",
     });
 
-    const creds = await loginOpenAICodex({
-      onAuth: baseOnAuth,
-      onPrompt,
-      onProgress: (msg: string) => spin.update(msg),
-    });
+    const creds = await withEnvProxyGlobalDispatcher(
+      async () =>
+        await loginOpenAICodex({
+          onAuth: baseOnAuth,
+          onPrompt,
+          onProgress: (msg: string) => spin.update(msg),
+        }),
+    );
     spin.stop("OpenAI OAuth complete");
     return creds ?? null;
   } catch (err) {

--- a/src/infra/net/env-proxy-global-dispatcher.ts
+++ b/src/infra/net/env-proxy-global-dispatcher.ts
@@ -1,0 +1,39 @@
+import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { hasProxyEnvConfigured } from "./proxy-env.js";
+
+function isEnvProxyDispatcher(dispatcher: unknown): boolean {
+  const ctorName = (dispatcher as { constructor?: { name?: string } })?.constructor?.name;
+  return typeof ctorName === "string" && ctorName.includes("EnvHttpProxyAgent");
+}
+
+export async function withEnvProxyGlobalDispatcher<T>(
+  run: () => Promise<T>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<T> {
+  if (!hasProxyEnvConfigured(env)) {
+    return await run();
+  }
+
+  let previous: unknown;
+  try {
+    previous = getGlobalDispatcher();
+  } catch {
+    return await run();
+  }
+
+  if (isEnvProxyDispatcher(previous)) {
+    return await run();
+  }
+
+  try {
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+  } catch {
+    return await run();
+  }
+
+  try {
+    return await run();
+  } finally {
+    setGlobalDispatcher(previous as Parameters<typeof setGlobalDispatcher>[0]);
+  }
+}


### PR DESCRIPTION
## Summary
- switch the OpenAI Codex OAuth runtime imports to `@mariozechner/pi-ai/oauth`
- install an env-proxy-aware undici dispatcher around the OpenAI Codex login and refresh calls
- add regressions for both the login path and the expired-token refresh path

## Root cause
The runtime OAuth helpers are exported from `@mariozechner/pi-ai/oauth`, not the root `@mariozechner/pi-ai` entrypoint. Separately, the OpenAI Codex OAuth helper performs token exchange/refresh with bare `fetch`, so proxy env vars were ignored unless an `EnvHttpProxyAgent` dispatcher was active.

## Fix
- import `loginOpenAICodex()`, `getOAuthProviders()`, and `getOAuthApiKey()` from the `/oauth` subpath
- wrap the OpenAI Codex login flow and refresh flow with a temporary env-proxy dispatcher
- cover the login wrapper and the refresh wrapper with targeted tests

## Testing
- `corepack pnpm exec vitest run src/commands/openai-codex-oauth.test.ts src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts`

Closes #42176