### PR TITLE
ci: add macos release workflow

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,209 @@
+name: macOS Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: macos-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "22.x"
+  PNPM_VERSION: "10.23.0"
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      package_version: ${{ steps.meta.outputs.package_version }}
+      release_title: ${{ steps.meta.outputs.release_title }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Validate release tag and package metadata
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_MAIN_REF: origin/main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          pnpm release:openclaw:npm:check
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_title=openclaw $PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$PACKAGE_VERSION" == *-beta.* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build_sign_notarize:
+    needs: prepare
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Validate release tag and package metadata
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_MAIN_REF: origin/main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          pnpm release:openclaw:npm:check
+
+      - name: Import Developer ID certificate
+        env:
+          MACOS_DEVELOPER_ID_P12: ${{ secrets.MACOS_DEVELOPER_ID_P12 }}
+          MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          CERT_PATH="$RUNNER_TEMP/openclaw-developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/openclaw-signing.keychain-db"
+          LOGIN_KEYCHAIN="$(security login-keychain | tr -d '"')"
+
+          node -e 'process.stdout.write(Buffer.from(process.env.MACOS_DEVELOPER_ID_P12 ?? "", "base64"))' > "$CERT_PATH"
+
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -f pkcs12 -k "$KEYCHAIN_PATH" \
+            -P "$MACOS_DEVELOPER_ID_P12_PASSWORD" -A
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "$LOGIN_KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Build, sign, and notarize macOS release artifacts
+        env:
+          APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_VERSION: ${{ needs.prepare.outputs.package_version }}
+          BUILD_CONFIG: release
+          BUNDLE_ID: ai.openclaw.mac
+          SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+        run: |
+          set -euo pipefail
+
+          KEY_FILE="$RUNNER_TEMP/openclaw-notary.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_P8" | sed 's/\\n/\n/g' > "$KEY_FILE"
+
+          export NOTARYTOOL_KEY="$KEY_FILE"
+          export NOTARYTOOL_KEY_ID="$APP_STORE_CONNECT_KEY_ID"
+          export NOTARYTOOL_ISSUER="$APP_STORE_CONNECT_ISSUER_ID"
+
+          scripts/package-mac-dist.sh
+
+      - name: Upload macOS release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: openclaw-macos-release
+          path: |
+            dist/OpenClaw-*.zip
+            dist/OpenClaw-*.dmg
+            dist/OpenClaw-*.dSYM.zip
+          if-no-files-found: error
+
+  publish_release_assets:
+    needs: [prepare, build_sign_notarize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Download macOS release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: openclaw-macos-release
+          path: release-assets/macos
+
+      - name: Render release notes
+        env:
+          PACKAGE_VERSION: ${{ needs.prepare.outputs.package_version }}
+        run: |
+          set -euo pipefail
+          node --import tsx scripts/render-github-release-notes.ts \
+            --version "$PACKAGE_VERSION" \
+            > "$RUNNER_TEMP/release-notes.md"
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TITLE: ${{ needs.prepare.outputs.release_title }}
+          IS_PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t ASSETS < <(find release-assets -type f | sort)
+          PRERELEASE_FLAG=()
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            PRERELEASE_FLAG+=(--prerelease)
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$RUNNER_TEMP/release-notes.md"
+            if [[ "${#ASSETS[@]}" -gt 0 ]]; then
+              gh release upload "$RELEASE_TAG" "${ASSETS[@]}" --clobber
+            fi
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              "${PRERELEASE_FLAG[@]}" \
+              "${ASSETS[@]}"
+          fi

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -80,7 +80,9 @@ Commit the updated `appcast.xml` alongside the release assets (zip + dSYM) when 
 
 ## Publish & verify
 
-- Upload `OpenClaw-2026.3.9.zip` (and `OpenClaw-2026.3.9.dSYM.zip`) to the GitHub release for tag `v2026.3.9`.
+- Pushing tag `v2026.3.9` now triggers `.github/workflows/macos-release.yml`, which builds, signs, notarizes, and uploads the macOS assets to the GitHub release.
+- `appcast.xml` is still manual for now.
+- Verify that `OpenClaw-2026.3.9.zip`, `OpenClaw-2026.3.9.dmg`, and `OpenClaw-2026.3.9.dSYM.zip` (if produced) are attached to the GitHub release for tag `v2026.3.9`.
 - Ensure the raw appcast URL matches the baked feed: `https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml`.
 - Sanity checks:
   - `curl -I https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml` returns 200.

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -89,6 +89,8 @@ Historical note:
 - [ ] Follow [macOS release](/platforms/mac/release) for the exact commands and required env vars.
   - `APP_BUILD` must be numeric + monotonic (no `-beta`) so Sparkle compares versions correctly.
   - If notarizing, use the `openclaw-notary` keychain profile created from App Store Connect API env vars (see [macOS release](/platforms/mac/release)).
+  - Pushing the release tag also triggers `.github/workflows/macos-release.yml`, which builds, signs, notarizes, and uploads macOS release assets to the GitHub release.
+  - `appcast.xml` remains a manual publish step for now.
 
 6. **Publish (npm)**
 
@@ -113,9 +115,11 @@ Historical note:
 7. **GitHub release + appcast**
 
 - [ ] Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z` (or `git push --tags`).
-  - Pushing the tag also triggers the npm release workflow.
-- [ ] Create/refresh the GitHub release for `vX.Y.Z` with **title `openclaw X.Y.Z`** (not just the tag); body should include the **full** changelog section for that version (Highlights + Changes + Fixes), inline (no bare links), and **must not repeat the title inside the body**.
-- [ ] Attach artifacts: `npm pack` tarball (optional), `OpenClaw-X.Y.Z.zip`, and `OpenClaw-X.Y.Z.dSYM.zip` (if generated).
+  - Pushing the tag also triggers `.github/workflows/openclaw-npm-release.yml` and `.github/workflows/macos-release.yml`.
+- [ ] Verify the GitHub release for `vX.Y.Z`.
+  - The macOS workflow creates or updates the release with **title `openclaw X.Y.Z`**, uses the matching changelog section as the body, and uploads the macOS assets.
+  - If you need to fix notes or assets after the workflow runs, refresh them manually.
+- [ ] Confirm the expected artifacts are attached: `npm pack` tarball (optional/manual), `OpenClaw-X.Y.Z.zip`, `OpenClaw-X.Y.Z.dmg`, and `OpenClaw-X.Y.Z.dSYM.zip` (if generated).
 - [ ] Commit the updated `appcast.xml` and push it (Sparkle feeds from main).
 - [ ] From a clean temp directory (no `package.json`), run `npx -y openclaw@X.Y.Z send --help` to confirm install/CLI entrypoints work.
 - [ ] Announce/share release notes.

--- a/scripts/render-github-release-notes.ts
+++ b/scripts/render-github-release-notes.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env -S node --import tsx
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+type Args = {
+  version: string;
+  changelogPath: string;
+};
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token?.startsWith("--")) {
+      continue;
+    }
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}.`);
+    }
+    values.set(key, value);
+    index += 1;
+  }
+
+  const version = values.get("version") ?? "";
+  const changelogPath = values.get("changelog") ?? "CHANGELOG.md";
+
+  if (!version) {
+    throw new Error("Missing --version.");
+  }
+
+  return { version, changelogPath };
+}
+
+export function extractReleaseNotesSection(content: string, version: string): string {
+  const lines = content.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => line.trim() === `## ${version}`);
+  if (startIndex === -1) {
+    throw new Error(`Version ${version} not found in CHANGELOG.md.`);
+  }
+
+  const collected: string[] = [];
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (line.startsWith("## ")) {
+      break;
+    }
+    collected.push(line);
+  }
+
+  const body = collected.join("\n").trim();
+  if (!body) {
+    throw new Error(`Version ${version} has an empty changelog section.`);
+  }
+
+  return `${body}\n`;
+}
+
+function main(argv: string[]): number {
+  const { version, changelogPath } = parseArgs(argv);
+  const changelog = readFileSync(changelogPath, "utf8");
+  process.stdout.write(extractReleaseNotesSection(changelog, version));
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/test/render-github-release-notes.test.ts
+++ b/test/render-github-release-notes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { extractReleaseNotesSection } from "../scripts/render-github-release-notes.ts";
+
+describe("extractReleaseNotesSection", () => {
+  it("returns the requested changelog section body without the heading", () => {
+    const changelog = `# Changelog
+
+## 2026.3.9
+
+### Changes
+
+- Added mac workflow.
+
+## 2026.3.8
+
+### Fixes
+
+- Older item.
+`;
+
+    expect(extractReleaseNotesSection(changelog, "2026.3.9")).toBe(`### Changes
+
+- Added mac workflow.
+`);
+  });
+
+  it("throws when the requested version is missing", () => {
+    expect(() => extractReleaseNotesSection("# Changelog\n", "2026.3.9")).toThrow(
+      "Version 2026.3.9 not found in CHANGELOG.md.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a tag-driven macOS release workflow that validates the release tag, builds the app, signs and notarizes the artifacts, and uploads them to the GitHub release
- add a changelog-driven helper for rendering GitHub release notes inside the workflow
- update the release docs to describe the automated macOS release path and the remaining manual `appcast.xml` step

## Testing
- pnpm check
- pnpm exec vitest run test/render-github-release-notes.test.ts
- node --import tsx scripts/render-github-release-notes.ts --version 2026.3.8
- git diff --check
