### PR TITLE
fix: accept old_text/new_text aliases for edit tool

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -7,7 +7,7 @@ import { createOpenClawCodingTools } from "./pi-tools.js";
 import { expectReadWriteEditTools } from "./test-helpers/pi-tools-fs-helpers.js";
 
 describe("createOpenClawCodingTools", () => {
-  it("accepts Claude Code parameter aliases for read/write/edit", async () => {
+  it("accepts Claude Code and snake_case parameter aliases for read/write/edit", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-alias-"));
     try {
       const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
@@ -21,8 +21,8 @@ describe("createOpenClawCodingTools", () => {
 
       await editTool?.execute("tool-alias-2", {
         file_path: filePath,
-        old_string: "world",
-        new_string: "universe",
+        old_text: "world",
+        new_text: "universe",
       });
 
       const result = await readTool?.execute("tool-alias-3", {
@@ -63,7 +63,7 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
-  it("coerces structured old/new text blocks for edit", async () => {
+  it("coerces structured old/new text blocks for edit across alias styles", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-structured-edit-"));
     try {
       const filePath = path.join(tmpDir, "structured-edit.js");
@@ -75,8 +75,8 @@ describe("createOpenClawCodingTools", () => {
 
       await editTool?.execute("tool-structured-edit", {
         file_path: "structured-edit.js",
-        old_string: [{ type: "text", text: "old" }],
-        new_string: [{ kind: "text", value: "new" }],
+        old_text: [{ type: "text", text: "old" }],
+        new_text: [{ kind: "text", value: "new" }],
       });
 
       const edited = await fs.readFile(filePath, "utf8");

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -21,12 +21,12 @@ export const CLAUDE_PARAM_GROUPS = {
   edit: [
     { keys: ["path", "file_path"], label: "path (path or file_path)" },
     {
-      keys: ["oldText", "old_string"],
-      label: "oldText (oldText or old_string)",
+      keys: ["oldText", "old_string", "old_text"],
+      label: "oldText (oldText, old_string, or old_text)",
     },
     {
-      keys: ["newText", "new_string"],
-      label: "newText (newText or new_string)",
+      keys: ["newText", "new_string", "new_text"],
+      label: "newText (newText, new_string, or new_text)",
       allowEmpty: true,
     },
   ],
@@ -96,15 +96,23 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
     normalized.path = normalized.file_path;
     delete normalized.file_path;
   }
-  // old_string → oldText (edit)
+  // old_string / old_text → oldText (edit)
   if ("old_string" in normalized && !("oldText" in normalized)) {
     normalized.oldText = normalized.old_string;
     delete normalized.old_string;
   }
-  // new_string → newText (edit)
+  if ("old_text" in normalized && !("oldText" in normalized)) {
+    normalized.oldText = normalized.old_text;
+    delete normalized.old_text;
+  }
+  // new_string / new_text → newText (edit)
   if ("new_string" in normalized && !("newText" in normalized)) {
     normalized.newText = normalized.new_string;
     delete normalized.new_string;
+  }
+  if ("new_text" in normalized && !("newText" in normalized)) {
+    normalized.newText = normalized.new_text;
+    delete normalized.new_text;
   }
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.
@@ -133,7 +141,9 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
   const aliasPairs: Array<{ original: string; alias: string }> = [
     { original: "path", alias: "file_path" },
     { original: "oldText", alias: "old_string" },
+    { original: "oldText", alias: "old_text" },
     { original: "newText", alias: "new_string" },
+    { original: "newText", alias: "new_text" },
   ];
 
   for (const { original, alias } of aliasPairs) {


### PR DESCRIPTION
## Summary
- accept `old_text` and `new_text` alongside the existing edit aliases
- normalize the new snake_case aliases into `oldText` / `newText` before execution
- expose the aliases in the patched tool schema and cover them in alias tests

## Notes
- closes #42488
- I did not run the full repo test suite locally because this machine currently lacks a working pnpm path (`pnpm` missing and `corepack pnpm` fails with a signing/key mismatch), so I kept the change tightly scoped and added targeted tests.