### PR TITLE
fix(cron): track bestEffort delivery failures and mark not delivered on partial failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/native commands: run native slash-command execution against the resolved runtime snapshot so DM commands still reply when fresh config reads surface unresolved SecretRefs. (#53179) Thanks @nimbleenigma.
 - Telegram/photos: preflight Telegram photo dimension and aspect-ratio rules, and fall back to document sends when image metadata is invalid or unavailable so photo uploads stop failing with `PHOTO_INVALID_DIMENSIONS`. (#52545) Thanks @hnshah.
 - Feishu/groups: when `groupPolicy` is `open`, stop implicitly requiring @mentions for unset `requireMention`, so image, file, audio, and other non-text group messages reach the bot unless operators explicitly keep mention gating on. (#54058) Thanks @byungsker.
+- Agents/cron: mark best-effort announce runs as not delivered when any payload fails, and log those partial delivery failures instead of silently reporting success. (#42535) Thanks @MoerAI.
 
 ## 2026.3.23
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 
 vi.mock("../../logger.js", () => ({
   logWarn: vi.fn(),
+  logError: vi.fn(),
 }));
 
 vi.mock("./subagent-followup.js", () => ({
@@ -354,6 +355,29 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(second.delivered).toBe(true);
     expect(second.deliveryAttempted).toBe(true);
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache partial bestEffort delivery replays as delivered", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+    vi.mocked(deliverOutboundPayloads).mockImplementation(async (params) => {
+      const failedPayload = Array.isArray(params.payloads) ? params.payloads[0] : undefined;
+      params.onError?.(new Error("payload failed"), failedPayload as never);
+      return [{ ok: true } as never];
+    });
+
+    const params = makeBaseParams({ synthesizedText: "Partial bestEffort replay." }) as Record<
+      string,
+      unknown
+    >;
+    params.deliveryBestEffort = true;
+
+    const first = await dispatchCronDelivery(params as never);
+    const second = await dispatchCronDelivery(params as never);
+
+    expect(first.delivered).toBe(false);
+    expect(second.delivered).toBe(false);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(2);
   });
 
   it("prunes the completed-delivery cache back to the entry cap", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -433,9 +433,9 @@ export async function dispatchCronDelivery(
         : await runDelivery();
       // Only mark delivered when ALL payloads succeeded (no partial failure).
       delivered = deliveryResults.length > 0 && !hadPartialFailure;
-      // Always cache successful results to prevent replay duplicates,
-      // even when some payloads failed (partial failure).
-      if (deliveryResults.length > 0) {
+      // Cache only fully successful deliveries. Caching partial failures would
+      // replay as delivered=true on the fast path and lose failure state.
+      if (delivered) {
         rememberCompletedDirectCronDelivery(deliveryIdempotencyKey, deliveryResults);
       }
       return null;

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -433,8 +433,9 @@ export async function dispatchCronDelivery(
         : await runDelivery();
       // Only mark delivered when ALL payloads succeeded (no partial failure).
       delivered = deliveryResults.length > 0 && !hadPartialFailure;
-      // Cache only fully successful deliveries. Caching partial failures would
-      // replay as delivered=true on the fast path and lose failure state.
+      // Intentionally leave partial success uncached: replay may duplicate the
+      // successful subset, but caching it here would permanently drop the
+      // failed payloads by converting the replay into delivered=true.
       if (delivered) {
         rememberCompletedDirectCronDelivery(deliveryIdempotencyKey, deliveryResults);
       }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -433,9 +433,9 @@ export async function dispatchCronDelivery(
         : await runDelivery();
       // Only mark delivered when ALL payloads succeeded (no partial failure).
       delivered = deliveryResults.length > 0 && !hadPartialFailure;
-      // Cache only fully successful deliveries. Caching partial failures would
-      // replay as delivered=true on the fast path and lose failure state.
-      if (delivered) {
+      // Always cache successful results to prevent replay duplicates,
+      // even when some payloads failed (partial failure).
+      if (deliveryResults.length > 0) {
         rememberCompletedDirectCronDelivery(deliveryIdempotencyKey, deliveryResults);
       }
       return null;

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -11,7 +11,7 @@ import {
 } from "../../infra/outbound/deliver.js";
 import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
-import { logWarn } from "../../logger.js";
+import { logWarn, logError } from "../../logger.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickSummaryFromOutput } from "./helpers.js";
@@ -390,6 +390,19 @@ export async function dispatchCronDelivery(
         agentId: params.agentId,
         sessionKey: params.agentSessionKey,
       });
+
+      // Track bestEffort partial failures so we can log them and avoid
+      // marking the job as delivered when payloads were silently dropped.
+      let hadPartialFailure = false;
+      const onError = params.deliveryBestEffort
+        ? (err: unknown, _payload: unknown) => {
+            hadPartialFailure = true;
+            logError(
+              `[cron:${params.job.id}] delivery payload failed (bestEffort): ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        : undefined;
+
       const runDelivery = async () =>
         await deliverOutboundPayloads({
           cfg: params.cfgWithAgentDefaults,
@@ -403,12 +416,13 @@ export async function dispatchCronDelivery(
           bestEffort: params.deliveryBestEffort,
           deps: createOutboundSendDeps(params.deps),
           abortSignal: params.abortSignal,
-          // Isolated cron direct delivery uses its own transient retry loop.
-          // Keep all attempts out of the write-ahead delivery queue so a
-          // late-successful first send cannot leave behind a failed queue
-          // entry that replays on the next restart.
-          // See: https://github.com/openclaw/openclaw/issues/40545
-          skipQueue: true,
+           onError,
+           // Isolated cron direct delivery uses its own transient retry loop.
+           // Keep all attempts out of the write-ahead delivery queue so a
+           // late-successful first send cannot leave behind a failed queue
+           // entry that replays on the next restart.
+           // See: https://github.com/openclaw/openclaw/issues/40545
+           skipQueue: true,
         });
       const deliveryResults = options?.retryTransient
         ? await retryTransientDirectCronDelivery({
@@ -417,7 +431,10 @@ export async function dispatchCronDelivery(
             run: runDelivery,
           })
         : await runDelivery();
-      delivered = deliveryResults.length > 0;
+      // Only mark delivered when ALL payloads succeeded (no partial failure).
+      delivered = deliveryResults.length > 0 && !hadPartialFailure;
+      // Cache only fully successful deliveries. Caching partial failures would
+      // replay as delivered=true on the fast path and lose failure state.
       if (delivered) {
         rememberCompletedDirectCronDelivery(deliveryIdempotencyKey, deliveryResults);
       }
@@ -433,6 +450,9 @@ export async function dispatchCronDelivery(
           ...params.telemetry,
         });
       }
+      logError(
+        `[cron:${params.job.id}] delivery failed (bestEffort): ${err instanceof Error ? err.message : String(err)}`,
+      );
       return null;
     }
   };

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -416,13 +416,13 @@ export async function dispatchCronDelivery(
           bestEffort: params.deliveryBestEffort,
           deps: createOutboundSendDeps(params.deps),
           abortSignal: params.abortSignal,
-           onError,
-           // Isolated cron direct delivery uses its own transient retry loop.
-           // Keep all attempts out of the write-ahead delivery queue so a
-           // late-successful first send cannot leave behind a failed queue
-           // entry that replays on the next restart.
-           // See: https://github.com/openclaw/openclaw/issues/40545
-           skipQueue: true,
+          onError,
+          // Isolated cron direct delivery uses its own transient retry loop.
+          // Keep all attempts out of the write-ahead delivery queue so a
+          // late-successful first send cannot leave behind a failed queue
+          // entry that replays on the next restart.
+          // See: https://github.com/openclaw/openclaw/issues/40545
+          skipQueue: true,
         });
       const deliveryResults = options?.retryTransient
         ? await retryTransientDirectCronDelivery({


### PR DESCRIPTION
## Summary

Fixes #27069

When cron delivery uses `bestEffort: true` mode, partial payload failures were silently swallowed with no logging and no impact on the `delivered` status flag. This caused cron jobs to report `delivered: true` even when some or all payloads failed to reach the channel.

## Changes

- Pass an `onError` callback from `dispatchCronDelivery` to `deliverOutboundPayloads` when `bestEffort` is enabled, tracking partial failures via a `hadPartialFailure` flag
- Log each bestEffort payload failure with `logError` so delivery issues are visible in gateway logs (previously silent)
- Change `delivered` assignment from `deliveryResults.length > 0` to `deliveryResults.length > 0 && !hadPartialFailure` — ensuring `delivered` is only `true` when ALL payloads succeeded
- Add `logError` to the bestEffort catch block so total delivery failures are also logged (previously returned `null` silently)

## Testing

All 33 existing delivery-dispatch tests pass (14 bestEffort tests + 19 unit tests). The new `logError` calls appear in stderr during bestEffort failure tests as expected.