### PR TITLE
fix(msteams): add fetch timeout to Microsoft Graph API call

### DIFF
--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -36,12 +36,20 @@ export async function fetchGraphJson<T>(params: {
   path: string;
   headers?: Record<string, string>;
 }): Promise<T> {
-  const res = await fetch(`${GRAPH_ROOT}${params.path}`, {
-    headers: {
-      Authorization: `Bearer ${params.token}`,
-      ...params.headers,
-    },
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${GRAPH_ROOT}${params.path}`, {
+      headers: {
+        Authorization: `Bearer ${params.token}`,
+        ...params.headers,
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Graph ${params.path} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`Graph ${params.path} failed (${res.status}): ${text || "unknown error"}`);


### PR DESCRIPTION
## Summary

- `fetchGraphJson()` in `extensions/msteams/src/graph.ts` calls `fetch()` without a timeout
- A stalled Microsoft Graph endpoint can hang the bot process indefinitely
- Adds `AbortSignal.timeout(30_000)` with try/catch for descriptive timeout error, consistent with #5926 and #6914

## Test plan

- [ ] Verify CI passes
- [ ] Confirm no existing tests break
- [ ] Manual: stalled Graph API now times out after 30s with clear error message

lobster-biscuit