### PR TITLE
fix(config): add missing firecrawl sub-schema to ToolsWebFetchSchema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -175,6 +175,45 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts tools.web.fetch.firecrawl config", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            enabled: true,
+            readability: false,
+            firecrawl: {
+              enabled: true,
+              apiKey: "fc-test-key",
+              baseUrl: "https://api.firecrawl.dev",
+              onlyMainContent: true,
+              maxAgeMs: 60000,
+              timeoutSeconds: 30,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects unknown keys inside tools.web.fetch.firecrawl", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            firecrawl: {
+              bogusKey: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
   it("rejects browser.extraArgs with non-array value", () => {
     const res = validateConfigObject({
       browser: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -327,6 +327,18 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## What

Adds the missing `firecrawl` property to `ToolsWebFetchSchema` so that `tools.web.fetch.firecrawl` config passes validation instead of crashing the gateway on startup.

Fixes #42570

## Root Cause

`ToolsWebFetchSchema` uses `.strict()` and did not include a `firecrawl` sub-schema, despite the TypeScript types and docs correctly documenting it. Any user with `tools.web.fetch.firecrawl` in their config hit:

```
Config invalid: tools.web.fetch: Unrecognized key: "firecrawl"
```

## Fix

Added the `firecrawl` sub-schema with all documented fields:
- `enabled`, `apiKey`, `baseUrl`, `onlyMainContent`, `maxAgeMs`, `timeoutSeconds`

## Tests

Added regression tests in `src/config/config.schema-regressions.test.ts` asserting a full `tools.web.fetch.firecrawl` config passes validation.