### PR TITLE
fix(config): accept subagent allowAgents defaults

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai";
+import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai/oauth";
 import { getOAuthApiKey, getOAuthProviders } from "@mariozechner/pi-ai/oauth";
 import { loadConfig, type OpenClawConfig } from "../../config/config.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import type { OAuthCredentials } from "@mariozechner/pi-ai/oauth";
 import { loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -110,6 +110,22 @@ describe("web search provider config", () => {
   });
 });
 
+describe("agents.defaults.subagents.allowAgents", () => {
+  it("accepts allowAgents in subagent defaults", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["*"],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});
+
 describe("talk.voiceAliases", () => {
   it("accepts a string map of voice aliases", () => {
     const res = validateConfigObject({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -267,6 +267,8 @@ export type AgentDefaultsConfig = {
   subagents?: {
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
     maxConcurrent?: number;
+    /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
+    allowAgents?: string[];
     /** Maximum depth allowed for sessions_spawn chains. Default behavior: 1 (no nested spawns). */
     maxSpawnDepth?: number;
     /** Maximum active children a single requester session may spawn. Default behavior: 5. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -163,6 +163,7 @@ export const AgentDefaultsSchema = z
     subagents: z
       .object({
         maxConcurrent: z.number().int().positive().optional(),
+        allowAgents: z.array(z.string()).optional(),
         maxSpawnDepth: z
           .number()
           .int()


### PR DESCRIPTION
## Summary
Fixes https://github.com/openclaw/openclaw/issues/10031

## Symptom
Config validation rejects `agents.defaults.subagents.allowAgents`, which blocks `sessions_spawn` and other subagent allowlist defaults from being configured even though the runtime understands the field.

## Root cause
The runtime/types layer already supports `allowAgents`, but `AgentDefaultsSchema` never accepted it.

## Fix
- add `allowAgents?: string[]` to `AgentDefaultsConfig["subagents"]`
- accept `agents.defaults.subagents.allowAgents` in the zod schema
- add a regression test in `src/config/config-misc.test.ts`

## Regression test
- `pnpm exec vitest run src/config/config-misc.test.ts`

## Note
This branch also includes the minimal `@mariozechner/pi-ai/oauth` import-path correction needed for current config test startup. The broader auth/proxy change is already tracked in https://github.com/openclaw/openclaw/pull/42344.