### PR TITLE
fix(config): allow agents.list params in schema

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,5 +1,9 @@
-import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai/oauth";
-import { getOAuthApiKey, getOAuthProviders } from "@mariozechner/pi-ai/oauth";
+import {
+  getOAuthApiKey,
+  getOAuthProviders,
+  type OAuthCredentials,
+  type OAuthProvider,
+} from "@mariozechner/pi-ai/oauth";
 import { loadConfig, type OpenClawConfig } from "../../config/config.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { withFileLock } from "../../infra/file-lock.js";

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai";
+import type { OAuthCredentials, OAuthProvider } from "@mariozechner/pi-ai/oauth";
 import { getOAuthApiKey, getOAuthProviders } from "@mariozechner/pi-ai/oauth";
 import { loadConfig, type OpenClawConfig } from "../../config/config.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import type { OAuthCredentials } from "@mariozechner/pi-ai/oauth";
 import { loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,5 +1,4 @@
-import type { OAuthCredentials } from "@mariozechner/pi-ai/oauth";
-import { loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
+import { loginOpenAICodex, type OAuthCredentials } from "@mariozechner/pi-ai/oauth";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -110,6 +110,26 @@ describe("web search provider config", () => {
   });
 });
 
+describe("agents.list[].params", () => {
+  it("accepts per-agent params overrides", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            params: {
+              cacheRetention: "none",
+              temperature: 0.2,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});
+
 describe("talk.voiceAliases", () => {
   it("accepts a string map of voice aliases", () => {
     const res = validateConfigObject({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -745,6 +745,7 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,
   })


### PR DESCRIPTION
Supersedes #42442, which `openclaw-barnacle[bot]` auto-closed when my active PR queue temporarily exceeded 10.

## Summary
Fixes https://github.com/openclaw/openclaw/issues/41160

## Symptom
Config validation rejects documented `agents.list[].params` blocks, so per-agent runtime parameters cannot be set in config.

## Root cause
`types.agents.ts` defines `params?: Record<string, unknown>`, but `AgentEntrySchema` omitted the field.

## Fix
- accept `params` on `agents.list[]` in `AgentEntrySchema`
- add a regression test in `src/config/config-misc.test.ts`

## Regression test
- `pnpm exec vitest run src/config/config-misc.test.ts`