### PR TITLE
fix(irc): default inbound replies to final-only delivery

### DIFF
--- a/extensions/irc/src/inbound.policy.test.ts
+++ b/extensions/irc/src/inbound.policy.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it } from "vitest";
 import { __testing } from "./inbound.js";
 
 describe("irc inbound policy", () => {
+  it("disables block streaming by default to preserve full final replies", () => {
+    expect(
+      __testing.resolveIrcDisableBlockStreaming({
+        config: {},
+      } as never),
+    ).toBe(true);
+  });
+
+  it("allows explicitly enabled IRC block streaming", () => {
+    expect(
+      __testing.resolveIrcDisableBlockStreaming({
+        config: { blockStreaming: true },
+      } as never),
+    ).toBe(false);
+  });
+
   it("keeps DM allowlist merged with pairing-store entries", () => {
     const resolved = __testing.resolveIrcEffectiveAllowlists({
       configAllowFrom: ["owner"],

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -80,6 +80,10 @@ async function deliverIrcReply(params: {
   params.statusSink?.({ lastOutboundAt: Date.now() });
 }
 
+function resolveIrcDisableBlockStreaming(account: ResolvedIrcAccount): boolean {
+  return account.config.blockStreaming === true ? false : true;
+}
+
 export async function handleIrcInbound(params: {
   message: IrcInboundMessage;
   account: ResolvedIrcAccount;
@@ -354,14 +358,12 @@ export async function handleIrcInbound(params: {
     },
     replyOptions: {
       skillFilter: groupMatch.groupConfig?.skills,
-      disableBlockStreaming:
-        typeof account.config.blockStreaming === "boolean"
-          ? !account.config.blockStreaming
-          : undefined,
+      disableBlockStreaming: resolveIrcDisableBlockStreaming(account),
     },
   });
 }
 
 export const __testing = {
   resolveIrcEffectiveAllowlists,
+  resolveIrcDisableBlockStreaming,
 };


### PR DESCRIPTION
## Summary
- default IRC inbound replies to `disableBlockStreaming: true` unless the IRC account explicitly opts into `blockStreaming: true`
- keep the override helper covered with focused IRC regression tests

## Testing
- corepack pnpm exec vitest run extensions/irc/src/inbound.policy.test.ts extensions/irc/src/send.test.ts extensions/irc/src/monitor.test.ts

Closes #42121.
