### PR TITLE
fix(hooks): add missing trigger and channelId to agent_end, llm_input, and llm_output hook contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback: recognize Venice `402 Insufficient USD or Diem balance` billing errors so configured model fallbacks trigger instead of surfacing the raw provider error. (#43205) Thanks @Squabble9.
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
 - Gateway/config errors: surface up to three validation issues in top-level `config.set`, `config.patch`, and `config.apply` error messages while preserving structured issue details. (#42664) Thanks @huntharo.
+- Hooks/plugin context parity followup: pass `trigger` and `channelId` through embedded `llm_input`, `agent_end`, and `llm_output` hook contexts so plugins receive the same agent metadata across hook phases. (#42362) Thanks @zhoulf1006.
 
 ## 2026.3.8
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1774,6 +1774,8 @@ export async function runEmbeddedAttempt(
                   sessionId: params.sessionId,
                   workspaceDir: params.workspaceDir,
                   messageProvider: params.messageProvider ?? undefined,
+                  trigger: params.trigger,
+                  channelId: params.messageChannel ?? params.messageProvider ?? undefined,
                 },
               )
               .catch((err) => {
@@ -1982,6 +1984,8 @@ export async function runEmbeddedAttempt(
                 sessionId: params.sessionId,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
+                trigger: params.trigger,
+                channelId: params.messageChannel ?? params.messageProvider ?? undefined,
               },
             )
             .catch((err) => {
@@ -2042,6 +2046,8 @@ export async function runEmbeddedAttempt(
               sessionId: params.sessionId,
               workspaceDir: params.workspaceDir,
               messageProvider: params.messageProvider ?? undefined,
+              trigger: params.trigger,
+              channelId: params.messageChannel ?? params.messageProvider ?? undefined,
             },
           )
           .catch((err) => {


### PR DESCRIPTION
## Summary

- PR #28623 added `trigger` and `channelId` fields to `PluginHookAgentContext` and threaded them through `hookCtx` for `before_prompt_build`, but missed the separate context objects constructed for `agent_end`, `llm_input`, and `llm_output` hooks.
- This caused `ctx.trigger` and `ctx.channelId` to always be `undefined` in those hook handlers, breaking plugins that rely on `trigger` to distinguish user-initiated vs memory/cron/heartbeat runs.
- Aligns all three hook context objects with `hookCtx` (line ~1636) so every hook phase receives identical context fields.

## Changes

Only one file changed: `src/agents/pi-embedded-runner/run/attempt.ts`

Added `trigger: params.trigger` and `channelId: params.messageChannel ?? params.messageProvider ?? undefined` to:

| Location | Hook | 
|----------|------|
| ~line 1770 | `llm_input` |
| ~line 1980 | `agent_end` |
| ~line 2042 | `llm_output` |

These match the existing `hookCtx` at line ~1636 which already has both fields.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` (type-check) passes with no errors
- [x] `pnpm test` — all pre-existing tests pass (5 pre-existing failures in `src/memory/batch-voyage.test.ts` and `src/memory/manager.batch.test.ts` are unrelated and also fail on upstream/main)
- [x] No new test files needed — change is additive field threading with no behavioral logic change

🤖 AI-assisted