### PR TITLE
docs(telegram): clarify group and sender allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: treat Gemini `MALFORMED_RESPONSE` stop reasons as retryable timeouts so preview-model enum drift falls back cleanly instead of crashing the run, without also reclassifying malformed function-call errors. (#42292) Thanks @jnMetaCode.
 - Discord/Telegram outbound runtime config: thread runtime-resolved config through Discord and Telegram send paths so SecretRef-based credentials stay resolved during message delivery. (#42352) Thanks @joshavant.
 - Secrets/SecretRef: reject exec SecretRef traversal ids across schema, runtime, and gateway. (#42370) Thanks @joshavant.
+- Telegram/docs: clarify that `channels.telegram.groups` allowlists chats while `groupAllowFrom` allowlists users inside those chats, and point invalid negative chat IDs at the right config key. (#42451) Thanks @altaywtf.
 
 ## 2026.3.8
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -187,16 +187,16 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
       groups: {
         "-1001234567890": {
           requireMention: true,
+          allowFrom: ["8734062810", "745123456"],
         },
       },
-      groupAllowFrom: ["8734062810", "745123456"],
     },
   },
 }
 ```
 
     <Warning>
-      Common mistake: `groupAllowFrom` is not a Telegram group whitelist.
+      Common mistake: `groupAllowFrom` is not a Telegram group allowlist.
 
       - Put negative Telegram group or supergroup chat IDs like `-1001234567890` under `channels.telegram.groups`.
       - Put Telegram user IDs like `8734062810` under `groupAllowFrom` when you want to limit which people inside an allowed group can trigger the bot.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -155,6 +155,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     `groupAllowFrom` is used for group sender filtering. If not set, Telegram falls back to `allowFrom`.
     `groupAllowFrom` entries should be numeric Telegram user IDs (`telegram:` / `tg:` prefixes are normalized).
+    Do not put Telegram group or supergroup chat IDs in `groupAllowFrom`. Negative chat IDs belong under `channels.telegram.groups`.
     Non-numeric entries are ignored for sender authorization.
     Security boundary (`2026.2.25+`): group sender auth does **not** inherit DM pairing-store approvals.
     Pairing stays DM-only. For groups, set `groupAllowFrom` or per-group/per-topic `allowFrom`.
@@ -176,6 +177,31 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   },
 }
 ```
+
+    Example: allow only specific users inside one specific group:
+
+```json5
+{
+  channels: {
+    telegram: {
+      groups: {
+        "-1001234567890": {
+          requireMention: true,
+        },
+      },
+      groupAllowFrom: ["8734062810", "745123456"],
+    },
+  },
+}
+```
+
+    <Warning>
+      Common mistake: `groupAllowFrom` is not a Telegram group whitelist.
+
+      - Put negative Telegram group or supergroup chat IDs like `-1001234567890` under `channels.telegram.groups`.
+      - Put Telegram user IDs like `8734062810` under `groupAllowFrom` when you want to limit which people inside an allowed group can trigger the bot.
+      - Use `groupAllowFrom: ["*"]` only when you want any member of an allowed group to be able to talk to the bot.
+    </Warning>
 
   </Tab>
 

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,7 +31,8 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
+        "- allowFrom/groupAllowFrom authorization expects numeric Telegram sender user IDs only.",
+        'To allow a Telegram group or supergroup, add its negative chat ID under "channels.telegram.groups" instead.',
         'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );


### PR DESCRIPTION
## Summary

- Problem: Telegram users are confusing `groupAllowFrom` (group sender allowlist) with `channels.telegram.groups` (group chat allowlist).
- Why it matters: that misunderstanding is generating invalid bug reports and duplicate PRs proposing negative group IDs in `groupAllowFrom`.
- What changed: clarified the Telegram docs, added an explicit example for whitelisting users inside a specific allowed group, added a “Common mistake” warning callout, and updated the runtime warning to point operators to `channels.telegram.groups` for negative Telegram chat IDs.
- What did NOT change (scope boundary): no Telegram allowlist semantics changed; this PR only clarifies the existing contract.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40444
- Related #40456
- Related #40461
- Related #40484
- Related #40569
- Related #40591
- Related #40662
- Related #40751
- Related #40763
- Related #40775
- Related #40925
- Related #41200
- Related #42326

## User-visible / Behavior Changes

- Telegram docs now show the correct split between `channels.telegram.groups` (allowed group chats) and `groupAllowFrom` (allowed users inside those chats).
- Operators who put negative Telegram group IDs in `groupAllowFrom` now get a warning that points them to `channels.telegram.groups`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram configs using `groupPolicy`, `groups`, `allowFrom`, and `groupAllowFrom`

### Steps

1. Read the Telegram access-control docs.
2. Trigger the invalid `groupAllowFrom` warning path with a negative Telegram chat ID.
3. Run the focused Telegram access-control tests.

### Expected

- Docs clearly distinguish group chat allowlisting from sender allowlisting.
- Runtime warning points operators at `channels.telegram.groups` for group chat IDs.
- Existing Telegram access-control tests still pass.

### Actual

- Before this change, docs and warning text made the group-vs-sender distinction easier to miss.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the Telegram access-control code path and updated docs/warning to match the existing behavior; ran the focused Telegram allowlist tests.
- Edge cases checked: explicit group entries, wildcard group entries, sender allowlist enforcement, missing sender identity handling.
- What you did **not** verify: full live Telegram bot interaction against a real group.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `docs/channels/telegram.md`, `src/telegram/bot-access.ts`
- Known bad symptoms reviewers should watch for: none beyond wording regressions in docs or warning output.

## Risks and Mitigations

None.
