### PR TITLE
fix: route embedded tool calls through in-process dispatch (#40237)

### DIFF
--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -226,4 +226,58 @@ describe("callGatewayTool local dispatch (#40237)", () => {
 
     expect(localDispatch).toHaveBeenCalledWith("health", {});
   });
+
+  it("bypasses local dispatch when explicit gatewayUrl is provided", async () => {
+    const localDispatch = vi.fn().mockResolvedValue({ local: true });
+    registerLocalGatewayDispatch(localDispatch);
+    callGatewayMock.mockResolvedValueOnce({ remote: true });
+
+    const result = await callGatewayTool(
+      "health",
+      { gatewayUrl: "ws://127.0.0.1:18789", gatewayToken: "t", timeoutMs: 5000 },
+      {},
+    );
+
+    expect(localDispatch).not.toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        token: "t",
+        timeoutMs: 5000,
+      }),
+    );
+    expect(result).toEqual({ remote: true });
+  });
+
+  it("bypasses local dispatch when expectFinal is true", async () => {
+    const localDispatch = vi.fn().mockResolvedValue({ local: true });
+    registerLocalGatewayDispatch(localDispatch);
+    callGatewayMock.mockResolvedValueOnce({ final: true });
+
+    const result = await callGatewayTool("agent", {}, { message: "hi" }, { expectFinal: true });
+
+    expect(localDispatch).not.toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        expectFinal: true,
+      }),
+    );
+    expect(result).toEqual({ final: true });
+  });
+
+  it("respects timeoutMs from opts when falling through to WS", async () => {
+    const localDispatch = vi.fn().mockResolvedValue({});
+    registerLocalGatewayDispatch(localDispatch);
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool(
+      "agent",
+      { timeoutMs: 60_000 },
+      { message: "test" },
+      { expectFinal: true },
+    );
+
+    expect(callGatewayMock).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 60_000 }));
+  });
 });

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -1,4 +1,8 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetLocalGatewayDispatch,
+  registerLocalGatewayDispatch,
+} from "../../gateway/local-dispatch.js";
 import { callGatewayTool, resolveGatewayOptions } from "./gateway.js";
 
 const callGatewayMock = vi.fn();
@@ -185,5 +189,41 @@ describe("gateway tool defaults", () => {
     await expect(
       callGatewayTool("health", { gatewayUrl: "ws://169.254.169.254", gatewayToken: "t" }, {}),
     ).rejects.toThrow(/gatewayUrl override rejected/i);
+  });
+});
+
+describe("callGatewayTool local dispatch (#40237)", () => {
+  afterEach(() => {
+    _resetLocalGatewayDispatch();
+    callGatewayMock.mockClear();
+  });
+
+  it("uses in-process dispatch when running inside the gateway", async () => {
+    const localDispatch = vi.fn().mockResolvedValue({ jobs: ["a", "b"] });
+    registerLocalGatewayDispatch(localDispatch);
+
+    const result = await callGatewayTool("cron.list", {}, { filter: "active" });
+
+    expect(result).toEqual({ jobs: ["a", "b"] });
+    expect(localDispatch).toHaveBeenCalledWith("cron.list", { filter: "active" });
+    // WS path must NOT be called
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to WS when no local dispatcher is registered", async () => {
+    callGatewayMock.mockResolvedValueOnce({ status: "ok" });
+
+    await callGatewayTool("cron.status", {}, {});
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes empty object when params is undefined", async () => {
+    const localDispatch = vi.fn().mockResolvedValue({});
+    registerLocalGatewayDispatch(localDispatch);
+
+    await callGatewayTool("health", {});
+
+    expect(localDispatch).toHaveBeenCalledWith("health", {});
   });
 });

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -146,9 +146,19 @@ export async function callGatewayTool<T = Record<string, unknown>>(
 ) {
   // When running inside the gateway process, dispatch directly in-process
   // to avoid WS self-contention during active LLM sessions (#40237).
-  const localResult = tryLocalGatewayDispatch<T>(method, (params ?? {}) as Record<string, unknown>);
-  if (localResult !== undefined) {
-    return await localResult;
+  // Skip local dispatch when:
+  //  - caller explicitly targets a specific gateway URL (may be remote)
+  //  - caller needs expectFinal semantics (completion-waiting not supported by local dispatch)
+  const hasExplicitUrl = trimToUndefined(opts.gatewayUrl) !== undefined;
+  const needsExpectFinal = extra?.expectFinal === true;
+  if (!hasExplicitUrl && !needsExpectFinal) {
+    const localResult = tryLocalGatewayDispatch<T>(
+      method,
+      (params ?? {}) as Record<string, unknown>,
+    );
+    if (localResult !== undefined) {
+      return await localResult;
+    }
   }
 
   const gateway = resolveGatewayOptions(opts);

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -1,6 +1,7 @@
 import { loadConfig, resolveGatewayPort } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import { resolveGatewayCredentialsFromConfig, trimToUndefined } from "../../gateway/credentials.js";
+import { tryLocalGatewayDispatch } from "../../gateway/local-dispatch.js";
 import { resolveLeastPrivilegeOperatorScopesForMethod } from "../../gateway/method-scopes.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { readStringParam } from "./common.js";
@@ -143,6 +144,13 @@ export async function callGatewayTool<T = Record<string, unknown>>(
   params?: unknown,
   extra?: { expectFinal?: boolean },
 ) {
+  // When running inside the gateway process, dispatch directly in-process
+  // to avoid WS self-contention during active LLM sessions (#40237).
+  const localResult = tryLocalGatewayDispatch<T>(method, (params ?? {}) as Record<string, unknown>);
+  if (localResult !== undefined) {
+    return await localResult;
+  }
+
   const gateway = resolveGatewayOptions(opts);
   const scopes = resolveLeastPrivilegeOperatorScopesForMethod(method);
   return await callGateway<T>({

--- a/src/gateway/local-dispatch.test.ts
+++ b/src/gateway/local-dispatch.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetLocalGatewayDispatch,
+  registerLocalGatewayDispatch,
+  tryLocalGatewayDispatch,
+} from "./local-dispatch.js";
+
+describe("local-dispatch", () => {
+  afterEach(() => {
+    _resetLocalGatewayDispatch();
+  });
+
+  it("returns undefined when no dispatcher is registered", () => {
+    const result = tryLocalGatewayDispatch("cron.list", {});
+    expect(result).toBeUndefined();
+  });
+
+  it("dispatches locally after registration", async () => {
+    const dispatcher = vi.fn().mockResolvedValue({ jobs: [] });
+    registerLocalGatewayDispatch(dispatcher);
+
+    const result = tryLocalGatewayDispatch("cron.list", { filter: "active" });
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toEqual({ jobs: [] });
+    expect(dispatcher).toHaveBeenCalledWith("cron.list", { filter: "active" });
+  });
+
+  it("returns undefined after reset", async () => {
+    const dispatcher = vi.fn().mockResolvedValue({});
+    registerLocalGatewayDispatch(dispatcher);
+
+    expect(tryLocalGatewayDispatch("health", {})).toBeInstanceOf(Promise);
+    _resetLocalGatewayDispatch();
+    expect(tryLocalGatewayDispatch("health", {})).toBeUndefined();
+  });
+
+  it("propagates errors from the dispatcher", async () => {
+    const dispatcher = vi.fn().mockRejectedValue(new Error("method failed"));
+    registerLocalGatewayDispatch(dispatcher);
+
+    const result = tryLocalGatewayDispatch("cron.add", {});
+    await expect(result).rejects.toThrow("method failed");
+  });
+});

--- a/src/gateway/local-dispatch.ts
+++ b/src/gateway/local-dispatch.ts
@@ -1,0 +1,42 @@
+/**
+ * Lightweight registry for in-process gateway method dispatch.
+ *
+ * The gateway server registers a dispatcher at startup so that agent tools
+ * running inside the same process can call gateway methods directly instead
+ * of opening a new WebSocket connection.  This avoids event-loop
+ * self-contention when a tool call originates from an active LLM session
+ * on the same gateway (see #40237).
+ *
+ * CLI / external callers never register a dispatcher, so
+ * `tryLocalGatewayDispatch` returns `undefined` and the caller falls back
+ * to the normal WS path.
+ */
+
+type LocalDispatchFn = <T>(method: string, params: Record<string, unknown>) => Promise<T>;
+
+let _localDispatch: LocalDispatchFn | undefined;
+
+/**
+ * Called once by the gateway server after setup to enable in-process dispatch.
+ */
+export function registerLocalGatewayDispatch(fn: LocalDispatchFn): void {
+  _localDispatch = fn;
+}
+
+/**
+ * Returns a promise for the result if in-process dispatch is available,
+ * or `undefined` when running outside the gateway (e.g. CLI).
+ */
+export function tryLocalGatewayDispatch<T>(
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T> | undefined {
+  return _localDispatch ? _localDispatch<T>(method, params) : undefined;
+}
+
+/**
+ * Test helper — resets the registered dispatcher.
+ */
+export function _resetLocalGatewayDispatch(): void {
+  _localDispatch = undefined;
+}

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -3,6 +3,7 @@ import type { loadConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
+import { registerLocalGatewayDispatch } from "./local-dispatch.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
 import type { ErrorShape } from "./protocol/index.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
@@ -43,6 +44,9 @@ const fallbackGatewayContextState = (() => {
 export function setFallbackGatewayContext(ctx: GatewayRequestContext): void {
   // TODO: This startup snapshot can become stale if runtime config/context changes.
   fallbackGatewayContextState.context = ctx;
+  // Enable in-process dispatch for agent tools running inside the gateway,
+  // avoiding WS self-contention during active LLM sessions (#40237).
+  registerLocalGatewayDispatch(dispatchGatewayMethod);
 }
 
 // ── Internal gateway dispatch for plugin runtime ────────────────────


### PR DESCRIPTION
## Summary

Fixes #40237 (also resolves #5703 and #6508 which were circular-duped shut).

When agent tools like `cron.run`, `cron.list`, `cron.add` are called from within an active LLM session, `callGatewayTool` opens a **new WebSocket connection** to the same gateway. Because the gateway's Node.js event loop is busy processing the current LLM turn, the second WS connection sits in queue and times out after 10s.

This PR routes embedded tool calls through the existing in-process dispatch path (`dispatchGatewayMethod`) when running inside the gateway process, bypassing WS entirely. External CLI tool calls continue to use WS unchanged.

## Changes

- **`src/gateway/local-dispatch.ts`** (new): lightweight registry that the gateway server populates at startup. Exposes `tryLocalGatewayDispatch` which returns a promise when in-process dispatch is available, or `undefined` when running outside the gateway (e.g. CLI).

- **`src/gateway/server-plugins.ts`**: registers `dispatchGatewayMethod` as the local dispatcher when `setFallbackGatewayContext` is called during gateway startup.

- **`src/agents/tools/gateway.ts`**: `callGatewayTool` now checks `tryLocalGatewayDispatch` first. If available (inside gateway), dispatches in-process with zero WS overhead. Otherwise falls through to the existing WS path.

## How it works

```
CLI tool call (external):
  callGatewayTool → tryLocalGatewayDispatch returns undefined → WS path (unchanged)

Embedded tool call (inside gateway LLM session):
  callGatewayTool → tryLocalGatewayDispatch returns Promise → dispatchGatewayMethod
    → handleGatewayRequest (in-process, no WS) → immediate response
```

The `dispatchGatewayMethod` function already exists and is battle-tested — it's used by plugin subagent runtime for sessions, agent dispatch, etc. This PR simply makes it available to agent tools via the registry pattern.

## Test plan

- [x] Unit tests for `local-dispatch.ts` (registry behavior, reset, error propagation)
- [x] Integration tests in `gateway.test.ts` verifying:
  - Embedded tool calls use in-process dispatch (no WS `callGateway` mock called)
  - External tool calls fall back to WS when no dispatcher registered
  - `undefined` params correctly normalized to `{}`
- [x] Existing `server-plugins.test.ts` tests pass (5/5)
- [x] Type check clean (`pnpm tsgo`)
- [x] Lint/format clean (`pnpm check`)