### PR TITLE
feat(telegram): persist inbound webhooks to survive restarts

### DIFF
--- a/src/infra/webhook-queue.test.ts
+++ b/src/infra/webhook-queue.test.ts
@@ -1,0 +1,267 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { dequeueWebhook, enqueueWebhook, replayPendingWebhooks } from "./webhook-queue.js";
+
+describe("webhook-queue", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "webhook-queue-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(stateDir, { recursive: true, force: true });
+  });
+
+  const payload = { update_id: 100, message: { text: "hello" } };
+
+  it("enqueue writes a file and dequeue removes it", async () => {
+    await enqueueWebhook("telegram", "100", payload, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toEqual(["telegram_100.json"]);
+
+    const content = JSON.parse(await fs.promises.readFile(path.join(queueDir, files[0]), "utf-8"));
+    expect(content.channelId).toBe("telegram");
+    expect(content.deduplicationId).toBe("100");
+    expect(content.payload).toEqual(payload);
+    expect(typeof content.enqueuedAt).toBe("number");
+
+    await dequeueWebhook("telegram", "100", stateDir);
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining).toEqual([]);
+  });
+
+  it("dequeue is idempotent (no error on missing file)", async () => {
+    await expect(dequeueWebhook("telegram", "999", stateDir)).resolves.toBeUndefined();
+  });
+
+  it("replayPendingWebhooks returns entries sorted by enqueue time", async () => {
+    const now = Date.now();
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+    // Ensure distinct timestamps.
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const file1 = path.join(queueDir, "telegram_1.json");
+    const entry1 = JSON.parse(await fs.promises.readFile(file1, "utf-8"));
+    entry1.enqueuedAt = now - 2000;
+    await fs.promises.writeFile(file1, JSON.stringify(entry1));
+
+    await enqueueWebhook("telegram", "2", { update_id: 2 }, stateDir);
+    const file2 = path.join(queueDir, "telegram_2.json");
+    const entry2 = JSON.parse(await fs.promises.readFile(file2, "utf-8"));
+    entry2.enqueuedAt = now - 5000; // Earlier timestamp.
+    await fs.promises.writeFile(file2, JSON.stringify(entry2));
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(2);
+    expect(pending[0].deduplicationId).toBe("2"); // Earlier first.
+    expect(pending[1].deduplicationId).toBe("1");
+  });
+
+  it("replayPendingWebhooks deduplicates by channelId+deduplicationId", async () => {
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 1 }, stateDir);
+    // Write a duplicate within the SAME channel — should be deduped.
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const dup: Record<string, unknown> = {
+      channelId: "telegram",
+      deduplicationId: "100",
+      enqueuedAt: Date.now() + 1000,
+      payload: { update_id: 100, v: 2 },
+    };
+    await fs.promises.writeFile(path.join(queueDir, "telegram_100_dup.json"), JSON.stringify(dup));
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect((pending[0].payload as Record<string, unknown>).v).toBe(1);
+  });
+
+  it("replayPendingWebhooks filters by channelId when specified", async () => {
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+    await enqueueWebhook("whatsapp", "2", { id: "abc" }, stateDir);
+
+    const telegramOnly = await replayPendingWebhooks("telegram", stateDir);
+    expect(telegramOnly).toHaveLength(1);
+    expect(telegramOnly[0].channelId).toBe("telegram");
+  });
+
+  it("replayPendingWebhooks cleans up entries older than 1 hour", async () => {
+    await enqueueWebhook("telegram", "old", { update_id: 1 }, stateDir);
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const oldFile = path.join(queueDir, "telegram_old.json");
+    const entry = JSON.parse(await fs.promises.readFile(oldFile, "utf-8"));
+    entry.enqueuedAt = Date.now() - 2 * 60 * 60 * 1000; // 2 hours ago.
+    await fs.promises.writeFile(oldFile, JSON.stringify(entry));
+
+    await enqueueWebhook("telegram", "fresh", { update_id: 2 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("fresh");
+
+    // Old file should be deleted.
+    await expect(fs.promises.access(oldFile)).rejects.toThrow();
+  });
+
+  it("replayPendingWebhooks returns empty array when queue dir does not exist", async () => {
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toEqual([]);
+  });
+
+  it("replayPendingWebhooks skips malformed files", async () => {
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    await fs.promises.writeFile(path.join(queueDir, "bad-file.json"), "not json{{{");
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("1");
+  });
+
+  it("handles many queued messages replayed in order", async () => {
+    const now = Date.now();
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    for (let i = 0; i < 50; i++) {
+      const entry = {
+        channelId: "telegram",
+        deduplicationId: String(i),
+        enqueuedAt: now - (50 - i) * 100, // Reverse ID order to test sorting.
+        payload: { update_id: i },
+      };
+      await fs.promises.writeFile(path.join(queueDir, `telegram_${i}.json`), JSON.stringify(entry));
+    }
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(50);
+    // Sorted by enqueuedAt ascending: update_id 0 has earliest enqueuedAt.
+    expect(pending[0].deduplicationId).toBe("0");
+    expect(pending[49].deduplicationId).toBe("49");
+  });
+
+  it("replayPendingWebhooks breaks timestamp ties by deduplicationId", async () => {
+    const now = Date.now();
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    // Three entries with the same timestamp — order must be deterministic.
+    for (const id of ["300", "100", "200"]) {
+      const entry = { channelId: "telegram", deduplicationId: id, enqueuedAt: now, payload: {} };
+      await fs.promises.writeFile(
+        path.join(queueDir, `telegram_${id}.json`),
+        JSON.stringify(entry),
+      );
+    }
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending.map((e) => e.deduplicationId)).toEqual(["100", "200", "300"]);
+  });
+
+  it("replayPendingWebhooks cleans up orphaned .tmp files", async () => {
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    // Simulate an orphaned temp file from an interrupted write.
+    await fs.promises.writeFile(path.join(queueDir, "telegram_42.json.12345.tmp"), "partial");
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("1");
+
+    // Orphaned tmp file should be deleted.
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining.some((f) => f.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("enqueue overwrites existing entry with same deduplicationId", async () => {
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 1 }, stateDir);
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 2 }, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toHaveLength(1);
+
+    const content = JSON.parse(await fs.promises.readFile(path.join(queueDir, files[0]), "utf-8"));
+    expect(content.payload.v).toBe(2);
+  });
+
+  it("replayPendingWebhooks removes entries with missing channelId", async () => {
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    const malformed = { deduplicationId: "1", enqueuedAt: Date.now(), payload: {} };
+    await fs.promises.writeFile(path.join(queueDir, "bad_1.json"), JSON.stringify(malformed));
+    await enqueueWebhook("telegram", "2", { ok: true }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("2");
+
+    // Malformed entry should be cleaned up from disk.
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining.some((f) => f === "bad_1.json")).toBe(false);
+  });
+
+  it("sanitizes channelId with special characters (slashes, colons) in filenames", async () => {
+    const specialChannel = "plugin:voice/call";
+    const specialDedup = "msg:123/456";
+    await enqueueWebhook(specialChannel, specialDedup, payload, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toHaveLength(1);
+    // Slashes and colons replaced with underscores.
+    expect(files[0]).toBe("plugin_voice_call_msg_123_456.json");
+
+    // Round-trip: replay should return the original channelId/deduplicationId.
+    const pending = await replayPendingWebhooks(specialChannel, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].channelId).toBe(specialChannel);
+    expect(pending[0].deduplicationId).toBe(specialDedup);
+
+    // Dequeue by original IDs should remove the file.
+    await dequeueWebhook(specialChannel, specialDedup, stateDir);
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining).toEqual([]);
+  });
+
+  it("path traversal in channelId is contained within queue dir", async () => {
+    await enqueueWebhook("../../etc", "passwd", { evil: true }, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toHaveLength(1);
+    // The file must live inside the queue dir, not escape via ../
+    const fullPath = path.join(queueDir, files[0]);
+    expect(path.resolve(fullPath).startsWith(path.resolve(queueDir))).toBe(true);
+    // The sanitized filename should not contain path separators
+    expect(files[0].includes("/")).toBe(false);
+    expect(files[0].includes("\\")).toBe(false);
+
+    // Verify the payload round-trips correctly
+    const content = JSON.parse(await fs.promises.readFile(fullPath, "utf-8"));
+    expect(content.channelId).toBe("../../etc");
+    expect(content.deduplicationId).toBe("passwd");
+
+    // No file should exist outside the queue dir
+    const parentFiles = await fs.promises.readdir(stateDir);
+    expect(parentFiles).toEqual(["webhook-queue"]);
+  });
+
+  it("dedup key includes channelId so cross-channel entries are preserved", async () => {
+    const now = Date.now();
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    // Two different channels with the same deduplicationId.
+    for (const ch of ["telegram", "signal"]) {
+      const entry = { channelId: ch, deduplicationId: "100", enqueuedAt: now, payload: { ch } };
+      await fs.promises.writeFile(path.join(queueDir, `${ch}_100.json`), JSON.stringify(entry));
+    }
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(2);
+    const channels = pending.map((e) => e.channelId).toSorted();
+    expect(channels).toEqual(["signal", "telegram"]);
+  });
+});

--- a/src/infra/webhook-queue.ts
+++ b/src/infra/webhook-queue.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+const QUEUE_DIRNAME = "webhook-queue";
+const MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+export interface WebhookQueueEntry {
+  channelId: string;
+  deduplicationId: string;
+  enqueuedAt: number;
+  payload: unknown;
+}
+
+function resolveQueueDir(stateDir?: string): string {
+  const base = stateDir ?? resolveStateDir();
+  return path.join(base, QUEUE_DIRNAME);
+}
+
+/** Sanitize a value for use in filenames (prevent path traversal). */
+function safeFileKey(raw: string): string {
+  return raw.replace(/[\\/:*?"<>|]/g, "_").replace(/\.\./g, "_");
+}
+
+function entryFilename(channelId: string, deduplicationId: string): string {
+  return `${safeFileKey(channelId)}_${safeFileKey(deduplicationId)}.json`;
+}
+
+async function ensureQueueDir(queueDir: string): Promise<void> {
+  await fs.promises.mkdir(queueDir, { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Persist an inbound webhook payload to disk before acknowledging receipt.
+ * Write failure must NOT block normal processing — callers should catch errors.
+ */
+export async function enqueueWebhook(
+  channelId: string,
+  deduplicationId: string,
+  payload: unknown,
+  stateDir?: string,
+): Promise<void> {
+  const queueDir = resolveQueueDir(stateDir);
+  await ensureQueueDir(queueDir);
+  const entry: WebhookQueueEntry = {
+    channelId,
+    deduplicationId,
+    enqueuedAt: Date.now(),
+    payload,
+  };
+  const filePath = path.join(queueDir, entryFilename(channelId, deduplicationId));
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await fs.promises.writeFile(tmp, JSON.stringify(entry), { encoding: "utf-8", mode: 0o600 });
+  await fs.promises.rename(tmp, filePath);
+}
+
+/** Remove a processed webhook entry from the queue. */
+export async function dequeueWebhook(
+  channelId: string,
+  deduplicationId: string,
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveQueueDir(stateDir), entryFilename(channelId, deduplicationId));
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code === "ENOENT"
+    ) {
+      return; // Already removed — no-op.
+    }
+    throw err;
+  }
+}
+
+/**
+ * Load all pending webhook entries, sorted by enqueue time, deduplicated by
+ * channelId+deduplicationId. Entries older than 1 hour are deleted (cleanup).
+ */
+export async function replayPendingWebhooks(
+  channelId?: string,
+  stateDir?: string,
+): Promise<WebhookQueueEntry[]> {
+  const queueDir = resolveQueueDir(stateDir);
+  let files: string[];
+  try {
+    files = await fs.promises.readdir(queueDir);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code !== "ENOENT"
+    ) {
+      console.warn("[webhook-queue] failed to read queue directory:", err);
+    }
+    return [];
+  }
+
+  const now = Date.now();
+  const entries: WebhookQueueEntry[] = [];
+
+  for (const file of files) {
+    // Clean up orphaned temp files from interrupted writes.
+    if (file.endsWith(".tmp")) {
+      await fs.promises.unlink(path.join(queueDir, file)).catch(() => {});
+      continue;
+    }
+    if (!file.endsWith(".json")) {
+      continue;
+    }
+    const filePath = path.join(queueDir, file);
+    try {
+      const raw = await fs.promises.readFile(filePath, "utf-8");
+      const entry = JSON.parse(raw) as WebhookQueueEntry;
+
+      // Validate required fields to avoid sort/dedup errors from malformed entries.
+      if (
+        typeof entry.channelId !== "string" ||
+        typeof entry.deduplicationId !== "string" ||
+        typeof entry.enqueuedAt !== "number"
+      ) {
+        await fs.promises.unlink(filePath).catch(() => {});
+        continue;
+      }
+
+      // Cleanup: delete entries older than 1 hour.
+      if (now - entry.enqueuedAt > MAX_AGE_MS) {
+        await fs.promises.unlink(filePath).catch(() => {});
+        continue;
+      }
+
+      // Filter by channel if specified.
+      if (channelId && entry.channelId !== channelId) {
+        continue;
+      }
+
+      entries.push(entry);
+    } catch {
+      // Skip malformed or inaccessible entries.
+    }
+  }
+
+  // Sort oldest first; break timestamp ties deterministically by deduplicationId.
+  entries.sort(
+    (a, b) => a.enqueuedAt - b.enqueuedAt || a.deduplicationId.localeCompare(b.deduplicationId),
+  );
+
+  // Deduplicate by channelId+deduplicationId (keep earliest).
+  const seen = new Set<string>();
+  return entries.filter((e) => {
+    const key = `${e.channelId}:${e.deduplicationId}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -44,6 +44,7 @@ import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
   MEDIA_GROUP_TIMEOUT_MS,
   type MediaGroupEntry,
+  resolveTelegramUpdateId,
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
@@ -125,6 +126,7 @@ export const registerTelegramHandlers = ({
   shouldSkipUpdate,
   processMessage,
   logger,
+  registerDeferredWork,
 }: RegisterTelegramHandlerParams) => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
@@ -149,9 +151,19 @@ export const registerTelegramHandlers = ({
     key: string;
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     timer: ReturnType<typeof setTimeout>;
+    /** Deferred-work resolvers for webhook queue tracking. */
+    deferredResolvers?: Array<() => void>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
   let textFragmentProcessing: Promise<void> = Promise.resolve();
+
+  // Register a deferred-work promise for the given update_id so the webhook
+  // queue does not dequeue the update until the deferred processing completes.
+  const registerDeferred = (updateId: number | undefined, promise: Promise<void>) => {
+    if (typeof updateId === "number" && registerDeferredWork) {
+      registerDeferredWork(updateId, promise);
+    }
+  };
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
   const FORWARD_BURST_DEBOUNCE_MS = 80;
@@ -164,6 +176,8 @@ export const registerTelegramHandlers = ({
     debounceKey: string | null;
     debounceLane: TelegramDebounceLane;
     botUsername?: string;
+    /** Resolve function for webhook queue deferred-work tracking. */
+    deferredResolve?: () => void;
   };
   const resolveTelegramDebounceLane = (msg: Message): TelegramDebounceLane => {
     const forwardMeta = msg as {
@@ -228,43 +242,54 @@ export const registerTelegramHandlers = ({
       return entry.allMedia.length === 0;
     },
     onFlush: async (entries) => {
-      const last = entries.at(-1);
-      if (!last) {
-        return;
+      try {
+        const last = entries.at(-1);
+        if (!last) {
+          return;
+        }
+        if (entries.length === 1) {
+          const replyMedia = await resolveReplyMediaForMessage(last.ctx, last.msg);
+          await processMessage(last.ctx, last.allMedia, last.storeAllowFrom, undefined, replyMedia);
+          return;
+        }
+        const combinedText = entries
+          .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
+          .filter(Boolean)
+          .join("\n");
+        const combinedMedia = entries.flatMap((entry) => entry.allMedia);
+        if (!combinedText.trim() && combinedMedia.length === 0) {
+          return;
+        }
+        const first = entries[0];
+        const baseCtx = first.ctx;
+        const syntheticMessage = buildSyntheticTextMessage({
+          base: first.msg,
+          text: combinedText,
+          date: last.msg.date ?? first.msg.date,
+        });
+        const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
+        const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
+        const replyMedia = await resolveReplyMediaForMessage(baseCtx, syntheticMessage);
+        await processMessage(
+          syntheticCtx,
+          combinedMedia,
+          first.storeAllowFrom,
+          messageIdOverride ? { messageIdOverride } : undefined,
+          replyMedia,
+        );
+      } finally {
+        for (const entry of entries) {
+          entry.deferredResolve?.();
+        }
       }
-      if (entries.length === 1) {
-        const replyMedia = await resolveReplyMediaForMessage(last.ctx, last.msg);
-        await processMessage(last.ctx, last.allMedia, last.storeAllowFrom, undefined, replyMedia);
-        return;
-      }
-      const combinedText = entries
-        .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
-        .filter(Boolean)
-        .join("\n");
-      const combinedMedia = entries.flatMap((entry) => entry.allMedia);
-      if (!combinedText.trim() && combinedMedia.length === 0) {
-        return;
-      }
-      const first = entries[0];
-      const baseCtx = first.ctx;
-      const syntheticMessage = buildSyntheticTextMessage({
-        base: first.msg,
-        text: combinedText,
-        date: last.msg.date ?? first.msg.date,
-      });
-      const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
-      const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
-      const replyMedia = await resolveReplyMediaForMessage(baseCtx, syntheticMessage);
-      await processMessage(
-        syntheticCtx,
-        combinedMedia,
-        first.storeAllowFrom,
-        messageIdOverride ? { messageIdOverride } : undefined,
-        replyMedia,
-      );
     },
     onError: (err, items) => {
       runtime.error?.(danger(`telegram debounce flush failed: ${String(err)}`));
+      // Defense-in-depth: onFlush's finally already resolves these, but if it
+      // somehow didn't run, resolve here to prevent the middleware from hanging.
+      for (const item of items) {
+        item.deferredResolve?.();
+      }
       const chatId = items[0]?.msg.chat.id;
       if (chatId != null) {
         const threadId = items[0]?.msg.message_thread_id;
@@ -387,6 +412,10 @@ export const registerTelegramHandlers = ({
       await processMessage(primaryEntry.ctx, allMedia, storeAllowFrom, undefined, replyMedia);
     } catch (err) {
       runtime.error?.(danger(`media group handler failed: ${String(err)}`));
+    } finally {
+      for (const resolve of entry.deferredResolvers ?? []) {
+        resolve();
+      }
     }
   };
 
@@ -419,6 +448,10 @@ export const registerTelegramHandlers = ({
       });
     } catch (err) {
       runtime.error?.(danger(`text fragment handler failed: ${String(err)}`));
+    } finally {
+      for (const resolve of entry.deferredResolvers ?? []) {
+        resolve();
+      }
     }
   };
 
@@ -866,6 +899,8 @@ export const registerTelegramHandlers = ({
     storeAllowFrom: string[];
     sendOversizeWarning: boolean;
     oversizeLogMessage: string;
+    /** Telegram update_id for deferred-work tracking (webhook queue). */
+    updateId?: number;
   }) => {
     const {
       ctx,
@@ -876,6 +911,7 @@ export const registerTelegramHandlers = ({
       storeAllowFrom,
       sendOversizeWarning,
       oversizeLogMessage,
+      updateId,
     } = params;
 
     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
@@ -913,6 +949,12 @@ export const registerTelegramHandlers = ({
             nextTotalChars <= TELEGRAM_TEXT_FRAGMENT_MAX_TOTAL_CHARS
           ) {
             existing.messages.push({ msg, ctx, receivedAtMs: nowMs });
+            if (typeof updateId === "number" && registerDeferredWork) {
+              const deferred = new Promise<void>((resolve) => {
+                (existing.deferredResolvers ??= []).push(resolve);
+              });
+              registerDeferred(updateId, deferred);
+            }
             scheduleTextFragmentFlush(existing);
             return;
           }
@@ -936,6 +978,12 @@ export const registerTelegramHandlers = ({
           messages: [{ msg, ctx, receivedAtMs: nowMs }],
           timer: setTimeout(() => {}, TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS),
         };
+        if (typeof updateId === "number" && registerDeferredWork) {
+          const deferred = new Promise<void>((resolve) => {
+            (entry.deferredResolvers ??= []).push(resolve);
+          });
+          registerDeferred(updateId, deferred);
+        }
         textFragmentBuffer.set(key, entry);
         scheduleTextFragmentFlush(entry);
         return;
@@ -949,6 +997,12 @@ export const registerTelegramHandlers = ({
       if (existing) {
         clearTimeout(existing.timer);
         existing.messages.push({ msg, ctx });
+        if (typeof updateId === "number" && registerDeferredWork) {
+          const deferred = new Promise<void>((resolve) => {
+            (existing.deferredResolvers ??= []).push(resolve);
+          });
+          registerDeferred(updateId, deferred);
+        }
         existing.timer = setTimeout(async () => {
           mediaGroupBuffer.delete(mediaGroupId);
           mediaGroupProcessing = mediaGroupProcessing
@@ -971,6 +1025,12 @@ export const registerTelegramHandlers = ({
             await mediaGroupProcessing;
           }, mediaGroupTimeoutMs),
         };
+        if (typeof updateId === "number" && registerDeferredWork) {
+          const deferred = new Promise<void>((resolve) => {
+            (entry.deferredResolvers ??= []).push(resolve);
+          });
+          registerDeferred(updateId, deferred);
+        }
         mediaGroupBuffer.set(mediaGroupId, entry);
       }
       return;
@@ -1032,6 +1092,13 @@ export const registerTelegramHandlers = ({
     const debounceKey = senderId
       ? `telegram:${accountId ?? "default"}:${conversationKey}:${senderId}:${debounceLane}`
       : null;
+    let deferredResolve: (() => void) | undefined;
+    if (typeof updateId === "number" && registerDeferredWork) {
+      const deferred = new Promise<void>((resolve) => {
+        deferredResolve = resolve;
+      });
+      registerDeferred(updateId, deferred);
+    }
     await inboundDebouncer.enqueue({
       ctx,
       msg,
@@ -1040,6 +1107,7 @@ export const registerTelegramHandlers = ({
       debounceKey,
       debounceLane,
       botUsername: ctx.me?.username,
+      deferredResolve,
     });
   };
   bot.on("callback_query", async (ctx) => {
@@ -1482,6 +1550,7 @@ export const registerTelegramHandlers = ({
         storeAllowFrom,
         sendOversizeWarning: event.sendOversizeWarning,
         oversizeLogMessage: event.oversizeLogMessage,
+        updateId: resolveTelegramUpdateId(event.ctxForDedupe),
       });
     } catch (err) {
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -114,6 +114,10 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
+  /** Register a promise that must settle before the webhook queue dequeues
+   *  the update. Used by deferred handlers (media group, text fragment,
+   *  inbound debounce) to prevent premature dequeue. */
+  registerDeferredWork?: (updateId: number, promise: Promise<void>) => void;
 };
 
 type RegisterTelegramNativeCommandsParams = {

--- a/src/telegram/bot-updates.ts
+++ b/src/telegram/bot-updates.ts
@@ -12,6 +12,8 @@ export type MediaGroupEntry = {
     ctx: TelegramContext;
   }>;
   timer: ReturnType<typeof setTimeout>;
+  /** Deferred-work resolvers for webhook queue tracking. */
+  deferredResolvers?: Array<() => void>;
 };
 
 export type TelegramUpdateKeyContext = {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -64,6 +64,8 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /** Called when a Telegram update has been fully processed (for webhook queue dequeue). */
+  onUpdateProcessed?: (updateId: number) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -218,6 +220,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     return skipped;
   };
 
+  // Track deferred processing promises per update_id. Handlers that buffer
+  // messages (media groups, text fragments, inbound debouncing) register a
+  // promise here so `onUpdateProcessed` only fires after the deferred work
+  // completes — not when the middleware `next()` returns.
+  const deferredWork = new Map<number, Promise<void>[]>();
+  const registerDeferredWork = (updateId: number, promise: Promise<void>) => {
+    const existing = deferredWork.get(updateId);
+    if (existing) {
+      existing.push(promise);
+    } else {
+      deferredWork.set(updateId, [promise]);
+    }
+  };
+
   bot.use(async (ctx, next) => {
     const updateId = resolveTelegramUpdateId(ctx);
     if (typeof updateId === "number") {
@@ -225,8 +241,21 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     }
     try {
       await next();
+      if (typeof updateId === "number") {
+        // Wait for any deferred processing (debounce, media group, text
+        // fragment buffering) before signaling the update as processed.
+        const deferred = deferredWork.get(updateId);
+        if (deferred) {
+          deferredWork.delete(updateId);
+          await Promise.all(deferred);
+        }
+        // Intentionally only called on success: on error the webhook queue
+        // retains the entry so it can be replayed on the next restart.
+        opts.onUpdateProcessed?.(updateId);
+      }
     } finally {
       if (typeof updateId === "number") {
+        deferredWork.delete(updateId);
         pendingUpdateIds.delete(updateId);
         if (highestCompletedUpdateId === null || updateId > highestCompletedUpdateId) {
           highestCompletedUpdateId = updateId;
@@ -449,6 +478,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     shouldSkipUpdate,
     processMessage,
     logger,
+    registerDeferredWork,
   });
 
   const originalStop = bot.stop.bind(bot);

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -605,6 +605,68 @@ describe("startTelegramWebhook", () => {
     );
   });
 
+  it("dequeues webhook file when onUpdateProcessed fires", async () => {
+    // Capture the onUpdateProcessed callback passed to createTelegramBot.
+    let capturedOnUpdateProcessed: ((updateId: number) => void) | undefined;
+    createTelegramBotSpy.mockImplementationOnce((...args: unknown[]) => {
+      const opts = args[0] as Record<string, unknown>;
+      capturedOnUpdateProcessed = opts.onUpdateProcessed as typeof capturedOnUpdateProcessed;
+      return {
+        init: initSpy,
+        api: { setWebhook: setWebhookSpy, deleteWebhook: deleteWebhookSpy },
+        stop: stopSpy,
+      };
+    });
+
+    // The webhookCallback handler should invoke the Grammy middleware which
+    // eventually calls onUpdateProcessed. In this mock we control it manually.
+    handlerSpy.mockImplementationOnce((...args: unknown[]) => {
+      const reply = args[1] as (json: string) => Promise<void>;
+      void reply("ok");
+    });
+
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "wh-dequeue-test-"));
+
+    try {
+      await withStartedWebhook(
+        {
+          secret: TELEGRAM_SECRET,
+          path: TELEGRAM_WEBHOOK_PATH,
+          stateDir,
+        },
+        async ({ port }) => {
+          const payload = JSON.stringify({ update_id: 42, message: { text: "test" } });
+          const response = await postWebhookJson({
+            url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+            payload,
+            secret: TELEGRAM_SECRET,
+          });
+          expect(response.status).toBe(200);
+
+          // Webhook file should be on disk (enqueued before processing).
+          const queueDir = path.join(stateDir, "webhook-queue");
+          const filesAfterEnqueue = await fs.promises.readdir(queueDir);
+          expect(filesAfterEnqueue.some((f: string) => f.includes("42"))).toBe(true);
+
+          // Simulate middleware completing — fire onUpdateProcessed.
+          expect(capturedOnUpdateProcessed).toBeDefined();
+          capturedOnUpdateProcessed!(42);
+
+          // Wait for async dequeue to complete.
+          await new Promise((r) => setTimeout(r, 50));
+
+          const filesAfterDequeue = await fs.promises.readdir(queueDir);
+          expect(filesAfterDequeue.some((f: string) => f.includes("42"))).toBe(false);
+        },
+      );
+    } finally {
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("de-registers webhook when shutting down", async () => {
     deleteWebhookSpy.mockClear();
     const abort = new AbortController();

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { readJsonBodyWithLimit } from "../infra/http-body.js";
+import { dequeueWebhook, enqueueWebhook, replayPendingWebhooks } from "../infra/webhook-queue.js";
 import {
   logWebhookError,
   logWebhookProcessed,
@@ -88,6 +89,8 @@ export async function startTelegramWebhook(opts: {
   healthPath?: string;
   publicUrl?: string;
   webhookCertPath?: string;
+  /** Override state directory for webhook queue (tests). */
+  stateDir?: string;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -102,18 +105,43 @@ export async function startTelegramWebhook(opts: {
   }
   const runtime = opts.runtime ?? defaultRuntime;
   const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
+  const queueChannelId = opts.accountId ? `telegram_${opts.accountId}` : "telegram";
   const bot = createTelegramBot({
     token: opts.token,
     runtime,
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    onUpdateProcessed: (updateId) => {
+      dequeueWebhook(queueChannelId, String(updateId), opts.stateDir).catch((err) => {
+        runtime.log?.(`[webhook-queue] dequeue failed: ${formatErrorMessage(err)}`);
+      });
+    },
   });
   await initializeTelegramWebhookBot({
     bot,
     runtime,
     abortSignal: opts.abortSignal,
   });
+
+  // Replay any webhook payloads that were enqueued but not fully processed
+  // before the last shutdown.
+  const pending = await replayPendingWebhooks(queueChannelId, opts.stateDir);
+  for (const entry of pending) {
+    try {
+      await bot.handleUpdate(entry.payload as Parameters<typeof bot.handleUpdate>[0]);
+      // Dequeue happens via onUpdateProcessed in the bot middleware on success.
+    } catch (err) {
+      runtime.log?.(
+        `webhook replay failed for update ${entry.deduplicationId}: ${formatErrorMessage(err)}`,
+      );
+      // Leave entry on disk — will be retried on next restart (1h TTL cleanup).
+    }
+  }
+  if (pending.length > 0) {
+    runtime.log?.(`webhook queue: replayed ${pending.length} pending update(s)`);
+  }
+
   const handler = webhookCallback(bot, "callback", {
     secretToken: secret,
     onTimeout: "return",
@@ -191,6 +219,25 @@ export async function startTelegramWebhook(opts: {
       };
       const secretHeaderRaw = req.headers["x-telegram-bot-api-secret-token"];
       const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
+
+      // Validate webhook secret before persisting anything to disk.
+      if (secretHeader !== secret) {
+        await unauthorized();
+        return;
+      }
+
+      // Persist payload to disk before processing so it survives a restart.
+      const updateId =
+        body.value && typeof body.value === "object" && "update_id" in body.value
+          ? (body.value as { update_id?: unknown }).update_id
+          : undefined;
+      if (typeof updateId === "number") {
+        try {
+          await enqueueWebhook(queueChannelId, String(updateId), body.value, opts.stateDir);
+        } catch {
+          // Queue write failure must not block normal processing.
+        }
+      }
 
       await handler(body.value, reply, secretHeader, unauthorized);
       if (!replied) {


### PR DESCRIPTION
## Summary

- **Problem:** In webhook mode the gateway ACKs Telegram's delivery with 200 before processing completes. If the gateway restarts between the ACK and completion the message is permanently lost -- Telegram considers it delivered and will not retry.
- **Why it matters:** Users send messages that silently vanish during routine restarts (config change, update, RPC). The window is small but non-zero, and on busy gateways it causes visible message loss.
- **What changed:** Disk-backed webhook queue with atomic writes (write-tmp-then-rename). Updates are enqueued before processing and dequeued only after all deferred work (media group assembly, text fragment buffering, inbound debouncing) settles. On startup, pending entries are replayed in enqueue-time order through the normal Grammy middleware pipeline. Compound `channelId+deduplicationId` dedup key prevents cross-channel collisions. `channelId` validation rejects malformed entries. Filenames use `safeFileKey` sanitization (matching the existing `pairing-store.ts` pattern) to prevent path traversal.
- **What did NOT change:** Grammy middleware pipeline ordering, existing Telegram bot lifecycle, non-Telegram webhook paths. The queue is purely additive -- if disk writes fail, processing continues as before.

### Design notes

The queue provides at-least-once delivery. Failed updates stay on disk for replay (cleaned up after 1h TTL). This is intentional and documented in code -- idempotency of the downstream handlers already handles duplicates.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42157
- Related #42185 (previous submission, closed for rework)

## User-visible / Behavior Changes

Messages received during a gateway restart window are now replayed on next startup instead of being silently dropped. No new config required -- the queue directory (`webhook-queue/` inside the state dir) is created automatically.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No -- webhook payloads already pass through the same middleware; disk persistence adds no new data access
- Path traversal: `safeFileKey()` strips `/\:*?"<>|` and `..` from channel/dedup IDs before constructing filenames. Queue directory created with mode 0o700, files with 0o600. Tested explicitly (see path traversal test).

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: N/A (transport layer)
- Integration/channel: Telegram (webhook mode)
- Relevant config: default Telegram webhook config

### Steps

1. Start gateway with Telegram webhook channel
2. Send a message via Telegram
3. Immediately restart the gateway (`kill -9` or `openclaw gateway restart`)
4. Wait for gateway to come back up

### Expected

- Message is replayed on startup and reaches the agent

### Actual (before this PR)

- Message is lost permanently

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

16 unit tests (`src/infra/webhook-queue.test.ts`): enqueue/dequeue round-trip, replay ordering, dedup by compound key, TTL cleanup, orphan `.tmp` cleanup, malformed entry handling, path traversal containment, cross-channel preservation, `channelId` validation, deterministic tie-breaking, 50-entry bulk replay.

1 integration test (`src/telegram/webhook.test.ts`): end-to-end enqueue on webhook receipt -> dequeue on `onUpdateProcessed` callback.

`pnpm build`, `pnpm check`, `pnpm test` green.

## Human Verification (required)

- Verified scenarios: gateway restart during active message processing; queue file appears on disk after webhook receipt; file removed after processing; replayed messages arrive at agent on restart
- Edge cases checked: media group spanning restart (deferred resolvers prevent premature dequeue), text fragment buffer flush, concurrent updates, path traversal attempts
- What I did **not** verify: non-Telegram webhook channels (no queue integration for those yet), extremely high-volume replay (>1000 queued entries)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No -- queue directory is created on first webhook receipt

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; queue directory can be safely deleted (`rm -rf <stateDir>/webhook-queue`)
- Files/config to restore: none
- Known bad symptoms: duplicate messages on startup (at-least-once semantics -- existing handler idempotency covers this), disk space growth (1h TTL cleanup prevents unbounded growth)

## Risks and Mitigations

- Risk: Disk write latency adds to webhook response time
  - Mitigation: Single atomic write (write-tmp + rename) per update; queue failures are caught and do not block processing
- Risk: Stale entries accumulate after unclean shutdown
  - Mitigation: 1h TTL cleanup during replay; orphaned `.tmp` files cleaned up on replay scan

---

This PR was developed with AI assistance (Claude). All code was reviewed, tested, and verified by a human contributor.