### PR TITLE
feat(models): expose provider rate-limit headroom in probe results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ dist/protocol.schema.json
 # Synthing
 **/.stfolder/
 .dev-state
+openclaw-*.log

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -88,6 +88,7 @@ export function registerModelsCli(program: Command) {
     .option("--probe-timeout <ms>", "Per-probe timeout in ms")
     .option("--probe-concurrency <n>", "Concurrent probes")
     .option("--probe-max-tokens <n>", "Probe max tokens (best-effort)")
+    .option("--rate-limits", "Include provider rate-limit headroom in probe output", false)
     .option(
       "--agent <id>",
       "Agent id to inspect (overrides OPENCLAW_AGENT_DIR/PI_CODING_AGENT_DIR)",
@@ -107,6 +108,7 @@ export function registerModelsCli(program: Command) {
             probeTimeout: opts.probeTimeout as string | undefined,
             probeConcurrency: opts.probeConcurrency as string | undefined,
             probeMaxTokens: opts.probeMaxTokens as string | undefined,
+            rateLimits: Boolean(opts.rateLimits),
             agent,
           },
           defaultRuntime,

--- a/src/commands/models/list.probe.test.ts
+++ b/src/commands/models/list.probe.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { mapFailoverReasonToProbeStatus } from "./list.probe.js";
+import {
+  formatRateLimitShort,
+  mapFailoverReasonToProbeStatus,
+  parseIntHeader,
+  parseRateLimitHeaders,
+} from "./list.probe.js";
 
 describe("mapFailoverReasonToProbeStatus", () => {
   it("maps auth_permanent to auth", () => {
@@ -19,5 +24,146 @@ describe("mapFailoverReasonToProbeStatus", () => {
     expect(mapFailoverReasonToProbeStatus(undefined)).toBe("unknown");
     expect(mapFailoverReasonToProbeStatus(null)).toBe("unknown");
     expect(mapFailoverReasonToProbeStatus("model_not_found")).toBe("unknown");
+  });
+});
+
+describe("parseIntHeader", () => {
+  it("parses valid integer strings", () => {
+    expect(parseIntHeader("42")).toBe(42);
+    expect(parseIntHeader("0")).toBe(0);
+    expect(parseIntHeader("1000000")).toBe(1_000_000);
+  });
+
+  it("returns undefined for null, undefined, or empty string", () => {
+    expect(parseIntHeader(null)).toBeUndefined();
+    expect(parseIntHeader(undefined)).toBeUndefined();
+    expect(parseIntHeader("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-numeric strings", () => {
+    expect(parseIntHeader("abc")).toBeUndefined();
+    expect(parseIntHeader("NaN")).toBeUndefined();
+    expect(parseIntHeader("Infinity")).toBeUndefined();
+  });
+
+  it("truncates floating-point strings to integer", () => {
+    expect(parseIntHeader("42.9")).toBe(42);
+  });
+});
+
+describe("parseRateLimitHeaders", () => {
+  function mockHeaders(map: Record<string, string>): { get(name: string): string | null } {
+    return {
+      get(name: string) {
+        return map[name] ?? null;
+      },
+    };
+  }
+
+  it("extracts all standard rate-limit headers", () => {
+    const result = parseRateLimitHeaders(
+      mockHeaders({
+        "x-ratelimit-remaining-requests": "945",
+        "x-ratelimit-limit-requests": "1000",
+        "x-ratelimit-remaining-tokens": "78000",
+        "x-ratelimit-limit-tokens": "80000",
+        "x-ratelimit-reset-requests": "2026-03-10T18:00:00Z",
+        "x-ratelimit-reset-tokens": "2026-03-10T18:00:00Z",
+      }),
+    );
+    expect(result).toEqual({
+      remainingRequests: 945,
+      limitRequests: 1000,
+      remainingTokens: 78000,
+      limitTokens: 80000,
+      resetRequests: "2026-03-10T18:00:00Z",
+      resetTokens: "2026-03-10T18:00:00Z",
+    });
+  });
+
+  it("returns undefined when no rate-limit headers are present", () => {
+    expect(parseRateLimitHeaders(mockHeaders({}))).toBeUndefined();
+  });
+
+  it("handles partial headers gracefully", () => {
+    const result = parseRateLimitHeaders(
+      mockHeaders({
+        "x-ratelimit-remaining-requests": "10",
+        "x-ratelimit-limit-requests": "100",
+      }),
+    );
+    expect(result).toEqual({
+      remainingRequests: 10,
+      limitRequests: 100,
+      remainingTokens: undefined,
+      limitTokens: undefined,
+      resetRequests: undefined,
+      resetTokens: undefined,
+    });
+  });
+
+  it("handles only token headers", () => {
+    const result = parseRateLimitHeaders(
+      mockHeaders({
+        "x-ratelimit-remaining-tokens": "500000",
+        "x-ratelimit-limit-tokens": "1000000",
+      }),
+    );
+    expect(result).toBeDefined();
+    expect(result?.remainingTokens).toBe(500000);
+    expect(result?.limitTokens).toBe(1000000);
+    expect(result?.remainingRequests).toBeUndefined();
+  });
+
+  it("handles non-numeric header values gracefully", () => {
+    const result = parseRateLimitHeaders(
+      mockHeaders({
+        "x-ratelimit-remaining-requests": "not-a-number",
+        "x-ratelimit-reset-requests": "1m30s",
+      }),
+    );
+    expect(result).toBeDefined();
+    expect(result?.remainingRequests).toBeUndefined();
+    expect(result?.resetRequests).toBe("1m30s");
+  });
+});
+
+describe("formatRateLimitShort", () => {
+  it("returns dashes for undefined/null input", () => {
+    expect(formatRateLimitShort(undefined)).toEqual({ rpm: "-", tpm: "-" });
+    expect(formatRateLimitShort(null)).toEqual({ rpm: "-", tpm: "-" });
+  });
+
+  it("formats remaining/limit pairs", () => {
+    expect(
+      formatRateLimitShort({
+        remainingRequests: 945,
+        limitRequests: 1000,
+        remainingTokens: 78000,
+        limitTokens: 80000,
+      }),
+    ).toEqual({ rpm: "945/1000", tpm: "78000/80000" });
+  });
+
+  it("formats remaining-only values", () => {
+    expect(
+      formatRateLimitShort({
+        remainingRequests: 500,
+        remainingTokens: 10000,
+      }),
+    ).toEqual({ rpm: "500", tpm: "10000" });
+  });
+
+  it("formats limit-only values", () => {
+    expect(
+      formatRateLimitShort({
+        limitRequests: 1000,
+        limitTokens: 80000,
+      }),
+    ).toEqual({ rpm: "-/1000", tpm: "-/80000" });
+  });
+
+  it("returns dashes for empty info object", () => {
+    expect(formatRateLimitShort({})).toEqual({ rpm: "-", tpm: "-" });
   });
 });

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -7,6 +7,7 @@ import {
   type AuthProfileEligibilityReasonCode,
   ensureAuthProfileStore,
   listProfilesForProvider,
+  resolveApiKeyForProfile,
   resolveAuthProfileDisplayLabel,
   resolveAuthProfileEligibility,
   resolveAuthProfileOrder,
@@ -30,6 +31,7 @@ import {
 import { coerceSecretRef, normalizeSecretInputString } from "../../config/types.secrets.js";
 import { type SecretRefResolveCache, resolveSecretRefString } from "../../secrets/resolve.js";
 import { redactSecrets } from "../status-all/format.js";
+import type { RateLimitInfo } from "./list.types.js";
 import { DEFAULT_PROVIDER, formatMs } from "./shared.js";
 
 const PROBE_PROMPT = "Reply with OK. Do not use tools.";
@@ -64,6 +66,7 @@ export type AuthProbeResult = {
   reasonCode?: AuthProbeReasonCode;
   error?: string;
   latencyMs?: number;
+  rateLimit?: RateLimitInfo;
 };
 
 type AuthProbeTarget = {
@@ -96,6 +99,8 @@ export type AuthProbeOptions = {
   timeoutMs: number;
   concurrency: number;
   maxTokens: number;
+  /** When true, make an additional lightweight API call to capture rate-limit headers. */
+  rateLimits?: boolean;
 };
 
 export function mapFailoverReasonToProbeStatus(reason?: string | null): AuthProbeStatus {
@@ -409,6 +414,223 @@ export async function buildProbeTargets(params: {
   return { targets, results };
 }
 
+// ---------------------------------------------------------------------------
+// Rate-limit header probing
+// ---------------------------------------------------------------------------
+
+/** Parse a numeric header value, returning `undefined` for missing/invalid values. */
+export function parseIntHeader(value: string | null | undefined): number | undefined {
+  if (value == null || value === "") {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/** Extract standardised rate-limit headers from a `Headers`-like object. */
+export function parseRateLimitHeaders(headers: {
+  get(name: string): string | null;
+}): RateLimitInfo | undefined {
+  const info: RateLimitInfo = {
+    remainingRequests: parseIntHeader(headers.get("x-ratelimit-remaining-requests")),
+    limitRequests: parseIntHeader(headers.get("x-ratelimit-limit-requests")),
+    remainingTokens: parseIntHeader(headers.get("x-ratelimit-remaining-tokens")),
+    limitTokens: parseIntHeader(headers.get("x-ratelimit-limit-tokens")),
+    resetRequests: headers.get("x-ratelimit-reset-requests") ?? undefined,
+    resetTokens: headers.get("x-ratelimit-reset-tokens") ?? undefined,
+  };
+
+  // If every field is undefined, the provider didn't send rate-limit headers.
+  const hasAny = Object.values(info).some((v) => v !== undefined);
+  return hasAny ? info : undefined;
+}
+
+type ProviderEndpoint = {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+};
+
+/** Default base URLs for known providers. */
+const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com/v1",
+  groq: "https://api.groq.com/openai/v1",
+  xai: "https://api.x.ai/v1",
+  cerebras: "https://api.cerebras.ai/v1",
+  mistral: "https://api.mistral.ai/v1",
+  openrouter: "https://openrouter.ai/api/v1",
+};
+
+/**
+ * Build the cheapest possible request for a provider — max_tokens=1, single-char prompt.
+ * Respects custom baseUrl from models.providers config when available.
+ */
+function buildProviderEndpoint(params: {
+  provider: string;
+  model: string;
+  apiKey: string;
+  customBaseUrl?: string;
+}): ProviderEndpoint | null {
+  const { provider, model, apiKey, customBaseUrl } = params;
+
+  if (provider === "anthropic") {
+    const raw = customBaseUrl?.replace(/\/+$/, "") ?? "https://api.anthropic.com";
+    // Avoid path doubling when custom baseUrl already includes a version segment (e.g. /v1)
+    const base = /\/v\d+$/.test(raw) ? raw : `${raw}/v1`;
+    return {
+      url: `${base}/messages`,
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      }),
+    };
+  }
+
+  // OpenAI-compatible providers (OpenAI, Groq, xAI, Cerebras, Mistral, OpenRouter)
+  const openAICompatible = ["openai", "groq", "xai", "cerebras", "mistral", "openrouter"];
+  if (openAICompatible.includes(provider)) {
+    const raw = customBaseUrl?.replace(/\/+$/, "") ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? null;
+    if (!raw) {
+      return null;
+    }
+    // Custom base URLs may or may not include the /chat/completions path segment;
+    // we always append it since rate-limit headers come from completion endpoints.
+    return {
+      url: `${raw}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      }),
+    };
+  }
+
+  // Google — uses API key in query param, different request format.
+  // Rate-limit headers may not follow the x-ratelimit-* convention.
+  if (provider === "google") {
+    const raw = customBaseUrl?.replace(/\/+$/, "") ?? "https://generativelanguage.googleapis.com";
+    // Avoid path doubling when custom baseUrl already includes a version segment (e.g. /v1beta)
+    const base = /\/v\d+(?:beta\d*|alpha\d*)?$/.test(raw) ? raw : `${raw}/v1beta`;
+    return {
+      url: `${base}/models/${model}:generateContent?key=${apiKey}`,
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: "." }] }],
+        generationConfig: { maxOutputTokens: 1 },
+      }),
+    };
+  }
+
+  return null;
+}
+
+/** Resolve the API key for a given probe target. */
+async function resolveApiKeyForTarget(params: {
+  cfg: OpenClawConfig;
+  agentDir: string;
+  target: AuthProbeTarget;
+}): Promise<string | null> {
+  const { cfg, target } = params;
+  if (target.profileId) {
+    const store = ensureAuthProfileStore(params.agentDir);
+    const result = await resolveApiKeyForProfile({
+      cfg,
+      store,
+      profileId: target.profileId,
+      agentDir: params.agentDir,
+    });
+    return result?.apiKey ?? null;
+  }
+  // Env-based or models.json-based key
+  const envKey = resolveEnvApiKey(target.provider);
+  if (envKey) {
+    return envKey.apiKey;
+  }
+  const customKey = getCustomProviderApiKey(cfg, target.provider);
+  if (customKey && !isNonSecretApiKeyMarker(customKey)) {
+    return customKey;
+  }
+  return null;
+}
+
+/** Resolve custom base URL from models.providers config, if configured. */
+function resolveCustomBaseUrl(cfg: OpenClawConfig, provider: string): string | undefined {
+  const providers = cfg?.models?.providers ?? {};
+  const providerConfig = (providers[provider] ?? providers[normalizeProviderId(provider)]) as
+    | { baseUrl?: string }
+    | undefined;
+  return providerConfig?.baseUrl?.trim() || undefined;
+}
+
+/**
+ * Make a lightweight direct HTTP call to capture rate-limit headers.
+ * Only called after the main probe succeeds (status === "ok").
+ */
+async function probeRateLimits(params: {
+  cfg: OpenClawConfig;
+  agentDir: string;
+  target: AuthProbeTarget;
+  timeoutMs: number;
+}): Promise<RateLimitInfo | undefined> {
+  const { cfg, target, timeoutMs } = params;
+  if (!target.model) {
+    return undefined;
+  }
+
+  const apiKey = await resolveApiKeyForTarget({
+    cfg,
+    agentDir: params.agentDir,
+    target,
+  });
+  if (!apiKey) {
+    return undefined;
+  }
+
+  const customBaseUrl = resolveCustomBaseUrl(cfg, target.model.provider);
+  const endpoint = buildProviderEndpoint({
+    provider: target.model.provider,
+    model: target.model.model,
+    apiKey,
+    customBaseUrl,
+  });
+  if (!endpoint) {
+    return undefined;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(endpoint.url, {
+        method: "POST",
+        headers: endpoint.headers,
+        body: endpoint.body,
+        signal: controller.signal,
+      });
+      // We only need the headers — even a 429 or error response may include them.
+      return parseRateLimitHeaders(response.headers);
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // Rate-limit probing is best-effort; never fail the overall probe.
+    return undefined;
+  }
+}
+
 async function probeTarget(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -418,6 +640,7 @@ async function probeTarget(params: {
   target: AuthProbeTarget;
   timeoutMs: number;
   maxTokens: number;
+  rateLimits?: boolean;
 }): Promise<AuthProbeResult> {
   const { cfg, agentId, agentDir, workspaceDir, sessionDir, target, timeoutMs, maxTokens } = params;
   if (!target.model) {
@@ -460,6 +683,14 @@ async function probeTarget(params: {
       verboseLevel: "off",
       streamParams: { maxTokens },
     });
+    const latencyMs = Date.now() - start;
+
+    // Optionally make a separate lightweight call to capture rate-limit headers.
+    let rateLimit: RateLimitInfo | undefined;
+    if (params.rateLimits) {
+      rateLimit = await probeRateLimits({ cfg, agentDir, target, timeoutMs });
+    }
+
     return {
       provider: target.provider,
       model: `${target.model.provider}/${target.model.model}`,
@@ -468,7 +699,8 @@ async function probeTarget(params: {
       source: target.source,
       mode: target.mode,
       status: "ok",
-      latencyMs: Date.now() - start,
+      latencyMs,
+      rateLimit,
     };
   } catch (err) {
     const described = describeFailoverError(err);
@@ -492,6 +724,7 @@ async function runTargetsWithConcurrency(params: {
   timeoutMs: number;
   maxTokens: number;
   concurrency: number;
+  rateLimits?: boolean;
   onProgress?: (update: { completed: number; total: number; label?: string }) => void;
 }): Promise<AuthProbeResult[]> {
   const { cfg, targets, timeoutMs, maxTokens, onProgress } = params;
@@ -530,6 +763,7 @@ async function runTargetsWithConcurrency(params: {
         target,
         timeoutMs,
         maxTokens,
+        rateLimits: params.rateLimits,
       });
       results[index] = result;
       completed += 1;
@@ -567,6 +801,7 @@ export async function runAuthProbes(params: {
         timeoutMs: params.options.timeoutMs,
         maxTokens: params.options.maxTokens,
         concurrency: params.options.concurrency,
+        rateLimits: params.options.rateLimits,
         onProgress: params.onProgress,
       })
     : [];
@@ -581,6 +816,32 @@ export async function runAuthProbes(params: {
     options: params.options,
     results: [...plan.results, ...results],
   };
+}
+
+export function formatRateLimitShort(info?: RateLimitInfo | null): {
+  rpm: string;
+  tpm: string;
+} {
+  if (!info) {
+    return { rpm: "-", tpm: "-" };
+  }
+  const rpm =
+    info.remainingRequests != null && info.limitRequests != null
+      ? `${info.remainingRequests}/${info.limitRequests}`
+      : info.remainingRequests != null
+        ? `${info.remainingRequests}`
+        : info.limitRequests != null
+          ? `-/${info.limitRequests}`
+          : "-";
+  const tpm =
+    info.remainingTokens != null && info.limitTokens != null
+      ? `${info.remainingTokens}/${info.limitTokens}`
+      : info.remainingTokens != null
+        ? `${info.remainingTokens}`
+        : info.limitTokens != null
+          ? `-/${info.limitTokens}`
+          : "-";
+  return { rpm, tpm };
 }
 
 export function formatProbeLatency(latencyMs?: number | null) {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -46,6 +46,7 @@ import { isRich } from "./list.format.js";
 import {
   describeProbeSummary,
   formatProbeLatency,
+  formatRateLimitShort,
   runAuthProbes,
   sortProbeResults,
   type AuthProbeSummary,
@@ -69,6 +70,7 @@ export async function modelsStatusCommand(
     probeTimeout?: string;
     probeConcurrency?: string;
     probeMaxTokens?: string;
+    rateLimits?: boolean;
     agent?: string;
   },
   runtime: RuntimeEnv,
@@ -249,6 +251,7 @@ export async function modelsStatusCommand(
             timeoutMs: probeTimeoutMs,
             concurrency: probeConcurrency,
             maxTokens: probeMaxTokens,
+            rateLimits: opts.rateLimits,
           },
           onProgress: update,
         });
@@ -651,6 +654,7 @@ export async function modelsStatusCommand(
         }
         return theme.muted;
       };
+      const showRateLimits = opts.rateLimits === true;
       const rows = sorted.map((result) => {
         const status = colorize(rich, statusColor(result.status), result.status);
         const latency = formatProbeLatency(result.latencyMs);
@@ -660,20 +664,33 @@ export async function modelsStatusCommand(
         const detail = result.error?.trim();
         const detailLabel = detail ? `\n${colorize(rich, theme.muted, `↳ ${detail}`)}` : "";
         const statusLabel = `${status}${colorize(rich, theme.muted, ` · ${latency}`)}${detailLabel}`;
-        return {
+        const row: Record<string, string> = {
           Model: colorize(rich, theme.heading, modelLabel),
           Profile: profile,
           Status: statusLabel,
         };
+        if (showRateLimits) {
+          const rl = formatRateLimitShort(result.rateLimit);
+          row["RPM"] = colorize(rich, rl.rpm === "-" ? theme.muted : theme.info, rl.rpm);
+          row["TPM"] = colorize(rich, rl.tpm === "-" ? theme.muted : theme.info, rl.tpm);
+        }
+        return row;
       });
+      const columns = [
+        { key: "Model", header: "Model", minWidth: 18 },
+        { key: "Profile", header: "Profile", minWidth: 24 },
+        { key: "Status", header: "Status", minWidth: 12 },
+        ...(showRateLimits
+          ? [
+              { key: "RPM", header: "RPM Remaining", minWidth: 14 },
+              { key: "TPM", header: "TPM Remaining", minWidth: 14 },
+            ]
+          : []),
+      ];
       runtime.log(
         renderTable({
           width: tableWidth,
-          columns: [
-            { key: "Model", header: "Model", minWidth: 18 },
-            { key: "Profile", header: "Profile", minWidth: 24 },
-            { key: "Status", header: "Status", minWidth: 12 },
-          ],
+          columns,
           rows,
         }).trimEnd(),
       );

--- a/src/commands/models/list.types.ts
+++ b/src/commands/models/list.types.ts
@@ -1,3 +1,19 @@
+/** Rate limit information extracted from provider HTTP response headers. */
+export type RateLimitInfo = {
+  /** Requests remaining in current window. */
+  remainingRequests?: number;
+  /** Total request limit per window. */
+  limitRequests?: number;
+  /** Tokens remaining in current window. */
+  remainingTokens?: number;
+  /** Total token limit per window. */
+  limitTokens?: number;
+  /** When the request limit resets (ISO 8601 or duration string). */
+  resetRequests?: string;
+  /** When the token limit resets (ISO 8601 or duration string). */
+  resetTokens?: string;
+};
+
 export type ConfiguredEntry = {
   key: string;
   ref: { provider: string; model: string };


### PR DESCRIPTION
## Summary

Adds rate-limit headroom information to `openclaw models status --probe` output. When `--rate-limits` is passed, each successful probe result includes remaining RPM/TPM data extracted from provider HTTP response headers.

Closes #42401

## Changes

### New types (`list.types.ts`)
- `RateLimitInfo` — structured rate-limit data (remaining/limit for requests and tokens, reset timestamps)

### Probe logic (`list.probe.ts`)
- `parseIntHeader()` — safely parse numeric header values
- `parseRateLimitHeaders()` — extract `x-ratelimit-*` headers into `RateLimitInfo`
- `buildProviderEndpoint()` — build minimal 1-token API requests per provider (Anthropic, OpenAI-compatible, Google). Respects custom `baseUrl` from `models.providers` config.
- `resolveApiKeyForTarget()` — resolve API key for a probe target (profile-based or env-based)
- `probeRateLimits()` — lightweight direct HTTP call to capture rate-limit headers. Only fires after the main probe succeeds. Best-effort: failures are silently ignored.
- `formatRateLimitShort()` — format remaining/limit as compact strings for CLI table
- `rateLimit` field added to `AuthProbeResult`
- `rateLimits` option threaded through `AuthProbeOptions` → `probeTarget` → `runTargetsWithConcurrency` → `runAuthProbes`

### CLI (`models-cli.ts`, `list.status-command.ts`)
- `--rate-limits` flag added to `models status`
- When set, the probe table includes RPM and TPM columns
- JSON output always includes `rateLimit` field (when `--rate-limits` is set)

### Tests (`list.probe.test.ts`)
- 13 new tests covering:
  - `parseIntHeader`: valid ints, null/undefined/empty, non-numeric, floats
  - `parseRateLimitHeaders`: full headers, no headers, partial headers, token-only, non-numeric values
  - `formatRateLimitShort`: null input, full pairs, remaining-only, limit-only, empty object

## Design Decisions

1. **Separate HTTP call** — Rather than modifying `runEmbeddedPiAgent` (core pipeline), rate-limit probing makes a separate lightweight `fetch()` call with `max_tokens=1`. This avoids touching the agent pipeline and keeps the change isolated.

2. **Opt-in** — The `--rate-limits` flag is required. Without it, behavior is identical to before. The extra API call costs fractions of a cent but is still a real billable call.

3. **Custom base URLs** — `buildProviderEndpoint()` reads `models.providers.<provider>.baseUrl` from config, so custom endpoints (proxies, Azure, etc.) are respected.

4. **Provider coverage** — Anthropic, OpenAI, Groq, xAI, Cerebras, Mistral, OpenRouter, and Google are supported. Unknown providers return `null` (no rate-limit data) without error.

5. **Best-effort** — Rate-limit probing never fails the overall probe. All errors are caught silently.

## Usage

```bash
# CLI table with rate limits
openclaw models status --probe --rate-limits

# JSON output (for scripting/automation)
openclaw models status --probe --rate-limits --json
```

## Example output

```
Auth probes
Model                    Profile              Status        RPM Remaining  TPM Remaining
anthropic/claude-opus-4-6  anthropic:key        ok · 1.2s     945/1000       78000/80000
openai/gpt-4o            env                  ok · 0.8s     4500/5000      890000/1000000
google/gemini-1.5-flash  env                  ok · 0.5s     -              -
```