### PR TITLE
fix(tools): keep minimal profile restrictive

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -244,4 +244,17 @@ describe("resolveEffectiveToolPolicy", () => {
     const result = resolveEffectiveToolPolicy({ config: cfg });
     expect(result.profileAlsoAllow).toBeUndefined();
   });
+
+  it("keeps explicit alsoAllow for the minimal profile", () => {
+    const cfg = {
+      tools: {
+        profile: "minimal",
+        alsoAllow: ["web_search"],
+        exec: { host: "sandbox" },
+        fs: { workspaceOnly: true },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toEqual(["web_search"]);
+  });
 });

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -232,4 +232,16 @@ describe("resolveEffectiveToolPolicy", () => {
     const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
     expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });
+
+  it("does not implicitly re-expose exec or fs tools for the minimal profile", () => {
+    const cfg = {
+      tools: {
+        profile: "minimal",
+        exec: { host: "sandbox" },
+        fs: { workspaceOnly: true },
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.profileAlsoAllow).toBeUndefined();
+  });
 });

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -208,7 +208,11 @@ function hasExplicitToolSection(section: unknown): boolean {
 function resolveImplicitProfileAlsoAllow(params: {
   globalTools?: OpenClawConfig["tools"];
   agentTools?: AgentToolsConfig;
+  profile?: string;
 }): string[] | undefined {
+  if (params.profile?.trim().toLowerCase() === "minimal") {
+    return undefined;
+  }
   const implicit = new Set<string>();
   if (
     hasExplicitToolSection(params.agentTools?.exec) ||
@@ -260,7 +264,11 @@ export function resolveEffectiveToolPolicy(params: {
   });
   const explicitProfileAlsoAllow =
     resolveExplicitProfileAlsoAllow(agentTools) ?? resolveExplicitProfileAlsoAllow(globalTools);
-  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({ globalTools, agentTools });
+  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({
+    globalTools,
+    agentTools,
+    profile,
+  });
   const profileAlsoAllow =
     explicitProfileAlsoAllow || implicitProfileAlsoAllow
       ? Array.from(


### PR DESCRIPTION
## Summary
- keep `tools.profile: "minimal"` restrictive even when `tools.fs` or `tools.exec` sections are present
- stop the implicit `alsoAllow` expansion for the minimal profile
- add a regression for the minimal-profile case

## Root cause
`resolveImplicitProfileAlsoAllow()` automatically re-exposed `read/write/edit` and `exec/process` whenever those config sections existed. That additive behavior makes sense for richer profiles, but it broke the contract of the `minimal` profile by silently reopening tools.

## Fix
- short-circuit implicit profile exposure when the effective profile is `minimal`
- keep explicit `alsoAllow` behavior unchanged
- cover the regression in `src/agents/pi-tools.policy.test.ts`

## Testing
- `corepack pnpm exec vitest run src/agents/pi-tools.policy.test.ts`

Closes #42165