### PR TITLE
docs: list chat-only-trigger community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -14,7 +14,7 @@ We accept PRs that add community plugins here when they meet the quality bar.
 
 ## Required for listing
 
-- Plugin package is published on npmjs (installable via `openclaw plugins install <npm-spec>`).
+- Plugin is installable either from npmjs (`openclaw plugins install <npm-spec>`) or from a public source checkout/local path using the documented [Plugins](/tools/plugin) install flow.
 - Source code is hosted on GitHub (public repository).
 - Repository includes setup/use docs and an issue tracker.
 - Plugin has a clear maintenance signal (active maintainer, recent updates, or responsive issue handling).
@@ -24,10 +24,10 @@ We accept PRs that add community plugins here when they meet the quality bar.
 Open a PR that adds your plugin to this page with:
 
 - Plugin name
-- npm package name
 - GitHub repository URL
 - One-line description
-- Install command
+- Install instructions
+- npm package name if published
 
 ## Review bar
 
@@ -39,11 +39,30 @@ Low-effort wrappers, unclear ownership, or unmaintained packages may be declined
 Use this format when adding entries:
 
 - **Plugin Name** — short description
-  npm: `@scope/package`
+  npm: `@scope/package` (omit if source-install only)
   repo: `https://github.com/org/repo`
   install: `openclaw plugins install @scope/package`
 
+For source-install plugins, use a fenced shell block under `install:` when setup takes more than one command:
+
+- **Plugin Name** — short description
+  repo: `https://github.com/org/repo`
+  install:
+  ```bash
+  git clone https://github.com/org/repo.git
+  openclaw plugins install ./repo
+  ```
+
 ## Listed plugins
+
+- **Chat Only Trigger** — Forces keyword-triggered or non-whitelisted turns into chat-only mode for safer public channels and group chats.
+  repo: `https://github.com/constansino/openclaw-chat-only-trigger`
+  install:
+
+  ```bash
+  git clone https://github.com/constansino/openclaw-chat-only-trigger.git
+  openclaw plugins install ./openclaw-chat-only-trigger
+  ```
 
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -336,6 +336,18 @@ describe("launchd install", () => {
         OPENCLAW_SERVICE_KIND: "node",
       }),
     ).toBe(false);
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        XPC_SERVICE_NAME: "ai.openclaw.gateway",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        XPC_SERVICE_NAME: "com.other.service",
+      }),
+    ).toBe(false);
   });
 
   it("restarts a loaded LaunchAgent with kickstart only", async () => {
@@ -416,11 +428,10 @@ describe("launchd install", () => {
         stdio: "ignore",
       }),
     );
-    expect(
-      Array.from(state.files.values()).some((content) =>
-        content.includes("launchctl kickstart -k"),
-      ),
-    ).toBe(true);
+    const [scriptPath, scriptContent] = Array.from(state.files.entries())[0] ?? [];
+    expect(scriptPath).toMatch(/openclaw-launchd-restart-[0-9a-f-]+\.sh$/);
+    expect(scriptContent).toContain("launchctl kickstart -k");
+    expect(scriptContent).toContain("grep -qiE 'no such process|could not find service|not found'");
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,6 +11,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  shouldUseDetachedLaunchAgentRestart,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -18,6 +19,8 @@ const state = vi.hoisted(() => ({
   listOutput: "",
   printOutput: "",
   bootstrapError: "",
+  kickstartResponses: [] as Array<{ stdout: string; stderr: string; code: number }>,
+  spawnCalls: [] as Array<{ file: string; args: string[]; options: Record<string, unknown> }>,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -49,7 +52,19 @@ vi.mock("./exec-file.js", () => ({
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
     }
+    if (call[0] === "kickstart" && state.kickstartResponses.length > 0) {
+      return state.kickstartResponses.shift()!;
+    }
     return { stdout: "", stderr: "", code: 0 };
+  }),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn((file: string, args: string[], options: Record<string, unknown>) => {
+    state.spawnCalls.push({ file, args, options });
+    return {
+      unref: vi.fn(),
+    };
   }),
 }));
 
@@ -109,6 +124,8 @@ beforeEach(() => {
   state.listOutput = "";
   state.printOutput = "";
   state.bootstrapError = "";
+  state.kickstartResponses.length = 0;
+  state.spawnCalls.length = 0;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -304,8 +321,55 @@ describe("launchd install", () => {
     expect(state.fileModes.get(plistPath)).toBe(0o644);
   });
 
-  it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {
+  it("detects gateway service env as detached-restart context", () => {
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseDetachedLaunchAgentRestart({
+        HOME: "/Users/test",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "node",
+      }),
+    ).toBe(false);
+  });
+
+  it("restarts a loaded LaunchAgent with kickstart only", async () => {
     const env = createDefaultLaunchdEnv();
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const serviceId = `${domain}/${label}`;
+    const kickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
+    );
+
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout")).toBe(false);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(false);
+    expect(state.launchctlCalls.some((c) => c[0] === "enable")).toBe(false);
+  });
+
+  it("bootstraps when kickstart reports the LaunchAgent is not loaded", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.kickstartResponses.push(
+      {
+        stdout: "",
+        stderr:
+          'Bad request. Could not find service "ai.openclaw.gateway" in domain for user gui: 501',
+        code: 1,
+      },
+      { stdout: "", stderr: "", code: 0 },
+    );
+
     await restartLaunchAgent({
       env,
       stdout: new PassThrough(),
@@ -315,62 +379,48 @@ describe("launchd install", () => {
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
     const serviceId = `${domain}/${label}`;
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === serviceId,
-    );
     const enableIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "enable" && c[1] === serviceId,
     );
     const bootstrapIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
     );
-    const kickstartIndex = state.launchctlCalls.findIndex(
+    const kickstartCalls = state.launchctlCalls.filter(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
-    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
     expect(enableIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(enableIndex);
-    expect(enableIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
+    expect(kickstartCalls).toHaveLength(2);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout")).toBe(false);
   });
 
-  it("waits for previous launchd pid to exit before bootstrapping", async () => {
-    const env = createDefaultLaunchdEnv();
-    state.printOutput = ["state = running", "pid = 4242"].join("\n");
-    const killSpy = vi.spyOn(process, "kill");
-    killSpy
-      .mockImplementationOnce(() => true)
-      .mockImplementationOnce(() => {
-        const err = new Error("no such process") as NodeJS.ErrnoException;
-        err.code = "ESRCH";
-        throw err;
-      });
+  it("uses a detached helper when restart is invoked from the managed gateway process tree", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
+    };
 
-    vi.useFakeTimers();
-    try {
-      const restartPromise = restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      });
-      await vi.advanceTimersByTimeAsync(250);
-      await restartPromise;
-      expect(killSpy).toHaveBeenCalledWith(4242, 0);
-      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-      const label = "ai.openclaw.gateway";
-      const bootoutIndex = state.launchctlCalls.findIndex(
-        (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
-      );
-      const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
-      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-      expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    } finally {
-      vi.useRealTimers();
-      killSpy.mockRestore();
-    }
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    expect(state.launchctlCalls).toEqual([]);
+    expect(state.spawnCalls).toHaveLength(1);
+    expect(state.spawnCalls[0]?.file).toBe("/bin/sh");
+    expect(state.spawnCalls[0]?.options).toEqual(
+      expect.objectContaining({
+        detached: true,
+        stdio: "ignore",
+      }),
+    );
+    expect(
+      Array.from(state.files.values()).some((content) =>
+        content.includes("launchctl kickstart -k"),
+      ),
+    ).toBe(true);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -393,17 +394,26 @@ async function prepareDetachedLaunchAgentRestartScript(
   plistPath: string,
 ): Promise<string | null> {
   try {
-    const scriptPath = path.join(os.tmpdir(), `openclaw-launchd-restart-${Date.now()}.sh`);
+    const scriptId = randomUUID();
+    const scriptPath = path.join(os.tmpdir(), `openclaw-launchd-restart-${scriptId}.sh`);
+    const kickstartErrPath = path.join(os.tmpdir(), `openclaw-launchd-kickstart-${scriptId}.log`);
     const escapedServiceId = shellEscape(serviceId);
     const escapedDomain = shellEscape(domain);
     const escapedPlistPath = shellEscape(plistPath);
+    const escapedKickstartErrPath = shellEscape(kickstartErrPath);
     const scriptContent = `#!/bin/sh
 sleep 1
-if ! launchctl kickstart -k '${escapedServiceId}' 2>/dev/null; then
+if launchctl kickstart -k '${escapedServiceId}' >'${escapedKickstartErrPath}' 2>&1; then
+  rm -f '${escapedKickstartErrPath}'
+  rm -f "$0"
+  exit 0
+fi
+if grep -qiE 'no such process|could not find service|not found' '${escapedKickstartErrPath}' 2>/dev/null; then
   launchctl enable '${escapedServiceId}' 2>/dev/null
   launchctl bootstrap '${escapedDomain}' '${escapedPlistPath}' 2>/dev/null
   launchctl kickstart -k '${escapedServiceId}' 2>/dev/null || true
 fi
+rm -f '${escapedKickstartErrPath}'
 rm -f "$0"
 `;
     await fs.writeFile(scriptPath, scriptContent, {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,6 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import {
@@ -27,6 +29,7 @@ import type {
 
 const LAUNCH_AGENT_DIR_MODE = 0o755;
 const LAUNCH_AGENT_PLIST_MODE = 0o644;
+const DETACHED_RESTART_SCRIPT_MODE = 0o700;
 
 function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefined> }): string {
   const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();
@@ -106,6 +109,10 @@ async function execLaunchctl(
   const file = isWindows ? (process.env.ComSpec ?? "cmd.exe") : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
   return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
+}
+
+function shellEscape(value: string): string {
+  return value.replace(/'/g, "'\\''");
 }
 
 function resolveGuiDomain(): string {
@@ -352,32 +359,69 @@ function isUnsupportedGuiDomain(detail: string): boolean {
   );
 }
 
-const RESTART_PID_WAIT_TIMEOUT_MS = 10_000;
-const RESTART_PID_WAIT_INTERVAL_MS = 200;
-
-async function sleepMs(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+function formatLaunchAgentBootstrapError(detail: string, domain: string): Error {
+  if (isUnsupportedGuiDomain(detail)) {
+    return new Error(
+      [
+        `launchctl bootstrap failed: ${detail}`,
+        `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
+        "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
+        "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway restart`.",
+        "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
+      ].join("\n"),
+    );
+  }
+  return new Error(`launchctl bootstrap failed: ${detail}`);
 }
 
-async function waitForPidExit(pid: number): Promise<void> {
-  if (!Number.isFinite(pid) || pid <= 1) {
-    return;
+export function shouldUseDetachedLaunchAgentRestart(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): boolean {
+  const marker = env.OPENCLAW_SERVICE_MARKER?.trim();
+  const serviceKind = env.OPENCLAW_SERVICE_KIND?.trim();
+  if (marker === "openclaw" && serviceKind === "gateway") {
+    return true;
   }
-  const deadline = Date.now() + RESTART_PID_WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ESRCH" || code === "EPERM") {
-        return;
-      }
-      return;
-    }
-    await sleepMs(RESTART_PID_WAIT_INTERVAL_MS);
+
+  const label = resolveLaunchAgentLabel({ env });
+  return env.XPC_SERVICE_NAME?.trim() === label;
+}
+
+async function prepareDetachedLaunchAgentRestartScript(
+  serviceId: string,
+  domain: string,
+  plistPath: string,
+): Promise<string | null> {
+  try {
+    const scriptPath = path.join(os.tmpdir(), `openclaw-launchd-restart-${Date.now()}.sh`);
+    const escapedServiceId = shellEscape(serviceId);
+    const escapedDomain = shellEscape(domain);
+    const escapedPlistPath = shellEscape(plistPath);
+    const scriptContent = `#!/bin/sh
+sleep 1
+if ! launchctl kickstart -k '${escapedServiceId}' 2>/dev/null; then
+  launchctl enable '${escapedServiceId}' 2>/dev/null
+  launchctl bootstrap '${escapedDomain}' '${escapedPlistPath}' 2>/dev/null
+  launchctl kickstart -k '${escapedServiceId}' 2>/dev/null || true
+fi
+rm -f "$0"
+`;
+    await fs.writeFile(scriptPath, scriptContent, {
+      encoding: "utf8",
+      mode: DETACHED_RESTART_SCRIPT_MODE,
+    });
+    return scriptPath;
+  } catch {
+    return null;
   }
+}
+
+async function runDetachedLaunchAgentRestart(scriptPath: string): Promise<void> {
+  const child = spawn("/bin/sh", [scriptPath], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
 }
 
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
@@ -476,47 +520,52 @@ export async function restartLaunchAgent({
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const serviceId = `${domain}/${label}`;
 
-  const runtime = await execLaunchctl(["print", `${domain}/${label}`]);
-  const previousPid =
-    runtime.code === 0
-      ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
-      : undefined;
-
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
-    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
+  if (shouldUseDetachedLaunchAgentRestart(serviceEnv)) {
+    const scriptPath = await prepareDetachedLaunchAgentRestartScript(serviceId, domain, plistPath);
+    if (scriptPath) {
+      await runDetachedLaunchAgentRestart(scriptPath);
+      try {
+        stdout.write(`${formatLine("Scheduled LaunchAgent restart", serviceId)}\n`);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+          throw err;
+        }
+      }
+      return;
+    }
   }
-  if (typeof previousPid === "number") {
-    await waitForPidExit(previousPid);
+
+  const start = await execLaunchctl(["kickstart", "-k", serviceId]);
+  if (start.code === 0) {
+    try {
+      stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+        throw err;
+      }
+    }
+    return;
+  }
+  if (!isLaunchctlNotLoaded(start)) {
+    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
 
-  // launchd can persist "disabled" state after bootout; clear it before bootstrap
-  // (matches the same guard in installLaunchAgent).
-  await execLaunchctl(["enable", `${domain}/${label}`]);
+  // launchd can persist "disabled" state while the plist still exists; clear it before bootstrap.
+  await execLaunchctl(["enable", serviceId]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();
-    if (isUnsupportedGuiDomain(detail)) {
-      throw new Error(
-        [
-          `launchctl bootstrap failed: ${detail}`,
-          `LaunchAgent restart requires a logged-in macOS GUI session for this user (${domain}).`,
-          "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
-          "Fix: sign in to the macOS desktop as the target user and rerun `openclaw gateway restart`.",
-          "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
-        ].join("\n"),
-      );
-    }
-    throw new Error(`launchctl bootstrap failed: ${detail}`);
+    throw formatLaunchAgentBootstrapError(detail, domain);
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
-  if (start.code !== 0) {
-    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+  const retry = await execLaunchctl(["kickstart", "-k", serviceId]);
+  if (retry.code !== 0) {
+    throw new Error(`launchctl kickstart failed: ${retry.stderr || retry.stdout}`.trim());
   }
   try {
-    stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+    stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
       throw err;


### PR DESCRIPTION
## Summary

- Problem: `docs/plugins/community.md` only allowed npm-published plugins even though OpenClaw already documents source/local-path plugin installs in `docs/tools/plugin.md`.
- Why it matters: community plugins that are safe and documented but not yet published on npm cannot be listed or discovered.
- What changed: broadened the community plugin listing criteria to allow npm or documented source-install workflows, and added `chat-only-trigger` with copy-pasteable source install commands.
- What did NOT change (scope boundary): no runtime/plugin loader behavior changed; docs only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: None
- Related:
  - https://github.com/constansino/openclaw-chat-only-trigger
  - https://github.com/constansino/openclaw-chat-only-trigger/releases/tag/v0.1.0
  - https://github.com/openclaw/openclaw/issues/25963#issuecomment-4034887315
  - https://github.com/openclaw/openclaw/issues/20321#issuecomment-4034887313
  - https://github.com/openclaw/openclaw/issues/36671#issuecomment-4034889908
  - https://github.com/openclaw/openclaw/pull/18810#issuecomment-4034891709
  - https://github.com/openclaw/openclaw/pull/33914#issuecomment-4034889916
  - https://github.com/openclaw/openclaw/pull/39479#issuecomment-4034889912

## User-visible / Behavior Changes

- `docs/plugins/community` now accepts community plugins installable from npm or from a public source checkout/local path.
- The page now lists `Chat Only Trigger`, a deployment-side safety plugin for keyword-triggered and whitelist-gated chat-only mode in public/group channels.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: docs-only change in local checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Compare `docs/plugins/community.md` against `docs/tools/plugin.md`.
2. Verify `docs/tools/plugin.md` already documents `openclaw plugins install <path>` and `openclaw plugins install -l <path>`.
3. Verify the updated community docs now allow source-install plugins and include a copy-pasteable install snippet for `chat-only-trigger`.

### Expected

- Community plugin docs reflect both supported installation paths.
- `chat-only-trigger` is listed as a community plugin with public repo/install docs.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Snippet used for verification:

```text
docs/tools/plugin.md
openclaw plugins install <path>                 # copy a local file/dir into ~/.openclaw/extensions/<id>
openclaw plugins install ./extensions/voice-call # relative path ok
openclaw plugins install -l ./extensions/voice-call # link (no copy) for dev
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked the updated page copy, install examples, and link target against existing docs.
- Edge cases checked: source-install-only entry format with fenced `install` block; existing npm-format entry unchanged.
- What you did **not** verify: Mintlify preview / repo prettier check; `pnpm exec prettier --check docs/plugins/community.md` failed locally because `prettier` is not available in this checkout.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or remove the docs entry/policy text.
- Files/config to restore: `docs/plugins/community.md`
- Known bad symptoms reviewers should watch for: confusion if docs policy wording implies remote Git URLs are installable directly; this PR intentionally documents source checkout/local-path install only.

## Risks and Mitigations

- Risk: Broadening listing criteria could make the page admit lower-signal source-only plugins.
  - Mitigation: The existing quality bar still requires a public repo, setup docs, issue tracker, and active maintenance signal, and the entry uses a documented local-path install flow already supported by OpenClaw.
