### PR TITLE
fix(auth-profiles): canonicalize legacy default oauth session override

### DIFF
--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -262,4 +262,72 @@ describe("resolveSessionAuthProfileOverride", () => {
       expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     });
   });
+
+  it("advances rotation when next raw profile canonicalizes back to the current alias", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            access: "access-token-default",
+          },
+          "openai-codex:token": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "token@example.com",
+            access: "access-token-token",
+          },
+          "openai-codex:user": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            access: "access-token-user",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:default", "openai-codex:token", "openai-codex:user"],
+        },
+      });
+
+      const cfg = {
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "oauth",
+              email: "josh@example.com",
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s6",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:user",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:telegram:direct:8578467390": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:direct:8578467390",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("openai-codex:token");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:token");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
 });

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -113,7 +113,7 @@ describe("resolveSessionAuthProfileOverride", () => {
     });
   });
 
-  it("prefers non-default oauth alias even when alias email metadata is missing", async () => {
+  it("prefers non-default oauth alias even when legacy default has no usable identity", async () => {
     await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
       const agentDir = path.join(stateDir, "agent");
       await fs.mkdir(agentDir, { recursive: true });
@@ -123,8 +123,6 @@ describe("resolveSessionAuthProfileOverride", () => {
           "openai-codex:default": {
             type: "oauth",
             provider: "openai-codex",
-            email: "josh@example.com",
-            accountId: "acct_123",
             access: "access-token-default",
           },
           "openai-codex:josh%40example.com": {
@@ -160,6 +158,58 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("openai-codex:josh%40example.com");
       expect(sessionEntry.authProfileOverride).toBe("openai-codex:josh%40example.com");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
+
+  it("does not remap to another alias when legacy default identity exists but does not match", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            accountId: "acct_josh",
+            access: "access-token-default",
+          },
+          "openai-codex:alex%40example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "alex@example.com",
+            accountId: "acct_alex",
+            access: "access-token-alex",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:default", "openai-codex:alex%40example.com"],
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s4",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:telegram:direct:8578467390": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:direct:8578467390",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
       expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     });
   });

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -214,6 +214,110 @@ describe("resolveSessionAuthProfileOverride", () => {
     });
   });
 
+  it("does not remap when email matches but account id conflicts", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            accountId: "acct_josh",
+            access: "access-token-default",
+          },
+          "openai-codex:josh%40example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            accountId: "acct_other",
+            access: "access-token-email",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:josh%40example.com", "openai-codex:default"],
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s4b",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:telegram:direct:8578467390": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:direct:8578467390",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
+
+  it("does not remap when account id matches but email conflicts", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            accountId: "acct_josh",
+            access: "access-token-default",
+          },
+          "openai-codex:acct_josh": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "alex@example.com",
+            accountId: "acct_josh",
+            access: "access-token-account",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:acct_josh", "openai-codex:default"],
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s4c",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:telegram:direct:8578467390": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:direct:8578467390",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
+
   it("does not remap non-oauth default overrides to oauth aliases", async () => {
     await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
       const agentDir = path.join(stateDir, "agent");

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -213,4 +213,53 @@ describe("resolveSessionAuthProfileOverride", () => {
       expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     });
   });
+
+  it("does not remap non-oauth default overrides to oauth aliases", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "api_key",
+            provider: "openai-codex",
+            key: "sk-default",
+          },
+          "openai-codex:josh%40example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            access: "access-token-josh",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:default", "openai-codex:josh%40example.com"],
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s5",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:telegram:direct:8578467390": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:direct:8578467390",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
 });

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -6,9 +6,9 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import { resolveSessionAuthProfileOverride } from "./session-override.js";
 
-async function writeAuthStore(agentDir: string) {
+async function writeAuthStore(agentDir: string, payload?: Record<string, unknown>) {
   const authPath = path.join(agentDir, "auth-profiles.json");
-  const payload = {
+  const defaultPayload = {
     version: 1,
     profiles: {
       "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
@@ -17,7 +17,7 @@ async function writeAuthStore(agentDir: string) {
       zai: ["zai:work"],
     },
   };
-  await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
+  await fs.writeFile(authPath, JSON.stringify(payload ?? defaultPayload), "utf-8");
 }
 
 describe("resolveSessionAuthProfileOverride", () => {
@@ -48,6 +48,119 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("canonicalizes legacy :default auto override to email profile when available", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            access: "access-token-default",
+          },
+          "openai-codex:josh@example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            access: "access-token-email",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:josh@example.com", "openai-codex:default"],
+        },
+      });
+
+      const cfg = {
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "oauth",
+              email: "josh@example.com",
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s2",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:telegram:direct:8578467390": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:direct:8578467390",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:josh@example.com");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:josh@example.com");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
+
+  it("prefers non-default oauth alias even when alias email metadata is missing", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "josh@example.com",
+            accountId: "acct_123",
+            access: "access-token-default",
+          },
+          "openai-codex:josh%40example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            accountId: "acct_123",
+            access: "access-token-email",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:default", "openai-codex:josh%40example.com"],
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s3",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:telegram:direct:8578467390": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:direct:8578467390",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:josh%40example.com");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:josh%40example.com");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     });
   });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -4,6 +4,7 @@ import {
   ensureAuthProfileStore,
   isProfileInCooldown,
   resolveAuthProfileOrder,
+  suggestOAuthProfileIdForLegacyDefault,
 } from "../auth-profiles.js";
 import { normalizeProviderId } from "../model-selection.js";
 
@@ -85,6 +86,59 @@ export async function resolveSessionAuthProfileOverride(params: {
     return undefined;
   }
 
+  const resolveCanonicalProfile = (profileId: string | undefined): string | undefined => {
+    if (!profileId) {
+      return undefined;
+    }
+    const suggested = suggestOAuthProfileIdForLegacyDefault({
+      cfg,
+      store,
+      provider,
+      legacyProfileId: profileId,
+    });
+    const candidate = suggested && suggested !== profileId ? suggested : undefined;
+    if (candidate && order.includes(candidate) && !isProfileInCooldown(store, candidate)) {
+      return candidate;
+    }
+    if (profileId.endsWith(":default")) {
+      const legacyEntry = store.profiles[profileId];
+      const fallback = order.find((candidateId) => {
+        if (candidateId === profileId || isProfileInCooldown(store, candidateId)) {
+          return false;
+        }
+        if (candidateId.endsWith(":default")) {
+          return false;
+        }
+        const entry = store.profiles[candidateId];
+        if (entry?.type !== "oauth") {
+          return false;
+        }
+        if (legacyEntry?.type === "oauth") {
+          const sameEmail =
+            typeof legacyEntry.email === "string" &&
+            typeof entry.email === "string" &&
+            legacyEntry.email.trim().length > 0 &&
+            legacyEntry.email.trim() === entry.email.trim();
+          const sameAccount =
+            typeof legacyEntry.accountId === "string" &&
+            typeof entry.accountId === "string" &&
+            legacyEntry.accountId.length > 0 &&
+            legacyEntry.accountId === entry.accountId;
+          if (sameEmail || sameAccount) {
+            return true;
+          }
+        }
+        // Compatibility fallback: any non-default oauth alias is still more canonical
+        // than provider:default for durable session overrides.
+        return true;
+      });
+      if (fallback) {
+        return fallback;
+      }
+    }
+    return profileId;
+  };
+
   const pickFirstAvailable = () =>
     order.find((profileId) => !isProfileInCooldown(store, profileId)) ?? order[0];
   const pickNextAvailable = (active: string) => {
@@ -118,14 +172,16 @@ export async function resolveSessionAuthProfileOverride(params: {
     return current;
   }
 
-  let next = current;
+  let next = resolveCanonicalProfile(current);
   if (isNewSession) {
-    next = current ? pickNextAvailable(current) : pickFirstAvailable();
+    next = current ? pickNextAvailable(next ?? current) : pickFirstAvailable();
   } else if (current && compactionCount > storedCompaction) {
-    next = pickNextAvailable(current);
-  } else if (!current || isProfileInCooldown(store, current)) {
+    next = pickNextAvailable(next ?? current);
+  } else if (!next || isProfileInCooldown(store, next)) {
     next = pickFirstAvailable();
   }
+
+  next = resolveCanonicalProfile(next);
 
   if (!next) {
     return current;

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -102,16 +102,18 @@ export async function resolveSessionAuthProfileOverride(params: {
       if (entry?.type !== "oauth") {
         return false;
       }
-      const sameEmail =
-        typeof legacyEntry.email === "string" &&
-        typeof entry.email === "string" &&
-        legacyEntry.email.trim().length > 0 &&
-        legacyEntry.email.trim() === entry.email.trim();
-      const sameAccount =
-        typeof legacyEntry.accountId === "string" &&
-        typeof entry.accountId === "string" &&
-        legacyEntry.accountId.length > 0 &&
-        legacyEntry.accountId === entry.accountId;
+      const legacyEmail = typeof legacyEntry.email === "string" ? legacyEntry.email.trim() : "";
+      const candidateEmail = typeof entry.email === "string" ? entry.email.trim() : "";
+      const legacyAccountId =
+        typeof legacyEntry.accountId === "string" ? legacyEntry.accountId.trim() : "";
+      const candidateAccountId = typeof entry.accountId === "string" ? entry.accountId.trim() : "";
+      const hasEmailOnBoth = legacyEmail.length > 0 && candidateEmail.length > 0;
+      const hasAccountOnBoth = legacyAccountId.length > 0 && candidateAccountId.length > 0;
+      const sameEmail = hasEmailOnBoth && legacyEmail === candidateEmail;
+      const sameAccount = hasAccountOnBoth && legacyAccountId === candidateAccountId;
+      if (hasEmailOnBoth && hasAccountOnBoth) {
+        return sameEmail && sameAccount;
+      }
       return sameEmail || sameAccount;
     };
     const suggested = suggestOAuthProfileIdForLegacyDefault({

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -159,18 +159,25 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   const pickFirstAvailable = () =>
     order.find((profileId) => !isProfileInCooldown(store, profileId)) ?? order[0];
-  const pickNextAvailable = (active: string) => {
+  const pickNextAvailableWithCanonicalProgress = (active: string) => {
     const startIndex = order.indexOf(active);
     if (startIndex < 0) {
       return pickFirstAvailable();
     }
+    const activeCanonical = resolveCanonicalProfile(active);
+    let firstAvailable: string | undefined;
     for (let offset = 1; offset <= order.length; offset += 1) {
       const candidate = order[(startIndex + offset) % order.length];
-      if (!isProfileInCooldown(store, candidate)) {
+      if (isProfileInCooldown(store, candidate)) {
+        continue;
+      }
+      firstAvailable ??= candidate;
+      const candidateCanonical = resolveCanonicalProfile(candidate);
+      if (candidateCanonical && candidateCanonical !== activeCanonical) {
         return candidate;
       }
     }
-    return order[startIndex] ?? order[0];
+    return firstAvailable ?? order[startIndex] ?? order[0];
   };
 
   const compactionCount = sessionEntry.compactionCount ?? 0;
@@ -192,11 +199,11 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   let next = resolveCanonicalProfile(current);
   if (isNewSession) {
-    next = resolveCanonicalProfile(
-      current ? pickNextAvailable(next ?? current) : pickFirstAvailable(),
-    );
+    next = current ? pickNextAvailableWithCanonicalProgress(next ?? current) : pickFirstAvailable();
+    next = resolveCanonicalProfile(next);
   } else if (current && compactionCount > storedCompaction) {
-    next = resolveCanonicalProfile(pickNextAvailable(next ?? current));
+    next = pickNextAvailableWithCanonicalProgress(next ?? current);
+    next = resolveCanonicalProfile(next);
   } else if (!next || isProfileInCooldown(store, next)) {
     next = resolveCanonicalProfile(pickFirstAvailable());
   }

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -91,14 +91,13 @@ export async function resolveSessionAuthProfileOverride(params: {
       return undefined;
     }
     const legacyEntry = store.profiles[profileId];
+    if (legacyEntry?.type !== "oauth") {
+      return profileId;
+    }
     const legacyHasIdentity =
-      legacyEntry?.type === "oauth" &&
-      ((typeof legacyEntry.email === "string" && legacyEntry.email.trim().length > 0) ||
-        (typeof legacyEntry.accountId === "string" && legacyEntry.accountId.length > 0));
+      (typeof legacyEntry.email === "string" && legacyEntry.email.trim().length > 0) ||
+      (typeof legacyEntry.accountId === "string" && legacyEntry.accountId.length > 0);
     const matchesLegacyIdentity = (candidateId: string) => {
-      if (legacyEntry?.type !== "oauth") {
-        return false;
-      }
       const entry = store.profiles[candidateId];
       if (entry?.type !== "oauth") {
         return false;
@@ -193,14 +192,14 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   let next = resolveCanonicalProfile(current);
   if (isNewSession) {
-    next = current ? pickNextAvailable(next ?? current) : pickFirstAvailable();
+    next = resolveCanonicalProfile(
+      current ? pickNextAvailable(next ?? current) : pickFirstAvailable(),
+    );
   } else if (current && compactionCount > storedCompaction) {
-    next = pickNextAvailable(next ?? current);
+    next = resolveCanonicalProfile(pickNextAvailable(next ?? current));
   } else if (!next || isProfileInCooldown(store, next)) {
-    next = pickFirstAvailable();
+    next = resolveCanonicalProfile(pickFirstAvailable());
   }
-
-  next = resolveCanonicalProfile(next);
 
   if (!next) {
     return current;

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -90,6 +90,31 @@ export async function resolveSessionAuthProfileOverride(params: {
     if (!profileId) {
       return undefined;
     }
+    const legacyEntry = store.profiles[profileId];
+    const legacyHasIdentity =
+      legacyEntry?.type === "oauth" &&
+      ((typeof legacyEntry.email === "string" && legacyEntry.email.trim().length > 0) ||
+        (typeof legacyEntry.accountId === "string" && legacyEntry.accountId.length > 0));
+    const matchesLegacyIdentity = (candidateId: string) => {
+      if (legacyEntry?.type !== "oauth") {
+        return false;
+      }
+      const entry = store.profiles[candidateId];
+      if (entry?.type !== "oauth") {
+        return false;
+      }
+      const sameEmail =
+        typeof legacyEntry.email === "string" &&
+        typeof entry.email === "string" &&
+        legacyEntry.email.trim().length > 0 &&
+        legacyEntry.email.trim() === entry.email.trim();
+      const sameAccount =
+        typeof legacyEntry.accountId === "string" &&
+        typeof entry.accountId === "string" &&
+        legacyEntry.accountId.length > 0 &&
+        legacyEntry.accountId === entry.accountId;
+      return sameEmail || sameAccount;
+    };
     const suggested = suggestOAuthProfileIdForLegacyDefault({
       cfg,
       store,
@@ -97,11 +122,15 @@ export async function resolveSessionAuthProfileOverride(params: {
       legacyProfileId: profileId,
     });
     const candidate = suggested && suggested !== profileId ? suggested : undefined;
-    if (candidate && order.includes(candidate) && !isProfileInCooldown(store, candidate)) {
+    if (
+      candidate &&
+      order.includes(candidate) &&
+      !isProfileInCooldown(store, candidate) &&
+      (!legacyHasIdentity || matchesLegacyIdentity(candidate))
+    ) {
       return candidate;
     }
     if (profileId.endsWith(":default")) {
-      const legacyEntry = store.profiles[profileId];
       const fallback = order.find((candidateId) => {
         if (candidateId === profileId || isProfileInCooldown(store, candidateId)) {
           return false;
@@ -113,23 +142,13 @@ export async function resolveSessionAuthProfileOverride(params: {
         if (entry?.type !== "oauth") {
           return false;
         }
-        if (legacyEntry?.type === "oauth") {
-          const sameEmail =
-            typeof legacyEntry.email === "string" &&
-            typeof entry.email === "string" &&
-            legacyEntry.email.trim().length > 0 &&
-            legacyEntry.email.trim() === entry.email.trim();
-          const sameAccount =
-            typeof legacyEntry.accountId === "string" &&
-            typeof entry.accountId === "string" &&
-            legacyEntry.accountId.length > 0 &&
-            legacyEntry.accountId === entry.accountId;
-          if (sameEmail || sameAccount) {
-            return true;
-          }
+        if (matchesLegacyIdentity(candidateId)) {
+          return true;
         }
-        // Compatibility fallback: any non-default oauth alias is still more canonical
-        // than provider:default for durable session overrides.
+        if (legacyHasIdentity) {
+          return false;
+        }
+        // Compatibility fallback: only when legacy default has no usable identity.
         return true;
       });
       if (fallback) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: sessions with `authProfileOverride=provider:default` could remain pinned to the legacy default id even when a canonical oauth alias (for example `provider:user@example.com`) existed.
- Why it matters: override drift makes profile identity less durable and can cause confusing auth/profile behavior across compaction/session lifecycle.
- What changed: `resolveSessionAuthProfileOverride` now canonicalizes legacy default ids to preferred oauth aliases (including fallback preference for non-`*:default` oauth aliases), with cooldown-aware selection.
- What did NOT change (scope boundary): no transport/auth provider protocol changes, no new permissions, no config schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Auto session overrides that were previously stored as `provider:default` now resolve to canonical oauth aliases when available, reducing legacy-default persistence.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Arch)
- Runtime/container: local dev checkout
- Model/provider: N/A (unit tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): auth profile store fixture with legacy default + oauth aliases

### Steps

1. Create auth profile store containing `openai-codex:default` and non-default oauth alias entries.
2. Set `sessionEntry.authProfileOverride = "openai-codex:default"` with source `auto`.
3. Call `resolveSessionAuthProfileOverride(...)`.

### Expected

- Resolution prefers canonical non-default oauth alias where available.

### Actual

- After patch, resolution returns alias (`openai-codex:josh@example.com` or fallback oauth alias) and updates session override accordingly.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

```bash
pnpm vitest run src/agents/auth-profiles/session-override.test.ts
# PASS: 3 tests
```

Added regression coverage:
- canonicalizes legacy `:default` auto override to email profile when available
- prefers non-default oauth alias even when alias email metadata is missing

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Legacy default auto override canonicalizes to oauth alias.
  - Fallback alias selection works without alias email metadata.
  - Existing test behavior remains green.
- Edge cases checked:
  - Cooldown-aware candidate selection remains respected by resolver flow.
- What you did **not** verify:
  - Full cross-provider matrix beyond `openai-codex` fixtures.
  - End-to-end multi-session rotation under production load.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `298c85847`.
- Files/config to restore:
  - `src/agents/auth-profiles/session-override.ts`
  - `src/agents/auth-profiles/session-override.test.ts`
- Known bad symptoms reviewers should watch for:
  - sessions unexpectedly sticking to legacy `provider:default` ids after override resolution.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: canonicalization may choose an unintended oauth alias when profile metadata is sparse.
  - Mitigation: preference order is constrained to provider order + oauth type + cooldown checks, with regression tests covering fallback behavior.

---
AI-assisted: Yes (implementation + drafting), human-reviewed and locally tested.
