### PR TITLE
fix(voice-call): add configurable responseAgentId

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -105,6 +105,7 @@ const voiceCallConfigSchema = {
     },
     store: { label: "Call Log Store Path", advanced: true },
     responseModel: { label: "Response Model", advanced: true },
+    responseAgentId: { label: "Response Agent ID", advanced: true },
     responseSystemPrompt: { label: "Response System Prompt", advanced: true },
     responseTimeoutMs: { label: "Response Timeout (ms)", advanced: true },
   },

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -342,6 +342,9 @@ export const VoiceCallConfigSchema = z
     /** Model for generating voice responses (e.g., "anthropic/claude-sonnet-4", "openai/gpt-4o") */
     responseModel: z.string().default("openai/gpt-4o-mini"),
 
+    /** Agent ID for voice response generation (defaults to "main") */
+    responseAgentId: z.string().min(1).optional(),
+
     /** System prompt for voice responses */
     responseSystemPrompt: z.string().optional(),
 

--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -42,6 +42,7 @@ type CoreAgentDeps = {
     lane?: string;
     extraSystemPrompt?: string;
     agentDir?: string;
+    agentId?: string;
   }) => Promise<{
     payloads?: Array<{ text?: string; isError?: boolean }>;
     meta?: { aborted?: boolean };

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createVoiceCallBaseConfig } from "./test-fixtures.js";
+
+const mockDeps = {
+  resolveStorePath: vi.fn().mockReturnValue("/tmp/store"),
+  resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent"),
+  resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
+  ensureAgentWorkspace: vi.fn().mockResolvedValue(undefined),
+  loadSessionStore: vi.fn().mockReturnValue({}),
+  saveSessionStore: vi.fn().mockResolvedValue(undefined),
+  resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/session.jsonl"),
+  resolveThinkingDefault: vi.fn().mockReturnValue("off"),
+  resolveAgentIdentity: vi.fn().mockReturnValue({ name: "TestBot" }),
+  resolveAgentTimeoutMs: vi.fn().mockReturnValue(30000),
+  runEmbeddedPiAgent: vi.fn().mockResolvedValue({ payloads: [{ text: "Hello" }] }),
+  DEFAULT_PROVIDER: "openai",
+  DEFAULT_MODEL: "gpt-4o-mini",
+};
+
+vi.mock("./core-bridge.js", () => ({
+  loadCoreAgentDeps: () => Promise.resolve(mockDeps),
+}));
+
+const { generateVoiceResponse } = await import("./response-generator.js");
+
+describe("generateVoiceResponse", () => {
+  const baseCoreConfig = { session: { store: "/tmp" } } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeps.loadSessionStore.mockReturnValue({});
+    mockDeps.runEmbeddedPiAgent.mockResolvedValue({ payloads: [{ text: "Hello" }] });
+  });
+
+  it("defaults agentId to 'main' when responseAgentId is not set", async () => {
+    const voiceConfig = createVoiceCallBaseConfig();
+
+    await generateVoiceResponse({
+      voiceConfig,
+      coreConfig: baseCoreConfig,
+      callId: "call-1",
+      from: "+15559991234",
+      transcript: [],
+      userMessage: "Hi",
+    });
+
+    expect(mockDeps.resolveStorePath).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ agentId: "main" }),
+    );
+    expect(mockDeps.resolveAgentDir).toHaveBeenCalledWith(expect.anything(), "main");
+    expect(mockDeps.resolveAgentWorkspaceDir).toHaveBeenCalledWith(expect.anything(), "main");
+    expect(mockDeps.resolveAgentIdentity).toHaveBeenCalledWith(expect.anything(), "main");
+    expect(mockDeps.resolveSessionFilePath).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ agentId: "main" }),
+    );
+    expect(mockDeps.runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main" }),
+    );
+  });
+
+  it("uses responseAgentId from config when set", async () => {
+    const voiceConfig = { ...createVoiceCallBaseConfig(), responseAgentId: "nikki" };
+
+    await generateVoiceResponse({
+      voiceConfig,
+      coreConfig: baseCoreConfig,
+      callId: "call-2",
+      from: "+15559991234",
+      transcript: [],
+      userMessage: "Hi",
+    });
+
+    expect(mockDeps.resolveStorePath).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ agentId: "nikki" }),
+    );
+    expect(mockDeps.resolveAgentDir).toHaveBeenCalledWith(expect.anything(), "nikki");
+    expect(mockDeps.resolveAgentWorkspaceDir).toHaveBeenCalledWith(expect.anything(), "nikki");
+    expect(mockDeps.resolveAgentIdentity).toHaveBeenCalledWith(expect.anything(), "nikki");
+    expect(mockDeps.resolveSessionFilePath).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ agentId: "nikki" }),
+    );
+    expect(mockDeps.runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "nikki" }),
+    );
+  });
+
+  it("passes agentId through to embedded run", async () => {
+    const voiceConfig = { ...createVoiceCallBaseConfig(), responseAgentId: "dev" };
+
+    await generateVoiceResponse({
+      voiceConfig,
+      coreConfig: baseCoreConfig,
+      callId: "call-3",
+      from: "+15559991234",
+      transcript: [],
+      userMessage: "Test",
+    });
+
+    const runCall = mockDeps.runEmbeddedPiAgent.mock.calls[0][0];
+    expect(runCall.agentId).toBe("dev");
+    expect(runCall.lane).toBe("voice");
+    expect(runCall.prompt).toBe("Test");
+  });
+
+  it("returns null text when coreConfig is falsy", async () => {
+    const voiceConfig = createVoiceCallBaseConfig();
+    const result = await generateVoiceResponse({
+      voiceConfig,
+      coreConfig: null as never,
+      callId: "call-4",
+      from: "+15559991234",
+      transcript: [],
+      userMessage: "Hi",
+    });
+
+    expect(result.text).toBeNull();
+    expect(result.error).toContain("Core config unavailable");
+  });
+});

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -59,7 +59,8 @@ export async function generateVoiceResponse(
   // Build voice-specific session key based on phone number
   const normalizedPhone = from.replace(/\D/g, "");
   const sessionKey = `voice:${normalizedPhone}`;
-  const agentId = "main";
+  // No existence validation — consistent with core (agentId refs are not validated at config time)
+  const agentId = voiceConfig.responseAgentId || "main";
 
   // Resolve paths
   const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
@@ -136,6 +137,7 @@ export async function generateVoiceResponse(
       lane: "voice",
       extraSystemPrompt,
       agentDir,
+      agentId,
     });
 
     // Extract text from payloads


### PR DESCRIPTION
## Summary

- **Problem:** The voice-call plugin hardcodes `"main"` as the agent ID for all path resolution (store, workspace, identity, session, embedded run). Multi-agent setups can't route voice responses to a specific agent's workspace/identity.
- **Why it matters:** Users running multiple agents (e.g. separate personas) have no way to make voice calls use anything other than the default "main" agent.
- **What changed:** Added an optional `responseAgentId` config field (Zod schema, UI config entry, core-bridge type). When set, it's threaded through all 6 resolution call sites: `resolveStorePath`, `resolveAgentDir`, `resolveAgentWorkspaceDir`, `resolveAgentIdentity`, `resolveSessionFilePath`, and `runEmbeddedPiAgent`.
- **What did NOT change:** Default behavior -- omitting `responseAgentId` falls back to `"main"`, identical to current behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42155
- Related #42129 (original PR, closed for rework)

## User-visible / Behavior Changes

New optional config field `responseAgentId` under `voice-call` plugin config. When set, voice responses use the specified agent's workspace, identity, session store, and directory. When omitted, behavior is unchanged (`"main"`).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No -- agent ID is already user-controlled in core; this threads an existing concept into the voice-call plugin.

No existence validation of the agent ID at config time -- consistent with core agent resolution patterns throughout the codebase (e.g. `agentId` refs in routing, session resolution). Zod schema uses `.min(1)` to reject empty strings at parse time.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / Bun
- Model/provider: Any (config-level change)
- Integration/channel: voice-call extension
- Relevant config: `voice-call.responseAgentId: "nikki"` (or omitted)

### Steps

1. Configure voice-call plugin with `responseAgentId: "nikki"`
2. Receive an inbound voice call
3. Observe that store path, agent dir, workspace, identity, session, and embedded run all resolve against `"nikki"` instead of `"main"`

### Expected

- All path resolution uses the configured agent ID

### Actual

- Before this fix: all resolution hardcoded to `"main"`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

4 unit tests added (`response-generator.test.ts`, 113 lines):
1. Default agentId falls back to `"main"` when `responseAgentId` not set
2. Custom agentId propagated through all 6 resolution call sites when set
3. `agentId` passed through to embedded run context alongside `lane` and `prompt`
4. Null `coreConfig` returns error without crashing

All 6 resolution call sites verified in assertions. `pnpm build`, `pnpm check`, `pnpm test` green.

## Human Verification (required)

- Verified scenarios: default (no config) and custom responseAgentId, null coreConfig guard
- Edge cases checked: empty string rejected by Zod `.min(1)`, undefined falls back to `"main"` via `||`
- What I did **not** verify: live Twilio call with a real multi-agent setup (no voice-call infra in dev environment)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes -- field is optional, default behavior unchanged
- Config/env changes? New optional field `responseAgentId` in voice-call config
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `responseAgentId` from voice-call config (falls back to `"main"`)
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Voice responses using wrong agent workspace/identity

## Risks and Mitigations

- Risk: Configured agent ID doesn't exist at runtime
  - Mitigation: Matches core behavior -- agent resolution is best-effort throughout the codebase; invalid IDs produce clear errors at the resolution layer, not silent corruption.

---

> [!NOTE]
> This PR was developed with Claude Code assistance. I reviewed all changes, verified test coverage, and confirmed build/lint/test pass locally.