### PR TITLE
fix(compaction): emergency fallback when summarization fails

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1547,6 +1547,351 @@ describe("compaction-safeguard double-compaction guard", () => {
   });
 });
 
+describe("compaction-safeguard emergency fallback", () => {
+  it("includes split-turn note when isSplitTurn and turnPrefixMessages present", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const spy = vi
+      .spyOn(compactionModule, "summarizeInStages")
+      .mockRejectedValue(new Error("split turn failure"));
+
+    const compactionHandler = createCompactionHandler();
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [
+          { role: "user", content: "prefix msg 1", timestamp: Date.now() - 9000 },
+          { role: "assistant", content: "prefix reply 1", timestamp: Date.now() - 8500 },
+        ] as AgentMessage[],
+        firstKeptEntryId: "entry-split",
+        tokensBefore: 999_999,
+        isSplitTurn: true,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: undefined,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      const result = (await compactionHandler(mockEvent, mockContext)) as {
+        cancel?: boolean;
+        compaction?: { summary: string };
+      };
+
+      expect(result.cancel).toBeUndefined();
+      expect(result.compaction).toBeDefined();
+      expect(result.compaction!.summary).toContain("Split-turn context lost");
+      expect(result.compaction!.summary).toContain("2 turn-prefix message(s)");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns emergency compaction instead of cancelling when summarization throws", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    // Mock summarizeInStages to throw deterministically so the test
+    // exercises the catch path regardless of token estimation internals.
+    const spy = vi
+      .spyOn(compactionModule, "summarizeInStages")
+      .mockRejectedValue(new Error("injected summarization failure"));
+
+    const compactionHandler = createCompactionHandler();
+
+    // Provide enough messages (>3 turns) so splitPreservedRecentTurns
+    // still leaves some for summarization (default preserves 3 recent turns).
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-emergency",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: ["a.ts"], edited: ["b.ts"], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: "Prior conversation context about the project.",
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      const result = (await compactionHandler(mockEvent, mockContext)) as {
+        cancel?: boolean;
+        compaction?: {
+          summary: string;
+          firstKeptEntryId: string;
+          tokensBefore: number;
+          details: { readFiles: string[]; modifiedFiles: string[] };
+        };
+      };
+
+      // Must NOT cancel — that creates the stuck-session loop.
+      expect(result.cancel).toBeUndefined();
+      expect(result.compaction).toBeDefined();
+      expect(result.compaction!.summary).toContain("Emergency compaction");
+      expect(result.compaction!.summary).toContain("injected summarization failure");
+      // Prior summary must be preserved in emergency fallback
+      expect(result.compaction!.summary).toContain("Prior conversation context about the project.");
+      expect(result.compaction!.firstKeptEntryId).toBe("entry-emergency");
+      expect(result.compaction!.tokensBefore).toBe(999_999);
+      expect(result.compaction!.details.readFiles).toEqual(["a.ts"]);
+      expect(result.compaction!.details.modifiedFiles).toEqual(["b.ts"]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("re-throws AbortError instead of triggering emergency fallback", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const abortError = new DOMException("The operation was aborted", "AbortError");
+    const spy = vi.spyOn(compactionModule, "summarizeInStages").mockRejectedValue(abortError);
+
+    const compactionHandler = createCompactionHandler();
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-abort",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: undefined,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      await expect(compactionHandler(mockEvent, mockContext)).rejects.toThrow(abortError);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("re-throws non-AbortError when signal is aborted (e.g. TimeoutError)", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const timeoutError = new Error("request timed out");
+    timeoutError.name = "TimeoutError";
+    const spy = vi.spyOn(compactionModule, "summarizeInStages").mockRejectedValue(timeoutError);
+
+    const compactionHandler = createCompactionHandler();
+
+    const abortController = new AbortController();
+    abortController.abort(timeoutError);
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-timeout-abort",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: undefined,
+      },
+      customInstructions: "",
+      signal: abortController.signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      await expect(compactionHandler(mockEvent, mockContext)).rejects.toThrow("request timed out");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("truncates long prior summary to prevent unbounded nesting", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const spy = vi
+      .spyOn(compactionModule, "summarizeInStages")
+      .mockRejectedValue(new Error("nesting failure"));
+
+    const compactionHandler = createCompactionHandler();
+
+    const longPrior = "x".repeat(10_000);
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-nesting",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: longPrior,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      const result = (await compactionHandler(mockEvent, mockContext)) as {
+        compaction?: { summary: string };
+      };
+
+      expect(result.compaction).toBeDefined();
+      expect(result.compaction!.summary).toContain("[…truncated]");
+      // The full 10k prior should NOT appear verbatim
+      expect(result.compaction!.summary).not.toContain(longPrior);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("truncates long error messages to prevent unbounded summary growth", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const longError = "E".repeat(500);
+    const spy = vi
+      .spyOn(compactionModule, "summarizeInStages")
+      .mockRejectedValue(new Error(longError));
+
+    const compactionHandler = createCompactionHandler();
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "old message 1", timestamp: Date.now() - 8000 },
+          { role: "assistant", content: "old reply 1", timestamp: Date.now() - 7000 },
+          { role: "user", content: "old message 2", timestamp: Date.now() - 6000 },
+          { role: "assistant", content: "old reply 2", timestamp: Date.now() - 5000 },
+          { role: "user", content: "old message 3", timestamp: Date.now() - 4000 },
+          { role: "assistant", content: "old reply 3", timestamp: Date.now() - 3000 },
+          { role: "user", content: "recent message", timestamp: Date.now() - 2000 },
+          { role: "assistant", content: "recent reply", timestamp: Date.now() - 1000 },
+          { role: "user", content: "latest message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-truncate-error",
+        tokensBefore: 999_999,
+        isSplitTurn: false,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 16_384 },
+        previousSummary: undefined,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("sk-test"),
+    });
+
+    try {
+      const result = (await compactionHandler(mockEvent, mockContext)) as {
+        compaction?: { summary: string };
+      };
+
+      expect(result.compaction).toBeDefined();
+      // The full 500-char error should NOT appear verbatim
+      expect(result.compaction!.summary).not.toContain(longError);
+      // Should be truncated with "..." suffix
+      expect(result.compaction!.summary).toContain("...");
+      expect(result.compaction!.summary).toContain("Emergency compaction");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 async function expectWorkspaceSummaryEmptyForAgentsAlias(
   createAlias: (outsidePath: string, agentsPath: string) => void,
 ) {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -20,7 +20,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
-import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
+import { sanitizeForPromptLiteral, wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
 import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
@@ -43,6 +43,8 @@ const MAX_EXTRACTED_IDENTIFIERS = 12;
 const MAX_UNTRUSTED_INSTRUCTION_CHARS = 4000;
 const MAX_ASK_OVERLAP_TOKENS = 12;
 const MIN_ASK_OVERLAP_TOKENS_FOR_DOUBLE_MATCH = 3;
+const MAX_EMERGENCY_ERROR_MESSAGE_CHARS = 200;
+const MAX_EMERGENCY_PRIOR_SUMMARY_CHARS = 4000;
 const REQUIRED_SUMMARY_SECTIONS = [
   "## Decisions",
   "## Open TODOs",
@@ -711,6 +713,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       ...preparation.turnPrefixMessages,
     ]);
     const toolFailureSection = formatToolFailuresSection(toolFailures);
+    let preservedTurnsSection = "";
+    let droppedSummary: string | undefined;
 
     // Model resolution: ctx.model is undefined in compact.ts workflow (extensionRunner.initialize() is never called).
     // Fall back to runtime.model which is explicitly passed when building extension paths.
@@ -762,8 +766,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         typeof preparation.tokensBefore === "number" && Number.isFinite(preparation.tokensBefore)
           ? preparation.tokensBefore
           : undefined;
-
-      let droppedSummary: string | undefined;
 
       if (tokensBefore !== undefined) {
         const summarizableTokens =
@@ -833,7 +835,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         recentTurnsPreserve,
       });
       messagesToSummarize = summaryTargetMessages;
-      const preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);
+      preservedTurnsSection = formatPreservedTurnsSection(preservedRecentMessages);
       const latestUserAsk = extractLatestUserAsk([...messagesToSummarize, ...turnPrefixMessages]);
       const identifierSeedText = [...messagesToSummarize, ...turnPrefixMessages]
         .slice(-10)
@@ -969,12 +971,66 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         },
       };
     } catch (error) {
+      // Re-throw abort errors so signal cancellation doesn't trigger emergency fallback.
+      // Check signal state first (covers all abort reasons including TimeoutError),
+      // then fall back to name check for cases where signal is unavailable.
+      if (signal?.aborted || (error instanceof Error && error.name === "AbortError")) {
+        throw error;
+      }
+      const rawErrorMessage = error instanceof Error ? error.message : String(error);
       log.warn(
-        `Compaction summarization failed; cancelling compaction to preserve history: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Compaction summarization failed; using emergency fallback to avoid stuck session: ${rawErrorMessage}`,
       );
-      return { cancel: true };
+      // Sanitize error message before embedding in LLM context to prevent prompt injection / secret leakage.
+      const sanitizedErrorMessage = sanitizeForPromptLiteral(rawErrorMessage);
+      const errorMessage =
+        sanitizedErrorMessage.length > MAX_EMERGENCY_ERROR_MESSAGE_CHARS
+          ? sanitizedErrorMessage.slice(0, MAX_EMERGENCY_ERROR_MESSAGE_CHARS) + "..."
+          : sanitizedErrorMessage;
+      // Emergency fallback: return a static summary instead of cancelling.
+      // Cancelling leaves the session at its current (oversized) context,
+      // causing a compaction-fail-retry loop on every subsequent message.
+      const effectivePrior = droppedSummary ?? preparation.previousSummary;
+      // Truncate carried-forward summary to prevent unbounded nesting across repeated failures.
+      const clampedPrior =
+        effectivePrior && effectivePrior.length > MAX_EMERGENCY_PRIOR_SUMMARY_CHARS
+          ? effectivePrior.slice(0, MAX_EMERGENCY_PRIOR_SUMMARY_CHARS) + "\n[…truncated]"
+          : effectivePrior;
+      const priorContext = clampedPrior
+        ? `\n\nPrior summary (carried forward):\n${clampedPrior}`
+        : "";
+      const splitTurnNote =
+        preparation.isSplitTurn && preparation.turnPrefixMessages?.length
+          ? `\n\n**Split-turn context lost:** ${preparation.turnPrefixMessages.length} turn-prefix message(s) could not be summarized due to the failure above.`
+          : "";
+      // Best-effort: include workspace critical rules (AGENTS.md Session Startup / Red Lines).
+      let workspaceCtx = "";
+      try {
+        workspaceCtx = await readWorkspaceContextForSummary();
+      } catch {
+        // best-effort; don't let this block the emergency return
+      }
+      // Intentionally lossy: when LLM summarization fails, we preserve whatever
+      // structured context we can extract (prior summary, recent turns, tool
+      // failures, file ops) rather than cancelling and leaving the session stuck
+      // in a compact-fail-compact loop. Some detail loss is the accepted tradeoff.
+      const emergencySummary =
+        `Emergency compaction: summarization failed (${errorMessage}). ` +
+        `History was cut at the SDK-computed boundary; content before that point is not summarized.` +
+        priorContext +
+        splitTurnNote +
+        preservedTurnsSection +
+        toolFailureSection +
+        fileOpsSummary +
+        workspaceCtx;
+      return {
+        compaction: {
+          summary: emergencySummary,
+          firstKeptEntryId: preparation.firstKeptEntryId,
+          tokensBefore: preparation.tokensBefore,
+          details: { readFiles, modifiedFiles },
+        },
+      };
     }
   });
 }


### PR DESCRIPTION
## Summary

- **Problem:** When `summarizeInStages` throws a non-abort error, the catch block returns `{ cancel: true }`, leaving the session at its oversized context window. Every subsequent message re-triggers compaction, which fails again -- infinite loop, session permanently stuck.
- **Why it matters:** Any transient API failure (rate limit, malformed response, provider outage) during compaction bricks the session until manual intervention.
- **What changed:** The catch block now builds an emergency static summary preserving whatever structured context is available (prior summary, recent conversation turns, file ops, tool failures, workspace rules) and returns it as a real compaction result instead of cancelling. Error messages are sanitized via `sanitizeForPromptLiteral` and truncated to 200 chars before embedding. Prior summaries are clamped to 4000 chars to prevent unbounded nesting across repeated failures.
- **What did NOT change:** Happy-path summarization is untouched. `AbortError` and signal-aborted errors are still re-thrown (not caught by the fallback). The emergency path is intentionally lossy -- a code comment explains this tradeoff.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42158
- Related #42182 (previous submission, closed for rework)

## User-visible / Behavior Changes

Sessions that previously got stuck in a compaction-fail-retry loop now degrade gracefully: the agent loses some conversation detail but remains functional and responsive.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Additional notes: Error messages from failed summarization are sanitized through `sanitizeForPromptLiteral` (strips control chars, normalizes whitespace) and hard-truncated to 200 characters before being embedded in the emergency summary that enters LLM context. This prevents prompt injection and secret leakage through crafted error messages.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: Any Anthropic model (compaction uses same model as the run)
- Integration/channel (if any): All channels
- Relevant config (redacted): Default compaction settings

### Steps

1. Start a session and fill context past the compaction threshold (~180K tokens for Opus).
2. Trigger compaction (send another message).
3. Have `summarizeInStages` fail with a non-abort error (e.g., API rate limit, malformed response).

### Expected

Session remains functional with a degraded (lossy) summary that preserves file ops, tool failures, recent turns, and prior summary context.

### Actual (before fix)

Compaction returns `{ cancel: true }`, session stays oversized, next message re-triggers compaction, which fails again -- infinite loop.

## Evidence

- [x] Failing test/log before + passing after

6 test cases covering:
1. Happy path (emergency summary returned instead of cancel)
2. `AbortError` re-thrown (not caught by fallback)
3. Signal-aborted error re-thrown (e.g., `TimeoutError` with aborted signal)
4. Split-turn note included when `isSplitTurn` with `turnPrefixMessages`
5. Long prior summary truncated to prevent unbounded nesting
6. Long error messages truncated to prevent unbounded summary growth

`pnpm build`, `pnpm check`, and `pnpm test` all pass.

## Human Verification (required)

- Verified scenarios: All 6 test cases above, plus manual code review of the emergency summary structure.
- Edge cases checked: AbortError passthrough, signal-aborted passthrough, prior summary nesting across repeated failures, error message sanitization and truncation, split-turn metadata preservation.
- What you did **not** verify: Production-scale compaction with real 180K+ token sessions (tested via unit tests with mocked `summarizeInStages`).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; the catch block goes back to `{ cancel: true }`.
- Files/config to restore: `src/agents/pi-extensions/compaction-safeguard.ts`
- Known bad symptoms reviewers should watch for: Emergency summaries appearing in sessions that should have succeeded at normal compaction (would indicate the happy path is broken).

## Risks and Mitigations

- Risk: Emergency summary is intentionally lossy -- agent loses conversation detail that a successful summarization would have preserved.
  - Mitigation: This is the explicit design tradeoff documented in a code comment. A lossy but functional session is strictly better than a permanently stuck one. The fallback preserves the most valuable structured context (prior summary, file ops, tool failures, recent turns, workspace rules).

---

> [!NOTE]
> AI-assisted (Claude). Fully tested and reviewed.