### PR TITLE
fix(sessions_spawn): inherit target agent workspace instead of requester workspace

### DIFF
--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -60,16 +60,20 @@ export function resolveSpawnedWorkspaceInheritance(params: {
   config: OpenClawConfig;
   requesterSessionKey?: string;
   explicitWorkspaceDir?: string | null;
+  targetAgentId?: string;
 }): string | undefined {
   const explicit = normalizeOptionalText(params.explicitWorkspaceDir);
   if (explicit) {
     return explicit;
   }
-  const requesterAgentId = params.requesterSessionKey
-    ? parseAgentSessionKey(params.requesterSessionKey)?.agentId
-    : undefined;
-  return requesterAgentId
-    ? resolveAgentWorkspaceDir(params.config, normalizeAgentId(requesterAgentId))
+  // Prefer targetAgentId (target agent), fall back to requesterAgentId (caller) if not provided
+  const agentId = params.targetAgentId || (
+    params.requesterSessionKey
+      ? parseAgentSessionKey(params.requesterSessionKey)?.agentId
+      : undefined
+  );
+  return agentId
+    ? resolveAgentWorkspaceDir(params.config, normalizeAgentId(agentId))
     : undefined;
 }
 

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -550,6 +550,7 @@ export async function spawnSubagentDirect(
       config: cfg,
       requesterSessionKey: requesterInternalKey,
       explicitWorkspaceDir: toolSpawnMetadata.workspaceDir,
+      targetAgentId,
     }),
   });
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the `sessions_spawn` tool where spawned subagents incorrectly inherited the **caller's** workspace directory instead of their **own** agent workspace directory.

### The Problem

When `main` agent spawns a `browser` agent subagent, the subagent was using `/root/.openclaw/workspace` (main's workspace) instead of `/root/.openclaw/workspace-browser` (browser's workspace).

### Root Cause

The `resolveSpawnedWorkspaceInheritance()` function in `src/agents/spawned-context.ts` was using `requesterSessionKey` to determine the workspace directory, which resolves to the **caller's** agent ID, not the **target** agent ID.

### The Fix

1. Added `targetAgentId` parameter to `resolveSpawnedWorkspaceInheritance()` function
2. Priority logic: Use `targetAgentId` if provided, otherwise fall back to `requesterAgentId`
3. Updated call site in `spawnSubagentDirect()` to pass the `targetAgentId`

### Files Changed

- `src/agents/spawned-context.ts` - Add targetAgentId parameter
- `src/agents/subagent-spawn.ts` - Pass targetAgentId when calling resolveSpawnedWorkspaceInheritance

### Backward Compatibility

This change is fully backward compatible. If `targetAgentId` is not provided, the function falls back to the original behavior.