### PR TITLE
fix(matrix): add fetch timeout to directory-live API helper

### DIFF
--- a/extensions/matrix/src/directory-live.ts
+++ b/extensions/matrix/src/directory-live.ts
@@ -49,16 +49,19 @@ async function fetchMatrixJson<T>(params: {
       body: params.body ? JSON.stringify(params.body) : undefined,
       signal: AbortSignal.timeout(30_000),
     });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Matrix API ${params.path} failed (${res.status}): ${text || "unknown error"}`);
+    }
+    return (await res.json()) as T;
   } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Matrix API")) {
+      throw err;
+    }
     throw new Error(
       `Matrix API ${params.path} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`Matrix API ${params.path} failed (${res.status}): ${text || "unknown error"}`);
-  }
-  return (await res.json()) as T;
 }
 
 function normalizeQuery(value?: string | null): string {

--- a/extensions/matrix/src/directory-live.ts
+++ b/extensions/matrix/src/directory-live.ts
@@ -38,14 +38,22 @@ async function fetchMatrixJson<T>(params: {
   method?: "GET" | "POST";
   body?: unknown;
 }): Promise<T> {
-  const res = await fetch(`${params.homeserver}${params.path}`, {
-    method: params.method ?? "GET",
-    headers: {
-      Authorization: `Bearer ${params.accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: params.body ? JSON.stringify(params.body) : undefined,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${params.homeserver}${params.path}`, {
+      method: params.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Matrix API ${params.path} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`Matrix API ${params.path} failed (${res.status}): ${text || "unknown error"}`);


### PR DESCRIPTION
## Summary

- `matrixApiRequest()` in `extensions/matrix/src/directory-live.ts` calls `fetch()` without a timeout
- A stalled Matrix homeserver can hang the bot process indefinitely
- Adds `AbortSignal.timeout(30_000)` with try/catch for descriptive error, consistent with #5926 and #6914

## Test plan

- [ ] Verify CI passes
- [ ] Confirm no existing tests break
- [ ] Manual: stalled homeserver now times out after 30s with clear error message

lobster-biscuit