### PR TITLE
feat: auto-inject shared bootstrap files into all agents

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { clearAllBootstrapSnapshots } from "./bootstrap-cache.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -20,8 +21,21 @@ function registerExtraBootstrapFileHook() {
         path: path.join(context.workspaceDir, "EXTRA.md"),
         content: "extra",
         missing: false,
-      } as unknown as WorkspaceBootstrapFile,
+      },
     ];
+  });
+}
+
+function registerMutatingPushHook() {
+  registerInternalHook("agent:bootstrap", (event) => {
+    const context = event.context as AgentBootstrapHookContext;
+    // Mimics shared-bootstrap hook: mutates via .push() instead of spread
+    context.bootstrapFiles.push({
+      name: "SHARED_TEST.md",
+      path: path.join(context.workspaceDir, "SHARED_TEST.md"),
+      content: "shared",
+      missing: false,
+    });
   });
 }
 
@@ -63,6 +77,30 @@ describe("resolveBootstrapFilesForRun", () => {
     const files = await resolveBootstrapFilesForRun({ workspaceDir });
 
     expect(files.some((file) => file.path === path.join(workspaceDir, "EXTRA.md"))).toBe(true);
+  });
+
+  it("does not accumulate hook-pushed files across cached calls", async () => {
+    registerMutatingPushHook();
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const sessionKey = "test-session-cache-mutation";
+
+    try {
+      const first = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountFirst = first.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountFirst).toBe(1);
+
+      const second = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountSecond = second.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountSecond).toBe(1);
+
+      // Third call to be thorough — would be 3 copies without the fix
+      const third = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountThird = third.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountThird).toBe(1);
+    } finally {
+      clearAllBootstrapSnapshots();
+    }
   });
 
   it("drops malformed hook files with missing/invalid paths", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -78,11 +78,13 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey: params.sessionKey,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
-    contextMode: params.contextMode,
-    runKind: params.runKind,
-  });
+  const bootstrapFiles = [
+    ...applyContextModeFilter({
+      files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+      contextMode: params.contextMode,
+      runKind: params.runKind,
+    }),
+  ];
 
   const updated = await applyBootstrapHookOverrides({
     files: bootstrapFiles,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -141,7 +141,9 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_MEMORY_ALT_FILENAME;
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  // Widened to accept arbitrary names (e.g. SHARED_*.md from the shared-bootstrap
+  // hook) while preserving autocomplete for known filenames.
+  name: WorkspaceBootstrapFileName | (string & {});
   path: string;
   content?: string;
   missing: boolean;

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -46,6 +46,20 @@ Logs all command events to a centralized audit file.
 openclaw hooks enable command-logger
 ```
 
+### 🔗 shared-bootstrap
+
+Injects shared `SHARED_*.md` files from `~/.openclaw/shared/` into every agent's bootstrap context.
+
+**Events**: `agent:bootstrap`
+**What it does**: Auto-discovers files matching `SHARED_*.md` in `<stateDir>/shared/`, sorts them alphabetically, and appends them to injected context for all session types (including subagent and cron).
+**Output**: No files written; context is modified in-memory only.
+
+**Enable**:
+
+```bash
+openclaw hooks enable shared-bootstrap
+```
+
 ### 🚀 boot-md
 
 Runs `BOOT.md` whenever the gateway starts (after channels start).

--- a/src/hooks/bundled/shared-bootstrap/HOOK.md
+++ b/src/hooks/bundled/shared-bootstrap/HOOK.md
@@ -1,0 +1,37 @@
+---
+name: shared-bootstrap
+description: "Inject shared SHARED_*.md bootstrap files from the state directory into all agents"
+homepage: https://docs.openclaw.ai/automation/hooks#shared-bootstrap
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔗",
+        "events": ["agent:bootstrap"],
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Shared Bootstrap Hook
+
+Auto-discovers `SHARED_*.md` files in `<stateDir>/shared/` (default `~/.openclaw/shared/`)
+and injects them into every agent's `Project Context` during `agent:bootstrap`.
+
+No configuration required. Drop files in the directory, restart, every agent gets them.
+
+## Setup
+
+```bash
+mkdir -p ~/.openclaw/shared
+echo "# Shared Rules" > ~/.openclaw/shared/SHARED_RULES.md
+```
+
+## Behavior
+
+- Only files matching `SHARED_*.md` are loaded (e.g. `SHARED_RULES.md`, `SHARED_SOUL.md`).
+- Files are sorted alphabetically and appended after workspace bootstrap files.
+- If the directory does not exist or contains no matching files, the hook does nothing.
+- If the directory exists but is unreadable, the error propagates to the hook runner (logged, does not block bootstrap).
+- If a matching file exists but cannot be read, it is skipped with a warning.
+- No subagent filtering — shared files appear in every session type.

--- a/src/hooks/bundled/shared-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/shared-bootstrap/handler.test.ts
@@ -1,0 +1,252 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentBootstrapHookContext } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+
+const mockStateDir = vi.hoisted(() => ({ value: "" }));
+vi.mock("../../../config/paths.js", () => ({
+  get STATE_DIR() {
+    return mockStateDir.value;
+  },
+}));
+
+// Import after mock setup — STATE_DIR is read at call time (not module load)
+import handler from "./handler.js";
+
+function createBootstrapContext(params: {
+  workspaceDir: string;
+  sessionKey: string;
+}): AgentBootstrapHookContext {
+  return {
+    workspaceDir: params.workspaceDir,
+    bootstrapFiles: [],
+    sessionKey: params.sessionKey,
+  };
+}
+
+describe("shared-bootstrap hook", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-shared-bootstrap-"));
+    mockStateDir.value = tempDir;
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does nothing when shared directory does not exist", async () => {
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("does nothing when shared directory is empty", async () => {
+    await fs.mkdir(path.join(tempDir, "shared"), { recursive: true });
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("does nothing when no SHARED_*.md files exist", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "RULES.md"), "no prefix", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "notes.txt"), "not md", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("injects SHARED_*.md files from shared directory", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared rules", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_SOUL.md"), "shared soul", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(2);
+
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+    expect(context.bootstrapFiles[0].content).toBe("shared rules");
+    expect(context.bootstrapFiles[0].path).toBe(path.join(sharedDir, "SHARED_RULES.md"));
+    expect(context.bootstrapFiles[0].missing).toBe(false);
+
+    expect(context.bootstrapFiles[1].name).toBe("SHARED_SOUL.md");
+    expect(context.bootstrapFiles[1].content).toBe("shared soul");
+    expect(context.bootstrapFiles[1].path).toBe(path.join(sharedDir, "SHARED_SOUL.md"));
+    expect(context.bootstrapFiles[1].missing).toBe(false);
+  });
+
+  it("sorts files alphabetically", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_C.md"), "c", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_A.md"), "a", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_B.md"), "b", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles.map((f) => f.name)).toEqual([
+      "SHARED_A.md",
+      "SHARED_B.md",
+      "SHARED_C.md",
+    ]);
+  });
+
+  it("ignores files without SHARED_ prefix", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SOUL.md"), "not shared", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "config.json"), "{}", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+  });
+
+  it("throws when shared directory exists but is unreadable", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.chmod(sharedDir, 0o000);
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+
+    try {
+      await expect(handler(event)).rejects.toThrow();
+    } finally {
+      await fs.chmod(sharedDir, 0o755);
+    }
+  });
+
+  it("skips files that fail boundary check", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_GOOD.md"), "good", "utf-8");
+    const filePath = path.join(sharedDir, "SHARED_BROKEN.md");
+    await fs.writeFile(filePath, "content", "utf-8");
+    await fs.chmod(filePath, 0o000);
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+
+    try {
+      await handler(event);
+      // SHARED_BROKEN.md skipped (boundary check fails), SHARED_GOOD.md loaded
+      expect(context.bootstrapFiles).toHaveLength(1);
+      expect(context.bootstrapFiles[0].name).toBe("SHARED_GOOD.md");
+    } finally {
+      await fs.chmod(filePath, 0o644);
+    }
+  });
+
+  it("skips symlinks pointing outside shared directory", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    const outsideFile = path.join(tempDir, "secret.md");
+    await fs.writeFile(outsideFile, "secret content", "utf-8");
+    await fs.symlink(outsideFile, path.join(sharedDir, "SHARED_ESCAPE.md"));
+    await fs.writeFile(path.join(sharedDir, "SHARED_LEGIT.md"), "legit", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    // Symlink escaping the shared dir is rejected by openBoundaryFile
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_LEGIT.md");
+  });
+
+  it("includes empty files with empty-string content", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_EMPTY.md"), "", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_EMPTY.md");
+    expect(context.bootstrapFiles[0].content).toBe("");
+  });
+
+  it("shared files survive in subagent sessions", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared rules", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:subagent:abc",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+  });
+});

--- a/src/hooks/bundled/shared-bootstrap/handler.ts
+++ b/src/hooks/bundled/shared-bootstrap/handler.ts
@@ -1,0 +1,64 @@
+import syncFs from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { STATE_DIR } from "../../../config/paths.js";
+import { openBoundaryFile } from "../../../infra/boundary-file-read.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
+
+const MAX_SHARED_FILE_BYTES = 2 * 1024 * 1024;
+const log = createSubsystemLogger("shared-bootstrap");
+
+const sharedBootstrapHook: HookHandler = async (event) => {
+  if (!isAgentBootstrapEvent(event)) {
+    return;
+  }
+
+  const sharedDir = path.join(STATE_DIR, "shared");
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sharedDir);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  const sharedFiles = entries
+    .filter((f) => f.startsWith("SHARED_") && f.endsWith(".md"))
+    .toSorted();
+  if (sharedFiles.length === 0) {
+    return;
+  }
+
+  for (const file of sharedFiles) {
+    const filePath = path.join(sharedDir, file);
+    const opened = await openBoundaryFile({
+      absolutePath: filePath,
+      rootPath: sharedDir,
+      boundaryLabel: "shared bootstrap",
+      maxBytes: MAX_SHARED_FILE_BYTES,
+    });
+    if (!opened.ok) {
+      log.warn(`skipping ${file}: ${opened.reason}`);
+      continue;
+    }
+    try {
+      const content = syncFs.readFileSync(opened.fd, "utf-8");
+      // Intentionally does NOT re-apply filterBootstrapFilesForSession so
+      // shared files reach subagent and cron sessions unconditionally.
+      event.context.bootstrapFiles.push({
+        name: file,
+        path: filePath,
+        content,
+        missing: false,
+      });
+    } finally {
+      syncFs.closeSync(opened.fd);
+    }
+  }
+};
+
+export default sharedBootstrapHook;


### PR DESCRIPTION
## Summary

- **Problem:** Multi-agent setups require manually duplicating shared context files (rules, persona, instructions) into every agent workspace. No built-in single-source-of-truth mechanism exists.
- **Why it matters:** Users running 3+ agents must keep N copies in sync. A missed update means one agent silently drifts from the others.
- **What changed:** New bundled `shared-bootstrap` hook discovers `SHARED_*.md` files from `<stateDir>/shared/` (default `~/.openclaw/shared/`) and injects them into bootstrap context for all agents. Uses `openBoundaryFile` for 2 MB size limit + symlink boundary validation. Fixes a latent mutation bug in `resolveBootstrapFilesForRun` where hooks that `.push()` onto the bootstrap array would accumulate duplicates across cached calls (the cached array was passed by reference, not copied).
- **What did NOT change:** Existing bootstrap pipeline, `filterBootstrapFilesForSession` behavior for other hooks, workspace-local bootstrap file loading.

Shared files intentionally bypass session filtering so they reach subagent and cron sessions -- documented in a code comment.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19620
- Related #42184 (previous submission, closed for rework)

## User-visible / Behavior Changes

- New bundled hook `shared-bootstrap` available via `openclaw hooks enable shared-bootstrap`.
- When enabled, `SHARED_*.md` files in `~/.openclaw/shared/` are injected into every agent's Project Context on bootstrap.
- `WorkspaceBootstrapFile.name` type widened to accept arbitrary strings (non-breaking -- union with branded `string & {}`).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No -- reads only from the user's own state directory (`<stateDir>/shared/`), using `openBoundaryFile` which enforces symlink boundary checks and a 2 MB size cap. No raw `fs.readFile`.

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node 22, Bun 1.2
- Model/provider: N/A (bootstrap pipeline, no LLM calls)
- Integration/channel: N/A

### Steps

1. `mkdir -p ~/.openclaw/shared && echo "# Shared Rules" > ~/.openclaw/shared/SHARED_RULES.md`
2. `openclaw hooks enable shared-bootstrap`
3. Start gateway, open any agent session.

### Expected

- `SHARED_RULES.md` content appears in the agent's Project Context section.

### Actual

- Confirmed: shared file content injected into bootstrap for main, subagent, and cron sessions.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

12 new tests across 2 files:
- `handler.test.ts` (10): injection, alphabetical sorting, prefix filtering, empty dir, missing dir, unreadable dir, unreadable file/boundary check, symlink escape, empty file content, subagent session survival.
- `bootstrap-files.test.ts` (2): hook-pushed files do not accumulate across cached calls (mutation bug regression test), existing extra-hook test updated to use proper type.

`pnpm build`, `pnpm check`, and `pnpm test` all pass.

## Human Verification (required)

- Verified scenarios: gateway bootstrap with 2 shared files across 3 agents, subagent session, cron session.
- Edge cases checked: missing dir (silent), empty dir (silent), symlink escape (rejected), unreadable file (skipped with warning), empty file (injected with empty content), no SHARED_ prefix (ignored).
- What I did **not** verify: Windows path handling (no Windows machine available).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes -- hook is opt-in (`openclaw hooks enable shared-bootstrap`). No behavior change unless enabled.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `openclaw hooks disable shared-bootstrap`
- Files/config to restore: None
- Known bad symptoms: unexpected content in agent system prompt; disable the hook to revert immediately.

## Risks and Mitigations

- Risk: Large files in `shared/` inflate context for every agent.
  - Mitigation: 2 MB per-file cap via `openBoundaryFile`. Only `SHARED_*.md` prefix matched.

---

> [!NOTE]
> AI-assisted (Claude). Fully tested. I understand what the code does.