### PR TITLE
fix(plugins): stop reinitializing hook runner on cached registry reuse

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -449,6 +449,35 @@ describe("loadOpenClawPlugins", () => {
     resetGlobalHookRunner();
   });
 
+  it("reuses the existing global hook runner when serving the same cached registry", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const plugin = writePlugin({
+      id: "cache-hook-runner-stable",
+      filename: "cache-hook-runner-stable.cjs",
+      body: `module.exports = { id: "cache-hook-runner-stable", register() {} };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["cache-hook-runner-stable"],
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins(options);
+    const firstRunner = getGlobalHookRunner();
+    expect(firstRunner).not.toBeNull();
+
+    const second = loadOpenClawPlugins(options);
+    expect(second).toBe(first);
+    expect(getGlobalHookRunner()).toBe(firstRunner);
+
+    resetGlobalHookRunner();
+  });
+
   it("loads plugins when source and root differ only by realpath alias", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -17,7 +17,11 @@ import {
   type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
-import { initializeGlobalHookRunner } from "./hook-runner-global.js";
+import {
+  getGlobalHookRunner,
+  getGlobalPluginRegistry,
+  initializeGlobalHookRunner,
+} from "./hook-runner-global.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
@@ -441,6 +445,9 @@ function warnAboutUntrackedLoadedPlugins(params: {
 
 function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): void {
   setActivePluginRegistry(registry, cacheKey);
+  if (getGlobalPluginRegistry() === registry && getGlobalHookRunner()) {
+    return;
+  }
   initializeGlobalHookRunner(registry);
 }
 


### PR DESCRIPTION
## Summary
- reuse the existing global hook runner when the active cached plugin registry is already installed
- still reinitialize from cache when the hook runner was explicitly reset or is missing
- add regression coverage for repeated cached loads

## Testing
- `npx vitest run src/plugins/loader.test.ts`

Closes #42146.
