### PR TITLE
fix(control-ui): ignore placeholder runtime versions

### DIFF
--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -149,8 +149,29 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" \t ")).toBeUndefined();
     expect(resolveUsableRuntimeVersion("0.0.0")).toBeUndefined();
     expect(resolveUsableRuntimeVersion(" 0.0.0 ")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion("dev")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion(" DEV ")).toBeUndefined();
+    expect(resolveUsableRuntimeVersion("unknown")).toBeUndefined();
     expect(resolveUsableRuntimeVersion("2026.3.2")).toBe("2026.3.2");
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
+  });
+
+  it("ignores placeholder OPENCLAW_VERSION values when resolving the runtime service version", () => {
+    expect(
+      resolveRuntimeServiceVersion({
+        OPENCLAW_VERSION: "dev",
+        OPENCLAW_SERVICE_VERSION: "2.2.2",
+        npm_package_version: "1.1.1",
+      }),
+    ).toBe(VERSION);
+
+    expect(
+      resolveRuntimeServiceVersion({
+        OPENCLAW_VERSION: "unknown",
+        OPENCLAW_SERVICE_VERSION: "2.2.2",
+        npm_package_version: "1.1.1",
+      }),
+    ).toBe(VERSION);
   });
 
   it("prefers runtime VERSION over service/package markers and ignores blank env values", () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -91,12 +91,13 @@ export type RuntimeVersionEnv = {
 };
 
 export const RUNTIME_SERVICE_VERSION_FALLBACK = "unknown";
+const UNUSABLE_RUNTIME_VERSION_MARKERS = new Set(["0.0.0", "dev", "unknown"]);
 
 export function resolveUsableRuntimeVersion(version: string | undefined): string | undefined {
   const trimmed = version?.trim();
-  // "0.0.0" is the resolver's hard fallback when module metadata cannot be read.
-  // Prefer explicit service/package markers in that edge case.
-  if (!trimmed || trimmed === "0.0.0") {
+  const normalized = trimmed?.toLowerCase();
+  // Placeholder markers like "dev" and "unknown" should not win over concrete versions.
+  if (!trimmed || !normalized || UNUSABLE_RUNTIME_VERSION_MARKERS.has(normalized)) {
     return undefined;
   }
   return trimmed;
@@ -106,16 +107,12 @@ export function resolveRuntimeServiceVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
   fallback = RUNTIME_SERVICE_VERSION_FALLBACK,
 ): string {
+  const envVersion = resolveUsableRuntimeVersion(env["OPENCLAW_VERSION"]);
   const runtimeVersion = resolveUsableRuntimeVersion(VERSION);
+  const serviceVersion = resolveUsableRuntimeVersion(env["OPENCLAW_SERVICE_VERSION"]);
+  const packageVersion = resolveUsableRuntimeVersion(env["npm_package_version"]);
 
-  return (
-    firstNonEmpty(
-      env["OPENCLAW_VERSION"],
-      runtimeVersion,
-      env["OPENCLAW_SERVICE_VERSION"],
-      env["npm_package_version"],
-    ) ?? fallback
-  );
+  return firstNonEmpty(envVersion, runtimeVersion, serviceVersion, packageVersion) ?? fallback;
 }
 
 // Single source of truth for the current OpenClaw version.


### PR DESCRIPTION
## Summary
- treat `dev` and `unknown` the same way as other placeholder runtime version markers
- normalize runtime version env candidates before selecting the version shown by the server/control UI
- add regressions covering placeholder env values

## Root cause
`resolveRuntimeServiceVersion()` treated any non-empty `OPENCLAW_VERSION` as authoritative. After an upgrade, placeholder values like `dev` could still win over the actual runtime/package version, so the Web Console kept showing `dev`.

## Fix
- classify `dev` and `unknown` as unusable runtime version markers
- run `OPENCLAW_VERSION`, `OPENCLAW_SERVICE_VERSION`, and `npm_package_version` through the same normalization path before picking the final version
- cover placeholder handling in `src/version.test.ts`

## Testing
- `corepack pnpm exec vitest run src/version.test.ts`

Closes #42205