### PR TITLE
fix(hooks): load workspace hooks for non-default agents

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -9,6 +9,7 @@ import {
 } from "../agents/model-selection.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
 import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
+import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -18,7 +19,7 @@ import {
   createInternalHookEvent,
   triggerInternalHook,
 } from "../hooks/internal-hooks.js";
-import { loadInternalHooks } from "../hooks/loader.js";
+import { loadInternalHooksForStartup } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
@@ -112,7 +113,11 @@ export async function startGatewaySidecars(params: {
   try {
     // Clear any previously registered hooks to ensure fresh loading
     clearInternalHooks();
-    const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
+    const loadedCount = await loadInternalHooksForStartup(
+      params.cfg,
+      params.defaultWorkspaceDir,
+      listAgentWorkspaceDirs(params.cfg),
+    );
     if (loadedCount > 0) {
       params.logHooks.info(
         `loaded ${loadedCount} internal hook handler${loadedCount > 1 ? "s" : ""}`,

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -56,9 +56,11 @@ describe("loader", () => {
   function createMultiAgentHooksConfig(params: {
     mainWorkspace: string;
     opsWorkspace: string;
+    defaultAgentId?: "main" | "ops";
     extraDirs?: string[];
     handlers?: Array<{ event: string; module: string; export?: string }>;
   }): OpenClawConfig {
+    const defaultAgentId = params.defaultAgentId ?? "main";
     return {
       hooks: {
         internal: {
@@ -71,8 +73,8 @@ describe("loader", () => {
       },
       agents: {
         list: [
-          { id: "main", default: true, workspace: params.mainWorkspace },
-          { id: "ops", workspace: params.opsWorkspace },
+          { id: "main", default: defaultAgentId === "main", workspace: params.mainWorkspace },
+          { id: "ops", default: defaultAgentId === "ops", workspace: params.opsWorkspace },
         ],
       },
     };
@@ -628,6 +630,44 @@ describe("loader", () => {
       const opsEvent = createInternalHookEvent("command", "new", "agent:ops:chat");
       await triggerInternalHook(opsEvent);
       expect(opsEvent.messages).toEqual(["shared"]);
+    });
+
+    it("uses the configured default agent workspace for legacy session keys without agent context", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "main-local",
+        events: ["command:new"],
+        message: "main-local",
+      });
+      await writeHook({
+        hooksRoot: path.join(opsWorkspace, "hooks"),
+        hookName: "ops-local",
+        events: ["command:new"],
+        message: "ops-local",
+      });
+
+      const cfg = createMultiAgentHooksConfig({
+        mainWorkspace,
+        opsWorkspace,
+        defaultAgentId: "ops",
+      });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        opsWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir: path.join(tmpDir, "managed-empty"),
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const event = createInternalHookEvent("command", "new", "legacy-chat");
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual(["ops-local"]);
     });
 
     it("runs shared startup hooks once and workspace startup hooks once per workspace", async () => {

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -98,6 +98,7 @@ describe("loader", () => {
     message: string;
     dirName?: string;
     handlerCode?: string;
+    openClawMetadata?: Record<string, unknown>;
   }): Promise<string> {
     const hookDir = path.join(params.hooksRoot, params.dirName ?? params.hookName);
     await fs.mkdir(hookDir, { recursive: true });
@@ -107,7 +108,12 @@ describe("loader", () => {
         "---",
         `name: ${params.hookName}`,
         `description: ${params.hookName} test hook`,
-        `metadata: ${JSON.stringify({ openclaw: { events: params.events } })}`,
+        `metadata: ${JSON.stringify({
+          openclaw: {
+            events: params.events,
+            ...params.openClawMetadata,
+          },
+        })}`,
         "---",
         "",
         `# ${params.hookName}`,
@@ -630,6 +636,46 @@ describe("loader", () => {
       const opsEvent = createInternalHookEvent("command", "new", "agent:ops:chat");
       await triggerInternalHook(opsEvent);
       expect(opsEvent.messages).toEqual(["shared"]);
+    });
+
+    it("does not suppress shared hooks when the matching workspace-local hook is ineligible", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "override-me",
+        events: ["command:new"],
+        message: "shared",
+      });
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "override-me",
+        events: ["command:new"],
+        message: "main-local",
+        openClawMetadata: {
+          requires: {
+            bins: ["__missing_openclaw_test_bin__"],
+          },
+        },
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(1);
+
+      const event = createInternalHookEvent("command", "new", "agent:main:chat");
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual(["shared"]);
     });
 
     it("uses the configured default agent workspace for legacy session keys without agent context", async () => {

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -1,7 +1,8 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { captureEnv } from "../test-utils/env.js";
 import {
@@ -121,6 +122,7 @@ describe("loader", () => {
   }
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     clearInternalHooks();
     envSnapshot.restore();
   });
@@ -495,6 +497,100 @@ describe("loader", () => {
       expect(event.messages).toEqual(["extra", "bundled", "managed", "legacy"]);
     });
 
+    it("continues loading workspace-local hooks when shared hook discovery fails", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "main-local",
+        events: ["command:new"],
+        message: "main-local",
+      });
+      await writeHook({
+        hooksRoot: path.join(opsWorkspace, "hooks"),
+        hookName: "ops-local",
+        events: ["command:new"],
+        message: "ops-local",
+      });
+
+      const originalReaddirSync = fsSync.readdirSync.bind(fsSync);
+      vi.spyOn(fsSync, "readdirSync").mockImplementation(((dir, options) => {
+        if (dir === managedHooksDir) {
+          throw new Error("managed-hooks exploded");
+        }
+        return originalReaddirSync(dir, options as never);
+      }) as typeof fsSync.readdirSync);
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const mainEvent = createInternalHookEvent("command", "new", "agent:main:chat");
+      await triggerInternalHook(mainEvent);
+      expect(mainEvent.messages).toEqual(["main-local"]);
+
+      const opsEvent = createInternalHookEvent("command", "new", "agent:ops:chat");
+      await triggerInternalHook(opsEvent);
+      expect(opsEvent.messages).toEqual(["ops-local"]);
+    });
+
+    it("continues loading other workspaces when one workspace hook discovery fails", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const mainHooksDir = path.join(mainWorkspace, "hooks");
+      await writeHook({
+        hooksRoot: mainHooksDir,
+        hookName: "main-local",
+        events: ["command:new"],
+        message: "main-local",
+      });
+      await writeHook({
+        hooksRoot: path.join(opsWorkspace, "hooks"),
+        hookName: "ops-local",
+        events: ["command:new"],
+        message: "ops-local",
+      });
+
+      const originalReaddirSync = fsSync.readdirSync.bind(fsSync);
+      vi.spyOn(fsSync, "readdirSync").mockImplementation(((dir, options) => {
+        if (dir === mainHooksDir) {
+          throw new Error("main workspace exploded");
+        }
+        return originalReaddirSync(dir, options as never);
+      }) as typeof fsSync.readdirSync);
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir: path.join(tmpDir, "managed-empty"),
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(1);
+
+      const mainEvent = createInternalHookEvent("command", "new", "agent:main:chat");
+      await triggerInternalHook(mainEvent);
+      expect(mainEvent.messages).toEqual([]);
+
+      const opsEvent = createInternalHookEvent("command", "new", "agent:ops:chat");
+      await triggerInternalHook(opsEvent);
+      expect(opsEvent.messages).toEqual(["ops-local"]);
+    });
+
     it("suppresses shared hooks when a matching workspace-local hook exists", async () => {
       const mainWorkspace = path.join(tmpDir, "workspace-main");
       const opsWorkspace = path.join(tmpDir, "workspace-ops");
@@ -580,6 +676,46 @@ describe("loader", () => {
       });
       await triggerInternalHook(event);
       expect(event.messages).toEqual(["shared-startup", mainWorkspace, opsWorkspace]);
+    });
+
+    it("suppresses shared startup hooks when a matching workspace-local startup hook exists", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "override-me",
+        events: ["gateway:startup"],
+        message: "shared-startup",
+      });
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "override-me",
+        events: ["gateway:startup"],
+        message: "main-startup",
+        handlerCode:
+          "export default async function(event) { event.messages.push(String(event.context.workspaceDir)); }\n",
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg,
+        workspaceDir: mainWorkspace,
+      });
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual([mainWorkspace]);
     });
   });
 });

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -758,6 +758,46 @@ describe("loader", () => {
       expect(event.messages).toEqual([mainWorkspace]);
     });
 
+    it("suppresses shared startup hooks when a non-default workspace provides the startup override", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "override-me",
+        events: ["gateway:startup"],
+        message: "shared-startup",
+      });
+      await writeHook({
+        hooksRoot: path.join(opsWorkspace, "hooks"),
+        hookName: "override-me",
+        events: ["gateway:startup"],
+        message: "ops-startup",
+        handlerCode:
+          "export default async function(event) { event.messages.push(String(event.context.workspaceDir)); }\n",
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg,
+        workspaceDir: mainWorkspace,
+      });
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual([opsWorkspace]);
+    });
+
     it("does not suppress shared startup hooks when the matching workspace-local hook does not subscribe to startup", async () => {
       const mainWorkspace = path.join(tmpDir, "workspace-main");
       const opsWorkspace = path.join(tmpDir, "workspace-ops");

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -757,5 +757,43 @@ describe("loader", () => {
       await triggerInternalHook(event);
       expect(event.messages).toEqual([mainWorkspace]);
     });
+
+    it("does not suppress shared startup hooks when the matching workspace-local hook does not subscribe to startup", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "override-me",
+        events: ["gateway:startup"],
+        message: "shared-startup",
+      });
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "override-me",
+        events: ["command:new"],
+        message: "main-command",
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg,
+        workspaceDir: mainWorkspace,
+      });
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual(["shared-startup"]);
+    });
   });
 });

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -10,7 +10,7 @@ import {
   triggerInternalHook,
   createInternalHookEvent,
 } from "./internal-hooks.js";
-import { loadInternalHooks } from "./loader.js";
+import { loadInternalHooks, loadInternalHooksForStartup } from "./loader.js";
 
 describe("loader", () => {
   let fixtureRoot = "";
@@ -50,6 +50,74 @@ describe("loader", () => {
         internal: handlers ? { enabled: true, handlers } : { enabled: true },
       },
     };
+  }
+
+  function createMultiAgentHooksConfig(params: {
+    mainWorkspace: string;
+    opsWorkspace: string;
+    extraDirs?: string[];
+    handlers?: Array<{ event: string; module: string; export?: string }>;
+  }): OpenClawConfig {
+    return {
+      hooks: {
+        internal: {
+          enabled: true,
+          ...(params.extraDirs && params.extraDirs.length > 0
+            ? { load: { extraDirs: params.extraDirs } }
+            : {}),
+          ...(params.handlers ? { handlers: params.handlers } : {}),
+        },
+      },
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: params.mainWorkspace },
+          { id: "ops", workspace: params.opsWorkspace },
+        ],
+      },
+    };
+  }
+
+  async function writeHandlerModuleInDir(
+    dir: string,
+    fileName: string,
+    code = "export default async function() {}",
+  ): Promise<string> {
+    await fs.mkdir(dir, { recursive: true });
+    const handlerPath = path.join(dir, fileName);
+    await fs.writeFile(handlerPath, code, "utf-8");
+    return handlerPath;
+  }
+
+  async function writeHook(params: {
+    hooksRoot: string;
+    hookName: string;
+    events: string[];
+    message: string;
+    dirName?: string;
+    handlerCode?: string;
+  }): Promise<string> {
+    const hookDir = path.join(params.hooksRoot, params.dirName ?? params.hookName);
+    await fs.mkdir(hookDir, { recursive: true });
+    await fs.writeFile(
+      path.join(hookDir, "HOOK.md"),
+      [
+        "---",
+        `name: ${params.hookName}`,
+        `description: ${params.hookName} test hook`,
+        `metadata: ${JSON.stringify({ openclaw: { events: params.events } })}`,
+        "---",
+        "",
+        `# ${params.hookName}`,
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(hookDir, "handler.js"),
+      params.handlerCode ??
+        `export default async function(event) { event.messages.push(${JSON.stringify(params.message)}); }\n`,
+      "utf-8",
+    );
+    return hookDir;
   }
 
   afterEach(async () => {
@@ -335,6 +403,183 @@ describe("loader", () => {
       }
 
       await expectNoCommandHookRegistration(createLegacyHandlerConfig());
+    });
+  });
+
+  describe("loadInternalHooksForStartup", () => {
+    it("loads workspace hooks for all configured workspaces and scopes them by session", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "main-local",
+        events: ["command:new"],
+        message: "main-local",
+      });
+      await writeHook({
+        hooksRoot: path.join(opsWorkspace, "hooks"),
+        hookName: "ops-local",
+        events: ["command:new"],
+        message: "ops-local",
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir: path.join(tmpDir, "managed-empty"),
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const mainEvent = createInternalHookEvent("command", "new", "agent:main:chat");
+      await triggerInternalHook(mainEvent);
+      expect(mainEvent.messages).toEqual(["main-local"]);
+
+      const opsEvent = createInternalHookEvent("command", "new", "agent:ops:chat");
+      await triggerInternalHook(opsEvent);
+      expect(opsEvent.messages).toEqual(["ops-local"]);
+    });
+
+    it("loads shared hooks only once across multiple workspaces", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const extraHooksDir = path.join(tmpDir, "extra-hooks");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      const bundledHooksDir = path.join(tmpDir, "bundled-hooks");
+      await writeHook({
+        hooksRoot: extraHooksDir,
+        hookName: "extra-shared",
+        events: ["command:new"],
+        message: "extra",
+      });
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "managed-shared",
+        events: ["command:new"],
+        message: "managed",
+      });
+      await writeHook({
+        hooksRoot: bundledHooksDir,
+        hookName: "bundled-shared",
+        events: ["command:new"],
+        message: "bundled",
+      });
+      await writeHandlerModuleInDir(
+        mainWorkspace,
+        "legacy-handler.js",
+        "export default async function(event) { event.messages.push('legacy'); }\n",
+      );
+
+      const cfg = createMultiAgentHooksConfig({
+        mainWorkspace,
+        opsWorkspace,
+        extraDirs: [extraHooksDir],
+        handlers: [{ event: "command:new", module: "legacy-handler.js" }],
+      });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        { managedHooksDir, bundledHooksDir },
+      );
+
+      expect(count).toBe(4);
+
+      const event = createInternalHookEvent("command", "new", "agent:ops:chat");
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual(["extra", "bundled", "managed", "legacy"]);
+    });
+
+    it("suppresses shared hooks when a matching workspace-local hook exists", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "override-me",
+        events: ["command:new"],
+        message: "shared",
+      });
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "override-me",
+        events: ["command:new"],
+        message: "main-local",
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const mainEvent = createInternalHookEvent("command", "new", "agent:main:chat");
+      await triggerInternalHook(mainEvent);
+      expect(mainEvent.messages).toEqual(["main-local"]);
+
+      const opsEvent = createInternalHookEvent("command", "new", "agent:ops:chat");
+      await triggerInternalHook(opsEvent);
+      expect(opsEvent.messages).toEqual(["shared"]);
+    });
+
+    it("runs shared startup hooks once and workspace startup hooks once per workspace", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "shared-startup",
+        events: ["gateway:startup"],
+        message: "shared-startup",
+      });
+      await writeHook({
+        hooksRoot: path.join(mainWorkspace, "hooks"),
+        hookName: "main-startup",
+        events: ["gateway:startup"],
+        message: "main-startup",
+        handlerCode:
+          "export default async function(event) { event.messages.push(String(event.context.workspaceDir)); }\n",
+      });
+      await writeHook({
+        hooksRoot: path.join(opsWorkspace, "hooks"),
+        hookName: "ops-startup",
+        events: ["gateway:startup"],
+        message: "ops-startup",
+        handlerCode:
+          "export default async function(event) { event.messages.push(String(event.context.workspaceDir)); }\n",
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(3);
+
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg,
+        workspaceDir: mainWorkspace,
+      });
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual(["shared-startup", mainWorkspace, opsWorkspace]);
     });
   });
 });

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -798,6 +798,46 @@ describe("loader", () => {
       expect(event.messages).toEqual([opsWorkspace]);
     });
 
+    it("suppresses shared startup hooks when a non-default workspace provides a generic gateway override", async () => {
+      const mainWorkspace = path.join(tmpDir, "workspace-main");
+      const opsWorkspace = path.join(tmpDir, "workspace-ops");
+      const managedHooksDir = path.join(tmpDir, "managed-hooks");
+      await writeHook({
+        hooksRoot: managedHooksDir,
+        hookName: "override-me",
+        events: ["gateway:startup"],
+        message: "shared-startup",
+      });
+      await writeHook({
+        hooksRoot: path.join(opsWorkspace, "hooks"),
+        hookName: "override-me",
+        events: ["gateway"],
+        message: "ops-gateway",
+        handlerCode:
+          "export default async function(event) { event.messages.push(String(event.context.workspaceDir)); }\n",
+      });
+
+      const cfg = createMultiAgentHooksConfig({ mainWorkspace, opsWorkspace });
+      const count = await loadInternalHooksForStartup(
+        cfg,
+        mainWorkspace,
+        [mainWorkspace, opsWorkspace],
+        {
+          managedHooksDir,
+          bundledHooksDir: path.join(tmpDir, "bundled-empty"),
+        },
+      );
+
+      expect(count).toBe(2);
+
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg,
+        workspaceDir: mainWorkspace,
+      });
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual([opsWorkspace]);
+    });
+
     it("does not suppress shared startup hooks when the matching workspace-local hook does not subscribe to startup", async () => {
       const mainWorkspace = path.join(tmpDir, "workspace-main");
       const opsWorkspace = path.join(tmpDir, "workspace-ops");

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -7,11 +7,10 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import { resolveBundledHooksDir } from "./bundled-dir.js";
 import { resolveHookConfig } from "./config.js";
@@ -444,7 +443,13 @@ function resolveEventWorkspaceDir(
   }
 
   return safeRealpathOrResolve(
-    resolveAgentWorkspaceDir(cfg, resolveAgentIdFromSessionKey(sessionKey)),
+    resolveAgentWorkspaceDir(
+      cfg,
+      resolveSessionAgentId({
+        sessionKey,
+        config: cfg,
+      }),
+    ),
   );
 }
 

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -421,14 +421,15 @@ function createSharedHookHandler(params: {
   handler: InternalHookHandler;
   overriddenWorkspaces?: ReadonlyMap<string, ReadonlySet<string>>;
 }): InternalHookHandler {
-  if (!params.overriddenWorkspaces || params.overriddenWorkspaces.size === 0) {
+  const overriddenWorkspaces = params.overriddenWorkspaces;
+  if (!overriddenWorkspaces || overriddenWorkspaces.size === 0) {
     return params.handler;
   }
 
   return async (event) => {
     const eventWorkspaceDir = resolveEventWorkspaceDir(event, params.cfg);
     if (isGatewayStartupEvent(event)) {
-      const hasStartupOverride = Array.from(params.overriddenWorkspaces.values()).some(
+      const hasStartupOverride = Array.from(overriddenWorkspaces.values()).some(
         (events) => events.has("gateway") || events.has("gateway:startup"),
       );
       if (hasStartupOverride) {
@@ -438,7 +439,7 @@ function createSharedHookHandler(params: {
       return;
     }
 
-    if (eventWorkspaceDir && params.overriddenWorkspaces?.has(eventWorkspaceDir)) {
+    if (eventWorkspaceDir && overriddenWorkspaces.has(eventWorkspaceDir)) {
       return;
     }
     await params.handler(event);

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -56,12 +56,16 @@ export async function loadInternalHooksForStartup(
 
   let loadedCount = 0;
   const normalizedWorkspaceDirs = normalizeWorkspaceDirs([defaultWorkspaceDir, ...workspaceDirs]);
-  const workspaceEntriesByDir = new Map<string, HookEntry[]>(
-    normalizedWorkspaceDirs.map((workspaceDir) => [
-      workspaceDir,
-      loadWorkspaceLocalHookEntries(workspaceDir),
-    ]),
-  );
+  const workspaceEntriesByDir = new Map<string, HookEntry[]>();
+  for (const workspaceDir of normalizedWorkspaceDirs) {
+    try {
+      workspaceEntriesByDir.set(workspaceDir, loadWorkspaceLocalHookEntries(workspaceDir));
+    } catch (err) {
+      log.error(
+        `Failed to load hooks for workspace ${workspaceDir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
   const overriddenWorkspacesByHookName = buildWorkspaceOverrideMap(workspaceEntriesByDir);
 
   try {
@@ -73,8 +77,12 @@ export async function loadInternalHooksForStartup(
           overriddenWorkspaceDirs: overriddenWorkspacesByHookName.get(entry.hook.name),
         }),
     });
+  } catch (err) {
+    log.error(`Failed to load shared hooks: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
-    for (const [workspaceDir, entries] of workspaceEntriesByDir) {
+  for (const [workspaceDir, entries] of workspaceEntriesByDir) {
+    try {
       loadedCount += await registerHookEntries(cfg, entries, {
         wrapHandler: (_entry, handler) =>
           createWorkspaceScopedHandler({
@@ -83,11 +91,11 @@ export async function loadInternalHooksForStartup(
             workspaceDir,
           }),
       });
+    } catch (err) {
+      log.error(
+        `Failed to load hooks for workspace ${workspaceDir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
-  } catch (err) {
-    log.error(
-      `Failed to load directory-based hooks: ${err instanceof Error ? err.message : String(err)}`,
-    );
   }
 
   loadedCount += await registerLegacyHookHandlers(cfg, defaultWorkspaceDir);
@@ -403,7 +411,6 @@ function createSharedHookHandler(params: {
 
   return async (event) => {
     if (isGatewayStartupEvent(event)) {
-      await params.handler(event);
       return;
     }
 

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -417,10 +417,10 @@ function createSharedHookHandler(params: {
   return async (event) => {
     const eventWorkspaceDir = resolveEventWorkspaceDir(event, params.cfg);
     if (isGatewayStartupEvent(event)) {
-      const startupOverrides = eventWorkspaceDir
-        ? params.overriddenWorkspaces?.get(eventWorkspaceDir)
-        : undefined;
-      if (startupOverrides?.has("gateway:startup")) {
+      const hasStartupOverride = Array.from(params.overriddenWorkspaces.values()).some((events) =>
+        events.has("gateway:startup"),
+      );
+      if (hasStartupOverride) {
         return;
       }
       await params.handler(event);

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -7,18 +7,92 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import { resolveBundledHooksDir } from "./bundled-dir.js";
 import { resolveHookConfig } from "./config.js";
 import { shouldIncludeHook } from "./config.js";
 import { buildImportUrl } from "./import-url.js";
-import type { InternalHookHandler } from "./internal-hooks.js";
+import type { InternalHookEvent, InternalHookHandler } from "./internal-hooks.js";
 import { registerInternalHook } from "./internal-hooks.js";
 import { resolveFunctionModuleExport } from "./module-loader.js";
-import { loadWorkspaceHookEntries } from "./workspace.js";
+import type { HookEntry } from "./types.js";
+import { loadHookEntriesFromDir, loadWorkspaceHookEntries } from "./workspace.js";
 
 const log = createSubsystemLogger("hooks:loader");
+
+type LoaderOptions = {
+  managedHooksDir?: string;
+  bundledHooksDir?: string;
+};
+
+type HookHandlerWrapper = (entry: HookEntry, handler: InternalHookHandler) => InternalHookHandler;
+
+type LoadedHookModule = {
+  handler: InternalHookHandler;
+  exportName: string;
+};
+
+/**
+ * Startup loader for multi-agent gateways.
+ *
+ * Shared hooks are registered once, while workspace-local hooks are loaded for
+ * every configured workspace and wrapped with a scope guard before they enter
+ * the global registry.
+ */
+export async function loadInternalHooksForStartup(
+  cfg: OpenClawConfig,
+  defaultWorkspaceDir: string,
+  workspaceDirs: readonly string[],
+  opts?: LoaderOptions,
+): Promise<number> {
+  if (!cfg.hooks?.internal?.enabled) {
+    return 0;
+  }
+
+  let loadedCount = 0;
+  const normalizedWorkspaceDirs = normalizeWorkspaceDirs([defaultWorkspaceDir, ...workspaceDirs]);
+  const workspaceEntriesByDir = new Map<string, HookEntry[]>(
+    normalizedWorkspaceDirs.map((workspaceDir) => [
+      workspaceDir,
+      loadWorkspaceLocalHookEntries(workspaceDir),
+    ]),
+  );
+  const overriddenWorkspacesByHookName = buildWorkspaceOverrideMap(workspaceEntriesByDir);
+
+  try {
+    loadedCount += await registerHookEntries(cfg, loadSharedHookEntries(cfg, opts), {
+      wrapHandler: (entry, handler) =>
+        createSharedHookHandler({
+          cfg,
+          handler,
+          overriddenWorkspaceDirs: overriddenWorkspacesByHookName.get(entry.hook.name),
+        }),
+    });
+
+    for (const [workspaceDir, entries] of workspaceEntriesByDir) {
+      loadedCount += await registerHookEntries(cfg, entries, {
+        wrapHandler: (_entry, handler) =>
+          createWorkspaceScopedHandler({
+            cfg,
+            handler,
+            workspaceDir,
+          }),
+      });
+    }
+  } catch (err) {
+    log.error(
+      `Failed to load directory-based hooks: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  loadedCount += await registerLegacyHookHandlers(cfg, defaultWorkspaceDir);
+  return loadedCount;
+}
 
 /**
  * Load and register all hook handlers
@@ -42,101 +116,122 @@ const log = createSubsystemLogger("hooks:loader");
 export async function loadInternalHooks(
   cfg: OpenClawConfig,
   workspaceDir: string,
-  opts?: {
-    managedHooksDir?: string;
-    bundledHooksDir?: string;
-  },
+  opts?: LoaderOptions,
 ): Promise<number> {
-  // Check if hooks are enabled
   if (!cfg.hooks?.internal?.enabled) {
     return 0;
   }
 
   let loadedCount = 0;
 
-  // 1. Load hooks from directories (new system)
   try {
-    const hookEntries = loadWorkspaceHookEntries(workspaceDir, {
-      config: cfg,
-      managedHooksDir: opts?.managedHooksDir,
-      bundledHooksDir: opts?.bundledHooksDir,
-    });
-
-    // Filter by eligibility
-    const eligible = hookEntries.filter((entry) => shouldIncludeHook({ entry, config: cfg }));
-
-    for (const entry of eligible) {
-      const hookConfig = resolveHookConfig(cfg, entry.hook.name);
-
-      // Skip if explicitly disabled in config
-      if (hookConfig?.enabled === false) {
-        continue;
-      }
-
-      try {
-        const hookBaseDir = safeRealpathOrResolve(entry.hook.baseDir);
-        const opened = await openBoundaryFile({
-          absolutePath: entry.hook.handlerPath,
-          rootPath: hookBaseDir,
-          boundaryLabel: "hook directory",
-        });
-        if (!opened.ok) {
-          log.error(
-            `Hook '${entry.hook.name}' handler path fails boundary checks: ${entry.hook.handlerPath}`,
-          );
-          continue;
-        }
-        const safeHandlerPath = opened.path;
-        fs.closeSync(opened.fd);
-
-        // Import handler module — only cache-bust mutable (workspace/managed) hooks
-        const importUrl = buildImportUrl(safeHandlerPath, entry.hook.source);
-        const mod = (await import(importUrl)) as Record<string, unknown>;
-
-        // Get handler function (default or named export)
-        const exportName = entry.metadata?.export ?? "default";
-        const handler = resolveFunctionModuleExport<InternalHookHandler>({
-          mod,
-          exportName,
-        });
-
-        if (!handler) {
-          log.error(`Handler '${exportName}' from ${entry.hook.name} is not a function`);
-          continue;
-        }
-
-        // Register for all events listed in metadata
-        const events = entry.metadata?.events ?? [];
-        if (events.length === 0) {
-          log.warn(`Hook '${entry.hook.name}' has no events defined in metadata`);
-          continue;
-        }
-
-        for (const event of events) {
-          registerInternalHook(event, handler);
-        }
-
-        log.info(
-          `Registered hook: ${entry.hook.name} -> ${events.join(", ")}${exportName !== "default" ? ` (export: ${exportName})` : ""}`,
-        );
-        loadedCount++;
-      } catch (err) {
-        log.error(
-          `Failed to load hook ${entry.hook.name}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
+    loadedCount += await registerHookEntries(
+      cfg,
+      loadWorkspaceHookEntries(workspaceDir, {
+        config: cfg,
+        managedHooksDir: opts?.managedHooksDir,
+        bundledHooksDir: opts?.bundledHooksDir,
+      }),
+    );
   } catch (err) {
     log.error(
       `Failed to load directory-based hooks: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
-  // 2. Load legacy config handlers (backwards compatibility)
-  const handlers = cfg.hooks.internal.handlers ?? [];
+  loadedCount += await registerLegacyHookHandlers(cfg, workspaceDir);
+  return loadedCount;
+}
+
+async function registerHookEntries(
+  cfg: OpenClawConfig,
+  entries: readonly HookEntry[],
+  opts?: {
+    wrapHandler?: HookHandlerWrapper;
+  },
+): Promise<number> {
+  let loadedCount = 0;
+  const eligible = entries.filter((entry) => shouldIncludeHook({ entry, config: cfg }));
+
+  for (const entry of eligible) {
+    const hookConfig = resolveHookConfig(cfg, entry.hook.name);
+    if (hookConfig?.enabled === false) {
+      continue;
+    }
+
+    try {
+      const loaded = await loadDirectoryHookHandler(entry);
+      if (!loaded) {
+        continue;
+      }
+
+      const events = entry.metadata?.events ?? [];
+      if (events.length === 0) {
+        log.warn(`Hook '${entry.hook.name}' has no events defined in metadata`);
+        continue;
+      }
+
+      const wrappedHandler = opts?.wrapHandler
+        ? opts.wrapHandler(entry, loaded.handler)
+        : loaded.handler;
+      for (const event of events) {
+        registerInternalHook(event, wrappedHandler);
+      }
+
+      log.info(
+        `Registered hook: ${entry.hook.name} -> ${events.join(", ")}${loaded.exportName !== "default" ? ` (export: ${loaded.exportName})` : ""}`,
+      );
+      loadedCount++;
+    } catch (err) {
+      log.error(
+        `Failed to load hook ${entry.hook.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return loadedCount;
+}
+
+async function loadDirectoryHookHandler(entry: HookEntry): Promise<LoadedHookModule | null> {
+  const hookBaseDir = safeRealpathOrResolve(entry.hook.baseDir);
+  const opened = await openBoundaryFile({
+    absolutePath: entry.hook.handlerPath,
+    rootPath: hookBaseDir,
+    boundaryLabel: "hook directory",
+  });
+  if (!opened.ok) {
+    log.error(
+      `Hook '${entry.hook.name}' handler path fails boundary checks: ${entry.hook.handlerPath}`,
+    );
+    return null;
+  }
+  const safeHandlerPath = opened.path;
+  fs.closeSync(opened.fd);
+
+  const importUrl = buildImportUrl(safeHandlerPath, entry.hook.source);
+  const mod = (await import(importUrl)) as Record<string, unknown>;
+  const exportName = entry.metadata?.export ?? "default";
+  const handler = resolveFunctionModuleExport<InternalHookHandler>({
+    mod,
+    exportName,
+  });
+
+  if (!handler) {
+    log.error(`Handler '${exportName}' from ${entry.hook.name} is not a function`);
+    return null;
+  }
+
+  return { handler, exportName };
+}
+
+async function registerLegacyHookHandlers(
+  cfg: OpenClawConfig,
+  workspaceDir: string,
+): Promise<number> {
+  let loadedCount = 0;
+  const handlers = cfg.hooks?.internal?.handlers ?? [];
   for (const handlerConfig of handlers) {
     try {
-      // Legacy handler paths: keep them workspace-relative.
       const rawModule = handlerConfig.module.trim();
       if (!rawModule) {
         log.error("Handler module path is empty");
@@ -198,6 +293,156 @@ export async function loadInternalHooks(
   }
 
   return loadedCount;
+}
+
+function loadSharedHookEntries(cfg: OpenClawConfig, opts?: LoaderOptions): HookEntry[] {
+  const managedHooksDir = opts?.managedHooksDir ?? path.join(CONFIG_DIR, "hooks");
+  const bundledHooksDir = opts?.bundledHooksDir ?? resolveBundledHooksDir();
+  const extraDirs = (cfg.hooks?.internal?.load?.extraDirs ?? [])
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+
+  const extraEntries = extraDirs.flatMap((dir) =>
+    loadHookEntriesFromDir({
+      dir: resolveUserPath(dir),
+      source: "openclaw-workspace",
+    }),
+  );
+  const bundledEntries = bundledHooksDir
+    ? loadHookEntriesFromDir({
+        dir: bundledHooksDir,
+        source: "openclaw-bundled",
+      })
+    : [];
+  const managedEntries = loadHookEntriesFromDir({
+    dir: managedHooksDir,
+    source: "openclaw-managed",
+  });
+
+  return mergeHookEntriesByName([...extraEntries, ...bundledEntries, ...managedEntries]);
+}
+
+function loadWorkspaceLocalHookEntries(workspaceDir: string): HookEntry[] {
+  return mergeHookEntriesByName(
+    loadHookEntriesFromDir({
+      dir: path.join(workspaceDir, "hooks"),
+      source: "openclaw-workspace",
+    }),
+  );
+}
+
+function mergeHookEntriesByName(entries: readonly HookEntry[]): HookEntry[] {
+  const merged = new Map<string, HookEntry>();
+  for (const entry of entries) {
+    merged.set(entry.hook.name, entry);
+  }
+  return Array.from(merged.values());
+}
+
+function normalizeWorkspaceDirs(workspaceDirs: readonly string[]): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const workspaceDir of workspaceDirs) {
+    const canonical = safeRealpathOrResolve(workspaceDir);
+    if (seen.has(canonical)) {
+      continue;
+    }
+    seen.add(canonical);
+    normalized.push(canonical);
+  }
+  return normalized;
+}
+
+function buildWorkspaceOverrideMap(
+  workspaceEntriesByDir: ReadonlyMap<string, readonly HookEntry[]>,
+): Map<string, Set<string>> {
+  const overrides = new Map<string, Set<string>>();
+  for (const [workspaceDir, entries] of workspaceEntriesByDir) {
+    for (const entry of entries) {
+      const current = overrides.get(entry.hook.name) ?? new Set<string>();
+      current.add(workspaceDir);
+      overrides.set(entry.hook.name, current);
+    }
+  }
+  return overrides;
+}
+
+function createWorkspaceScopedHandler(params: {
+  cfg: OpenClawConfig;
+  handler: InternalHookHandler;
+  workspaceDir: string;
+}): InternalHookHandler {
+  const targetWorkspaceDir = safeRealpathOrResolve(params.workspaceDir);
+  return async (event) => {
+    if (isGatewayStartupEvent(event)) {
+      await params.handler({
+        ...event,
+        context: {
+          ...event.context,
+          workspaceDir: targetWorkspaceDir,
+        },
+      });
+      return;
+    }
+    const eventWorkspaceDir = resolveEventWorkspaceDir(event, params.cfg);
+    if (eventWorkspaceDir !== targetWorkspaceDir) {
+      return;
+    }
+    await params.handler(event);
+  };
+}
+
+function createSharedHookHandler(params: {
+  cfg: OpenClawConfig;
+  handler: InternalHookHandler;
+  overriddenWorkspaceDirs?: ReadonlySet<string>;
+}): InternalHookHandler {
+  if (!params.overriddenWorkspaceDirs || params.overriddenWorkspaceDirs.size === 0) {
+    return params.handler;
+  }
+
+  return async (event) => {
+    if (isGatewayStartupEvent(event)) {
+      await params.handler(event);
+      return;
+    }
+
+    const eventWorkspaceDir = resolveEventWorkspaceDir(event, params.cfg);
+    if (eventWorkspaceDir && params.overriddenWorkspaceDirs?.has(eventWorkspaceDir)) {
+      return;
+    }
+    await params.handler(event);
+  };
+}
+
+function resolveEventWorkspaceDir(
+  event: InternalHookEvent,
+  cfg: OpenClawConfig,
+): string | undefined {
+  const context = event.context;
+  const contextWorkspaceDir =
+    typeof context.workspaceDir === "string" ? context.workspaceDir.trim() : "";
+  if (contextWorkspaceDir) {
+    return safeRealpathOrResolve(contextWorkspaceDir);
+  }
+
+  const contextAgentId = typeof context.agentId === "string" ? context.agentId.trim() : "";
+  if (contextAgentId) {
+    return safeRealpathOrResolve(resolveAgentWorkspaceDir(cfg, contextAgentId));
+  }
+
+  const sessionKey = event.sessionKey?.trim();
+  if (!sessionKey || isGatewayStartupEvent(event)) {
+    return undefined;
+  }
+
+  return safeRealpathOrResolve(
+    resolveAgentWorkspaceDir(cfg, resolveAgentIdFromSessionKey(sessionKey)),
+  );
+}
+
+function isGatewayStartupEvent(event: InternalHookEvent): boolean {
+  return event.type === "gateway" && event.action === "startup";
 }
 
 function safeRealpathOrResolve(value: string): string {

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -60,7 +60,10 @@ export async function loadInternalHooksForStartup(
   const workspaceEntriesByDir = new Map<string, HookEntry[]>();
   for (const workspaceDir of normalizedWorkspaceDirs) {
     try {
-      workspaceEntriesByDir.set(workspaceDir, loadWorkspaceLocalHookEntries(workspaceDir));
+      workspaceEntriesByDir.set(
+        workspaceDir,
+        filterRegisterableHookEntries(cfg, loadWorkspaceLocalHookEntries(workspaceDir)),
+      );
     } catch (err) {
       log.error(
         `Failed to load hooks for workspace ${workspaceDir}: ${err instanceof Error ? err.message : String(err)}`,
@@ -160,14 +163,9 @@ async function registerHookEntries(
   },
 ): Promise<number> {
   let loadedCount = 0;
-  const eligible = entries.filter((entry) => shouldIncludeHook({ entry, config: cfg }));
+  const registerableEntries = filterRegisterableHookEntries(cfg, entries);
 
-  for (const entry of eligible) {
-    const hookConfig = resolveHookConfig(cfg, entry.hook.name);
-    if (hookConfig?.enabled === false) {
-      continue;
-    }
-
+  for (const entry of registerableEntries) {
     try {
       const loaded = await loadDirectoryHookHandler(entry);
       if (!loaded) {
@@ -378,6 +376,19 @@ function buildWorkspaceOverrideMap(
     }
   }
   return overrides;
+}
+
+function filterRegisterableHookEntries(
+  cfg: OpenClawConfig,
+  entries: readonly HookEntry[],
+): HookEntry[] {
+  return entries.filter((entry) => {
+    if (!shouldIncludeHook({ entry, config: cfg })) {
+      return false;
+    }
+    const hookConfig = resolveHookConfig(cfg, entry.hook.name);
+    return hookConfig?.enabled !== false;
+  });
 }
 
 function createWorkspaceScopedHandler(params: {

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -36,6 +36,8 @@ type LoadedHookModule = {
   exportName: string;
 };
 
+type WorkspaceOverrideMap = Map<string, Set<string>>;
+
 /**
  * Startup loader for multi-agent gateways.
  *
@@ -73,7 +75,7 @@ export async function loadInternalHooksForStartup(
         createSharedHookHandler({
           cfg,
           handler,
-          overriddenWorkspaceDirs: overriddenWorkspacesByHookName.get(entry.hook.name),
+          overriddenWorkspaces: overriddenWorkspacesByHookName.get(entry.hook.name),
         }),
     });
   } catch (err) {
@@ -362,13 +364,17 @@ function normalizeWorkspaceDirs(workspaceDirs: readonly string[]): string[] {
 
 function buildWorkspaceOverrideMap(
   workspaceEntriesByDir: ReadonlyMap<string, readonly HookEntry[]>,
-): Map<string, Set<string>> {
-  const overrides = new Map<string, Set<string>>();
+): Map<string, WorkspaceOverrideMap> {
+  const overrides = new Map<string, WorkspaceOverrideMap>();
   for (const [workspaceDir, entries] of workspaceEntriesByDir) {
     for (const entry of entries) {
-      const current = overrides.get(entry.hook.name) ?? new Set<string>();
-      current.add(workspaceDir);
-      overrides.set(entry.hook.name, current);
+      const workspaceOverrides = overrides.get(entry.hook.name) ?? new Map<string, Set<string>>();
+      const events = workspaceOverrides.get(workspaceDir) ?? new Set<string>();
+      for (const event of entry.metadata?.events ?? []) {
+        events.add(event);
+      }
+      workspaceOverrides.set(workspaceDir, events);
+      overrides.set(entry.hook.name, workspaceOverrides);
     }
   }
   return overrides;
@@ -402,19 +408,26 @@ function createWorkspaceScopedHandler(params: {
 function createSharedHookHandler(params: {
   cfg: OpenClawConfig;
   handler: InternalHookHandler;
-  overriddenWorkspaceDirs?: ReadonlySet<string>;
+  overriddenWorkspaces?: ReadonlyMap<string, ReadonlySet<string>>;
 }): InternalHookHandler {
-  if (!params.overriddenWorkspaceDirs || params.overriddenWorkspaceDirs.size === 0) {
+  if (!params.overriddenWorkspaces || params.overriddenWorkspaces.size === 0) {
     return params.handler;
   }
 
   return async (event) => {
+    const eventWorkspaceDir = resolveEventWorkspaceDir(event, params.cfg);
     if (isGatewayStartupEvent(event)) {
+      const startupOverrides = eventWorkspaceDir
+        ? params.overriddenWorkspaces?.get(eventWorkspaceDir)
+        : undefined;
+      if (startupOverrides?.has("gateway:startup")) {
+        return;
+      }
+      await params.handler(event);
       return;
     }
 
-    const eventWorkspaceDir = resolveEventWorkspaceDir(event, params.cfg);
-    if (eventWorkspaceDir && params.overriddenWorkspaceDirs?.has(eventWorkspaceDir)) {
+    if (eventWorkspaceDir && params.overriddenWorkspaces?.has(eventWorkspaceDir)) {
       return;
     }
     await params.handler(event);

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -417,8 +417,8 @@ function createSharedHookHandler(params: {
   return async (event) => {
     const eventWorkspaceDir = resolveEventWorkspaceDir(event, params.cfg);
     if (isGatewayStartupEvent(event)) {
-      const hasStartupOverride = Array.from(params.overriddenWorkspaces.values()).some((events) =>
-        events.has("gateway:startup"),
+      const hasStartupOverride = Array.from(params.overriddenWorkspaces.values()).some(
+        (events) => events.has("gateway") || events.has("gateway:startup"),
       );
       if (hasStartupOverride) {
         return;


### PR DESCRIPTION
## Summary
Fixes #42072 by loading workspace-local hooks for every configured agent workspace at gateway startup, without changing the global hook registry model.

## Root cause
Gateway startup only called `loadInternalHooks(cfg, defaultWorkspaceDir)` once, so only the default workspace contributed `<workspace>/hooks/` entries to the global registry.

## Changes
- added a startup-specific multi-workspace loader in `src/hooks/loader.ts`
- loaded shared hooks once and workspace-local hooks once per actual workspace hooks directory
- wrapped workspace-local handlers with workspace-aware scope guards based on event workspace, agent, or session
- preserved legacy handler loading relative to the default workspace
- updated `src/gateway/server-startup.ts` to enumerate all agent workspaces via `listAgentWorkspaceDirs`

## Validation
- added regression coverage for:
  - multi-workspace loading
  - scope isolation
  - shared-hook dedupe
  - shared/local precedence
  - `gateway:startup` behavior
- passed:
  - `pnpm exec vitest run src/hooks/loader.test.ts`
  - `pnpm build`

## Notes
- this keeps the existing global internal hook registry unchanged
- this PR avoids broad event-emitter or registry refactors