### PR TITLE
fix(feishu): enable autoReconnect for WSClient resilience

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -64,8 +64,10 @@ const baseAccount: ResolvedFeishuAccount = {
   config: {} as FeishuConfig,
 };
 
-function firstWsClientOptions(): { agent?: unknown } {
-  const calls = wsClientCtorMock.mock.calls as unknown as Array<[options: { agent?: unknown }]>;
+function firstWsClientOptions(): { agent?: unknown; autoReconnect?: boolean } {
+  const calls = wsClientCtorMock.mock.calls as unknown as Array<
+    [options: { agent?: unknown; autoReconnect?: boolean }]
+  >;
   return calls[0]?.[0] ?? {};
 }
 
@@ -257,6 +259,13 @@ describe("createFeishuClient HTTP timeout", () => {
 });
 
 describe("createFeishuWSClient proxy handling", () => {
+  it("enables autoReconnect for WebSocket resilience", () => {
+    createFeishuWSClient(baseAccount);
+
+    const options = firstWsClientOptions();
+    expect(options.autoReconnect).toBe(true);
+  });
+
   it("does not set a ws proxy agent when proxy env is absent", () => {
     createFeishuWSClient(baseAccount);
 

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -163,6 +163,7 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
     appSecret,
     domain: resolveDomain(domain),
     loggerLevel: Lark.LoggerLevel.info,
+    autoReconnect: true,
     ...(agent ? { agent } : {}),
   });
 }


### PR DESCRIPTION
## Summary

The Lark SDK `WSClient` constructor overwrites its internal `autoReconnect` default (`true`) with `undefined` when the caller omits the parameter. This causes the WebSocket client to never attempt reconnection after transient failures like `code: 1000040351, system busy`.

This PR explicitly passes `autoReconnect: true` so the client recovers from transient server-side errors ("system busy") and network interruptions.

## Root cause

`WSConfig` initializes `ws.autoReconnect = true`, but the `WSClient` constructor calls `this.wsConfig.updateWs({ autoReconnect })` which uses `Object.assign` — setting `autoReconnect` to `undefined` when it is not provided, effectively disabling reconnection.

## Test plan

- [x] Added test: verifies `autoReconnect: true` is passed to WSClient constructor
- [x] All existing feishu client tests pass (`pnpm test extensions/feishu/src/client.test.ts`)

Closes #42354