### PR TITLE
Browser: harden noVNC bootstrap headers

### DIFF
--- a/src/browser/bridge-server.auth.test.ts
+++ b/src/browser/bridge-server.auth.test.ts
@@ -99,7 +99,13 @@ describe("startBrowserBridgeServer auth", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("location")).toBeNull();
     expect(res.headers.get("cache-control")).toContain("no-store");
+    const csp = res.headers.get("content-security-policy");
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("script-src 'nonce-");
     expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
 
     const body = await res.text();
     expect(body).toContain("window.location.replace");
@@ -107,5 +113,8 @@ describe("startBrowserBridgeServer auth", () => {
       "http://127.0.0.1:45678/vnc.html#autoconnect=1&resize=remote&password=Abc123xy",
     );
     expect(body).not.toContain("?password=");
+    const nonce = body.match(/<script nonce="([^"]+)">/)?.[1];
+    expect(nonce).toBeTruthy();
+    expect(csp).toContain(`script-src 'nonce-${nonce}'`);
   });
 });

--- a/src/browser/bridge-server.ts
+++ b/src/browser/bridge-server.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import express from "express";
@@ -28,7 +29,12 @@ type ResolvedNoVncObserver = {
   password?: string;
 };
 
-function buildNoVncBootstrapHtml(params: ResolvedNoVncObserver): string {
+type NoVncBootstrapResponse = {
+  csp: string;
+  html: string;
+};
+
+function buildNoVncBootstrapResponse(params: ResolvedNoVncObserver): NoVncBootstrapResponse {
   const hash = new URLSearchParams({
     autoconnect: "1",
     resize: "remote",
@@ -38,7 +44,16 @@ function buildNoVncBootstrapHtml(params: ResolvedNoVncObserver): string {
   }
   const targetUrl = `http://127.0.0.1:${params.noVncPort}/vnc.html#${hash.toString()}`;
   const encodedTarget = JSON.stringify(targetUrl);
-  return `<!doctype html>
+  const nonce = crypto.randomBytes(16).toString("base64");
+  return {
+    csp: [
+      "default-src 'none'",
+      "base-uri 'none'",
+      "form-action 'none'",
+      "frame-ancestors 'none'",
+      `script-src 'nonce-${nonce}'`,
+    ].join("; "),
+    html: `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -48,12 +63,13 @@ function buildNoVncBootstrapHtml(params: ResolvedNoVncObserver): string {
 </head>
 <body>
   <p>Opening sandbox observer...</p>
-  <script>
+  <script nonce="${nonce}">
     const target = ${encodedTarget};
     window.location.replace(target);
   </script>
 </body>
-</html>`;
+</html>`,
+  };
 }
 
 export async function startBrowserBridgeServer(params: {
@@ -90,7 +106,11 @@ export async function startBrowserBridgeServer(params: {
         res.status(404).send("Invalid or expired token");
         return;
       }
-      res.type("html").status(200).send(buildNoVncBootstrapHtml(resolved));
+      const bootstrap = buildNoVncBootstrapResponse(resolved);
+      res.setHeader("Content-Security-Policy", bootstrap.csp);
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("X-Frame-Options", "DENY");
+      res.type("html").status(200).send(bootstrap.html);
     });
   }
 


### PR DESCRIPTION
## Summary

- Problem: the loopback-only `/sandbox/novnc` bootstrap page relied on `no-store` and `no-referrer`, but it did not send a document CSP, `nosniff`, or frame-deny headers.
- Why it matters: this page carries the short-lived observer redirect flow, so it should be locked down as tightly as possible even though the route is loopback-only and token-gated.
- What changed: generate a per-response script nonce, attach a restrictive CSP, and add `X-Content-Type-Options: nosniff` plus `X-Frame-Options: DENY`.
- What did NOT change (scope boundary): the existing one-time observer token URL flow and noVNC redirect behavior stay the same.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #42476

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Browser bridge / sandbox noVNC observer
- Relevant config (redacted): loopback browser bridge with auth token and short-lived noVNC observer token

### Steps

1. Start the browser bridge with `resolveSandboxNoVncToken` enabled.
2. Request `/sandbox/novnc?token=<valid-token>`.
3. Inspect response headers and bootstrap HTML.

### Expected

- The bootstrap page still redirects to the local noVNC target.
- The response includes no-store/no-referrer plus strict document hardening headers.
- The password remains in the URL fragment, not the query string or `Location` header.

### Actual

- The response now includes a nonce-based CSP, `X-Content-Type-Options: nosniff`, and `X-Frame-Options: DENY` while preserving the existing redirect flow.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `/sandbox/novnc` still serves bootstrap HTML, still embeds the target noVNC fragment URL, and now emits the expected CSP / frame / nosniff headers.
- Edge cases checked: the CSP nonce in the header matches the nonce attached to the inline bootstrap script; token helper tests still pass.
- What you did **not** verify: end-to-end browser navigation in a real noVNC session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 4cf57794f1b6c1b3aa1bf7fd0d22ea842c45da36.
- Files/config to restore: `src/browser/bridge-server.ts`, `src/browser/bridge-server.auth.test.ts`
- Known bad symptoms reviewers should watch for: `/sandbox/novnc` returns 200 but the bootstrap script is blocked by CSP, or headers regress to being absent.

## Risks and Mitigations

- Risk: an incorrect CSP could block the bootstrap redirect script.
- Mitigation: the test now asserts that the per-response nonce is present both in the HTML and the header, and the redirect body content is unchanged.
