### PR TITLE
feat(cli): add top-level restart/start/stop aliases

### DIFF
--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -215,6 +215,29 @@ const coreEntries: CoreCliEntry[] = [
       mod.registerBrowserCli(program);
     },
   },
+  {
+    commands: [
+      {
+        name: "restart",
+        description: "Restart the Gateway service",
+        hasSubcommands: false,
+      },
+      {
+        name: "start",
+        description: "Start the Gateway service",
+        hasSubcommands: false,
+      },
+      {
+        name: "stop",
+        description: "Stop the Gateway service",
+        hasSubcommands: false,
+      },
+    ],
+    register: async ({ program }) => {
+      const mod = await import("./register.lifecycle-aliases.js");
+      mod.registerLifecycleAliasCommands(program);
+    },
+  },
 ];
 
 function collectCoreCliCommandNames(predicate?: (command: CoreCliCommandDescriptor) => boolean) {

--- a/src/cli/program/register.lifecycle-aliases.test.ts
+++ b/src/cli/program/register.lifecycle-aliases.test.ts
@@ -1,0 +1,87 @@
+import { Command } from "commander";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runDaemonRestart = vi.fn();
+const runDaemonStart = vi.fn();
+const runDaemonStop = vi.fn();
+
+vi.mock("../daemon-cli/runners.js", () => ({
+  runDaemonRestart,
+  runDaemonStart,
+  runDaemonStop,
+}));
+
+let registerLifecycleAliasCommands: typeof import("./register.lifecycle-aliases.js").registerLifecycleAliasCommands;
+
+beforeAll(async () => {
+  ({ registerLifecycleAliasCommands } = await import("./register.lifecycle-aliases.js"));
+});
+
+describe("registerLifecycleAliasCommands", () => {
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerLifecycleAliasCommands(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runDaemonRestart.mockResolvedValue(undefined);
+    runDaemonStart.mockResolvedValue(undefined);
+    runDaemonStop.mockResolvedValue(undefined);
+  });
+
+  it("registers restart command with correct description", () => {
+    const program = new Command();
+    registerLifecycleAliasCommands(program);
+    const cmd = program.commands.find((c) => c.name() === "restart");
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toContain("Restart the Gateway service");
+  });
+
+  it("registers start command with correct description", () => {
+    const program = new Command();
+    registerLifecycleAliasCommands(program);
+    const cmd = program.commands.find((c) => c.name() === "start");
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toContain("Start the Gateway service");
+  });
+
+  it("registers stop command with correct description", () => {
+    const program = new Command();
+    registerLifecycleAliasCommands(program);
+    const cmd = program.commands.find((c) => c.name() === "stop");
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toContain("Stop the Gateway service");
+  });
+
+  it("delegates restart to runDaemonRestart", async () => {
+    await runCli(["restart"]);
+    expect(runDaemonRestart).toHaveBeenCalledWith({ json: false });
+  });
+
+  it("delegates restart --json to runDaemonRestart with json: true", async () => {
+    await runCli(["restart", "--json"]);
+    expect(runDaemonRestart).toHaveBeenCalledWith({ json: true });
+  });
+
+  it("delegates start to runDaemonStart", async () => {
+    await runCli(["start"]);
+    expect(runDaemonStart).toHaveBeenCalledWith({ json: false });
+  });
+
+  it("delegates start --json to runDaemonStart with json: true", async () => {
+    await runCli(["start", "--json"]);
+    expect(runDaemonStart).toHaveBeenCalledWith({ json: true });
+  });
+
+  it("delegates stop to runDaemonStop", async () => {
+    await runCli(["stop"]);
+    expect(runDaemonStop).toHaveBeenCalledWith({ json: false });
+  });
+
+  it("delegates stop --json to runDaemonStop with json: true", async () => {
+    await runCli(["stop", "--json"]);
+    expect(runDaemonStop).toHaveBeenCalledWith({ json: true });
+  });
+});

--- a/src/cli/program/register.lifecycle-aliases.ts
+++ b/src/cli/program/register.lifecycle-aliases.ts
@@ -1,0 +1,54 @@
+import type { Command } from "commander";
+import { theme } from "../../terminal/theme.js";
+import { runDaemonRestart, runDaemonStart, runDaemonStop } from "../daemon-cli/runners.js";
+import { formatHelpExamples } from "../help-format.js";
+
+export function registerLifecycleAliasCommands(program: Command) {
+  program
+    .command("restart")
+    .description("Restart the Gateway service (alias for `openclaw gateway restart`)")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw restart", "Restart the gateway service."],
+          ["openclaw restart --json", "Machine-readable output."],
+        ])}`,
+    )
+    .action(async (opts) => {
+      await runDaemonRestart({ json: Boolean(opts.json) });
+    });
+
+  program
+    .command("start")
+    .description("Start the Gateway service (alias for `openclaw gateway start`)")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw start", "Start the gateway service."],
+          ["openclaw start --json", "Machine-readable output."],
+        ])}`,
+    )
+    .action(async (opts) => {
+      await runDaemonStart({ json: Boolean(opts.json) });
+    });
+
+  program
+    .command("stop")
+    .description("Stop the Gateway service (alias for `openclaw gateway stop`)")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw stop", "Stop the gateway service."],
+          ["openclaw stop --json", "Machine-readable output."],
+        ])}`,
+    )
+    .action(async (opts) => {
+      await runDaemonStop({ json: Boolean(opts.json) });
+    });
+}


### PR DESCRIPTION
## Summary

Add `openclaw restart`, `openclaw start`, and `openclaw stop` as user-friendly top-level aliases for the corresponding `openclaw gateway restart/start/stop` subcommands.

## Motivation

Currently, restarting OpenClaw requires running `openclaw gateway restart`, which is unintuitive for most users. A simpler `openclaw restart` command is more natural and discoverable.

Closes #42166

## Changes

- **`src/cli/program/register.lifecycle-aliases.ts`** — New registrar that adds `restart`, `start`, `stop` commands to the top-level program. Each delegates to the existing daemon lifecycle runners (`runDaemonRestart`, `runDaemonStart`, `runDaemonStop`).
- **`src/cli/program/command-registry.ts`** — Register the new lifecycle alias commands in the core entries array with lazy loading.
- **`src/cli/program/register.lifecycle-aliases.test.ts`** — 9 tests covering command registration, descriptions, and correct delegation with `--json` flag.

## Usage

```bash
# Before (still works)
openclaw gateway restart
openclaw gateway start
openclaw gateway stop

# After (new aliases)
openclaw restart
openclaw start
openclaw stop
openclaw restart --json
```

## Testing

All 9 new tests pass:
- ✅ Commands register with correct descriptions
- ✅ Each command delegates to the correct daemon runner
- ✅ `--json` flag is correctly forwarded