### PR TITLE
fix(memory): follow symlinks in memory indexer, reader, and watcher

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -204,10 +204,6 @@ async function scanMemoryFiles(
   const resolvedExtraPaths = normalizeExtraMemoryPaths(workspaceDir, extraPaths);
   for (const extraPath of resolvedExtraPaths) {
     try {
-      const stat = await fs.lstat(extraPath);
-      if (stat.isSymbolicLink()) {
-        continue;
-      }
       const extraCheck = await checkReadableFile(extraPath);
       if (extraCheck.issue) {
         issues.push(extraCheck.issue);

--- a/src/memory/fs-utils.ts
+++ b/src/memory/fs-utils.ts
@@ -17,14 +17,14 @@ export function isFileMissingError(
 export async function statRegularFile(absPath: string): Promise<RegularFileStatResult> {
   let stat: Stats;
   try {
-    stat = await fs.lstat(absPath);
+    stat = await fs.stat(absPath);
   } catch (err) {
     if (isFileMissingError(err)) {
       return { missing: true };
     }
     throw err;
   }
-  if (stat.isSymbolicLink() || !stat.isFile()) {
+  if (!stat.isFile()) {
     throw new Error("path required");
   }
   return { missing: false, stat };

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -390,7 +390,7 @@ describe("memory index", () => {
     await expect(manager.readFile({ relPath: "NOTES.md" })).rejects.toThrow("path required");
   });
 
-  it("allows reading from additional memory paths and blocks symlinks", async () => {
+  it("allows reading from additional memory paths and follows symlinks", async () => {
     await fs.mkdir(extraDir, { recursive: true });
     await fs.writeFile(path.join(extraDir, "extra.md"), "Extra content.");
 
@@ -414,9 +414,10 @@ describe("memory index", () => {
       }
     }
     if (symlinkOk) {
-      await expect(manager.readFile({ relPath: "extra/linked.md" })).rejects.toThrow(
-        "path required",
-      );
+      await expect(manager.readFile({ relPath: "extra/linked.md" })).resolves.toEqual({
+        path: "extra/linked.md",
+        text: "Extra content.",
+      });
     }
   });
 });

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -87,7 +87,7 @@ describe("listMemoryFiles", () => {
     expect(files).toHaveLength(1);
   });
 
-  it("ignores symlinked files and directories", async () => {
+  it("follows symlinked files and directories", async () => {
     const tmpDir = getTmpDir();
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Default memory");
     const extraDir = path.join(tmpDir, "extra");
@@ -119,8 +119,38 @@ describe("listMemoryFiles", () => {
     const files = await listMemoryFiles(tmpDir, [extraDir, linkDir]);
     expect(files.some((file) => file.endsWith("note.md"))).toBe(true);
     if (symlinksOk) {
-      expect(files.some((file) => file.endsWith("linked.md"))).toBe(false);
-      expect(files.some((file) => file.endsWith("nested.md"))).toBe(false);
+      expect(files.some((file) => file.endsWith("linked.md"))).toBe(true);
+      expect(files.some((file) => file.endsWith("nested.md"))).toBe(true);
+    }
+  });
+
+  it("terminates on circular symlinks without hanging", async () => {
+    const tmpDir = getTmpDir();
+    const memDir = path.join(tmpDir, "memory");
+    const subDir = path.join(memDir, "sub");
+    await fs.mkdir(subDir, { recursive: true });
+    await fs.writeFile(path.join(subDir, "note.md"), "# Note");
+
+    let symlinksOk = true;
+    try {
+      // sub/link -> memory (creates a cycle: memory/sub/link -> memory)
+      await fs.symlink(memDir, path.join(subDir, "link"), "dir");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") {
+        symlinksOk = false;
+      } else {
+        throw err;
+      }
+    }
+
+    // Must terminate (not hang) and still find the real file
+    const files = await listMemoryFiles(tmpDir);
+    expect(files.some((file) => file.endsWith("note.md"))).toBe(true);
+    if (symlinksOk) {
+      // Should not duplicate via the cycle
+      const noteFiles = files.filter((file) => file.endsWith("note.md"));
+      expect(noteFiles).toHaveLength(1);
     }
   });
 

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -56,15 +56,37 @@ export function isMemoryPath(relPath: string): boolean {
   return normalized.startsWith("memory/");
 }
 
-async function walkDir(dir: string, files: string[]) {
+async function walkDir(dir: string, files: string[], visited?: Set<string>) {
+  const seen = visited ?? new Set<string>();
+  let realDir: string;
+  try {
+    realDir = await fs.realpath(dir);
+  } catch {
+    return; // Broken symlink or inaccessible
+  }
+  if (seen.has(realDir)) {
+    return; // Cycle detected — prevent infinite recursion
+  }
+  seen.add(realDir);
+
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isSymbolicLink()) {
+      try {
+        const targetStat = await fs.stat(full);
+        if (targetStat.isDirectory()) {
+          await walkDir(full, files, seen);
+        } else if (targetStat.isFile() && entry.name.endsWith(".md")) {
+          files.push(full);
+        }
+      } catch {
+        // Skip broken symlinks, circular symlinks (ELOOP), and permission errors
+      }
       continue;
     }
     if (entry.isDirectory()) {
-      await walkDir(full, files);
+      await walkDir(full, files, seen);
       continue;
     }
     if (!entry.isFile()) {
@@ -88,8 +110,8 @@ export async function listMemoryFiles(
 
   const addMarkdownFile = async (absPath: string) => {
     try {
-      const stat = await fs.lstat(absPath);
-      if (stat.isSymbolicLink() || !stat.isFile()) {
+      const stat = await fs.stat(absPath);
+      if (!stat.isFile()) {
         return;
       }
       if (!absPath.endsWith(".md")) {
@@ -102,8 +124,8 @@ export async function listMemoryFiles(
   await addMarkdownFile(memoryFile);
   await addMarkdownFile(altMemoryFile);
   try {
-    const dirStat = await fs.lstat(memoryDir);
-    if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
+    const dirStat = await fs.stat(memoryDir);
+    if (dirStat.isDirectory()) {
       await walkDir(memoryDir, result);
     }
   } catch {}
@@ -112,10 +134,7 @@ export async function listMemoryFiles(
   if (normalizedExtraPaths.length > 0) {
     for (const inputPath of normalizedExtraPaths) {
       try {
-        const stat = await fs.lstat(inputPath);
-        if (stat.isSymbolicLink()) {
-          continue;
-        }
+        const stat = await fs.stat(inputPath);
         if (stat.isDirectory()) {
           await walkDir(inputPath, result);
           continue;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -377,10 +377,7 @@ export abstract class MemoryManagerSyncOps {
     const additionalPaths = normalizeExtraMemoryPaths(this.workspaceDir, this.settings.extraPaths);
     for (const entry of additionalPaths) {
       try {
-        const stat = fsSync.lstatSync(entry);
-        if (stat.isSymbolicLink()) {
-          continue;
-        }
+        const stat = fsSync.statSync(entry);
         if (stat.isDirectory()) {
           watchPaths.add(path.join(entry, "**", "*.md"));
           continue;
@@ -392,6 +389,9 @@ export abstract class MemoryManagerSyncOps {
         // Skip missing/unreadable additional paths.
       }
     }
+    // chokidar defaults to followSymlinks:true — symlinked dirs may fire duplicate
+    // events (once for the link path, once for the target). This is harmless because
+    // the handler only sets dirty=true and schedules a debounced sync.
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -574,10 +574,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       );
       for (const additionalPath of additionalPaths) {
         try {
-          const stat = await fs.lstat(additionalPath);
-          if (stat.isSymbolicLink()) {
-            continue;
-          }
+          const stat = await fs.stat(additionalPath);
           if (stat.isDirectory()) {
             if (absPath === additionalPath || absPath.startsWith(`${additionalPath}${path.sep}`)) {
               allowedAdditional = true;

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2119,7 +2119,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("blocks non-markdown or symlink reads for qmd paths", async () => {
+  it("blocks non-markdown reads but allows symlinks for qmd paths", async () => {
     const { manager } = await createManager();
 
     const textPath = path.join(workspaceDir, "secret.txt");
@@ -2132,9 +2132,8 @@ describe("QmdMemoryManager", () => {
     await fs.writeFile(target, "ok", "utf-8");
     const link = path.join(workspaceDir, "link.md");
     await fs.symlink(target, link);
-    await expect(manager.readFile({ relPath: "qmd/workspace-main/link.md" })).rejects.toThrow(
-      "path required",
-    );
+    const result = await manager.readFile({ relPath: "qmd/workspace-main/link.md" });
+    expect(result.text).toBe("ok");
 
     await manager.close();
   });


### PR DESCRIPTION
## Summary

- **Problem:** The memory subsystem uses `lstat` throughout the indexer, reader, and watcher. `lstat` returns the symlink's own metadata rather than its target's, so any symlinked `.md` file or directory is silently skipped with no error or warning. Operators who organize memory via symlinks (e.g., shared context files symlinked into multiple agent workspaces) get invisible data loss.
- **Why it matters:** Symlinked memory directories/files are a natural pattern for multi-agent setups where agents share context files. The current behavior silently drops all symlinked content from the memory index.
- **What changed:** `lstat` -> `stat` across the indexer (`internal.ts`), reader (`fs-utils.ts`), watcher setup (`manager-sync-ops.ts`), manager path validation (`manager.ts`), and CLI scanner (`memory-cli.ts`). `walkDir` gains realpath-based cycle detection via a visited set. Broken/circular symlink errors are caught and skipped gracefully.
- **What did NOT change:** Non-memory file operations are untouched. The existing `lstat` call in `qmd-manager.ts` that *creates* symlinks (for `.qmd` management) is intentionally left as-is -- it needs link metadata, not target metadata.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #23619
- Related #23620 (previous submission, closed for rework)

## User-visible / Behavior Changes

- Symlinked `.md` files and symlinked directories inside the memory directory (and extra memory paths) are now indexed, readable, and watched -- previously silently skipped.
- Circular symlinks terminate gracefully instead of causing infinite recursion.
- Broken symlinks are skipped silently (same as before for missing files).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes -- memory indexer now follows symlinks within the memory directory.
  - **Risk + mitigation:** This PR intentionally follows symlinks. The memory directory is operator-controlled (not user-supplied input). Symlink following within an operator-managed workspace is expected behavior per the project's trust model (see `SECURITY.md`). `walkDir` has realpath-based cycle detection as defense-in-depth beyond OS-level `ELOOP` limits. Read scope remains restricted to `.md` files only.

## Repro + Verification

### Environment

- OS: macOS 15 / Linux
- Runtime: Node 22+
- Model/provider: N/A (filesystem-only change)

### Steps

1. Create a workspace with a `memory/` directory.
2. Create a `.md` file outside the memory directory and symlink it into `memory/`.
3. Run the memory indexer (`listMemoryFiles`) or read the file via `readFile`.

### Expected

- Symlinked `.md` file appears in the file list and is readable.

### Actual (before fix)

- Symlinked `.md` file is silently skipped; `readFile` throws `"path required"`.

## Evidence

- [x] Failing test/log before + passing after

Test suite covers:
- `follows symlinked files and directories` -- verifies symlinked files and directories in extra paths are indexed.
- `terminates on circular symlinks without hanging` -- creates `memory/sub/link -> memory` cycle, verifies termination and no duplicate entries.
- `blocks non-markdown reads but allows symlinks for qmd paths` -- verifies symlinked `.md` in qmd workspace is readable.
- `allows reading from additional memory paths and follows symlinks` -- verifies `readFile` resolves symlinked content.
- `pnpm build`, `pnpm check`, `pnpm test` all green.

## Human Verification (required)

- Verified scenarios: symlinked files indexed, symlinked directories walked, circular symlinks terminate, broken symlinks skipped, qmd symlink reads work.
- Edge cases checked: circular symlinks (realpath cycle detection), broken symlinks (ENOENT catch), permission errors on symlink creation (Windows CI compat -- tests skip gracefully).
- What I did **not** verify: Windows production behavior (tests handle EPERM/EACCES gracefully for CI; Windows symlinks require elevated privileges).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit -- single commit, clean revert.
- Files/config to restore: None.
- Known bad symptoms reviewers should watch for: memory indexer hanging (would indicate cycle detection failure -- tested against), duplicate file entries from symlink resolution.

## Risks and Mitigations

- Risk: Symlink following could theoretically traverse outside the workspace.
  - Mitigation: Memory directory is operator-controlled per the project's trust model. `walkDir` only collects `.md` files. Realpath-based visited set prevents cycles. `readFile` path validation is unchanged.

---

> [!NOTE]
> This PR was developed with Claude Code assistance. All changes were reviewed, tested, and verified by a human developer.