### PR TITLE
fix(gateway): honor commands.restart on config writes

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai";
+import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai/oauth";
 import { getOAuthApiKey, getOAuthProviders } from "@mariozechner/pi-ai/oauth";
 import { loadConfig, type OpenClawConfig } from "../../config/config.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import type { OAuthCredentials } from "@mariozechner/pi-ai/oauth";
 import { loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -189,6 +189,16 @@ function resolveConfigRestartRequest(params: unknown): {
   };
 }
 
+function isConfigWriteRestartAllowed(params: {
+  previousConfig?: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+}): boolean {
+  return (
+    params.previousConfig?.commands?.restart !== false &&
+    params.nextConfig.commands?.restart !== false
+  );
+}
+
 function buildConfigRestartSentinelPayload(params: {
   kind: RestartSentinelPayload["kind"];
   mode: string;
@@ -222,6 +232,53 @@ async function tryWriteRestartSentinelPayload(
   } catch {
     return null;
   }
+}
+
+async function scheduleConfigWriteRestart(params: {
+  enabled: boolean;
+  rawParams: unknown;
+  kind: RestartSentinelPayload["kind"];
+  mode: "config.patch" | "config.apply";
+  actor: ReturnType<typeof resolveControlPlaneActor>;
+  changedPaths: string[];
+  logGateway?: { warn?: (message: string) => void };
+}) {
+  if (!params.enabled) {
+    params.logGateway?.warn?.(
+      `${params.mode} automatic restart skipped; commands.restart=false in current or next config`,
+    );
+    return { restart: null, sentinel: null };
+  }
+
+  const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
+    resolveConfigRestartRequest(params.rawParams);
+  const payload = buildConfigRestartSentinelPayload({
+    kind: params.kind,
+    mode: params.mode,
+    sessionKey,
+    deliveryContext,
+    threadId,
+    note,
+  });
+  const sentinelPath = await tryWriteRestartSentinelPayload(payload);
+  const restart = scheduleGatewaySigusr1Restart({
+    delayMs: restartDelayMs,
+    reason: params.mode,
+    audit: {
+      actor: params.actor.actor,
+      deviceId: params.actor.deviceId,
+      clientIp: params.actor.clientIp,
+      changedPaths: params.changedPaths,
+    },
+  });
+
+  return {
+    restart,
+    sentinel: {
+      path: sentinelPath,
+      payload,
+    },
+  };
 }
 
 function loadSchemaWithPlugins(): ConfigSchemaResponse {
@@ -411,28 +468,19 @@ export const configHandlers: GatewayRequestHandlers = {
     );
     await writeConfigFile(validated.config, writeOptions);
 
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
-      resolveConfigRestartRequest(params);
-    const payload = buildConfigRestartSentinelPayload({
+    const { restart, sentinel } = await scheduleConfigWriteRestart({
+      enabled: isConfigWriteRestartAllowed({
+        previousConfig: snapshot.config,
+        nextConfig: validated.config,
+      }),
+      rawParams: params,
       kind: "config-patch",
       mode: "config.patch",
-      sessionKey,
-      deliveryContext,
-      threadId,
-      note,
+      actor,
+      changedPaths,
+      logGateway: context?.logGateway,
     });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.patch",
-      audit: {
-        actor: actor.actor,
-        deviceId: actor.deviceId,
-        clientIp: actor.clientIp,
-        changedPaths,
-      },
-    });
-    if (restart.coalesced) {
+    if (restart?.coalesced) {
       context?.logGateway?.warn(
         `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
       );
@@ -444,10 +492,7 @@ export const configHandlers: GatewayRequestHandlers = {
         path: createConfigIO().configPath,
         config: redactConfigObject(validated.config, schemaPatch.uiHints),
         restart,
-        sentinel: {
-          path: sentinelPath,
-          payload,
-        },
+        sentinel,
       },
       undefined,
     );
@@ -471,28 +516,19 @@ export const configHandlers: GatewayRequestHandlers = {
     );
     await writeConfigFile(parsed.config, writeOptions);
 
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
-      resolveConfigRestartRequest(params);
-    const payload = buildConfigRestartSentinelPayload({
+    const { restart, sentinel } = await scheduleConfigWriteRestart({
+      enabled: isConfigWriteRestartAllowed({
+        previousConfig: snapshot.config,
+        nextConfig: parsed.config,
+      }),
+      rawParams: params,
       kind: "config-apply",
       mode: "config.apply",
-      sessionKey,
-      deliveryContext,
-      threadId,
-      note,
+      actor,
+      changedPaths,
+      logGateway: context?.logGateway,
     });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.apply",
-      audit: {
-        actor: actor.actor,
-        deviceId: actor.deviceId,
-        clientIp: actor.clientIp,
-        changedPaths,
-      },
-    });
-    if (restart.coalesced) {
+    if (restart?.coalesced) {
       context?.logGateway?.warn(
         `config.apply restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
       );
@@ -504,10 +540,7 @@ export const configHandlers: GatewayRequestHandlers = {
         path: createConfigIO().configPath,
         config: redactConfigObject(parsed.config, parsed.schema.uiHints),
         restart,
-        sentinel: {
-          path: sentinelPath,
-          payload,
-        },
+        sentinel,
       },
       undefined,
     );

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -46,6 +46,43 @@ async function resetTempDir(name: string): Promise<string> {
   return dir;
 }
 
+type LiveConfig = Record<string, unknown> & {
+  commands?: { restart?: boolean };
+  logging?: { level?: string };
+};
+
+async function getLiveConfig(): Promise<{ hash: string; config: LiveConfig }> {
+  const res = await rpcReq<{
+    raw?: unknown;
+    hash?: string;
+    config?: LiveConfig;
+  }>(requireWs(), "config.get", {});
+  expect(res.ok).toBe(true);
+  expect(typeof res.payload?.hash).toBe("string");
+  expect(res.payload?.config).toBeTruthy();
+  return {
+    hash: res.payload?.hash as string,
+    config: res.payload?.config as LiveConfig,
+  };
+}
+
+async function writeLiveConfig(config: LiveConfig, baseHash: string): Promise<void> {
+  const res = await rpcReq<{
+    ok?: boolean;
+    path?: string;
+    config?: LiveConfig;
+  }>(requireWs(), "config.set", {
+    raw: JSON.stringify(config, null, 2),
+    baseHash,
+  });
+  expect(res.ok).toBe(true);
+  expect(res.payload?.config).toBeTruthy();
+}
+
+function pickAlternateLogLevel(config: LiveConfig): string {
+  return config.logging?.level === "debug" ? "info" : "debug";
+}
+
 describe("gateway config methods", () => {
   it("round-trips config.set and returns the live config path", async () => {
     const { createConfigIO } = await import("../config/config.js");
@@ -145,6 +182,65 @@ describe("gateway config methods", () => {
     });
     expect(res.ok).toBe(false);
     expect(res.error?.message ?? "").toContain("raw must be an object");
+  });
+
+  it("skips automatic restart for config.patch when commands.restart is disabled", async () => {
+    const original = await getLiveConfig();
+    try {
+      const nextLogLevel = pickAlternateLogLevel(original.config);
+      const restartDisabled = structuredClone(original.config);
+      restartDisabled.commands = { ...(restartDisabled.commands ?? {}), restart: false };
+      await writeLiveConfig(restartDisabled, original.hash);
+
+      const current = await getLiveConfig();
+      const res = await rpcReq<{
+        ok?: boolean;
+        config?: LiveConfig;
+        restart?: unknown;
+        sentinel?: unknown;
+      }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ logging: { level: nextLogLevel } }, null, 2),
+        baseHash: current.hash,
+      });
+
+      expect(res.ok).toBe(true);
+      expect(res.payload?.restart).toBeNull();
+      expect(res.payload?.sentinel).toBeNull();
+      expect(res.payload?.config?.commands?.restart).toBe(false);
+      expect(res.payload?.config?.logging?.level).toBe(nextLogLevel);
+    } finally {
+      const latest = await getLiveConfig();
+      await writeLiveConfig(original.config, latest.hash);
+    }
+  });
+
+  it("skips automatic restart for config.apply when commands.restart is disabled", async () => {
+    const original = await getLiveConfig();
+    try {
+      const nextLogLevel = pickAlternateLogLevel(original.config);
+      const updated = structuredClone(original.config);
+      updated.commands = { ...(updated.commands ?? {}), restart: false };
+      updated.logging = { ...(updated.logging ?? {}), level: nextLogLevel };
+
+      const res = await rpcReq<{
+        ok?: boolean;
+        config?: LiveConfig;
+        restart?: unknown;
+        sentinel?: unknown;
+      }>(requireWs(), "config.apply", {
+        raw: JSON.stringify(updated, null, 2),
+        baseHash: original.hash,
+      });
+
+      expect(res.ok).toBe(true);
+      expect(res.payload?.restart).toBeNull();
+      expect(res.payload?.sentinel).toBeNull();
+      expect(res.payload?.config?.commands?.restart).toBe(false);
+      expect(res.payload?.config?.logging?.level).toBe(nextLogLevel);
+    } finally {
+      const latest = await getLiveConfig();
+      await writeLiveConfig(original.config, latest.hash);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/openclaw/openclaw/issues/20245

## Symptom
`config.patch` and `config.apply` still schedule a restart even when `commands.restart=false` is set.

## Root cause
Both handlers always wrote the restart sentinel and queued SIGUSR1 after config writes, without checking whether automatic restarts were disabled in the current or next config.

## Fix
- centralize restart scheduling for config writes
- skip sentinel creation and restart scheduling when `commands.restart=false` in either the current or updated config
- return `restart: null` and `sentinel: null` in that disabled case
- add regression coverage for both `config.patch` and `config.apply`

## Regression test
- `pnpm exec vitest run src/gateway/server.config-patch.test.ts`

## Note
This branch also includes the minimal `@mariozechner/pi-ai/oauth` import-path correction needed for current gateway test startup. The broader auth/proxy change is already tracked in https://github.com/openclaw/openclaw/pull/42344.