### PR TITLE
[AI-assisted] feat(matrix): stream reasoning bubble with a single redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Docs: https://docs.openclaw.ai
 - LLM Task/Lobster: add an optional `thinking` override so workflow calls can explicitly set embedded reasoning level with shared validation for invalid values and unsupported `xhigh` modes. (#15606) Thanks @xadenryan and @ImLukeF.
 - Mattermost/reply threading: add `channels.mattermost.replyToMode` for channel and group messages so top-level posts can start thread-scoped sessions without the manual reply-then-thread workaround. (#29587) Thanks @teconomix.
 - iOS/push relay: add relay-backed official-build push delivery with App Attest + receipt verification, gateway-bound send delegation, and config-based relay URL setup on the gateway. (#43369) Thanks @ngutman.
+- Matrix/reasoning stream: collapse streamed reasoning into one transient message and redact it before the final reply so rooms do not accumulate multiple partial reasoning events.
 
 ### Breaking
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -231,6 +231,12 @@ Notes:
 - `channels.matrix.replyToMode` controls reply-to metadata when not replying in a thread:
   - `off` (default), `first`, `all`
 
+## Reasoning stream
+
+- When reasoning streaming is enabled, Matrix writes reasoning updates into one transient message instead of sending a new reasoning message for every update.
+- OpenClaw edits that transient message as reasoning evolves, then redacts it before sending the final answer so the room keeps the final reply without leftover reasoning drafts.
+- Reasoning-only payloads are skipped from the normal Matrix reply path while the transient reasoning message is active.
+
 ## Capabilities
 
 | Feature         | Status                                                                                |

--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -140,7 +140,7 @@ OpenClaw can expose or hide model reasoning:
 
 - `/reasoning on|off|stream` controls visibility.
 - Reasoning content still counts toward token usage when produced by the model.
-- Telegram supports reasoning stream into the draft bubble.
+- Telegram and Matrix support reasoning stream into a transient preview message.
 
 Details: [Thinking + reasoning directives](/tools/thinking) and [Token use](/reference/token-use).
 

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -142,6 +142,11 @@ Telegram:
 - Preview streaming is skipped when Telegram block streaming is explicitly enabled (to avoid double-streaming).
 - `/reasoning stream` can write reasoning to preview.
 
+Matrix:
+
+- `/reasoning stream` can write reasoning into one transient Matrix message.
+- OpenClaw edits that message as reasoning changes and redacts it before the final answer is delivered.
+
 Discord:
 
 - Uses send + edit preview messages.

--- a/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
@@ -1,0 +1,233 @@
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import type { PluginRuntime, RuntimeEnv, RuntimeLogger } from "openclaw/plugin-sdk";
+import type { ReplyPayload } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMessageMatrixMock = vi.hoisted(() => vi.fn());
+const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../send.js", () => ({
+  sendMessageMatrix: (...args: unknown[]) => sendMessageMatrixMock(...args),
+  sendTypingMatrix: vi.fn().mockResolvedValue(undefined),
+  reactMatrixMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./replies.js", () => ({
+  deliverMatrixReplies: (...args: unknown[]) => deliverMatrixRepliesMock(...args),
+}));
+
+import { setMatrixRuntime } from "../../runtime.js";
+import { createMatrixRoomMessageHandler } from "./handler.js";
+import { EventType, type MatrixRawEvent } from "./types.js";
+
+describe("createMatrixRoomMessageHandler reasoning stream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendMessageMatrixMock.mockResolvedValue({ messageId: "$reason-root", roomId: "!room:example" });
+    deliverMatrixRepliesMock.mockResolvedValue(undefined);
+  });
+
+  it("streams reasoning into one transient bubble, then deletes it before final reply", async () => {
+    const callOrder: string[] = [];
+    const markDispatchIdle = vi.fn();
+    let deliverFromDispatcher:
+      | ((payload: ReplyPayload, info: { kind: "tool" | "block" | "final" }) => Promise<void>)
+      | undefined;
+
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "main",
+            accountId: undefined,
+            sessionKey: "agent:main:matrix:user:@alice:example.org",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession: vi.fn().mockResolvedValue(undefined),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockImplementation((options: unknown) => {
+            const typed = options as {
+              deliver: (
+                payload: ReplyPayload,
+                info: { kind: "tool" | "block" | "final" },
+              ) => Promise<void>;
+            };
+            deliverFromDispatcher = typed.deliver;
+            return {
+              dispatcher: {
+                sendToolResult: vi.fn(),
+                sendBlockReply: vi.fn(),
+                sendFinalReply: vi.fn(),
+              },
+              replyOptions: {},
+              markDispatchIdle,
+            };
+          }),
+          withReplyDispatcher: vi.fn().mockImplementation(
+            async (params: {
+              run: () => Promise<{
+                queuedFinal: boolean;
+                counts: { final: number; block: number; tool: number };
+              }>;
+              onSettled?: () => void | Promise<void>;
+            }) => {
+              const result = await params.run();
+              await params.onSettled?.();
+              return result;
+            },
+          ),
+          dispatchReplyFromConfig: vi.fn().mockImplementation(
+            async (params: {
+              replyOptions?: {
+                onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
+              };
+            }) => {
+              await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 1" });
+              await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 2" });
+              await deliverFromDispatcher?.({ text: "Final answer" }, { kind: "final" });
+              return { queuedFinal: true, counts: { final: 1, block: 0, tool: 0 } };
+            },
+          ),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+          convertMarkdownTables: vi.fn((text: string) => text),
+          resolveChunkMode: vi.fn().mockReturnValue("length"),
+          chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+        },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+          detectDirectMentionFromRegexes: vi.fn().mockReturnValue(false),
+          detectBotMentionFromRegexes: vi.fn().mockReturnValue(false),
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
+        reactions: {
+          shouldAckReaction: vi.fn().mockReturnValue(false),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+      logging: {
+        shouldLogVerbose: vi.fn().mockReturnValue(false),
+      },
+      config: {
+        loadConfig: vi.fn().mockReturnValue({}),
+      },
+    } as unknown as PluginRuntime;
+    setMatrixRuntime(core);
+
+    sendMessageMatrixMock.mockImplementation(async () => {
+      callOrder.push("send-reasoning");
+      return { messageId: "$reason-root", roomId: "!room:example" };
+    });
+    deliverMatrixRepliesMock.mockImplementation(async () => {
+      callOrder.push("deliver-final");
+      return undefined;
+    });
+
+    const runtimeError = vi.fn();
+    const runtime = {
+      error: runtimeError,
+      log: vi.fn(),
+    } as unknown as RuntimeEnv;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as RuntimeLogger;
+
+    const clientSendMessage = vi.fn().mockImplementation(async () => {
+      callOrder.push("edit-reasoning");
+      return "$reason-edit";
+    });
+    const clientRedactEvent = vi.fn().mockImplementation(async () => {
+      callOrder.push("delete-reasoning");
+      return undefined;
+    });
+
+    const client = {
+      getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+      sendMessage: clientSendMessage,
+      redactEvent: clientRedactEvent,
+    } as unknown as MatrixClient;
+
+    const handler = createMatrixRoomMessageHandler({
+      client,
+      core,
+      cfg: {},
+      runtime,
+      logger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [],
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "off",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(true),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "DM",
+        canonicalAlias: undefined,
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Alice"),
+      accountId: undefined,
+    });
+
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$inbound-1",
+      sender: "@alice:example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "hello",
+      },
+    } as unknown as MatrixRawEvent;
+
+    await handler("!room:example", event);
+
+    expect(runtimeError).not.toHaveBeenCalled();
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(clientSendMessage).toHaveBeenCalledTimes(1);
+    expect(clientRedactEvent).toHaveBeenCalledTimes(1);
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual([
+      "send-reasoning",
+      "edit-reasoning",
+      "delete-reasoning",
+      "deliver-final",
+    ]);
+    expect(markDispatchIdle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
@@ -259,6 +259,212 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
     expect(markDispatchIdle).toHaveBeenCalledTimes(1);
   });
 
+  it("drops stale queued reasoning edits before delivering the final reply", async () => {
+    const callOrder: string[] = [];
+    const markDispatchIdle = vi.fn();
+    let deliverFromDispatcher:
+      | ((payload: ReplyPayload, info: { kind: "tool" | "block" | "final" }) => Promise<void>)
+      | undefined;
+    let resolveBlockedEdit: ((value: string) => void) | undefined;
+
+    dispatchReplyFromConfigWithSettledDispatcherMock.mockImplementationOnce(
+      async (params: {
+        dispatcher: { sendFinalReply: (payload: ReplyPayload) => boolean };
+        onSettled?: () => void | Promise<void>;
+        replyOptions?: {
+          onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
+        };
+      }) => {
+        await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 1" });
+        const queuedEdit = params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 2" });
+        const staleQueuedEdit = params.replyOptions?.onReasoningStream?.({
+          text: "Reasoning:\nstep 3",
+        });
+        params.dispatcher.sendFinalReply({ text: "Final answer" });
+        resolveBlockedEdit?.("$reason-edit");
+        await Promise.allSettled([queuedEdit, staleQueuedEdit, finalDeliveryPromise]);
+        await params.onSettled?.();
+        return { queuedFinal: true, counts: { final: 1, block: 0, tool: 0 } };
+      },
+    );
+
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "main",
+            accountId: undefined,
+            sessionKey: "agent:main:matrix:user:@alice:example.org",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession: vi.fn().mockResolvedValue(undefined),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockImplementation((options: unknown) => {
+            const typed = options as {
+              deliver: (
+                payload: ReplyPayload,
+                info: { kind: "tool" | "block" | "final" },
+              ) => Promise<void>;
+            };
+            deliverFromDispatcher = typed.deliver;
+            return {
+              dispatcher: {
+                getQueuedCounts: vi.fn(() => ({ final: 0, block: 0, tool: 0 })),
+                markComplete: vi.fn(),
+                sendToolResult: vi.fn(),
+                sendBlockReply: vi.fn(),
+                sendFinalReply: vi.fn((payload: ReplyPayload) => {
+                  finalDeliveryPromise = deliverFromDispatcher?.(payload, { kind: "final" });
+                  return true;
+                }),
+                waitForIdle: vi.fn().mockResolvedValue(undefined),
+              },
+              replyOptions: {},
+              markDispatchIdle,
+            };
+          }),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+          convertMarkdownTables: vi.fn((text: string) => text),
+          resolveChunkMode: vi.fn().mockReturnValue("length"),
+          chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+        },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+          detectDirectMentionFromRegexes: vi.fn().mockReturnValue(false),
+          detectBotMentionFromRegexes: vi.fn().mockReturnValue(false),
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
+        reactions: {
+          shouldAckReaction: vi.fn().mockReturnValue(false),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+      logging: {
+        shouldLogVerbose: vi.fn().mockReturnValue(false),
+      },
+      config: {
+        loadConfig: vi.fn().mockReturnValue({}),
+      },
+    } as unknown as PluginRuntime;
+    setMatrixRuntime(core);
+
+    deliverMatrixRepliesMock.mockImplementation(async () => {
+      callOrder.push("deliver-final");
+      return undefined;
+    });
+
+    const runtime = {
+      error: vi.fn(),
+      log: vi.fn(),
+    } as unknown as RuntimeEnv;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as RuntimeLogger;
+
+    const blockedEdit = new Promise<string>((resolve) => {
+      resolveBlockedEdit = resolve;
+    });
+    const clientSendMessage = vi.fn().mockImplementation(async (_roomId, content) => {
+      if (content && typeof content === "object" && "m.new_content" in content) {
+        callOrder.push(`edit:${String(content["m.new_content"].body)}`);
+        return await blockedEdit;
+      }
+      callOrder.push("send-reasoning");
+      return "$reason-root";
+    });
+    const clientRedactEvent = vi.fn().mockImplementation(async () => {
+      callOrder.push("delete-reasoning");
+      return undefined;
+    });
+
+    const client = {
+      getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+      sendMessage: clientSendMessage,
+      redactEvent: clientRedactEvent,
+    } as unknown as MatrixClient;
+
+    const handler = createMatrixRoomMessageHandler({
+      client,
+      core,
+      cfg: {},
+      runtime,
+      logger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [],
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "off",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(true),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "DM",
+        canonicalAlias: undefined,
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Alice"),
+      accountId: undefined,
+    });
+
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$inbound-1",
+      sender: "@alice:example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "hello",
+      },
+    } as unknown as MatrixRawEvent;
+
+    await handler("!room:example", event);
+
+    expect(clientSendMessage).toHaveBeenCalledTimes(2);
+    expect(clientRedactEvent).toHaveBeenCalledTimes(1);
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual([
+      "send-reasoning",
+      "edit:Reasoning:\nstep 2",
+      "delete-reasoning",
+      "deliver-final",
+    ]);
+    expect(markDispatchIdle).toHaveBeenCalledTimes(1);
+  });
+
   it("retries reasoning draft cleanup on settle when the first redact fails", async () => {
     const markDispatchIdle = vi.fn();
     let deliverFromDispatcher:

--- a/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
@@ -3,8 +3,25 @@ import type { PluginRuntime, RuntimeEnv, RuntimeLogger } from "openclaw/plugin-s
 import type { ReplyPayload } from "openclaw/plugin-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: () => undefined,
+  getOAuthProviders: () => [],
+}));
+
+const dispatchReplyFromConfigWithSettledDispatcherMock = vi.hoisted(() => vi.fn());
 const sendMessageMatrixMock = vi.hoisted(() => vi.fn());
 const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/matrix", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/matrix")>(
+    "openclaw/plugin-sdk/matrix",
+  );
+  return {
+    ...actual,
+    dispatchReplyFromConfigWithSettledDispatcher: (...args: unknown[]) =>
+      dispatchReplyFromConfigWithSettledDispatcherMock(...args),
+  };
+});
 
 vi.mock("../send.js", () => ({
   sendMessageMatrix: (...args: unknown[]) => sendMessageMatrixMock(...args),
@@ -21,8 +38,27 @@ import { createMatrixRoomMessageHandler } from "./handler.js";
 import { EventType, type MatrixRawEvent } from "./types.js";
 
 describe("createMatrixRoomMessageHandler reasoning stream", () => {
+  let finalDeliveryPromise: Promise<void> | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    finalDeliveryPromise = undefined;
+    dispatchReplyFromConfigWithSettledDispatcherMock.mockImplementation(
+      async (params: {
+        dispatcher: { sendFinalReply: (payload: ReplyPayload) => boolean };
+        onSettled?: () => void | Promise<void>;
+        replyOptions?: {
+          onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
+        };
+      }) => {
+        await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 1" });
+        await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 2" });
+        params.dispatcher.sendFinalReply({ text: "Final answer" });
+        await finalDeliveryPromise;
+        await params.onSettled?.();
+        return { queuedFinal: true, counts: { final: 1, block: 0, tool: 0 } };
+      },
+    );
     sendMessageMatrixMock.mockResolvedValue({ messageId: "$reason-root", roomId: "!room:example" });
     deliverMatrixRepliesMock.mockResolvedValue(undefined);
   });
@@ -72,39 +108,20 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
             deliverFromDispatcher = typed.deliver;
             return {
               dispatcher: {
+                getQueuedCounts: vi.fn(() => ({ final: 0, block: 0, tool: 0 })),
+                markComplete: vi.fn(),
                 sendToolResult: vi.fn(),
                 sendBlockReply: vi.fn(),
-                sendFinalReply: vi.fn(),
+                sendFinalReply: vi.fn((payload: ReplyPayload) => {
+                  finalDeliveryPromise = deliverFromDispatcher?.(payload, { kind: "final" });
+                  return true;
+                }),
+                waitForIdle: vi.fn().mockResolvedValue(undefined),
               },
               replyOptions: {},
               markDispatchIdle,
             };
           }),
-          withReplyDispatcher: vi.fn().mockImplementation(
-            async (params: {
-              run: () => Promise<{
-                queuedFinal: boolean;
-                counts: { final: number; block: number; tool: number };
-              }>;
-              onSettled?: () => void | Promise<void>;
-            }) => {
-              const result = await params.run();
-              await params.onSettled?.();
-              return result;
-            },
-          ),
-          dispatchReplyFromConfig: vi.fn().mockImplementation(
-            async (params: {
-              replyOptions?: {
-                onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
-              };
-            }) => {
-              await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 1" });
-              await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 2" });
-              await deliverFromDispatcher?.({ text: "Final answer" }, { kind: "final" });
-              return { queuedFinal: true, counts: { final: 1, block: 0, tool: 0 } };
-            },
-          ),
         },
         commands: {
           shouldHandleTextCommands: vi.fn().mockReturnValue(true),

--- a/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
@@ -629,4 +629,209 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
     expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
     expect(markDispatchIdle).toHaveBeenCalledTimes(1);
   });
+
+  it("still delivers the final reply when an in-flight reasoning edit fails", async () => {
+    const markDispatchIdle = vi.fn();
+    let deliverFromDispatcher:
+      | ((payload: ReplyPayload, info: { kind: "tool" | "block" | "final" }) => Promise<void>)
+      | undefined;
+
+    dispatchReplyFromConfigWithSettledDispatcherMock.mockImplementationOnce(
+      async (params: {
+        dispatcher: { sendFinalReply: (payload: ReplyPayload) => boolean };
+        onSettled?: () => void | Promise<void>;
+        replyOptions?: {
+          onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
+        };
+      }) => {
+        await params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 1" });
+        const failedEdit = params.replyOptions?.onReasoningStream?.({ text: "Reasoning:\nstep 2" });
+        await Promise.resolve();
+        params.dispatcher.sendFinalReply({ text: "Final answer" });
+        await finalDeliveryPromise;
+        await params.onSettled?.();
+        await Promise.allSettled([failedEdit]);
+        return { queuedFinal: true, counts: { final: 1, block: 0, tool: 0 } };
+      },
+    );
+
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "main",
+            accountId: undefined,
+            sessionKey: "agent:main:matrix:user:@alice:example.org",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession: vi.fn().mockResolvedValue(undefined),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockImplementation((options: unknown) => {
+            const typed = options as {
+              deliver: (
+                payload: ReplyPayload,
+                info: { kind: "tool" | "block" | "final" },
+              ) => Promise<void>;
+            };
+            deliverFromDispatcher = typed.deliver;
+            return {
+              dispatcher: {
+                getQueuedCounts: vi.fn(() => ({ final: 0, block: 0, tool: 0 })),
+                markComplete: vi.fn(),
+                sendFinalReply: vi.fn((payload: ReplyPayload) => {
+                  finalDeliveryPromise = typed.deliver(payload, { kind: "final" });
+                  return true;
+                }),
+                waitForIdle: vi.fn().mockResolvedValue(undefined),
+              },
+              replyOptions: {},
+              markDispatchIdle,
+            };
+          }),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+          convertMarkdownTables: vi.fn((text: string) => text),
+          resolveChunkMode: vi.fn().mockReturnValue("length"),
+          chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+        },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+          detectDirectMentionFromRegexes: vi.fn().mockReturnValue(false),
+          detectBotMentionFromRegexes: vi.fn().mockReturnValue(false),
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
+        reactions: {
+          shouldAckReaction: vi.fn().mockReturnValue(false),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+      logging: {
+        shouldLogVerbose: vi.fn().mockReturnValue(false),
+      },
+      config: {
+        loadConfig: vi.fn().mockReturnValue({}),
+      },
+    } as unknown as PluginRuntime;
+    setMatrixRuntime(core);
+
+    const runtime = {
+      error: vi.fn(),
+      log: vi.fn(),
+    } as unknown as RuntimeEnv;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as RuntimeLogger;
+
+    const callOrder: string[] = [];
+    deliverMatrixRepliesMock.mockImplementation(async () => {
+      callOrder.push("deliver-final");
+      return undefined;
+    });
+    let sendCount = 0;
+    const clientSendMessage = vi.fn().mockImplementation(async () => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        callOrder.push("send-reasoning");
+        return "$reason-root";
+      }
+      if (sendCount === 2) {
+        callOrder.push("edit-reasoning");
+        throw new Error("transient edit failure");
+      }
+      return "$unexpected";
+    });
+    const clientRedactEvent = vi.fn().mockImplementation(async () => {
+      callOrder.push("delete-reasoning");
+    });
+
+    const client = {
+      getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+      sendMessage: clientSendMessage,
+      redactEvent: clientRedactEvent,
+    } as unknown as MatrixClient;
+
+    const handler = createMatrixRoomMessageHandler({
+      client,
+      core,
+      cfg: {},
+      runtime,
+      logger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [],
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "off",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(true),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "DM",
+        canonicalAlias: undefined,
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Alice"),
+      accountId: undefined,
+    });
+
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$inbound-1",
+      sender: "@alice:example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "hello",
+      },
+    } as unknown as MatrixRawEvent;
+
+    await handler("!room:example", event);
+
+    expect(clientRedactEvent).toHaveBeenCalledTimes(1);
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+    expect(markDispatchIdle).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual([
+      "send-reasoning",
+      "edit-reasoning",
+      "delete-reasoning",
+      "deliver-final",
+    ]);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "matrix reasoning draft update failed: Error: transient edit failure",
+      ),
+    );
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
@@ -10,6 +10,9 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
 
 const dispatchReplyFromConfigWithSettledDispatcherMock = vi.hoisted(() => vi.fn());
 const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn());
+const enqueueSendMock = vi.hoisted(() =>
+  vi.fn(async (_roomId: string, fn: () => Promise<unknown>) => await fn()),
+);
 
 vi.mock("openclaw/plugin-sdk/matrix", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/matrix")>(
@@ -28,6 +31,10 @@ vi.mock("../send.js", () => ({
   reactMatrixMessage: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../send-queue.js", () => ({
+  enqueueSend: (roomId: string, fn: () => Promise<unknown>) => enqueueSendMock(roomId, fn),
+}));
+
 vi.mock("./replies.js", () => ({
   deliverMatrixReplies: (...args: unknown[]) => deliverMatrixRepliesMock(...args),
 }));
@@ -42,6 +49,9 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     finalDeliveryPromise = undefined;
+    enqueueSendMock.mockImplementation(
+      async (_roomId: string, fn: () => Promise<unknown>) => await fn(),
+    );
     dispatchReplyFromConfigWithSettledDispatcherMock.mockImplementation(
       async (params: {
         dispatcher: { sendFinalReply: (payload: ReplyPayload) => boolean };
@@ -235,6 +245,10 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
 
     expect(clientSendMessage).toHaveBeenCalledTimes(2);
     expect(clientRedactEvent).toHaveBeenCalledTimes(1);
+    expect(enqueueSendMock).toHaveBeenCalledTimes(3);
+    expect(enqueueSendMock).toHaveBeenNthCalledWith(1, "!room:example", expect.any(Function));
+    expect(enqueueSendMock).toHaveBeenNthCalledWith(2, "!room:example", expect.any(Function));
+    expect(enqueueSendMock).toHaveBeenNthCalledWith(3, "!room:example", expect.any(Function));
     expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual([
       "send-reasoning",
@@ -405,6 +419,7 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
     await handler("!room:example", event);
 
     expect(clientRedactEvent).toHaveBeenCalledTimes(2);
+    expect(enqueueSendMock).toHaveBeenCalledTimes(4);
     expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
     expect(markDispatchIdle).toHaveBeenCalledTimes(1);
   });

--- a/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.reasoning-stream.test.ts
@@ -9,7 +9,6 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
 }));
 
 const dispatchReplyFromConfigWithSettledDispatcherMock = vi.hoisted(() => vi.fn());
-const sendMessageMatrixMock = vi.hoisted(() => vi.fn());
 const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/matrix", async () => {
@@ -24,7 +23,7 @@ vi.mock("openclaw/plugin-sdk/matrix", async () => {
 });
 
 vi.mock("../send.js", () => ({
-  sendMessageMatrix: (...args: unknown[]) => sendMessageMatrixMock(...args),
+  sendMessageMatrix: vi.fn(),
   sendTypingMatrix: vi.fn().mockResolvedValue(undefined),
   reactMatrixMessage: vi.fn().mockResolvedValue(undefined),
 }));
@@ -59,7 +58,6 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
         return { queuedFinal: true, counts: { final: 1, block: 0, tool: 0 } };
       },
     );
-    sendMessageMatrixMock.mockResolvedValue({ messageId: "$reason-root", roomId: "!room:example" });
     deliverMatrixRepliesMock.mockResolvedValue(undefined);
   });
 
@@ -155,10 +153,6 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
     } as unknown as PluginRuntime;
     setMatrixRuntime(core);
 
-    sendMessageMatrixMock.mockImplementation(async () => {
-      callOrder.push("send-reasoning");
-      return { messageId: "$reason-root", roomId: "!room:example" };
-    });
     deliverMatrixRepliesMock.mockImplementation(async () => {
       callOrder.push("deliver-final");
       return undefined;
@@ -174,9 +168,13 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
       warn: vi.fn(),
     } as unknown as RuntimeLogger;
 
-    const clientSendMessage = vi.fn().mockImplementation(async () => {
-      callOrder.push("edit-reasoning");
-      return "$reason-edit";
+    const clientSendMessage = vi.fn().mockImplementation(async (_roomId, content) => {
+      if (content && typeof content === "object" && "m.new_content" in content) {
+        callOrder.push("edit-reasoning");
+        return "$reason-edit";
+      }
+      callOrder.push("send-reasoning");
+      return "$reason-root";
     });
     const clientRedactEvent = vi.fn().mockImplementation(async () => {
       callOrder.push("delete-reasoning");
@@ -235,8 +233,7 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
 
     expect(runtimeError).not.toHaveBeenCalled();
 
-    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
-    expect(clientSendMessage).toHaveBeenCalledTimes(1);
+    expect(clientSendMessage).toHaveBeenCalledTimes(2);
     expect(clientRedactEvent).toHaveBeenCalledTimes(1);
     expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual([
@@ -245,6 +242,170 @@ describe("createMatrixRoomMessageHandler reasoning stream", () => {
       "delete-reasoning",
       "deliver-final",
     ]);
+    expect(markDispatchIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries reasoning draft cleanup on settle when the first redact fails", async () => {
+    const markDispatchIdle = vi.fn();
+    let deliverFromDispatcher:
+      | ((payload: ReplyPayload, info: { kind: "tool" | "block" | "final" }) => Promise<void>)
+      | undefined;
+
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "main",
+            accountId: undefined,
+            sessionKey: "agent:main:matrix:user:@alice:example.org",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession: vi.fn().mockResolvedValue(undefined),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockImplementation((options: unknown) => {
+            const typed = options as {
+              deliver: (
+                payload: ReplyPayload,
+                info: { kind: "tool" | "block" | "final" },
+              ) => Promise<void>;
+            };
+            deliverFromDispatcher = typed.deliver;
+            return {
+              dispatcher: {
+                getQueuedCounts: vi.fn(() => ({ final: 0, block: 0, tool: 0 })),
+                markComplete: vi.fn(),
+                sendToolResult: vi.fn(),
+                sendBlockReply: vi.fn(),
+                sendFinalReply: vi.fn((payload: ReplyPayload) => {
+                  finalDeliveryPromise = deliverFromDispatcher?.(payload, { kind: "final" });
+                  return true;
+                }),
+                waitForIdle: vi.fn().mockResolvedValue(undefined),
+              },
+              replyOptions: {},
+              markDispatchIdle,
+            };
+          }),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+          convertMarkdownTables: vi.fn((text: string) => text),
+          resolveChunkMode: vi.fn().mockReturnValue("length"),
+          chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+        },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+          detectDirectMentionFromRegexes: vi.fn().mockReturnValue(false),
+          detectBotMentionFromRegexes: vi.fn().mockReturnValue(false),
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
+        reactions: {
+          shouldAckReaction: vi.fn().mockReturnValue(false),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+      logging: {
+        shouldLogVerbose: vi.fn().mockReturnValue(false),
+      },
+      config: {
+        loadConfig: vi.fn().mockReturnValue({}),
+      },
+    } as unknown as PluginRuntime;
+    setMatrixRuntime(core);
+
+    const runtime = {
+      error: vi.fn(),
+      log: vi.fn(),
+    } as unknown as RuntimeEnv;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as RuntimeLogger;
+
+    const clientSendMessage = vi
+      .fn()
+      .mockResolvedValueOnce("$reason-root")
+      .mockResolvedValueOnce("$reason-edit");
+    const clientRedactEvent = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient redact failure"))
+      .mockResolvedValueOnce(undefined);
+
+    const client = {
+      getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+      sendMessage: clientSendMessage,
+      redactEvent: clientRedactEvent,
+    } as unknown as MatrixClient;
+
+    const handler = createMatrixRoomMessageHandler({
+      client,
+      core,
+      cfg: {},
+      runtime,
+      logger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [],
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "off",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(true),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "DM",
+        canonicalAlias: undefined,
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Alice"),
+      accountId: undefined,
+    });
+
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$inbound-1",
+      sender: "@alice:example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "hello",
+      },
+    } as unknown as MatrixRawEvent;
+
+    await handler("!room:example", event);
+
+    expect(clientRedactEvent).toHaveBeenCalledTimes(2);
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
     expect(markDispatchIdle).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -699,7 +699,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               }
               return;
             }
-            const editEventId = await client.sendMessage(roomId, {
+            await client.sendMessage(roomId, {
               msgtype: "m.text",
               body: `* ${trimmedText}`,
               "m.new_content": {
@@ -711,7 +711,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                 event_id: reasoningDraftState.messageId,
               },
             });
-            void editEventId;
           })
           .catch((err) => {
             runtime.error?.(`matrix reasoning draft update failed: ${String(err)}`);

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -24,6 +24,7 @@ import {
   type PollStartContent,
 } from "../poll-types.js";
 import { reactMatrixMessage, sendMessageMatrix, sendTypingMatrix } from "../send.js";
+import { buildReplyRelation, buildTextContent, buildThreadRelation } from "../send/formatting.js";
 import { enforceMatrixDirectMessageAccess, resolveMatrixAccessState } from "./access-policy.js";
 import {
   normalizeMatrixAllowList,
@@ -688,14 +689,15 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         reasoningDraftState.updateChain = reasoningDraftState.updateChain
           .then(async () => {
             if (!reasoningDraftState.messageId) {
-              const result = await sendMessageMatrix(`room:${roomId}`, trimmedText, {
-                client,
-                replyToId: replyToMode === "off" ? undefined : messageId,
-                threadId: threadTarget,
-                accountId: route.accountId,
-              });
-              if (result.messageId) {
-                reasoningDraftState.messageId = result.messageId;
+              const relation = threadTarget
+                ? buildThreadRelation(threadTarget, replyToMode === "off" ? undefined : messageId)
+                : buildReplyRelation(replyToMode === "off" ? undefined : messageId);
+              const eventId = await client.sendMessage(
+                roomId,
+                buildTextContent(trimmedText, relation),
+              );
+              if (eventId) {
+                reasoningDraftState.messageId = eventId;
               }
               return;
             }
@@ -725,11 +727,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         const eventId = reasoningDraftState.messageId;
         try {
           await client.redactEvent(roomId, eventId);
+          reasoningDraftState.messageId = undefined;
+          reasoningDraftState.lastText = "";
         } catch (err) {
           logVerboseMessage(`matrix reasoning draft cleanup failed (${eventId}): ${String(err)}`);
         }
-        reasoningDraftState.messageId = undefined;
-        reasoningDraftState.lastText = "";
       };
 
       let didSendReply = false;

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -1,6 +1,7 @@
 import type { LocationMessageEventContent, MatrixClient } from "@vector-im/matrix-bot-sdk";
 import {
   DEFAULT_ACCOUNT_ID,
+  createDraftStreamLoop,
   createScopedPairingAccess,
   createReplyPrefixOptions,
   createTypingCallbacks,
@@ -15,7 +16,6 @@ import {
   type RuntimeEnv,
   type RuntimeLogger,
 } from "openclaw/plugin-sdk/matrix";
-import { createDraftStreamLoop } from "../../../../../src/channels/draft-stream-loop.js";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import { fetchEventSummary } from "../actions/summary.js";
 import {
@@ -737,7 +737,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const clearReasoningDraft = async () => {
         reasoningDraftState.stopUpdates = true;
         reasoningDraftLoop.stop();
-        await reasoningDraftLoop.waitForInFlight();
+        try {
+          await reasoningDraftLoop.waitForInFlight();
+        } catch (err) {
+          logVerboseMessage(`matrix reasoning draft in-flight update failed: ${String(err)}`);
+        }
         if (!reasoningDraftState.messageId) {
           return;
         }

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -23,6 +23,7 @@ import {
   parsePollStartContent,
   type PollStartContent,
 } from "../poll-types.js";
+import { enqueueSend } from "../send-queue.js";
 import { reactMatrixMessage, sendMessageMatrix, sendTypingMatrix } from "../send.js";
 import { buildReplyRelation, buildTextContent, buildThreadRelation } from "../send/formatting.js";
 import { enforceMatrixDirectMessageAccess, resolveMatrixAccessState } from "./access-policy.js";
@@ -692,27 +693,32 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               const relation = threadTarget
                 ? buildThreadRelation(threadTarget, replyToMode === "off" ? undefined : messageId)
                 : buildReplyRelation(replyToMode === "off" ? undefined : messageId);
-              const eventId = await client.sendMessage(
+              const eventId = await enqueueSend(
                 roomId,
-                buildTextContent(trimmedText, relation),
+                async () =>
+                  await client.sendMessage(roomId, buildTextContent(trimmedText, relation)),
               );
               if (eventId) {
                 reasoningDraftState.messageId = eventId;
               }
               return;
             }
-            await client.sendMessage(roomId, {
-              msgtype: "m.text",
-              body: `* ${trimmedText}`,
-              "m.new_content": {
-                msgtype: "m.text",
-                body: trimmedText,
-              },
-              "m.relates_to": {
-                rel_type: RelationType.Replace,
-                event_id: reasoningDraftState.messageId,
-              },
-            });
+            await enqueueSend(
+              roomId,
+              async () =>
+                await client.sendMessage(roomId, {
+                  msgtype: "m.text",
+                  body: `* ${trimmedText}`,
+                  "m.new_content": {
+                    msgtype: "m.text",
+                    body: trimmedText,
+                  },
+                  "m.relates_to": {
+                    rel_type: RelationType.Replace,
+                    event_id: reasoningDraftState.messageId,
+                  },
+                }),
+            );
           })
           .catch((err) => {
             runtime.error?.(`matrix reasoning draft update failed: ${String(err)}`);
@@ -726,7 +732,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
         const eventId = reasoningDraftState.messageId;
         try {
-          await client.redactEvent(roomId, eventId);
+          await enqueueSend(roomId, async () => await client.redactEvent(roomId, eventId));
           reasoningDraftState.messageId = undefined;
           reasoningDraftState.lastText = "";
         } catch (err) {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -674,6 +674,65 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
 
+      const reasoningDraftState = {
+        messageId: undefined as string | undefined,
+        lastText: "",
+        updateChain: Promise.resolve(),
+      };
+      const enqueueReasoningDraftUpdate = async (text?: string) => {
+        const trimmedText = text?.trim();
+        if (!trimmedText || trimmedText === reasoningDraftState.lastText) {
+          return;
+        }
+        reasoningDraftState.lastText = trimmedText;
+        reasoningDraftState.updateChain = reasoningDraftState.updateChain
+          .then(async () => {
+            if (!reasoningDraftState.messageId) {
+              const result = await sendMessageMatrix(`room:${roomId}`, trimmedText, {
+                client,
+                replyToId: replyToMode === "off" ? undefined : messageId,
+                threadId: threadTarget,
+                accountId: route.accountId,
+              });
+              if (result.messageId) {
+                reasoningDraftState.messageId = result.messageId;
+              }
+              return;
+            }
+            const editEventId = await client.sendMessage(roomId, {
+              msgtype: "m.text",
+              body: `* ${trimmedText}`,
+              "m.new_content": {
+                msgtype: "m.text",
+                body: trimmedText,
+              },
+              "m.relates_to": {
+                rel_type: RelationType.Replace,
+                event_id: reasoningDraftState.messageId,
+              },
+            });
+            void editEventId;
+          })
+          .catch((err) => {
+            runtime.error?.(`matrix reasoning draft update failed: ${String(err)}`);
+          });
+        await reasoningDraftState.updateChain;
+      };
+      const clearReasoningDraft = async () => {
+        await reasoningDraftState.updateChain;
+        if (!reasoningDraftState.messageId) {
+          return;
+        }
+        const eventId = reasoningDraftState.messageId;
+        try {
+          await client.redactEvent(roomId, eventId);
+        } catch (err) {
+          logVerboseMessage(`matrix reasoning draft cleanup failed (${eventId}): ${String(err)}`);
+        }
+        reasoningDraftState.messageId = undefined;
+        reasoningDraftState.lastText = "";
+      };
+
       let didSendReply = false;
       const tableMode = core.channel.text.resolveMarkdownTableMode({
         cfg,
@@ -713,7 +772,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           ...prefixOptions,
           humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
           typingCallbacks,
-          deliver: async (payload) => {
+          deliver: async (payload, info) => {
+            if (info.kind === "final") {
+              await clearReasoningDraft();
+            }
             await deliverMatrixReplies({
               replies: [payload],
               roomId,
@@ -736,11 +798,15 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         cfg,
         ctxPayload,
         dispatcher,
-        onSettled: () => {
+        onSettled: async () => {
+          await clearReasoningDraft();
           markDispatchIdle();
         },
         replyOptions: {
           ...replyOptions,
+          onReasoningStream: async (payload) => {
+            await enqueueReasoningDraftUpdate(payload.text);
+          },
           skillFilter: roomConfig?.skills,
           onModelSelected,
         },

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -15,6 +15,7 @@ import {
   type RuntimeEnv,
   type RuntimeLogger,
 } from "openclaw/plugin-sdk/matrix";
+import { createDraftStreamLoop } from "../../../../../src/channels/draft-stream-loop.js";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import { fetchEventSummary } from "../actions/summary.js";
 import {
@@ -679,54 +680,64 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const reasoningDraftState = {
         messageId: undefined as string | undefined,
         lastText: "",
-        updateChain: Promise.resolve(),
+        stopUpdates: false,
       };
+      const reasoningDraftLoop = createDraftStreamLoop({
+        throttleMs: 0,
+        isStopped: () => reasoningDraftState.stopUpdates,
+        sendOrEditStreamMessage: async (text: string) => {
+          const trimmedText = text.trim();
+          if (!trimmedText || trimmedText === reasoningDraftState.lastText) {
+            return;
+          }
+          reasoningDraftState.lastText = trimmedText;
+          if (!reasoningDraftState.messageId) {
+            const relation = threadTarget
+              ? buildThreadRelation(threadTarget, replyToMode === "off" ? undefined : messageId)
+              : buildReplyRelation(replyToMode === "off" ? undefined : messageId);
+            const eventId = await enqueueSend(
+              roomId,
+              async () => await client.sendMessage(roomId, buildTextContent(trimmedText, relation)),
+            );
+            if (eventId) {
+              reasoningDraftState.messageId = eventId;
+            }
+            return;
+          }
+          await enqueueSend(
+            roomId,
+            async () =>
+              await client.sendMessage(roomId, {
+                msgtype: "m.text",
+                body: `* ${trimmedText}`,
+                "m.new_content": {
+                  msgtype: "m.text",
+                  body: trimmedText,
+                },
+                "m.relates_to": {
+                  rel_type: RelationType.Replace,
+                  event_id: reasoningDraftState.messageId,
+                },
+              }),
+          );
+        },
+      });
       const enqueueReasoningDraftUpdate = async (text?: string) => {
         const trimmedText = text?.trim();
-        if (!trimmedText || trimmedText === reasoningDraftState.lastText) {
+        if (!trimmedText || reasoningDraftState.stopUpdates) {
           return;
         }
-        reasoningDraftState.lastText = trimmedText;
-        reasoningDraftState.updateChain = reasoningDraftState.updateChain
-          .then(async () => {
-            if (!reasoningDraftState.messageId) {
-              const relation = threadTarget
-                ? buildThreadRelation(threadTarget, replyToMode === "off" ? undefined : messageId)
-                : buildReplyRelation(replyToMode === "off" ? undefined : messageId);
-              const eventId = await enqueueSend(
-                roomId,
-                async () =>
-                  await client.sendMessage(roomId, buildTextContent(trimmedText, relation)),
-              );
-              if (eventId) {
-                reasoningDraftState.messageId = eventId;
-              }
-              return;
-            }
-            await enqueueSend(
-              roomId,
-              async () =>
-                await client.sendMessage(roomId, {
-                  msgtype: "m.text",
-                  body: `* ${trimmedText}`,
-                  "m.new_content": {
-                    msgtype: "m.text",
-                    body: trimmedText,
-                  },
-                  "m.relates_to": {
-                    rel_type: RelationType.Replace,
-                    event_id: reasoningDraftState.messageId,
-                  },
-                }),
-            );
-          })
-          .catch((err) => {
-            runtime.error?.(`matrix reasoning draft update failed: ${String(err)}`);
-          });
-        await reasoningDraftState.updateChain;
+        reasoningDraftLoop.update(trimmedText);
+        try {
+          await reasoningDraftLoop.flush();
+        } catch (err) {
+          runtime.error?.(`matrix reasoning draft update failed: ${String(err)}`);
+        }
       };
       const clearReasoningDraft = async () => {
-        await reasoningDraftState.updateChain;
+        reasoningDraftState.stopUpdates = true;
+        reasoningDraftLoop.stop();
+        await reasoningDraftLoop.waitForInFlight();
         if (!reasoningDraftState.messageId) {
           return;
         }

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -2,6 +2,11 @@ import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { PluginRuntime, RuntimeEnv } from "openclaw/plugin-sdk/matrix";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: () => undefined,
+  getOAuthProviders: () => [],
+}));
+
 const sendMessageMatrixMock = vi.hoisted(() => vi.fn().mockResolvedValue({ messageId: "mx-1" }));
 
 vi.mock("../send.js", () => ({

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -17,6 +17,13 @@ export function createDraftStreamLoop(params: {
   let inFlightPromise: Promise<void | boolean> | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
 
+  const launchFlush = () => {
+    void flush().catch(() => {
+      // Explicit flush/waitForInFlight callers observe failures directly.
+      // Background flushes must not leak unhandled rejections.
+    });
+  };
+
   const flush = async () => {
     if (timer) {
       clearTimeout(timer);
@@ -57,7 +64,7 @@ export function createDraftStreamLoop(params: {
     }
     const delay = Math.max(0, params.throttleMs - (Date.now() - lastSentAt));
     timer = setTimeout(() => {
-      void flush();
+      launchFlush();
     }, delay);
   };
 
@@ -72,7 +79,7 @@ export function createDraftStreamLoop(params: {
         return;
       }
       if (!timer && Date.now() - lastSentAt >= params.throttleMs) {
-        void flush();
+        launchFlush();
         return;
       }
       schedule();

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -14,6 +14,7 @@ export {
   resolveAllowlistCandidates,
   resolveAllowlistMatchByCandidates,
 } from "../channels/allowlist-match.js";
+export { createDraftStreamLoop } from "../channels/draft-stream-loop.js";
 export { mergeAllowlist, summarizeMapping } from "../channels/allowlists/resolve-utils.js";
 export { resolveControlCommandGate } from "../channels/command-gating.js";
 export type { NormalizedLocation } from "../channels/location.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Matrix reasoning streaming could emit multiple partial reasoning events into a room instead of treating the stream as a single transient preview.
- Why it matters: partial reasoning updates create noisy room history and leave behind intermediary content after the final answer arrives.
- What changed: Matrix now streams reasoning into one transient message, edits that message in place as reasoning evolves, and redacts it before the final reply; docs and changelog were updated and the focused Matrix tests were aligned with the rebased settled-dispatcher path.
- What did NOT change (scope boundary): this PR does not change non-Matrix channels, model reasoning generation, or the broader reply-dispatch contract outside Matrix integration usage.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Matrix reasoning-stream updates now reuse one transient message instead of leaving multiple partial reasoning events in the room.
- OpenClaw redacts that transient Matrix reasoning message before sending the final reply.
- Matrix channel docs and generic streaming/reasoning docs now describe this behavior.

## Security Impact (required)

- New permissions/capabilities? (Yes/No): No
- Secrets/tokens handling changed? (Yes/No): No
- New/changed network calls? (Yes/No): No
- Command/tool execution surface changed? (Yes/No): No
- Data access scope changed? (Yes/No): No
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm test run
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): default Matrix test fixtures

### Steps

1. Configure a Matrix reply flow with reasoning streaming enabled.
2. Trigger a reply that emits multiple reasoning-stream updates before the final answer.
3. Observe Matrix events produced during reasoning and after final reply delivery.

### Expected

- Reasoning updates stay confined to one transient Matrix message that is edited in place and redacted before the final reply is posted.

### Actual

- Before this change, reasoning updates could accumulate as partial room events instead of behaving like one transient preview.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran focused Matrix tests covering reasoning-only suppression and the single-message/edit/redaction lifecycle for reasoning streams.
- Edge cases checked: repeated reasoning updates reuse the same draft, the final answer is delivered once, and the transient reasoning event is redacted once after final delivery.
- What you did **not** verify: live Matrix homeserver/manual room testing outside the existing automated tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes/No): Yes
- Config/env changes? (Yes/No): No
- Migration needed? (Yes/No): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or disable Matrix reasoning streaming configuration.
- Files/config to restore: Matrix monitor handler and related docs/tests in this PR.
- Known bad symptoms reviewers should watch for: multiple lingering reasoning events in Matrix rooms, missing final reply delivery, or transient reasoning messages not being redacted.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the Matrix-specific reasoning cleanup could regress when reply-dispatch lifecycle behavior changes again.
- Mitigation: focused reasoning-stream tests now cover the rebased settled-dispatcher integration and redaction timing.

AI assistance: This PR was prepared with GPT-5.4 support. I reviewed the code changes, ran the targeted tests locally, and verified the PR content before opening it.
