### PR TITLE
fix(mattermost): add fetch timeout to file upload

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -256,13 +256,21 @@ export async function uploadMattermostFile(
   form.append("files", blob, fileName);
   form.append("channel_id", params.channelId);
 
-  const res = await fetch(`${client.apiBaseUrl}/files`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${client.token}`,
-    },
-    body: form,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${client.apiBaseUrl}/files`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${client.token}`,
+      },
+      body: form,
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Mattermost file upload failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   if (!res.ok) {
     const detail = await readMattermostError(res);


### PR DESCRIPTION
## Summary

- `uploadFileMattermost()` in `extensions/mattermost/src/mattermost/client.ts` calls `fetch()` without a timeout
- A stalled Mattermost server can hang the bot process indefinitely during file uploads
- Adds `AbortSignal.timeout(60_000)` (60s for large uploads) with try/catch for descriptive error, consistent with #5926 and #6914

## Test plan

- [ ] Verify CI passes
- [ ] Confirm no existing tests break
- [ ] Manual: stalled upload now times out after 60s with clear error message

lobster-biscuit