### PR TITLE
fix(voice-call): add fetch timeout to OpenAI TTS request

### DIFF
--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -119,9 +119,8 @@ export class OpenAITTSProvider {
       body.instructions = effectiveInstructions;
     }
 
-    let response: Response;
     try {
-      response = await fetch("https://api.openai.com/v1/audio/speech", {
+      const response = await fetch("https://api.openai.com/v1/audio/speech", {
         method: "POST",
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
@@ -130,19 +129,22 @@ export class OpenAITTSProvider {
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(30_000),
       });
+
+      if (!response.ok) {
+        const error = await response.text();
+        throw new Error(`OpenAI TTS failed: ${response.status} - ${error}`);
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      return Buffer.from(arrayBuffer);
     } catch (err) {
+      if (err instanceof Error && err.message.startsWith("OpenAI TTS failed:")) {
+        throw err;
+      }
       throw new Error(
         `OpenAI TTS failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`OpenAI TTS failed: ${response.status} - ${error}`);
-    }
-
-    const arrayBuffer = await response.arrayBuffer();
-    return Buffer.from(arrayBuffer);
   }
 
   /**

--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -119,14 +119,22 @@ export class OpenAITTSProvider {
       body.instructions = effectiveInstructions;
     }
 
-    const response = await fetch("https://api.openai.com/v1/audio/speech", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await fetch("https://api.openai.com/v1/audio/speech", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch (err) {
+      throw new Error(
+        `OpenAI TTS failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
     if (!response.ok) {
       const error = await response.text();

--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -119,8 +119,9 @@ export class OpenAITTSProvider {
       body.instructions = effectiveInstructions;
     }
 
+    let response: Response;
     try {
-      const response = await fetch("https://api.openai.com/v1/audio/speech", {
+      response = await fetch("https://api.openai.com/v1/audio/speech", {
         method: "POST",
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
@@ -129,22 +130,29 @@ export class OpenAITTSProvider {
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(30_000),
       });
-
-      if (!response.ok) {
-        const error = await response.text();
-        throw new Error(`OpenAI TTS failed: ${response.status} - ${error}`);
-      }
-
-      const arrayBuffer = await response.arrayBuffer();
-      return Buffer.from(arrayBuffer);
     } catch (err) {
-      if (err instanceof Error && err.message.startsWith("OpenAI TTS failed:")) {
-        throw err;
-      }
       throw new Error(
         `OpenAI TTS failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
       );
     }
+
+    if (!response.ok) {
+      const error = await response.text().catch(() => "");
+      throw new Error(`OpenAI TTS failed: ${response.status} - ${error}`);
+    }
+
+    let arrayBuffer: ArrayBuffer;
+    try {
+      arrayBuffer = await response.arrayBuffer();
+    } catch (err) {
+      throw new Error(
+        `OpenAI TTS failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    return Buffer.from(arrayBuffer);
   }
 
   /**


### PR DESCRIPTION
## Summary

- OpenAI TTS `fetch()` in `extensions/voice-call/src/providers/tts-openai.ts` has no timeout
- A stalled OpenAI endpoint can hang the voice-call process indefinitely
- Adds `AbortSignal.timeout(30_000)` with try/catch for descriptive error, consistent with #5926 and #6914

## Test plan

- [ ] Verify CI passes
- [ ] Confirm no existing tests break
- [ ] Manual: stalled TTS endpoint now times out after 30s with clear error message

lobster-biscuit