### PR TITLE
fix(skills): honor skills.allowBundled during workspace sync

### DIFF
--- a/src/agents/skills/workspace.sync.test.ts
+++ b/src/agents/skills/workspace.sync.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeSkill } from "../skills.e2e-test-helpers.js";
+import { syncSkillsToWorkspace } from "./workspace.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("syncSkillsToWorkspace", () => {
+  it("only copies bundled skills allowed by skills.allowBundled", async () => {
+    const sourceWorkspaceDir = await makeTempDir("openclaw-skills-source-");
+    const targetWorkspaceDir = await makeTempDir("openclaw-skills-target-");
+    const bundledSkillsDir = await makeTempDir("openclaw-skills-bundled-");
+
+    await writeSkill({
+      dir: path.join(bundledSkillsDir, "frontend-design"),
+      name: "frontend-design",
+      description: "allowed bundled skill",
+    });
+    await writeSkill({
+      dir: path.join(bundledSkillsDir, "ops-debug"),
+      name: "ops-debug",
+      description: "filtered bundled skill",
+    });
+
+    await syncSkillsToWorkspace({
+      sourceWorkspaceDir,
+      targetWorkspaceDir,
+      bundledSkillsDir,
+      config: {
+        skills: {
+          allowBundled: ["frontend-design"],
+        },
+      },
+    });
+
+    const syncedEntries = await fs.readdir(path.join(targetWorkspaceDir, "skills"));
+    expect(syncedEntries).toEqual(["frontend-design"]);
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -723,11 +723,12 @@ export async function syncSkillsToWorkspace(params: {
   await serializeByKey(`syncSkills:${targetDir}`, async () => {
     const targetSkillsDir = path.join(targetDir, "skills");
 
-    const entries = loadSkillEntries(sourceDir, {
+    const loadedEntries = loadSkillEntries(sourceDir, {
       config: params.config,
       managedSkillsDir: params.managedSkillsDir,
       bundledSkillsDir: params.bundledSkillsDir,
     });
+    const entries = filterSkillEntries(loadedEntries, params.config);
 
     await fsp.rm(targetSkillsDir, { recursive: true, force: true });
     await fsp.mkdir(targetSkillsDir, { recursive: true });


### PR DESCRIPTION
## Summary
Fixes https://github.com/openclaw/openclaw/issues/10236

## Symptom
`skills.allowBundled` is ignored during sandbox skill sync, so disallowed bundled skills still get copied into the workspace.

## Root cause
`syncSkillsToWorkspace()` loads bundled skill entries but never runs them through `filterSkillEntries()` before copying.

## Fix
- filter loaded skill entries with the active config before syncing
- add a regression test covering a mixed bundled skill set where only one skill is allowlisted

## Regression test
- `pnpm exec vitest run src/agents/skills/workspace.sync.test.ts`