### PR TITLE
Gateway: add trustedProxy.loopbackUser for loopback auth

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -134,6 +134,11 @@ export type GatewayTrustedProxyConfig = {
    */
   userHeader: string;
   /**
+   * Optional fallback user identity for direct loopback requests when
+   * userHeader is missing (for example local CLI/sub-agent traffic).
+   */
+  loopbackUser?: string;
+  /**
    * Additional headers that MUST be present for the request to be trusted.
    * Use this to verify the request actually came through the proxy.
    * Example: ["x-forwarded-proto", "x-forwarded-host"]

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -668,6 +668,10 @@ export const OpenClawSchema = z
             trustedProxy: z
               .object({
                 userHeader: z.string().min(1, "userHeader is required for trusted-proxy mode"),
+                loopbackUser: z
+                  .string()
+                  .min(1, "loopbackUser cannot be empty when provided")
+                  .optional(),
                 requiredHeaders: z.array(z.string()).optional(),
                 allowUsers: z.array(z.string()).optional(),
               })

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -532,6 +532,62 @@ describe("trusted-proxy auth", () => {
     expect(res.reason).toBe("trusted_proxy_user_missing");
   });
 
+  it("accepts loopbackUser when user header is missing on loopback", async () => {
+    const res = await authorizeTrustedProxy({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+          loopbackUser: "local@example.com",
+        },
+      },
+      trustedProxies: ["127.0.0.1"],
+      remoteAddress: "127.0.0.1",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("trusted-proxy");
+    expect(res.user).toBe("local@example.com");
+  });
+
+  it("rejects missing user header from non-loopback even when loopbackUser is set", async () => {
+    const res = await authorizeTrustedProxy({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+          loopbackUser: "local@example.com",
+        },
+      },
+      trustedProxies: ["10.0.0.1"],
+      remoteAddress: "10.0.0.1",
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_user_missing");
+  });
+
+  it("applies allowUsers to loopbackUser fallback", async () => {
+    const res = await authorizeTrustedProxy({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+          loopbackUser: "local@example.com",
+          allowUsers: ["admin@example.com"],
+        },
+      },
+      trustedProxies: ["::1"],
+      remoteAddress: "::1",
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_user_not_allowed");
+  });
+
   it("rejects request with missing required headers", async () => {
     const res = await authorizeTrustedProxy({
       headers: {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -357,11 +357,17 @@ function authorizeTrustedProxy(params: {
   }
 
   const userHeaderValue = headerValue(req.headers[trustedProxyConfig.userHeader.toLowerCase()]);
-  if (!userHeaderValue || userHeaderValue.trim() === "") {
+  const userFromHeader = userHeaderValue?.trim();
+  const loopbackUser = trustedProxyConfig.loopbackUser?.trim();
+  const user =
+    userFromHeader && userFromHeader.length > 0
+      ? userFromHeader
+      : isLoopbackAddress(remoteAddr) && loopbackUser && loopbackUser.length > 0
+        ? loopbackUser
+        : undefined;
+  if (!user) {
     return { reason: "trusted_proxy_user_missing" };
   }
-
-  const user = userHeaderValue.trim();
 
   const allowUsers = trustedProxyConfig.allowUsers ?? [];
   if (allowUsers.length > 0 && !allowUsers.includes(user)) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In `gateway.auth.mode: trusted-proxy`, loopback CLI/sub-agent requests are rejected when they cannot provide the configured `userHeader`.
- Why it matters: Local CLI/sub-agent flows (including spawn/session workflows) break even when the gateway is running locally behind a reverse proxy.
- What changed: Added optional `gateway.auth.trustedProxy.loopbackUser` and used it as a fallback identity only when the request is from a trusted loopback address and `userHeader` is missing.
- What did NOT change (scope boundary): No fallback for non-loopback sources; token/password auth flows and trusted-proxy allowlist semantics remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26007
- Related #

## User-visible / Behavior Changes

- New optional config: `gateway.auth.trustedProxy.loopbackUser`.
- In `trusted-proxy` mode, if a request comes from a trusted loopback IP (`127.0.0.1`/`::1`) and `userHeader` is missing, gateway now authenticates as `loopbackUser`.
- `allowUsers` still applies to the resolved identity (including `loopbackUser`).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway auth
- Relevant config (redacted): `gateway.auth.mode=trusted-proxy`, `gateway.trustedProxies` includes loopback

### Steps

1. Configure `gateway.auth.mode: "trusted-proxy"` and `gateway.auth.trustedProxy.userHeader`.
2. Send a local loopback request without the user header.
3. Set `gateway.auth.trustedProxy.loopbackUser` and retry.

### Expected

- Step 2: rejected (`trusted_proxy_user_missing`).
- Step 3: accepted as `loopbackUser` when source is trusted loopback.

### Actual

- Matches expected; covered by new tests.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test command and result:

- `pnpm test src/gateway/auth.test.ts src/config/schema.test.ts` → passed (`2` files, `62` tests)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: loopback fallback success, non-loopback still rejected without header, allowlist enforced on loopback fallback.
- Edge cases checked: IPv4 loopback and IPv6 loopback paths in tests.
- What you did **not** verify: full end-to-end gateway runtime with live reverse proxy.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `gateway.auth.trustedProxy.loopbackUser` (or revert this commit).
- Files/config to restore: gateway auth config (`gateway.auth.trustedProxy`).
- Known bad symptoms reviewers should watch for: unexpected loopback auth acceptance if `loopbackUser` is set intentionally.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Operator misconfiguration of `loopbackUser` identity string.
  - Mitigation: Fallback is restricted to trusted loopback sources; `allowUsers` still gates access.
