### PR TITLE
Plugins: avoid redundant hook runner re-init on cache hits

### DIFF
--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -20,6 +20,10 @@ let globalRegistry: PluginRegistry | null = null;
  * Called once when plugins are loaded during gateway startup.
  */
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
+  if (globalRegistry === registry && globalHookRunner) {
+    return;
+  }
+
   globalRegistry = registry;
   globalHookRunner = createHookRunner(registry, {
     logger: {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -424,6 +424,35 @@ describe("loadOpenClawPlugins", () => {
     resetGlobalHookRunner();
   });
 
+  it("does not re-initialize global hook runner on cache hit when already initialized", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const plugin = writePlugin({
+      id: "cache-hook-runner-stable",
+      filename: "cache-hook-runner-stable.cjs",
+      body: `module.exports = { id: "cache-hook-runner-stable", register() {} };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["cache-hook-runner-stable"],
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins(options);
+    const firstRunner = getGlobalHookRunner();
+    expect(firstRunner).not.toBeNull();
+
+    const second = loadOpenClawPlugins(options);
+    expect(second).toBe(first);
+    expect(getGlobalHookRunner()).toBe(firstRunner);
+
+    resetGlobalHookRunner();
+  });
+
   it("loads plugins when source and root differ only by realpath alias", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({


### PR DESCRIPTION
## Summary
- make `initializeGlobalHookRunner` idempotent when the same plugin registry is already active
- prevent cached plugin-registry lookups from recreating the global hook runner and re-emitting initialization logs
- add a regression test to verify cache hits keep the same global hook runner instance when already initialized

## Validation
- `pnpm test src/plugins/loader.test.ts` (pass: 1 file, 44 tests)

Closes #42146
