### PR TITLE
Gateway: self-heal invalid enum config on startup

### DIFF
--- a/src/gateway/config-startup-heal.test.ts
+++ b/src/gateway/config-startup-heal.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ConfigFileSnapshot, ConfigValidationIssue } from "../config/types.openclaw.js";
+import {
+  stripAllowedValueIssuesFromConfig,
+  tryStartupConfigAllowedValueSelfHeal,
+} from "./config-startup-heal.js";
+
+function createSnapshot(params: {
+  valid: boolean;
+  resolved?: Record<string, unknown>;
+  issues?: ConfigValidationIssue[];
+}): ConfigFileSnapshot {
+  const resolved = params.resolved ?? {};
+  return {
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: JSON.stringify(resolved),
+    parsed: resolved,
+    resolved,
+    valid: params.valid,
+    config: resolved,
+    issues: params.issues ?? [],
+    warnings: [],
+    legacyIssues: [],
+  };
+}
+
+describe("stripAllowedValueIssuesFromConfig", () => {
+  it("strips paths tied to allowed-values issues", () => {
+    const config = {
+      gateway: { mode: "remote", bind: "internet" },
+      channels: { discord: { streaming: "full-on" } },
+    };
+    const issues: ConfigValidationIssue[] = [
+      {
+        path: "gateway.bind",
+        message: "Invalid option",
+        allowedValues: ["loopback", "lan", "tailnet", "auto", "custom"],
+      },
+      {
+        path: "channels.discord.streaming",
+        message: "Invalid option",
+        allowedValues: ["off", "partial", "block", "progress"],
+      },
+    ];
+
+    const result = stripAllowedValueIssuesFromConfig({
+      config,
+      issues,
+    });
+
+    expect(result.strippedPaths).toEqual(["channels.discord.streaming", "gateway.bind"]);
+    expect(result.config).toEqual({
+      gateway: { mode: "remote" },
+    });
+  });
+
+  it("ignores issues without allowed values", () => {
+    const config = { gateway: { bind: "internet" } };
+    const issues: ConfigValidationIssue[] = [
+      {
+        path: "gateway.bind",
+        message: "some other validation error",
+      },
+    ];
+
+    const result = stripAllowedValueIssuesFromConfig({
+      config,
+      issues,
+    });
+
+    expect(result.strippedPaths).toEqual([]);
+    expect(result.config).toEqual(config);
+  });
+
+  it("strips array entries by index when allowed-values issues target arrays", () => {
+    const config = {
+      channels: {
+        telegram: {
+          accounts: [
+            { id: "a", mode: "bad" },
+            { id: "b", mode: "bad" },
+            { id: "c", mode: "ok" },
+          ],
+        },
+      },
+    };
+    const issues: ConfigValidationIssue[] = [
+      {
+        path: "channels.telegram.accounts.0.mode",
+        message: "Invalid option",
+        allowedValues: ["thread", "top-level"],
+      },
+      {
+        path: "channels.telegram.accounts.1.mode",
+        message: "Invalid option",
+        allowedValues: ["thread", "top-level"],
+      },
+    ];
+
+    const result = stripAllowedValueIssuesFromConfig({
+      config,
+      issues,
+    });
+
+    expect(result.strippedPaths).toEqual([
+      "channels.telegram.accounts.0.mode",
+      "channels.telegram.accounts.1.mode",
+    ]);
+    expect(result.config).toEqual({
+      channels: {
+        telegram: {
+          accounts: [{ id: "a" }, { id: "b" }, { id: "c", mode: "ok" }],
+        },
+      },
+    });
+  });
+});
+
+describe("tryStartupConfigAllowedValueSelfHeal", () => {
+  it("writes healed config and reloads snapshot when enum issues are strip-repairable", async () => {
+    const invalidSnapshot = createSnapshot({
+      valid: false,
+      resolved: { gateway: { bind: "internet", mode: "local" } },
+      issues: [
+        {
+          path: "gateway.bind",
+          message: "Invalid option",
+          allowedValues: ["loopback", "lan", "tailnet", "auto", "custom"],
+        },
+      ],
+    });
+    const healedSnapshot = createSnapshot({
+      valid: true,
+      resolved: { gateway: { mode: "local" } },
+    });
+
+    const writeConfig = vi.fn(async () => {});
+    const readSnapshot = vi.fn(async () => healedSnapshot);
+    const logWarn = vi.fn();
+
+    const result = await tryStartupConfigAllowedValueSelfHeal({
+      snapshot: invalidSnapshot,
+      writeConfig,
+      readSnapshot,
+      logWarn,
+    });
+
+    expect(writeConfig).toHaveBeenCalledTimes(1);
+    expect(writeConfig).toHaveBeenCalledWith({ gateway: { mode: "local" } });
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(result).toBe(healedSnapshot);
+    expect(logWarn).toHaveBeenCalledWith(
+      "gateway: stripped invalid config enum paths during startup: gateway.bind",
+    );
+  });
+
+  it("returns original snapshot when no allowed-values paths are present", async () => {
+    const invalidSnapshot = createSnapshot({
+      valid: false,
+      resolved: { gateway: { bind: "internet", mode: "local" } },
+      issues: [{ path: "gateway.bind", message: "wrong type" }],
+    });
+
+    const writeConfig = vi.fn(async () => {});
+    const readSnapshot = vi.fn(async () => invalidSnapshot);
+    const logWarn = vi.fn();
+
+    const result = await tryStartupConfigAllowedValueSelfHeal({
+      snapshot: invalidSnapshot,
+      writeConfig,
+      readSnapshot,
+      logWarn,
+    });
+
+    expect(result).toBe(invalidSnapshot);
+    expect(writeConfig).not.toHaveBeenCalled();
+    expect(readSnapshot).not.toHaveBeenCalled();
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("keeps original snapshot when write fails", async () => {
+    const invalidSnapshot = createSnapshot({
+      valid: false,
+      resolved: { gateway: { bind: "internet", mode: "local" } },
+      issues: [
+        {
+          path: "gateway.bind",
+          message: "Invalid option",
+          allowedValues: ["loopback", "lan", "tailnet", "auto", "custom"],
+        },
+      ],
+    });
+    const writeConfig = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const readSnapshot = vi.fn(async () => invalidSnapshot);
+    const logWarn = vi.fn();
+
+    const result = await tryStartupConfigAllowedValueSelfHeal({
+      snapshot: invalidSnapshot,
+      writeConfig,
+      readSnapshot,
+      logWarn,
+    });
+
+    expect(result).toBe(invalidSnapshot);
+    expect(writeConfig).toHaveBeenCalledTimes(1);
+    expect(readSnapshot).not.toHaveBeenCalled();
+    expect(logWarn).toHaveBeenCalledWith(
+      "gateway: startup enum self-heal failed while stripping invalid config paths (gateway.bind): Error: boom",
+    );
+  });
+});

--- a/src/gateway/config-startup-heal.ts
+++ b/src/gateway/config-startup-heal.ts
@@ -1,0 +1,216 @@
+import { isBlockedObjectKey } from "../config/prototype-keys.js";
+import type {
+  ConfigFileSnapshot,
+  ConfigValidationIssue,
+  OpenClawConfig,
+} from "../config/types.openclaw.js";
+
+const PRUNED_OBJECT = Symbol("pruned-object");
+
+type UnsetResult = {
+  changed: boolean;
+  value: unknown;
+};
+
+function isNumericPathSegment(raw: string): boolean {
+  return /^[0-9]+$/.test(raw);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwnObjectKey(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function parsePathSegments(raw: string): string[] | null {
+  const segments = raw
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  if (segments.length === 0) {
+    return null;
+  }
+  for (const segment of segments) {
+    if (isNumericPathSegment(segment)) {
+      continue;
+    }
+    if (isBlockedObjectKey(segment)) {
+      return null;
+    }
+  }
+  return segments;
+}
+
+function shouldStripIssue(issue: ConfigValidationIssue): boolean {
+  if (!Array.isArray(issue.allowedValues) || issue.allowedValues.length === 0) {
+    return false;
+  }
+  return Boolean(issue.path?.trim());
+}
+
+function unsetPathAt(value: unknown, segments: string[], depth: number): UnsetResult {
+  if (depth >= segments.length) {
+    return { changed: false, value };
+  }
+  const segment = segments[depth];
+  const isLeaf = depth === segments.length - 1;
+
+  if (Array.isArray(value)) {
+    if (!isNumericPathSegment(segment)) {
+      return { changed: false, value };
+    }
+    const index = Number.parseInt(segment, 10);
+    if (!Number.isFinite(index) || index < 0 || index >= value.length) {
+      return { changed: false, value };
+    }
+    if (isLeaf) {
+      const next = value.slice();
+      next.splice(index, 1);
+      return { changed: true, value: next };
+    }
+    const child = unsetPathAt(value[index], segments, depth + 1);
+    if (!child.changed) {
+      return { changed: false, value };
+    }
+    const next = value.slice();
+    if (child.value === PRUNED_OBJECT) {
+      next.splice(index, 1);
+    } else {
+      next[index] = child.value;
+    }
+    return { changed: true, value: next };
+  }
+
+  if (!isPlainObject(value) || !hasOwnObjectKey(value, segment)) {
+    return { changed: false, value };
+  }
+  if (isLeaf) {
+    const next: Record<string, unknown> = { ...value };
+    delete next[segment];
+    return {
+      changed: true,
+      value: Object.keys(next).length === 0 ? PRUNED_OBJECT : next,
+    };
+  }
+
+  const child = unsetPathAt(value[segment], segments, depth + 1);
+  if (!child.changed) {
+    return { changed: false, value };
+  }
+  const next: Record<string, unknown> = { ...value };
+  if (child.value === PRUNED_OBJECT) {
+    delete next[segment];
+  } else {
+    next[segment] = child.value;
+  }
+  return {
+    changed: true,
+    value: Object.keys(next).length === 0 ? PRUNED_OBJECT : next,
+  };
+}
+
+function unsetPath(
+  config: OpenClawConfig,
+  segments: string[],
+): { changed: boolean; next: OpenClawConfig } {
+  if (segments.length === 0) {
+    return { changed: false, next: config };
+  }
+  const result = unsetPathAt(config, segments, 0);
+  if (!result.changed) {
+    return { changed: false, next: config };
+  }
+  if (result.value === PRUNED_OBJECT) {
+    return { changed: true, next: {} };
+  }
+  if (isPlainObject(result.value)) {
+    return { changed: true, next: result.value as OpenClawConfig };
+  }
+  return { changed: false, next: config };
+}
+
+function comparePathSegments(a: string[], b: string[]): number {
+  const parentA = a.slice(0, -1).join(".");
+  const parentB = b.slice(0, -1).join(".");
+  if (parentA === parentB) {
+    const leafA = a[a.length - 1] ?? "";
+    const leafB = b[b.length - 1] ?? "";
+    if (isNumericPathSegment(leafA) && isNumericPathSegment(leafB)) {
+      return Number.parseInt(leafB, 10) - Number.parseInt(leafA, 10);
+    }
+  }
+  if (a.length !== b.length) {
+    return b.length - a.length;
+  }
+  return a.join(".").localeCompare(b.join("."));
+}
+
+export function stripAllowedValueIssuesFromConfig(params: {
+  config: OpenClawConfig;
+  issues: ConfigValidationIssue[];
+}): { config: OpenClawConfig; strippedPaths: string[] } {
+  const unique = new Map<string, string[]>();
+  for (const issue of params.issues) {
+    if (!shouldStripIssue(issue)) {
+      continue;
+    }
+    const segments = parsePathSegments(issue.path);
+    if (!segments) {
+      continue;
+    }
+    unique.set(segments.join("."), segments);
+  }
+
+  const candidates = Array.from(unique.values()).toSorted(comparePathSegments);
+  let next = params.config;
+  const strippedPaths: string[] = [];
+  for (const segments of candidates) {
+    const result = unsetPath(next, segments);
+    if (!result.changed) {
+      continue;
+    }
+    next = result.next;
+    strippedPaths.push(segments.join("."));
+  }
+  return { config: next, strippedPaths };
+}
+
+export async function tryStartupConfigAllowedValueSelfHeal(params: {
+  snapshot: ConfigFileSnapshot;
+  writeConfig: (cfg: OpenClawConfig) => Promise<void>;
+  readSnapshot: () => Promise<ConfigFileSnapshot>;
+  logWarn: (message: string) => void;
+}): Promise<ConfigFileSnapshot> {
+  const { snapshot } = params;
+  if (!snapshot.exists || snapshot.valid) {
+    return snapshot;
+  }
+  const resolved = snapshot.resolved;
+  if (!resolved || typeof resolved !== "object" || Array.isArray(resolved)) {
+    return snapshot;
+  }
+
+  const stripped = stripAllowedValueIssuesFromConfig({
+    config: structuredClone(resolved),
+    issues: snapshot.issues,
+  });
+  if (stripped.strippedPaths.length === 0) {
+    return snapshot;
+  }
+
+  try {
+    await params.writeConfig(stripped.config);
+  } catch (err) {
+    params.logWarn(
+      `gateway: startup enum self-heal failed while stripping invalid config paths (${stripped.strippedPaths.join(", ")}): ${String(err)}`,
+    );
+    return snapshot;
+  }
+
+  params.logWarn(
+    `gateway: stripped invalid config enum paths during startup: ${stripped.strippedPaths.join(", ")}`,
+  );
+  return await params.readSnapshot();
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -66,6 +66,7 @@ import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
+import { tryStartupConfigAllowedValueSelfHeal } from "./config-startup-heal.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
@@ -305,6 +306,14 @@ export async function startGatewayServer(
   }
 
   configSnapshot = await readConfigFileSnapshot();
+  configSnapshot = await tryStartupConfigAllowedValueSelfHeal({
+    snapshot: configSnapshot,
+    writeConfig: writeConfigFile,
+    readSnapshot: readConfigFileSnapshot,
+    logWarn: (message) => {
+      log.warn(message);
+    },
+  });
   if (configSnapshot.exists && !configSnapshot.valid) {
     const issues =
       configSnapshot.issues.length > 0


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Invalid enum-like config values can leave `openclaw.json` in a state that blocks gateway startup.
- Why it matters: Agent-driven config edits can introduce bad values, and startup currently hard-fails until users manually repair config.
- What changed: Added startup self-heal that strips only invalid paths surfaced with schema `allowedValues`, rewrites config, and retries snapshot validation before startup continues.
- What did NOT change (scope boundary): No schema changes, no widening of accepted values, and no behavior changes for valid configs.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40015
- Related #

## User-visible / Behavior Changes

- On startup, when config is invalid specifically due fields with known `allowedValues` (enum-like validation failures), gateway now removes those invalid fields, persists the healed config, and retries validation.
- If self-heal cannot write, gateway keeps previous behavior and surfaces the invalid-config error.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + Vitest (repo local test harness)
- Model/provider: N/A
- Integration/channel (if any): Gateway config startup + config RPC tests
- Relevant config (redacted): synthetic invalid enum paths in test snapshots

### Steps

1. Create config snapshot with invalid enum-like values (issues include `allowedValues`).
2. Start gateway startup flow.
3. Observe startup self-heal path strip + rewrite + re-read.

### Expected

- Invalid enum-like paths are removed and startup can continue when resulting config validates.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands run locally:

- `pnpm vitest run src/gateway/config-startup-heal.test.ts src/gateway/server.legacy-migration.test.ts src/gateway/server.config-patch.test.ts`
  - Result: 3 files passed, 18 tests passed.
- `pnpm format`
  - Result: passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Allowed-values issues are converted to removable paths.
  - Startup self-heal writes stripped config and re-reads snapshot.
  - Startup behavior unchanged when no strip candidates exist.
  - Startup behavior unchanged (still fails) when self-heal write fails.
- Edge cases checked:
  - Array-indexed paths.
  - Prototype-key guard on path parsing.
- What you did **not** verify:
  - Manual live run against real user config files/channels.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fd63018b0`.
- Files/config to restore: `src/gateway/server.impl.ts`, `src/gateway/config-startup-heal.ts`.
- Known bad symptoms reviewers should watch for: unexpected startup-time removal of non-target config paths.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-stripping if an allowed-values issue is not truly enum-like.
  - Mitigation: Strip is limited to startup-invalid snapshots, only issues with non-empty `allowedValues`, and uses guarded path parsing (blocked prototype keys). Startup still re-validates after write.
