### PR TITLE
fix(acpx): strip skill env from spawned runtime processes

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWindowsCmdShimFixture } from "../../../shared/windows-cmd-shim-test-fixtures.js";
+import { applySkillEnvOverridesFromSnapshot } from "../../../../src/agents/skills/env-overrides.js";
 import {
+  resolveAcpxSpawnEnv,
   resolveSpawnCommand,
   spawnAndCollect,
   type SpawnCommandCache,
@@ -41,6 +43,34 @@ afterEach(async () => {
       retryDelay: 8,
     });
   }
+});
+
+describe("resolveAcpxSpawnEnv", () => {
+  it("sets OPENCLAW_SHELL marker and preserves unrelated env", () => {
+    const env = resolveAcpxSpawnEnv({
+      PATH: "/usr/bin",
+      USER: "openclaw",
+    });
+
+    expect(env.OPENCLAW_SHELL).toBe("acp");
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.USER).toBe("openclaw");
+  });
+
+  it("strips skill-injected env keys before spawning", () => {
+    const env = resolveAcpxSpawnEnv(
+      {
+        OPENAI_API_KEY: "openai-test-value", // pragma: allowlist secret
+        ANTHROPIC_API_KEY: "anthropic-test-value", // pragma: allowlist secret
+        OPENCLAW_SHELL: "wrong",
+      },
+      { stripKeys: new Set(["OPENAI_API_KEY", "OPENCLAW_SHELL"]) },
+    );
+
+    expect(env.OPENCLAW_SHELL).toBe("acp");
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBe("anthropic-test-value");
+  });
 });
 
 describe("resolveSpawnCommand", () => {
@@ -384,5 +414,50 @@ describe("spawnAndCollect", () => {
     expect(parsed.hf).toBe("hf-secret");
     expect(parsed.openclaw).toBe("keep-me");
     expect(parsed.shell).toBe("acp");
+  });
+
+  it("strips active skill-injected env vars from spawned acpx children", async () => {
+    const revert = applySkillEnvOverridesFromSnapshot({
+      snapshot: {
+        prompt: "",
+        skills: [{ name: "skill-test" }],
+      },
+      config: {
+        skills: {
+          entries: {
+            "skill-test": {
+              env: {
+                CUSTOM_SKILL_TOKEN: "from-skill",
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    try {
+      expect(process.env.CUSTOM_SKILL_TOKEN).toBe("from-skill");
+
+      const result = await spawnAndCollect({
+        command: process.execPath,
+        args: [
+          "-e",
+          "process.stdout.write(JSON.stringify({custom:process.env.CUSTOM_SKILL_TOKEN,shell:process.env.OPENCLAW_SHELL}))",
+        ],
+        cwd: process.cwd(),
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.error).toBeNull();
+
+      const parsed = JSON.parse(result.stdout) as {
+        custom?: string;
+        shell?: string;
+      };
+      expect(parsed.custom).toBeUndefined();
+      expect(parsed.shell).toBe("acp");
+    } finally {
+      revert();
+    }
   });
 });

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -427,7 +427,7 @@ describe("spawnAndCollect", () => {
           entries: {
             "skill-test": {
               env: {
-                CUSTOM_SKILL_TOKEN: "from-skill",
+                SKILL_TEST_VALUE: "from-skill",
               },
             },
           },
@@ -436,13 +436,13 @@ describe("spawnAndCollect", () => {
     });
 
     try {
-      expect(process.env.CUSTOM_SKILL_TOKEN).toBe("from-skill");
+      expect(process.env.SKILL_TEST_VALUE).toBe("from-skill");
 
       const result = await spawnAndCollect({
         command: process.execPath,
         args: [
           "-e",
-          "process.stdout.write(JSON.stringify({custom:process.env.CUSTOM_SKILL_TOKEN,shell:process.env.OPENCLAW_SHELL}))",
+          "process.stdout.write(JSON.stringify({custom:process.env.SKILL_TEST_VALUE,shell:process.env.OPENCLAW_SHELL}))",
         ],
         cwd: process.cwd(),
       });

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -12,6 +12,7 @@ import {
   omitEnvKeysCaseInsensitive,
   resolveWindowsSpawnProgramCandidate,
 } from "openclaw/plugin-sdk/acpx";
+import { getActiveSkillEnvKeys } from "../../../../src/agents/skills/env-overrides.runtime.js";
 
 export type SpawnExit = {
   code: number | null;
@@ -56,6 +57,20 @@ const DEFAULT_RUNTIME: SpawnRuntime = {
   env: process.env,
   execPath: process.execPath,
 };
+
+export function resolveAcpxSpawnEnv(
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  options?: { stripKeys?: ReadonlySet<string> },
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+  if (options?.stripKeys) {
+    for (const key of options.stripKeys) {
+      delete env[key];
+    }
+  }
+  env.OPENCLAW_SHELL = "acp";
+  return env;
+}
 
 export function resolveSpawnCommand(
   params: { command: string; args: string[] },
@@ -143,11 +158,12 @@ export function spawnWithResolvedCommand(
     process.env,
     params.stripProviderAuthEnvVars ? listKnownProviderAuthEnvVarNames() : [],
   );
-  childEnv.OPENCLAW_SHELL = "acp";
 
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,
-    env: childEnv,
+    env: resolveAcpxSpawnEnv(childEnv, {
+      stripKeys: getActiveSkillEnvKeys(),
+    }),
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
     windowsHide: resolved.windowsHide,


### PR DESCRIPTION
## Summary
- strip active skill-injected env keys before spawning acpx runtime processes
- preserve the `OPENCLAW_SHELL=acp` marker after env cleanup
- add regressions for the spawn-env shaping logic

## Root cause
The ACP client spawn path already strips skill-injected keys, but the acpx runtime spawn path forwarded raw `process.env`. Because skill env overrides are applied globally, the first agent's API keys could leak into later acpx-backed sessions.

## Fix
- add a dedicated `resolveAcpxSpawnEnv()` helper for acpx process spawns
- remove active skill env keys before calling `spawn()`
- keep the acpx shell marker intact after stripping
- cover the behavior in `extensions/acpx/src/runtime-internals/process.test.ts`

## Testing
- `corepack pnpm exec vitest run extensions/acpx/src/runtime-internals/process.test.ts`

Closes #42189