### PR TITLE
fix(discord): preserve mentionedUsers on debounced synthetic messages

### DIFF
--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -76,7 +76,9 @@ export function createDiscordMessageHandler(
       if (!message) {
         return false;
       }
-      const baseText = resolveDiscordMessageText(message, { includeForwarded: false });
+      const baseText = resolveDiscordMessageText(message, {
+        includeForwarded: false,
+      });
       return shouldDebounceTextInbound({
         text: baseText,
         cfg: params.cfg,
@@ -111,13 +113,35 @@ export function createDiscordMessageHandler(
         return;
       }
       const combinedBaseText = entries
-        .map((entry) => resolveDiscordMessageText(entry.data.message, { includeForwarded: false }))
+        .map((entry) =>
+          resolveDiscordMessageText(entry.data.message, {
+            includeForwarded: false,
+          }),
+        )
         .filter(Boolean)
         .join("\n");
+      // Collect mentioned users from ALL entries so mention detection works
+      // after debouncing.  The spread of last.data.message drops Carbon
+      // Message prototype getters (mentionedUsers, mentionedRoles, etc.),
+      // so we materialise them here as plain arrays.
+      const seenMentionIds = new Set<string>();
+      const allMentionedUsers: Array<{ id: string }> = [];
+      for (const entry of entries) {
+        const mentioned = entry.data.message.mentionedUsers ?? [];
+        for (const u of mentioned) {
+          if (u.id && !seenMentionIds.has(u.id)) {
+            seenMentionIds.add(u.id);
+            allMentionedUsers.push(u);
+          }
+        }
+      }
       const syntheticMessage = {
         ...last.data.message,
         content: combinedBaseText,
         attachments: [],
+        mentionedUsers: allMentionedUsers,
+        mentionedRoles: last.data.message.mentionedRoles ?? [],
+        mentionedEveryone: last.data.message.mentionedEveryone ?? false,
         message_snapshots: (last.data.message as { message_snapshots?: unknown }).message_snapshots,
         messageSnapshots: (last.data.message as { messageSnapshots?: unknown }).messageSnapshots,
         rawData: {
@@ -174,7 +198,11 @@ export function createDiscordMessageHandler(
         return;
       }
 
-      await debouncer.enqueue({ data, client, abortSignal: options?.abortSignal });
+      await debouncer.enqueue({
+        data,
+        client,
+        abortSignal: options?.abortSignal,
+      });
     } catch (err) {
       params.runtime.error?.(danger(`handler failed: ${String(err)}`));
     }

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -124,15 +124,26 @@ export function createDiscordMessageHandler(
       // after debouncing.  The spread of last.data.message drops Carbon
       // Message prototype getters (mentionedUsers, mentionedRoles, etc.),
       // so we materialise them here as plain arrays.
-      const seenMentionIds = new Set<string>();
+      const seenUserIds = new Set<string>();
       const allMentionedUsers: Array<{ id: string }> = [];
+      const seenRoleIds = new Set<string>();
+      const allMentionedRoles: Array<{ id: string }> = [];
+      let anyMentionedEveryone = false;
       for (const entry of entries) {
-        const mentioned = entry.data.message.mentionedUsers ?? [];
-        for (const u of mentioned) {
-          if (u.id && !seenMentionIds.has(u.id)) {
-            seenMentionIds.add(u.id);
+        for (const u of entry.data.message.mentionedUsers ?? []) {
+          if (u.id && !seenUserIds.has(u.id)) {
+            seenUserIds.add(u.id);
             allMentionedUsers.push(u);
           }
+        }
+        for (const r of entry.data.message.mentionedRoles ?? []) {
+          if (r.id && !seenRoleIds.has(r.id)) {
+            seenRoleIds.add(r.id);
+            allMentionedRoles.push(r);
+          }
+        }
+        if (entry.data.message.mentionedEveryone) {
+          anyMentionedEveryone = true;
         }
       }
       const syntheticMessage = {
@@ -140,8 +151,8 @@ export function createDiscordMessageHandler(
         content: combinedBaseText,
         attachments: [],
         mentionedUsers: allMentionedUsers,
-        mentionedRoles: last.data.message.mentionedRoles ?? [],
-        mentionedEveryone: last.data.message.mentionedEveryone ?? false,
+        mentionedRoles: allMentionedRoles,
+        mentionedEveryone: anyMentionedEveryone,
         message_snapshots: (last.data.message as { message_snapshots?: unknown }).message_snapshots,
         messageSnapshots: (last.data.message as { messageSnapshots?: unknown }).messageSnapshots,
         rawData: {


### PR DESCRIPTION
## Summary

- When multiple Discord messages are debounced (e.g. chunked bot replies), the synthetic message created via object spread (`{ ...last.data.message }`) loses Carbon `Message` prototype getters (`mentionedUsers`, `mentionedRoles`, `mentionedEveryone`)
- This causes bot-to-bot @mention detection to always fail for multi-chunk messages, since `explicitlyMentioned` evaluates to `false` on the plain object
- Fix: materialise mention data from all debounced entries into the synthetic message object

## Root cause

`src/discord/monitor/message-handler.ts` creates a synthetic message when debouncing multiple inbound messages into one:

```ts
const syntheticMessage = {
  ...last.data.message,   // ← Carbon Message instance; spread copies own props only
  content: combinedBaseText,
  // mentionedUsers getter lives on the prototype → lost after spread
};
```

In `preflightDiscordMessage`, `message.mentionedUsers` returns `undefined` instead of the mention array, so:
1. `explicitlyMentioned = Boolean(botId && message.mentionedUsers?.some(...))` → `false`
2. Text-based regex also fails because `resolveDiscordMentions` already rewrote `<@ID>` → `@name` in the combined text
3. Result: "no-mention" skip for every bot-to-bot @mention in chunked messages

User-to-bot mentions work because single messages (`entries.length === 1`) pass through the original Carbon Message instance.

## Test plan

- [ ] Bot A sends a multi-chunk message mentioning Bot B → Bot B should now detect the mention and respond
- [ ] Single-message mentions (user→bot, bot→bot) continue to work
- [ ] Messages with no mentions still get "no-mention" skip as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)