### PR TITLE
[ignore] feat(discord): add autoThreadName config with LLM summarization

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -356,6 +356,8 @@ export const DiscordGuildChannelSchema = z
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
+    /** Naming strategy for auto-created threads. "message" uses the message text (default), "summarize" uses LLM to generate a title. */
+    autoThreadName: z.enum(["message", "summarize"]).optional(),
     /** Archive duration for auto-created threads in minutes. Discord supports 60, 1440 (1 day), 4320 (3 days), 10080 (1 week). Default: 60. */
     autoArchiveDuration: z
       .union([

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -356,6 +356,16 @@ export const DiscordGuildChannelSchema = z
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
+    /** Archive duration for auto-created threads in minutes. Discord supports 60, 1440 (1 day), 4320 (3 days), 10080 (1 week). Default: 60. */
+    autoArchiveDuration: z
+      .union([
+        z.enum(["60", "1440", "4320", "10080"]),
+        z.literal(60),
+        z.literal(1440),
+        z.literal(4320),
+        z.literal(10080),
+      ])
+      .optional(),
   })
   .strict();
 

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -39,6 +39,7 @@ export type DiscordGuildEntryResolved = {
       systemPrompt?: string;
       includeThreadStarter?: boolean;
       autoThread?: boolean;
+      autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
     }
   >;
 };
@@ -54,6 +55,7 @@ export type DiscordChannelConfigResolved = {
   systemPrompt?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
+  autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
   matchKey?: string;
   matchSource?: ChannelMatchSource;
 };
@@ -400,6 +402,7 @@ function resolveDiscordChannelConfigEntry(
     systemPrompt: entry.systemPrompt,
     includeThreadStarter: entry.includeThreadStarter,
     autoThread: entry.autoThread,
+    autoArchiveDuration: entry.autoArchiveDuration,
   };
   return resolved;
 }

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -39,6 +39,7 @@ export type DiscordGuildEntryResolved = {
       systemPrompt?: string;
       includeThreadStarter?: boolean;
       autoThread?: boolean;
+      autoThreadName?: "message" | "summarize";
       autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
     }
   >;
@@ -55,6 +56,7 @@ export type DiscordChannelConfigResolved = {
   systemPrompt?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
+  autoThreadName?: "message" | "summarize";
   autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
   matchKey?: string;
   matchSource?: ChannelMatchSource;
@@ -402,6 +404,7 @@ function resolveDiscordChannelConfigEntry(
     systemPrompt: entry.systemPrompt,
     includeThreadStarter: entry.includeThreadStarter,
     autoThread: entry.autoThread,
+    autoThreadName: entry.autoThreadName,
     autoArchiveDuration: entry.autoArchiveDuration,
   };
   return resolved;

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -328,6 +328,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     replyToMode,
     agentId: route.agentId,
     channel: route.channel,
+    cfg,
   });
   const deliverTarget = replyPlan.deliverTarget;
   const replyTarget = replyPlan.replyTarget;

--- a/src/discord/monitor/thread-title.ts
+++ b/src/discord/monitor/thread-title.ts
@@ -1,0 +1,105 @@
+import { complete, type Model, type Api } from "@mariozechner/pi-ai";
+import { resolveOpenClawAgentDir } from "../../agents/agent-paths.js";
+import { getApiKeyForModel } from "../../agents/model-auth.js";
+import { discoverAuthStorage, discoverModels } from "../../agents/pi-model-discovery.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
+import { logVerbose } from "../../globals.js";
+
+/**
+ * Generate a short thread title using the agent's configured model.
+ * Falls back to truncated message text if model/API is unavailable.
+ */
+export async function generateThreadTitle(params: {
+  cfg: OpenClawConfig;
+  messageText: string;
+  agentDir?: string;
+}): Promise<string> {
+  const text = params.messageText.trim();
+  if (!text) {
+    return "New Thread";
+  }
+
+  // Fallback: truncated message
+  const fallback = text.length > 80 ? text.slice(0, 77) + "..." : text;
+
+  try {
+    // Get agent's configured model
+    const modelRef = resolveAgentModelPrimaryValue(params.cfg?.agents?.defaults?.model);
+    if (!modelRef) {
+      logVerbose("thread-title: no model configured, using fallback");
+      return fallback;
+    }
+
+    // Parse provider/model from ref (e.g., "anthropic/claude-sonnet-4-6")
+    const [provider, modelId] = modelRef.includes("/")
+      ? modelRef.split("/", 2)
+      : ["openai", modelRef];
+
+    // Discover models and auth
+    const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+    const authStorage = discoverAuthStorage(agentDir);
+    const modelRegistry = discoverModels(authStorage, agentDir);
+
+    // Find the model in registry
+    const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+    if (!model) {
+      logVerbose(`thread-title: model ${provider}/${modelId} not found, using fallback`);
+      return fallback;
+    }
+
+    // Get API key
+    const apiKeyInfo = await getApiKeyForModel({
+      model,
+      cfg: params.cfg,
+      agentDir,
+    });
+    if (!apiKeyInfo.apiKey) {
+      logVerbose(`thread-title: no API key for ${provider}, using fallback`);
+      return fallback;
+    }
+
+    const prompt = `Generate a 3-6 word title for this Discord thread. Be concise and descriptive. Return ONLY the title, no quotes or extra text.
+
+Message: ${text.slice(0, 500)}`;
+
+    // Make completion call using pi-ai
+    const message = await complete(
+      model,
+      { messages: [] },
+      {
+        apiKey: apiKeyInfo.apiKey,
+        maxTokens: 30,
+        systemPrompt: prompt,
+      },
+    );
+
+    // Extract title from response
+    let title = "";
+    if (typeof message.content === "string") {
+      title = (message.content as string).trim();
+    } else if (Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (
+          typeof part === "object" &&
+          part !== null &&
+          "type" in part &&
+          part.type === "text" &&
+          "text" in part
+        ) {
+          title += String((part as { text: unknown }).text);
+        }
+      }
+      title = title.trim();
+    }
+
+    // Validate and return
+    if (title && title.length > 0 && title.length <= 100) {
+      return title;
+    }
+    return fallback;
+  } catch (err) {
+    logVerbose(`thread-title: error generating title: ${String(err)}`);
+    return fallback;
+  }
+}

--- a/src/discord/monitor/threading.auto-thread.test.ts
+++ b/src/discord/monitor/threading.auto-thread.test.ts
@@ -1,5 +1,5 @@
 import { ChannelType } from "@buape/carbon";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { maybeCreateDiscordAutoThread } from "./threading.js";
 
 describe("maybeCreateDiscordAutoThread", () => {
@@ -87,5 +87,76 @@ describe("maybeCreateDiscordAutoThread", () => {
     });
     expect(result).toBe("thread1");
     expect(postMock).toHaveBeenCalled();
+  });
+});
+
+describe("maybeCreateDiscordAutoThread autoArchiveDuration", () => {
+  const postMock = vi.fn();
+  const getMock = vi.fn();
+  const mockClient = {
+    rest: { post: postMock, get: getMock },
+  } as unknown as Parameters<typeof maybeCreateDiscordAutoThread>[0]["client"];
+  const mockMessage = {
+    id: "msg1",
+    timestamp: "123",
+  } as unknown as Parameters<typeof maybeCreateDiscordAutoThread>[0]["message"];
+
+  beforeEach(() => {
+    postMock.mockReset();
+    getMock.mockReset();
+  });
+
+  it("uses configured autoArchiveDuration", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    await maybeCreateDiscordAutoThread({
+      client: mockClient,
+      message: mockMessage,
+      messageChannelId: "text1",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThread: true, autoArchiveDuration: "10080" },
+      channelType: ChannelType.GuildText,
+      baseText: "test",
+      combinedBody: "test",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ auto_archive_duration: 10080 }) }),
+    );
+  });
+
+  it("accepts numeric autoArchiveDuration", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    await maybeCreateDiscordAutoThread({
+      client: mockClient,
+      message: mockMessage,
+      messageChannelId: "text1",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThread: true, autoArchiveDuration: 4320 },
+      channelType: ChannelType.GuildText,
+      baseText: "test",
+      combinedBody: "test",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ auto_archive_duration: 4320 }) }),
+    );
+  });
+
+  it("defaults to 60 when autoArchiveDuration not set", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    await maybeCreateDiscordAutoThread({
+      client: mockClient,
+      message: mockMessage,
+      messageChannelId: "text1",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThread: true },
+      channelType: ChannelType.GuildText,
+      baseText: "test",
+      combinedBody: "test",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ auto_archive_duration: 60 }) }),
+    );
   });
 });

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -397,12 +397,18 @@ export async function maybeCreateDiscordAutoThread(params: {
       params.baseText || params.combinedBody || "Thread",
       params.message.id,
     );
+
+    // Parse archive duration from config, default to 60 minutes
+    const archiveDuration = params.channelConfig?.autoArchiveDuration
+      ? Number(params.channelConfig.autoArchiveDuration)
+      : 60;
+
     const created = (await params.client.rest.post(
       `${Routes.channelMessage(messageChannelId, params.message.id)}/threads`,
       {
         body: {
           name: threadName,
-          auto_archive_duration: 60,
+          auto_archive_duration: archiveDuration,
         },
       },
     )) as { id?: string };

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -12,6 +12,7 @@ import {
   resolveDiscordEmbedText,
   resolveDiscordMessageChannelId,
 } from "./message-utils.js";
+import { generateThreadTitle } from "./thread-title.js";
 
 export type DiscordThreadChannel = {
   id: string;
@@ -314,6 +315,7 @@ export async function resolveDiscordAutoThreadReplyPlan(params: {
   replyToMode: ReplyToMode;
   agentId: string;
   channel: string;
+  cfg?: import("../../config/config.js").OpenClawConfig;
 }): Promise<DiscordAutoThreadReplyPlan> {
   const messageChannelId = (
     params.messageChannelId ||
@@ -334,6 +336,7 @@ export async function resolveDiscordAutoThreadReplyPlan(params: {
     channelType: params.channelType,
     baseText: params.baseText,
     combinedBody: params.combinedBody,
+    cfg: params.cfg,
   });
   const deliveryPlan = resolveDiscordReplyDeliveryPlan({
     replyTarget: originalReplyTarget,
@@ -363,6 +366,7 @@ export async function maybeCreateDiscordAutoThread(params: {
   channelType?: ChannelType;
   baseText: string;
   combinedBody: string;
+  cfg?: import("../../config/config.js").OpenClawConfig;
 }): Promise<string | undefined> {
   if (!params.isGuildMessage) {
     return undefined;
@@ -393,10 +397,15 @@ export async function maybeCreateDiscordAutoThread(params: {
     return undefined;
   }
   try {
-    const threadName = sanitizeDiscordThreadName(
-      params.baseText || params.combinedBody || "Thread",
-      params.message.id,
-    );
+    // Apply naming strategy: "summarize" uses LLM, "message" (default) uses full text
+    const rawText = params.baseText || params.combinedBody || "Thread";
+    let nameSource = rawText;
+
+    if (params.channelConfig?.autoThreadName === "summarize" && params.cfg) {
+      nameSource = await generateThreadTitle({ cfg: params.cfg, messageText: rawText });
+    }
+
+    const threadName = sanitizeDiscordThreadName(nameSource, params.message.id);
 
     // Parse archive duration from config, default to 60 minutes
     const archiveDuration = params.channelConfig?.autoArchiveDuration


### PR DESCRIPTION
Adds `autoThreadName` config option that uses LLM summarization to generate descriptive thread names when auto-creating threads.

Also includes `autoArchiveDuration` config option for setting thread archive duration.

## Changes
- Add `autoThreadName` config option with `summarize` strategy
- Add `autoArchiveDuration` config for thread archive timing
- LLM summarizes first message to generate thread title