### PR TITLE
fix(telegram): answer callbacks before sequentialize

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1050,16 +1050,8 @@ export const registerTelegramHandlers = ({
     if (shouldSkipUpdate(ctx)) {
       return;
     }
-    const answerCallbackQuery =
-      typeof (ctx as { answerCallbackQuery?: unknown }).answerCallbackQuery === "function"
-        ? () => ctx.answerCallbackQuery()
-        : () => bot.api.answerCallbackQuery(callback.id);
-    // Answer immediately to prevent Telegram from retrying while we process
-    await withTelegramApiErrorLogging({
-      operation: "answerCallbackQuery",
-      runtime,
-      fn: answerCallbackQuery,
-    }).catch(() => {});
+    // answerCallbackQuery is handled by the pre-sequentialize middleware in bot.ts
+    // to avoid Telegram's ~15s server-side timeout when updates are queued.
     try {
       const data = (callback.data ?? "").trim();
       const callbackMessage = callback.message;

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -116,6 +116,49 @@ describe("createTelegramBot", () => {
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(sequentializeKey).toBe(getTelegramSequentialKey);
   });
+  it("answers callback queries in pre-sequentialize middleware", async () => {
+    createTelegramBot({ token: "tok" });
+    // The pre-sequentialize middleware is registered via bot.use before sequentialize.
+    // Find it: it's the middleware registered right before the sequentialize middleware.
+    const seqMiddleware = sequentializeSpy.mock.results[0]?.value;
+    const allMiddlewares = middlewareUseSpy.mock.calls.map((call) => call[0]);
+    const seqIdx = allMiddlewares.indexOf(seqMiddleware);
+    expect(seqIdx).toBeGreaterThan(0);
+    const preSeqMiddleware = allMiddlewares[seqIdx - 1] as (
+      ctx: Record<string, unknown>,
+      next: () => Promise<void>,
+    ) => Promise<void>;
+    expect(typeof preSeqMiddleware).toBe("function");
+
+    const nextSpy = vi.fn(async () => {});
+
+    // With callbackQuery present: should answer
+    await preSeqMiddleware(
+      { callbackQuery: { id: "cbq-test" }, answerCallbackQuery: answerCallbackQuerySpy },
+      nextSpy,
+    );
+    expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+    expect(nextSpy).toHaveBeenCalledTimes(1);
+
+    answerCallbackQuerySpy.mockClear();
+    nextSpy.mockClear();
+
+    // Without callbackQuery: should not answer, still call next
+    await preSeqMiddleware({}, nextSpy);
+    expect(answerCallbackQuerySpy).not.toHaveBeenCalled();
+    expect(nextSpy).toHaveBeenCalledTimes(1);
+
+    answerCallbackQuerySpy.mockClear();
+    nextSpy.mockClear();
+
+    // answerCallbackQuery rejection: still calls next (fire-and-forget)
+    answerCallbackQuerySpy.mockRejectedValueOnce(new Error("Telegram 400"));
+    await preSeqMiddleware(
+      { callbackQuery: { id: "cbq-err" }, answerCallbackQuery: answerCallbackQuerySpy },
+      nextSpy,
+    );
+    expect(nextSpy).toHaveBeenCalledTimes(1);
+  });
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
@@ -141,7 +184,6 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = replySpy.mock.calls[0][0];
     expect(payload.Body).toContain("cmd:option_a");
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
   });
   it("wraps inbound message with Telegram envelope", async () => {
     await withEnvAsync({ TZ: "Europe/Vienna" }, async () => {

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -7,7 +7,6 @@ import {
 } from "../auto-reply/commands-registry.js";
 import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
 import {
-  answerCallbackQuerySpy,
   commandSpy,
   editMessageTextSpy,
   enqueueSystemEventSpy,
@@ -206,7 +205,6 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).not.toHaveBeenCalled();
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-2");
   });
 
   it("allows callback_query in groups when group policy authorizes the sender", async () => {
@@ -250,7 +248,6 @@ describe("createTelegramBot", () => {
 
     // The callback should be processed (not silently blocked)
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-group-1");
   });
 
   it("edits commands list for pagination callbacks", async () => {
@@ -363,7 +360,6 @@ describe("createTelegramBot", () => {
     });
 
     expect(editMessageTextSpy).not.toHaveBeenCalled();
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-4");
   });
 
   it("routes compact model callbacks by inferring provider", async () => {
@@ -411,7 +407,6 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = replySpy.mock.calls[0]?.[0];
     expect(payload?.Body).toContain(`/model amazon-bedrock/${modelId}`);
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-compact-1");
   });
 
   it("rejects ambiguous compact model callbacks and returns provider list", async () => {
@@ -464,7 +459,6 @@ describe("createTelegramBot", () => {
     expect(editMessageTextSpy.mock.calls[0]?.[2]).toContain(
       'Could not resolve model "shared-model".',
     );
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-compact-2");
   });
 
   it("includes sender identity in group envelope headers", async () => {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -28,6 +28,7 @@ import { getChildLogger } from "../logging.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
+import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { registerTelegramHandlers } from "./bot-handlers.js";
 import { createTelegramMessageProcessor } from "./bot-message.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
@@ -234,6 +235,21 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         maybePersistSafeWatermark();
       }
     }
+  });
+
+  // Answer callback queries BEFORE sequentialize to avoid Telegram's ~15s timeout.
+  // When an agent turn is running, sequentialize queues updates for the same topic.
+  // By the time the queued callback is processed, the answer window is dead.
+  // Note: this also answers queries for updates that shouldSkipUpdate would later reject,
+  // but answerCallbackQuery is idempotent and Telegram ignores redundant answers.
+  bot.use(async (ctx, next) => {
+    if (ctx.callbackQuery) {
+      void withTelegramApiErrorLogging({
+        operation: "answerCallbackQuery",
+        fn: () => ctx.answerCallbackQuery(),
+      }).catch(() => {});
+    }
+    await next();
   });
 
   bot.use(sequentialize(getTelegramSequentialKey));


### PR DESCRIPTION
## Summary

- **Problem:** Telegram callback queries (inline button presses) time out when queued behind `sequentialize`. Telegram enforces a ~15s server-side deadline on `answerCallbackQuery` -- if another update for the same chat is already being processed (e.g. an agent turn), the callback sits in the sequentialize queue and the answer window expires. Users see a stuck spinning button.
- **Why it matters:** Every inline-button interaction during an active agent turn silently fails from the user's perspective.
- **What changed:** Moved `answerCallbackQuery` into a pre-sequentialize middleware in `bot.ts` so it fires immediately on arrival, before the update enters the per-chat queue. The call is fire-and-forget (errors logged, not thrown).
- **What did NOT change:** Callback handler logic in `bot-handlers.ts` is untouched -- only the answer timing moved. Existing grammy middleware registration order is preserved; the new middleware is inserted directly before `sequentialize`.

Fixes #42156. Resubmission of #42181 (closed for rework).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Fixes #42156
- Related #42181 (previous submission, closed for rework)

## User-visible / Behavior Changes

Inline button presses in Telegram no longer show a stuck spinner when an agent turn is running in the same chat.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same `answerCallbackQuery` call, just earlier)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Telegram

### Steps

1. Start a long-running agent turn in a Telegram chat
2. While the turn is active, press an inline button in the same chat
3. Observe the button spinner

### Expected

- Button spinner dismissed immediately

### Actual (before fix)

- Button spinner stays until the agent turn completes or Telegram's 15s timeout expires

## Evidence

- [x] Failing test/log before + passing after
- `pnpm build` clean
- `pnpm check` clean
- `pnpm test` -- 879 test files passed
- Dedicated test covers: callback answered before sequentialize, non-callback updates pass through, `answerCallbackQuery` rejection still calls `next()`

## Human Verification (required)

- Verified scenarios: callback queries during active agent turns, callback queries with no active turn, rapid successive button presses
- Edge cases checked: `answerCallbackQuery` API failure (test confirms `next()` still called), updates without `callbackQuery` field (no-op, passes through)
- What I did **not** verify: behavior under Telegram webhook retry storms (theoretical, mitigated by idempotent `answerCallbackQuery`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; `answerCallbackQuery` moves back into `bot-handlers.ts` callback handler
- Known bad symptoms: if the pre-sequentialize middleware throws instead of catching, it could block downstream middleware. Mitigated by `.catch(() => {})` and `void` fire-and-forget pattern.

## Risks and Mitigations

- Risk: Answering callbacks for updates that `shouldSkipUpdate` would later reject (e.g. unauthorized senders in groups)
  - Mitigation: `answerCallbackQuery` is idempotent and Telegram ignores redundant answers. No side effects beyond dismissing the spinner.

---

> [!NOTE]
> AI Disclosure: This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and verified by the author.