### PR TITLE
fix(errors): surface friendly overloaded/rate-limit messages on Telegram

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -11,6 +11,8 @@ export {
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,
+  OVERLOADED_ERROR_USER_MESSAGE,
+  RATE_LIMIT_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -39,8 +39,8 @@ export function formatBillingErrorMessage(provider?: string, model?: string): st
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 
-const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
-const OVERLOADED_ERROR_USER_MESSAGE =
+export const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
+export const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -6,9 +6,12 @@ import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
+  classifyFailoverReason,
   isCompactionFailureError,
   isContextOverflowError,
   isLikelyContextOverflowError,
+  isOverloadedErrorMessage,
+  isRateLimitErrorMessage,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -606,6 +609,10 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+      const failoverReason = classifyFailoverReason(message);
+      const isOverloaded = failoverReason === "overloaded" || isOverloadedErrorMessage(message);
+      const isRateLimit =
+        !isOverloaded && (failoverReason === "rate_limit" || isRateLimitErrorMessage(message));
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
@@ -614,7 +621,11 @@ export async function runAgentTurnWithFallback(params: {
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : isOverloaded
+            ? "The AI service is temporarily overloaded. Please try again in a moment."
+            : isRateLimit
+              ? "⚠️ API rate limit reached. Please try again later."
+              : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -13,6 +13,8 @@ import {
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
   isTransientHttpError,
+  OVERLOADED_ERROR_USER_MESSAGE,
+  RATE_LIMIT_ERROR_USER_MESSAGE,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -622,9 +624,9 @@ export async function runAgentTurnWithFallback(params: {
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
           : isOverloaded
-            ? "The AI service is temporarily overloaded. Please try again in a moment."
+            ? OVERLOADED_ERROR_USER_MESSAGE
             : isRateLimit
-              ? "⚠️ API rate limit reached. Please try again later."
+              ? RATE_LIMIT_ERROR_USER_MESSAGE
               : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1628,3 +1628,101 @@ describe("runReplyAgent transient HTTP retry", () => {
     expect(payload?.text).toContain("Recovered response");
   });
 });
+
+describe("runReplyAgent overloaded/rate-limit error surfacing", () => {
+  function createOverloadRun(errorMessage: string) {
+    vi.useFakeTimers();
+    runEmbeddedPiAgentMock.mockRejectedValue(new Error(errorMessage));
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    return runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+  }
+
+  it("surfaces friendly overloaded message for 529 errors", async () => {
+    const runPromise = createOverloadRun(
+      '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+    );
+
+    // First attempt triggers transient HTTP retry backoff; second attempt also fails.
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+  });
+
+  it("surfaces friendly rate-limit message for 429 errors", async () => {
+    const runPromise = createOverloadRun(
+      '429 {"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}',
+    );
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toBe("⚠️ API rate limit reached. Please try again later.");
+  });
+
+  it("surfaces friendly message for overloaded keyword in non-HTTP error", async () => {
+    const runPromise = createOverloadRun("Anthropic API is overloaded");
+
+    const result = await runPromise;
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+  });
+});

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -3,6 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OVERLOADED_ERROR_USER_MESSAGE,
+  RATE_LIMIT_ERROR_USER_MESSAGE,
+} from "../../agents/pi-embedded-helpers.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
@@ -1698,9 +1702,7 @@ describe("runReplyAgent overloaded/rate-limit error surfacing", () => {
     const result = await runPromise;
 
     const payload = Array.isArray(result) ? result[0] : result;
-    expect(payload?.text).toBe(
-      "The AI service is temporarily overloaded. Please try again in a moment.",
-    );
+    expect(payload?.text).toBe(OVERLOADED_ERROR_USER_MESSAGE);
   });
 
   it("surfaces friendly rate-limit message for 429 errors", async () => {
@@ -1712,7 +1714,7 @@ describe("runReplyAgent overloaded/rate-limit error surfacing", () => {
     const result = await runPromise;
 
     const payload = Array.isArray(result) ? result[0] : result;
-    expect(payload?.text).toBe("⚠️ API rate limit reached. Please try again later.");
+    expect(payload?.text).toBe(RATE_LIMIT_ERROR_USER_MESSAGE);
   });
 
   it("surfaces friendly message for overloaded keyword in non-HTTP error", async () => {
@@ -1721,8 +1723,6 @@ describe("runReplyAgent overloaded/rate-limit error surfacing", () => {
     const result = await runPromise;
 
     const payload = Array.isArray(result) ? result[0] : result;
-    expect(payload?.text).toBe(
-      "The AI service is temporarily overloaded. Please try again in a moment.",
-    );
+    expect(payload?.text).toBe(OVERLOADED_ERROR_USER_MESSAGE);
   });
 });


### PR DESCRIPTION
## Summary

- Detect overloaded (529) and rate-limit (429) errors in the agent-runner catch block and return clean, user-friendly messages instead of raw API error text
- Follows the same pattern used for context overflow and role ordering error handling
- Prevents raw JSON/HTTP payloads from reaching Telegram HTML parser, which could cause silent delivery failures under `bestEffort` mode

Fixes #42432

## Changes

**`src/auto-reply/reply/agent-runner-execution.ts`**
- Import `classifyFailoverReason`, `isOverloadedErrorMessage`, `isRateLimitErrorMessage` from helpers
- In the catch block, classify the error and return friendly messages:
  - Overloaded: "The AI service is temporarily overloaded. Please try again in a moment."
  - Rate limit: "⚠️ API rate limit reached. Please try again later."

**`src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`**
- Add 3 tests covering: 529 overloaded, 429 rate limit, and keyword-based overloaded detection

## Test plan

- [x] `pnpm test -- --run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` — 31 tests pass (3 new)
- [x] `pnpm check` — passes
- [x] `pnpm tsgo` — passes
- [x] `pnpm format` — passes

This contribution was developed with AI assistance (Claude Code).