### PR TITLE
fix(kimi-coding): ignore stale Anthropic tool compat overrides

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -732,7 +732,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
   });
 
-  it("does not rewrite tool schema for kimi-coding (native Anthropic format)", () => {
+  it("does not rewrite tool schema for kimi-coding even with stale compat metadata", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -762,6 +762,9 @@ describe("applyExtraParamsToAgent", () => {
       provider: "kimi-coding",
       id: "k2p5",
       baseUrl: "https://api.kimi.com/coding/",
+      compat: {
+        requiresOpenAiAnthropicToolPayload: true,
+      },
     } as Model<"anthropic-messages">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { normalizeProviderId } from "../model-selection.js";
 import {
   requiresOpenAiCompatibleAnthropicToolPayload,
   usesOpenAiFunctionAnthropicToolSchema,
@@ -69,6 +70,12 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
     return true;
   }
 
+  // Kimi Coding's Anthropic endpoint expects native tool framing.
+  // Ignore stale compat overrides so the old OpenAI-function rewrite cannot regress.
+  if (typeof model.provider === "string" && normalizeProviderId(model.provider) === "kimi-coding") {
+    return false;
+  }
+
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
     return false;
   }
@@ -85,6 +92,9 @@ function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
 }): boolean {
   if (typeof model.provider === "string" && usesOpenAiFunctionAnthropicToolSchema(model.provider)) {
     return true;
+  }
+  if (typeof model.provider === "string" && normalizeProviderId(model.provider) === "kimi-coding") {
+    return false;
   }
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
     return false;
@@ -104,6 +114,9 @@ function usesOpenAiStringModeAnthropicToolChoiceForModel(model: {
     usesOpenAiStringModeAnthropicToolChoice(model.provider)
   ) {
     return true;
+  }
+  if (typeof model.provider === "string" && normalizeProviderId(model.provider) === "kimi-coding") {
+    return false;
   }
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
     return false;


### PR DESCRIPTION
## Summary

- Problem: stale `compat.requiresOpenAiAnthropicToolPayload` metadata can still force `kimi-coding` back onto OpenAI-style tool payload rewriting
- Why it matters: Kimi Coding expects native Anthropic tool framing, so a stale compat override can regress tool calls back into plain-text/XML fallback
- What changed: hard-stop Anthropic tool payload normalization for `kimi-coding`, and add a regression test that sets the stale compat flag and verifies the payload stays native
- What did NOT change (scope boundary): the generic Anthropic compatibility wrapper remains in place for custom proxies that still need OpenAI-function-style tool payloads

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #40552

## User-visible / Behavior Changes

`kimi-coding` no longer honors stale OpenAI-Anthropic compat metadata for tool payload rewriting; it stays on native Anthropic tool framing.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: `kimi-coding` / `anthropic-messages`
- Integration/channel (if any): N/A
- Relevant config (redacted): stale `compat.requiresOpenAiAnthropicToolPayload: true` on a `kimi-coding` model

### Steps

1. Configure or construct a `kimi-coding` Anthropic model with `compat.requiresOpenAiAnthropicToolPayload: true`.
2. Send a tool-enabled request through the embedded runner extra-params path.
3. Inspect the emitted payload.

### Expected

- `tools` remain in native Anthropic format with `input_schema`.
- `tool_choice` remains native Anthropic format.

### Actual

- Before this change, stale compat metadata could still trigger OpenAI-style tool payload normalization.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused test run against a temp checkout built from the PR branch snapshot
- Edge cases checked: `kimi-coding` with stale compat metadata still stays native; custom non-Kimi compat path remains covered by existing tests
- What you did **not** verify: full `pnpm build`, full `pnpm check`, and full `pnpm test`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two commits in this PR
- Files/config to restore: `src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts`, `src/agents/pi-embedded-runner-extraparams.test.ts`
- Known bad symptoms reviewers should watch for: unexpected OpenAI-function tool payload rewriting on `kimi-coding`, or lost compat rewriting for custom non-Kimi Anthropic proxies

## Risks and Mitigations

- Risk: the provider-specific guard could accidentally block a legitimate compat override for `kimi-coding`
  - Mitigation: that provider's documented/implemented behavior is native Anthropic framing, and the regression test locks in the expected native payload
