### PR TITLE
fix(qwen-portal-auth,minimax-portal-auth): add fetch timeout to OAuth calls

### DIFF
--- a/extensions/minimax-portal-auth/oauth.ts
+++ b/extensions/minimax-portal-auth/oauth.ts
@@ -65,22 +65,30 @@ async function requestOAuthCode(params: {
   region: MiniMaxRegion;
 }): Promise<MiniMaxOAuthAuthorization> {
   const endpoints = getOAuthEndpoints(params.region);
-  const response = await fetch(endpoints.codeEndpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-      "x-request-id": randomUUID(),
-    },
-    body: toFormUrlEncoded({
-      response_type: "code",
-      client_id: endpoints.clientId,
-      scope: MINIMAX_OAUTH_SCOPE,
-      code_challenge: params.challenge,
-      code_challenge_method: "S256",
-      state: params.state,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(endpoints.codeEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "x-request-id": randomUUID(),
+      },
+      body: toFormUrlEncoded({
+        response_type: "code",
+        client_id: endpoints.clientId,
+        scope: MINIMAX_OAUTH_SCOPE,
+        code_challenge: params.challenge,
+        code_challenge_method: "S256",
+        state: params.state,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `MiniMax OAuth authorization failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   if (!response.ok) {
     const text = await response.text();
@@ -106,19 +114,28 @@ async function pollOAuthToken(params: {
   region: MiniMaxRegion;
 }): Promise<TokenResult> {
   const endpoints = getOAuthEndpoints(params.region);
-  const response = await fetch(endpoints.tokenEndpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-    },
-    body: toFormUrlEncoded({
-      grant_type: MINIMAX_OAUTH_GRANT_TYPE,
-      client_id: endpoints.clientId,
-      user_code: params.userCode,
-      code_verifier: params.verifier,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(endpoints.tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: toFormUrlEncoded({
+        grant_type: MINIMAX_OAUTH_GRANT_TYPE,
+        client_id: endpoints.clientId,
+        user_code: params.userCode,
+        code_verifier: params.verifier,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    return {
+      status: "error" as const,
+      message: `MiniMax token poll failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 
   const text = await response.text();
   let payload:

--- a/extensions/minimax-portal-auth/oauth.ts
+++ b/extensions/minimax-portal-auth/oauth.ts
@@ -87,6 +87,7 @@ async function requestOAuthCode(params: {
   } catch (err) {
     throw new Error(
       `MiniMax OAuth authorization failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
@@ -130,11 +131,11 @@ async function pollOAuthToken(params: {
       }),
       signal: AbortSignal.timeout(30_000),
     });
-  } catch (err) {
-    return {
-      status: "error" as const,
-      message: `MiniMax token poll failed: ${err instanceof Error ? err.message : String(err)}`,
-    };
+  } catch {
+    // Network or timeout error on a single poll should not abort the
+    // entire device-auth flow — treat it as "pending" so the caller
+    // retries on the next interval.
+    return { status: "pending" as const };
   }
 
   const text = await response.text();

--- a/extensions/qwen-portal-auth/oauth.ts
+++ b/extensions/qwen-portal-auth/oauth.ts
@@ -35,20 +35,28 @@ type DeviceTokenResult =
   | { status: "error"; message: string };
 
 async function requestDeviceCode(params: { challenge: string }): Promise<QwenDeviceAuthorization> {
-  const response = await fetch(QWEN_OAUTH_DEVICE_CODE_ENDPOINT, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-      "x-request-id": randomUUID(),
-    },
-    body: toFormUrlEncoded({
-      client_id: QWEN_OAUTH_CLIENT_ID,
-      scope: QWEN_OAUTH_SCOPE,
-      code_challenge: params.challenge,
-      code_challenge_method: "S256",
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(QWEN_OAUTH_DEVICE_CODE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "x-request-id": randomUUID(),
+      },
+      body: toFormUrlEncoded({
+        client_id: QWEN_OAUTH_CLIENT_ID,
+        scope: QWEN_OAUTH_SCOPE,
+        code_challenge: params.challenge,
+        code_challenge_method: "S256",
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Qwen device authorization failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   if (!response.ok) {
     const text = await response.text();
@@ -69,19 +77,28 @@ async function pollDeviceToken(params: {
   deviceCode: string;
   verifier: string;
 }): Promise<DeviceTokenResult> {
-  const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-    },
-    body: toFormUrlEncoded({
-      grant_type: QWEN_OAUTH_GRANT_TYPE,
-      client_id: QWEN_OAUTH_CLIENT_ID,
-      device_code: params.deviceCode,
-      code_verifier: params.verifier,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: toFormUrlEncoded({
+        grant_type: QWEN_OAUTH_GRANT_TYPE,
+        client_id: QWEN_OAUTH_CLIENT_ID,
+        device_code: params.deviceCode,
+        code_verifier: params.verifier,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    return {
+      status: "error" as const,
+      message: `Qwen token poll failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 
   if (!response.ok) {
     let payload: { error?: string; error_description?: string } | undefined;

--- a/extensions/qwen-portal-auth/oauth.ts
+++ b/extensions/qwen-portal-auth/oauth.ts
@@ -55,6 +55,7 @@ async function requestDeviceCode(params: { challenge: string }): Promise<QwenDev
   } catch (err) {
     throw new Error(
       `Qwen device authorization failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
@@ -93,11 +94,11 @@ async function pollDeviceToken(params: {
       }),
       signal: AbortSignal.timeout(30_000),
     });
-  } catch (err) {
-    return {
-      status: "error" as const,
-      message: `Qwen token poll failed: ${err instanceof Error ? err.message : String(err)}`,
-    };
+  } catch {
+    // Network or timeout error on a single poll should not abort the
+    // entire device-auth flow — treat it as "pending" so the caller
+    // retries on the next interval.
+    return { status: "pending" as const };
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

- `qwen-portal-auth/oauth.ts` and `minimax-portal-auth/oauth.ts` both have OAuth device-code and token-poll `fetch()` calls without a timeout (4 calls total)
- A stalled OAuth endpoint can hang the auth flow indefinitely
- Adds `AbortSignal.timeout(30_000)` to all 4 calls with appropriate error handling (throw for device-code, return error for token-poll), consistent with #5926 and #6914

## Test plan

- [ ] Verify CI passes
- [ ] Confirm no existing tests break
- [ ] Manual: stalled OAuth server now times out after 30s with clear error

lobster-biscuit