### PR TITLE
fix(outbound): reject unconfigured channels in message channel selection

### DIFF
--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -231,6 +231,21 @@ describe("resolveMessageChannelSelection", () => {
   });
 
   it("throws when explicit channel is known but not configured (#42080)", async () => {
+    // whatsapp plugin is available (loaded) but not in configured list
+    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) => ({
+      id: channel,
+    }));
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "telegram",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({}),
+          isConfigured: async () => true,
+        },
+      },
+    ]);
+
     await expect(
       resolveMessageChannelSelection({
         cfg: {} as never,
@@ -240,6 +255,9 @@ describe("resolveMessageChannelSelection", () => {
   });
 
   it("falls back to context channel when explicit channel is unconfigured (#42080)", async () => {
+    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) => ({
+      id: channel,
+    }));
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "discord",
@@ -265,6 +283,9 @@ describe("resolveMessageChannelSelection", () => {
   });
 
   it("includes configured channels hint in unconfigured channel error (#42080)", async () => {
+    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) => ({
+      id: channel,
+    }));
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "telegram",

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -102,6 +102,17 @@ describe("resolveMessageChannelSelection", () => {
   });
 
   it("keeps explicit known channels and marks source explicit", async () => {
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "telegram",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({}),
+          isConfigured: async () => true,
+        },
+      },
+    ]);
+
     const selection = await resolveMessageChannelSelection({
       cfg: {} as never,
       channel: "telegram",
@@ -109,7 +120,7 @@ describe("resolveMessageChannelSelection", () => {
 
     expect(selection).toEqual({
       channel: "telegram",
-      configured: [],
+      configured: ["telegram"],
       source: "explicit",
     });
   });
@@ -217,5 +228,59 @@ describe("resolveMessageChannelSelection", () => {
     ).rejects.toThrow(
       "Channel is required when multiple channels are configured: discord, telegram",
     );
+  });
+
+  it("throws when explicit channel is known but not configured (#42080)", async () => {
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).rejects.toThrow('Channel "whatsapp" is not configured.');
+  });
+
+  it("falls back to context channel when explicit channel is unconfigured (#42080)", async () => {
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "discord",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({}),
+          isConfigured: async () => true,
+        },
+      },
+    ]);
+
+    const selection = await resolveMessageChannelSelection({
+      cfg: {} as never,
+      channel: "whatsapp",
+      fallbackChannel: "discord",
+    });
+
+    expect(selection).toEqual({
+      channel: "discord",
+      configured: ["discord"],
+      source: "tool-context-fallback",
+    });
+  });
+
+  it("includes configured channels hint in unconfigured channel error (#42080)", async () => {
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "telegram",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({}),
+          isConfigured: async () => true,
+        },
+      },
+    ]);
+
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).rejects.toThrow('Channel "whatsapp" is not configured. Configured channels: telegram.');
   });
 });

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -132,9 +132,20 @@ export async function resolveMessageChannelSelection(params: {
       }
       throw new Error(`Channel is unavailable: ${String(normalized)}`);
     }
+    const configured = await listConfiguredMessageChannels(params.cfg);
+    if (!configured.includes(normalized as MessageChannelId)) {
+      // Channel is known but not configured — fall back to tool-context channel
+      // so agents don't fan out to providers absent from the config (#42080).
+      const fallback = resolveKnownChannel(params.fallbackChannel);
+      if (fallback && configured.includes(fallback)) {
+        return { channel: fallback, configured, source: "tool-context-fallback" };
+      }
+      const hint = configured.length > 0 ? ` Configured channels: ${configured.join(", ")}.` : "";
+      throw new Error(`Channel "${normalized}" is not configured.${hint}`);
+    }
     return {
       channel: availableExplicit,
-      configured: await listConfiguredMessageChannels(params.cfg),
+      configured,
       source: "explicit",
     };
   }

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -133,14 +133,14 @@ export async function resolveMessageChannelSelection(params: {
       throw new Error(`Channel is unavailable: ${String(normalized)}`);
     }
     const configured = await listConfiguredMessageChannels(params.cfg);
-    if (!configured.includes(normalized as MessageChannelId)) {
+    if (configured.length > 0 && !configured.includes(normalized as MessageChannelId)) {
       // Channel is known but not configured — fall back to tool-context channel
       // so agents don't fan out to providers absent from the config (#42080).
       const fallback = resolveKnownChannel(params.fallbackChannel);
       if (fallback && configured.includes(fallback)) {
         return { channel: fallback, configured, source: "tool-context-fallback" };
       }
-      const hint = configured.length > 0 ? ` Configured channels: ${configured.join(", ")}.` : "";
+      const hint = ` Configured channels: ${configured.join(", ")}.`;
       throw new Error(`Channel "${normalized}" is not configured.${hint}`);
     }
     return {


### PR DESCRIPTION
## Summary

When an agent tool call specifies a channel that is registered but not configured (e.g. `channel: "whatsapp"` with no `channels.whatsapp` block in `openclaw.json`), `resolveMessageChannelSelection` previously accepted it unconditionally — the only gate was `isKnownChannel`, which checks plugin registration, not configuration.

This caused the gateway to attempt target resolution and action dispatch against providers that have no credentials or accounts, producing confusing errors like `Unknown target "Nick" for whatsapp` and `Message action channel-list not supported for channel whatsapp`.

### Changes

- **`resolveMessageChannelSelection`**: when a channel is explicitly specified and known, verify it appears in the configured channel list before accepting it. If unconfigured, fall back to the tool-context channel (if available and configured); otherwise throw a clear error with the list of configured channels.
- Updated existing test to register a configured plugin when testing the explicit-channel path.
- Added 3 new test cases covering: unconfigured channel throws, unconfigured channel falls back to context, and error message includes configured channel hint.

Closes #42080

## Test plan

- [x] Existing `channel-selection.test.ts` tests pass (updated for new behavior)
- [x] 3 new test cases verify: throws for unconfigured channel, falls back to context channel, error includes hint
- [x] `message-action-runner.threading.test.ts` unaffected (mocks `resolveMessageChannelSelection`)
