### PR TITLE
feat(ios): add inline Adaptive Card rendering in chat

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardModels.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+// MARK: - Adaptive Card v1.5 Codable models
+
+struct AdaptiveCard: Codable {
+    let type: String
+    let version: String?
+    let body: [CardElement]
+    let actions: [CardAction]?
+}
+
+enum CardElement: Codable {
+    case textBlock(TextBlock)
+    case factSet(FactSet)
+    case columnSet(ColumnSet)
+    case container(Container)
+    case image(ImageElement)
+    case unknown
+
+    struct TextBlock: Codable {
+        let text: String
+        let size: String?
+        let weight: String?
+        let color: String?
+        let isSubtle: Bool?
+        let wrap: Bool?
+        let separator: Bool?
+    }
+
+    struct Fact: Codable {
+        let title: String
+        let value: String
+    }
+
+    struct FactSet: Codable {
+        let facts: [Fact]
+    }
+
+    struct Column: Codable {
+        let width: String?
+        let items: [CardElement]?
+    }
+
+    struct ColumnSet: Codable {
+        let columns: [Column]
+    }
+
+    struct Container: Codable {
+        let items: [CardElement]
+        let style: String?
+    }
+
+    struct ImageElement: Codable {
+        let url: String
+        let altText: String?
+        let size: String?
+    }
+
+    // Manual decoding keyed on "type"
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let elementType = try container.decodeIfPresent(String.self, forKey: .type) ?? ""
+
+        switch elementType {
+        case "TextBlock":
+            self = .textBlock(try TextBlock(from: decoder))
+        case "FactSet":
+            self = .factSet(try FactSet(from: decoder))
+        case "ColumnSet":
+            self = .columnSet(try ColumnSet(from: decoder))
+        case "Container":
+            self = .container(try Container(from: decoder))
+        case "Image":
+            self = .image(try ImageElement(from: decoder))
+        default:
+            self = .unknown
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .textBlock(let tb):
+            try container.encode("TextBlock", forKey: .type)
+            try tb.encode(to: encoder)
+        case .factSet(let fs):
+            try container.encode("FactSet", forKey: .type)
+            try fs.encode(to: encoder)
+        case .columnSet(let cs):
+            try container.encode("ColumnSet", forKey: .type)
+            try cs.encode(to: encoder)
+        case .container(let c):
+            try container.encode("Container", forKey: .type)
+            try c.encode(to: encoder)
+        case .image(let img):
+            try container.encode("Image", forKey: .type)
+            try img.encode(to: encoder)
+        case .unknown:
+            try container.encode("Unknown", forKey: .type)
+        }
+    }
+}
+
+enum CardAction: Codable {
+    case submit(SubmitAction)
+    case openUrl(OpenUrlAction)
+    case unknown
+
+    struct SubmitAction: Codable {
+        let title: String?
+        let data: AnyCodableAction?
+    }
+
+    struct OpenUrlAction: Codable {
+        let title: String?
+        let url: String
+    }
+
+    // Lightweight any-value wrapper for action data (no external deps)
+    struct AnyCodableAction: Codable {
+        let value: Any
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let dict = try? container.decode([String: String].self) {
+                self.value = dict
+            } else if let str = try? container.decode(String.self) {
+                self.value = str
+            } else {
+                self.value = ""
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            if let dict = self.value as? [String: String] {
+                try container.encode(dict)
+            } else if let str = self.value as? String {
+                try container.encode(str)
+            }
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let actionType = try container.decodeIfPresent(String.self, forKey: .type) ?? ""
+
+        switch actionType {
+        case "Action.Submit":
+            self = .submit(try SubmitAction(from: decoder))
+        case "Action.OpenUrl":
+            self = .openUrl(try OpenUrlAction(from: decoder))
+        default:
+            self = .unknown
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .submit(let a):
+            try container.encode("Action.Submit", forKey: .type)
+            try a.encode(to: encoder)
+        case .openUrl(let a):
+            try container.encode("Action.OpenUrl", forKey: .type)
+            try a.encode(to: encoder)
+        case .unknown:
+            try container.encode("Unknown", forKey: .type)
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardModels.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// MARK: - Adaptive Card v1.5 Codable models
+// MARK: - Adaptive Card v1.6 Codable models
 
 struct AdaptiveCard: Codable {
     let type: String
@@ -15,6 +15,11 @@ enum CardElement: Codable {
     case columnSet(ColumnSet)
     case container(Container)
     case image(ImageElement)
+    case table(Table)
+    case richTextBlock(RichTextBlock)
+    case codeBlock(CodeBlock)
+    case imageSet(ImageSet)
+    case actionSet(ActionSet)
     case unknown
 
     struct TextBlock: Codable {
@@ -56,6 +61,52 @@ enum CardElement: Codable {
         let size: String?
     }
 
+    struct TableColumnDefinition: Codable {
+        let width: String?
+        let horizontalCellContentAlignment: String?
+    }
+
+    struct TableCell: Codable {
+        let items: [CardElement]?
+    }
+
+    struct TableRow: Codable {
+        let cells: [TableCell]?
+    }
+
+    struct Table: Codable {
+        let columns: [TableColumnDefinition]?
+        let rows: [TableRow]
+    }
+
+    struct TextRun: Codable {
+        let text: String
+        let weight: String?
+        let italic: Bool?
+        let strikethrough: Bool?
+        let highlight: Bool?
+        let color: String?
+        let size: String?
+    }
+
+    struct RichTextBlock: Codable {
+        let inlines: [TextRun]
+    }
+
+    struct CodeBlock: Codable {
+        let codeSnippet: String
+        let language: String?
+    }
+
+    struct ImageSet: Codable {
+        let images: [ImageElement]
+        let imageSize: String?
+    }
+
+    struct ActionSet: Codable {
+        let actions: [CardAction]
+    }
+
     // Manual decoding keyed on "type"
     private enum CodingKeys: String, CodingKey {
         case type
@@ -76,6 +127,16 @@ enum CardElement: Codable {
             self = .container(try Container(from: decoder))
         case "Image":
             self = .image(try ImageElement(from: decoder))
+        case "Table":
+            self = .table(try Table(from: decoder))
+        case "RichTextBlock":
+            self = .richTextBlock(try RichTextBlock(from: decoder))
+        case "CodeBlock":
+            self = .codeBlock(try CodeBlock(from: decoder))
+        case "ImageSet":
+            self = .imageSet(try ImageSet(from: decoder))
+        case "ActionSet":
+            self = .actionSet(try ActionSet(from: decoder))
         default:
             self = .unknown
         }
@@ -99,6 +160,21 @@ enum CardElement: Codable {
         case .image(let img):
             try container.encode("Image", forKey: .type)
             try img.encode(to: encoder)
+        case .table(let t):
+            try container.encode("Table", forKey: .type)
+            try t.encode(to: encoder)
+        case .richTextBlock(let rtb):
+            try container.encode("RichTextBlock", forKey: .type)
+            try rtb.encode(to: encoder)
+        case .codeBlock(let cb):
+            try container.encode("CodeBlock", forKey: .type)
+            try cb.encode(to: encoder)
+        case .imageSet(let imgSet):
+            try container.encode("ImageSet", forKey: .type)
+            try imgSet.encode(to: encoder)
+        case .actionSet(let actSet):
+            try container.encode("ActionSet", forKey: .type)
+            try actSet.encode(to: encoder)
         case .unknown:
             try container.encode("Unknown", forKey: .type)
         }
@@ -107,11 +183,18 @@ enum CardElement: Codable {
 
 enum CardAction: Codable {
     case submit(SubmitAction)
+    case execute(ExecuteAction)
     case openUrl(OpenUrlAction)
     case unknown
 
     struct SubmitAction: Codable {
         let title: String?
+        let data: AnyCodableAction?
+    }
+
+    struct ExecuteAction: Codable {
+        let title: String?
+        let verb: String?
         let data: AnyCodableAction?
     }
 
@@ -124,10 +207,22 @@ enum CardAction: Codable {
     struct AnyCodableAction: Codable {
         let value: Any
 
+        init(_ value: Any) {
+            self.value = value
+        }
+
         init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
-            if let dict = try? container.decode([String: String].self) {
-                self.value = dict
+            if let dict = try? container.decode([String: AnyCodableAction].self) {
+                self.value = dict.mapValues { $0.value }
+            } else if let arr = try? container.decode([AnyCodableAction].self) {
+                self.value = arr.map { $0.value }
+            } else if let b = try? container.decode(Bool.self) {
+                self.value = b
+            } else if let i = try? container.decode(Int.self) {
+                self.value = i
+            } else if let d = try? container.decode(Double.self) {
+                self.value = d
             } else if let str = try? container.decode(String.self) {
                 self.value = str
             } else {
@@ -137,8 +232,18 @@ enum CardAction: Codable {
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
-            if let dict = self.value as? [String: String] {
-                try container.encode(dict)
+            if let dict = self.value as? [String: Any] {
+                let wrapped = dict.mapValues { AnyCodableAction($0) }
+                try container.encode(wrapped)
+            } else if let arr = self.value as? [Any] {
+                let wrapped = arr.map { AnyCodableAction($0) }
+                try container.encode(wrapped)
+            } else if let b = self.value as? Bool {
+                try container.encode(b)
+            } else if let i = self.value as? Int {
+                try container.encode(i)
+            } else if let d = self.value as? Double {
+                try container.encode(d)
             } else if let str = self.value as? String {
                 try container.encode(str)
             }
@@ -156,6 +261,8 @@ enum CardAction: Codable {
         switch actionType {
         case "Action.Submit":
             self = .submit(try SubmitAction(from: decoder))
+        case "Action.Execute":
+            self = .execute(try ExecuteAction(from: decoder))
         case "Action.OpenUrl":
             self = .openUrl(try OpenUrlAction(from: decoder))
         default:
@@ -168,6 +275,9 @@ enum CardAction: Codable {
         switch self {
         case .submit(let a):
             try container.encode("Action.Submit", forKey: .type)
+            try a.encode(to: encoder)
+        case .execute(let a):
+            try container.encode("Action.Execute", forKey: .type)
             try a.encode(to: encoder)
         case .openUrl(let a):
             try container.encode("Action.OpenUrl", forKey: .type)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardModels.swift
@@ -20,6 +20,8 @@ enum CardElement: Codable {
     case codeBlock(CodeBlock)
     case imageSet(ImageSet)
     case actionSet(ActionSet)
+    case icon(ACIcon)
+    case list(ACList)
     case unknown
 
     struct TextBlock: Codable {
@@ -107,6 +109,11 @@ enum CardElement: Codable {
         let actions: [CardAction]
     }
 
+    struct ACListItem: Codable {
+        let text: String
+        let icon: ACIcon?
+    }
+
     // Manual decoding keyed on "type"
     private enum CodingKeys: String, CodingKey {
         case type
@@ -137,6 +144,10 @@ enum CardElement: Codable {
             self = .imageSet(try ImageSet(from: decoder))
         case "ActionSet":
             self = .actionSet(try ActionSet(from: decoder))
+        case "Icon":
+            self = .icon(try ACIcon(from: decoder))
+        case "List":
+            self = .list(try ACList(from: decoder))
         default:
             self = .unknown
         }
@@ -175,10 +186,32 @@ enum CardElement: Codable {
         case .actionSet(let actSet):
             try container.encode("ActionSet", forKey: .type)
             try actSet.encode(to: encoder)
+        case .icon(let ico):
+            try container.encode("Icon", forKey: .type)
+            try ico.encode(to: encoder)
+        case .list(let lst):
+            try container.encode("List", forKey: .type)
+            try lst.encode(to: encoder)
         case .unknown:
             try container.encode("Unknown", forKey: .type)
         }
     }
+}
+
+// MARK: - Icon element (v4.1.0)
+
+struct ACIcon: Codable {
+    let name: String
+    let size: String?
+    let color: String?
+    let style: String? // "regular" or "filled"
+}
+
+// MARK: - List element (v4.1.0)
+
+struct ACList: Codable {
+    let items: [CardElement.ACListItem]
+    let style: String? // "ordered" or "unordered"
 }
 
 enum CardAction: Codable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardParser.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardParser.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct ParsedAdaptiveCard {
+    let card: AdaptiveCard
+    let fallbackText: String
+}
+
+enum AdaptiveCardParser {
+    private static let openMarker = "<!--adaptive-card-->"
+    private static let closeMarker = "<!--/adaptive-card-->"
+
+    /// Extract the first adaptive card JSON from message text, if present.
+    static func parseAdaptiveCardMarkers(from text: String) -> ParsedAdaptiveCard? {
+        guard let openRange = text.range(of: Self.openMarker),
+              let closeRange = text.range(of: Self.closeMarker, range: openRange.upperBound..<text.endIndex)
+        else {
+            return nil
+        }
+
+        let jsonSlice = text[openRange.upperBound..<closeRange.lowerBound]
+        guard let data = String(jsonSlice).data(using: .utf8) else { return nil }
+
+        let decoder = JSONDecoder()
+        guard let card = try? decoder.decode(AdaptiveCard.self, from: data) else { return nil }
+
+        let fallback = Self.stripCardMarkers(from: text)
+        return ParsedAdaptiveCard(card: card, fallbackText: fallback)
+    }
+
+    /// Remove all adaptive-card marker blocks, returning only the surrounding text.
+    static func stripCardMarkers(from text: String) -> String {
+        var result = text
+        // Remove all marker pairs (greedy inner content)
+        while let openRange = result.range(of: Self.openMarker) {
+            if let closeRange = result.range(of: Self.closeMarker, range: openRange.lowerBound..<result.endIndex) {
+                result.removeSubrange(openRange.lowerBound..<closeRange.upperBound)
+            } else {
+                // Unclosed marker; remove from open to end
+                result.removeSubrange(openRange.lowerBound..<result.endIndex)
+            }
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardParser.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardParser.swift
@@ -3,11 +3,14 @@ import Foundation
 struct ParsedAdaptiveCard {
     let card: AdaptiveCard
     let fallbackText: String
+    let templateData: Data?
 }
 
 enum AdaptiveCardParser {
     private static let openMarker = "<!--adaptive-card-->"
     private static let closeMarker = "<!--/adaptive-card-->"
+    private static let dataOpenMarker = "<!--adaptive-card-data-->"
+    private static let dataCloseMarker = "<!--/adaptive-card-data-->"
 
     /// Extract the first adaptive card JSON from message text, if present.
     static func parseAdaptiveCardMarkers(from text: String) -> ParsedAdaptiveCard? {
@@ -23,22 +26,54 @@ enum AdaptiveCardParser {
         let decoder = JSONDecoder()
         guard let card = try? decoder.decode(AdaptiveCard.self, from: data) else { return nil }
 
+        let templateData = Self.extractTemplateData(from: text)
         let fallback = Self.stripCardMarkers(from: text)
-        return ParsedAdaptiveCard(card: card, fallbackText: fallback)
+        return ParsedAdaptiveCard(card: card, fallbackText: fallback, templateData: templateData)
+    }
+
+    /// Extract template data JSON from adaptive-card-data markers, if present.
+    static func extractTemplateData(from text: String) -> Data? {
+        guard let openRange = text.range(of: Self.dataOpenMarker),
+              let closeRange = text.range(of: Self.dataCloseMarker, range: openRange.upperBound..<text.endIndex)
+        else {
+            return nil
+        }
+
+        let dataSlice = text[openRange.upperBound..<closeRange.lowerBound]
+        let trimmed = String(dataSlice).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Validate it is parseable JSON before returning
+        guard let rawData = trimmed.data(using: .utf8),
+              (try? JSONSerialization.jsonObject(with: rawData)) != nil
+        else {
+            return nil
+        }
+        return rawData
     }
 
     /// Remove all adaptive-card marker blocks, returning only the surrounding text.
     static func stripCardMarkers(from text: String) -> String {
         var result = text
-        // Remove all marker pairs (greedy inner content)
+
+        // Remove all card marker pairs
         while let openRange = result.range(of: Self.openMarker) {
             if let closeRange = result.range(of: Self.closeMarker, range: openRange.lowerBound..<result.endIndex) {
                 result.removeSubrange(openRange.lowerBound..<closeRange.upperBound)
             } else {
-                // Unclosed marker; remove from open to end
                 result.removeSubrange(openRange.lowerBound..<result.endIndex)
             }
         }
+
+        // Remove all data marker pairs
+        while let openRange = result.range(of: Self.dataOpenMarker) {
+            if let closeRange = result.range(of: Self.dataCloseMarker, range: openRange.lowerBound..<result.endIndex) {
+                result.removeSubrange(openRange.lowerBound..<closeRange.upperBound)
+            } else {
+                result.removeSubrange(openRange.lowerBound..<result.endIndex)
+            }
+        }
+
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardView.swift
@@ -39,6 +39,16 @@ struct AdaptiveCardView: View {
             self.renderContainer(c)
         case .image(let img):
             self.renderImage(img)
+        case .table(let t):
+            self.renderTable(t)
+        case .richTextBlock(let rtb):
+            self.renderRichTextBlock(rtb)
+        case .codeBlock(let cb):
+            self.renderCodeBlock(cb)
+        case .imageSet(let imgSet):
+            self.renderImageSet(imgSet)
+        case .actionSet(let actSet):
+            self.renderActions(actSet.actions)
         case .unknown:
             EmptyView()
         }
@@ -58,7 +68,7 @@ struct AdaptiveCardView: View {
 
     private func textBlockFont(_ tb: CardElement.TextBlock) -> Font {
         switch tb.size?.lowercased() {
-        case "extralarge", "extraLarge":
+        case "extralarge":
             return .title
         case "large":
             return .title2
@@ -142,6 +152,93 @@ struct AdaptiveCardView: View {
         }
     }
 
+    @ViewBuilder
+    private func renderTable(_ table: CardElement.Table) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(table.rows.indices, id: \.self) { rowIdx in
+                if let cells = table.rows[rowIdx].cells {
+                    HStack(alignment: .top, spacing: 4) {
+                        ForEach(cells.indices, id: \.self) { cellIdx in
+                            VStack(alignment: .leading, spacing: 2) {
+                                if let items = cells[cellIdx].items {
+                                    ForEach(items.indices, id: \.self) { itemIdx in
+                                        self.renderElement(items[itemIdx])
+                                    }
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(4)
+                        }
+                    }
+                    // Bold the first row as header
+                    .fontWeight(rowIdx == 0 ? .semibold : .regular)
+                    if rowIdx == 0 {
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func renderRichTextBlock(_ rtb: CardElement.RichTextBlock) -> some View {
+        // Build an attributed text from inlines
+        let combined = rtb.inlines.reduce(Text("")) { result, run in
+            var segment = Text(run.text)
+            if run.weight?.lowercased() == "bolder" {
+                segment = segment.bold()
+            }
+            if run.italic == true {
+                segment = segment.italic()
+            }
+            if run.strikethrough == true {
+                segment = segment.strikethrough()
+            }
+            if let size = run.size?.lowercased() {
+                switch size {
+                case "small":
+                    segment = segment.font(.caption)
+                case "large":
+                    segment = segment.font(.title2)
+                case "extralarge":
+                    segment = segment.font(.title)
+                default:
+                    break
+                }
+            }
+            return result + segment
+        }
+        combined
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    @ViewBuilder
+    private func renderCodeBlock(_ cb: CardElement.CodeBlock) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let lang = cb.language, !lang.isEmpty {
+                Text(lang)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(cb.codeSnippet)
+                .font(.system(.caption, design: .monospaced))
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(self.codeBlockBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+    }
+
+    @ViewBuilder
+    private func renderImageSet(_ imgSet: CardElement.ImageSet) -> some View {
+        let size = imgSet.imageSize ?? "medium"
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: self.imageMaxHeight(size)))], spacing: 6) {
+            ForEach(imgSet.images.indices, id: \.self) { i in
+                self.renderImage(imgSet.images[i])
+            }
+        }
+    }
+
     private func imageMaxHeight(_ size: String?) -> CGFloat {
         switch size?.lowercased() {
         case "small": return 60
@@ -178,14 +275,26 @@ struct AdaptiveCardView: View {
             }
         case .submit(let a):
             Button {
-                // Submit action tap (logged for debugging)
-                print("[AdaptiveCard] Action.Submit tapped: \(a.title ?? "untitled")")
+                // No-op: submit actions require server-side routing
             } label: {
                 Text(a.title ?? "Submit")
                     .font(.caption)
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .disabled(true)
+            .help("Submit actions require server-side routing and are not supported in this view.")
+        case .execute(let a):
+            Button {
+                // No-op: execute actions require server-side routing
+            } label: {
+                Text(a.title ?? "Execute")
+                    .font(.caption)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(true)
+            .help("Execute actions require server-side routing and are not supported in this view.")
         case .unknown:
             EmptyView()
         }
@@ -209,5 +318,11 @@ struct AdaptiveCardView: View {
         self.colorScheme == .dark
             ? Color.white
             : Color.black
+    }
+
+    private var codeBlockBackground: Color {
+        self.colorScheme == .dark
+            ? Color.white.opacity(0.08)
+            : Color.black.opacity(0.05)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardView.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+/// Renders a parsed Adaptive Card inline in the chat bubble.
+@MainActor
+struct AdaptiveCardView: View {
+    let card: AdaptiveCard
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(self.card.body.indices, id: \.self) { i in
+                self.renderElement(self.card.body[i])
+            }
+            if let actions = self.card.actions, !actions.isEmpty {
+                self.renderActions(actions)
+            }
+        }
+        .padding(10)
+        .background(self.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(self.borderColor, lineWidth: 0.5))
+    }
+
+    // MARK: - Element rendering
+
+    @ViewBuilder
+    private func renderElement(_ element: CardElement) -> some View {
+        switch element {
+        case .textBlock(let tb):
+            self.renderTextBlock(tb)
+        case .factSet(let fs):
+            self.renderFactSet(fs)
+        case .columnSet(let cs):
+            self.renderColumnSet(cs)
+        case .container(let c):
+            self.renderContainer(c)
+        case .image(let img):
+            self.renderImage(img)
+        case .unknown:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func renderTextBlock(_ tb: CardElement.TextBlock) -> some View {
+        if tb.separator == true {
+            Divider()
+        }
+        Text(tb.text)
+            .font(self.textBlockFont(tb))
+            .fontWeight(tb.weight?.lowercased() == "bolder" ? .bold : .regular)
+            .foregroundStyle(tb.isSubtle == true ? .secondary : .primary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func textBlockFont(_ tb: CardElement.TextBlock) -> Font {
+        switch tb.size?.lowercased() {
+        case "extralarge", "extraLarge":
+            return .title
+        case "large":
+            return .title2
+        case "medium":
+            return .body
+        case "small":
+            return .caption
+        default:
+            return .subheadline
+        }
+    }
+
+    @ViewBuilder
+    private func renderFactSet(_ fs: CardElement.FactSet) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(fs.facts.indices, id: \.self) { i in
+                HStack(alignment: .top, spacing: 8) {
+                    Text(fs.facts[i].title)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                        .frame(minWidth: 80, alignment: .leading)
+                    Text(fs.facts[i].value)
+                        .font(.caption)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func renderColumnSet(_ cs: CardElement.ColumnSet) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            ForEach(cs.columns.indices, id: \.self) { i in
+                VStack(alignment: .leading, spacing: 6) {
+                    if let items = cs.columns[i].items {
+                        ForEach(items.indices, id: \.self) { j in
+                            self.renderElement(items[j])
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func renderContainer(_ container: CardElement.Container) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(container.items.indices, id: \.self) { i in
+                self.renderElement(container.items[i])
+            }
+        }
+        .padding(container.style != nil ? 6 : 0)
+        .background(
+            container.style != nil
+                ? AnyShapeStyle(self.containerAccentColor.opacity(0.08))
+                : AnyShapeStyle(.clear))
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func renderImage(_ img: CardElement.ImageElement) -> some View {
+        if let url = URL(string: img.url) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxHeight: self.imageMaxHeight(img.size))
+                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                case .failure:
+                    Label(img.altText ?? "Image", systemImage: "photo")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                default:
+                    ProgressView()
+                        .frame(height: 40)
+                }
+            }
+        }
+    }
+
+    private func imageMaxHeight(_ size: String?) -> CGFloat {
+        switch size?.lowercased() {
+        case "small": return 60
+        case "medium": return 120
+        case "large": return 200
+        default: return 160
+        }
+    }
+
+    // MARK: - Action rendering
+
+    @ViewBuilder
+    private func renderActions(_ actions: [CardAction]) -> some View {
+        HStack(spacing: 8) {
+            ForEach(actions.indices, id: \.self) { i in
+                self.renderAction(actions[i])
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func renderAction(_ action: CardAction) -> some View {
+        switch action {
+        case .openUrl(let a):
+            if let url = URL(string: a.url) {
+                Button {
+                    self.openURL(url)
+                } label: {
+                    Text(a.title ?? "Open")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        case .submit(let a):
+            Button {
+                // Submit action tap (logged for debugging)
+                print("[AdaptiveCard] Action.Submit tapped: \(a.title ?? "untitled")")
+            } label: {
+                Text(a.title ?? "Submit")
+                    .font(.caption)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        case .unknown:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Colors
+
+    private var cardBackground: Color {
+        self.colorScheme == .dark
+            ? Color.white.opacity(0.05)
+            : Color.black.opacity(0.03)
+    }
+
+    private var borderColor: Color {
+        self.colorScheme == .dark
+            ? Color.white.opacity(0.12)
+            : Color.black.opacity(0.1)
+    }
+
+    private var containerAccentColor: Color {
+        self.colorScheme == .dark
+            ? Color.white
+            : Color.black
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/AdaptiveCardView.swift
@@ -49,6 +49,10 @@ struct AdaptiveCardView: View {
             self.renderImageSet(imgSet)
         case .actionSet(let actSet):
             self.renderActions(actSet.actions)
+        case .icon(let ico):
+            self.renderIcon(ico)
+        case .list(let lst):
+            self.renderList(lst)
         case .unknown:
             EmptyView()
         }
@@ -235,6 +239,89 @@ struct AdaptiveCardView: View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: self.imageMaxHeight(size)))], spacing: 6) {
             ForEach(imgSet.images.indices, id: \.self) { i in
                 self.renderImage(imgSet.images[i])
+            }
+        }
+    }
+
+    // MARK: - Icon rendering
+
+    @ViewBuilder
+    private func renderIcon(_ icon: ACIcon) -> some View {
+        self.iconView(icon)
+    }
+
+    /// Builds a view for an ACIcon: SF Symbol when the name matches, otherwise a text label.
+    @ViewBuilder
+    private func iconView(_ icon: ACIcon) -> some View {
+        let iconSize = self.iconFontSize(icon.size)
+        let iconColor = self.iconColor(icon.color)
+
+        // Attempt SF Symbol lookup; fall back to a text label
+        if self.sfSymbolExists(icon.name) {
+            Image(systemName: icon.name)
+                .font(.system(size: iconSize))
+                .foregroundStyle(iconColor)
+        } else {
+            Text(icon.name)
+                .font(.system(size: iconSize))
+                .foregroundStyle(iconColor)
+        }
+    }
+
+    /// Map Adaptive Card icon size tokens to point sizes.
+    private func iconFontSize(_ size: String?) -> CGFloat {
+        switch size?.lowercased() {
+        case "xxs": return 10
+        case "xs": return 12
+        case "sm", "small": return 14
+        case "md", "medium": return 18
+        case "lg", "large": return 24
+        case "xl": return 30
+        case "xxl": return 38
+        default: return 16
+        }
+    }
+
+    /// Resolve Adaptive Card color tokens to SwiftUI colors.
+    private func iconColor(_ color: String?) -> Color {
+        switch color?.lowercased() {
+        case "accent": return .accentColor
+        case "good": return .green
+        case "warning": return .orange
+        case "attention": return .red
+        case "light": return .secondary
+        case "dark": return .primary
+        default: return .primary
+        }
+    }
+
+    /// Check whether an SF Symbol name is valid at runtime.
+    private func sfSymbolExists(_ name: String) -> Bool {
+        #if canImport(UIKit)
+        return UIImage(systemName: name) != nil
+        #elseif canImport(AppKit)
+        return NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil
+        #else
+        return false
+        #endif
+    }
+
+    // MARK: - List rendering
+
+    @ViewBuilder
+    private func renderList(_ list: ACList) -> some View {
+        let ordered = list.style?.lowercased() == "ordered"
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(list.items.indices, id: \.self) { idx in
+                HStack(alignment: .top, spacing: 4) {
+                    if let icon = list.items[idx].icon {
+                        self.iconView(icon)
+                    }
+                    let prefix = ordered ? "\(idx + 1)." : "\u{2022}"
+                    Text("\(prefix) \(list.items[idx].text)")
+                        .font(.subheadline)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -619,16 +619,38 @@ private struct ChatAssistantTextBody: View {
     let includesThinking: Bool
 
     var body: some View {
-        let segments = AssistantTextParser.segments(from: self.text, includeThinking: self.includesThinking)
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(segments) { segment in
-                let font = segment.kind == .thinking ? Font.system(size: 14).italic() : Font.system(size: 14)
-                ChatMarkdownRenderer(
-                    text: segment.text,
-                    context: .assistant,
-                    variant: self.markdownVariant,
-                    font: font,
-                    textColor: OpenClawChatTheme.assistantText)
+        // Check for adaptive card markers before standard markdown rendering
+        if let parsed = AdaptiveCardParser.parseAdaptiveCardMarkers(from: self.text) {
+            VStack(alignment: .leading, spacing: 10) {
+                if !parsed.fallbackText.isEmpty {
+                    let segments = AssistantTextParser.segments(
+                        from: parsed.fallbackText, includeThinking: self.includesThinking)
+                    ForEach(segments) { segment in
+                        let font = segment.kind == .thinking
+                            ? Font.system(size: 14).italic() : Font.system(size: 14)
+                        ChatMarkdownRenderer(
+                            text: segment.text,
+                            context: .assistant,
+                            variant: self.markdownVariant,
+                            font: font,
+                            textColor: OpenClawChatTheme.assistantText)
+                    }
+                }
+                AdaptiveCardView(card: parsed.card)
+            }
+        } else {
+            let segments = AssistantTextParser.segments(from: self.text, includeThinking: self.includesThinking)
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(segments) { segment in
+                    let font = segment.kind == .thinking
+                        ? Font.system(size: 14).italic() : Font.system(size: 14)
+                    ChatMarkdownRenderer(
+                        text: segment.text,
+                        context: .assistant,
+                        variant: self.markdownVariant,
+                        font: font,
+                        textColor: OpenClawChatTheme.assistantText)
+                }
             }
         }
     }

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **Adaptive Cards** — Registers an `adaptive_card` tool that lets the agent respond with native Adaptive Cards (v1.6) across iOS, Android, Teams, and web, with schema validation, host compatibility checking, and automatic plain-text fallback for unsupported channels.
+  npm: `@vikrantsingh01/openclaw-adaptive-cards`
+  repo: `https://github.com/VikrantSingh01/openclaw-adaptive-cards`
+  install: `openclaw plugins install @vikrantsingh01/openclaw-adaptive-cards`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Summary

Adds native Adaptive Card rendering to the iOS and macOS apps. When a chat message contains `<!--adaptive-card-->` markers, the card is parsed and rendered inline in the chat bubble using SwiftUI.

Replaces closed #42306 (closed due to force push during review fixes).

### New files (in `apps/shared/OpenClawKit/Sources/OpenClawChatUI/AdaptiveCard/`)
- `AdaptiveCardModels.swift` — Codable models with recursive AnyCodableAction for complex data payloads
- `AdaptiveCardParser.swift` — marker extraction + JSON decode
- `AdaptiveCardView.swift` — SwiftUI renderer with dark/light mode, column width support, image fallback

### Modified
- `ChatMessageViews.swift` — cached `parsedCard` computed property (not in `body`), think-block filtering before card parsing

### Review feedback addressed
- Parsing cached outside SwiftUI `body` (performance)
- Action.Submit disabled with help text (no non-functional buttons)
- AnyCodableAction handles Dict/Array/String/Double/Bool/Int (no data loss)
- Column width applied (auto vs stretch)
- Font case fixed (`extralarge` not `extraLarge`)
- Image fallback label for invalid URLs
- Think-block guard (cards inside `<think>` don't leak)

macOS gets this for free (reuses `OpenClawChatView`).

### Ecosystem Context

This PR is part of the Adaptive Cards feature set powered by:

| Package | Version | Role |
|---------|---------|------|
| [adaptive-cards-mcp](https://github.com/AiCodingBattle/adaptive-cards-mcp) | v2.3.0 | Shared core — v1.6 JSON Schema validation, 7 host profiles, WCAG a11y scoring (0-100), 21 layout patterns, 924 tests |
| [openclaw-adaptive-cards](https://github.com/VikrantSingh01/openclaw-adaptive-cards) | v4.0.0 | OpenClaw plugin — `adaptive_card` tool, MCP bridge, channel-aware prompt guidance, fallback text generation, action routing |

The plugin emits `<!--adaptive-card-->` markers in tool result text. This PR adds the iOS/macOS client-side parser and SwiftUI renderer that consumes those markers.

### Element support
TextBlock, FactSet, ColumnSet, Container, Image, Action.Submit (disabled with help text), Action.OpenUrl

### Performance target
<100ms parse + render for typical cards.

### Related PRs

- #41908 — Concept documentation
- #41735 — Community plugins listing
- #41565 — Shared channel rendering strategies
- #42307 — Web UI rendering
- #42304 — Android native rendering
