### PR TITLE
fix(models): apply Gemini model-id normalization to google-vertex provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,6 +372,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded runner: carry provider-observed overflow token counts into compaction so overflow retries and diagnostics use the rejected live prompt size instead of only transcript estimates. (#40357) thanks @rabsef-bicrym.
 - Agents/compaction transcript updates: emit a transcript-update event immediately after successful embedded compaction so downstream listeners observe the post-compact transcript without waiting for a later write. (#25558) thanks @rodrigouroz.
 - Agents/sessions_spawn: use the target agent workspace for cross-agent spawned runs instead of inheriting the caller workspace, so child sessions load the correct workspace-scoped instructions and persona files. (#40176) Thanks @moshehbenavraham.
+
 - Models/google-vertex Gemini flash-lite normalization: apply existing bare-ID preview normalization to `google-vertex` model refs and provider configs so `google-vertex/gemini-3.1-flash-lite` resolves as `gemini-3.1-flash-lite-preview`. (#42435) thanks @scoootscooob.
 
 ## 2026.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,6 +372,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded runner: carry provider-observed overflow token counts into compaction so overflow retries and diagnostics use the rejected live prompt size instead of only transcript estimates. (#40357) thanks @rabsef-bicrym.
 - Agents/compaction transcript updates: emit a transcript-update event immediately after successful embedded compaction so downstream listeners observe the post-compact transcript without waiting for a later write. (#25558) thanks @rodrigouroz.
 - Agents/sessions_spawn: use the target agent workspace for cross-agent spawned runs instead of inheriting the caller workspace, so child sessions load the correct workspace-scoped instructions and persona files. (#40176) Thanks @moshehbenavraham.
+- Models/google-vertex Gemini flash-lite normalization: apply existing bare-ID preview normalization to `google-vertex` model refs and provider configs so `google-vertex/gemini-3.1-flash-lite` resolves as `gemini-3.1-flash-lite-preview`. (#42435) thanks @scoootscooob.
 
 ## 2026.3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Discord/allowlists: honor raw `guild_id` when hydrated guild objects are missing so allowlisted channels and threads like `#maintainers` no longer get false-dropped before channel allowlist checks.
 - macOS/runtime locator: require Node >=22.16.0 during macOS runtime discovery so the app no longer accepts Node versions that the main runtime guard rejects later. Thanks @sumleo.
 - Agents/custom providers: preserve blank API keys for loopback OpenAI-compatible custom providers by clearing the synthetic Authorization header at runtime, while keeping explicit apiKey and oauth/token config from silently downgrading into fake bearer auth. (#45631) Thanks @xinhuagu.
+- Models/google-vertex Gemini flash-lite normalization: apply existing bare-ID preview normalization to `google-vertex` model refs and provider configs so `google-vertex/gemini-3.1-flash-lite` resolves as `gemini-3.1-flash-lite-preview`. (#42435) thanks @scoootscooob.
 
 ## 2026.3.12
 
@@ -373,7 +374,6 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction transcript updates: emit a transcript-update event immediately after successful embedded compaction so downstream listeners observe the post-compact transcript without waiting for a later write. (#25558) thanks @rodrigouroz.
 - Agents/sessions_spawn: use the target agent workspace for cross-agent spawned runs instead of inheriting the caller workspace, so child sessions load the correct workspace-scoped instructions and persona files. (#40176) Thanks @moshehbenavraham.
 
-- Models/google-vertex Gemini flash-lite normalization: apply existing bare-ID preview normalization to `google-vertex` model refs and provider configs so `google-vertex/gemini-3.1-flash-lite` resolves as `gemini-3.1-flash-lite-preview`. (#42435) thanks @scoootscooob.
 
 ## 2026.3.7
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -241,6 +241,12 @@ describe("model-selection", () => {
         defaultProvider: "anthropic",
         expected: { provider: "openai", model: "gpt-5.3-codex-codex" },
       },
+      {
+        name: "normalizes gemini 3.1 flash-lite ids for google-vertex",
+        variants: ["google-vertex/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
+        defaultProvider: "google-vertex",
+        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite-preview" },
+      },
     ])("$name", ({ variants, defaultProvider, expected }) => {
       expectParsedModelVariants(variants, defaultProvider, expected);
     });
@@ -252,7 +258,6 @@ describe("model-selection", () => {
         "anthropic/claude-opus-4-6",
       );
     });
-
     it.each(["", "  ", "/", "anthropic/", "/model"])("returns null for invalid ref %j", (raw) => {
       expect(parseModelRef(raw, "anthropic")).toBeNull();
     });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -171,7 +171,7 @@ function normalizeProviderModelId(provider: string, model: string): string {
       return `anthropic/${normalizedAnthropicModel}`;
     }
   }
-  if (provider === "google") {
+  if (provider === "google" || provider === "google-vertex") {
     return normalizeGoogleModelId(model);
   }
   // OpenRouter-native models (e.g. "openrouter/aurora-alpha") need the full

--- a/src/agents/models-config.providers.google-antigravity.test.ts
+++ b/src/agents/models-config.providers.google-antigravity.test.ts
@@ -97,3 +97,33 @@ describe("google-antigravity provider normalization", () => {
     expect(normalized).toBe(providers);
   });
 });
+
+describe("google-vertex provider normalization", () => {
+  it("normalizes gemini flash-lite IDs for google-vertex providers", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = {
+      "google-vertex": buildProvider(["gemini-3.1-flash-lite", "gemini-3-flash-preview"]),
+      openai: buildProvider(["gpt-5"]),
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    expect(normalized).not.toBe(providers);
+    expect(normalized?.["google-vertex"]?.models.map((model) => model.id)).toEqual([
+      "gemini-3.1-flash-lite-preview",
+      "gemini-3-flash-preview",
+    ]);
+    expect(normalized?.openai).toBe(providers.openai);
+  });
+
+  it("returns original providers object when no google-vertex IDs need normalization", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = {
+      "google-vertex": buildProvider(["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview"]),
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    expect(normalized).toBe(providers);
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -545,7 +545,7 @@ export function normalizeProviders(params: {
       }
     }
 
-    if (normalizedKey === "google") {
+    if (normalizedKey === "google" || normalizedKey === "google-vertex") {
       const googleNormalized = normalizeGoogleProvider(normalizedProvider);
       if (googleNormalized !== normalizedProvider) {
         mutated = true;


### PR DESCRIPTION
## Summary

- `normalizeGoogleModelId()` (which maps bare IDs like `gemini-3.1-flash-lite` → `gemini-3.1-flash-lite-preview`) was only applied for the `google` provider. Users configuring `google-vertex/gemini-3.1-flash-lite` got a "missing" model because the `-preview` suffix was never appended.
- Extend the same normalization to `google-vertex` in both `normalizeProviderModelId` (model-selection ref parsing) and `normalizeProviders` (config provider normalization).

Fixes the gap noted in https://github.com/openclaw/openclaw/pull/36918#issuecomment-4032732959 and completes the support requested in #36838.

## Changes

- `src/agents/model-selection.ts`: add `|| provider === "google-vertex"` to the Google normalization branch
- `src/agents/models-config.providers.ts`: add `|| normalizedKey === "google-vertex"` to the provider config normalization branch
- `src/agents/model-selection.test.ts`: add test for `google-vertex/gemini-3.1-flash-lite` normalization
- `src/agents/models-config.providers.google-antigravity.test.ts`: add 2 tests for google-vertex provider normalization

## Test plan

- [x] `model-selection.test.ts` — 48/48 pass (1 new)
- [x] `models-config.providers.google-antigravity.test.ts` — 13/13 pass (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)