### PR TITLE
fix(discord): restore triage reactions for guild_id-only reaction payloads

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1209,6 +1209,43 @@ describe("discord DM reaction handling", () => {
     expect(text).not.toContain("Reaction command:");
   });
 
+  it("emits triage command even when own-mode message fetch fails", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      emojiName: "❌",
+      userId: "123",
+      messageId: "msg-own-fetch-fail",
+      guild: { name: "Test Guild" },
+      messageFetch: vi.fn(async () => {
+        throw new Error("fetch failed");
+      }),
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionListener(
+      makeReactionListenerParams({
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "own",
+            users: ["123"],
+          },
+        }),
+      }),
+    );
+
+    await listener.handle(data, client);
+
+    expect(resolveAgentRouteMock).toHaveBeenCalledOnce();
+
+    const commandCall = enqueueSystemEventSpy.mock.calls.find(([text]) =>
+      String(text).includes("Reaction command: reject (❌)"),
+    );
+    expect(commandCall).toBeDefined();
+  });
+
   it("adds a stable dedupe key to triage command intents", async () => {
     enqueueSystemEventSpy.mockClear();
     resolveAgentRouteMock.mockClear();

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1126,9 +1126,25 @@ describe("discord DM reaction handling", () => {
     enqueueSystemEventSpy.mockClear();
     resolveAgentRouteMock.mockClear();
 
-    const data = makeReactionEvent({ botAsAuthor: true, emojiName: "✅" });
-    const client = makeReactionClient({ channelType: ChannelType.DM });
-    const listener = new DiscordReactionListener(makeReactionListenerParams());
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      botAsAuthor: true,
+      emojiName: "✅",
+      userId: "123",
+      guild: { name: "Test Guild" },
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionListener(
+      makeReactionListenerParams({
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "own",
+            users: ["123"],
+          },
+        }),
+      }),
+    );
 
     await listener.handle(data, client);
 
@@ -1148,6 +1164,40 @@ describe("discord DM reaction handling", () => {
     expect(secondCall[0]).toContain("Reaction command: accept (✅)");
     expect(secondCall[1].sessionKey).toBe(firstCall[1].sessionKey);
     expect(secondCall[1].contextKey).toBe(firstCall[1].contextKey);
+  });
+
+  it("does not emit triage reaction commands for unauthorized reactors", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      botAsAuthor: true,
+      emojiName: "✅",
+      userId: "untrusted-user",
+      guild: { name: "Test Guild" },
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionListener(
+      makeReactionListenerParams({
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "own",
+            users: ["123"],
+          },
+        }),
+      }),
+    );
+
+    await listener.handle(data, client);
+
+    expect(resolveAgentRouteMock).toHaveBeenCalledOnce();
+    expect(enqueueSystemEventSpy).toHaveBeenCalledOnce();
+
+    const [text] = enqueueSystemEventSpy.mock.calls[0] as [string, { sessionKey: string }];
+    expect(text).toContain("Discord reaction added");
+    expect(text).not.toContain("Reaction command:");
   });
 });
 

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1308,6 +1308,39 @@ describe("discord DM reaction handling", () => {
     );
     expect(commandCalls).toHaveLength(0);
   });
+
+  it("emits triage command intents when allowNameMatching authorizes by username", async () => {
+    enqueueSystemEventSpy.mockClear();
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      botAsAuthor: true,
+      emojiName: "✅",
+      userId: "user-not-in-id-allowlist",
+      messageId: "msg-name-match",
+      guild: { name: "Test Guild" },
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionListener(
+      makeReactionListenerParams({
+        allowNameMatching: true,
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "allowlist",
+            users: ["testuser"],
+          },
+        }),
+      }),
+    );
+
+    await listener.handle(data, client);
+
+    const commandCalls = enqueueSystemEventSpy.mock.calls.filter(([text]) =>
+      String(text).includes("Reaction command: accept (✅)"),
+    );
+    expect(commandCalls).toHaveLength(1);
+  });
 });
 
 describe("discord reaction notification modes", () => {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1199,6 +1199,42 @@ describe("discord DM reaction handling", () => {
     expect(text).toContain("Discord reaction added");
     expect(text).not.toContain("Reaction command:");
   });
+
+  it("adds a stable dedupe key to triage command intents", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      botAsAuthor: true,
+      emojiName: "✅",
+      userId: "123",
+      messageId: "msg-replay-1",
+      guild: { name: "Test Guild" },
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionListener(
+      makeReactionListenerParams({
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "own",
+            users: ["123"],
+          },
+        }),
+      }),
+    );
+
+    await listener.handle(data, client);
+
+    const commandCall = enqueueSystemEventSpy.mock.calls.find(([text]) =>
+      String(text).includes("Reaction command: accept (✅)"),
+    );
+    expect(commandCall).toBeDefined();
+    const options = commandCall?.[1] as { dedupeKey?: string; dedupeTtlMs?: number };
+    expect(options.dedupeKey).toBe("discord:reaction:cmd:added:msg-replay-1:123:✅:accept");
+    expect(options.dedupeTtlMs).toBe(60_000);
+  });
 });
 
 describe("discord reaction notification modes", () => {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1276,6 +1276,38 @@ describe("discord DM reaction handling", () => {
     expect(sessionKey).toBe("discord:acc-1:dm:user-1");
     expect(dedupeKey).toBe("discord:reaction:cmd:added:msg-replay-1:123:✅:accept");
   });
+
+  it("does not emit triage command intents for non-bot-authored messages in allowlist mode", async () => {
+    enqueueSystemEventSpy.mockClear();
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      botAsAuthor: false,
+      emojiName: "✅",
+      userId: "123",
+      messageId: "msg-allowlist-nonbot",
+      guild: { name: "Test Guild" },
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionListener(
+      makeReactionListenerParams({
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "allowlist",
+            users: ["123"],
+          },
+        }),
+      }),
+    );
+
+    await listener.handle(data, client);
+
+    const commandCalls = enqueueSystemEventSpy.mock.calls.filter(([text]) =>
+      String(text).includes("Reaction command:"),
+    );
+    expect(commandCalls).toHaveLength(0);
+  });
 });
 
 describe("discord reaction notification modes", () => {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1121,6 +1121,34 @@ describe("discord DM reaction handling", () => {
     }
     expect(routeArgs.peer).toEqual({ kind: "group", id: "channel-1" });
   });
+
+  it("reuses one route and one context key for triage reaction commands", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({ botAsAuthor: true, emojiName: "✅" });
+    const client = makeReactionClient({ channelType: ChannelType.DM });
+    const listener = new DiscordReactionListener(makeReactionListenerParams());
+
+    await listener.handle(data, client);
+
+    expect(resolveAgentRouteMock).toHaveBeenCalledOnce();
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(2);
+
+    const firstCall = enqueueSystemEventSpy.mock.calls[0] as [
+      string,
+      { sessionKey: string; contextKey?: string },
+    ];
+    const secondCall = enqueueSystemEventSpy.mock.calls[1] as [
+      string,
+      { sessionKey: string; contextKey?: string },
+    ];
+
+    expect(firstCall[0]).toContain("Discord reaction added");
+    expect(secondCall[0]).toContain("Reaction command: accept (✅)");
+    expect(secondCall[1].sessionKey).toBe(firstCall[1].sessionKey);
+    expect(secondCall[1].contextKey).toBe(firstCall[1].contextKey);
+  });
 });
 
 describe("discord reaction notification modes", () => {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -18,7 +18,11 @@ import {
   sanitizeDiscordThreadName,
   shouldEmitDiscordReactionNotification,
 } from "./monitor.js";
-import { DiscordMessageListener, DiscordReactionListener } from "./monitor/listeners.js";
+import {
+  DiscordMessageListener,
+  DiscordReactionListener,
+  DiscordReactionRemoveListener,
+} from "./monitor/listeners.js";
 
 const readAllowFromStoreMock = vi.hoisted(() => vi.fn());
 
@@ -834,19 +838,23 @@ describe("discord media payload", () => {
 // These test that handleDiscordReactionEvent (via DiscordReactionListener)
 // properly handles DM reactions instead of silently dropping them.
 
-const { enqueueSystemEventSpy, resolveAgentRouteMock } = vi.hoisted(() => ({
-  enqueueSystemEventSpy: vi.fn(),
-  resolveAgentRouteMock: vi.fn((params: unknown) => ({
-    agentId: "default",
-    channel: "discord",
-    accountId: "acc-1",
-    sessionKey: "discord:acc-1:dm:user-1",
-    ...(typeof params === "object" && params !== null ? { _params: params } : {}),
-  })),
-}));
+const { enqueueSystemEventSpy, clearSystemEventDedupeKeySpy, resolveAgentRouteMock } = vi.hoisted(
+  () => ({
+    enqueueSystemEventSpy: vi.fn(),
+    clearSystemEventDedupeKeySpy: vi.fn(),
+    resolveAgentRouteMock: vi.fn((params: unknown) => ({
+      agentId: "default",
+      channel: "discord",
+      accountId: "acc-1",
+      sessionKey: "discord:acc-1:dm:user-1",
+      ...(typeof params === "object" && params !== null ? { _params: params } : {}),
+    })),
+  }),
+);
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: enqueueSystemEventSpy,
+  clearSystemEventDedupeKey: clearSystemEventDedupeKeySpy,
 }));
 
 vi.mock("../routing/resolve-route.js", () => ({
@@ -952,6 +960,7 @@ function makeReactionListenerParams(overrides?: {
 describe("discord DM reaction handling", () => {
   beforeEach(() => {
     enqueueSystemEventSpy.mockClear();
+    clearSystemEventDedupeKeySpy.mockClear();
     resolveAgentRouteMock.mockClear();
     readAllowFromStoreMock.mockReset().mockResolvedValue([]);
   });
@@ -1234,6 +1243,38 @@ describe("discord DM reaction handling", () => {
     const options = commandCall?.[1] as { dedupeKey?: string; dedupeTtlMs?: number };
     expect(options.dedupeKey).toBe("discord:reaction:cmd:added:msg-replay-1:123:✅:accept");
     expect(options.dedupeTtlMs).toBe(60_000);
+  });
+
+  it("clears triage command dedupe key on reaction remove", async () => {
+    clearSystemEventDedupeKeySpy.mockClear();
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      botAsAuthor: true,
+      emojiName: "✅",
+      userId: "123",
+      messageId: "msg-replay-1",
+      guild: { name: "Test Guild" },
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionRemoveListener(
+      makeReactionListenerParams({
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "own",
+            users: ["123"],
+          },
+        }),
+      }),
+    );
+
+    await listener.handle(data, client);
+
+    expect(clearSystemEventDedupeKeySpy).toHaveBeenCalledOnce();
+    const [sessionKey, dedupeKey] = clearSystemEventDedupeKeySpy.mock.calls[0] as [string, string];
+    expect(sessionKey).toBe("discord:acc-1:dm:user-1");
+    expect(dedupeKey).toBe("discord:reaction:cmd:added:msg-replay-1:123:✅:accept");
   });
 });
 

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1277,6 +1277,40 @@ describe("discord DM reaction handling", () => {
     expect(dedupeKey).toBe("discord:reaction:cmd:added:msg-replay-1:123:✅:accept");
   });
 
+  it("clears triage command dedupe key on remove even when own-mode message fetch fails", async () => {
+    clearSystemEventDedupeKeySpy.mockClear();
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      emojiName: "✅",
+      userId: "123",
+      messageId: "msg-remove-fetch-fail",
+      guild: { name: "Test Guild" },
+      messageFetch: vi.fn(async () => {
+        throw new Error("fetch failed");
+      }),
+    });
+    const client = makeReactionClient({ channelType: ChannelType.GuildText });
+    const listener = new DiscordReactionRemoveListener(
+      makeReactionListenerParams({
+        guildEntries: makeEntries({
+          "guild-123": {
+            slug: "guild-123",
+            reactionNotifications: "own",
+            users: ["123"],
+          },
+        }),
+      }),
+    );
+
+    await listener.handle(data, client);
+
+    expect(clearSystemEventDedupeKeySpy).toHaveBeenCalledOnce();
+    const [sessionKey, dedupeKey] = clearSystemEventDedupeKeySpy.mock.calls[0] as [string, string];
+    expect(sessionKey).toBe("discord:acc-1:dm:user-1");
+    expect(dedupeKey).toBe("discord:reaction:cmd:added:msg-remove-fetch-fail:123:✅:accept");
+  });
+
   it("does not emit triage command intents for non-bot-authored messages in allowlist mode", async () => {
     enqueueSystemEventSpy.mockClear();
 

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -555,6 +555,14 @@ async function handleDiscordReactionEvent(
         allowNameMatching: params.allowNameMatching,
       });
     };
+    const canForceReactionCommandWithoutAuthor = (options: {
+      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+      mode?: "off" | "own" | "all" | "allowlist";
+      messageAuthorId?: string;
+    }) => {
+      const mode = options.mode ?? guildInfo?.reactionNotifications ?? "own";
+      return mode === "own" && !options.messageAuthorId && canEmitReactionCommand(options);
+    };
     const resolveReactionCommand = () => {
       const emojiLabel = formatDiscordReactionEmoji(data.emoji);
       const reactionCommand =
@@ -618,6 +626,7 @@ async function handleDiscordReactionEvent(
       channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
       messageAuthorId?: string;
       mode?: "off" | "own" | "all" | "allowlist";
+      forceWhenAuthorUnknown?: boolean;
     }) => {
       const resolved = resolveReactionCommand();
       if (!resolved) {
@@ -633,7 +642,10 @@ async function handleDiscordReactionEvent(
       ) {
         return;
       }
-      if (!shouldEmitReactionCommandForMessageAuthor(params.messageAuthorId)) {
+      if (
+        !shouldEmitReactionCommandForMessageAuthor(params.messageAuthorId) &&
+        !params.forceWhenAuthorUnknown
+      ) {
         return;
       }
       enqueueSystemEvent(
@@ -775,13 +787,21 @@ async function handleDiscordReactionEvent(
         channelConfig: threadChannelConfig,
         mode: reactionMode,
       });
-      if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId })) {
+      const canNotify = shouldNotifyReaction({ mode: reactionMode, messageAuthorId });
+      const forceCommandWithoutAuthor = canForceReactionCommandWithoutAuthor({
+        channelConfig: threadChannelConfig,
+        mode: reactionMode,
+        messageAuthorId,
+      });
+      if (!canNotify && !forceCommandWithoutAuthor) {
         return;
       }
 
       const route = resolveReactionRoute(parentId);
       const { contextKey } = resolveReactionBase();
-      emitReactionWithAuthor(message, route, contextKey);
+      if (canNotify) {
+        emitReactionWithAuthor(message, route, contextKey);
+      }
       if (action === "added") {
         emitReactionCommand({
           route,
@@ -789,6 +809,7 @@ async function handleDiscordReactionEvent(
           channelConfig: threadChannelConfig,
           messageAuthorId,
           mode: reactionMode,
+          forceWhenAuthorUnknown: forceCommandWithoutAuthor,
         });
       }
       return;
@@ -851,13 +872,21 @@ async function handleDiscordReactionEvent(
     const message = await loadReactionMessage();
     const messageAuthorId = message?.author?.id ?? undefined;
     clearReactionCommandDedupeForRemove({ channelConfig, mode: reactionMode });
-    if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId })) {
+    const canNotify = shouldNotifyReaction({ mode: reactionMode, messageAuthorId });
+    const forceCommandWithoutAuthor = canForceReactionCommandWithoutAuthor({
+      channelConfig,
+      mode: reactionMode,
+      messageAuthorId,
+    });
+    if (!canNotify && !forceCommandWithoutAuthor) {
       return;
     }
 
     const route = resolveReactionRoute(parentId);
     const { contextKey } = resolveReactionBase();
-    emitReactionWithAuthor(message, route, contextKey);
+    if (canNotify) {
+      emitReactionWithAuthor(message, route, contextKey);
+    }
     if (action === "added") {
       emitReactionCommand({
         route,
@@ -865,6 +894,7 @@ async function handleDiscordReactionEvent(
         channelConfig,
         messageAuthorId,
         mode: reactionMode,
+        forceWhenAuthorUnknown: forceCommandWithoutAuthor,
       });
     }
   } catch (err) {

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -531,14 +531,19 @@ async function handleDiscordReactionEvent(
     };
     const canEmitReactionCommand = (options: {
       channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+      mode?: "off" | "own" | "all" | "allowlist";
     }) => {
+      const mode = options.mode ?? guildInfo?.reactionNotifications ?? "own";
+      if (mode === "off") {
+        return false;
+      }
       const userAllowList = options.channelConfig?.users ?? guildInfo?.users;
       const roleAllowList = options.channelConfig?.roles ?? guildInfo?.roles;
       const hasRestriction =
         (Array.isArray(userAllowList) && userAllowList.length > 0) ||
         (Array.isArray(roleAllowList) && roleAllowList.length > 0);
       if (!hasRestriction) {
-        return false;
+        return mode !== "allowlist";
       }
       return resolveDiscordMemberAllowed({
         userAllowList,
@@ -572,6 +577,7 @@ async function handleDiscordReactionEvent(
       Boolean(botUserId && messageAuthorId && messageAuthorId === botUserId);
     const shouldAttemptReactionCommand = (params: {
       channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+      mode?: "off" | "own" | "all" | "allowlist";
     }) => {
       const resolved = resolveReactionCommand();
       if (!resolved) {
@@ -580,13 +586,17 @@ async function handleDiscordReactionEvent(
       if (action === "removed") {
         return true;
       }
-      return action === "added" && canEmitReactionCommand({ channelConfig: params.channelConfig });
+      return (
+        action === "added" &&
+        canEmitReactionCommand({ channelConfig: params.channelConfig, mode: params.mode })
+      );
     };
     const emitReactionCommand = (params: {
       route: ReturnType<typeof resolveAgentRoute>;
       contextKey: string;
       channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
       messageAuthorId?: string;
+      mode?: "off" | "own" | "all" | "allowlist";
     }) => {
       const resolved = resolveReactionCommand();
       if (!resolved) {
@@ -596,7 +606,10 @@ async function handleDiscordReactionEvent(
         clearSystemEventDedupeKey(params.route.sessionKey, resolved.dedupeKey);
         return;
       }
-      if (action !== "added" || !canEmitReactionCommand({ channelConfig: params.channelConfig })) {
+      if (
+        action !== "added" ||
+        !canEmitReactionCommand({ channelConfig: params.channelConfig, mode: params.mode })
+      ) {
         return;
       }
       if (!shouldEmitReactionCommandForMessageAuthor(params.messageAuthorId)) {
@@ -709,7 +722,10 @@ async function handleDiscordReactionEvent(
           }
         }
 
-        const messageAuthorId = shouldAttemptReactionCommand({ channelConfig: threadChannelConfig })
+        const messageAuthorId = shouldAttemptReactionCommand({
+          channelConfig: threadChannelConfig,
+          mode: reactionMode,
+        })
           ? await loadReactionMessageAuthorId()
           : undefined;
         const route = resolveReactionRoute(parentId);
@@ -720,6 +736,7 @@ async function handleDiscordReactionEvent(
           contextKey,
           channelConfig: threadChannelConfig,
           messageAuthorId,
+          mode: reactionMode,
         });
         return;
       }
@@ -745,6 +762,7 @@ async function handleDiscordReactionEvent(
         contextKey,
         channelConfig: threadChannelConfig,
         messageAuthorId,
+        mode: reactionMode,
       });
       return;
     }
@@ -783,13 +801,22 @@ async function handleDiscordReactionEvent(
         }
       }
 
-      const messageAuthorId = shouldAttemptReactionCommand({ channelConfig })
+      const messageAuthorId = shouldAttemptReactionCommand({
+        channelConfig,
+        mode: reactionMode,
+      })
         ? await loadReactionMessageAuthorId()
         : undefined;
       const route = resolveReactionRoute(parentId);
       const { baseText, contextKey } = resolveReactionBase();
       emitReaction(baseText, route, contextKey);
-      emitReactionCommand({ route, contextKey, channelConfig, messageAuthorId });
+      emitReactionCommand({
+        route,
+        contextKey,
+        channelConfig,
+        messageAuthorId,
+        mode: reactionMode,
+      });
       return;
     }
 
@@ -803,7 +830,7 @@ async function handleDiscordReactionEvent(
     const route = resolveReactionRoute(parentId);
     const { contextKey } = resolveReactionBase();
     emitReactionWithAuthor(message, route, contextKey);
-    emitReactionCommand({ route, contextKey, channelConfig, messageAuthorId });
+    emitReactionCommand({ route, contextKey, channelConfig, messageAuthorId, mode: reactionMode });
   } catch (err) {
     params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
   }

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -529,11 +529,11 @@ async function handleDiscordReactionEvent(
         contextKey,
       });
     };
-    const canEmitReactionCommand = (params: {
+    const canEmitReactionCommand = (options: {
       channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
     }) => {
-      const userAllowList = params.channelConfig?.users ?? guildInfo?.users;
-      const roleAllowList = params.channelConfig?.roles ?? guildInfo?.roles;
+      const userAllowList = options.channelConfig?.users ?? guildInfo?.users;
+      const roleAllowList = options.channelConfig?.roles ?? guildInfo?.roles;
       const hasRestriction =
         (Array.isArray(userAllowList) && userAllowList.length > 0) ||
         (Array.isArray(roleAllowList) && roleAllowList.length > 0);

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -24,6 +24,7 @@ import {
   normalizeDiscordSlug,
   resolveDiscordAllowListMatch,
   resolveDiscordChannelConfigWithFallback,
+  resolveDiscordMemberAllowed,
   resolveGroupDmAllow,
   resolveDiscordGuildEntry,
   shouldEmitDiscordReactionNotification,
@@ -528,11 +529,33 @@ async function handleDiscordReactionEvent(
         contextKey,
       });
     };
+    const canEmitReactionCommand = (params: {
+      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+    }) => {
+      const userAllowList = params.channelConfig?.users ?? guildInfo?.users;
+      const roleAllowList = params.channelConfig?.roles ?? guildInfo?.roles;
+      const hasRestriction =
+        (Array.isArray(userAllowList) && userAllowList.length > 0) ||
+        (Array.isArray(roleAllowList) && roleAllowList.length > 0);
+      if (!hasRestriction) {
+        return false;
+      }
+      return resolveDiscordMemberAllowed({
+        userAllowList,
+        roleAllowList,
+        memberRoleIds,
+        userId: user.id,
+        userName: user.username,
+        userTag: formatDiscordUserTag(user),
+        allowNameMatching: params.allowNameMatching,
+      });
+    };
     const emitReactionCommand = (params: {
       route: ReturnType<typeof resolveAgentRoute>;
       contextKey: string;
+      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
     }) => {
-      if (action !== "added") {
+      if (action !== "added" || !canEmitReactionCommand({ channelConfig: params.channelConfig })) {
         return;
       }
       const emojiLabel = formatDiscordReactionEmoji(data.emoji);
@@ -634,6 +657,8 @@ async function handleDiscordReactionEvent(
           return;
         }
 
+        const threadChannelConfig = resolveThreadChannelConfig();
+
         // For allowlist mode, check if user is in allowlist first
         if (reactionMode === "allowlist") {
           if (!shouldNotifyReaction({ mode: reactionMode })) {
@@ -644,7 +669,7 @@ async function handleDiscordReactionEvent(
         const route = resolveReactionRoute(parentId);
         const { baseText, contextKey } = resolveReactionBase();
         emitReaction(baseText, route, contextKey);
-        emitReactionCommand({ route, contextKey });
+        emitReactionCommand({ route, contextKey, channelConfig: threadChannelConfig });
         return;
       }
 
@@ -662,10 +687,11 @@ async function handleDiscordReactionEvent(
         return;
       }
 
+      const threadChannelConfig = resolveThreadChannelConfig();
       const route = resolveReactionRoute(parentId);
       const { contextKey } = resolveReactionBase();
       emitReactionWithAuthor(message, route, contextKey);
-      emitReactionCommand({ route, contextKey });
+      emitReactionCommand({ route, contextKey, channelConfig: threadChannelConfig });
       return;
     }
 
@@ -706,7 +732,7 @@ async function handleDiscordReactionEvent(
       const route = resolveReactionRoute(parentId);
       const { baseText, contextKey } = resolveReactionBase();
       emitReaction(baseText, route, contextKey);
-      emitReactionCommand({ route, contextKey });
+      emitReactionCommand({ route, contextKey, channelConfig });
       return;
     }
 
@@ -720,7 +746,7 @@ async function handleDiscordReactionEvent(
     const route = resolveReactionRoute(parentId);
     const { contextKey } = resolveReactionBase();
     emitReactionWithAuthor(message, route, contextKey);
-    emitReactionCommand({ route, contextKey });
+    emitReactionCommand({ route, contextKey, channelConfig });
   } catch (err) {
     params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
   }

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -591,6 +591,27 @@ async function handleDiscordReactionEvent(
         canEmitReactionCommand({ channelConfig: params.channelConfig, mode: params.mode })
       );
     };
+    const clearReactionCommandDedupeForRemove = (params: {
+      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+      mode?: "off" | "own" | "all" | "allowlist";
+    }) => {
+      if (action !== "removed") {
+        return;
+      }
+      if (
+        !shouldAttemptReactionCommand({ channelConfig: params.channelConfig, mode: params.mode })
+      ) {
+        return;
+      }
+      const route = resolveReactionRoute(parentId);
+      const { contextKey } = resolveReactionBase();
+      emitReactionCommand({
+        route,
+        contextKey,
+        channelConfig: params.channelConfig,
+        mode: params.mode,
+      });
+    };
     const emitReactionCommand = (params: {
       route: ReturnType<typeof resolveAgentRoute>;
       contextKey: string;
@@ -749,21 +770,27 @@ async function handleDiscordReactionEvent(
       }
 
       const messageAuthorId = message?.author?.id ?? undefined;
+      const threadChannelConfig = resolveThreadChannelConfig();
+      clearReactionCommandDedupeForRemove({
+        channelConfig: threadChannelConfig,
+        mode: reactionMode,
+      });
       if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId })) {
         return;
       }
 
-      const threadChannelConfig = resolveThreadChannelConfig();
       const route = resolveReactionRoute(parentId);
       const { contextKey } = resolveReactionBase();
       emitReactionWithAuthor(message, route, contextKey);
-      emitReactionCommand({
-        route,
-        contextKey,
-        channelConfig: threadChannelConfig,
-        messageAuthorId,
-        mode: reactionMode,
-      });
+      if (action === "added") {
+        emitReactionCommand({
+          route,
+          contextKey,
+          channelConfig: threadChannelConfig,
+          messageAuthorId,
+          mode: reactionMode,
+        });
+      }
       return;
     }
 
@@ -823,6 +850,7 @@ async function handleDiscordReactionEvent(
     // For "own" mode, we need to fetch the message to check the author
     const message = await loadReactionMessage();
     const messageAuthorId = message?.author?.id ?? undefined;
+    clearReactionCommandDedupeForRemove({ channelConfig, mode: reactionMode });
     if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId })) {
       return;
     }
@@ -830,7 +858,15 @@ async function handleDiscordReactionEvent(
     const route = resolveReactionRoute(parentId);
     const { contextKey } = resolveReactionBase();
     emitReactionWithAuthor(message, route, contextKey);
-    emitReactionCommand({ route, contextKey, channelConfig, messageAuthorId, mode: reactionMode });
+    if (action === "added") {
+      emitReactionCommand({
+        route,
+        contextKey,
+        channelConfig,
+        messageAuthorId,
+        mode: reactionMode,
+      });
+    }
   } catch (err) {
     params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
   }

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -411,12 +411,32 @@ async function handleDiscordReactionEvent(
     }
 
     const isGuildMessage = Boolean(data.guild_id);
-    const guildInfo = isGuildMessage
+    let guildInfo = isGuildMessage
       ? resolveDiscordGuildEntry({
           guild: data.guild ?? undefined,
           guildEntries,
         })
       : null;
+    if (isGuildMessage && !guildInfo && data.guild_id && guildEntries) {
+      const guildEntryById = guildEntries[data.guild_id];
+      if (guildEntryById) {
+        guildInfo = {
+          ...guildEntryById,
+          id: data.guild_id,
+          slug: guildEntryById.slug ?? data.guild_id,
+        };
+      }
+      if (!guildInfo) {
+        const wildcardGuildEntry = guildEntries["*"];
+        if (wildcardGuildEntry) {
+          guildInfo = {
+            ...wildcardGuildEntry,
+            id: data.guild_id,
+            slug: wildcardGuildEntry.slug ?? data.guild_id,
+          };
+        }
+      }
+    }
     if (isGuildMessage && guildEntries && Object.keys(guildEntries).length > 0 && !guildInfo) {
       return;
     }
@@ -504,6 +524,45 @@ async function handleDiscordReactionEvent(
         contextKey,
       });
     };
+    const emitReactionCommand = (parentPeerId?: string) => {
+      if (action !== "added") {
+        return;
+      }
+      const emojiLabel = formatDiscordReactionEmoji(data.emoji);
+      const reactionCommand =
+        emojiLabel === "✅"
+          ? "accept"
+          : emojiLabel === "❌"
+            ? "reject"
+            : emojiLabel === "🔁"
+              ? "correct"
+              : emojiLabel === "✨"
+                ? "confirm"
+                : null;
+      if (!reactionCommand) {
+        return;
+      }
+      const { contextKey } = resolveReactionBase();
+      const route = resolveAgentRoute({
+        cfg: params.cfg,
+        channel: "discord",
+        accountId: params.accountId,
+        guildId: data.guild_id ?? undefined,
+        memberRoleIds,
+        peer: {
+          kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
+          id: isDirectMessage ? user.id : data.channel_id,
+        },
+        parentPeer: parentPeerId ? { kind: "channel", id: parentPeerId } : undefined,
+      });
+      enqueueSystemEvent(
+        `Reaction command: ${reactionCommand} (${emojiLabel}) for message ${data.message_id}`,
+        {
+          sessionKey: route.sessionKey,
+          contextKey: `${contextKey}:cmd:${reactionCommand}`,
+        },
+      );
+    };
     const shouldNotifyReaction = (options: {
       mode: "off" | "own" | "all" | "allowlist";
       messageAuthorId?: string;
@@ -586,6 +645,7 @@ async function handleDiscordReactionEvent(
 
         const { baseText } = resolveReactionBase();
         emitReaction(baseText, parentId);
+        emitReactionCommand(parentId);
         return;
       }
 
@@ -604,6 +664,7 @@ async function handleDiscordReactionEvent(
       }
 
       emitReactionWithAuthor(message);
+      emitReactionCommand(parentId);
       return;
     }
 
@@ -643,6 +704,7 @@ async function handleDiscordReactionEvent(
 
       const { baseText } = resolveReactionBase();
       emitReaction(baseText, parentId);
+      emitReactionCommand(parentId);
       return;
     }
 
@@ -654,6 +716,7 @@ async function handleDiscordReactionEvent(
     }
 
     emitReactionWithAuthor(message);
+    emitReactionCommand(parentId);
   } catch (err) {
     params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
   }

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -11,7 +11,7 @@ import {
 import type { OpenClawConfig } from "../../config/config.js";
 import { danger, logVerbose } from "../../globals.js";
 import { formatDurationSeconds } from "../../infra/format-time/format-duration.ts";
-import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { clearSystemEventDedupeKey, enqueueSystemEvent } from "../../infra/system-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import {
@@ -550,14 +550,7 @@ async function handleDiscordReactionEvent(
         allowNameMatching: params.allowNameMatching,
       });
     };
-    const emitReactionCommand = (params: {
-      route: ReturnType<typeof resolveAgentRoute>;
-      contextKey: string;
-      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
-    }) => {
-      if (action !== "added" || !canEmitReactionCommand({ channelConfig: params.channelConfig })) {
-        return;
-      }
+    const resolveReactionCommand = () => {
       const emojiLabel = formatDiscordReactionEmoji(data.emoji);
       const reactionCommand =
         emojiLabel === "✅"
@@ -570,14 +563,33 @@ async function handleDiscordReactionEvent(
                 ? "confirm"
                 : null;
       if (!reactionCommand) {
+        return null;
+      }
+      const dedupeKey = `discord:reaction:cmd:added:${data.message_id}:${user.id}:${emojiLabel}:${reactionCommand}`;
+      return { emojiLabel, reactionCommand, dedupeKey };
+    };
+    const emitReactionCommand = (params: {
+      route: ReturnType<typeof resolveAgentRoute>;
+      contextKey: string;
+      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+    }) => {
+      const resolved = resolveReactionCommand();
+      if (!resolved) {
+        return;
+      }
+      if (action === "removed") {
+        clearSystemEventDedupeKey(params.route.sessionKey, resolved.dedupeKey);
+        return;
+      }
+      if (action !== "added" || !canEmitReactionCommand({ channelConfig: params.channelConfig })) {
         return;
       }
       enqueueSystemEvent(
-        `Reaction command: ${reactionCommand} (${emojiLabel}) for message ${data.message_id}`,
+        `Reaction command: ${resolved.reactionCommand} (${resolved.emojiLabel}) for message ${data.message_id}`,
         {
           sessionKey: params.route.sessionKey,
           contextKey: params.contextKey,
-          dedupeKey: `discord:reaction:cmd:${action}:${data.message_id}:${user.id}:${emojiLabel}:${reactionCommand}`,
+          dedupeKey: resolved.dedupeKey,
           dedupeTtlMs: 60_000,
         },
       );

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -577,6 +577,8 @@ async function handleDiscordReactionEvent(
         {
           sessionKey: params.route.sessionKey,
           contextKey: params.contextKey,
+          dedupeKey: `discord:reaction:cmd:${action}:${data.message_id}:${user.id}:${emojiLabel}:${reactionCommand}`,
+          dedupeTtlMs: 60_000,
         },
       );
     };

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -568,10 +568,25 @@ async function handleDiscordReactionEvent(
       const dedupeKey = `discord:reaction:cmd:added:${data.message_id}:${user.id}:${emojiLabel}:${reactionCommand}`;
       return { emojiLabel, reactionCommand, dedupeKey };
     };
+    const shouldEmitReactionCommandForMessageAuthor = (messageAuthorId?: string) =>
+      Boolean(botUserId && messageAuthorId && messageAuthorId === botUserId);
+    const shouldAttemptReactionCommand = (params: {
+      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+    }) => {
+      const resolved = resolveReactionCommand();
+      if (!resolved) {
+        return false;
+      }
+      if (action === "removed") {
+        return true;
+      }
+      return action === "added" && canEmitReactionCommand({ channelConfig: params.channelConfig });
+    };
     const emitReactionCommand = (params: {
       route: ReturnType<typeof resolveAgentRoute>;
       contextKey: string;
       channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+      messageAuthorId?: string;
     }) => {
       const resolved = resolveReactionCommand();
       if (!resolved) {
@@ -582,6 +597,9 @@ async function handleDiscordReactionEvent(
         return;
       }
       if (action !== "added" || !canEmitReactionCommand({ channelConfig: params.channelConfig })) {
+        return;
+      }
+      if (!shouldEmitReactionCommandForMessageAuthor(params.messageAuthorId)) {
         return;
       }
       enqueueSystemEvent(
@@ -617,6 +635,17 @@ async function handleDiscordReactionEvent(
       const authorLabel = message?.author ? formatDiscordUserTag(message.author) : undefined;
       const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
       emitReaction(text, route, contextKey);
+    };
+    let reactionMessagePromise: Promise<{ author?: User } | null> | null = null;
+    const loadReactionMessage = async () => {
+      if (!reactionMessagePromise) {
+        reactionMessagePromise = data.message.fetch().catch(() => null);
+      }
+      return await reactionMessagePromise;
+    };
+    const loadReactionMessageAuthorId = async () => {
+      const message = await loadReactionMessage();
+      return message?.author?.id ?? undefined;
     };
     const loadThreadParentInfo = async () => {
       if (!parentId) {
@@ -680,17 +709,23 @@ async function handleDiscordReactionEvent(
           }
         }
 
+        const messageAuthorId = shouldAttemptReactionCommand({ channelConfig: threadChannelConfig })
+          ? await loadReactionMessageAuthorId()
+          : undefined;
         const route = resolveReactionRoute(parentId);
         const { baseText, contextKey } = resolveReactionBase();
         emitReaction(baseText, route, contextKey);
-        emitReactionCommand({ route, contextKey, channelConfig: threadChannelConfig });
+        emitReactionCommand({
+          route,
+          contextKey,
+          channelConfig: threadChannelConfig,
+          messageAuthorId,
+        });
         return;
       }
 
       // For "own" mode, we need to fetch the message to check the author
-      const messagePromise = data.message.fetch().catch(() => null);
-
-      const [channelInfo, message] = await Promise.all([channelInfoPromise, messagePromise]);
+      const [channelInfo, message] = await Promise.all([channelInfoPromise, loadReactionMessage()]);
       const threadAccess = await authorizeThreadChannelAccess(channelInfo);
       if (!threadAccess.allowed) {
         return;
@@ -705,7 +740,12 @@ async function handleDiscordReactionEvent(
       const route = resolveReactionRoute(parentId);
       const { contextKey } = resolveReactionBase();
       emitReactionWithAuthor(message, route, contextKey);
-      emitReactionCommand({ route, contextKey, channelConfig: threadChannelConfig });
+      emitReactionCommand({
+        route,
+        contextKey,
+        channelConfig: threadChannelConfig,
+        messageAuthorId,
+      });
       return;
     }
 
@@ -743,15 +783,18 @@ async function handleDiscordReactionEvent(
         }
       }
 
+      const messageAuthorId = shouldAttemptReactionCommand({ channelConfig })
+        ? await loadReactionMessageAuthorId()
+        : undefined;
       const route = resolveReactionRoute(parentId);
       const { baseText, contextKey } = resolveReactionBase();
       emitReaction(baseText, route, contextKey);
-      emitReactionCommand({ route, contextKey, channelConfig });
+      emitReactionCommand({ route, contextKey, channelConfig, messageAuthorId });
       return;
     }
 
     // For "own" mode, we need to fetch the message to check the author
-    const message = await data.message.fetch().catch(() => null);
+    const message = await loadReactionMessage();
     const messageAuthorId = message?.author?.id ?? undefined;
     if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId })) {
       return;
@@ -760,7 +803,7 @@ async function handleDiscordReactionEvent(
     const route = resolveReactionRoute(parentId);
     const { contextKey } = resolveReactionBase();
     emitReactionWithAuthor(message, route, contextKey);
-    emitReactionCommand({ route, contextKey, channelConfig });
+    emitReactionCommand({ route, contextKey, channelConfig, messageAuthorId });
   } catch (err) {
     params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
   }

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -505,9 +505,8 @@ async function handleDiscordReactionEvent(
       reactionBase = { baseText, contextKey };
       return reactionBase;
     };
-    const emitReaction = (text: string, parentPeerId?: string) => {
-      const { contextKey } = resolveReactionBase();
-      const route = resolveAgentRoute({
+    const resolveReactionRoute = (parentPeerId?: string) =>
+      resolveAgentRoute({
         cfg: params.cfg,
         channel: "discord",
         accountId: params.accountId,
@@ -519,12 +518,20 @@ async function handleDiscordReactionEvent(
         },
         parentPeer: parentPeerId ? { kind: "channel", id: parentPeerId } : undefined,
       });
+    const emitReaction = (
+      text: string,
+      route: ReturnType<typeof resolveAgentRoute>,
+      contextKey: string,
+    ) => {
       enqueueSystemEvent(text, {
         sessionKey: route.sessionKey,
         contextKey,
       });
     };
-    const emitReactionCommand = (parentPeerId?: string) => {
+    const emitReactionCommand = (params: {
+      route: ReturnType<typeof resolveAgentRoute>;
+      contextKey: string;
+    }) => {
       if (action !== "added") {
         return;
       }
@@ -542,24 +549,11 @@ async function handleDiscordReactionEvent(
       if (!reactionCommand) {
         return;
       }
-      const { contextKey } = resolveReactionBase();
-      const route = resolveAgentRoute({
-        cfg: params.cfg,
-        channel: "discord",
-        accountId: params.accountId,
-        guildId: data.guild_id ?? undefined,
-        memberRoleIds,
-        peer: {
-          kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
-          id: isDirectMessage ? user.id : data.channel_id,
-        },
-        parentPeer: parentPeerId ? { kind: "channel", id: parentPeerId } : undefined,
-      });
       enqueueSystemEvent(
         `Reaction command: ${reactionCommand} (${emojiLabel}) for message ${data.message_id}`,
         {
-          sessionKey: route.sessionKey,
-          contextKey: `${contextKey}:cmd:${reactionCommand}`,
+          sessionKey: params.route.sessionKey,
+          contextKey: params.contextKey,
         },
       );
     };
@@ -577,11 +571,15 @@ async function handleDiscordReactionEvent(
         allowlist: guildInfo?.users,
         allowNameMatching: params.allowNameMatching,
       });
-    const emitReactionWithAuthor = (message: { author?: User } | null) => {
+    const emitReactionWithAuthor = (
+      message: { author?: User } | null,
+      route: ReturnType<typeof resolveAgentRoute>,
+      contextKey: string,
+    ) => {
       const { baseText } = resolveReactionBase();
       const authorLabel = message?.author ? formatDiscordUserTag(message.author) : undefined;
       const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
-      emitReaction(text, parentId);
+      emitReaction(text, route, contextKey);
     };
     const loadThreadParentInfo = async () => {
       if (!parentId) {
@@ -643,9 +641,10 @@ async function handleDiscordReactionEvent(
           }
         }
 
-        const { baseText } = resolveReactionBase();
-        emitReaction(baseText, parentId);
-        emitReactionCommand(parentId);
+        const route = resolveReactionRoute(parentId);
+        const { baseText, contextKey } = resolveReactionBase();
+        emitReaction(baseText, route, contextKey);
+        emitReactionCommand({ route, contextKey });
         return;
       }
 
@@ -663,8 +662,10 @@ async function handleDiscordReactionEvent(
         return;
       }
 
-      emitReactionWithAuthor(message);
-      emitReactionCommand(parentId);
+      const route = resolveReactionRoute(parentId);
+      const { contextKey } = resolveReactionBase();
+      emitReactionWithAuthor(message, route, contextKey);
+      emitReactionCommand({ route, contextKey });
       return;
     }
 
@@ -702,9 +703,10 @@ async function handleDiscordReactionEvent(
         }
       }
 
-      const { baseText } = resolveReactionBase();
-      emitReaction(baseText, parentId);
-      emitReactionCommand(parentId);
+      const route = resolveReactionRoute(parentId);
+      const { baseText, contextKey } = resolveReactionBase();
+      emitReaction(baseText, route, contextKey);
+      emitReactionCommand({ route, contextKey });
       return;
     }
 
@@ -715,8 +717,10 @@ async function handleDiscordReactionEvent(
       return;
     }
 
-    emitReactionWithAuthor(message);
-    emitReactionCommand(parentId);
+    const route = resolveReactionRoute(parentId);
+    const { contextKey } = resolveReactionBase();
+    emitReactionWithAuthor(message, route, contextKey);
+    emitReactionCommand({ route, contextKey });
   } catch (err) {
     params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
   }

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
 import {
+  clearSystemEventDedupeKey,
   enqueueSystemEvent,
   isSystemEventContextChanged,
   peekSystemEvents,
@@ -93,6 +94,27 @@ describe("system events (session routing)", () => {
 
     expect(first).toBe(true);
     expect(second).toBe(false);
+  });
+
+  it("allows re-enqueue after dedupe key is explicitly cleared", () => {
+    const sessionKey = "agent:main:test-dedupe-key-clear";
+    const dedupeKey = "discord:reaction:cmd:added:msg-1:user-1:✅:accept";
+
+    const first = enqueueSystemEvent("Reaction command: accept", {
+      sessionKey,
+      dedupeKey,
+      dedupeTtlMs: 60_000,
+    });
+    const cleared = clearSystemEventDedupeKey(sessionKey, dedupeKey);
+    const second = enqueueSystemEvent("Reaction command: accept (retry)", {
+      sessionKey,
+      dedupeKey,
+      dedupeTtlMs: 60_000,
+    });
+
+    expect(first).toBe(true);
+    expect(cleared).toBe(true);
+    expect(second).toBe(true);
   });
 
   it("filters heartbeat/noise lines, returning undefined", async () => {

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -106,7 +106,7 @@ describe("system events (session routing)", () => {
       dedupeTtlMs: 60_000,
     });
     const cleared = clearSystemEventDedupeKey(sessionKey, dedupeKey);
-    const second = enqueueSystemEvent("Reaction command: accept (retry)", {
+    const second = enqueueSystemEvent("Reaction command: accept", {
       sessionKey,
       dedupeKey,
       dedupeTtlMs: 60_000,

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -3,7 +3,12 @@ import { drainFormattedSystemEvents } from "../auto-reply/reply/session-updates.
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
-import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
+import {
+  enqueueSystemEvent,
+  isSystemEventContextChanged,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "./system-events.js";
 
 const cfg = {} as unknown as OpenClawConfig;
 const mainKey = resolveMainSessionKey(cfg);
@@ -54,6 +59,23 @@ describe("system events (session routing)", () => {
 
     expect(first).toBe(true);
     expect(second).toBe(false);
+  });
+
+  it("keeps the previous context key when a duplicate event is skipped", () => {
+    const sessionKey = "agent:main:test-context-duplicate";
+
+    enqueueSystemEvent("Node connected", {
+      sessionKey,
+      contextKey: "presence:node:a",
+    });
+    const duplicate = enqueueSystemEvent("Node connected", {
+      sessionKey,
+      contextKey: "presence:node:b",
+    });
+
+    expect(duplicate).toBe(false);
+    expect(isSystemEventContextChanged(sessionKey, "presence:node:a")).toBe(false);
+    expect(isSystemEventContextChanged(sessionKey, "presence:node:b")).toBe(true);
   });
 
   it("filters heartbeat/noise lines, returning undefined", async () => {

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -78,6 +78,23 @@ describe("system events (session routing)", () => {
     expect(isSystemEventContextChanged(sessionKey, "presence:node:b")).toBe(true);
   });
 
+  it("dedupes events by stable dedupeKey within TTL", () => {
+    const sessionKey = "agent:main:test-dedupe-key";
+    const first = enqueueSystemEvent("Reaction command: accept", {
+      sessionKey,
+      dedupeKey: "discord:reaction:cmd:added:msg-1:user-1:✅:accept",
+      dedupeTtlMs: 60_000,
+    });
+    const second = enqueueSystemEvent("Reaction command: accept", {
+      sessionKey,
+      dedupeKey: "discord:reaction:cmd:added:msg-1:user-1:✅:accept",
+      dedupeTtlMs: 60_000,
+    });
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
   it("filters heartbeat/noise lines, returning undefined", async () => {
     const key = "agent:main:test-heartbeat-filter";
     enqueueSystemEvent("Read HEARTBEAT.md before continuing", { sessionKey: key });

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -108,9 +108,10 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
   }
 
   const normalizedContextKey = normalizeContextKey(options?.contextKey);
-  if (entry.lastText === cleaned) {
+  const hasExplicitDedupeWindow = Boolean(normalizedDedupeKey && dedupeTtlMs > 0);
+  if (!hasExplicitDedupeWindow && entry.lastText === cleaned) {
     return false;
-  } // skip consecutive duplicates
+  } // skip consecutive duplicates unless a dedupe-key window governs replay
   entry.lastText = cleaned;
   entry.lastContextKey = normalizedContextKey;
   if (normalizedDedupeKey && dedupeTtlMs > 0) {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -10,6 +10,7 @@ type SessionQueue = {
   queue: SystemEvent[];
   lastText: string | null;
   lastContextKey: string | null;
+  dedupeKeys: Map<string, number>;
 };
 
 const queues = new Map<string, SessionQueue>();
@@ -17,6 +18,8 @@ const queues = new Map<string, SessionQueue>();
 type SystemEventOptions = {
   sessionKey: string;
   contextKey?: string | null;
+  dedupeKey?: string | null;
+  dedupeTtlMs?: number;
 };
 
 function requireSessionKey(key?: string | null): string {
@@ -38,6 +41,32 @@ function normalizeContextKey(key?: string | null): string | null {
   return trimmed.toLowerCase();
 }
 
+function normalizeDedupeKey(key?: string | null): string | null {
+  if (!key) {
+    return null;
+  }
+  const trimmed = key.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.toLowerCase();
+}
+
+function normalizeDedupeTtlMs(value?: number): number {
+  if (!Number.isFinite(value) || !value || value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+function pruneExpiredDedupeKeys(entry: SessionQueue, now: number) {
+  for (const [key, expiresAt] of entry.dedupeKeys.entries()) {
+    if (expiresAt <= now) {
+      entry.dedupeKeys.delete(key);
+    }
+  }
+}
+
 export function isSystemEventContextChanged(
   sessionKey: string,
   contextKey?: string | null,
@@ -57,6 +86,7 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
         queue: [],
         lastText: null,
         lastContextKey: null,
+        dedupeKeys: new Map<string, number>(),
       };
       queues.set(key, created);
       return created;
@@ -65,15 +95,30 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
   if (!cleaned) {
     return false;
   }
+  const now = Date.now();
+  pruneExpiredDedupeKeys(entry, now);
+
+  const normalizedDedupeKey = normalizeDedupeKey(options?.dedupeKey);
+  const dedupeTtlMs = normalizeDedupeTtlMs(options?.dedupeTtlMs);
+  if (normalizedDedupeKey && dedupeTtlMs > 0) {
+    const existingExpiry = entry.dedupeKeys.get(normalizedDedupeKey) ?? 0;
+    if (existingExpiry > now) {
+      return false;
+    }
+  }
+
   const normalizedContextKey = normalizeContextKey(options?.contextKey);
   if (entry.lastText === cleaned) {
     return false;
   } // skip consecutive duplicates
   entry.lastText = cleaned;
   entry.lastContextKey = normalizedContextKey;
+  if (normalizedDedupeKey && dedupeTtlMs > 0) {
+    entry.dedupeKeys.set(normalizedDedupeKey, now + dedupeTtlMs);
+  }
   entry.queue.push({
     text: cleaned,
-    ts: Date.now(),
+    ts: now,
     contextKey: normalizedContextKey,
   });
   if (entry.queue.length > MAX_EVENTS) {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -66,11 +66,11 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
     return false;
   }
   const normalizedContextKey = normalizeContextKey(options?.contextKey);
-  entry.lastContextKey = normalizedContextKey;
   if (entry.lastText === cleaned) {
     return false;
   } // skip consecutive duplicates
   entry.lastText = cleaned;
+  entry.lastContextKey = normalizedContextKey;
   entry.queue.push({
     text: cleaned,
     ts: Date.now(),

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -159,6 +159,19 @@ export function hasSystemEvents(sessionKey: string) {
   return (queues.get(key)?.queue.length ?? 0) > 0;
 }
 
+export function clearSystemEventDedupeKey(sessionKey: string, dedupeKey?: string | null) {
+  const key = requireSessionKey(sessionKey);
+  const normalized = normalizeDedupeKey(dedupeKey);
+  if (!normalized) {
+    return false;
+  }
+  const entry = queues.get(key);
+  if (!entry) {
+    return false;
+  }
+  return entry.dedupeKeys.delete(normalized);
+}
+
 export function resetSystemEventsForTest() {
   queues.clear();
 }


### PR DESCRIPTION
## Summary
Fixes a Discord reaction-routing gap where guild reaction events can be dropped when `guild_id` is present but the embedded `guild` object is missing.

Also adds explicit reaction-command system events for triage emojis so reaction-driven flows get deterministic intent payloads.

Closes #42601

## Changes
- `src/discord/monitor/listeners.ts`
  - Add guild resolution fallback by `data.guild_id` and wildcard `*` entry before early-return gate.
  - Emit explicit command system events for reaction add events:
    - ✅ → `accept`
    - ❌ → `reject`
    - 🔁 → `correct`
    - ✨ → `confirm`

## Why
In live Discord channels, triage reactions occasionally produced no action although `reactionNotifications` and allowlists were configured correctly. This was traced to reaction payloads that had `guild_id` but no embedded `guild`, causing the handler to return early.

## Validation
- Verified in a live Discord channel: reaction toggle now triggers triage flow again.
- Local static check performed by building patch against runtime bundles.

## Notes
- This PR keeps behavior channel-agnostic (no hardcoded guild/channel IDs).
- Fallback is only used when normal guild resolution fails.
