### PR TITLE
docs: clarify stable host-IP pattern for WSL2 + Windows remote Chrome CDP

### DIFF
--- a/docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
+++ b/docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
@@ -76,6 +76,44 @@ Use:
 
 Do not default to a LAN IP for the Control UI. Plain HTTP on a LAN or tailnet address can trigger insecure-origin/device-auth behavior that is unrelated to CDP itself. See [Control UI](/web/control-ui).
 
+## Prefer the Windows host IP as seen from WSL over the Wi-Fi/LAN IP
+
+In this WSL2 + Windows topology, Chrome on Windows is usually launched with remote debugging bound to loopback (`127.0.0.1:9222`). Because of that loopback-first setup, using a Wi-Fi/LAN address such as `192.168.1.x:9222` as `cdpUrl` from WSL2 can be fragile across reboot, network changes, or forwarding drift.
+
+For this setup, a more stable pattern is to:
+
+- get the Windows host IP from inside WSL
+- expose that host IP on Windows with `portproxy`
+- forward it to `127.0.0.1:9222`
+- use that host IP in the OpenClaw remote `cdpUrl`
+
+Get the Windows host IP from WSL:
+
+```bash
+ip route show | grep -i default | awk '{ print $3 }'
+```
+
+On Windows, run `portproxy` from an Administrator (elevated) PowerShell window:
+
+```powershell
+netsh interface portproxy add v4tov4 listenaddress=WINDOWS_HOST_IP listenport=9222 connectaddress=127.0.0.1 connectport=9222
+```
+
+Note: the Windows host IP seen from WSL is dynamic and can change after WSL restart or system reboot. If it changes, refresh the `portproxy` rule and update the configured `cdpUrl` to match.
+
+Quick validation flow:
+
+1. On Windows, verify local Chrome CDP:
+   - `curl http://127.0.0.1:9222/json/version`
+2. In WSL2, verify the host-IP endpoint you will use in `cdpUrl`:
+   - `curl http://WINDOWS_HOST_IP:9222/json/version`
+3. Restart Gateway and confirm browser visibility:
+   - `openclaw gateway restart`
+   - `openclaw browser profiles`
+   - `openclaw browser tabs --browser-profile remote`
+
+If steps 1 and 2 succeed with the same target, OpenClaw profile failures are usually configuration-level rather than transport-level.
+
 ## Validate in layers
 
 Work top to bottom. Do not skip ahead.


### PR DESCRIPTION
## Summary

Follow-up clarification to the existing WSL2 + Windows remote Chrome CDP troubleshooting guide.

- Explains why Wi-Fi/LAN-IP-based `cdpUrl` values can be fragile in this topology.
- Recommends using the Windows host IP as seen from WSL plus `portproxy` forwarding to `127.0.0.1:9222`.
- Adds practical notes that `netsh interface portproxy` should be run from an Administrator (elevated) PowerShell window and that the WSL-visible Windows host IP is dynamic after restart/reboot.
- Keeps the practical validation sequence for Windows local CDP, WSL host-IP CDP reachability, and OpenClaw browser profile checks.
- Based on post-reboot validation of a working setup; documented as a recommended pattern for this topology, not a universal rule.

## Scope

- Docs-only change
- No code changes
- No unrelated files modified