### PR TITLE
fix(exec): route notifyOnExit through exec-event and add heartbeat completion tracing

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -218,12 +218,12 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     return;
   }
   const summary = output
-    ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
-    : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
-  enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow(
-    scopedHeartbeatWakeOptions(sessionKey, { reason: `exec:${session.id}:exit` }),
-  );
+    ? `exec finished: ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
+    : `exec finished: ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
+  emitExecSystemEvent(summary, {
+    sessionKey,
+    contextKey: `exec:${session.id}:exit`,
+  });
 }
 
 export function createApprovalSlug(id: string) {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -37,7 +37,7 @@ const PROCESS_STATUS_COMPLETED = "completed";
 const PROCESS_STATUS_FAILED = "failed";
 const OUTPUT_DONE = "done";
 const OUTPUT_NOPE = "nope";
-const OUTPUT_EXEC_COMPLETED = "Exec completed";
+const OUTPUT_EXEC_COMPLETED = "exec finished: completed";
 const OUTPUT_EXIT_CODE_1 = "Command exited with code 1";
 const shellEcho = (message: string) => (isWin ? `Write-Output ${message}` : `echo ${message}`);
 const COMMAND_ECHO_HELLO = shellEcho("hello");
@@ -540,12 +540,12 @@ describe("exec notifyOnExit", () => {
       wakeHandler as unknown as Parameters<typeof setHeartbeatWakeHandler>[0],
     );
     try {
-      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify"));
+      await startBackgroundCommand(tool, echoAfterDelay("notify"));
 
       await expect
         .poll(() => wakeHandler.mock.calls[0]?.[0], NOTIFY_POLL_OPTIONS)
         .toMatchObject({
-          reason: `exec:${sessionId}:exit`,
+          reason: "exec-event",
           sessionKey: DEFAULT_NOTIFY_SESSION_KEY,
         });
     } finally {
@@ -560,12 +560,12 @@ describe("exec notifyOnExit", () => {
       wakeHandler as unknown as Parameters<typeof setHeartbeatWakeHandler>[0],
     );
     try {
-      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify"));
+      await startBackgroundCommand(tool, echoAfterDelay("notify"));
 
       await expect
         .poll(() => wakeHandler.mock.calls[0]?.[0], NOTIFY_POLL_OPTIONS)
         .toEqual({
-          reason: `exec:${sessionId}:exit`,
+          reason: "exec-event",
         });
     } finally {
       dispose();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Async `exec` completion notification path was not using the canonical exec-event wake flow.
- Completion event text/wake reason shape made exec-completion handling less consistent.
- Why it matters:
- Long-running task completion handoff could be unreliable, causing “started but no final completion notification” behavior in some flows.
- What changed:
- In `notifyOnExit`, route completion through `emitExecSystemEvent(...)` unified path.
- Normalize completion event text to `exec finished: ...` so exec-completion filters can reliably detect it.
- Normalize wake reason to canonical `exec-event` (instead of dynamic `exec:<id>:exit`) for consistent heartbeat reason handling.
- Update tests in `bash-tools.test.ts` to match new completion text + wake reason.
- What did NOT change (scope boundary):
- No new tool capabilities.
- No auth/token logic changes.
- No API contract changes.
- No new logging/tracing behavior included in this final cleaned PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

- Improves reliability of async completion handoff for background `exec` tasks.
- No UI changes.
- Note: deployment config may need `agents.defaults.heartbeat.target = "last"` to relay async completion back to current chat.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
- N/A

## Repro + Verification

### Environment

- OS: Ubuntu (WSL2)
- Runtime/container: OpenClaw source runtime (Node.js)
- Model/provider: `openai/gpt-5.3-codex`
- Integration/channel (if any): Feishu DM
- Relevant config (redacted):
- `agents.defaults.heartbeat.target = "last"`

### Steps

1. Start gateway from source branch.
2. Trigger background `exec` flow (e.g., clone repo via chat task).
3. Verify completion is handed off and user receives completion message.

### Expected

- Start acknowledgement is sent.
- Completion path is recognized as exec-event and completion message is relayed.

### Actual

- After fix: completion relay works in repeated real runs.

## Evidence

Attach at least one:

- [x] Failing behavior before + passing after (real run logs)
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Multiple real clone tasks from chat completed with final completion messages.
- Completion wake path behaved consistently with canonical exec-event.
- Edge cases checked:
- notifyOnExit success path and test expectation alignment.
- What you did **not** verify:
- Non-Feishu channels end-to-end.
- Multi-account routing permutations beyond current environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`Yes`)
- If yes, exact upgrade steps:
1. Deploy this code change.
2. Ensure config has `agents.defaults.heartbeat.target = "last"` if async completion should return to current chat.
3. Restart gateway.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Revert this commit and restart gateway.
- Files/config to restore:
- `src/agents/bash-tools.exec-runtime.ts`
- `src/agents/bash-tools.test.ts`
- (optional runtime config) `agents.defaults.heartbeat.target`
- Known bad symptoms reviewers should watch for:
- Background exec finishes but no completion relay to user.
- Completion path falls back to non-canonical reason and is skipped.

## Risks and Mitigations

- Risk:
- Behavior relies on heartbeat delivery target config in deployment.
- Mitigation:
- Explicitly document and set `agents.defaults.heartbeat.target = "last"` in runtime config.